### PR TITLE
test: migrate service boundary sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
@@ -253,10 +253,10 @@ def test_extract_images_from_docx_uses_internal_files_url():
         dify_config.INTERNAL_FILES_URL = original_internal_files_url
 
 
-def test_extract_hyperlinks(monkeypatch: pytest.MonkeyPatch):
+def test_extract_hyperlinks(monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
     # Mock db and storage to avoid issues during image extraction (even if no images are present)
     monkeypatch.setattr(we, "storage", SimpleNamespace(save=lambda k, d: None))
-    db_stub = SimpleNamespace(session=SimpleNamespace(add=lambda o: None, commit=lambda: None))
+    db_stub = SimpleNamespace(session=unbound_session)
     monkeypatch.setattr(we, "db", db_stub)
     monkeypatch.setattr(we.dify_config, "FILES_URL", "http://files.local", raising=False)
     monkeypatch.setattr(we.dify_config, "STORAGE_TYPE", "local", raising=False)
@@ -298,10 +298,10 @@ def test_extract_hyperlinks(monkeypatch: pytest.MonkeyPatch):
             os.remove(tmp_path)
 
 
-def test_extract_legacy_hyperlinks(monkeypatch: pytest.MonkeyPatch):
+def test_extract_legacy_hyperlinks(monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
     # Mock db and storage
     monkeypatch.setattr(we, "storage", SimpleNamespace(save=lambda k, d: None))
-    db_stub = SimpleNamespace(session=SimpleNamespace(add=lambda o: None, commit=lambda: None))
+    db_stub = SimpleNamespace(session=unbound_session)
     monkeypatch.setattr(we, "db", db_stub)
     monkeypatch.setattr(we.dify_config, "FILES_URL", "http://files.local", raising=False)
     monkeypatch.setattr(we.dify_config, "STORAGE_TYPE", "local", raising=False)
@@ -442,7 +442,7 @@ def test_close_closes_awaitable_close_result():
     extractor.temp_file.close.assert_called_once()
 
 
-def test_extract_images_handles_invalid_external_cases(monkeypatch: pytest.MonkeyPatch):
+def test_extract_images_handles_invalid_external_cases(monkeypatch: pytest.MonkeyPatch, sqlite_session: Session):
     class FakeTargetRef:
         def __contains__(self, item):
             return item == "image"
@@ -473,7 +473,7 @@ def test_extract_images_handles_invalid_external_cases(monkeypatch: pytest.Monke
         return SimpleNamespace(status_code=200, headers={"Content-Type": "application/unknown"}, content=b"x")
 
     monkeypatch.setattr(we, "remote_fetcher", SimpleNamespace(make_request=fake_make_request))
-    db_stub = SimpleNamespace(session=SimpleNamespace(add=lambda obj: None, commit=MagicMock()))
+    db_stub = SimpleNamespace(session=sqlite_session)
     monkeypatch.setattr(we, "db", db_stub)
     monkeypatch.setattr(we, "storage", SimpleNamespace(save=lambda key, data: None))
     monkeypatch.setattr(we.dify_config, "FILES_URL", "http://files.local", raising=False)
@@ -482,11 +482,13 @@ def test_extract_images_handles_invalid_external_cases(monkeypatch: pytest.Monke
     extractor.tenant_id = "tenant"
     extractor.user_id = "user"
     extractor._session = None
+    transaction_events: list[str] = []
+    event.listen(sqlite_session, "after_commit", lambda _session: transaction_events.append("commit"))
 
     result = extractor._extract_images_from_docx(doc)
 
     assert result == {}
-    db_stub.session.commit.assert_called_once()
+    assert transaction_events == ["commit"]
 
 
 def test_table_to_markdown_and_parse_helpers(monkeypatch: pytest.MonkeyPatch):

--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
@@ -1017,9 +1017,6 @@ def test_set_datasource_variables_success(
     mock_db_exec.node_type = "datasource"
     mock_repo_instance._to_db_model.return_value = mock_db_exec
 
-    # Mock Session and begin
-    mocker.patch("services.rag_pipeline.rag_pipeline.Session", return_value=mocker.MagicMock())
-
     # Mock DraftVariableSaver
     mock_saver_instance = mocker.Mock()
     mocker.patch("services.rag_pipeline.rag_pipeline.DraftVariableSaver", return_value=mock_saver_instance)
@@ -1171,10 +1168,6 @@ def test_run_draft_workflow_node_seeds_llm_environment_variable(
         get_execution_by_id=mocker.Mock(return_value="db")
     )
     mocker.patch("services.rag_pipeline.rag_pipeline.DraftVariableSaver", return_value=mocker.Mock())
-    session_ctx = mocker.MagicMock()
-    session_ctx.begin.return_value = mocker.MagicMock()
-    mocker.patch("services.rag_pipeline.rag_pipeline.Session", return_value=session_ctx)
-
     rag_pipeline_service.service.run_draft_workflow_node(pipeline, "node-1", {}, account)
 
     getter = handle_node_run_result.call_args.kwargs["getter"]
@@ -1212,11 +1205,6 @@ def test_run_draft_workflow_node_saves_execution_and_variables(
     )
     saver = mocker.Mock()
     mocker.patch("services.rag_pipeline.rag_pipeline.DraftVariableSaver", return_value=saver)
-
-    session_ctx = mocker.MagicMock()
-    begin_ctx = mocker.MagicMock()
-    session_ctx.begin.return_value = begin_ctx
-    mocker.patch("services.rag_pipeline.rag_pipeline.Session", return_value=session_ctx)
 
     result = rag_pipeline_service.service.run_draft_workflow_node(pipeline, "node-1", {"q": "x"}, account)
 
@@ -1884,10 +1872,7 @@ def test_get_pipeline_raises_when_pipeline_missing(
         rag_pipeline_service.service.get_pipeline("t1", "d1")
 
 
-def test_init_uses_default_sessionmaker_when_none(
-    mocker: MockerFixture, sqlite_session: Session, sqlite_session_factory: sessionmaker[Session]
-) -> None:
-    mocker.patch("services.rag_pipeline.rag_pipeline.sessionmaker", return_value=sqlite_session_factory)
+def test_init_uses_default_sessionmaker_when_none(mocker: MockerFixture, sqlite_session: Session) -> None:
     mocker.patch("services.rag_pipeline.rag_pipeline.db", SimpleNamespace(engine=sqlite_session.get_bind()))
     create_exec_repo = mocker.patch(
         "services.rag_pipeline.rag_pipeline.DifyAPIRepositoryFactory.create_api_workflow_node_execution_repository"
@@ -1898,8 +1883,11 @@ def test_init_uses_default_sessionmaker_when_none(
 
     RagPipelineService(session=sqlite_session, session_maker=None)
 
-    create_exec_repo.assert_called_once_with(sqlite_session_factory)
-    create_run_repo.assert_called_once_with(sqlite_session_factory)
+    exec_session_maker = create_exec_repo.call_args.args[0]
+    run_session_maker = create_run_repo.call_args.args[0]
+    assert exec_session_maker is run_session_maker
+    assert exec_session_maker.kw["bind"] is sqlite_session.get_bind()
+    assert exec_session_maker.kw["expire_on_commit"] is False
 
 
 def test_get_pipeline_templates_builtin_en_us_no_fallback(mocker: MockerFixture, sqlite_session: Session) -> None:

--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
@@ -1198,9 +1198,7 @@ def test_run_draft_workflow_node_saves_execution_and_variables(
     account = _make_account()
     draft_workflow = _make_workflow(workflow_id="wf-1")
     mocker.patch.object(draft_workflow, "get_node_config_by_id", return_value={"id": "node-1"})
-    mocker.patch.object(
-        draft_workflow, "get_enclosing_node_type_and_id", return_value=("loop", "enclosing-node")
-    )
+    mocker.patch.object(draft_workflow, "get_enclosing_node_type_and_id", return_value=("loop", "enclosing-node"))
     mocker.patch.object(rag_pipeline_service.service, "get_draft_workflow", return_value=draft_workflow)
 
     execution = SimpleNamespace(id="exec-1", node_id="node-1", node_type="llm", process_data={}, outputs={})

--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
@@ -28,7 +28,7 @@ from models.dataset import (
     PipelineRecommendedPlugin,
 )
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus
-from models.workflow import Workflow
+from models.workflow import Workflow, WorkflowRun
 from services.entities.knowledge_entities.rag_pipeline_entities import IconInfo, PipelineTemplateInfoEntity
 from services.rag_pipeline.rag_pipeline import RagPipelineService
 from services.workflow_ref_service import WorkflowRef
@@ -102,6 +102,7 @@ def _make_workflow(
     app_id: str = "p1",
     graph: dict[str, object] | None = None,
     features: dict[str, object] | None = None,
+    rag_pipeline_variables: list[dict[str, object]] | None = None,
     created_by: str = "u1",
 ) -> Workflow:
     workflow = Workflow(
@@ -120,7 +121,7 @@ def _make_workflow(
         updated_at=datetime(2024, 1, 1),
         environment_variables=[],
         conversation_variables=[],
-        rag_pipeline_variables=[],
+        rag_pipeline_variables=rag_pipeline_variables or [],
     )
     return workflow
 
@@ -150,6 +151,15 @@ def _make_document(*, document_id: str = "doc-1", dataset_id: str = "d1", tenant
         indexing_status=IndexingStatus.WAITING,
         doc_form=IndexStructureType.PARAGRAPH_INDEX,
     )
+
+
+def _rag_variable(variable: str, *, belong_to_node_id: str = "shared") -> dict[str, object]:
+    return {
+        "variable": variable,
+        "belong_to_node_id": belong_to_node_id,
+        "type": "text-input",
+        "label": variable.title(),
+    }
 
 
 def _persist(session: Session, *entities: object) -> None:
@@ -623,25 +633,24 @@ def test_run_datasource_workflow_node_website_crawl(
     from core.datasource.entities.datasource_entities import DatasourceProviderType
 
     # 1. Setup workflow and node
-    pipeline = mocker.Mock()
-    pipeline.id = "p1"
-    pipeline.tenant_id = "t1"
+    pipeline = _make_pipeline()
 
-    workflow = mocker.Mock()
-    workflow.graph_dict = {
-        "nodes": [
-            {
-                "id": "node-1",
-                "data": {
-                    "type": "datasource",
-                    "plugin_id": "p-1",
-                    "provider_name": "firecrawl",
-                    "datasource_name": "website_crawl",
-                    "datasource_parameters": {"url": {"value": "{{#start.url#}}"}},
-                },
-            }
-        ]
-    }
+    workflow = _make_workflow(
+        graph={
+            "nodes": [
+                {
+                    "id": "node-1",
+                    "data": {
+                        "type": "datasource",
+                        "plugin_id": "p-1",
+                        "provider_name": "firecrawl",
+                        "datasource_name": "website_crawl",
+                        "datasource_parameters": {"url": {"value": "{{#start.url#}}"}},
+                    },
+                }
+            ]
+        }
+    )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     # 2. Mock DatasourceManager and Runtime
@@ -676,7 +685,7 @@ def test_run_datasource_workflow_node_website_crawl(
         pipeline=pipeline,
         node_id="node-1",
         user_inputs={"url": "https://example.com"},
-        account=mocker.Mock(id="u1"),
+        account=_make_account(),
         datasource_type="website_crawl",
         is_published=True,
     )
@@ -701,29 +710,28 @@ def test_run_datasource_node_preview_online_document(
     from core.datasource.entities.datasource_entities import DatasourceMessage, DatasourceProviderType
 
     # 1. Setup workflow and node
-    pipeline = mocker.Mock()
-    pipeline.id = "p1"
-    pipeline.tenant_id = "t1"
+    pipeline = _make_pipeline()
 
-    workflow = mocker.Mock()
-    workflow.graph_dict = {
-        "nodes": [
-            {
-                "id": "node-1",
-                "data": {
-                    "type": "datasource",
-                    "plugin_id": "p-1",
-                    "provider_name": "notion",
-                    "datasource_name": "online_document",
-                    "datasource_parameters": {
-                        "workspace_id": {"value": "ws-1"},
-                        "page_id": {"value": "pg-1"},
-                        "type": {"value": "page"},
+    workflow = _make_workflow(
+        graph={
+            "nodes": [
+                {
+                    "id": "node-1",
+                    "data": {
+                        "type": "datasource",
+                        "plugin_id": "p-1",
+                        "provider_name": "notion",
+                        "datasource_name": "online_document",
+                        "datasource_parameters": {
+                            "workspace_id": {"value": "ws-1"},
+                            "page_id": {"value": "pg-1"},
+                            "type": {"value": "page"},
+                        },
                     },
-                },
-            }
-        ]
-    }
+                }
+            ]
+        }
+    )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     # 2. Mock Runtime and results
@@ -758,7 +766,7 @@ def test_run_datasource_node_preview_online_document(
         pipeline=pipeline,
         node_id="node-1",
         user_inputs={},
-        account=mocker.Mock(id="u1"),
+        account=_make_account(),
         datasource_type="online_document",
         is_published=True,
     )
@@ -819,12 +827,11 @@ def test_get_first_step_parameters_success(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
     # 1. Setup mock workflow
-    pipeline = mocker.Mock()
-    workflow = mocker.Mock()
-    workflow.graph_dict = {
-        "nodes": [{"id": "node-1", "data": {"datasource_parameters": {"url": {"value": "{{#start.url#}}"}}}}]
-    }
-    workflow.rag_pipeline_variables = [{"variable": "url", "label": "URL", "type": "string"}]
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(
+        graph={"nodes": [{"id": "node-1", "data": {"datasource_parameters": {"url": {"value": "{{#start.url#}}"}}}}]},
+        rag_pipeline_variables=[_rag_variable("url")],
+    )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     # 2. Run test
@@ -839,17 +846,18 @@ def test_get_second_step_parameters_success(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
     # 1. Setup mock workflow
-    pipeline = mocker.Mock()
-    workflow = mocker.Mock()
-    workflow.graph_dict = {
-        "nodes": [
-            {
-                "id": "node-1",
-                "data": {},  # Second step logic is slightly different in how it gets variables
-            }
-        ]
-    }
-    workflow.rag_pipeline_variables = [{"variable": "var1", "label": "Var 1"}]
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(
+        graph={
+            "nodes": [
+                {
+                    "id": "node-1",
+                    "data": {},  # Second step logic is slightly different in how it gets variables
+                }
+            ]
+        },
+        rag_pipeline_variables=[_rag_variable("var1", belong_to_node_id="other-node")],
+    )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     # 2. Run test
@@ -945,8 +953,8 @@ def test_get_datasource_plugins_success(
 def test_retry_error_document_success(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    dataset = mocker.Mock()
-    document = SimpleNamespace(id="doc-1")
+    dataset = _make_dataset()
+    document = _make_document()
 
     log = DocumentPipelineExecutionLog(
         pipeline_id="p-1",
@@ -1148,9 +1156,10 @@ def test_run_draft_workflow_node_seeds_llm_environment_variable(
             "description": "Shared summarization model",
         }
     )
-    draft_workflow = mocker.Mock(id="wf-1", environment_variables=[llm_environment_variable])
-    draft_workflow.get_node_config_by_id.return_value = {"id": "node-1"}
-    draft_workflow.get_enclosing_node_type_and_id.return_value = None
+    draft_workflow = _make_workflow(workflow_id="wf-1")
+    draft_workflow.environment_variables = [llm_environment_variable]
+    mocker.patch.object(draft_workflow, "get_node_config_by_id", return_value={"id": "node-1"})
+    mocker.patch.object(draft_workflow, "get_enclosing_node_type_and_id", return_value=None)
     mocker.patch.object(rag_pipeline_service.service, "get_draft_workflow", return_value=draft_workflow)
 
     execution = SimpleNamespace(id="exec-1", node_id="node-1", node_type="llm", process_data={}, outputs={})
@@ -1187,9 +1196,11 @@ def test_run_draft_workflow_node_saves_execution_and_variables(
 ) -> None:
     pipeline = _make_pipeline()
     account = _make_account()
-    draft_workflow = mocker.Mock(id="wf-1")
-    draft_workflow.get_node_config_by_id.return_value = {"id": "node-1"}
-    draft_workflow.get_enclosing_node_type_and_id.return_value = ("loop", "enclosing-node")
+    draft_workflow = _make_workflow(workflow_id="wf-1")
+    mocker.patch.object(draft_workflow, "get_node_config_by_id", return_value={"id": "node-1"})
+    mocker.patch.object(
+        draft_workflow, "get_enclosing_node_type_and_id", return_value=("loop", "enclosing-node")
+    )
     mocker.patch.object(rag_pipeline_service.service, "get_draft_workflow", return_value=draft_workflow)
 
     execution = SimpleNamespace(id="exec-1", node_id="node-1", node_type="llm", process_data={}, outputs={})
@@ -1217,7 +1228,7 @@ def test_run_draft_workflow_node_saves_execution_and_variables(
 def test_run_datasource_workflow_node_returns_error_when_workflow_missing(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
+    pipeline = _make_pipeline()
     mocker.patch.object(rag_pipeline_service.service, "get_draft_workflow", return_value=None)
 
     events = list(
@@ -1225,7 +1236,7 @@ def test_run_datasource_workflow_node_returns_error_when_workflow_missing(
             pipeline=pipeline,
             node_id="node-1",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="online_document",
             is_published=False,
         )
@@ -1239,22 +1250,23 @@ def test_run_datasource_workflow_node_online_document_success(
 ) -> None:
     from core.datasource.entities.datasource_entities import DatasourceProviderType
 
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
-    workflow = mocker.Mock()
-    workflow.graph_dict = {
-        "nodes": [
-            {
-                "id": "node-1",
-                "data": {
-                    "type": "datasource",
-                    "plugin_id": "pid",
-                    "provider_name": "notion",
-                    "datasource_name": "online_document",
-                    "datasource_parameters": {"workspace_id": {"value": None}, "page_id": {"value": "fixed"}},
-                },
-            }
-        ]
-    }
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(
+        graph={
+            "nodes": [
+                {
+                    "id": "node-1",
+                    "data": {
+                        "type": "datasource",
+                        "plugin_id": "pid",
+                        "provider_name": "notion",
+                        "datasource_name": "online_document",
+                        "datasource_parameters": {"workspace_id": {"value": None}, "page_id": {"value": "fixed"}},
+                    },
+                }
+            ]
+        }
+    )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     runtime = mocker.Mock()
@@ -1272,7 +1284,7 @@ def test_run_datasource_workflow_node_online_document_success(
             pipeline=pipeline,
             node_id="node-1",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type=DatasourceProviderType.ONLINE_DOCUMENT,
             is_published=True,
         )
@@ -1287,22 +1299,26 @@ def test_run_datasource_workflow_node_online_drive_success(
 ) -> None:
     from core.datasource.entities.datasource_entities import DatasourceProviderType
 
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
-    workflow = mocker.Mock()
-    workflow.graph_dict = {
-        "nodes": [
-            {
-                "id": "node-1",
-                "data": {
-                    "type": "datasource",
-                    "plugin_id": "pid",
-                    "provider_name": "drive",
-                    "datasource_name": "online_drive",
-                    "datasource_parameters": {"bucket": {"value": "bucket-1"}, "next_page_parameters": {"value": []}},
-                },
-            }
-        ]
-    }
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(
+        graph={
+            "nodes": [
+                {
+                    "id": "node-1",
+                    "data": {
+                        "type": "datasource",
+                        "plugin_id": "pid",
+                        "provider_name": "drive",
+                        "datasource_name": "online_drive",
+                        "datasource_parameters": {
+                            "bucket": {"value": "bucket-1"},
+                            "next_page_parameters": {"value": []},
+                        },
+                    },
+                }
+            ]
+        }
+    )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     runtime = mocker.Mock()
@@ -1320,7 +1336,7 @@ def test_run_datasource_workflow_node_online_drive_success(
             pipeline=pipeline,
             node_id="node-1",
             user_inputs={"bucket": "bucket-1"},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type=DatasourceProviderType.ONLINE_DRIVE,
             is_published=True,
         )
@@ -1379,23 +1395,23 @@ def test_handle_node_run_result_default_value_strategy(
 def test_get_first_step_parameters_raises_when_datasource_node_missing(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    workflow = SimpleNamespace(graph_dict={"nodes": []}, rag_pipeline_variables=[{"variable": "url"}])
+    workflow = _make_workflow(graph={"nodes": []}, rag_pipeline_variables=[_rag_variable("url")])
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     with pytest.raises(ValueError, match="Datasource node data not found"):
-        rag_pipeline_service.service.get_first_step_parameters(SimpleNamespace(), "missing-node")
+        rag_pipeline_service.service.get_first_step_parameters(_make_pipeline(), "missing-node")
 
 
 def test_get_second_step_parameters_handles_string_and_list_variable_references(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    workflow = SimpleNamespace(
+    workflow = _make_workflow(
         rag_pipeline_variables=[
-            {"variable": "url", "belong_to_node_id": "node-1"},
-            {"variable": "bucket", "belong_to_node_id": "shared"},
-            {"variable": "keep", "belong_to_node_id": "node-1"},
+            _rag_variable("url", belong_to_node_id="node-1"),
+            _rag_variable("bucket"),
+            _rag_variable("keep", belong_to_node_id="node-1"),
         ],
-        graph_dict={
+        graph={
             "nodes": [
                 {
                     "id": "node-1",
@@ -1411,9 +1427,10 @@ def test_get_second_step_parameters_handles_string_and_list_variable_references(
     )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
-    result = rag_pipeline_service.service.get_second_step_parameters(SimpleNamespace(), "node-1")
+    result = rag_pipeline_service.service.get_second_step_parameters(_make_pipeline(), "node-1")
 
-    assert result == [{"variable": "keep", "belong_to_node_id": "node-1"}]
+    assert [item["variable"] for item in result] == ["keep"]
+    assert result[0]["belong_to_node_id"] == "node-1"
 
 
 def test_get_rag_pipeline_workflow_run_node_executions_empty_when_run_missing(
@@ -1434,7 +1451,7 @@ def test_get_rag_pipeline_workflow_run_node_executions_assembles_configured_repo
 ) -> None:
     pipeline = _make_pipeline()
     mocker.patch.object(
-        rag_pipeline_service.service, "get_rag_pipeline_workflow_run", return_value=SimpleNamespace(id="run-1")
+        rag_pipeline_service.service, "get_rag_pipeline_workflow_run", return_value=WorkflowRun(id="run-1")
     )
     node_repo = rag_pipeline_service.service._node_execution_service_repo
     expected_executions = ["n1", "n2"]
@@ -1507,12 +1524,12 @@ def test_get_node_last_run_delegates_to_repository(
 def test_set_datasource_variables_raises_when_node_id_missing(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
-    workflow = mocker.Mock()
+    pipeline = _make_pipeline()
+    workflow = _make_workflow()
     mocker.patch.object(rag_pipeline_service.service, "get_draft_workflow", return_value=workflow)
 
     with pytest.raises(ValueError, match="Node id is required"):
-        rag_pipeline_service.service.set_datasource_variables(pipeline, {"start_node_id": ""}, SimpleNamespace(id="u1"))
+        rag_pipeline_service.service.set_datasource_variables(pipeline, {"start_node_id": ""}, _make_account())
 
 
 def test_get_default_block_configs_skips_empty_configs(
@@ -1543,8 +1560,8 @@ def test_get_default_block_configs_skips_empty_configs(
 def test_run_datasource_workflow_node_returns_error_when_node_missing(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
-    workflow = SimpleNamespace(graph_dict={"nodes": []})
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(graph={"nodes": []})
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
     events = list(
@@ -1552,7 +1569,7 @@ def test_run_datasource_workflow_node_returns_error_when_node_missing(
             pipeline=pipeline,
             node_id="missing-node",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="online_document",
             is_published=True,
         )
@@ -1565,9 +1582,9 @@ def test_run_datasource_workflow_node_returns_error_when_node_missing(
 def test_run_datasource_workflow_node_online_document_exception(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
-    workflow = SimpleNamespace(
-        graph_dict={
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "node-1",
@@ -1605,7 +1622,7 @@ def test_run_datasource_workflow_node_online_document_exception(
             pipeline=pipeline,
             node_id="node-1",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="online_document",
             is_published=True,
         )
@@ -1621,9 +1638,9 @@ def test_run_datasource_node_preview_raises_for_stream_non_string(
 ) -> None:
     from core.datasource.entities.datasource_entities import DatasourceMessage
 
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
-    workflow = SimpleNamespace(
-        graph_dict={
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "node-1",
@@ -1660,7 +1677,7 @@ def test_run_datasource_node_preview_raises_for_stream_non_string(
             pipeline=pipeline,
             node_id="node-1",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="online_document",
             is_published=True,
         )
@@ -1669,13 +1686,13 @@ def test_run_datasource_node_preview_raises_for_stream_non_string(
 def test_get_first_step_parameters_returns_empty_when_no_rag_variables(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    workflow = SimpleNamespace(
-        graph_dict={"nodes": [{"id": "node-1", "data": {"datasource_parameters": {"url": {"value": "literal"}}}}]},
+    workflow = _make_workflow(
+        graph={"nodes": [{"id": "node-1", "data": {"datasource_parameters": {"url": {"value": "literal"}}}}]},
         rag_pipeline_variables=[],
     )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
-    result = rag_pipeline_service.service.get_first_step_parameters(SimpleNamespace(), "node-1")
+    result = rag_pipeline_service.service.get_first_step_parameters(_make_pipeline(), "node-1")
 
     assert result == []
 
@@ -1683,8 +1700,8 @@ def test_get_first_step_parameters_returns_empty_when_no_rag_variables(
 def test_get_second_step_parameters_filters_first_step_variables(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "node-1",
@@ -1698,26 +1715,25 @@ def test_get_second_step_parameters_filters_first_step_variables(
             ]
         },
         rag_pipeline_variables=[
-            {"variable": "workspace", "belong_to_node_id": "shared"},
-            {"variable": "bucket", "belong_to_node_id": "shared"},
-            {"variable": "keep", "belong_to_node_id": "shared"},
-            {"variable": "other-node", "belong_to_node_id": "node-x"},
+            _rag_variable("workspace"),
+            _rag_variable("bucket"),
+            _rag_variable("keep"),
+            _rag_variable("other-node", belong_to_node_id="node-x"),
         ],
     )
     mocker.patch.object(rag_pipeline_service.service, "get_published_workflow", return_value=workflow)
 
-    result = rag_pipeline_service.service.get_second_step_parameters(SimpleNamespace(), "node-1")
+    result = rag_pipeline_service.service.get_second_step_parameters(_make_pipeline(), "node-1")
 
-    assert result == [{"variable": "keep", "belong_to_node_id": "shared"}]
+    assert [item["variable"] for item in result] == ["keep"]
+    assert result[0]["belong_to_node_id"] == "shared"
 
 
 def test_retry_error_document_raises_when_execution_log_not_found(
     rag_pipeline_service: RagPipelineServiceTestContext,
 ) -> None:
     with pytest.raises(ValueError, match="Document pipeline execution log not found"):
-        rag_pipeline_service.service.retry_error_document(
-            SimpleNamespace(), SimpleNamespace(id="doc-1"), SimpleNamespace(id="u1")
-        )
+        rag_pipeline_service.service.retry_error_document(_make_dataset(), _make_document(), _make_account())
 
 
 def test_get_datasource_plugins_raises_when_workflow_not_found(
@@ -1800,9 +1816,9 @@ def test_handle_node_run_result_does_not_write_when_pipeline_dataset_is_missing(
 def test_run_datasource_node_preview_raises_for_unsupported_provider(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    pipeline = SimpleNamespace(id="p1", tenant_id="t1")
-    workflow = SimpleNamespace(
-        graph_dict={
+    pipeline = _make_pipeline()
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "node-1",
@@ -1829,7 +1845,7 @@ def test_run_datasource_node_preview_raises_for_unsupported_provider(
             pipeline=pipeline,
             node_id="node-1",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="website_crawl",
             is_published=True,
         )
@@ -1980,8 +1996,8 @@ def test_run_datasource_workflow_node_handles_variable_parameter_types(
 ) -> None:
     from core.datasource.entities.datasource_entities import DatasourceProviderType
 
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "node-1",
@@ -2014,10 +2030,10 @@ def test_run_datasource_workflow_node_handles_variable_parameter_types(
 
     events = list(
         rag_pipeline_service.service.run_datasource_workflow_node(
-            pipeline=SimpleNamespace(id="p1", tenant_id="t1"),
+            pipeline=_make_pipeline(),
             node_id="node-1",
             user_inputs={"k": "mapped"},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="website_crawl",
             is_published=True,
         )
@@ -2032,8 +2048,8 @@ def test_run_datasource_workflow_node_online_drive_branch(
 ) -> None:
     from core.datasource.entities.datasource_entities import DatasourceProviderType
 
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "node-1",
@@ -2062,10 +2078,10 @@ def test_run_datasource_workflow_node_online_drive_branch(
 
     events = list(
         rag_pipeline_service.service.run_datasource_workflow_node(
-            pipeline=SimpleNamespace(id="p1", tenant_id="t1"),
+            pipeline=_make_pipeline(),
             node_id="node-1",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="online_drive",
             is_published=True,
         )
@@ -2080,8 +2096,8 @@ def test_run_datasource_node_preview_not_published_uses_draft(
 ) -> None:
     from core.datasource.entities.datasource_entities import DatasourceMessage
 
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "n1",
@@ -2111,10 +2127,10 @@ def test_run_datasource_node_preview_not_published_uses_draft(
     )
 
     result = rag_pipeline_service.service.run_datasource_node_preview(
-        pipeline=SimpleNamespace(id="p1", tenant_id="t1"),
+        pipeline=_make_pipeline(),
         node_id="n1",
         user_inputs={},
-        account=SimpleNamespace(id="u1"),
+        account=_make_account(),
         datasource_type="online_document",
         is_published=False,
     )
@@ -2195,9 +2211,7 @@ def test_retry_error_document_raises_when_pipeline_missing(
     _persist(rag_pipeline_service.session, exec_log)
 
     with pytest.raises(ValueError, match="Pipeline not found"):
-        rag_pipeline_service.service.retry_error_document(
-            SimpleNamespace(), SimpleNamespace(id="doc-1"), SimpleNamespace(id="u1")
-        )
+        rag_pipeline_service.service.retry_error_document(_make_dataset(), _make_document(), _make_account())
 
 
 def test_retry_error_document_raises_when_workflow_missing(
@@ -2216,9 +2230,7 @@ def test_retry_error_document_raises_when_workflow_missing(
     _persist(rag_pipeline_service.session, exec_log, pipeline)
 
     with pytest.raises(ValueError, match="Workflow not found"):
-        rag_pipeline_service.service.retry_error_document(
-            SimpleNamespace(), SimpleNamespace(id="doc-1"), SimpleNamespace(id="u1")
-        )
+        rag_pipeline_service.service.retry_error_document(_make_dataset(), _make_document(), _make_account())
 
 
 def test_get_datasource_plugins_returns_empty_for_non_datasource_nodes(
@@ -2253,10 +2265,10 @@ def test_run_datasource_node_preview_raises_when_workflow_missing(
 
     with pytest.raises(RuntimeError, match="Workflow not initialized"):
         rag_pipeline_service.service.run_datasource_node_preview(
-            pipeline=SimpleNamespace(id="p1", tenant_id="t1"),
+            pipeline=_make_pipeline(),
             node_id="n1",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="online_document",
             is_published=True,
         )
@@ -2266,15 +2278,15 @@ def test_run_datasource_node_preview_raises_when_node_missing(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
     mocker.patch.object(
-        rag_pipeline_service.service, "get_published_workflow", return_value=SimpleNamespace(graph_dict={"nodes": []})
+        rag_pipeline_service.service, "get_published_workflow", return_value=_make_workflow(graph={"nodes": []})
     )
 
     with pytest.raises(RuntimeError, match="Datasource node data not found"):
         rag_pipeline_service.service.run_datasource_node_preview(
-            pipeline=SimpleNamespace(id="p1", tenant_id="t1"),
+            pipeline=_make_pipeline(),
             node_id="missing",
             user_inputs={},
-            account=SimpleNamespace(id="u1"),
+            account=_make_account(),
             datasource_type="online_document",
             is_published=True,
         )
@@ -2285,8 +2297,8 @@ def test_run_datasource_node_preview_keeps_existing_user_input(
 ) -> None:
     from core.datasource.entities.datasource_entities import DatasourceMessage
 
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "n1",
@@ -2318,10 +2330,10 @@ def test_run_datasource_node_preview_keeps_existing_user_input(
     )
 
     result = rag_pipeline_service.service.run_datasource_node_preview(
-        pipeline=SimpleNamespace(id="p1", tenant_id="t1"),
+        pipeline=_make_pipeline(),
         node_id="n1",
         user_inputs={"workspace_id": "existing"},
-        account=SimpleNamespace(id="u1"),
+        account=_make_account(),
         datasource_type="online_document",
         is_published=True,
     )
@@ -2331,8 +2343,8 @@ def test_run_datasource_node_preview_keeps_existing_user_input(
 def test_run_datasource_node_preview_ignores_non_variable_messages(
     mocker: MockerFixture, rag_pipeline_service: RagPipelineServiceTestContext
 ) -> None:
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _make_workflow(
+        graph={
             "nodes": [
                 {
                     "id": "n1",
@@ -2359,10 +2371,10 @@ def test_run_datasource_node_preview_ignores_non_variable_messages(
     )
 
     result = rag_pipeline_service.service.run_datasource_node_preview(
-        pipeline=SimpleNamespace(id="p1", tenant_id="t1"),
+        pipeline=_make_pipeline(),
         node_id="n1",
         user_inputs={},
-        account=SimpleNamespace(id="u1"),
+        account=_make_account(),
         datasource_type="online_document",
         is_published=True,
     )
@@ -2376,9 +2388,9 @@ def test_set_datasource_variables_raises_when_workflow_missing(
 
     with pytest.raises(ValueError, match="Workflow not initialized"):
         rag_pipeline_service.service.set_datasource_variables(
-            SimpleNamespace(id="p1", tenant_id="t1"),
+            _make_pipeline(),
             {"start_node_id": "n1"},
-            SimpleNamespace(id="u1"),
+            _make_account(),
         )
 
 

--- a/api/tests/unit_tests/services/test_app_model_config_service.py
+++ b/api/tests/unit_tests/services/test_app_model_config_service.py
@@ -1,6 +1,7 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
+from sqlalchemy.orm import Session
 
 from models.model import AppMode
 from services.app_model_config_service import AppModelConfigService
@@ -40,7 +41,7 @@ class TestAppModelConfigService:
         ],
     )
     def test_should_route_validation_to_correct_manager_based_on_app_mode(
-        self, app_mode, selected_manager, mock_config_managers
+        self, app_mode, selected_manager, mock_config_managers, unbound_session: Session
     ):
         """Test configuration validation is delegated to the expected manager for each supported app mode."""
         tenant_id = "tenant-123"
@@ -50,28 +51,28 @@ class TestAppModelConfigService:
         mock_agent_validate = mock_config_managers["agent"]
         mock_completion_validate = mock_config_managers["completion"]
 
-        session = MagicMock()
-
         result = AppModelConfigService.validate_configuration(
-            tenant_id=tenant_id, config=config, app_mode=app_mode, session=session
+            tenant_id=tenant_id, config=config, app_mode=app_mode, session=unbound_session
         )
 
         assert result == {"manager": selected_manager}
 
         if selected_manager == "chat":
-            mock_chat_validate.assert_called_once_with(tenant_id, config, session)
+            mock_chat_validate.assert_called_once_with(tenant_id, config, unbound_session)
             mock_agent_validate.assert_not_called()
             mock_completion_validate.assert_not_called()
         elif selected_manager == "agent":
-            mock_agent_validate.assert_called_once_with(tenant_id, config, session)
+            mock_agent_validate.assert_called_once_with(tenant_id, config, unbound_session)
             mock_chat_validate.assert_not_called()
             mock_completion_validate.assert_not_called()
         else:
-            mock_completion_validate.assert_called_once_with(tenant_id, config, session)
+            mock_completion_validate.assert_called_once_with(tenant_id, config, unbound_session)
             mock_chat_validate.assert_not_called()
             mock_agent_validate.assert_not_called()
 
-    def test_should_raise_value_error_when_app_mode_is_not_supported(self, mock_config_managers):
+    def test_should_raise_value_error_when_app_mode_is_not_supported(
+        self, mock_config_managers, unbound_session: Session
+    ):
         """Test unsupported app modes raise ValueError with the invalid mode in the message."""
         tenant_id = "tenant-123"
         config = {"temperature": 0.5}
@@ -85,7 +86,7 @@ class TestAppModelConfigService:
                 tenant_id=tenant_id,
                 config=config,
                 app_mode=AppMode.WORKFLOW,
-                session=MagicMock(),
+                session=unbound_session,
             )
 
         mock_chat_validate.assert_not_called()

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -233,218 +233,103 @@ def _seed_external_retrieval_dependencies(
 
 
 class TestExternalDatasetServiceGetAPIs:
-    """Test get_external_knowledge_apis operations - comprehensive coverage."""
+    """Exercise API filtering, ordering, pagination, and tenant scope through SQLite."""
 
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_success_basic(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test successful retrieval of external knowledge APIs with pagination."""
-        # Arrange
-        tenant_id = "tenant-123"
-        page = 1
-        per_page = 10
+    def test_get_external_knowledge_apis_paginates_in_descending_order_and_scopes_tenant(
+        self, sqlite_session: Session
+    ) -> None:
+        apis = []
+        for index in range(15):
+            api = _make_external_knowledge_api(
+                api_id=f"api-{index:02d}",
+                name=f"API {index:02d}",
+            )
+            api.created_at = datetime(2024, 1, index + 1, 12, 0)
+            apis.append(api)
+        foreign_api = _make_external_knowledge_api(
+            api_id="api-foreign",
+            tenant_id="tenant-foreign",
+            name="Foreign API",
+        )
+        foreign_api.created_at = datetime(2025, 1, 1, 12, 0)
+        _add_and_commit(sqlite_session, *apis, foreign_api)
 
-        apis = [factory.create_external_knowledge_api_mock(api_id=f"api-{i}", name=f"API {i}") for i in range(5)]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis
-        mock_pagination.total = 5
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
         result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=page, per_page=per_page, tenant_id=tenant_id, session=MagicMock()
+            page=2,
+            per_page=5,
+            tenant_id="tenant-123",
+            session=sqlite_session,
         )
 
-        # Assert
-        assert len(result_items) == 5
-        assert result_total == 5
-        assert result_items[0].id == "api-0"
-        assert result_items[4].id == "api-4"
-        mock_paginate_query.assert_called_once()
+        assert result_total == 15
+        assert [api.id for api in result_items] == ["api-09", "api-08", "api-07", "api-06", "api-05"]
+        assert all(api.tenant_id == "tenant-123" for api in result_items)
 
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_with_search_filter(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test retrieval with search filter."""
-        # Arrange
-        tenant_id = "tenant-123"
-        search = "production"
-
-        apis = [factory.create_external_knowledge_api_mock(name="Production API")]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis
-        mock_pagination.total = 1
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
-        result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=1, per_page=10, tenant_id=tenant_id, search=search, session=MagicMock()
+    @pytest.mark.parametrize(
+        ("search", "expected_names"),
+        [
+            ("PRODUCTION", {"Production API", "production backup"}),
+            ("v2.0", {"API-v2.0 (beta)"}),
+        ],
+    )
+    def test_get_external_knowledge_apis_filters_names_case_insensitively(
+        self, sqlite_session: Session, search: str, expected_names: set[str]
+    ) -> None:
+        _add_and_commit(
+            sqlite_session,
+            _make_external_knowledge_api(api_id="api-production", name="Production API"),
+            _make_external_knowledge_api(api_id="api-backup", name="production backup"),
+            _make_external_knowledge_api(api_id="api-versioned", name="API-v2.0 (beta)"),
+            _make_external_knowledge_api(api_id="api-unrelated", name="Staging API"),
+            _make_external_knowledge_api(
+                api_id="api-foreign",
+                tenant_id="tenant-foreign",
+                name="Production foreign",
+            ),
         )
 
-        # Assert
-        assert len(result_items) == 1
-        assert result_total == 1
-        assert result_items[0].name == "Production API"
-
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_empty_results(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test retrieval with no results."""
-        # Arrange
-        mock_pagination = MagicMock()
-        mock_pagination.items = []
-        mock_pagination.total = 0
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
         result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=1, per_page=10, tenant_id="tenant-123", session=MagicMock()
+            page=1,
+            per_page=10,
+            tenant_id="tenant-123",
+            search=search,
+            session=sqlite_session,
         )
 
-        # Assert
-        assert len(result_items) == 0
+        assert result_total == len(expected_names)
+        assert {api.name for api in result_items} == expected_names
+
+    def test_get_external_knowledge_apis_returns_empty_page(self, sqlite_session: Session) -> None:
+        _add_and_commit(
+            sqlite_session,
+            _make_external_knowledge_api(api_id="api-foreign", tenant_id="tenant-foreign"),
+        )
+
+        result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
+            page=1,
+            per_page=10,
+            tenant_id="tenant-123",
+            session=sqlite_session,
+        )
+
+        assert result_items == []
         assert result_total == 0
 
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_large_result_set(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test retrieval with large result set."""
-        # Arrange
-        apis = [factory.create_external_knowledge_api_mock(api_id=f"api-{i}") for i in range(100)]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis[:10]
-        mock_pagination.total = 100
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
-        result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=1, per_page=10, tenant_id="tenant-123", session=MagicMock()
+    def test_get_external_knowledge_apis_caps_page_size_at_one_hundred(self, sqlite_session: Session) -> None:
+        _add_and_commit(
+            sqlite_session,
+            *[_make_external_knowledge_api(api_id=f"api-{index:03d}", name=f"API {index:03d}") for index in range(101)],
         )
 
-        # Assert
-        assert len(result_items) == 10
-        assert result_total == 100
-
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_pagination_last_page(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test last page pagination with partial results."""
-        # Arrange
-        apis = [factory.create_external_knowledge_api_mock(api_id=f"api-{i}") for i in range(95, 100)]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis
-        mock_pagination.total = 100
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
         result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=10, per_page=10, tenant_id="tenant-123", session=MagicMock()
+            page=1,
+            per_page=1000,
+            tenant_id="tenant-123",
+            session=sqlite_session,
         )
 
-        # Assert
-        assert len(result_items) == 5
-        assert result_total == 100
-
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_case_insensitive_search(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test case-insensitive search functionality."""
-        # Arrange
-        apis = [
-            factory.create_external_knowledge_api_mock(name="Production API"),
-            factory.create_external_knowledge_api_mock(name="production backup"),
-        ]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis
-        mock_pagination.total = 2
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
-        result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=1, per_page=10, tenant_id="tenant-123", search="PRODUCTION", session=MagicMock()
-        )
-
-        # Assert
-        assert len(result_items) == 2
-        assert result_total == 2
-
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_special_characters_search(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test search with special characters."""
-        # Arrange
-        apis = [factory.create_external_knowledge_api_mock(name="API-v2.0 (beta)")]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis
-        mock_pagination.total = 1
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
-        result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=1, per_page=10, tenant_id="tenant-123", search="v2.0", session=MagicMock()
-        )
-
-        # Assert
-        assert len(result_items) == 1
-
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_max_per_page_limit(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test that max_per_page limit is enforced."""
-        # Arrange
-        apis = [factory.create_external_knowledge_api_mock(api_id=f"api-{i}") for i in range(100)]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis
-        mock_pagination.total = 1000
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
-        result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=1, per_page=100, tenant_id="tenant-123", session=MagicMock()
-        )
-
-        # Assert
-        call_args = mock_paginate_query.call_args
-        assert call_args.kwargs["max_per_page"] == 100
-
-    @patch("services.external_knowledge_service.paginate_query")
-    def test_get_external_knowledge_apis_ordered_by_created_at_desc(
-        self, mock_paginate_query, factory: ExternalDatasetServiceTestDataFactory
-    ):
-        """Test that results are ordered by created_at descending."""
-        # Arrange
-        apis = [
-            factory.create_external_knowledge_api_mock(api_id=f"api-{i}", created_at=datetime(2024, 1, i, 12, 0))
-            for i in range(1, 6)
-        ]
-
-        mock_pagination = MagicMock()
-        mock_pagination.items = apis[::-1]  # Reversed to simulate DESC order
-        mock_pagination.total = 5
-        mock_paginate_query.return_value = mock_pagination
-
-        # Act
-        result_items, result_total = ExternalDatasetService.get_external_knowledge_apis(
-            page=1, per_page=10, tenant_id="tenant-123", session=MagicMock()
-        )
-
-        # Assert
-        assert result_items[0].created_at > result_items[-1].created_at
+        assert len(result_items) == 100
+        assert result_total == 101
 
 
 class TestExternalDatasetServiceValidateAPIList:

--- a/api/tests/unit_tests/services/test_metadata_service_session_boundary.py
+++ b/api/tests/unit_tests/services/test_metadata_service_session_boundary.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import event, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.rag.index_processor.constant.built_in_field import BuiltInField
 from models import Account
@@ -120,10 +119,22 @@ def test_update_documents_metadata_uses_caller_session_for_uploader(sqlite_sessi
     assert document.doc_metadata[BuiltInField.uploader] == "User"
 
 
-def test_update_documents_metadata_rejects_foreign_metadata_before_writes() -> None:
-    session = MagicMock()
-    session.scalars.return_value.all.return_value = []
-    dataset = MagicMock(id="dataset-1", tenant_id="tenant-1")
+def test_update_documents_metadata_rejects_foreign_metadata_before_writes(sqlite_session: Session) -> None:
+    dataset = _dataset(built_in_field_enabled=False)
+    document = _document()
+    foreign_metadata = DatasetMetadata(
+        tenant_id="tenant-2",
+        dataset_id="dataset-2",
+        type="string",
+        name="spoofed",
+        created_by="account-2",
+    )
+    foreign_metadata.id = FOREIGN_METADATA_ID
+    sqlite_session.add_all([_account(), dataset, document, foreign_metadata])
+    sqlite_session.commit()
+    transaction_events: list[str] = []
+    event.listen(sqlite_session, "after_flush", lambda _session, _context: transaction_events.append("flush"))
+    event.listen(sqlite_session, "after_commit", lambda _session: transaction_events.append("commit"))
     metadata_args = MetadataOperationData(
         operation_data=[
             DocumentMetadataOperation(
@@ -138,19 +149,30 @@ def test_update_documents_metadata_rejects_foreign_metadata_before_writes() -> N
         pytest.raises(MetadataResourceNotFoundError, match="Metadata not found"),
         patch.object(MetadataService, "knowledge_base_metadata_lock_check") as lock_check,
     ):
-        MetadataService.update_documents_metadata(dataset, metadata_args, _account(), session=session)
+        MetadataService.update_documents_metadata(dataset, metadata_args, _account(), session=sqlite_session)
 
     lock_check.assert_not_called()
-    session.add.assert_not_called()
-    session.execute.assert_not_called()
-    session.commit.assert_not_called()
+    assert transaction_events == []
+    assert sqlite_session.scalars(select(DatasetMetadataBinding)).all() == []
+    assert sqlite_session.get(Document, DOCUMENT_ID).doc_metadata == {}
 
 
-def test_update_documents_metadata_validates_all_documents_before_writes() -> None:
-    session = MagicMock()
-    metadata = SimpleNamespace(id=METADATA_ID, name="canonical")
-    session.scalars.return_value.all.side_effect = [[metadata], [DOCUMENT_ID]]
-    dataset = MagicMock(id="dataset-1", tenant_id="tenant-1", built_in_field_enabled=False)
+def test_update_documents_metadata_validates_all_documents_before_writes(sqlite_session: Session) -> None:
+    dataset = _dataset(built_in_field_enabled=False)
+    document = _document()
+    metadata = DatasetMetadata(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        type="string",
+        name="canonical",
+        created_by="account-1",
+    )
+    metadata.id = METADATA_ID
+    sqlite_session.add_all([_account(), dataset, document, metadata])
+    sqlite_session.commit()
+    transaction_events: list[str] = []
+    event.listen(sqlite_session, "after_flush", lambda _session, _context: transaction_events.append("flush"))
+    event.listen(sqlite_session, "after_commit", lambda _session: transaction_events.append("commit"))
     metadata_detail = MetadataDetail(id=metadata.id, name="spoofed", value="value")
     metadata_args = MetadataOperationData(
         operation_data=[
@@ -166,21 +188,29 @@ def test_update_documents_metadata_validates_all_documents_before_writes() -> No
         patch.object(MetadataService, "knowledge_base_metadata_lock_check") as lock_check,
         patch("services.metadata_service.redis_client.delete"),
     ):
-        MetadataService.update_documents_metadata(dataset, metadata_args, _account(), session=session)
+        MetadataService.update_documents_metadata(dataset, metadata_args, _account(), session=sqlite_session)
 
     lock_check.assert_not_called()
-    session.add.assert_not_called()
-    session.execute.assert_not_called()
-    session.commit.assert_not_called()
+    assert transaction_events == []
+    assert sqlite_session.scalars(select(DatasetMetadataBinding)).all() == []
+    assert sqlite_session.get(Document, DOCUMENT_ID).doc_metadata == {}
 
 
-def test_update_documents_metadata_uses_canonical_metadata_name() -> None:
-    session = MagicMock()
-    metadata = SimpleNamespace(id=METADATA_ID, name="canonical")
-    session.scalars.return_value.all.side_effect = [[metadata], [DOCUMENT_ID]]
-    dataset = MagicMock(id="dataset-1", tenant_id="tenant-1", built_in_field_enabled=False)
+def test_update_documents_metadata_uses_canonical_metadata_name(
+    sqlite_session: Session, sqlite_session_factory: sessionmaker[Session]
+) -> None:
+    dataset = _dataset(built_in_field_enabled=False)
     document = _document()
-    session.scalar.return_value = document
+    metadata = DatasetMetadata(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        type="string",
+        name="canonical",
+        created_by="account-1",
+    )
+    metadata.id = METADATA_ID
+    sqlite_session.add_all([_account(), dataset, document, metadata])
+    sqlite_session.commit()
     metadata_args = MetadataOperationData(
         operation_data=[
             DocumentMetadataOperation(
@@ -195,9 +225,15 @@ def test_update_documents_metadata_uses_canonical_metadata_name() -> None:
         patch.object(MetadataService, "knowledge_base_metadata_lock_check"),
         patch("services.metadata_service.redis_client.delete"),
     ):
-        MetadataService.update_documents_metadata(dataset, metadata_args, _account(), session=session)
+        MetadataService.update_documents_metadata(dataset, metadata_args, _account(), session=sqlite_session)
 
-    assert document.doc_metadata == {"canonical": "value"}
+    with sqlite_session_factory() as observer:
+        persisted_document = observer.get(Document, document.id)
+        assert persisted_document is not None
+        assert persisted_document.doc_metadata == {"canonical": "value"}
+        binding = observer.scalar(select(DatasetMetadataBinding))
+        assert binding is not None
+        assert binding.metadata_id == metadata.id
 
 
 def test_metadata_operation_normalizes_uuid_ids() -> None:
@@ -210,25 +246,32 @@ def test_metadata_operation_normalizes_uuid_ids() -> None:
     assert operation.metadata_list[0].id == METADATA_ID
 
 
-def test_document_metadata_details_scopes_binding_to_document_owner() -> None:
-    session = MagicMock()
-    session.scalars.return_value.all.return_value = []
-    document = MagicMock(
-        id="document-1",
-        tenant_id="tenant-1",
-        dataset_id="dataset-1",
-        doc_metadata={"canonical": "value"},
+def test_document_metadata_details_scopes_binding_to_document_owner(sqlite_session: Session) -> None:
+    dataset = _dataset(built_in_field_enabled=False)
+    document = _document()
+    document.doc_metadata = {"canonical": "value"}
+    foreign_metadata = DatasetMetadata(
+        tenant_id="tenant-2",
+        dataset_id="dataset-2",
+        type="string",
+        name="canonical",
+        created_by="account-2",
     )
-    document.get_built_in_fields.return_value = []
+    foreign_metadata.id = FOREIGN_METADATA_ID
+    foreign_binding = DatasetMetadataBinding(
+        tenant_id="tenant-2",
+        dataset_id="dataset-2",
+        document_id=document.id,
+        metadata_id=foreign_metadata.id,
+        created_by="account-2",
+    )
+    sqlite_session.add_all([_account(), dataset, document, foreign_metadata, foreign_binding])
+    sqlite_session.commit()
 
-    assert Document.get_doc_metadata_details(document, session=session) == []
+    details = document.get_doc_metadata_details(session=sqlite_session)
 
-    statement = str(session.scalars.call_args.args[0])
-    assert "dataset_metadatas.tenant_id" in statement
-    assert "dataset_metadatas.dataset_id" in statement
-    assert "dataset_metadata_bindings.tenant_id" in statement
-    assert "dataset_metadata_bindings.dataset_id" in statement
-    assert "dataset_metadata_bindings.document_id" in statement
+    assert details is not None
+    assert [detail for detail in details if detail["id"] != "built-in"] == []
 
 
 def test_get_dataset_metadatas_uses_caller_session(monkeypatch, sqlite_session: Session) -> None:

--- a/api/tests/unit_tests/services/test_model_provider_service.py
+++ b/api/tests/unit_tests/services/test_model_provider_service.py
@@ -3,6 +3,9 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
 
 from core.entities.model_entities import ModelStatus
 from core.entities.provider_entities import CredentialConfiguration
@@ -12,7 +15,13 @@ from enums import DeploymentEdition
 from graphon.model_runtime.entities.common_entities import I18nObject
 from graphon.model_runtime.entities.model_entities import FetchFrom, ModelType, ParameterRule, ParameterType
 from graphon.model_runtime.entities.provider_entities import ConfigurateMethod
-from models.provider import ProviderType
+from models.provider import (
+    Provider,
+    ProviderCredential,
+    ProviderModel,
+    ProviderType,
+    TenantPreferredModelProvider,
+)
 from services import model_provider_service as service_module
 from services.errors.app_model_config import ProviderNotFoundError
 from services.model_provider_service import ModelProviderService, _ProviderSummaryState
@@ -389,56 +398,96 @@ class TestModelProviderServiceConfiguration:
 
         assert preferred_provider_type == ProviderType.CUSTOM
 
-    def test_load_provider_summary_states_reads_only_lightweight_columns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_load_provider_summary_states_reads_only_lightweight_columns(
+        self,
+        sqlite_engine: Engine,
+        sqlite_session: Session,
+    ) -> None:
         canonical_provider = "langgenius/openai/openai"
-        session = MagicMock()
-        session.execute.side_effect = [
-            SimpleNamespace(
-                all=lambda: [
-                    SimpleNamespace(
-                        provider_name="openai",
-                        credential_id="credential-legacy",
-                        credential_provider_name="openai",
-                        credential_name="Legacy",
-                    ),
-                    SimpleNamespace(
-                        provider_name=canonical_provider,
-                        credential_id="credential-current",
-                        credential_provider_name=canonical_provider,
-                        credential_name="Production",
-                    ),
-                ]
-            ),
-            SimpleNamespace(
-                all=lambda: [
-                    SimpleNamespace(
-                        id="credential-legacy",
-                        provider_name="openai",
-                        credential_name="Legacy",
-                    ),
-                    SimpleNamespace(
-                        id="credential-current",
-                        provider_name=canonical_provider,
-                        credential_name="Production",
-                    ),
-                ]
-            ),
-            SimpleNamespace(all=lambda: [SimpleNamespace(provider_name="openai")]),
-            SimpleNamespace(
-                all=lambda: [
-                    SimpleNamespace(
-                        provider_name=canonical_provider,
-                        preferred_provider_type=ProviderType.SYSTEM,
-                    )
-                ]
-            ),
-        ]
-        session_context = MagicMock()
-        session_context.__enter__.return_value = session
-        create_session = MagicMock(return_value=session_context)
-        monkeypatch.setattr(service_module.session_factory, "create_session", create_session)
+        legacy_credential = ProviderCredential(
+            tenant_id="tenant-1",
+            provider_name="openai",
+            credential_name="Legacy",
+            encrypted_config="legacy-secret",
+        )
+        legacy_credential.id = "credential-legacy"
+        current_credential = ProviderCredential(
+            tenant_id="tenant-1",
+            provider_name=canonical_provider,
+            credential_name="Production",
+            encrypted_config="production-secret",
+        )
+        current_credential.id = "credential-current"
+        foreign_credential = ProviderCredential(
+            tenant_id="tenant-2",
+            provider_name=canonical_provider,
+            credential_name="Foreign",
+            encrypted_config="foreign-secret",
+        )
+        foreign_credential.id = "credential-foreign"
+        sqlite_session.add_all(
+            [
+                legacy_credential,
+                current_credential,
+                foreign_credential,
+                Provider(
+                    tenant_id="tenant-1",
+                    provider_name="openai",
+                    provider_type=ProviderType.CUSTOM,
+                    is_valid=True,
+                    credential_id=legacy_credential.id,
+                ),
+                Provider(
+                    tenant_id="tenant-1",
+                    provider_name=canonical_provider,
+                    provider_type=ProviderType.CUSTOM,
+                    is_valid=True,
+                    credential_id=current_credential.id,
+                ),
+                Provider(
+                    tenant_id="tenant-2",
+                    provider_name=canonical_provider,
+                    provider_type=ProviderType.CUSTOM,
+                    is_valid=True,
+                    credential_id=foreign_credential.id,
+                ),
+                ProviderModel(
+                    tenant_id="tenant-1",
+                    provider_name="openai",
+                    model_name="gpt-4o",
+                    model_type=ModelType.LLM,
+                    is_valid=True,
+                ),
+                ProviderModel(
+                    tenant_id="tenant-2",
+                    provider_name="langgenius/foreign/foreign",
+                    model_name="foreign-model",
+                    model_type=ModelType.LLM,
+                    is_valid=True,
+                ),
+                TenantPreferredModelProvider(
+                    tenant_id="tenant-1",
+                    provider_name=canonical_provider,
+                    preferred_provider_type=ProviderType.SYSTEM,
+                ),
+                TenantPreferredModelProvider(
+                    tenant_id="tenant-2",
+                    provider_name=canonical_provider,
+                    preferred_provider_type=ProviderType.CUSTOM,
+                ),
+            ]
+        )
+        sqlite_session.commit()
+        statements: list[str] = []
 
-        states = ModelProviderService._load_provider_summary_states("tenant-1")
+        def capture_statement(_connection, _cursor, statement, _parameters, _context, _executemany) -> None:
+            statements.append(statement)
+
+        event.listen(sqlite_engine, "before_cursor_execute", capture_statement)
+        try:
+            states = ModelProviderService._load_provider_summary_states("tenant-1")
+        finally:
+            event.remove(sqlite_engine, "before_cursor_execute", capture_statement)
 
         state = states[canonical_provider]
         assert state.has_custom_provider is True
@@ -458,7 +507,6 @@ class TestModelProviderServiceConfiguration:
         assert state.current_credential_usable is True
         assert state.preferred_provider_type == ProviderType.SYSTEM
 
-        statements = [str(execute_call.args[0]) for execute_call in session.execute.call_args_list]
         assert len(statements) == 4
         assert all("encrypted_config" not in statement for statement in statements)
         assert "count(" not in statements[1].lower()

--- a/api/tests/unit_tests/services/test_workflow_service.py
+++ b/api/tests/unit_tests/services/test_workflow_service.py
@@ -2780,7 +2780,9 @@ class TestWorkflowServiceDraftExecution:
     def service(self, sqlite_engine: Engine) -> WorkflowService:
         return WorkflowService(sessionmaker(bind=sqlite_engine, expire_on_commit=False))
 
-    def test_run_draft_workflow_node_should_execute_start_node_successfully(self, service: WorkflowService) -> None:
+    def test_run_draft_workflow_node_should_execute_start_node_successfully(
+        self, service: WorkflowService, sqlite_engine: Engine
+    ) -> None:
         # Arrange
         app = TestWorkflowAssociatedDataFactory.create_app(app_id="app-1", tenant_id="tenant-1")
         account = TestWorkflowAssociatedDataFactory.create_account(account_id="user-1")
@@ -2802,8 +2804,7 @@ class TestWorkflowServiceDraftExecution:
 
         # Mocking complex dependencies
         with (
-            patch("services.workflow_service.db"),
-            patch("services.workflow_service.Session"),
+            patch("services.workflow_service.db", SimpleNamespace(engine=sqlite_engine)),
             patch("services.workflow_service.WorkflowDraftVariableService"),
             patch("services.workflow_service.StartNodeData") as mock_start_data,
             patch(
@@ -2859,7 +2860,9 @@ class TestWorkflowServiceDraftExecution:
             mock_repo.save.assert_called_once()
             mock_saver_cls.return_value.save.assert_called_once()
 
-    def test_run_draft_workflow_node_should_execute_non_start_node_successfully(self, service: WorkflowService) -> None:
+    def test_run_draft_workflow_node_should_execute_non_start_node_successfully(
+        self, service: WorkflowService, sqlite_engine: Engine
+    ) -> None:
         # Arrange
         app = TestWorkflowAssociatedDataFactory.create_app(app_id="app-1", tenant_id="tenant-1")
         account = TestWorkflowAssociatedDataFactory.create_account(account_id="user-1")
@@ -2884,8 +2887,7 @@ class TestWorkflowServiceDraftExecution:
         )
 
         with (
-            patch("services.workflow_service.db"),
-            patch("services.workflow_service.Session"),
+            patch("services.workflow_service.db", SimpleNamespace(engine=sqlite_engine)),
             patch("services.workflow_service.WorkflowDraftVariableService"),
             patch("services.workflow_service.VariablePool") as mock_pool_cls,
             patch("services.workflow_service.default_system_variables") as mock_default_system_variables,
@@ -3119,14 +3121,13 @@ class TestWorkflowServiceHumanInputOperations:
 
         assert result == []
 
-    def test_build_human_input_variable_pool(self, service: WorkflowService) -> None:
+    def test_build_human_input_variable_pool(self, service: WorkflowService, sqlite_engine: Engine) -> None:
         workflow = TestWorkflowAssociatedDataFactory.create_workflow()
         node_data = MagicMock()
         node_data.extract_variable_selector_to_variable_mapping.return_value = {}
 
         with (
-            patch("services.workflow_service.db"),
-            patch("services.workflow_service.Session"),
+            patch("services.workflow_service.db", SimpleNamespace(engine=sqlite_engine)),
             patch("services.workflow_service.WorkflowDraftVariableService"),
             patch("services.workflow_service.VariablePool") as mock_pool_cls,
             patch("services.workflow_service.DraftVarLoader"),

--- a/api/tests/unit_tests/services/test_workspace_credit_pool.py
+++ b/api/tests/unit_tests/services/test_workspace_credit_pool.py
@@ -1,7 +1,8 @@
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
+from sqlalchemy.orm import Session
 
 from enums import CloudPlan, DeploymentEdition
 from services.credit_pool_service import CreditPoolBalance
@@ -13,9 +14,12 @@ from services.workspace_service import WorkspaceService
     [(500, 120, 380, False), (-1, 999, -1, True)],
 )
 def test_get_effective_credit_pool_prefers_available_paid_pool(
-    quota_limit: int, quota_used: int, remaining_credits: int, is_unlimited: bool
+    quota_limit: int,
+    quota_used: int,
+    remaining_credits: int,
+    is_unlimited: bool,
+    unbound_session: Session,
 ) -> None:
-    session = MagicMock()
     paid_pool = CreditPoolBalance(
         tenant_id="tenant-1",
         pool_type="paid",
@@ -34,9 +38,9 @@ def test_get_effective_credit_pool_prefers_available_paid_pool(
         patch("services.workspace_service.BillingService.get_info", return_value=billing_info),
         patch("services.credit_pool_service.CreditPoolService.get_pool", return_value=paid_pool) as get_pool,
     ):
-        result = WorkspaceService.get_effective_credit_pool("tenant-1", session=session)
+        result = WorkspaceService.get_effective_credit_pool("tenant-1", session=unbound_session)
 
-    get_pool.assert_called_once_with(tenant_id="tenant-1", pool_type="paid", session=session)
+    get_pool.assert_called_once_with(tenant_id="tenant-1", pool_type="paid", session=unbound_session)
     assert result.pool_type == "paid"
     assert result.quota_limit == quota_limit
     assert result.quota_used == quota_used
@@ -46,8 +50,7 @@ def test_get_effective_credit_pool_prefers_available_paid_pool(
     assert result.next_credit_reset_date == 1775001600
 
 
-def test_get_effective_credit_pool_exposes_exhausted_trial_pool() -> None:
-    session = MagicMock()
+def test_get_effective_credit_pool_exposes_exhausted_trial_pool(unbound_session: Session) -> None:
     trial_pool = CreditPoolBalance(
         tenant_id="tenant-1",
         pool_type="trial",
@@ -66,9 +69,9 @@ def test_get_effective_credit_pool_exposes_exhausted_trial_pool() -> None:
         patch("services.workspace_service.BillingService.get_info", return_value=billing_info),
         patch("services.credit_pool_service.CreditPoolService.get_pool", return_value=trial_pool) as get_pool,
     ):
-        result = WorkspaceService.get_effective_credit_pool("tenant-1", session=session)
+        result = WorkspaceService.get_effective_credit_pool("tenant-1", session=unbound_session)
 
-    get_pool.assert_called_once_with(tenant_id="tenant-1", pool_type="trial", session=session)
+    get_pool.assert_called_once_with(tenant_id="tenant-1", pool_type="trial", session=unbound_session)
     assert result.pool_type == "trial"
     assert result.remaining_credits == 0
     assert result.is_unlimited is False


### PR DESCRIPTION
## Summary

- replace remaining SQLAlchemy session doubles across eight service-boundary test modules
- execute external-knowledge filtering, ordering, pagination, and tenant isolation against real SQLite rows
- execute metadata preflight validation and canonical-name writes with real datasets, documents, metadata, and bindings
- seed provider summary state with real provider credentials, models, preferences, and cross-tenant decoys
- replace residual RAG pipeline `Pipeline`, `Workflow`, `Dataset`, `Document`, `Account`, and `WorkflowRun` stand-ins with real mapped instances
- remove no-op Session/sessionmaker patches from workflow and RAG pipeline tests

## Real persistence coverage

The tests cover tenant-scoped external API pagination and search, the 100-row page cap, metadata validation before writes, canonical metadata binding persistence, document-owner scoping, lightweight provider-state SQL projections, extractor transaction ownership, and workflow/RAG session lifecycle using real SQLite sessions and engines. RAG workflow fixtures now also pass through real mapped properties and validate serialized RAG pipeline variables.

## Production changes

None.

## Size

- 498 additions, 515 deletions
- 1,013 changed lines

## Validation

- targeted tests for the original eight affected modules — 403 passed
- `make test TARGET_TESTS=./api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py` — 94 passed, 2 warnings
- post-format focused rerun of the RAG pipeline module — 94 passed, 2 warnings
- `make lint` — passed
- `make type-check` — pyrefly passed; mypy 1.20.2 exits with its existing internal error in bundled `typeshed/stdlib/zipimport.pyi:17`
- structural audit — no mocked SQLAlchemy Session/sessionmaker/db.session result chains or mapped-model stand-ins remain in the changed modules

The full test suite was not run, per request.
