### PR TITLE
test: migrate Explore controller sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/console/explore/test_audio.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_audio.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.exceptions import InternalServerError
 
 import controllers.console.explore.audio as audio_module
@@ -22,6 +23,8 @@ from core.errors.error import (
     QuotaExceededError,
 )
 from graphon.model_runtime.errors.invoke import InvokeError
+from models import Account
+from models.model import App, AppMode, InstalledApp
 from services.app_ref_service import AppRef, MessageRef
 from services.errors.audio import (
     AudioTooLargeServiceError,
@@ -40,13 +43,33 @@ def unwrap(func):
 
 
 @pytest.fixture
-def installed_app():
-    app = MagicMock()
-    app.app = MagicMock()
-    app.app.id = "app-1"
-    app.app.tenant_id = "tenant-1"
-    app.app_with_session.return_value = app.app
-    return app
+def installed_app(
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    app = App(
+        id="app-1",
+        tenant_id="tenant-1",
+        name="Explore App",
+        mode=AppMode.CHAT,
+        enable_site=True,
+        enable_api=False,
+    )
+    installed = InstalledApp(
+        tenant_id="viewer-tenant",
+        app_id=app.id,
+        app_owner_tenant_id=app.tenant_id,
+        position=0,
+        is_pinned=False,
+        last_used_at=None,
+    )
+    sqlite_session.add_all([app, installed])
+    sqlite_session.commit()
+    session_proxy = scoped_session(sqlite_session_factory)
+    monkeypatch.setattr(audio_module.db, "session", session_proxy)
+    yield installed
+    session_proxy.remove()
 
 
 @pytest.fixture
@@ -259,6 +282,8 @@ class TestChatTextApi:
         self.method = unwrap(self.api.post)
 
     def test_post_success(self, app: Flask, installed_app):
+        account = Account(name="User", email="user@example.com")
+        account.id = "account-1"
         transcript_tts = MagicMock(return_value={"audio": "ok"})
 
         with (
@@ -269,7 +294,7 @@ class TestChatTextApi:
             patch.object(
                 audio_module,
                 "current_account_with_tenant",
-                return_value=(MagicMock(id="account-1"), "tenant-1"),
+                return_value=(account, "tenant-1"),
             ),
             patch.object(audio_module.AudioService, "transcript_tts", transcript_tts),
         ):

--- a/api/tests/unit_tests/controllers/console/explore/test_completion.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_completion.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from flask import Flask
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, object_session
 from werkzeug.exceptions import InternalServerError
 
 import controllers.console.explore.completion as completion_module
@@ -14,7 +14,7 @@ from controllers.console.app.error import (
 from controllers.console.explore.error import NotChatAppError, NotCompletionAppError
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from models import Account
-from models.model import AppMode
+from models.model import App, AppMode, InstalledApp
 from services.errors.llm import InvokeRateLimitError
 
 
@@ -25,21 +25,48 @@ def user():
     return account
 
 
-@pytest.fixture
-def completion_app():
-    return _installed_app(AppMode.COMPLETION)
+@pytest.fixture(autouse=True)
+def bind_database(sqlite_session: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(completion_module.db, "session", sqlite_session)
 
 
 @pytest.fixture
-def chat_app():
-    return _installed_app(AppMode.CHAT)
+def completion_app(sqlite_session: Session) -> InstalledApp:
+    return _installed_app(AppMode.COMPLETION, sqlite_session)
 
 
-def _installed_app(mode: AppMode):
-    app = MagicMock(mode=mode)
-    installed_app = MagicMock(app=app)
-    installed_app.app_with_session.return_value = app
+@pytest.fixture
+def chat_app(sqlite_session: Session) -> InstalledApp:
+    return _installed_app(AppMode.CHAT, sqlite_session)
+
+
+def _installed_app(mode: AppMode, session: Session) -> InstalledApp:
+    app = App(
+        tenant_id="owner-tenant",
+        name=f"{mode.value} App",
+        mode=mode,
+        enable_site=True,
+        enable_api=False,
+    )
+    session.add(app)
+    session.flush()
+    installed_app = InstalledApp(
+        tenant_id="viewer-tenant",
+        app_id=app.id,
+        app_owner_tenant_id=app.tenant_id,
+        position=0,
+        is_pinned=False,
+        last_used_at=None,
+    )
+    session.add(installed_app)
+    session.commit()
     return installed_app
+
+
+def _session(installed_app: InstalledApp) -> Session:
+    session = object_session(installed_app)
+    assert session is not None
+    return session
 
 
 @pytest.fixture
@@ -79,24 +106,24 @@ class TestCompletionApi:
             result = method(
                 api,
                 completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                MagicMock(),
+                _session(completion_app),
                 user,
                 completion_app,
             )
 
         assert result == ("ok", 200)
 
-    def test_post_wrong_app_mode(self, user):
+    def test_post_wrong_app_mode(self, user, sqlite_session: Session):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
-        installed_app = _installed_app(AppMode.CHAT)
+        installed_app = _installed_app(AppMode.CHAT, sqlite_session)
 
         with pytest.raises(NotCompletionAppError):
             method(
                 api,
                 completion_module.CompletionMessageExplorePayload.model_validate({"inputs": {}, "query": "hi"}),
-                MagicMock(),
+                sqlite_session,
                 user,
                 installed_app,
             )
@@ -118,7 +145,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -140,7 +167,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -162,7 +189,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -184,7 +211,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -206,7 +233,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -228,7 +255,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -250,7 +277,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -272,7 +299,7 @@ class TestCompletionApi:
                 method(
                     api,
                     completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
-                    MagicMock(),
+                    _session(completion_app),
                     user,
                     completion_app,
                 )
@@ -284,19 +311,19 @@ class TestCompletionStopApi:
         method = unwrap(api.post)
 
         with patch.object(completion_module.AppTaskService, "stop_task"):
-            resp, status = method(api, MagicMock(), "u1", completion_app, "task-1")
+            resp, status = method(api, _session(completion_app), "u1", completion_app, "task-1")
 
         assert status == 200
         assert resp == {"result": "success"}
 
-    def test_stop_wrong_app_mode(self):
+    def test_stop_wrong_app_mode(self, sqlite_session: Session):
         api = completion_module.CompletionStopApi()
         method = unwrap(api.post)
 
-        installed_app = _installed_app(AppMode.CHAT)
+        installed_app = _installed_app(AppMode.CHAT, sqlite_session)
 
         with pytest.raises(NotCompletionAppError):
-            method(api, MagicMock(), "u1", installed_app, "task")
+            method(api, sqlite_session, "u1", installed_app, "task")
 
 
 class TestChatApi:
@@ -319,22 +346,26 @@ class TestChatApi:
             ),
         ):
             result = method(
-                api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                api,
+                completion_module.ChatMessagePayload.model_validate(payload_data),
+                _session(chat_app),
+                user,
+                chat_app,
             )
 
         assert result == ("ok", 200)
 
-    def test_post_not_chat_app(self, user):
+    def test_post_not_chat_app(self, user, sqlite_session: Session):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
-        installed_app = _installed_app(AppMode.COMPLETION)
+        installed_app = _installed_app(AppMode.COMPLETION, sqlite_session)
 
         with pytest.raises(NotChatAppError):
             method(
                 api,
                 completion_module.ChatMessagePayload.model_validate({"inputs": {}, "query": "hi"}),
-                MagicMock(),
+                sqlite_session,
                 user,
                 installed_app,
             )
@@ -354,7 +385,11 @@ class TestChatApi:
         ):
             with pytest.raises(InvokeRateLimitHttpError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
     def test_conversation_completed_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
@@ -372,7 +407,11 @@ class TestChatApi:
         ):
             with pytest.raises(ConversationCompletedError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
     def test_conversation_not_exists_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
@@ -390,12 +429,14 @@ class TestChatApi:
         ):
             with pytest.raises(completion_module.NotFound):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
-    def test_invalid_conversation_id_fails_fast_as_not_found(
-        self, app: Flask, chat_app, user, unbound_session: Session
-    ) -> None:
+    def test_invalid_conversation_id_fails_fast_as_not_found(self, app: Flask, chat_app, user) -> None:
         # A nonexistent conversation_id must fail fast as 404, before the streaming
         # generator is created. Previously the lookup only ran inside the generator,
         # so an invalid id surfaced as a hang instead of a clean error.
@@ -410,7 +451,7 @@ class TestChatApi:
         get_conversation_mock = MagicMock(
             side_effect=completion_module.services.errors.conversation.ConversationNotExistsError()
         )
-        session = unbound_session
+        session = _session(chat_app)
 
         api = completion_module.ChatApi()
         method = unwrap(api.post)
@@ -455,7 +496,11 @@ class TestChatApi:
         ):
             with pytest.raises(completion_module.AppUnavailableError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
     def test_provider_not_initialized_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
@@ -473,7 +518,11 @@ class TestChatApi:
         ):
             with pytest.raises(completion_module.ProviderNotInitializeError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
     def test_quota_exceeded_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
@@ -491,7 +540,11 @@ class TestChatApi:
         ):
             with pytest.raises(completion_module.ProviderQuotaExceededError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
     def test_model_not_supported_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
@@ -509,7 +562,11 @@ class TestChatApi:
         ):
             with pytest.raises(completion_module.ProviderModelCurrentlyNotSupportError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
     def test_invoke_error_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
@@ -527,7 +584,11 @@ class TestChatApi:
         ):
             with pytest.raises(completion_module.CompletionRequestError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
     def test_internal_error_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
@@ -545,7 +606,11 @@ class TestChatApi:
         ):
             with pytest.raises(InternalServerError):
                 method(
-                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(payload_data),
+                    _session(chat_app),
+                    user,
+                    chat_app,
                 )
 
 
@@ -554,16 +619,16 @@ class TestChatStopApi:
         api = completion_module.ChatStopApi()
         method = unwrap(api.post)
         with patch.object(completion_module.AppTaskService, "stop_task"):
-            resp, status = method(api, MagicMock(), "u1", chat_app, "task-1")
+            resp, status = method(api, _session(chat_app), "u1", chat_app, "task-1")
 
         assert status == 200
         assert resp == {"result": "success"}
 
-    def test_stop_not_chat_app(self):
+    def test_stop_not_chat_app(self, sqlite_session: Session):
         api = completion_module.ChatStopApi()
         method = unwrap(api.post)
 
-        installed_app = _installed_app(AppMode.COMPLETION)
+        installed_app = _installed_app(AppMode.COMPLETION, sqlite_session)
 
         with pytest.raises(NotChatAppError):
-            method(api, MagicMock(), "u1", installed_app, "task")
+            method(api, sqlite_session, "u1", installed_app, "task")

--- a/api/tests/unit_tests/controllers/console/explore/test_message.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_message.py
@@ -1,7 +1,9 @@
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import controllers.console.explore.message as module
@@ -23,6 +25,9 @@ from core.errors.error import (
     QuotaExceededError,
 )
 from graphon.model_runtime.errors.invoke import InvokeError
+from models import Account
+from models.enums import ConversationFromSource
+from models.model import App, AppMode, InstalledApp, Message
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.message import (
     FirstMessageNotExistsError,
@@ -40,43 +45,82 @@ def unwrap(func):
     return func
 
 
-def make_message():
-    msg = MagicMock()
-    msg.id = "m1"
-    msg.conversation_id = "11111111-1111-1111-1111-111111111111"
-    msg.parent_message_id = None
-    msg.inputs = {}
-    msg.query = "hello"
-    msg.re_sign_file_url_answer = ""
-    msg.user_feedback = MagicMock(rating=None)
-    msg.inputs_with_session.return_value = msg.inputs
-    msg.user_feedback_with_session.return_value = msg.user_feedback
-    msg.total_price = None
-    msg.currency = None
-    msg.status = "normal"
-    msg.error = None
-    return msg
+def make_message(*, app_id: str):
+    message = Message(
+        id="m1",
+        app_id=app_id,
+        conversation_id="11111111-1111-1111-1111-111111111111",
+        query="hello",
+        message={"role": "user", "content": "hello"},
+        answer="",
+        message_tokens=0,
+        message_unit_price=Decimal(0),
+        answer_tokens=0,
+        answer_unit_price=Decimal(0),
+        provider_response_latency=0,
+        currency="USD",
+        from_source=ConversationFromSource.API,
+        app_mode=AppMode.CHAT,
+    )
+    message._inputs = {}
+    message.status = "normal"
+    return message
 
 
-def make_installed_app(mode: str | None = None):
-    app_model = MagicMock(mode=mode)
-    installed_app = MagicMock()
-    installed_app.app = app_model
-    installed_app.app_with_session.return_value = app_model
+def make_installed_app(session: Session, mode: str | None = None) -> InstalledApp:
+    app_model = App(
+        tenant_id="owner-tenant",
+        name="Explore App",
+        mode=mode or AppMode.CHAT,
+        enable_site=True,
+        enable_api=False,
+    )
+    session.add(app_model)
+    session.flush()
+    installed_app = InstalledApp(
+        tenant_id="viewer-tenant",
+        app_id=app_model.id,
+        app_owner_tenant_id=app_model.tenant_id,
+        position=0,
+        is_pinned=False,
+        last_used_at=None,
+    )
+    session.add(installed_app)
+    session.commit()
     return installed_app
 
 
-class TestMessageListApi:
+class _UsesSQLiteSession:
+    sqlite_session: Session
+    account: Account
+
+    @pytest.fixture(autouse=True)
+    def _bind_database(
+        self,
+        sqlite_session: Session,
+        sqlite_session_factory: sessionmaker[Session],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        self.sqlite_session = sqlite_session
+        self.account = Account(name="User", email="user@example.com")
+        self.account.id = "account-1"
+        session_proxy = scoped_session(sqlite_session_factory)
+        monkeypatch.setattr(module.db, "session", session_proxy)
+        yield
+        session_proxy.remove()
+
+
+class TestMessageListApi(_UsesSQLiteSession):
     def test_get_success(self, app: Flask):
         api = module.MessageListApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         pagination = MagicMock(
             limit=20,
             has_more=False,
-            data=[make_message(), make_message()],
+            data=[make_message(app_id=installed_app.app_id), make_message(app_id=installed_app.app_id)],
         )
 
         with (
@@ -90,7 +134,7 @@ class TestMessageListApi:
                 return_value=pagination,
             ),
         ):
-            result = method(MagicMock(), installed_app)
+            result = method(self.account, installed_app)
 
         assert result["limit"] == 20
         assert result["has_more"] is False
@@ -100,16 +144,16 @@ class TestMessageListApi:
         api = module.MessageListApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with pytest.raises(NotChatAppError):
-            method(MagicMock(), installed_app)
+            method(self.account, installed_app)
 
     def test_conversation_not_exists(self, app: Flask):
         api = module.MessageListApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             app.test_request_context(
@@ -123,13 +167,13 @@ class TestMessageListApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(MagicMock(), installed_app)
+                method(self.account, installed_app)
 
     def test_first_message_not_exists(self, app: Flask):
         api = module.MessageListApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             app.test_request_context(
@@ -143,15 +187,15 @@ class TestMessageListApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(MagicMock(), installed_app)
+                method(self.account, installed_app)
 
 
-class TestMessageFeedbackApi:
+class TestMessageFeedbackApi(_UsesSQLiteSession):
     def test_post_success(self, app: Flask):
         api = module.MessageFeedbackApi()
         method = unwrap(api.post)
 
-        installed_app = make_installed_app()
+        installed_app = make_installed_app(self.sqlite_session)
 
         with (
             app.test_request_context("/", json={"rating": "like"}),
@@ -161,7 +205,7 @@ class TestMessageFeedbackApi:
             ),
         ):
             result = method(
-                module.MessageFeedbackPayload.model_validate({"rating": "like"}), MagicMock(), installed_app, "mid"
+                module.MessageFeedbackPayload.model_validate({"rating": "like"}), self.account, installed_app, "mid"
             )
 
         assert result["result"] == "success"
@@ -170,7 +214,7 @@ class TestMessageFeedbackApi:
         api = module.MessageFeedbackApi()
         method = unwrap(api.post)
 
-        installed_app = make_installed_app()
+        installed_app = make_installed_app(self.sqlite_session)
 
         with (
             app.test_request_context("/", json={}),
@@ -181,15 +225,15 @@ class TestMessageFeedbackApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(module.MessageFeedbackPayload.model_validate({}), MagicMock(), installed_app, "mid")
+                method(module.MessageFeedbackPayload.model_validate({}), self.account, installed_app, "mid")
 
 
-class TestMessageMoreLikeThisApi:
+class TestMessageMoreLikeThisApi(_UsesSQLiteSession):
     def test_get_success(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -207,7 +251,7 @@ class TestMessageMoreLikeThisApi:
                 return_value=("ok", 200),
             ),
         ):
-            resp = method(MagicMock(), MagicMock(), installed_app, "mid")
+            resp = method(self.sqlite_session, self.account, installed_app, "mid")
 
         assert resp == ("ok", 200)
 
@@ -215,16 +259,16 @@ class TestMessageMoreLikeThisApi:
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with pytest.raises(NotCompletionAppError):
-            method(MagicMock(), MagicMock(), installed_app, "mid")
+            method(self.sqlite_session, self.account, installed_app, "mid")
 
     def test_more_like_this_disabled(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -238,13 +282,13 @@ class TestMessageMoreLikeThisApi:
             ),
         ):
             with pytest.raises(AppMoreLikeThisDisabledError):
-                method(MagicMock(), MagicMock(), installed_app, "mid")
+                method(self.sqlite_session, self.account, installed_app, "mid")
 
     def test_message_not_exists_more_like_this(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -258,13 +302,13 @@ class TestMessageMoreLikeThisApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(MagicMock(), MagicMock(), installed_app, "mid")
+                method(self.sqlite_session, self.account, installed_app, "mid")
 
     def test_provider_not_init_more_like_this(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -278,13 +322,13 @@ class TestMessageMoreLikeThisApi:
             ),
         ):
             with pytest.raises(ProviderNotInitializeError):
-                method(MagicMock(), MagicMock(), installed_app, "mid")
+                method(self.sqlite_session, self.account, installed_app, "mid")
 
     def test_quota_exceeded_more_like_this(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -298,13 +342,13 @@ class TestMessageMoreLikeThisApi:
             ),
         ):
             with pytest.raises(ProviderQuotaExceededError):
-                method(MagicMock(), MagicMock(), installed_app, "mid")
+                method(self.sqlite_session, self.account, installed_app, "mid")
 
     def test_model_not_support_more_like_this(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -318,13 +362,13 @@ class TestMessageMoreLikeThisApi:
             ),
         ):
             with pytest.raises(ProviderModelCurrentlyNotSupportError):
-                method(MagicMock(), MagicMock(), installed_app, "mid")
+                method(self.sqlite_session, self.account, installed_app, "mid")
 
     def test_invoke_error_more_like_this(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -338,13 +382,13 @@ class TestMessageMoreLikeThisApi:
             ),
         ):
             with pytest.raises(CompletionRequestError):
-                method(MagicMock(), MagicMock(), installed_app, "mid")
+                method(self.sqlite_session, self.account, installed_app, "mid")
 
     def test_unexpected_error_more_like_this(self, app: Flask):
         api = module.MessageMoreLikeThisApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with (
             app.test_request_context(
@@ -358,15 +402,15 @@ class TestMessageMoreLikeThisApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                method(MagicMock(), MagicMock(), installed_app, "mid")
+                method(self.sqlite_session, self.account, installed_app, "mid")
 
 
-class TestMessageSuggestedQuestionApi:
+class TestMessageSuggestedQuestionApi(_UsesSQLiteSession):
     def test_get_success(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -375,7 +419,7 @@ class TestMessageSuggestedQuestionApi:
                 return_value=["q1", "q2"],
             ),
         ):
-            result = method(MagicMock(), installed_app, "mid")
+            result = method(self.account, installed_app, "mid")
 
         assert result["data"] == ["q1", "q2"]
 
@@ -383,16 +427,16 @@ class TestMessageSuggestedQuestionApi:
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode="completion")
 
         with pytest.raises(NotChatAppError):
-            method(MagicMock(), installed_app, "mid")
+            method(self.account, installed_app, "mid")
 
     def test_disabled(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -402,13 +446,13 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(AppSuggestedQuestionsAfterAnswerDisabledError):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")
 
     def test_message_not_exists_suggested_question(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -418,13 +462,13 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")
 
     def test_conversation_not_exists_suggested_question(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -434,13 +478,13 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")
 
     def test_provider_not_init_suggested_question(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -450,13 +494,13 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(ProviderNotInitializeError):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")
 
     def test_quota_exceeded_suggested_question(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -466,13 +510,13 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(ProviderQuotaExceededError):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")
 
     def test_model_not_support_suggested_question(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -482,13 +526,13 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(ProviderModelCurrentlyNotSupportError):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")
 
     def test_invoke_error_suggested_question(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -498,13 +542,13 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(CompletionRequestError):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")
 
     def test_unexpected_error_suggested_question(self):
         api = module.MessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode="chat")
 
         with (
             patch.object(
@@ -514,4 +558,4 @@ class TestMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                method(MagicMock(), installed_app, "mid")
+                method(self.account, installed_app, "mid")

--- a/api/tests/unit_tests/controllers/console/explore/test_parameter.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_parameter.py
@@ -6,11 +6,19 @@ import pytest
 
 import controllers.console.explore.parameter as module
 from controllers.console.app.error import AppUnavailableError
+from models.model import InstalledApp
 from services.app_definition_query_service import AppDefinitionQueryService, AppDefinitionUnavailableError
 
 
-def _installed_app() -> MagicMock:
-    return MagicMock(app_id="app-1")
+def _installed_app() -> InstalledApp:
+    return InstalledApp(
+        tenant_id="viewer-tenant",
+        app_id="app-1",
+        app_owner_tenant_id="owner-tenant",
+        position=0,
+        is_pinned=False,
+        last_used_at=None,
+    )
 
 
 def _application_services() -> tuple[SimpleNamespace, MagicMock]:

--- a/api/tests/unit_tests/controllers/console/explore/test_saved_message.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_saved_message.py
@@ -1,36 +1,77 @@
+from decimal import Decimal
 from inspect import unwrap
 from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import uuid4
 
 import pytest
 from flask import Flask
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.exceptions import NotFound
 
 import controllers.console.explore.saved_message as module
 from controllers.console.explore.error import NotCompletionAppError
+from models import Account
+from models.enums import ConversationFromSource, FeedbackFromSource, FeedbackRating
+from models.model import App, AppMode, InstalledApp, Message, MessageFeedback
 from services.errors.message import MessageNotExistsError
 
 
-def make_saved_message():
-    msg = MagicMock()
-    msg.id = str(uuid4())
-    msg.message_id = str(uuid4())
-    msg.app_id = str(uuid4())
-    msg.inputs = {}
-    msg.query = "hello"
-    msg.answer = "world"
-    msg.user_feedback = MagicMock(rating="like")
-    msg.inputs_with_session.return_value = msg.inputs
-    msg.user_feedback_with_session.return_value = msg.user_feedback
-    msg.created_at = None
-    return msg
+def make_message(session: Session, *, app_id: str, account_id: str) -> Message:
+    message = Message(
+        id=str(uuid4()),
+        app_id=app_id,
+        conversation_id=str(uuid4()),
+        query="hello",
+        message={"role": "user", "content": "hello"},
+        answer="world",
+        message_tokens=1,
+        message_unit_price=Decimal(0),
+        answer_tokens=1,
+        answer_unit_price=Decimal(0),
+        provider_response_latency=0,
+        currency="USD",
+        from_source=ConversationFromSource.API,
+        from_account_id=account_id,
+        app_mode=AppMode.COMPLETION,
+    )
+    message._inputs = {}
+    message.status = "normal"
+    session.add(message)
+    session.flush()
+    session.add(
+        MessageFeedback(
+            app_id=app_id,
+            conversation_id=message.conversation_id,
+            message_id=message.id,
+            rating=FeedbackRating.LIKE,
+            from_source=FeedbackFromSource.USER,
+            from_account_id=account_id,
+        )
+    )
+    session.flush()
+    return message
 
 
-def make_installed_app(mode: str):
-    app_model = MagicMock(mode=mode)
-    installed_app = MagicMock()
-    installed_app.app = app_model
-    installed_app.app_with_session.return_value = app_model
+def make_installed_app(session: Session, mode: AppMode | str) -> InstalledApp:
+    app_model = App(
+        tenant_id="owner-tenant",
+        name="Explore App",
+        mode=AppMode.value_of(mode),
+        enable_site=True,
+        enable_api=False,
+    )
+    session.add(app_model)
+    session.flush()
+    installed_app = InstalledApp(
+        tenant_id="viewer-tenant",
+        app_id=app_model.id,
+        app_owner_tenant_id=app_model.tenant_id,
+        position=0,
+        is_pinned=False,
+        last_used_at=None,
+    )
+    session.add(installed_app)
+    session.commit()
     return installed_app
 
 
@@ -47,19 +88,43 @@ def payload_patch():
     return _patch
 
 
-class TestSavedMessageListApi:
+class _UsesSQLiteSession:
+    sqlite_session: Session
+    account: Account
+
+    @pytest.fixture(autouse=True)
+    def _bind_database(
+        self,
+        sqlite_session: Session,
+        sqlite_session_factory: sessionmaker[Session],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        self.sqlite_session = sqlite_session
+        self.account = Account(name="User", email="user@example.com")
+        self.sqlite_session.add(self.account)
+        self.sqlite_session.commit()
+        session_proxy = scoped_session(sqlite_session_factory)
+        monkeypatch.setattr(module.db, "session", session_proxy)
+        yield
+        session_proxy.remove()
+
+
+class TestSavedMessageListApi(_UsesSQLiteSession):
     def test_get_success(self, app: Flask):
         api = module.SavedMessageListApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode=AppMode.COMPLETION)
 
         pagination = MagicMock(
             limit=20,
             has_more=False,
-            data=[make_saved_message(), make_saved_message()],
+            data=[
+                make_message(self.sqlite_session, app_id=installed_app.app_id, account_id=self.account.id),
+                make_message(self.sqlite_session, app_id=installed_app.app_id, account_id=self.account.id),
+            ],
         )
-        current_user = MagicMock()
+        self.sqlite_session.commit()
 
         with (
             app.test_request_context("/", query_string={}),
@@ -69,10 +134,10 @@ class TestSavedMessageListApi:
                 return_value=pagination,
             ) as pagination_mock,
         ):
-            result = method(api, current_user, installed_app)
+            result = method(api, self.account, installed_app)
 
         pagination_mock.assert_called_once()
-        assert pagination_mock.call_args.args[1] is current_user
+        assert pagination_mock.call_args.args[1] is self.account
         assert result["limit"] == 20
         assert result["has_more"] is False
         assert len(result["data"]) == 2
@@ -81,36 +146,35 @@ class TestSavedMessageListApi:
         api = module.SavedMessageListApi()
         method = unwrap(api.get)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode=AppMode.CHAT)
 
         with pytest.raises(NotCompletionAppError):
-            method(api, MagicMock(), installed_app)
+            method(api, self.account, installed_app)
 
     def test_post_success(self, app: Flask, payload_patch):
         api = module.SavedMessageListApi()
         method = unwrap(api.post)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode=AppMode.COMPLETION)
 
         payload = {"message_id": str(uuid4())}
-        current_user = MagicMock()
 
         with (
             app.test_request_context("/", json=payload),
             payload_patch(payload),
             patch.object(module.SavedMessageService, "save") as save_mock,
         ):
-            result = method(api, module.SavedMessageCreatePayload.model_validate(payload), current_user, installed_app)
+            result = method(api, module.SavedMessageCreatePayload.model_validate(payload), self.account, installed_app)
 
         save_mock.assert_called_once()
-        assert save_mock.call_args.args[1] is current_user
+        assert save_mock.call_args.args[1] is self.account
         assert result == {"result": "success"}
 
     def test_post_message_not_exists(self, app: Flask, payload_patch):
         api = module.SavedMessageListApi()
         method = unwrap(api.post)
 
-        installed_app = make_installed_app(mode="completion")
+        installed_app = make_installed_app(self.sqlite_session, mode=AppMode.COMPLETION)
 
         payload = {"message_id": str(uuid4())}
 
@@ -124,24 +188,23 @@ class TestSavedMessageListApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(api, module.SavedMessageCreatePayload.model_validate(payload), MagicMock(), installed_app)
+                method(api, module.SavedMessageCreatePayload.model_validate(payload), self.account, installed_app)
 
 
-class TestSavedMessageApi:
+class TestSavedMessageApi(_UsesSQLiteSession):
     def test_delete_success(self):
         api = module.SavedMessageApi()
         method = unwrap(api.delete)
 
-        installed_app = make_installed_app(mode="completion")
-        current_user = MagicMock()
+        installed_app = make_installed_app(self.sqlite_session, mode=AppMode.COMPLETION)
 
         with (
             patch.object(module.SavedMessageService, "delete") as delete_mock,
         ):
-            result, status = method(api, current_user, installed_app, str(uuid4()))
+            result, status = method(api, self.account, installed_app, str(uuid4()))
 
         delete_mock.assert_called_once()
-        assert delete_mock.call_args.args[1] is current_user
+        assert delete_mock.call_args.args[1] is self.account
         assert status == 204
         assert result == ""
 
@@ -149,7 +212,7 @@ class TestSavedMessageApi:
         api = module.SavedMessageApi()
         method = unwrap(api.delete)
 
-        installed_app = make_installed_app(mode="chat")
+        installed_app = make_installed_app(self.sqlite_session, mode=AppMode.CHAT)
 
         with pytest.raises(NotCompletionAppError):
-            method(api, MagicMock(), installed_app, str(uuid4()))
+            method(api, self.account, installed_app, str(uuid4()))

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 
 import pytest
 from flask import Flask, request
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
@@ -40,9 +39,12 @@ from core.helper import encrypter
 from core.workflow.llm_environment_variable import LLMEnvironmentVariable
 from graphon.model_runtime.errors.invoke import InvokeError
 from graphon.variables import SecretVariable, StringVariable
-from models import Account
+from models import Account, Tenant
 from models.account import TenantStatus
-from models.model import AppMode, Site
+from models.dataset import Dataset
+from models.model import App, AppMode, Site, UploadFile
+from models.tools import WorkflowToolProvider
+from models.workflow import Workflow
 from services.app_ref_service import AppRef, MessageRef
 from services.errors.audio import SpeechToTextDisabledServiceError
 from services.errors.conversation import ConversationNotExistsError
@@ -55,10 +57,8 @@ class _UsesSQLiteSession:
     sqlite_session: Session
 
     @pytest.fixture(autouse=True)
-    def _provide_sqlite_session(self, sqlite_engine: Engine):
-        with Session(sqlite_engine, expire_on_commit=False) as session:
-            self.sqlite_session = session
-            yield
+    def _provide_sqlite_session(self, sqlite_session: Session):
+        self.sqlite_session = sqlite_session
 
 
 @pytest.fixture
@@ -66,6 +66,35 @@ def account() -> Account:
     acc = Account(name="User", email="user@example.com")
     acc.id = "u1"
     return acc
+
+
+def _app(*, app_id: str, mode: AppMode, tenant_id: str = "tenant-1") -> App:
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        name="Trial App",
+        mode=mode,
+        enable_site=True,
+        enable_api=False,
+    )
+
+
+def _upload_file(*, file_id: str = "upload-file-id", tenant_id: str = "app-tenant-id") -> UploadFile:
+    upload_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type="opendal",
+        key="trial/file.txt",
+        name="file.txt",
+        size=1,
+        extension="txt",
+        mime_type="text/plain",
+        created_by_role="account",
+        created_by="u1",
+        created_at=datetime(2024, 1, 1),
+        used=False,
+    )
+    upload_file.id = file_id
+    return upload_file
 
 
 def _file_data() -> Any:
@@ -87,27 +116,18 @@ def _persist_site(sqlite_session: Session, app_id: str) -> Site:
 
 
 @pytest.fixture
-def trial_app_chat() -> MagicMock:
-    app = MagicMock()
-    app.id = "a-chat"
-    app.mode = AppMode.CHAT
-    return app
+def trial_app_chat() -> App:
+    return _app(app_id="a-chat", mode=AppMode.CHAT)
 
 
 @pytest.fixture
-def trial_app_completion() -> MagicMock:
-    app = MagicMock()
-    app.id = "a-comp"
-    app.mode = AppMode.COMPLETION
-    return app
+def trial_app_completion() -> App:
+    return _app(app_id="a-comp", mode=AppMode.COMPLETION)
 
 
 @pytest.fixture
-def trial_app_workflow() -> MagicMock:
-    app = MagicMock()
-    app.id = "a-workflow"
-    app.mode = AppMode.WORKFLOW
-    return app
+def trial_app_workflow() -> App:
+    return _app(app_id="a-workflow", mode=AppMode.WORKFLOW)
 
 
 def test_trial_workflow_uses_trial_scoped_simple_account_model() -> None:
@@ -116,30 +136,27 @@ def test_trial_workflow_uses_trial_scoped_simple_account_model() -> None:
 
 
 def test_trial_dataset_list_preserves_slim_dataset_fields(app: Flask, unbound_session: Session):
-    class DatasetListItem:
-        id = "dataset-1"
-        name = "Dataset"
-        description = "description"
-        permission = "only_me"
-        data_source_type = "upload_file"
-        indexing_technique = "high_quality"
-        created_by = "user-1"
-        created_at = datetime(2024, 1, 1, tzinfo=UTC)
-        permission_keys = ["dataset.acl.readonly"]
-
-        @property
-        def app_count(self):
-            raise AssertionError("trial dataset list should not serialize detail-only computed fields")
-
     api = module.DatasetListApi()
     method = unwrap(api.get)
-    app_model = SimpleNamespace(tenant_id="tenant-1")
+    app_model = _app(app_id="app-1", mode=AppMode.CHAT)
+    dataset = Dataset(
+        id="dataset-1",
+        tenant_id=app_model.tenant_id,
+        name="Dataset",
+        description="description",
+        permission="only_me",
+        data_source_type="upload_file",
+        indexing_technique="high_quality",
+        created_by="user-1",
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    dataset.permission_keys = ["dataset.acl.readonly"]  # type: ignore[attr-defined]
     with (
         app.test_request_context("/?page=1&limit=20&ids=dataset-1"),
         patch.object(
             module.DatasetService,
             "get_datasets_by_ids",
-            return_value=([DatasetListItem()], 1),
+            return_value=([dataset], 1),
         ) as get_datasets,
     ):
         result = method(api, unbound_session, app_model)
@@ -180,7 +197,7 @@ def test_trial_app_handlers_use_explicit_read_session(api_type: type) -> None:
 def test_trial_app_detail_serializes_with_explicit_session(
     app: Flask, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
 ) -> None:
-    app_model = MagicMock()
+    app_model = _app(app_id="app-1", mode=AppMode.CHAT)
     response_view = MagicMock()
     get_app = MagicMock(return_value=app_model)
     build_view = MagicMock(return_value=response_view)
@@ -203,8 +220,8 @@ class TestTrialAppFileUploadApi:
     def test_upload_uses_trial_app_tenant(self, app: Flask, account: Account) -> None:
         api = module.TrialAppFileUploadApi()
         method = unwrap(api.post)
-        app_model = SimpleNamespace(tenant_id="app-tenant-id")
-        upload_file = MagicMock()
+        app_model = _app(app_id="app-1", mode=AppMode.CHAT, tenant_id="app-tenant-id")
+        upload_file = _upload_file()
 
         with (
             app.test_request_context("/", method="POST"),
@@ -222,7 +239,7 @@ class TestTrialAppRemoteFileUploadApi:
     def test_upload_uses_trial_app_tenant(self, app: Flask, account: Account) -> None:
         api = module.TrialAppRemoteFileUploadApi()
         method = unwrap(api.post)
-        app_model = SimpleNamespace(tenant_id="app-tenant-id")
+        app_model = _app(app_id="app-1", mode=AppMode.CHAT, tenant_id="app-tenant-id")
         remote_file = MagicMock()
         remote_file.model_dump.return_value = {"id": "upload-file-id"}
 
@@ -249,10 +266,10 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     WorkflowRunRequest.model_validate(request.get_json()),
                     self.sqlite_session,
                     account,
-                    MagicMock(mode=AppMode.CHAT),
+                    _app(app_id="not-workflow", mode=AppMode.CHAT),
                 )
 
-    def test_success(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_success(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -271,7 +288,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
 
         assert result is not None
 
-    def test_workflow_provider_not_init(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_workflow_provider_not_init(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -292,7 +309,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     trial_app_workflow,
                 )
 
-    def test_workflow_quota_exceeded(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_workflow_quota_exceeded(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -313,7 +330,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     trial_app_workflow,
                 )
 
-    def test_workflow_model_not_support(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_workflow_model_not_support(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -334,7 +351,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     trial_app_workflow,
                 )
 
-    def test_workflow_invoke_error(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_workflow_invoke_error(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -355,7 +372,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     trial_app_workflow,
                 )
 
-    def test_workflow_rate_limit_error(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_workflow_rate_limit_error(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -376,7 +393,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     trial_app_workflow,
                 )
 
-    def test_workflow_value_error(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_workflow_value_error(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -397,7 +414,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     trial_app_workflow,
                 )
 
-    def test_workflow_generic_exception(self, app: Flask, trial_app_workflow: MagicMock, account: Account) -> None:
+    def test_workflow_generic_exception(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
@@ -431,10 +448,10 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     ChatRequest.model_validate(request.get_json()),
                     self.sqlite_session,
                     account,
-                    MagicMock(mode="completion"),
+                    _app(app_id="not-chat", mode=AppMode.COMPLETION),
                 )
 
-    def test_success(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_success(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -449,7 +466,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
 
         assert result is not None
 
-    def test_chat_conversation_not_exists(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_conversation_not_exists(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -466,7 +483,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_conversation_completed(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_conversation_completed(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -483,7 +500,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_app_config_broken(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_app_config_broken(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -500,7 +517,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_provider_not_init(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_provider_not_init(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -517,7 +534,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_quota_exceeded(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_quota_exceeded(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -534,7 +551,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_model_not_support(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_model_not_support(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -551,7 +568,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_invoke_error(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_invoke_error(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -568,7 +585,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_rate_limit_error(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_rate_limit_error(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -585,7 +602,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_value_error(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_value_error(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -602,7 +619,7 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
                 )
 
-    def test_chat_generic_exception(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_chat_generic_exception(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
@@ -632,10 +649,10 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     CompletionRequest.model_validate(request.get_json()),
                     self.sqlite_session,
                     account,
-                    MagicMock(mode=AppMode.CHAT),
+                    _app(app_id="not-completion", mode=AppMode.CHAT),
                 )
 
-    def test_success(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_success(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -654,7 +671,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
 
         assert result is not None
 
-    def test_completion_app_config_broken(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_app_config_broken(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -675,7 +692,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     trial_app_completion,
                 )
 
-    def test_completion_provider_not_init(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_provider_not_init(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -696,7 +713,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     trial_app_completion,
                 )
 
-    def test_completion_quota_exceeded(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_quota_exceeded(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -717,7 +734,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     trial_app_completion,
                 )
 
-    def test_completion_model_not_support(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_model_not_support(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -738,7 +755,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     trial_app_completion,
                 )
 
-    def test_completion_invoke_error(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_invoke_error(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -759,7 +776,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     trial_app_completion,
                 )
 
-    def test_completion_rate_limit_error(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_rate_limit_error(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -780,7 +797,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     trial_app_completion,
                 )
 
-    def test_completion_value_error(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_value_error(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -801,7 +818,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     trial_app_completion,
                 )
 
-    def test_completion_generic_exception(self, app: Flask, trial_app_completion: MagicMock, account: Account) -> None:
+    def test_completion_generic_exception(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
@@ -830,9 +847,9 @@ class TestTrialMessageSuggestedQuestionApi:
 
         with app.test_request_context("/"):
             with pytest.raises(NotChatAppError):
-                method(api, account, MagicMock(mode="completion"), str(uuid4()))
+                method(api, account, _app(app_id="not-chat", mode=AppMode.COMPLETION), str(uuid4()))
 
-    def test_success(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_success(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialMessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
@@ -848,7 +865,7 @@ class TestTrialMessageSuggestedQuestionApi:
 
         assert result == {"data": ["q1", "q2"]}
 
-    def test_conversation_not_exists(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_conversation_not_exists(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialMessageSuggestedQuestionApi()
         method = unwrap(api.get)
 
@@ -882,7 +899,7 @@ class TestTrialAppParameterApi:
         services = SimpleNamespace(app_definitions=app_definitions)
 
         with patch.object(module, "application_services", return_value=services):
-            result = method(api, unbound_session, SimpleNamespace(id="app-1"))
+            result = method(api, unbound_session, _app(app_id="app-1", mode=AppMode.CHAT))
 
         assert result == expected
         app_definitions.get_parameters.assert_called_once_with("app-1")
@@ -898,11 +915,11 @@ class TestTrialAppParameterApi:
             patch.object(module, "application_services", return_value=services),
             pytest.raises(AppUnavailableError),
         ):
-            method(api, unbound_session, SimpleNamespace(id="app-1"))
+            method(api, unbound_session, _app(app_id="app-1", mode=AppMode.CHAT))
 
 
 class TestTrialChatAudioApi:
-    def test_success(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_success(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -919,7 +936,7 @@ class TestTrialChatAudioApi:
 
         assert result == {"text": "hello"}
 
-    def test_app_config_broken(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_app_config_broken(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -942,7 +959,7 @@ class TestTrialChatAudioApi:
                     trial_app_chat,
                 )
 
-    def test_no_audio_uploaded(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_no_audio_uploaded(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -965,7 +982,7 @@ class TestTrialChatAudioApi:
                     trial_app_chat,
                 )
 
-    def test_missing_file_field_returns_400(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_missing_file_field_returns_400(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         """A multipart POST with no `file` field must surface as 400, not 500.
 
         Verifies the controller passes file=None to AudioService.transcript_asr
@@ -992,7 +1009,7 @@ class TestTrialChatAudioApi:
 
         assert exc_info.value.code == 400
 
-    def test_audio_too_large(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_audio_too_large(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1015,7 +1032,7 @@ class TestTrialChatAudioApi:
                     trial_app_chat,
                 )
 
-    def test_unsupported_audio_type(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_unsupported_audio_type(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1038,7 +1055,7 @@ class TestTrialChatAudioApi:
                     trial_app_chat,
                 )
 
-    def test_provider_not_support_tts(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_provider_not_support_tts(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1061,7 +1078,7 @@ class TestTrialChatAudioApi:
                     trial_app_chat,
                 )
 
-    def test_speech_to_text_disabled(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_speech_to_text_disabled(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
         file_data = _file_data()
@@ -1083,7 +1100,7 @@ class TestTrialChatAudioApi:
                     trial_app_chat,
                 )
 
-    def test_provider_not_init(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_provider_not_init(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1102,7 +1119,7 @@ class TestTrialChatAudioApi:
                     trial_app_chat,
                 )
 
-    def test_quota_exceeded(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_quota_exceeded(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1123,7 +1140,7 @@ class TestTrialChatAudioApi:
 
 
 class TestTrialChatTextApi:
-    def test_success(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_success(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1138,7 +1155,7 @@ class TestTrialChatTextApi:
 
         assert result == {"audio": "base64_data"}
 
-    def test_success_with_message_ref(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_success_with_message_ref(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
         transcript_tts = MagicMock(return_value={"audio": "base64_data"})
@@ -1160,7 +1177,7 @@ class TestTrialChatTextApi:
             account_id="u1",
         )
 
-    def test_app_config_broken(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_app_config_broken(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1180,7 +1197,7 @@ class TestTrialChatTextApi:
                     trial_app_chat,
                 )
 
-    def test_provider_not_support(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_provider_not_support(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1200,7 +1217,7 @@ class TestTrialChatTextApi:
                     trial_app_chat,
                 )
 
-    def test_audio_too_large(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_audio_too_large(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1220,7 +1237,7 @@ class TestTrialChatTextApi:
                     trial_app_chat,
                 )
 
-    def test_no_audio_uploaded(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_no_audio_uploaded(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1240,7 +1257,7 @@ class TestTrialChatTextApi:
                     trial_app_chat,
                 )
 
-    def test_provider_not_init(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_provider_not_init(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1256,7 +1273,7 @@ class TestTrialChatTextApi:
                     trial_app_chat,
                 )
 
-    def test_quota_exceeded(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_quota_exceeded(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1272,7 +1289,7 @@ class TestTrialChatTextApi:
                     trial_app_chat,
                 )
 
-    def test_model_not_support(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_model_not_support(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1288,7 +1305,7 @@ class TestTrialChatTextApi:
                     trial_app_chat,
                 )
 
-    def test_invoke_error(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_invoke_error(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1306,14 +1323,14 @@ class TestTrialChatTextApi:
 
 
 class TestTrialAppWorkflowTaskStopApi:
-    def test_not_workflow_app(self, app: Flask, trial_app_chat: MagicMock) -> None:
+    def test_not_workflow_app(self, app: Flask, trial_app_chat: App) -> None:
         api = module.TrialAppWorkflowTaskStopApi()
 
         with app.test_request_context("/", json={"inputs": {}}):
             with pytest.raises(NotWorkflowAppError):
                 api.post(trial_app_chat, str(uuid4()))
 
-    def test_success(self, app: Flask, trial_app_workflow: MagicMock) -> None:
+    def test_success(self, app: Flask, trial_app_workflow: App) -> None:
         api = module.TrialAppWorkflowTaskStopApi()
 
         task_id = str(uuid4())
@@ -1330,7 +1347,6 @@ class TestTrialAppWorkflowTaskStopApi:
 
 
 class TestTrialSitApi:
-    @pytest.mark.parametrize("sqlite_session", [(Site,)], indirect=True)
     def test_no_site(
         self,
         app: Flask,
@@ -1338,14 +1354,12 @@ class TestTrialSitApi:
     ) -> None:
         api = module.TrialSitApi()
         method = unwrap(api.get)
-        app_model = MagicMock()
-        app_model.id = str(uuid4())
+        app_model = _app(app_id=str(uuid4()), mode=AppMode.CHAT)
 
         with app.test_request_context("/"):
             with pytest.raises(Forbidden):
                 method(api, sqlite_session, app_model)
 
-    @pytest.mark.parametrize("sqlite_session", [(Site,)], indirect=True)
     def test_archived_tenant(
         self,
         app: Flask,
@@ -1354,8 +1368,9 @@ class TestTrialSitApi:
         api = module.TrialSitApi()
         method = unwrap(api.get)
 
-        app_model = SimpleNamespace(id=str(uuid4()), tenant_id="tenant-1")
-        tenant = SimpleNamespace(status=TenantStatus.ARCHIVE)
+        app_model = _app(app_id=str(uuid4()), mode=AppMode.CHAT)
+        tenant = Tenant(name="Archived Tenant", status=TenantStatus.ARCHIVE)
+        tenant.id = app_model.tenant_id
         _persist_site(sqlite_session, app_model.id)
 
         with (
@@ -1367,7 +1382,6 @@ class TestTrialSitApi:
 
         get_tenant_by_id.assert_called_once_with("tenant-1", session=sqlite_session)
 
-    @pytest.mark.parametrize("sqlite_session", [(Site,)], indirect=True)
     def test_success(
         self,
         app: Flask,
@@ -1376,8 +1390,9 @@ class TestTrialSitApi:
         api = module.TrialSitApi()
         method = unwrap(api.get)
 
-        app_model = SimpleNamespace(id=str(uuid4()), tenant_id="tenant-1")
-        tenant = SimpleNamespace(status=TenantStatus.NORMAL)
+        app_model = _app(app_id=str(uuid4()), mode=AppMode.CHAT)
+        tenant = Tenant(name="Active Tenant", status=TenantStatus.NORMAL)
+        tenant.id = app_model.tenant_id
         site = _persist_site(sqlite_session, app_model.id)
 
         with (
@@ -1396,56 +1411,69 @@ class TestTrialSitApi:
 
 
 class TestAppWorkflowApi:
-    def test_uses_injected_session(self, unbound_session: Session) -> None:
+    def test_uses_injected_session(self, sqlite_session: Session) -> None:
         api = module.AppWorkflowApi()
         method = unwrap(api.get)
-        created_by = SimpleNamespace(id="account-1", name="Creator", email="creator@example.com")
-        workflow = SimpleNamespace(
-            id="workflow-1",
-            graph_dict={"nodes": []},
-            features_dict={},
-            unique_hash="workflow-hash",
-            version="draft",
-            marked_name="",
-            marked_comment="",
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-            updated_at=datetime(2024, 1, 2, tzinfo=UTC),
-            environment_variables=[
-                SecretVariable(
-                    id="env-secret",
-                    name="api_key",
-                    value="plaintext-secret",
-                ),
-                LLMEnvironmentVariable(
-                    id="env-llm",
-                    name="shared_model",
-                    value={"provider": "provider", "name": "model", "mode": "chat"},
-                ),
-            ],
-            conversation_variables=[
-                StringVariable(
-                    id="conversation-variable-1",
-                    name="topic",
-                    value="sqlite",
-                    selector=["conversation", "topic"],
-                )
-            ],
-            rag_pipeline_variables=[],
-            get_created_by_account=MagicMock(return_value=created_by),
-            get_updated_by_account=MagicMock(return_value=None),
-            get_tool_published=MagicMock(return_value=True),
+        created_by = Account(name="Creator", email="creator@example.com")
+        created_by.id = "account-1"
+        app_model = _app(app_id="app-1", mode=AppMode.WORKFLOW)
+        with patch("models.workflow.encrypter.encrypt_token", return_value="encrypted-secret"):
+            workflow = Workflow.new(
+                tenant_id=app_model.tenant_id,
+                app_id=app_model.id,
+                type="workflow",
+                version="draft",
+                graph='{"nodes": []}',
+                features="{}",
+                created_by=created_by.id,
+                environment_variables=[
+                    SecretVariable(
+                        id="env-secret",
+                        name="api_key",
+                        value="plaintext-secret",
+                    ),
+                    LLMEnvironmentVariable(
+                        id="env-llm",
+                        name="shared_model",
+                        value={"provider": "provider", "name": "model", "mode": "chat"},
+                    ),
+                ],
+                conversation_variables=[
+                    StringVariable(
+                        id="conversation-variable-1",
+                        name="topic",
+                        value="sqlite",
+                        selector=["conversation", "topic"],
+                    )
+                ],
+                rag_pipeline_variables=[],
+            )
+        workflow.id = "workflow-1"
+        workflow.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+        workflow.updated_at = datetime(2024, 1, 2, tzinfo=UTC)
+        app_model.workflow_id = workflow.id
+        tool_provider = WorkflowToolProvider(
+            name="trial-workflow",
+            label="Trial Workflow",
+            icon="icon",
+            app_id=app_model.id,
+            version="1.0.0",
+            user_id=created_by.id,
+            tenant_id=app_model.tenant_id,
+            description="Trial workflow provider",
+            parameter_configuration="[]",
         )
-        app_model = SimpleNamespace(
-            workflow_id="workflow-1",
-            workflow_with_session=MagicMock(return_value=workflow),
-        )
-        result = method(api, unbound_session, app_model)
+        sqlite_session.add_all([created_by, app_model, workflow, tool_provider])
+        sqlite_session.commit()
+
+        with patch("models.workflow.encrypter.decrypt_token", return_value="plaintext-secret"):
+            result = method(api, sqlite_session, app_model)
 
         assert result == {
             "id": "workflow-1",
             "graph": {"nodes": []},
             "features": {},
-            "hash": "workflow-hash",
+            "hash": workflow.unique_hash,
             "version": "draft",
             "marked_name": "",
             "marked_comment": "",
@@ -1461,7 +1489,7 @@ class TestAppWorkflowApi:
                     "id": "env-secret",
                     "name": "api_key",
                     "description": "",
-                    "selector": [],
+                    "selector": ["env", "api_key"],
                 },
                 {
                     "value_type": "llm",
@@ -1469,7 +1497,7 @@ class TestAppWorkflowApi:
                     "id": "env-llm",
                     "name": "shared_model",
                     "description": "",
-                    "selector": [],
+                    "selector": ["env", "shared_model"],
                 },
             ],
             "conversation_variables": [
@@ -1483,14 +1511,10 @@ class TestAppWorkflowApi:
             ],
             "rag_pipeline_variables": [],
         }
-        app_model.workflow_with_session.assert_called_once_with(session=unbound_session)
-        workflow.get_created_by_account.assert_called_once_with(session=unbound_session)
-        workflow.get_updated_by_account.assert_called_once_with(session=unbound_session)
-        workflow.get_tool_published.assert_called_once_with(session=unbound_session)
 
 
 class TestTrialChatAudioApiExceptionHandlers:
-    def test_provider_not_init(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_provider_not_init(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1513,7 +1537,7 @@ class TestTrialChatAudioApiExceptionHandlers:
                     trial_app_chat,
                 )
 
-    def test_quota_exceeded(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_quota_exceeded(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1536,7 +1560,7 @@ class TestTrialChatAudioApiExceptionHandlers:
                     trial_app_chat,
                 )
 
-    def test_invoke_error(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_invoke_error(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -1561,7 +1585,7 @@ class TestTrialChatAudioApiExceptionHandlers:
 
 
 class TestTrialChatTextApiExceptionHandlers:
-    def test_app_config_broken(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_app_config_broken(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
@@ -1581,7 +1605,7 @@ class TestTrialChatTextApiExceptionHandlers:
                     trial_app_chat,
                 )
 
-    def test_unsupported_audio_type(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+    def test_unsupported_audio_type(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 

--- a/api/tests/unit_tests/controllers/console/explore/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_workflow.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import InternalServerError
 
 from controllers.common.controller_schemas import WorkflowRunPayload
@@ -12,7 +13,8 @@ from controllers.console.explore.workflow import (
     InstalledAppWorkflowTaskStopApi,
 )
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
-from models.model import AppMode
+from models import Account
+from models.model import App, AppMode, InstalledApp
 from services.errors.llm import InvokeRateLimitError
 
 
@@ -23,31 +25,26 @@ def app():
     return app
 
 
-@pytest.fixture
-def user():
-    return MagicMock()
-
-
-@pytest.fixture
-def workflow_app():
-    app = MagicMock()
-    app.mode = AppMode.WORKFLOW
-    return app
-
-
-@pytest.fixture
-def installed_workflow_app(workflow_app):
-    installed_app = MagicMock(app=workflow_app)
-    installed_app.app_with_session.return_value = workflow_app
-    return installed_app
-
-
-@pytest.fixture
-def non_workflow_installed_app():
-    app = MagicMock()
-    app.mode = AppMode.CHAT
-    installed_app = MagicMock(app=app)
-    installed_app.app_with_session.return_value = app
+def make_installed_app(session: Session, *, mode: AppMode) -> InstalledApp:
+    app = App(
+        tenant_id="owner-tenant",
+        name="Explore App",
+        mode=mode,
+        enable_site=True,
+        enable_api=False,
+    )
+    session.add(app)
+    session.flush()
+    installed_app = InstalledApp(
+        tenant_id="viewer-tenant",
+        app_id=app.id,
+        app_owner_tenant_id=app.tenant_id,
+        position=0,
+        is_pinned=False,
+        last_used_at=None,
+    )
+    session.add(installed_app)
+    session.commit()
     return installed_app
 
 
@@ -57,24 +54,28 @@ def payload():
 
 
 class TestInstalledAppWorkflowRunApi:
-    def test_not_workflow_app(self, app: Flask, non_workflow_installed_app):
+    def test_not_workflow_app(self, app: Flask, sqlite_session: Session):
         api = InstalledAppWorkflowRunApi()
         method = unwrap(api.post)
+        installed_app = make_installed_app(sqlite_session, mode=AppMode.CHAT)
+        user = Account(name="User", email="user@example.com")
 
         with app.test_request_context("/"):
             with pytest.raises(NotWorkflowAppError):
                 method(
                     api,
                     WorkflowRunPayload.model_validate({"inputs": {}}),
-                    MagicMock(),
-                    MagicMock(),
-                    non_workflow_installed_app,
+                    sqlite_session,
+                    user,
+                    installed_app,
                 )
 
-    def test_success(self, app: Flask, installed_workflow_app, user, payload):
+    def test_success(self, app: Flask, sqlite_session: Session, payload):
         api = InstalledAppWorkflowRunApi()
         method = unwrap(api.post)
         req_data = WorkflowRunPayload.model_validate(payload)
+        installed_app = make_installed_app(sqlite_session, mode=AppMode.WORKFLOW)
+        user = Account(name="User", email="user@example.com")
 
         with (
             app.test_request_context("/", json=payload),
@@ -83,16 +84,18 @@ class TestInstalledAppWorkflowRunApi:
                 return_value=MagicMock(),
             ) as generate_mock,
         ):
-            result = method(api, req_data, MagicMock(), user, installed_workflow_app)
+            result = method(api, req_data, sqlite_session, user, installed_app)
 
             generate_mock.assert_called_once()
             assert generate_mock.call_args.kwargs["user"] is user
             assert result is not None
 
-    def test_rate_limit_error(self, app: Flask, installed_workflow_app, user, payload):
+    def test_rate_limit_error(self, app: Flask, sqlite_session: Session, payload):
         api = InstalledAppWorkflowRunApi()
         method = unwrap(api.post)
         req_data = WorkflowRunPayload.model_validate(payload)
+        installed_app = make_installed_app(sqlite_session, mode=AppMode.WORKFLOW)
+        user = Account(name="User", email="user@example.com")
 
         with (
             app.test_request_context("/", json=payload),
@@ -102,12 +105,14 @@ class TestInstalledAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(InvokeRateLimitHttpError):
-                method(api, req_data, MagicMock(), user, installed_workflow_app)
+                method(api, req_data, sqlite_session, user, installed_app)
 
-    def test_unexpected_exception(self, app: Flask, installed_workflow_app, user, payload):
+    def test_unexpected_exception(self, app: Flask, sqlite_session: Session, payload):
         api = InstalledAppWorkflowRunApi()
         method = unwrap(api.post)
         req_data = WorkflowRunPayload.model_validate(payload)
+        installed_app = make_installed_app(sqlite_session, mode=AppMode.WORKFLOW)
+        user = Account(name="User", email="user@example.com")
 
         with (
             app.test_request_context("/", json=payload),
@@ -117,26 +122,28 @@ class TestInstalledAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                method(api, req_data, MagicMock(), user, installed_workflow_app)
+                method(api, req_data, sqlite_session, user, installed_app)
 
 
 class TestInstalledAppWorkflowTaskStopApi:
-    def test_not_workflow_app(self, non_workflow_installed_app):
+    def test_not_workflow_app(self, sqlite_session: Session):
         api = InstalledAppWorkflowTaskStopApi()
         method = unwrap(api.post)
+        installed_app = make_installed_app(sqlite_session, mode=AppMode.CHAT)
 
         with pytest.raises(NotWorkflowAppError):
-            method(api, MagicMock(), non_workflow_installed_app, "task-1")
+            method(api, sqlite_session, installed_app, "task-1")
 
-    def test_success(self, installed_workflow_app):
+    def test_success(self, sqlite_session: Session):
         api = InstalledAppWorkflowTaskStopApi()
         method = unwrap(api.post)
+        installed_app = make_installed_app(sqlite_session, mode=AppMode.WORKFLOW)
 
         with (
             patch("controllers.console.explore.workflow.AppQueueManager.set_stop_flag_no_user_check") as stop_flag,
             patch("controllers.console.explore.workflow.GraphEngineManager.send_stop_command") as send_stop,
         ):
-            result = method(api, MagicMock(), installed_workflow_app, "task-1")
+            result = method(api, sqlite_session, installed_app, "task-1")
 
             stop_flag.assert_called_once_with("task-1")
             send_stop.assert_called_once_with("task-1")


### PR DESCRIPTION
## Summary




- replace mocked SQLAlchemy sessions in Explore audio, completion, message, parameter, saved-message, trial, and workflow controller tests with shared SQLite-backed sessions

- replace App, InstalledApp, AppModelConfig, Workflow, Message, MessageFeedback, Account, Dataset, Tenant, and UploadFile stand-ins with real mapped instances
- persist ownership/resource chains needed by secondary serializer queries while retaining mocks only for external services, DTO/Pydantic responses, pagination, Redis, crypto, and file-provider objects



## Real persistence coverage



- callable Flask db.session behavior through scoped sessions backed by sqlite_session_factory
- injected controller sessions through sqlite_session/unbound_session according to ownership
- installed-app to app resolution, workflow/config lookup, message feedback and file queries, tenant/app ownership, and committed model defaults
- missing app/config/workflow behavior through actual database lookups

No production changes.



## Size


725 additions + 439 deletions = 1,164 changed lines.



## Validation


- make test TARGET_TESTS=./api/tests/unit_tests/controllers/console/explore — 234 passed
- uv run --project . pytest -q <seven changed Explore modules> --no-cov — 171 passed
- make lint — passed
- make type-check — blocked by mypy 1.20.2 internal error at api/.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17
- AST/text audit — no mocked SQLAlchemy sessions/factories and no mapped ORM stand-ins remain in the changed modules

The full test suite was not run, per request.