### PR TITLE
test: migrate remaining controller sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/console/app/test_agent_manage_guard.py
+++ b/api/tests/unit_tests/controllers/console/app/test_agent_manage_guard.py
@@ -1,16 +1,17 @@
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.exceptions import Forbidden
 
 from controllers.console.app.error import AppNotFoundError
 from controllers.console.app.wraps import agent_manage_required_for_agent_app
 from core.rbac import RBACPermission, RBACResourceScope
-from models.agent import AgentScope
+from models import Account
+from models.agent import Agent, AgentScope, AgentSource, AgentStatus
+from models.model import App, AppMode
 
 TENANT_ID = "tenant-1"
-ACCOUNT = SimpleNamespace(id="account-1")
 
 
 def _guarded_view():
@@ -24,28 +25,64 @@ def _guarded_view():
     return view, calls
 
 
-def _app_with_binding(binding):
-    app_model = MagicMock()
-    app_model.agent_app_binding_with_session.return_value = binding
+def _persist_app(
+    session: Session,
+    *,
+    scope: AgentScope | None = None,
+    status: AgentStatus = AgentStatus.ACTIVE,
+) -> App:
+    app_model = App(
+        id="app-1",
+        tenant_id=TENANT_ID,
+        name="Managed App",
+        mode=AppMode.AGENT if scope is not None else AppMode.CHAT,
+        enable_site=True,
+        enable_api=False,
+    )
+    session.add(app_model)
+    if scope is not None:
+        agent = Agent(
+            tenant_id=TENANT_ID,
+            name=f"{scope.value} agent",
+            scope=scope,
+            source=AgentSource.AGENT_APP if scope == AgentScope.ROSTER else AgentSource.WORKFLOW,
+            status=status,
+            app_id=app_model.id if scope == AgentScope.ROSTER else None,
+            backing_app_id=app_model.id if scope == AgentScope.WORKFLOW_ONLY else None,
+        )
+        session.add(agent)
+    session.commit()
     return app_model
 
 
-def _patch_guard(app_model, rbac_enabled: bool):
-    mock_db = MagicMock()
-    mock_db.session.scalar.return_value = app_model
+def _patch_guard(account: Account, rbac_enabled: bool):
     return (
-        patch("controllers.console.app.wraps.db", mock_db),
-        patch("controllers.console.app.wraps.current_account_with_tenant", return_value=(ACCOUNT, TENANT_ID)),
+        patch("controllers.console.app.wraps.current_account_with_tenant", return_value=(account, TENANT_ID)),
         patch("controllers.console.app.wraps.dify_config.RBAC_ENABLED", rbac_enabled),
     )
 
 
 class TestAgentManageRequiredForAgentApp:
+    @pytest.fixture(autouse=True)
+    def _bind_database(
+        self,
+        sqlite_session: Session,
+        sqlite_session_factory: sessionmaker[Session],
+    ):
+        self.sqlite_session = sqlite_session
+        self.account = Account(name="Guard User", email="guard@example.com")
+        self.account.id = "account-1"
+        session_proxy = scoped_session(sqlite_session_factory)
+        with patch("controllers.console.app.wraps.db.session", session_proxy):
+            yield
+        session_proxy.remove()
+
     def test_non_agent_app_passes_through_without_workspace_check(self):
         view, calls = _guarded_view()
-        patches = _patch_guard(_app_with_binding(None), rbac_enabled=True)
+        _persist_app(self.sqlite_session)
+        patches = _patch_guard(self.account, rbac_enabled=True)
 
-        with patches[0], patches[1], patches[2], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
+        with patches[0], patches[1], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
             assert view(app_id="app-1") == "ok"
 
         gate.assert_not_called()
@@ -53,15 +90,15 @@ class TestAgentManageRequiredForAgentApp:
 
     def test_roster_agent_app_requires_agent_manage_when_rbac_enabled(self):
         view, _ = _guarded_view()
-        binding = SimpleNamespace(scope=AgentScope.ROSTER)
-        patches = _patch_guard(_app_with_binding(binding), rbac_enabled=True)
+        _persist_app(self.sqlite_session, scope=AgentScope.ROSTER)
+        patches = _patch_guard(self.account, rbac_enabled=True)
 
-        with patches[0], patches[1], patches[2], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
+        with patches[0], patches[1], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
             assert view(app_id="app-1") == "ok"
 
         gate.assert_called_once_with(
             tenant_id=TENANT_ID,
-            account_id=ACCOUNT.id,
+            account_id=self.account.id,
             resource_type=RBACResourceScope.WORKSPACE,
             scene=RBACPermission.AGENT_MANAGE,
             resource_required=False,
@@ -69,13 +106,12 @@ class TestAgentManageRequiredForAgentApp:
 
     def test_roster_agent_app_denied_without_agent_manage(self):
         view, calls = _guarded_view()
-        binding = SimpleNamespace(scope=AgentScope.ROSTER)
-        patches = _patch_guard(_app_with_binding(binding), rbac_enabled=True)
+        _persist_app(self.sqlite_session, scope=AgentScope.ROSTER)
+        patches = _patch_guard(self.account, rbac_enabled=True)
 
         with (
             patches[0],
             patches[1],
-            patches[2],
             patch("controllers.console.app.wraps.enforce_rbac_access", side_effect=Forbidden()),
         ):
             with pytest.raises(Forbidden):
@@ -85,10 +121,10 @@ class TestAgentManageRequiredForAgentApp:
 
     def test_roster_agent_app_skips_workspace_check_when_rbac_disabled(self):
         view, _ = _guarded_view()
-        binding = SimpleNamespace(scope=AgentScope.ROSTER)
-        patches = _patch_guard(_app_with_binding(binding), rbac_enabled=False)
+        _persist_app(self.sqlite_session, scope=AgentScope.ROSTER)
+        patches = _patch_guard(self.account, rbac_enabled=False)
 
-        with patches[0], patches[1], patches[2], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
+        with patches[0], patches[1], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
             assert view(app_id="app-1") == "ok"
 
         gate.assert_not_called()
@@ -96,10 +132,10 @@ class TestAgentManageRequiredForAgentApp:
     def test_hidden_backing_app_is_rejected_even_without_rbac(self):
         """A workflow-only backing App is not part of the general app management plane."""
         view, calls = _guarded_view()
-        binding = SimpleNamespace(scope=AgentScope.WORKFLOW_ONLY)
-        patches = _patch_guard(_app_with_binding(binding), rbac_enabled=False)
+        _persist_app(self.sqlite_session, scope=AgentScope.WORKFLOW_ONLY)
+        patches = _patch_guard(self.account, rbac_enabled=False)
 
-        with patches[0], patches[1], patches[2]:
+        with patches[0], patches[1]:
             with pytest.raises(AppNotFoundError):
                 view(app_id="app-1")
 
@@ -107,10 +143,10 @@ class TestAgentManageRequiredForAgentApp:
 
     def test_hidden_backing_app_is_rejected_before_workspace_check(self):
         view, calls = _guarded_view()
-        binding = SimpleNamespace(scope=AgentScope.WORKFLOW_ONLY)
-        patches = _patch_guard(_app_with_binding(binding), rbac_enabled=True)
+        _persist_app(self.sqlite_session, scope=AgentScope.WORKFLOW_ONLY)
+        patches = _patch_guard(self.account, rbac_enabled=True)
 
-        with patches[0], patches[1], patches[2], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
+        with patches[0], patches[1], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
             with pytest.raises(AppNotFoundError):
                 view(app_id="app-1")
 
@@ -120,30 +156,29 @@ class TestAgentManageRequiredForAgentApp:
     def test_binding_lookup_covers_archived_agents(self):
         """An Agent App stays gated after its roster Agent is archived."""
         view, _ = _guarded_view()
-        app_model = _app_with_binding(SimpleNamespace(scope=AgentScope.ROSTER))
-        patches = _patch_guard(app_model, rbac_enabled=True)
+        _persist_app(self.sqlite_session, scope=AgentScope.ROSTER, status=AgentStatus.ARCHIVED)
+        patches = _patch_guard(self.account, rbac_enabled=True)
 
-        with patches[0], patches[1], patches[2], patch("controllers.console.app.wraps.enforce_rbac_access"):
+        with patches[0], patches[1], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
             view(app_id="app-1")
 
-        _, call_kwargs = app_model.agent_app_binding_with_session.call_args
-        assert call_kwargs["include_archived"] is True
+        gate.assert_called_once()
 
     def test_resource_id_path_alias_is_resolved(self):
         view, _ = _guarded_view()
-        binding = SimpleNamespace(scope=AgentScope.ROSTER)
-        patches = _patch_guard(_app_with_binding(binding), rbac_enabled=True)
+        _persist_app(self.sqlite_session, scope=AgentScope.ROSTER)
+        patches = _patch_guard(self.account, rbac_enabled=True)
 
-        with patches[0], patches[1], patches[2], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
+        with patches[0], patches[1], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
             assert view(resource_id="app-1") == "ok"
 
         gate.assert_called_once()
 
     def test_unknown_app_passes_through_for_downstream_handling(self):
         view, calls = _guarded_view()
-        patches = _patch_guard(None, rbac_enabled=True)
+        patches = _patch_guard(self.account, rbac_enabled=True)
 
-        with patches[0], patches[1], patches[2], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
+        with patches[0], patches[1], patch("controllers.console.app.wraps.enforce_rbac_access") as gate:
             assert view(app_id="app-1") == "ok"
 
         gate.assert_not_called()

--- a/api/tests/unit_tests/controllers/console/app/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow.py
@@ -5,14 +5,13 @@ import json
 from contextlib import contextmanager, nullcontext
 from datetime import datetime
 from types import SimpleNamespace
-from typing import cast
 from unittest.mock import Mock
 
 import pytest
 from flask import Flask
 from pydantic import ValidationError
 from sqlalchemy import Engine
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.exceptions import HTTPException, NotFound
 
 from controllers.common.errors import InvalidArgumentError
@@ -22,41 +21,79 @@ from core.workflow.llm_environment_variable import LLMEnvironmentVariable
 from graphon.file import File, FileTransferMethod, FileType
 from graphon.variables import SecretVariable, StringVariable
 from graphon.variables.variables import RAGPipelineVariable
+from models import Account, App
+from models.model import AppMode
+from models.workflow import Workflow
 
 
-def _make_workflow(**overrides):
-    workflow = SimpleNamespace(
-        id="workflow-1",
-        graph_dict={"nodes": [], "edges": []},
-        features_dict={"file_upload": {"enabled": False}},
-        unique_hash="hash-1",
-        version="1",
-        marked_name="Release 1",
-        marked_comment="Initial release",
-        created_by_account=SimpleNamespace(id="user-1", name="Alice", email="alice@example.com"),
-        created_at=datetime(2024, 1, 1, 12, 0, 0),
-        updated_by_account=None,
-        updated_at=datetime(2024, 1, 1, 12, 1, 0),
-        tool_published=False,
-        environment_variables=[
-            {
-                "id": "env-1",
-                "name": "API_KEY",
-                "value": "[__HIDDEN__]",
-                "value_type": "secret",
-                "description": "API key",
-            }
+@pytest.fixture(autouse=True)
+def _bind_database(
+    sqlite_session_factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session_proxy = scoped_session(sqlite_session_factory)
+    monkeypatch.setattr(workflow_module.db, "session", session_proxy)
+    monkeypatch.setattr(workflow_module.encrypter, "encrypt_token", lambda tenant_id, token: token)
+    monkeypatch.setattr(workflow_module.encrypter, "decrypt_token", lambda tenant_id, token: token)
+    yield
+    session_proxy.remove()
+
+
+def _make_app(*, app_id: str = "app", tenant_id: str = "t1", workflow_id: str | None = None) -> App:
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        name="Workflow App",
+        mode=AppMode.WORKFLOW,
+        workflow_id=workflow_id,
+        enable_site=True,
+        enable_api=False,
+    )
+
+
+def _make_account(*, account_id: str = "account-1") -> Account:
+    account = Account(name="Alice", email="alice@example.com")
+    account.id = account_id
+    return account
+
+
+def _transient_workflow(*, features: dict | None = None, tenant_id: str = "t1") -> Workflow:
+    workflow = Workflow()
+    workflow.tenant_id = tenant_id
+    workflow._features = json.dumps(features or {})
+    return workflow
+
+
+def _make_workflow(session: Session, **overrides) -> Workflow:
+    graph = overrides.pop("graph_dict", {"nodes": [], "edges": []})
+    features = overrides.pop("features_dict", {"file_upload": {"enabled": False}})
+    environment_variables = overrides.pop(
+        "environment_variables",
+        [
+            SecretVariable(
+                id="env-1",
+                name="API_KEY",
+                value="[__HIDDEN__]",
+                selector=["env", "API_KEY"],
+                description="API key",
+            )
         ],
-        conversation_variables=[
-            {
-                "id": "conv-1",
-                "name": "topic",
-                "value": "hello",
-                "value_type": "string",
-                "description": "Topic",
-            }
+    )
+    conversation_variables = overrides.pop(
+        "conversation_variables",
+        [
+            StringVariable(
+                id="conv-1",
+                name="topic",
+                value="hello",
+                selector=["conversation", "topic"],
+                description="Topic",
+            )
         ],
-        rag_pipeline_variables=[
+    )
+    rag_pipeline_variables = overrides.pop(
+        "rag_pipeline_variables",
+        [
             {
                 "variable": "query",
                 "type": "text-input",
@@ -75,8 +112,33 @@ def _make_workflow(**overrides):
             }
         ],
     )
+    account = _make_account(account_id="user-1")
+    app = _make_app()
+    workflow = Workflow.new(
+        tenant_id=app.tenant_id,
+        app_id=app.id,
+        type="workflow",
+        version="1",
+        graph=json.dumps(graph),
+        features=json.dumps(features),
+        created_by=account.id,
+        environment_variables=environment_variables
+        if all(not isinstance(item, dict) for item in environment_variables)
+        else [],
+        conversation_variables=conversation_variables,
+        rag_pipeline_variables=rag_pipeline_variables,
+        marked_name="Release 1",
+        marked_comment="Initial release",
+    )
+    workflow.id = "workflow-1"
+    workflow.created_at = datetime(2024, 1, 1, 12, 0, 0)
+    workflow.updated_at = datetime(2024, 1, 1, 12, 1, 0)
+    if environment_variables and any(isinstance(item, dict) for item in environment_variables):
+        workflow._environment_variables = json.dumps({"invalid": environment_variables[0]})
     for key, value in overrides.items():
         setattr(workflow, key, value)
+    session.add_all([account, app, workflow])
+    session.commit()
     return workflow
 
 
@@ -175,9 +237,9 @@ def test_delete_workflow_retires_candidates_only_after_transaction_exit(
 
 def test_parse_file_no_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(workflow_module.FileUploadConfigManager, "convert", lambda *_args, **_kwargs: None)
-    workflow = SimpleNamespace(features_dict={}, tenant_id="t1")
+    workflow = _transient_workflow()
 
-    assert workflow_module._parse_file(cast(workflow_module.Workflow, workflow), files=[{"id": "f"}]) == []
+    assert workflow_module._parse_file(workflow, files=[{"id": "f"}]) == []
 
 
 def test_parse_file_with_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -194,8 +256,8 @@ def test_parse_file_with_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(workflow_module.FileUploadConfigManager, "convert", lambda *_args, **_kwargs: config)
     monkeypatch.setattr(workflow_module.file_factory, "build_from_mappings", build_mock)
 
-    workflow = SimpleNamespace(features_dict={}, tenant_id="t1")
-    result = workflow_module._parse_file(cast(workflow_module.Workflow, workflow), files=[{"id": "f"}])
+    workflow = _transient_workflow()
+    result = workflow_module._parse_file(workflow, files=[{"id": "f"}])
 
     assert result == file_list
     build_mock.assert_called_once()
@@ -207,7 +269,7 @@ def test_sync_draft_workflow_invalid_content_type(app: Flask, monkeypatch: pytes
 
     with app.test_request_context("/apps/app/workflows/draft", method="POST", data="x", content_type="text/html"):
         with pytest.raises(HTTPException) as exc:
-            handler(api, "t1", app_model=SimpleNamespace(id="app"))
+            handler(api, "t1", app_model=_make_app())
 
     assert exc.value.code == 415
 
@@ -222,18 +284,14 @@ def test_sync_draft_workflow_invalid_json(app: Flask, monkeypatch: pytest.Monkey
         data="[]",
         content_type="application/json",
     ):
-        response, status = handler(api, "t1", app_model=SimpleNamespace(id="app"))
+        response, status = handler(api, "t1", app_model=_make_app())
 
     assert status == 400
     assert response["message"] == "Invalid JSON data"
 
 
-def test_sync_draft_workflow_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow = SimpleNamespace(
-        unique_hash="h",
-        updated_at=None,
-        created_at=datetime(2024, 1, 1),
-    )
+def test_sync_draft_workflow_success(app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
+    workflow = _make_workflow(sqlite_session)
 
     monkeypatch.setattr(
         workflow_module.variable_factory, "build_environment_variable_from_mapping", lambda *_args: "env"
@@ -254,19 +312,17 @@ def test_sync_draft_workflow_success(app: Flask, monkeypatch: pytest.MonkeyPatch
         method="POST",
         json={"graph": {}, "features": {}, "hash": "h"},
     ):
-        response = handler(api, "t1", app_model=SimpleNamespace(id="app"))
+        response = handler(api, "t1", app_model=_make_app())
 
     assert response["result"] == "success"
     assert sync_draft_workflow.call_args.kwargs["environment_variables"] == []
     assert sync_draft_workflow.call_args.kwargs["preserve_environment_variables"] is True
 
 
-def test_sync_draft_workflow_passes_environment_patch(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow = SimpleNamespace(
-        unique_hash="next-hash",
-        updated_at=None,
-        created_at=datetime(2024, 1, 1),
-    )
+def test_sync_draft_workflow_passes_environment_patch(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
+    workflow = _make_workflow(sqlite_session)
     patched_variable = StringVariable(
         id="env-model",
         name="shared_model",
@@ -308,7 +364,7 @@ def test_sync_draft_workflow_passes_environment_patch(app: Flask, monkeypatch: p
             },
         },
     ):
-        response = handler(api, "t1", app_model=SimpleNamespace(id="app"))
+        response = handler(api, "t1", app_model=_make_app())
 
     assert response["result"] == "success"
     assert sync_draft_workflow.call_args.kwargs["preserve_environment_variables"] is True
@@ -359,7 +415,7 @@ def test_sync_draft_workflow_hash_mismatch(app: Flask, monkeypatch: pytest.Monke
         json={"graph": {}, "features": {}, "hash": "h"},
     ):
         with pytest.raises(DraftWorkflowNotSync):
-            handler(api, "t1", app_model=SimpleNamespace(id="app"))
+            handler(api, "t1", app_model=_make_app())
 
 
 def test_sync_draft_workflow_variable_validation_error(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -380,18 +436,15 @@ def test_sync_draft_workflow_variable_validation_error(app: Flask, monkeypatch: 
         json={"graph": {}, "features": {}, "hash": "h", "conversation_variables": [{"name": "topic"}]},
     ):
         with pytest.raises(InvalidArgumentError) as exc:
-            handler(api, "t1", app_model=SimpleNamespace(id="app"))
+            handler(api, "t1", app_model=_make_app())
 
     assert exc.value.description == "description too long"
 
 
-def test_restore_published_workflow_to_draft_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow = SimpleNamespace(
-        unique_hash="restored-hash",
-        updated_at=None,
-        created_at=datetime(2024, 1, 1),
-    )
-    user = SimpleNamespace(id="account-1")
+def test_restore_published_workflow_to_draft_success(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
+    workflow = _make_workflow(sqlite_session)
 
     monkeypatch.setattr(
         workflow_module,
@@ -409,12 +462,12 @@ def test_restore_published_workflow_to_draft_success(app: Flask, monkeypatch: py
         response = handler(
             api,
             "t1",
-            app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
+            app_model=_make_app(tenant_id="tenant-1"),
             workflow_id="published-workflow",
         )
 
     assert response["result"] == "success"
-    assert response["hash"] == "restored-hash"
+    assert response["hash"] == workflow.unique_hash
 
 
 def test_restore_published_workflow_to_draft_not_found(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -439,7 +492,7 @@ def test_restore_published_workflow_to_draft_not_found(app: Flask, monkeypatch: 
             handler(
                 api,
                 "t1",
-                app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
+                app_model=_make_app(tenant_id="tenant-1"),
                 workflow_id="published-workflow",
             )
 
@@ -471,7 +524,7 @@ def test_restore_published_workflow_to_draft_returns_400_for_draft_source(
             handler(
                 api,
                 "t1",
-                app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
+                app_model=_make_app(tenant_id="tenant-1"),
                 workflow_id="draft-workflow",
             )
 
@@ -503,7 +556,7 @@ def test_restore_published_workflow_to_draft_returns_400_for_invalid_structure(
             handler(
                 api,
                 "t1",
-                app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
+                app_model=_make_app(tenant_id="tenant-1"),
                 workflow_id="published-workflow",
             )
 
@@ -512,28 +565,22 @@ def test_restore_published_workflow_to_draft_returns_400_for_invalid_structure(
 
 
 def test_get_published_workflows_serializes_items_before_session_closes(
-    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_engine: Engine,
+    sqlite_session: Session,
 ) -> None:
     api = workflow_module.PublishedAllWorkflowApi()
     handler = inspect.unwrap(api.get)
 
-    base_workflow = _make_workflow()
-
-    class _Workflow:
-        def __init__(self, session: Session) -> None:
-            self._session = session
-
-        def __getattr__(self, name):
-            return getattr(base_workflow, name)
-
-        @property
-        def id(self):
-            assert self._session.in_transaction()
-            return "w1"
+    workflow = _make_workflow(sqlite_session)
 
     def get_all_published_workflow(*, session: Session, **_kwargs):
         assert isinstance(session, Session)
-        return [_Workflow(session)], False
+        assert session.in_transaction()
+        persisted_workflow = session.get(Workflow, workflow.id)
+        assert persisted_workflow is not None
+        return [persisted_workflow], False
 
     monkeypatch.setattr(workflow_module, "db", SimpleNamespace(engine=sqlite_engine))
     monkeypatch.setattr(
@@ -547,16 +594,16 @@ def test_get_published_workflows_serializes_items_before_session_closes(
         method="GET",
         query_string={"page": 1, "limit": 10, "user_id": "", "named_only": "false"},
     ):
-        response = handler(api, "t1", app_model=SimpleNamespace(id="app", workflow_id="wf-1"))
+        response = handler(api, "t1", app_model=_make_app(workflow_id="wf-1"))
 
-    assert response["items"][0]["id"] == "w1"
+    assert response["items"][0]["id"] == workflow.id
     assert response["page"] == 1
     assert response["limit"] == 10
     assert response["has_more"] is False
 
 
-def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow = _make_workflow()
+def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
+    workflow = _make_workflow(sqlite_session)
     monkeypatch.setattr(
         workflow_module, "WorkflowService", lambda: SimpleNamespace(get_draft_workflow=lambda **_kwargs: workflow)
     )
@@ -564,12 +611,12 @@ def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.Monkey
     api = workflow_module.DraftWorkflowApi()
     handler = inspect.unwrap(api.get)
 
-    response = handler(api, app_model=SimpleNamespace(id="app"))
+    response = handler(api, app_model=_make_app())
 
     assert response["id"] == "workflow-1"
     assert response["graph"] == {"nodes": [], "edges": []}
     assert response["features"] == {"file_upload": {"enabled": False}}
-    assert response["hash"] == "hash-1"
+    assert response["hash"] == workflow.unique_hash
     assert response["created_by"] == {"id": "user-1", "name": "Alice", "email": "alice@example.com"}
     assert response["updated_by"] is None
     assert response["created_at"] == int(datetime(2024, 1, 1, 12, 0, 0).timestamp())
@@ -578,7 +625,7 @@ def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.Monkey
         {
             "id": "env-1",
             "name": "API_KEY",
-            "value": "[__HIDDEN__]",
+            "value": workflow_module.encrypter.full_mask_token(),
             "value_type": "secret",
             "description": "API key",
         }
@@ -663,12 +710,13 @@ def test_pipeline_variable_response_accepts_explicit_null_optional_fields() -> N
     assert response["allowed_file_upload_methods"] is None
 
 
-def test_workflow_response_masks_secret_environment_variables() -> None:
+def test_workflow_response_masks_secret_environment_variables(sqlite_session: Session) -> None:
     workflow = _make_workflow(
+        sqlite_session,
         environment_variables=[
             SecretVariable(id="env-secret", name="API_KEY", value="plain-token", selector=["env", "API_KEY"]),
             StringVariable(id="env-string", name="REGION", value="us-east-1", selector=["env", "REGION"]),
-        ]
+        ],
     )
 
     response = workflow_module.WorkflowResponse.model_validate(workflow, from_attributes=True).model_dump(mode="json")
@@ -691,8 +739,9 @@ def test_workflow_response_masks_secret_environment_variables() -> None:
     ]
 
 
-def test_workflow_response_preserves_llm_environment_variable_type() -> None:
+def test_workflow_response_preserves_llm_environment_variable_type(sqlite_session: Session) -> None:
     workflow = _make_workflow(
+        sqlite_session,
         environment_variables=[
             LLMEnvironmentVariable(
                 id="env-llm",
@@ -700,7 +749,7 @@ def test_workflow_response_preserves_llm_environment_variable_type() -> None:
                 value={"provider": "provider", "name": "model", "mode": "chat"},
                 selector=["env", "for_summarize"],
             )
-        ]
+        ],
     )
 
     response = workflow_module.WorkflowResponse.model_validate(workflow, from_attributes=True).model_dump(mode="json")
@@ -716,8 +765,8 @@ def test_workflow_response_preserves_llm_environment_variable_type() -> None:
     ]
 
 
-def test_workflow_response_rejects_invalid_environment_variable_dict() -> None:
-    workflow = _make_workflow(environment_variables=[{"value_type": "not-a-segment-type"}])
+def test_workflow_response_rejects_invalid_environment_variable_dict(sqlite_session: Session) -> None:
+    workflow = _make_workflow(sqlite_session, environment_variables=[{"value_type": "not-a-segment-type"}])
 
     with pytest.raises(ValidationError):
         workflow_module.WorkflowResponse.model_validate(workflow, from_attributes=True)
@@ -732,11 +781,14 @@ def test_draft_workflow_get_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     handler = inspect.unwrap(api.get)
 
     with pytest.raises(DraftWorkflowNotExist):
-        handler(api, app_model=SimpleNamespace(id="app"))
+        handler(api, app_model=_make_app())
 
 
-def test_draft_workflow_get_projects_agent_node_job_to_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_draft_workflow_get_projects_agent_node_job_to_graph(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     workflow = _make_workflow(
+        sqlite_session,
         graph_dict={
             "nodes": [
                 {
@@ -749,7 +801,7 @@ def test_draft_workflow_get_projects_agent_node_job_to_graph(monkeypatch: pytest
                 }
             ],
             "edges": [],
-        }
+        },
     )
     projected_graph = {
         "nodes": [
@@ -784,12 +836,14 @@ def test_draft_workflow_get_projects_agent_node_job_to_graph(monkeypatch: pytest
     api = workflow_module.DraftWorkflowApi()
     handler = inspect.unwrap(api.get)
 
-    response = handler(api, app_model=SimpleNamespace(id="app"))
+    response = handler(api, app_model=_make_app())
 
     assert response["graph"] == projected_graph
 
 
-def test_advanced_chat_run_conversation_not_exists(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_advanced_chat_run_conversation_not_exists(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+) -> None:
     monkeypatch.setattr(
         workflow_module.AppGenerateService,
         "generate",
@@ -807,7 +861,7 @@ def test_advanced_chat_run_conversation_not_exists(app: Flask, monkeypatch: pyte
         json={"inputs": {}},
     ):
         with pytest.raises(NotFound):
-            handler(api, Mock(), "t1", app_model=SimpleNamespace(id="app"))
+            handler(api, unbound_session, _make_account(), app_model=_make_app())
 
 
 @pytest.mark.parametrize(
@@ -831,12 +885,13 @@ def test_trigger_run_loads_draft_with_request_session(
         lambda: SimpleNamespace(get_draft_workflow=get_draft_workflow),
     )
     session = unbound_session
-    app_model = SimpleNamespace(id="app-1")
+    app_model = _make_app(app_id="app-1")
+    account = _make_account()
     handler = inspect.unwrap(resource.post)
 
     with app.test_request_context("/", method="POST", json=payload):
         with pytest.raises(ValueError, match="Workflow not found"):
-            handler(resource(), session, SimpleNamespace(id="account-1"), app_model)
+            handler(resource(), session, account, app_model)
 
     get_draft_workflow.assert_called_once_with(app_model, session=session)
 

--- a/api/tests/unit_tests/controllers/console/app/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow.py
@@ -5,13 +5,14 @@ import json
 from contextlib import contextmanager, nullcontext
 from datetime import datetime
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
 from flask import Flask
 from pydantic import ValidationError
 from sqlalchemy import Engine
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import HTTPException, NotFound
 
 from controllers.common.errors import InvalidArgumentError
@@ -21,79 +22,41 @@ from core.workflow.llm_environment_variable import LLMEnvironmentVariable
 from graphon.file import File, FileTransferMethod, FileType
 from graphon.variables import SecretVariable, StringVariable
 from graphon.variables.variables import RAGPipelineVariable
-from models import Account, App
-from models.model import AppMode
-from models.workflow import Workflow
 
 
-@pytest.fixture(autouse=True)
-def _bind_database(
-    sqlite_session_factory: sessionmaker[Session],
-    monkeypatch: pytest.MonkeyPatch,
-):
-    session_proxy = scoped_session(sqlite_session_factory)
-    monkeypatch.setattr(workflow_module.db, "session", session_proxy)
-    monkeypatch.setattr(workflow_module.encrypter, "encrypt_token", lambda tenant_id, token: token)
-    monkeypatch.setattr(workflow_module.encrypter, "decrypt_token", lambda tenant_id, token: token)
-    yield
-    session_proxy.remove()
-
-
-def _make_app(*, app_id: str = "app", tenant_id: str = "t1", workflow_id: str | None = None) -> App:
-    return App(
-        id=app_id,
-        tenant_id=tenant_id,
-        name="Workflow App",
-        mode=AppMode.WORKFLOW,
-        workflow_id=workflow_id,
-        enable_site=True,
-        enable_api=False,
-    )
-
-
-def _make_account(*, account_id: str = "account-1") -> Account:
-    account = Account(name="Alice", email="alice@example.com")
-    account.id = account_id
-    return account
-
-
-def _transient_workflow(*, features: dict | None = None, tenant_id: str = "t1") -> Workflow:
-    workflow = Workflow()
-    workflow.tenant_id = tenant_id
-    workflow._features = json.dumps(features or {})
-    return workflow
-
-
-def _make_workflow(session: Session, **overrides) -> Workflow:
-    graph = overrides.pop("graph_dict", {"nodes": [], "edges": []})
-    features = overrides.pop("features_dict", {"file_upload": {"enabled": False}})
-    environment_variables = overrides.pop(
-        "environment_variables",
-        [
-            SecretVariable(
-                id="env-1",
-                name="API_KEY",
-                value="[__HIDDEN__]",
-                selector=["env", "API_KEY"],
-                description="API key",
-            )
+def _make_workflow(**overrides):
+    workflow = SimpleNamespace(
+        id="workflow-1",
+        graph_dict={"nodes": [], "edges": []},
+        features_dict={"file_upload": {"enabled": False}},
+        unique_hash="hash-1",
+        version="1",
+        marked_name="Release 1",
+        marked_comment="Initial release",
+        created_by_account=SimpleNamespace(id="user-1", name="Alice", email="alice@example.com"),
+        created_at=datetime(2024, 1, 1, 12, 0, 0),
+        updated_by_account=None,
+        updated_at=datetime(2024, 1, 1, 12, 1, 0),
+        tool_published=False,
+        environment_variables=[
+            {
+                "id": "env-1",
+                "name": "API_KEY",
+                "value": "[__HIDDEN__]",
+                "value_type": "secret",
+                "description": "API key",
+            }
         ],
-    )
-    conversation_variables = overrides.pop(
-        "conversation_variables",
-        [
-            StringVariable(
-                id="conv-1",
-                name="topic",
-                value="hello",
-                selector=["conversation", "topic"],
-                description="Topic",
-            )
+        conversation_variables=[
+            {
+                "id": "conv-1",
+                "name": "topic",
+                "value": "hello",
+                "value_type": "string",
+                "description": "Topic",
+            }
         ],
-    )
-    rag_pipeline_variables = overrides.pop(
-        "rag_pipeline_variables",
-        [
+        rag_pipeline_variables=[
             {
                 "variable": "query",
                 "type": "text-input",
@@ -112,33 +75,8 @@ def _make_workflow(session: Session, **overrides) -> Workflow:
             }
         ],
     )
-    account = _make_account(account_id="user-1")
-    app = _make_app()
-    workflow = Workflow.new(
-        tenant_id=app.tenant_id,
-        app_id=app.id,
-        type="workflow",
-        version="1",
-        graph=json.dumps(graph),
-        features=json.dumps(features),
-        created_by=account.id,
-        environment_variables=environment_variables
-        if all(not isinstance(item, dict) for item in environment_variables)
-        else [],
-        conversation_variables=conversation_variables,
-        rag_pipeline_variables=rag_pipeline_variables,
-        marked_name="Release 1",
-        marked_comment="Initial release",
-    )
-    workflow.id = "workflow-1"
-    workflow.created_at = datetime(2024, 1, 1, 12, 0, 0)
-    workflow.updated_at = datetime(2024, 1, 1, 12, 1, 0)
-    if environment_variables and any(isinstance(item, dict) for item in environment_variables):
-        workflow._environment_variables = json.dumps({"invalid": environment_variables[0]})
     for key, value in overrides.items():
         setattr(workflow, key, value)
-    session.add_all([account, app, workflow])
-    session.commit()
     return workflow
 
 
@@ -237,9 +175,9 @@ def test_delete_workflow_retires_candidates_only_after_transaction_exit(
 
 def test_parse_file_no_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(workflow_module.FileUploadConfigManager, "convert", lambda *_args, **_kwargs: None)
-    workflow = _transient_workflow()
+    workflow = SimpleNamespace(features_dict={}, tenant_id="t1")
 
-    assert workflow_module._parse_file(workflow, files=[{"id": "f"}]) == []
+    assert workflow_module._parse_file(cast(workflow_module.Workflow, workflow), files=[{"id": "f"}]) == []
 
 
 def test_parse_file_with_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -256,8 +194,8 @@ def test_parse_file_with_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(workflow_module.FileUploadConfigManager, "convert", lambda *_args, **_kwargs: config)
     monkeypatch.setattr(workflow_module.file_factory, "build_from_mappings", build_mock)
 
-    workflow = _transient_workflow()
-    result = workflow_module._parse_file(workflow, files=[{"id": "f"}])
+    workflow = SimpleNamespace(features_dict={}, tenant_id="t1")
+    result = workflow_module._parse_file(cast(workflow_module.Workflow, workflow), files=[{"id": "f"}])
 
     assert result == file_list
     build_mock.assert_called_once()
@@ -269,7 +207,7 @@ def test_sync_draft_workflow_invalid_content_type(app: Flask, monkeypatch: pytes
 
     with app.test_request_context("/apps/app/workflows/draft", method="POST", data="x", content_type="text/html"):
         with pytest.raises(HTTPException) as exc:
-            handler(api, "t1", app_model=_make_app())
+            handler(api, "t1", app_model=SimpleNamespace(id="app"))
 
     assert exc.value.code == 415
 
@@ -284,14 +222,18 @@ def test_sync_draft_workflow_invalid_json(app: Flask, monkeypatch: pytest.Monkey
         data="[]",
         content_type="application/json",
     ):
-        response, status = handler(api, "t1", app_model=_make_app())
+        response, status = handler(api, "t1", app_model=SimpleNamespace(id="app"))
 
     assert status == 400
     assert response["message"] == "Invalid JSON data"
 
 
-def test_sync_draft_workflow_success(app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
-    workflow = _make_workflow(sqlite_session)
+def test_sync_draft_workflow_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = SimpleNamespace(
+        unique_hash="h",
+        updated_at=None,
+        created_at=datetime(2024, 1, 1),
+    )
 
     monkeypatch.setattr(
         workflow_module.variable_factory, "build_environment_variable_from_mapping", lambda *_args: "env"
@@ -312,17 +254,19 @@ def test_sync_draft_workflow_success(app: Flask, monkeypatch: pytest.MonkeyPatch
         method="POST",
         json={"graph": {}, "features": {}, "hash": "h"},
     ):
-        response = handler(api, "t1", app_model=_make_app())
+        response = handler(api, "t1", app_model=SimpleNamespace(id="app"))
 
     assert response["result"] == "success"
     assert sync_draft_workflow.call_args.kwargs["environment_variables"] == []
     assert sync_draft_workflow.call_args.kwargs["preserve_environment_variables"] is True
 
 
-def test_sync_draft_workflow_passes_environment_patch(
-    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-) -> None:
-    workflow = _make_workflow(sqlite_session)
+def test_sync_draft_workflow_passes_environment_patch(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = SimpleNamespace(
+        unique_hash="next-hash",
+        updated_at=None,
+        created_at=datetime(2024, 1, 1),
+    )
     patched_variable = StringVariable(
         id="env-model",
         name="shared_model",
@@ -364,7 +308,7 @@ def test_sync_draft_workflow_passes_environment_patch(
             },
         },
     ):
-        response = handler(api, "t1", app_model=_make_app())
+        response = handler(api, "t1", app_model=SimpleNamespace(id="app"))
 
     assert response["result"] == "success"
     assert sync_draft_workflow.call_args.kwargs["preserve_environment_variables"] is True
@@ -415,7 +359,7 @@ def test_sync_draft_workflow_hash_mismatch(app: Flask, monkeypatch: pytest.Monke
         json={"graph": {}, "features": {}, "hash": "h"},
     ):
         with pytest.raises(DraftWorkflowNotSync):
-            handler(api, "t1", app_model=_make_app())
+            handler(api, "t1", app_model=SimpleNamespace(id="app"))
 
 
 def test_sync_draft_workflow_variable_validation_error(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -436,15 +380,18 @@ def test_sync_draft_workflow_variable_validation_error(app: Flask, monkeypatch: 
         json={"graph": {}, "features": {}, "hash": "h", "conversation_variables": [{"name": "topic"}]},
     ):
         with pytest.raises(InvalidArgumentError) as exc:
-            handler(api, "t1", app_model=_make_app())
+            handler(api, "t1", app_model=SimpleNamespace(id="app"))
 
     assert exc.value.description == "description too long"
 
 
-def test_restore_published_workflow_to_draft_success(
-    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-) -> None:
-    workflow = _make_workflow(sqlite_session)
+def test_restore_published_workflow_to_draft_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = SimpleNamespace(
+        unique_hash="restored-hash",
+        updated_at=None,
+        created_at=datetime(2024, 1, 1),
+    )
+    user = SimpleNamespace(id="account-1")
 
     monkeypatch.setattr(
         workflow_module,
@@ -462,12 +409,12 @@ def test_restore_published_workflow_to_draft_success(
         response = handler(
             api,
             "t1",
-            app_model=_make_app(tenant_id="tenant-1"),
+            app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
             workflow_id="published-workflow",
         )
 
     assert response["result"] == "success"
-    assert response["hash"] == workflow.unique_hash
+    assert response["hash"] == "restored-hash"
 
 
 def test_restore_published_workflow_to_draft_not_found(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -492,7 +439,7 @@ def test_restore_published_workflow_to_draft_not_found(app: Flask, monkeypatch: 
             handler(
                 api,
                 "t1",
-                app_model=_make_app(tenant_id="tenant-1"),
+                app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
                 workflow_id="published-workflow",
             )
 
@@ -524,7 +471,7 @@ def test_restore_published_workflow_to_draft_returns_400_for_draft_source(
             handler(
                 api,
                 "t1",
-                app_model=_make_app(tenant_id="tenant-1"),
+                app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
                 workflow_id="draft-workflow",
             )
 
@@ -556,7 +503,7 @@ def test_restore_published_workflow_to_draft_returns_400_for_invalid_structure(
             handler(
                 api,
                 "t1",
-                app_model=_make_app(tenant_id="tenant-1"),
+                app_model=SimpleNamespace(id="app", tenant_id="tenant-1"),
                 workflow_id="published-workflow",
             )
 
@@ -565,22 +512,28 @@ def test_restore_published_workflow_to_draft_returns_400_for_invalid_structure(
 
 
 def test_get_published_workflows_serializes_items_before_session_closes(
-    app: Flask,
-    monkeypatch: pytest.MonkeyPatch,
-    sqlite_engine: Engine,
-    sqlite_session: Session,
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine
 ) -> None:
     api = workflow_module.PublishedAllWorkflowApi()
     handler = inspect.unwrap(api.get)
 
-    workflow = _make_workflow(sqlite_session)
+    base_workflow = _make_workflow()
+
+    class _Workflow:
+        def __init__(self, session: Session) -> None:
+            self._session = session
+
+        def __getattr__(self, name):
+            return getattr(base_workflow, name)
+
+        @property
+        def id(self):
+            assert self._session.in_transaction()
+            return "w1"
 
     def get_all_published_workflow(*, session: Session, **_kwargs):
         assert isinstance(session, Session)
-        assert session.in_transaction()
-        persisted_workflow = session.get(Workflow, workflow.id)
-        assert persisted_workflow is not None
-        return [persisted_workflow], False
+        return [_Workflow(session)], False
 
     monkeypatch.setattr(workflow_module, "db", SimpleNamespace(engine=sqlite_engine))
     monkeypatch.setattr(
@@ -594,16 +547,16 @@ def test_get_published_workflows_serializes_items_before_session_closes(
         method="GET",
         query_string={"page": 1, "limit": 10, "user_id": "", "named_only": "false"},
     ):
-        response = handler(api, "t1", app_model=_make_app(workflow_id="wf-1"))
+        response = handler(api, "t1", app_model=SimpleNamespace(id="app", workflow_id="wf-1"))
 
-    assert response["items"][0]["id"] == workflow.id
+    assert response["items"][0]["id"] == "w1"
     assert response["page"] == 1
     assert response["limit"] == 10
     assert response["has_more"] is False
 
 
-def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
-    workflow = _make_workflow(sqlite_session)
+def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = _make_workflow()
     monkeypatch.setattr(
         workflow_module, "WorkflowService", lambda: SimpleNamespace(get_draft_workflow=lambda **_kwargs: workflow)
     )
@@ -611,12 +564,12 @@ def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.Monkey
     api = workflow_module.DraftWorkflowApi()
     handler = inspect.unwrap(api.get)
 
-    response = handler(api, app_model=_make_app())
+    response = handler(api, app_model=SimpleNamespace(id="app"))
 
     assert response["id"] == "workflow-1"
     assert response["graph"] == {"nodes": [], "edges": []}
     assert response["features"] == {"file_upload": {"enabled": False}}
-    assert response["hash"] == workflow.unique_hash
+    assert response["hash"] == "hash-1"
     assert response["created_by"] == {"id": "user-1", "name": "Alice", "email": "alice@example.com"}
     assert response["updated_by"] is None
     assert response["created_at"] == int(datetime(2024, 1, 1, 12, 0, 0).timestamp())
@@ -625,7 +578,7 @@ def test_draft_workflow_get_serializes_response_model(monkeypatch: pytest.Monkey
         {
             "id": "env-1",
             "name": "API_KEY",
-            "value": workflow_module.encrypter.full_mask_token(),
+            "value": "[__HIDDEN__]",
             "value_type": "secret",
             "description": "API key",
         }
@@ -710,13 +663,12 @@ def test_pipeline_variable_response_accepts_explicit_null_optional_fields() -> N
     assert response["allowed_file_upload_methods"] is None
 
 
-def test_workflow_response_masks_secret_environment_variables(sqlite_session: Session) -> None:
+def test_workflow_response_masks_secret_environment_variables() -> None:
     workflow = _make_workflow(
-        sqlite_session,
         environment_variables=[
             SecretVariable(id="env-secret", name="API_KEY", value="plain-token", selector=["env", "API_KEY"]),
             StringVariable(id="env-string", name="REGION", value="us-east-1", selector=["env", "REGION"]),
-        ],
+        ]
     )
 
     response = workflow_module.WorkflowResponse.model_validate(workflow, from_attributes=True).model_dump(mode="json")
@@ -739,9 +691,8 @@ def test_workflow_response_masks_secret_environment_variables(sqlite_session: Se
     ]
 
 
-def test_workflow_response_preserves_llm_environment_variable_type(sqlite_session: Session) -> None:
+def test_workflow_response_preserves_llm_environment_variable_type() -> None:
     workflow = _make_workflow(
-        sqlite_session,
         environment_variables=[
             LLMEnvironmentVariable(
                 id="env-llm",
@@ -749,7 +700,7 @@ def test_workflow_response_preserves_llm_environment_variable_type(sqlite_sessio
                 value={"provider": "provider", "name": "model", "mode": "chat"},
                 selector=["env", "for_summarize"],
             )
-        ],
+        ]
     )
 
     response = workflow_module.WorkflowResponse.model_validate(workflow, from_attributes=True).model_dump(mode="json")
@@ -765,8 +716,8 @@ def test_workflow_response_preserves_llm_environment_variable_type(sqlite_sessio
     ]
 
 
-def test_workflow_response_rejects_invalid_environment_variable_dict(sqlite_session: Session) -> None:
-    workflow = _make_workflow(sqlite_session, environment_variables=[{"value_type": "not-a-segment-type"}])
+def test_workflow_response_rejects_invalid_environment_variable_dict() -> None:
+    workflow = _make_workflow(environment_variables=[{"value_type": "not-a-segment-type"}])
 
     with pytest.raises(ValidationError):
         workflow_module.WorkflowResponse.model_validate(workflow, from_attributes=True)
@@ -781,14 +732,11 @@ def test_draft_workflow_get_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     handler = inspect.unwrap(api.get)
 
     with pytest.raises(DraftWorkflowNotExist):
-        handler(api, app_model=_make_app())
+        handler(api, app_model=SimpleNamespace(id="app"))
 
 
-def test_draft_workflow_get_projects_agent_node_job_to_graph(
-    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-) -> None:
+def test_draft_workflow_get_projects_agent_node_job_to_graph(monkeypatch: pytest.MonkeyPatch) -> None:
     workflow = _make_workflow(
-        sqlite_session,
         graph_dict={
             "nodes": [
                 {
@@ -801,7 +749,7 @@ def test_draft_workflow_get_projects_agent_node_job_to_graph(
                 }
             ],
             "edges": [],
-        },
+        }
     )
     projected_graph = {
         "nodes": [
@@ -836,14 +784,12 @@ def test_draft_workflow_get_projects_agent_node_job_to_graph(
     api = workflow_module.DraftWorkflowApi()
     handler = inspect.unwrap(api.get)
 
-    response = handler(api, app_model=_make_app())
+    response = handler(api, app_model=SimpleNamespace(id="app"))
 
     assert response["graph"] == projected_graph
 
 
-def test_advanced_chat_run_conversation_not_exists(
-    app: Flask, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
-) -> None:
+def test_advanced_chat_run_conversation_not_exists(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         workflow_module.AppGenerateService,
         "generate",
@@ -861,7 +807,7 @@ def test_advanced_chat_run_conversation_not_exists(
         json={"inputs": {}},
     ):
         with pytest.raises(NotFound):
-            handler(api, unbound_session, _make_account(), app_model=_make_app())
+            handler(api, Mock(), "t1", app_model=SimpleNamespace(id="app"))
 
 
 @pytest.mark.parametrize(
@@ -885,13 +831,12 @@ def test_trigger_run_loads_draft_with_request_session(
         lambda: SimpleNamespace(get_draft_workflow=get_draft_workflow),
     )
     session = unbound_session
-    app_model = _make_app(app_id="app-1")
-    account = _make_account()
+    app_model = SimpleNamespace(id="app-1")
     handler = inspect.unwrap(resource.post)
 
     with app.test_request_context("/", method="POST", json=payload):
         with pytest.raises(ValueError, match="Workflow not found"):
-            handler(resource(), session, account, app_model)
+            handler(resource(), session, SimpleNamespace(id="account-1"), app_model)
 
     get_draft_workflow.assert_called_once_with(app_model, session=session)
 

--- a/api/tests/unit_tests/controllers/console/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/test_wraps.py
@@ -40,7 +40,7 @@ from enums import DeploymentEdition
 from libs.login import AccountWithTenant
 from machinery.context import RequestContext
 from machinery.errors import ActiveWorkspaceRequiredError, AdmissionConfigurationError
-from models import Account
+from models import Account, DifySetup
 from models.account import AccountStatus, TenantAccountRole
 from models.dataset import Dataset, RateLimitLog
 from services.entities.feature_entities import LicenseStatus
@@ -980,86 +980,91 @@ class TestCloudUtmRecord:
 class TestSystemSetup:
     """Test system setup decorator"""
 
-    @patch("controllers.console.wraps.db")
-    def test_should_allow_when_setup_complete(self, mock_db: MagicMock):
+    @staticmethod
+    def _complete_setup(session: Session) -> DifySetup:
+        setup = DifySetup(version="1.0")
+        session.add(setup)
+        session.commit()
+        return setup
+
+    def test_should_allow_when_setup_complete(self, sqlite_session: Session):
         """Test that requests are allowed when setup is complete"""
-        # Arrange
+        self._complete_setup(sqlite_session)
 
         @setup_required
         def admin_view():
             return "admin_success"
 
         # Act
-        with patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY):
+        with (
+            patch("controllers.console.wraps.db.session", sqlite_session),
+            patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
+        ):
             result = admin_view()
 
         # Assert
         assert result == "admin_success"
 
-    @patch("controllers.console.wraps.db")
-    def test_should_cache_completed_setup(self, mock_db):
+    def test_should_cache_completed_setup(self, sqlite_session: Session):
         """Test that completed setup skips repeated DB reads in this process"""
-        mock_db.session.scalar.return_value = MagicMock()
-
-        @setup_required
-        def admin_view():
-            return "admin_success"
-
-        with patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY):
-            assert admin_view() == "admin_success"
-            assert admin_view() == "admin_success"
-
-        assert mock_db.session.scalar.call_count == 1
-
-    @patch("controllers.console.wraps.db")
-    def test_should_not_cache_missing_setup(self, mock_db):
-        """Test that first-time bootstrap completion can be observed later in the same process"""
-        mock_db.session.scalar.side_effect = [None, MagicMock()]
+        setup = self._complete_setup(sqlite_session)
 
         @setup_required
         def admin_view():
             return "admin_success"
 
         with (
+            patch("controllers.console.wraps.db.session", sqlite_session),
+            patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
+        ):
+            assert admin_view() == "admin_success"
+            sqlite_session.delete(setup)
+            sqlite_session.commit()
+            assert admin_view() == "admin_success"
+
+        assert sqlite_session.get(DifySetup, "1.0") is None
+
+    def test_should_not_cache_missing_setup(self, sqlite_session: Session):
+        """Test that first-time bootstrap completion can be observed later in the same process"""
+
+        @setup_required
+        def admin_view():
+            return "admin_success"
+
+        with (
+            patch("controllers.console.wraps.db.session", sqlite_session),
             patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
             patch("controllers.console.wraps.dify_config.INIT_PASSWORD", ""),
         ):
             with pytest.raises(NotSetupError):
                 admin_view()
+            self._complete_setup(sqlite_session)
             assert admin_view() == "admin_success"
 
-        assert mock_db.session.scalar.call_count == 2
-
-    @patch("controllers.console.wraps.db")
-    def test_should_raise_not_init_validate_error_with_init_password(self, mock_db: MagicMock):
+    def test_should_raise_not_init_validate_error_with_init_password(self, sqlite_session: Session):
         """Test NotInitValidateError when INIT_PASSWORD is set but setup not complete"""
-        # Arrange
-        mock_db.session.scalar.return_value = None  # No setup
-
         @setup_required
         def admin_view():
             return "admin_success"
 
         # Act & Assert
         with (
+            patch("controllers.console.wraps.db.session", sqlite_session),
             patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
             patch("controllers.console.wraps.dify_config.INIT_PASSWORD", "some_password"),
         ):
             with pytest.raises(NotInitValidateError):
                 admin_view()
 
-    @patch("controllers.console.wraps.db")
-    def test_should_raise_not_setup_error_without_init_password(self, mock_db: MagicMock):
+    def test_should_raise_not_setup_error_without_init_password(self, sqlite_session: Session):
         """Test NotSetupError when no INIT_PASSWORD and setup not complete"""
-        # Arrange
-        mock_db.session.scalar.return_value = None  # No setup
-
         @setup_required
         def admin_view():
             return "admin_success"
 
         # Act & Assert
         with (
+            patch("controllers.console.wraps.db.session", sqlite_session),
             patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
             patch("controllers.console.wraps.dify_config.INIT_PASSWORD", ""),
         ):

--- a/api/tests/unit_tests/controllers/console/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/test_wraps.py
@@ -1043,6 +1043,7 @@ class TestSystemSetup:
 
     def test_should_raise_not_init_validate_error_with_init_password(self, sqlite_session: Session):
         """Test NotInitValidateError when INIT_PASSWORD is set but setup not complete"""
+
         @setup_required
         def admin_view():
             return "admin_success"
@@ -1058,6 +1059,7 @@ class TestSystemSetup:
 
     def test_should_raise_not_setup_error_without_init_password(self, sqlite_session: Session):
         """Test NotSetupError when no INIT_PASSWORD and setup not complete"""
+
         @setup_required
         def admin_view():
             return "admin_success"

--- a/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
+++ b/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import pytest
 from flask import Flask
 from pydantic import ValidationError
-from sqlalchemy import event, select
+from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
@@ -24,8 +24,8 @@ from controllers.inner_api.app.dsl import (
     InnerAppDSLImportPayload,
     _get_active_account,
 )
-from models import Account, App
-from models.account import AccountStatus
+from models import Account, App, Tenant, TenantAccountJoin
+from models.account import AccountStatus, TenantAccountRole
 from models.model import AppMode, IconType
 from services.app_dsl_service import Import, ImportStatus
 from services.errors.app import IsDraftWorkflowError, WorkflowNotFoundError
@@ -46,6 +46,24 @@ def _persist_app(session: Session) -> App:
     session.add(app)
     session.commit()
     return app
+
+
+def _persist_account(session: Session, *, workspace_id: str = "ws-123") -> Account:
+    account = Account(name="DSL Creator", email="user@example.com", status=AccountStatus.ACTIVE)
+    tenant = Tenant(name="DSL Workspace")
+    tenant.id = workspace_id
+    session.add_all([account, tenant])
+    session.flush()
+    session.add(
+        TenantAccountJoin(
+            tenant_id=tenant.id,
+            account_id=account.id,
+            current=True,
+            role=TenantAccountRole.OWNER,
+        )
+    )
+    session.commit()
+    return account
 
 
 class TestInnerAppDSLImportPayload:
@@ -160,9 +178,10 @@ class TestEnterpriseAppDSLImport:
 
     @pytest.mark.usefixtures("_mock_import_deps")
     @patch("controllers.inner_api.app.dsl._get_active_account")
-    def test_import_success_returns_200(self, mock_get_account, api_instance, app: Flask):
-        mock_account = MagicMock()
-        mock_get_account.return_value = mock_account
+    def test_import_success_returns_200(self, mock_get_account, api_instance, app: Flask, sqlite_session: Session):
+        account = _persist_account(sqlite_session)
+        self._transaction_events.clear()
+        mock_get_account.return_value = account
         self._mock_dsl.import_app.return_value = self._make_import_result(ImportStatus.COMPLETED)
 
         unwrapped = inspect.unwrap(api_instance.post)
@@ -177,14 +196,15 @@ class TestEnterpriseAppDSLImport:
         body, status_code = result
         assert status_code == 200
         assert body["status"] == "completed"
-        call_session = mock_account.set_tenant_id_with_session.call_args.kwargs["session"]
-        assert isinstance(call_session, Session)
+        assert account.current_tenant_id == "ws-123"
+        assert self._mock_dsl.import_app.call_args.kwargs["account"] is account
         assert self._transaction_events == ["commit"]
 
     @pytest.mark.usefixtures("_mock_import_deps")
     @patch("controllers.inner_api.app.dsl._get_active_account")
-    def test_import_pending_returns_202(self, mock_get_account, api_instance, app: Flask):
-        mock_get_account.return_value = MagicMock()
+    def test_import_pending_returns_202(self, mock_get_account, api_instance, app: Flask, sqlite_session: Session):
+        mock_get_account.return_value = _persist_account(sqlite_session)
+        self._transaction_events.clear()
         self._mock_dsl.import_app.return_value = self._make_import_result(ImportStatus.PENDING)
 
         unwrapped = inspect.unwrap(api_instance.post)
@@ -199,10 +219,9 @@ class TestEnterpriseAppDSLImport:
 
     @pytest.mark.usefixtures("_mock_import_deps")
     @patch("controllers.inner_api.app.dsl._get_active_account")
-    def test_import_failed_returns_400(self, mock_get_account, api_instance, app: Flask):
-        mock_account = MagicMock()
-        mock_account.set_tenant_id_with_session.side_effect = lambda _tenant_id, *, session: session.execute(select(1))
-        mock_get_account.return_value = mock_account
+    def test_import_failed_returns_400(self, mock_get_account, api_instance, app: Flask, sqlite_session: Session):
+        mock_get_account.return_value = _persist_account(sqlite_session)
+        self._transaction_events.clear()
         self._mock_dsl.import_app.return_value = self._make_import_result(ImportStatus.FAILED)
 
         unwrapped = inspect.unwrap(api_instance.post)

--- a/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
@@ -8,11 +8,12 @@ handler tests use inspect.unwrap() to bypass them and focus on business logic.
 
 import inspect
 from datetime import datetime
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from flask import Flask
 from pydantic import ValidationError
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from controllers.inner_api.workspace.workspace import (
     EnterpriseWorkspace,
@@ -20,7 +21,16 @@ from controllers.inner_api.workspace.workspace import (
     WorkspaceCreatePayload,
     WorkspaceOwnerlessPayload,
 )
+from models import Account, Tenant
 from models.account import TenantStatus
+
+
+@pytest.fixture
+def database_session(sqlite_session_factory: sessionmaker[Session]):
+    session_proxy = scoped_session(sqlite_session_factory)
+    with patch("controllers.inner_api.workspace.workspace.db.session", session_proxy):
+        yield session_proxy
+    session_proxy.remove()
 
 
 class TestWorkspaceCreatePayload:
@@ -85,23 +95,21 @@ class TestEnterpriseWorkspace:
         assert callable(api_instance.post)
 
     @patch("controllers.inner_api.workspace.workspace.TenantService")
-    @patch("controllers.inner_api.workspace.workspace.db")
-    def test_post_creates_workspace_with_owner(self, mock_db, mock_tenant_svc, api_instance, app: Flask):
+    def test_post_creates_workspace_with_owner(
+        self, mock_tenant_svc, api_instance, app: Flask, sqlite_session: Session, database_session
+    ):
         """Test that post() creates a workspace and assigns the owner account"""
         # Arrange
-        mock_account = MagicMock()
-        mock_account.email = "owner@example.com"
-        mock_db.session.scalar.return_value = mock_account
+        account = Account(name="Owner", email="owner@example.com")
+        sqlite_session.add(account)
+        sqlite_session.commit()
 
         now = datetime(2025, 1, 1, 12, 0, 0)
-        mock_tenant = MagicMock()
-        mock_tenant.id = "tenant-id"
-        mock_tenant.name = "My Workspace"
-        mock_tenant.plan = "sandbox"
-        mock_tenant.status = TenantStatus.NORMAL
-        mock_tenant.created_at = now
-        mock_tenant.updated_at = now
-        mock_tenant_svc.create_owner_tenant.return_value = mock_tenant
+        tenant = Tenant(name="My Workspace", plan="sandbox", status=TenantStatus.NORMAL)
+        tenant.id = "tenant-id"
+        tenant.created_at = now
+        tenant.updated_at = now
+        mock_tenant_svc.create_owner_tenant.return_value = tenant
 
         # Act — unwrap to bypass auth/setup decorators (tested in test_auth_wraps.py)
         unwrapped_post = inspect.unwrap(api_instance.post)
@@ -114,19 +122,18 @@ class TestEnterpriseWorkspace:
         assert result["message"] == "enterprise workspace created."
         assert result["tenant"]["id"] == "tenant-id"
         assert result["tenant"]["name"] == "My Workspace"
-        mock_tenant_svc.create_owner_tenant.assert_called_once_with(
-            mock_account,
-            name="My Workspace",
-            is_from_dashboard=True,
-            session=ANY,
-        )
+        mock_tenant_svc.create_owner_tenant.assert_called_once()
+        call_args = mock_tenant_svc.create_owner_tenant.call_args
+        assert call_args.args[0].id == account.id
+        assert call_args.kwargs == {
+            "name": "My Workspace",
+            "is_from_dashboard": True,
+            "session": database_session(),
+        }
 
-    @patch("controllers.inner_api.workspace.workspace.db")
-    def test_post_returns_404_when_owner_not_found(self, mock_db, api_instance, app: Flask):
+    @pytest.mark.usefixtures("database_session")
+    def test_post_returns_404_when_owner_not_found(self, api_instance, app: Flask):
         """Test that post() returns 404 when the owner account does not exist"""
-        # Arrange
-        mock_db.session.scalar.return_value = None
-
         # Act
         unwrapped_post = inspect.unwrap(api_instance.post)
         with app.test_request_context():
@@ -156,20 +163,22 @@ class TestEnterpriseWorkspaceNoOwnerEmail:
 
     @patch("controllers.inner_api.workspace.workspace.tenant_was_created")
     @patch("controllers.inner_api.workspace.workspace.TenantService")
-    def test_post_creates_ownerless_workspace(self, mock_tenant_svc, mock_event, api_instance, app: Flask):
+    def test_post_creates_ownerless_workspace(
+        self, mock_tenant_svc, mock_event, api_instance, app: Flask, database_session
+    ):
         """Test that post() creates a workspace without an owner and returns expected fields"""
         # Arrange
         now = datetime(2025, 1, 1, 12, 0, 0)
-        mock_tenant = MagicMock()
-        mock_tenant.id = "tenant-id"
-        mock_tenant.name = "My Workspace"
-        mock_tenant.encrypt_public_key = "pub-key"
-        mock_tenant.plan = "sandbox"
-        mock_tenant.status = TenantStatus.NORMAL
-        mock_tenant.custom_config = None
-        mock_tenant.created_at = now
-        mock_tenant.updated_at = now
-        mock_tenant_svc.create_tenant.return_value = mock_tenant
+        tenant = Tenant(
+            name="My Workspace",
+            encrypt_public_key="pub-key",
+            plan="sandbox",
+            status=TenantStatus.NORMAL,
+        )
+        tenant.id = "tenant-id"
+        tenant.created_at = now
+        tenant.updated_at = now
+        mock_tenant_svc.create_tenant.return_value = tenant
 
         # Act — unwrap to bypass auth/setup decorators (tested in test_auth_wraps.py)
         unwrapped_post = inspect.unwrap(api_instance.post)
@@ -183,5 +192,7 @@ class TestEnterpriseWorkspaceNoOwnerEmail:
         assert result["tenant"]["id"] == "tenant-id"
         assert result["tenant"]["encrypt_public_key"] == "pub-key"
         assert result["tenant"]["custom_config"] == {}
-        mock_tenant_svc.create_tenant.assert_called_once_with("My Workspace", is_from_dashboard=True, session=ANY)
-        mock_event.send.assert_called_once_with(mock_tenant)
+        mock_tenant_svc.create_tenant.assert_called_once_with(
+            "My Workspace", is_from_dashboard=True, session=database_session()
+        )
+        mock_event.send.assert_called_once_with(tenant)

--- a/api/tests/unit_tests/controllers/service_api/dataset/rag_pipeline/test_rag_pipeline_workflow.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/rag_pipeline/test_rag_pipeline_workflow.py
@@ -13,18 +13,19 @@ Strategy:
 - Endpoint methods on these resources have no billing decorators on the method
   itself.  ``method_decorators = [validate_dataset_token]`` is only invoked by
   Flask-RESTx dispatch, not by direct calls, so we call methods directly.
-- Only ``KnowledgebasePipelineFileUploadApi.post`` touches ``db`` inline
-  (via ``FileService(db.engine)``); the other endpoints delegate to services.
+- Dataset ownership checks run against the shared SQLite fixture; pipeline and
+  upload responses use real mapped instances while external services stay mocked.
 """
 
 import io
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 from flask import Flask
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import Forbidden, NotFound
 
@@ -37,6 +38,7 @@ from controllers.common.errors import (
     FileTooLargeError as FileTooLargeHTTPError,
 )
 from controllers.service_api.dataset.error import PipelineRunError
+from controllers.service_api.dataset.rag_pipeline import rag_pipeline_workflow as workflow_module
 from controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow import (
     DatasourceNodeRunApi,
     DatasourceNodeRunPayload,
@@ -45,8 +47,11 @@ from controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow import (
     PipelineRunApi,
 )
 from core.app.entities.app_invoke_entities import InvokeFrom
+from extensions.storage.storage_type import StorageType
 from models.account import Account
-from models.dataset import Dataset
+from models.dataset import Dataset, Pipeline
+from models.enums import CreatorUserRole
+from models.model import UploadFile
 from services.errors.file import FileTooLargeError as FileTooLargeServiceError
 from services.errors.file import UnsupportedFileTypeError
 from services.rag_pipeline.entity.pipeline_service_api_entities import (
@@ -68,6 +73,21 @@ def _persist_dataset(session: Session, *, tenant_id: str, dataset_id: str) -> Da
     session.add(dataset)
     session.commit()
     return dataset
+
+
+def _persist_pipeline(session: Session, *, tenant_id: str) -> Pipeline:
+    pipeline = Pipeline(tenant_id=tenant_id, name="Knowledge pipeline")
+    session.add(pipeline)
+    session.commit()
+    return pipeline
+
+
+@pytest.fixture(autouse=True)
+def _bind_database(sqlite_session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch):
+    session_proxy = scoped_session(sqlite_session_factory)
+    monkeypatch.setattr(workflow_module.db, "session", session_proxy)
+    yield
+    session_proxy.remove()
 
 
 class TestDatasourceNodeRunPayload:
@@ -398,15 +418,13 @@ class TestDatasourcePluginsApiGet:
     an inline dataset query, so no ``db`` patching is needed.
     """
 
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.RagPipelineService")
-    def test_get_plugins_success(self, mock_svc_cls, mock_db, app: Flask):
+    def test_get_plugins_success(self, mock_svc_cls, app: Flask, sqlite_session: Session):
         """Test successful retrieval of datasource plugins."""
         tenant_id = str(uuid.uuid4())
         dataset_id = str(uuid.uuid4())
 
-        mock_dataset = Mock()
-        mock_db.session.scalar.return_value = mock_dataset
+        _persist_dataset(sqlite_session, tenant_id=tenant_id, dataset_id=dataset_id)
 
         datasource_plugins = [
             {
@@ -433,14 +451,13 @@ class TestDatasourcePluginsApiGet:
             tenant_id=tenant_id, dataset_id=dataset_id, is_published=True
         )
 
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.RagPipelineService")
-    def test_get_plugins_parses_false_is_published_query(self, mock_svc_cls, mock_db, app: Flask):
+    def test_get_plugins_parses_false_is_published_query(self, mock_svc_cls, app: Flask, sqlite_session: Session):
         """Test false query string is parsed as boolean False."""
         tenant_id = str(uuid.uuid4())
         dataset_id = str(uuid.uuid4())
 
-        mock_db.session.scalar.return_value = Mock()
+        _persist_dataset(sqlite_session, tenant_id=tenant_id, dataset_id=dataset_id)
         mock_svc_instance = Mock()
         mock_svc_instance.get_datasource_plugins.return_value = []
         mock_svc_cls.return_value = mock_svc_instance
@@ -455,28 +472,30 @@ class TestDatasourcePluginsApiGet:
             tenant_id=tenant_id, dataset_id=dataset_id, is_published=False
         )
 
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
-    def test_get_plugins_not_found(self, mock_db, app: Flask):
+    def test_get_plugins_not_found(self, app: Flask, sqlite_session: Session):
         """Test NotFound when dataset check fails."""
-        mock_db.session.scalar.return_value = None
+        tenant_id = str(uuid.uuid4())
+        dataset_id = str(uuid.uuid4())
+        _persist_dataset(sqlite_session, tenant_id="other-tenant", dataset_id=dataset_id)
 
         with app.test_request_context("/datasets/test/pipeline/datasource-plugins"):
             api = DatasourcePluginsApi()
             with pytest.raises(NotFound):
-                api.get(tenant_id=str(uuid.uuid4()), dataset_id=str(uuid.uuid4()))
+                api.get(tenant_id=tenant_id, dataset_id=dataset_id)
 
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.RagPipelineService")
-    def test_get_plugins_empty_list(self, mock_svc_cls, mock_db, app: Flask):
+    def test_get_plugins_empty_list(self, mock_svc_cls, app: Flask, sqlite_session: Session):
         """Test empty plugin list."""
-        mock_db.session.scalar.return_value = Mock()
+        tenant_id = str(uuid.uuid4())
+        dataset_id = str(uuid.uuid4())
+        _persist_dataset(sqlite_session, tenant_id=tenant_id, dataset_id=dataset_id)
         mock_svc_instance = Mock()
         mock_svc_instance.get_datasource_plugins.return_value = []
         mock_svc_cls.return_value = mock_svc_instance
 
         with app.test_request_context("/datasets/test/pipeline/datasource-plugins"):
             api = DatasourcePluginsApi()
-            response, status = api.get(tenant_id=str(uuid.uuid4()), dataset_id=str(uuid.uuid4()))
+            response, status = api.get(tenant_id=tenant_id, dataset_id=dataset_id)
 
         assert status == 200
         assert response == []
@@ -497,15 +516,23 @@ class TestDatasourceNodeRunApiPost:
         new_callable=lambda: Account(name="Test Account", email="test@example.com"),
     )
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.RagPipelineService")
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.service_api_ns")
-    def test_post_success(self, mock_ns, mock_db, mock_svc_cls, mock_current_user, mock_gen, mock_helper, app: Flask):
+    def test_post_success(
+        self,
+        mock_ns,
+        mock_svc_cls,
+        current_account,
+        mock_gen,
+        mock_helper,
+        app: Flask,
+        sqlite_session: Session,
+    ):
         """Test successful datasource node run."""
         tenant_id = str(uuid.uuid4())
         dataset_id = str(uuid.uuid4())
         node_id = "node_abc"
 
-        mock_db.session.scalar.return_value = Mock()
+        _persist_dataset(sqlite_session, tenant_id=tenant_id, dataset_id=dataset_id)
 
         mock_ns.payload = {
             "inputs": {"url": "https://example.com"},
@@ -513,10 +540,9 @@ class TestDatasourceNodeRunApiPost:
             "is_published": True,
         }
 
-        mock_pipeline = Mock()
-        mock_pipeline.id = str(uuid.uuid4())
+        pipeline = _persist_pipeline(sqlite_session, tenant_id=tenant_id)
         mock_svc_instance = Mock()
-        mock_svc_instance.get_pipeline.return_value = mock_pipeline
+        mock_svc_instance.get_pipeline.return_value = pipeline
         mock_svc_instance.run_datasource_workflow_node.return_value = iter(["event1"])
         mock_svc_cls.return_value = mock_svc_instance
 
@@ -532,10 +558,8 @@ class TestDatasourceNodeRunApiPost:
         mock_svc_instance.get_pipeline.assert_called_once_with(tenant_id=tenant_id, dataset_id=dataset_id)
         mock_svc_instance.run_datasource_workflow_node.assert_called_once()
 
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
-    def test_post_not_found(self, mock_db, app: Flask):
+    def test_post_not_found(self, app: Flask, sqlite_session: Session):
         """Test NotFound when dataset check fails."""
-        mock_db.session.scalar.return_value = None
 
         with app.test_request_context("/datasets/test/pipeline/datasource/nodes/n1/run", method="POST"):
             api = DatasourceNodeRunApi()
@@ -546,11 +570,12 @@ class TestDatasourceNodeRunApiPost:
         "controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.current_user",
         new="not_account",
     )
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.service_api_ns")
-    def test_post_fails_when_current_user_not_account(self, mock_ns, mock_db, app: Flask):
+    def test_post_fails_when_current_user_not_account(self, mock_ns, app: Flask, sqlite_session: Session):
         """Test AssertionError when current_user is not an Account instance."""
-        mock_db.session.scalar.return_value = Mock()
+        tenant_id = str(uuid.uuid4())
+        dataset_id = str(uuid.uuid4())
+        _persist_dataset(sqlite_session, tenant_id=tenant_id, dataset_id=dataset_id)
         mock_ns.payload = {
             "inputs": {},
             "datasource_type": "local_file",
@@ -560,7 +585,7 @@ class TestDatasourceNodeRunApiPost:
         with app.test_request_context("/datasets/test/pipeline/datasource/nodes/n1/run", method="POST"):
             api = DatasourceNodeRunApi()
             with pytest.raises(AssertionError):
-                api.post(tenant_id=str(uuid.uuid4()), dataset_id=str(uuid.uuid4()), node_id="n1")
+                api.post(tenant_id=tenant_id, dataset_id=dataset_id, node_id="n1")
 
 
 class TestPipelineRunApiPost:
@@ -592,9 +617,9 @@ class TestPipelineRunApiPost:
             "response_mode": "streaming",
         }
 
-        mock_pipeline = Mock()
+        pipeline = _persist_pipeline(sqlite_session, tenant_id=tenant_id)
         mock_svc_instance = Mock()
-        mock_svc_instance.get_pipeline.return_value = mock_pipeline
+        mock_svc_instance.get_pipeline.return_value = pipeline
         mock_svc_cls.return_value = mock_svc_instance
 
         mock_gen_svc.generate.return_value = {"result": "ok"}
@@ -651,23 +676,29 @@ class TestFileUploadApiPost:
     """Tests for KnowledgebasePipelineFileUploadApi.post()."""
 
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.FileService")
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.current_user")
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
-    def test_upload_success(self, mock_db, mock_current_user, mock_file_svc_cls, app: Flask):
+    @patch(
+        "controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.current_user",
+        new_callable=lambda: Account(name="Upload User", email="upload@example.com"),
+    )
+    def test_upload_success(self, current_account, mock_file_svc_cls, app: Flask, sqlite_engine):
         """Test successful file upload."""
-        mock_current_user.__bool__ = Mock(return_value=True)
-
-        mock_upload = Mock()
-        mock_upload.id = str(uuid.uuid4())
-        mock_upload.name = "doc.pdf"
-        mock_upload.size = 1024
-        mock_upload.extension = "pdf"
-        mock_upload.mime_type = "application/pdf"
-        mock_upload.created_by = str(uuid.uuid4())
-        mock_upload.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+        current_account.id = str(uuid.uuid4())
+        upload = UploadFile(
+            tenant_id=str(uuid.uuid4()),
+            storage_type=StorageType.LOCAL,
+            key="pipeline/doc.pdf",
+            name="doc.pdf",
+            size=1024,
+            extension="pdf",
+            mime_type="application/pdf",
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by=current_account.id,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            used=False,
+        )
 
         mock_file_svc_instance = Mock()
-        mock_file_svc_instance.upload_file.return_value = mock_upload
+        mock_file_svc_instance.upload_file.return_value = upload
         mock_file_svc_cls.return_value = mock_file_svc_instance
 
         file_data = FileStorage(
@@ -676,14 +707,16 @@ class TestFileUploadApiPost:
             content_type="application/pdf",
         )
 
-        with app.test_request_context(
-            "/datasets/pipeline/file-upload",
-            method="POST",
-            content_type="multipart/form-data",
-            data={"file": file_data},
+        with (
+            patch.object(workflow_module, "db", SimpleNamespace(engine=sqlite_engine)),
+            app.test_request_context(
+                "/datasets/pipeline/file-upload",
+                method="POST",
+                content_type="multipart/form-data",
+                data={"file": file_data},
+            ),
         ):
-            api = KnowledgebasePipelineFileUploadApi()
-            response, status = api.post(tenant_id=str(uuid.uuid4()))
+            response, status = KnowledgebasePipelineFileUploadApi().post(tenant_id=str(uuid.uuid4()))
 
         assert status == 201
         assert response["name"] == "doc.pdf"
@@ -695,12 +728,13 @@ class TestFileUploadApiPost:
         return_value=15,
     )
     @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.FileService")
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.current_user")
-    @patch("controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.db")
+    @patch(
+        "controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow.current_user",
+        new_callable=lambda: Account(name="Upload User", email="upload@example.com"),
+    )
     def test_upload_file_too_large_returns_http_413(
-        self, mock_db, mock_current_user, mock_file_svc_cls, mock_get_limit, app: Flask
+        self, current_account, mock_file_svc_cls, mock_get_limit, app: Flask, sqlite_engine
     ):
-        mock_current_user.__bool__ = Mock(return_value=True)
         mock_file_svc_cls.return_value.upload_file.side_effect = FileTooLargeServiceError()
         file_data = FileStorage(
             stream=io.BytesIO(b"oversized content"),
@@ -708,11 +742,14 @@ class TestFileUploadApiPost:
             content_type="application/pdf",
         )
 
-        with app.test_request_context(
-            "/datasets/pipeline/file-upload",
-            method="POST",
-            content_type="multipart/form-data",
-            data={"file": file_data},
+        with (
+            patch.object(workflow_module, "db", SimpleNamespace(engine=sqlite_engine)),
+            app.test_request_context(
+                "/datasets/pipeline/file-upload",
+                method="POST",
+                content_type="multipart/form-data",
+                data={"file": file_data},
+            ),
         ):
             with pytest.raises(FileTooLargeHTTPError) as exc_info:
                 KnowledgebasePipelineFileUploadApi().post(tenant_id="tenant-1")

--- a/api/tests/unit_tests/extensions/test_ext_login.py
+++ b/api/tests/unit_tests/extensions/test_ext_login.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from flask import Flask, Response, request
+from sqlalchemy.orm import Session
 
 from constants import COOKIE_NAME_ACCESS_TOKEN
 from core.logging.context import clear_request_context, get_identity_context
@@ -87,19 +88,22 @@ def test_on_user_logged_in_logs_unsupported_user_type(caplog: pytest.LogCaptureF
     assert "Failed to set logging identity context" in caplog.text
 
 
-def test_admin_api_key_header_takes_precedence_over_console_cookie(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_admin_api_key_header_takes_precedence_over_console_cookie(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     app = Flask(__name__)
-    session = mock.Mock(spec=ext_login.Session)
     tenant = ext_login.Tenant(name="Test Tenant")
-    tenant_account_join = ext_login.TenantAccountJoin(
-        tenant_id="tenant-id",
-        account_id="account-id",
-        role=TenantAccountRole.NORMAL,
-    )
+    tenant.id = "workspace-id"
     account = ext_login.Account(name="Test Account", email="test@example.com")
-    session.execute.return_value.one_or_none.return_value = (tenant, tenant_account_join)
-    session.scalar.side_effect = [account, tenant_account_join]
-    session.scalars.return_value.one.return_value = tenant
+    sqlite_session.add_all([tenant, account])
+    sqlite_session.flush()
+    tenant_account_join = ext_login.TenantAccountJoin(
+        tenant_id=tenant.id,
+        account_id=account.id,
+        role=TenantAccountRole.OWNER,
+    )
+    sqlite_session.add(tenant_account_join)
+    sqlite_session.commit()
     monkeypatch.setattr(ext_login.dify_config, "ADMIN_API_KEY_ENABLE", True)
     monkeypatch.setattr(ext_login.dify_config, "ADMIN_API_KEY", "admin-key")
     monkeypatch.setattr(ext_login.dify_config, "CONSOLE_WEB_URL", "http://console.example.com")
@@ -114,7 +118,7 @@ def test_admin_api_key_header_takes_precedence_over_console_cookie(monkeypatch: 
             "X-WORKSPACE-ID": "workspace-id",
         },
     ):
-        result = ext_login._load_user_from_request(request, session)
+        result = ext_login._load_user_from_request(request, sqlite_session)
 
     assert result is account
     assert account.current_tenant is tenant


### PR DESCRIPTION
## Summary

- replace residual controller SQLAlchemy session doubles with SQLite sessions and engines
- replace mapped Agent, Account, Tenant, DifySetup, Dataset, Pipeline, Site, EndUser, UploadFile, and related stand-ins with real ORM instances
- cover agent-management scoping, setup/bootstrap, inner API workspace/DSL ownership, Service API dataset scoping, web site resolution, and admin-key login against real persistence
- keep workflow controller coverage in its dedicated workflow PR to avoid overlapping files

## Real persistence coverage

- active and archived roster Agent bindings plus hidden workflow-only backing Apps
- successful setup caching after row deletion and initial setup miss followed by persisted bootstrap
- account/tenant membership resolution for inner API DSL/workspace and admin API-key login
- tenant-scoped Dataset reads with cross-tenant decoys, persisted Pipeline IDs, Site/EndUser resolution, and real UploadFile response serialization

No production changes.

## Size

370 additions, 221 deletions (591 changed lines) across seven test modules.

## Validation

- targeted run covering all current modules (executed before the overlapping workflow module was removed) — 179 passed
- direct focused run of the same target set — 179 passed
- `make lint` — passed
- `make type-check` — blocked by the existing mypy 1.20.2 internal error at `api/.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- AST/text audit — no mocked SQLAlchemy sessions/factories and no mapped ORM stand-ins remain in the changed modules

The full test suite was not run, per request.
