### PR TITLE
test: migrate core service residuals sessions and ORM models to SQLite

### DIFF
--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -173,6 +173,9 @@ class DifyTestContainers:
         self.dify_sandbox.waiting_for(_wait_for_log_message("config init success", 60))
         self.dify_sandbox.env = {
             "API_KEY": "test_api_key",
+            # Match Docker Compose: the image's 5-second limit can expire during
+            # Python/Jinja2 startup under parallel CI load.
+            "WORKER_TIMEOUT": "15",
         }
         self.dify_sandbox.start()
         sandbox_host = self.dify_sandbox.get_container_host_ip()

--- a/api/tests/unit_tests/conftest.py
+++ b/api/tests/unit_tests/conftest.py
@@ -242,20 +242,3 @@ def persist_service_api_dataset_owner(
     """Persist the tenant-owner mapping resolved by dataset-token authentication."""
     session.add_all([tenant, tenant_account_join])
     session.commit()
-
-
-def setup_mock_tenant_owner_execute_result(mock_db: MagicMock, mock_tenant: object, mock_owner: object) -> None:
-    """Stub the legacy owner query; SQLite-backed tests use ``persist_service_api_tenant_owner``."""
-    mock_db.session.execute.return_value.one_or_none.return_value = (mock_tenant, mock_owner)
-
-
-def setup_mock_dataset_owner_execute_result(
-    mock_db: MagicMock,
-    mock_tenant: object,
-    mock_tenant_account_join: object,
-) -> None:
-    """Stub the legacy dataset-owner query; SQLite tests use ``persist_service_api_dataset_owner``."""
-    mock_db.session.execute.return_value.one_or_none.return_value = (
-        mock_tenant,
-        mock_tenant_account_join,
-    )

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import nullcontext
 from datetime import datetime
 from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from core.app.apps.advanced_chat import generate_task_pipeline as pipeline_module
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -21,7 +23,7 @@ from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
 from graphon.enums import WorkflowExecutionStatus
 from models.enums import MessageStatus
 from models.execution_extra_content import HumanInputContent
-from models.model import AppMode, EndUser
+from models.model import AppMode, EndUser, Message
 
 
 def _build_pipeline() -> pipeline_module.AdvancedChatAppGenerateTaskPipeline:
@@ -51,77 +53,58 @@ def test_process_passes_message_id_to_conversation_name_generation() -> None:
     )
 
 
-def test_persist_human_input_extra_content_adds_record(monkeypatch: pytest.MonkeyPatch) -> None:
+def _message(*, status: MessageStatus, answer: str = "") -> Message:
+    return Message(
+        id="message-1",
+        status=status,
+        answer=answer,
+        invoke_from=InvokeFrom.WEB_APP,
+        from_end_user_id="user-1",
+    )
+
+
+def test_persist_human_input_extra_content_adds_record(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     pipeline = _build_pipeline()
     monkeypatch.setattr(pipeline, "_load_human_input_form_id", lambda **kwargs: "form-1")
 
-    captured_session: dict[str, mock.Mock] = {}
-
-    @contextmanager
-    def fake_session():
-        session = mock.Mock()
-        session.scalar.return_value = None
-        captured_session["session"] = session
-        yield session
-
-    pipeline._database_session = fake_session  # type: ignore[method-assign]
-
     pipeline._persist_human_input_extra_content(node_id="node-1")
 
-    session = captured_session["session"]
-    session.add.assert_called_once()
-    content = session.add.call_args.args[0]
-    assert isinstance(content, HumanInputContent)
+    content = sqlite_session.scalar(select(HumanInputContent))
+    assert content is not None
     assert content.workflow_run_id == "run-1"
     assert content.message_id == "message-1"
     assert content.form_id == "form-1"
 
 
-def test_persist_human_input_extra_content_skips_when_form_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_persist_human_input_extra_content_skips_when_form_missing(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     pipeline = _build_pipeline()
     monkeypatch.setattr(pipeline, "_load_human_input_form_id", lambda **kwargs: None)
 
-    called = {"value": False}
-
-    @contextmanager
-    def fake_session():
-        called["value"] = True
-        session = mock.Mock()
-        yield session
-
-    pipeline._database_session = fake_session  # type: ignore[method-assign]
-
     pipeline._persist_human_input_extra_content(node_id="node-1")
 
-    assert called["value"] is False
+    assert sqlite_session.scalar(select(HumanInputContent)) is None
 
 
-def test_persist_human_input_extra_content_skips_when_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_persist_human_input_extra_content_skips_when_existing(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     pipeline = _build_pipeline()
     monkeypatch.setattr(pipeline, "_load_human_input_form_id", lambda **kwargs: "form-1")
-
-    captured_session: dict[str, mock.Mock] = {}
-
-    @contextmanager
-    def fake_session():
-        session = mock.Mock()
-        session.scalar.return_value = HumanInputContent(
-            workflow_run_id="run-1",
-            message_id="message-1",
-            form_id="form-1",
-        )
-        captured_session["session"] = session
-        yield session
-
-    pipeline._database_session = fake_session  # type: ignore[method-assign]
+    existing = HumanInputContent.new(workflow_run_id="run-1", message_id="message-1", form_id="form-1")
+    sqlite_session.add(existing)
+    sqlite_session.commit()
 
     pipeline._persist_human_input_extra_content(node_id="node-1")
 
-    session = captured_session["session"]
-    session.add.assert_not_called()
+    contents = list(sqlite_session.scalars(select(HumanInputContent)))
+    assert [content.id for content in contents] == [existing.id]
 
 
-def test_handle_workflow_paused_event_persists_human_input_extra_content() -> None:
+def test_handle_workflow_paused_event_persists_human_input_extra_content(unbound_session: Session) -> None:
     pipeline = _build_pipeline()
     pipeline._application_generate_entity = SimpleNamespace(task_id="task-1")
     pipeline._workflow_response_converter = mock.Mock()
@@ -133,19 +116,14 @@ def test_handle_workflow_paused_event_persists_human_input_extra_content() -> No
         ),
     )
     pipeline._save_message = mock.Mock()
-    message = SimpleNamespace(status=MessageStatus.NORMAL)
+    message = _message(status=MessageStatus.NORMAL)
     pipeline._get_message = mock.Mock(return_value=message)
     pipeline._persist_human_input_extra_content = mock.Mock()
     pipeline._base_task_pipeline = mock.Mock()
     pipeline._base_task_pipeline.queue_manager = mock.Mock()
     pipeline._message_saved_on_pause = False
 
-    @contextmanager
-    def fake_session():
-        session = mock.Mock()
-        yield session
-
-    pipeline._database_session = fake_session  # type: ignore[method-assign]
+    pipeline._database_session = lambda: nullcontext(unbound_session)  # type: ignore[method-assign]
 
     reason = HumanInputRequired(
         form_id="form-1",
@@ -164,7 +142,7 @@ def test_handle_workflow_paused_event_persists_human_input_extra_content() -> No
     assert message.status == MessageStatus.PAUSED
 
 
-def test_resume_appends_chunks_to_paused_answer() -> None:
+def test_resume_appends_chunks_to_paused_answer(unbound_session: Session) -> None:
     app_config = SimpleNamespace(app_id="app-1", tenant_id="tenant-1", sensitive_word_avoidance=None)
     application_generate_entity = SimpleNamespace(
         app_config=app_config,
@@ -203,30 +181,12 @@ def test_resume_appends_chunks_to_paused_answer() -> None:
         draft_var_saver_factory=SimpleNamespace(),
     )
 
-    stored_message = SimpleNamespace(
-        id="message-1",
-        answer="before",
-        status=MessageStatus.PAUSED,
-        updated_at=None,
-        provider_response_latency=0,
-        message_tokens=0,
-        message_unit_price=0,
-        message_price_unit=0,
-        answer_tokens=0,
-        answer_unit_price=0,
-        answer_price_unit=0,
-        total_price=0,
-        currency="USD",
-        message_metadata=None,
-        invoke_from=InvokeFrom.WEB_APP,
-        from_account_id=None,
-        from_end_user_id="user-1",
-    )
+    stored_message = _message(status=MessageStatus.PAUSED, answer="before")
     pipeline._get_message = mock.Mock(return_value=stored_message)
     pipeline._recorded_files = []
 
     list(pipeline._handle_text_chunk_event(QueueTextChunkEvent(text="after")))
-    pipeline._save_message(session=mock.Mock())
+    pipeline._save_message(session=unbound_session)
 
     assert stored_message.answer == "beforeafter"
     assert stored_message.status == MessageStatus.NORMAL

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -493,7 +493,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         pipeline._base_task_pipeline.queue_manager.publish = lambda *args, **kwargs: None
         pipeline._base_task_pipeline.handle_error = lambda **kwargs: ValueError("boom")
         pipeline._base_task_pipeline.error_to_stream_response = lambda err: err
-        pipeline._get_message = lambda **kwargs: SimpleNamespace(id="message-id")
+        pipeline._get_message = lambda **kwargs: Message(id="message-id")
 
         succeeded_responses = list(pipeline._handle_workflow_succeeded_event(QueueWorkflowSucceededEvent(outputs={})))
         assert len(succeeded_responses) == 2
@@ -587,7 +587,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         assert result is False
         assert seen == ["token"]
 
-    def test_handle_retriever_and_annotation_events(self, monkeypatch: pytest.MonkeyPatch):
+    def test_handle_retriever_and_annotation_events(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
         pipeline = _make_pipeline()
         calls = {"retriever": 0, "annotation": 0}
 
@@ -603,11 +603,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         retriever_event = QueueRetrieverResourcesEvent(retriever_resources=[])
         annotation_event = QueueAnnotationReplyEvent(message_annotation_id="ann")
 
-        @contextmanager
-        def _fake_session():
-            yield SimpleNamespace()
-
-        monkeypatch.setattr(pipeline, "_database_session", _fake_session)
+        monkeypatch.setattr(pipeline, "_database_session", lambda: nullcontext(unbound_session))
 
         assert list(pipeline._handle_retriever_resources_event(retriever_event)) == []
         assert list(pipeline._handle_annotation_reply_event(annotation_event)) == []

--- a/api/tests/unit_tests/core/mcp/test_mcp_client.py
+++ b/api/tests/unit_tests/core/mcp/test_mcp_client.py
@@ -1,10 +1,12 @@
 """Unit tests for MCP client."""
 
 from contextlib import ExitStack
-from types import TracebackType
+from types import SimpleNamespace, TracebackType
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from sqlalchemy import event, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
 from core.entities.mcp_provider import MCPProviderEntity
@@ -482,14 +484,16 @@ class TestMCPClientWithAuthRetry:
         assert client.by_server_id is True
         assert client._has_retried is False
 
-    @patch("core.mcp.auth_client.db")
-    @patch("core.mcp.auth_client.Session")
     @patch("services.tools.mcp_tools_manage_service.MCPToolManageService")
     def test_handle_auth_error_success(
-        self, mock_service_class, mock_session_class, mock_db, auth_client, mock_provider
+        self,
+        mock_service_class,
+        auth_client,
+        mock_provider,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_engine: Engine,
     ):
-        mock_session = MagicMock(spec=Session)
-        mock_session_class.return_value.__enter__.return_value = mock_session
+        monkeypatch.setattr("core.mcp.auth_client.db", SimpleNamespace(engine=sqlite_engine))
 
         mock_service = mock_service_class.return_value
         new_provider = MagicMock(spec=MCPProviderEntity)
@@ -506,6 +510,10 @@ class TestMCPClientWithAuthRetry:
         error = MCPAuthError("Auth failed", www_authenticate_header=www_auth)
 
         auth_client._handle_auth_error(error)
+
+        service_session = mock_service_class.call_args.kwargs["session"]
+        assert isinstance(service_session, Session)
+        assert service_session.in_transaction() is False
 
         # Verify service calls - error.resource_metadata_url and error.scope_hint are parsed from header
         mock_service.auth_with_actions.assert_called_once_with(
@@ -544,14 +552,17 @@ class TestMCPClientWithAuthRetry:
 
         assert exc_info.value == error
 
-    @patch("core.mcp.auth_client.db")
-    @patch("core.mcp.auth_client.Session")
     @patch("services.tools.mcp_tools_manage_service.MCPToolManageService")
     def test_handle_auth_error_no_token(
-        self, mock_service_class, mock_session_class, mock_db, auth_client, mock_provider
+        self,
+        mock_service_class,
+        auth_client,
+        mock_provider,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_engine: Engine,
     ):
         """Test auth error handling when no token is received."""
-        mock_session_class.return_value.__enter__.return_value = MagicMock()
+        monkeypatch.setattr("core.mcp.auth_client.db", SimpleNamespace(engine=sqlite_engine))
         mock_service = mock_service_class.return_value
 
         new_provider = MagicMock(spec=MCPProviderEntity)
@@ -565,28 +576,48 @@ class TestMCPClientWithAuthRetry:
 
         assert "Authentication failed - no token received" in str(exc_info.value)
 
-    @patch("core.mcp.auth_client.db")
-    @patch("core.mcp.auth_client.Session")
     @patch("services.tools.mcp_tools_manage_service.MCPToolManageService")
-    def test_handle_auth_error_generic_exception(self, mock_service_class, mock_session_class, mock_db, auth_client):
+    def test_handle_auth_error_generic_exception(
+        self,
+        mock_service_class,
+        auth_client,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_engine: Engine,
+    ):
         """Test auth error handling when a generic exception occurs."""
-        mock_session_class.side_effect = Exception("DB error")
+        monkeypatch.setattr("core.mcp.auth_client.db", SimpleNamespace(engine=sqlite_engine))
+        service = mock_service_class.return_value
+
+        def fail_statement(*_args, **_kwargs):
+            raise RuntimeError("DB error")
+
+        def execute_statement(*_args, **_kwargs):
+            service_session = mock_service_class.call_args.kwargs["session"]
+            service_session.execute(text("SELECT 1"))
+
+        service.auth_with_actions.side_effect = execute_statement
+        event.listen(sqlite_engine, "before_cursor_execute", fail_statement)
 
         error = MCPAuthError("Auth failed")
 
-        with pytest.raises(MCPAuthError) as exc_info:
-            auth_client._handle_auth_error(error)
+        try:
+            with pytest.raises(MCPAuthError) as exc_info:
+                auth_client._handle_auth_error(error)
+        finally:
+            event.remove(sqlite_engine, "before_cursor_execute", fail_statement)
 
         assert "Authentication retry failed: DB error" in str(exc_info.value)
 
-    @patch("core.mcp.auth_client.db")
-    @patch("core.mcp.auth_client.Session")
     @patch("services.tools.mcp_tools_manage_service.MCPToolManageService")
     def test_handle_auth_error_mcp_auth_error_propagation(
-        self, mock_service_class, mock_session_class, mock_db, auth_client
+        self,
+        mock_service_class,
+        auth_client,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_engine: Engine,
     ):
         """Test that MCPAuthError during refresh is propagated as is."""
-        mock_session_class.return_value.__enter__.return_value = MagicMock()
+        monkeypatch.setattr("core.mcp.auth_client.db", SimpleNamespace(engine=sqlite_engine))
         mock_service = mock_service_class.return_value
         mock_service.auth_with_actions.side_effect = MCPAuthError("Refresh failed")
 

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -17,12 +17,22 @@ from sqlalchemy import Engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 import core.ops.ops_trace_manager as module
+from core.moderation.base import ModerationAction, ModerationInputsResult
 from core.ops.ops_trace_manager import OpsTraceManager, TraceQueueManager, TraceTask, TraceTaskName
 from core.rag.models.document import Document as RetrievalDocument
 from graphon.enums import WorkflowExecutionStatus
 from graphon.file import FileTransferMethod, FileType
 from models.enums import ConversationFromSource, CreatorUserRole, MessageStatus, WorkflowRunTriggeredFrom
-from models.model import App, AppMode, AppModelConfig, Conversation, Message, MessageFile, TraceAppConfig
+from models.model import (
+    App,
+    AppMode,
+    AppModelConfig,
+    Conversation,
+    Message,
+    MessageAgentThought,
+    MessageFile,
+    TraceAppConfig,
+)
 from models.workflow import WorkflowAppLog, WorkflowAppLogCreatedFrom, WorkflowRun, WorkflowType
 from repositories.sqlalchemy_api_workflow_run_repository import DifyAPISQLAlchemyWorkflowRunRepository
 from tests.unit_tests.config_override import apply_config_overrides
@@ -295,8 +305,6 @@ def _message_data(**overrides):
         agent_thoughts_with_session=lambda *, session: data["agent_thoughts"],
         to_dict=lambda: data,
     )
-
-
 def test_encrypt_decrypt_obfuscate_and_cache(
     trace_environment: None,
     encryption_functions: tuple[EncryptTokenRecorder, BatchDecryptTokenRecorder, ObfuscatedTokenRecorder],
@@ -487,7 +495,6 @@ def test_update_and_get_app_tracing_config_persist_state(trace_environment: None
 
 
 def test_message_trace_reads_real_conversation_app_and_message_file(
-    monkeypatch: pytest.MonkeyPatch,
     trace_environment: None,
     database: Session,
 ) -> None:
@@ -503,7 +510,6 @@ def test_message_trace_reads_real_conversation_app_and_message_file(
     )
     database.add(file)
     database.commit()
-    monkeypatch.setattr(module, "get_message_data", lambda _message_id: _message_data())
     result = TraceTask(
         trace_type=TraceTaskName.MESSAGE_TRACE,
         message_id=message.id,
@@ -515,9 +521,10 @@ def test_message_trace_reads_real_conversation_app_and_message_file(
 
 
 def test_workflow_log_enriches_moderation_and_suggested_question_traces(
-    monkeypatch: pytest.MonkeyPatch,
     database: Session,
 ) -> None:
+    app = _app(database)
+    _, message = _conversation_message(database, app)
     log = WorkflowAppLog(
         tenant_id="tenant-1",
         app_id="app-id",
@@ -529,11 +536,15 @@ def test_workflow_log_enriches_moderation_and_suggested_question_traces(
     )
     database.add(log)
     database.commit()
-    monkeypatch.setattr(module, "get_message_data", lambda _message_id: _message_data())
-    task = TraceTask(trace_type=TraceTaskName.MODERATION_TRACE, message_id="message-1")
-    moderation = SimpleNamespace(action="block", preset_response="no", query="q", flagged=True)
+    task = TraceTask(trace_type=TraceTaskName.MODERATION_TRACE, message_id=message.id)
+    moderation = ModerationInputsResult(
+        action=ModerationAction.DIRECT_OUTPUT,
+        preset_response="no",
+        query="q",
+        flagged=True,
+    )
     result = task.moderation_trace(
-        "message-1",
+        message.id,
         {"start": 1, "end": 2},
         moderation_result=moderation,
         inputs={"source": "payload"},
@@ -541,22 +552,21 @@ def test_workflow_log_enriches_moderation_and_suggested_question_traces(
     assert result.message_id == log.id
     assert result.flagged is True
     assert result.inputs == {"source": "payload"}
-    suggested = task.suggested_question_trace("message-1", {"start": 1, "end": 2}, suggested_question=["q1"])
+    suggested = task.suggested_question_trace(message.id, {"start": 1, "end": 2}, suggested_question=["q1"])
     assert suggested.message_id == log.id
     assert suggested.suggested_question == ["q1"]
 
 
 def test_dataset_retrieval_trace_serializes_documents(
-    monkeypatch: pytest.MonkeyPatch,
     trace_environment: None,
     database: Session,
 ) -> None:
-    _app(database)
-    monkeypatch.setattr(module, "get_message_data", lambda _message_id: _message_data())
+    app = _app(database)
+    _, message = _conversation_message(database, app)
     document = RetrievalDocument(page_content="value")
 
     result = TraceTask(trace_type=TraceTaskName.DATASET_RETRIEVAL_TRACE).dataset_retrieval_trace(
-        "message-1",
+        message.id,
         {"start": 1, "end": 2},
         documents=[document],
     )
@@ -618,25 +628,29 @@ def test_workflow_trace_reads_real_workflow_log_from_owned_session(
     assert result.completion_tokens == 7
 
 
-def test_tool_trace_reads_real_message_file(monkeypatch: pytest.MonkeyPatch, database: Session) -> None:
+def test_tool_trace_reads_real_message_file(database: Session) -> None:
+    app = _app(database)
+    _, message = _conversation_message(database, app)
     file = MessageFile(
-        message_id="message-1",
+        message_id=message.id,
         type=FileType.DOCUMENT,
         transfer_method=FileTransferMethod.REMOTE_URL,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="user-1",
         url="tool/file",
     )
-    database.add(file)
-    database.commit()
-    thought = SimpleNamespace(
-        tools=["tool-a"],
-        created_at=datetime(2025, 2, 20, 12, 1),
-        tool_meta={"tool-a": {"tool_config": {}, "time_cost": 5, "error": "", "tool_parameters": {}}},
+    thought = MessageAgentThought(
+        message_id=message.id,
+        position=1,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="user-1",
+        tool="tool-a",
+        tool_meta_str=json.dumps({"tool-a": {"tool_config": {}, "time_cost": 5, "error": "", "tool_parameters": {}}}),
     )
-    monkeypatch.setattr(module, "get_message_data", lambda _message_id: _message_data(agent_thoughts=[thought]))
+    database.add_all([file, thought])
+    database.commit()
     result = TraceTask(trace_type=TraceTaskName.TOOL_TRACE).tool_trace(
-        "message-1", {"start": 1, "end": 2}, tool_name="tool-a", tool_inputs={}, tool_outputs="result"
+        message.id, {"start": 1, "end": 2}, tool_name="tool-a", tool_inputs={}, tool_outputs="result"
     )
     assert result.tool_name == "tool-a"
     assert result.time_cost == 5
@@ -672,7 +686,7 @@ def test_trace_helpers_and_streaming_metrics(trace_environment: None) -> None:
     assert OpsTraceManager.get_trace_config_project_url({}, "dummy") == "https://project.fake"
     task = TraceTask(trace_type=TraceTaskName.MESSAGE_TRACE, message_id="message-1")
     assert task.conversation_trace(foo="bar") == {"foo": "bar"}
-    assert task._extract_streaming_metrics(_message_data(message_metadata="invalid")) == {}
+    assert task._extract_streaming_metrics(Message(message_metadata="invalid")) == {}
     assert task.generate_name_trace("conversation", {"start": 1, "end": 2}, tenant_id=None) == {}
     generated = task.generate_name_trace(
         "conversation",

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -305,6 +305,8 @@ def _message_data(**overrides):
         agent_thoughts_with_session=lambda *, session: data["agent_thoughts"],
         to_dict=lambda: data,
     )
+
+
 def test_encrypt_decrypt_obfuscate_and_cache(
     trace_environment: None,
     encryption_functions: tuple[EncryptTokenRecorder, BatchDecryptTokenRecorder, ObfuscatedTokenRecorder],

--- a/api/tests/unit_tests/core/rag/indexing/test_index_processor_base.py
+++ b/api/tests/unit_tests/core/rag/indexing/test_index_processor_base.py
@@ -6,20 +6,25 @@ from uuid import uuid4
 
 import httpx
 import pytest
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
 from core.entities.knowledge_entities import PreviewDetail
+from core.rag.extractor.entity.extract_setting import ExtractSetting
 from core.rag.index_processor.constant.doc_type import DocType
 from core.rag.index_processor.index_processor_base import BaseIndexProcessor
 from core.rag.models.document import AttachmentDocument, Document
 from extensions.storage.storage_type import StorageType
+from models.account import Account
+from models.dataset import Dataset
+from models.dataset import Document as DatasetDocument
 from models.enums import CreatorUserRole
 from models.model import UploadFile
 from models.tools import ToolFile
 from tests.unit_tests.config_override import config_overrides_context
 
 
-def _persist_upload(session: Session, *, upload_id: str, name: str) -> UploadFile:
+def _upload(*, upload_id: str, name: str) -> UploadFile:
     upload = UploadFile(
         tenant_id=str(uuid4()),
         storage_type=StorageType.LOCAL,
@@ -34,8 +39,19 @@ def _persist_upload(session: Session, *, upload_id: str, name: str) -> UploadFil
         used=True,
     )
     upload.id = upload_id
+    return upload
+
+
+def _persist_upload(session: Session, *, upload_id: str, name: str) -> UploadFile:
+    upload = _upload(upload_id=upload_id, name=name)
     session.add(upload)
     return upload
+
+
+def _account() -> Account:
+    account = Account(name="Indexer", email=f"{uuid4()}@example.com")
+    account.id = str(uuid4())
+    return account
 
 
 class _ForwardingBaseIndexProcessor(BaseIndexProcessor):
@@ -99,7 +115,7 @@ class TestBaseIndexProcessor:
         self, processor: _ForwardingBaseIndexProcessor, unbound_session: Session
     ) -> None:
         with pytest.raises(NotImplementedError):
-            processor.extract(Mock(), session=unbound_session)
+            processor.extract(ExtractSetting(datasource_type="upload_file"), session=unbound_session)
         with pytest.raises(NotImplementedError):
             processor.transform([], session=unbound_session)
         with pytest.raises(NotImplementedError):
@@ -107,11 +123,11 @@ class TestBaseIndexProcessor:
                 "tenant", [PreviewDetail(content="c")], {"enable": False}, session=unbound_session
             )
         with pytest.raises(NotImplementedError):
-            processor.load(Mock(), [], session=unbound_session)
+            processor.load(Dataset(), [], session=unbound_session)
         with pytest.raises(NotImplementedError):
-            processor.clean(Mock(), None, session=unbound_session)
+            processor.clean(Dataset(), None, session=unbound_session)
         with pytest.raises(NotImplementedError):
-            processor.index(Mock(), Mock(), {}, unbound_session)
+            processor.index(Dataset(), DatasetDocument(), {}, unbound_session)
         with pytest.raises(NotImplementedError):
             processor.format_preview([])
 
@@ -172,7 +188,7 @@ class TestBaseIndexProcessor:
         tool_upload = _persist_upload(sqlite_session, upload_id=str(uuid4()), name="tool.png")
         remote_upload = _persist_upload(sqlite_session, upload_id=str(uuid4()), name="remote.png")
         sqlite_session.commit()
-        current_user = Mock()
+        current_user = _account()
 
         with (
             patch.object(processor, "_extract_markdown_images", return_value=images),
@@ -240,7 +256,7 @@ class TestBaseIndexProcessor:
         assert files == []
 
     def test_download_image_success_with_filename_from_content_disposition(
-        self, processor: _ForwardingBaseIndexProcessor
+        self, processor: _ForwardingBaseIndexProcessor, sqlite_engine: Engine
     ) -> None:
         response = Mock()
         response.headers = {
@@ -250,20 +266,20 @@ class TestBaseIndexProcessor:
         }
         response.raise_for_status.return_value = None
         response.iter_bytes.return_value = [b"data"]
-        upload_result = SimpleNamespace(id="upload-id")
-
-        mock_db = Mock()
-        mock_db.engine = Mock()
+        upload_result = _upload(upload_id=str(uuid4()), name="test-image.png")
 
         with (
             patch("core.rag.index_processor.index_processor_base.remote_fetcher.make_request", return_value=response),
-            patch("core.rag.index_processor.index_processor_base.db", mock_db),
+            patch(
+                "core.rag.index_processor.index_processor_base.db",
+                SimpleNamespace(engine=sqlite_engine),
+            ),
             patch("services.file_service.FileService") as mock_file_service,
         ):
             mock_file_service.return_value.upload_file.return_value = upload_result
-            upload_id = processor._download_image("https://example.com/test.png", current_user=Mock())
+            upload_id = processor._download_image("https://example.com/test.png", current_user=_account())
 
-        assert upload_id == "upload-id"
+        assert upload_id == upload_result.id
         mock_file_service.return_value.upload_file.assert_called_once()
 
     def test_download_image_validates_size_and_empty_content(self, processor: _ForwardingBaseIndexProcessor) -> None:
@@ -272,7 +288,7 @@ class TestBaseIndexProcessor:
         too_large.raise_for_status.return_value = None
 
         with patch("core.rag.index_processor.index_processor_base.remote_fetcher.make_request", return_value=too_large):
-            assert processor._download_image("https://example.com/too-large.png", current_user=Mock()) is None
+            assert processor._download_image("https://example.com/too-large.png", current_user=_account()) is None
 
         empty = Mock()
         empty.headers = {"Content-Length": "0", "content-type": "image/png"}
@@ -280,7 +296,7 @@ class TestBaseIndexProcessor:
         empty.iter_bytes.return_value = []
 
         with patch("core.rag.index_processor.index_processor_base.remote_fetcher.make_request", return_value=empty):
-            assert processor._download_image("https://example.com/empty.png", current_user=Mock()) is None
+            assert processor._download_image("https://example.com/empty.png", current_user=_account()) is None
 
     def test_download_image_limits_stream_size(self, processor: _ForwardingBaseIndexProcessor) -> None:
         response = Mock()
@@ -289,7 +305,7 @@ class TestBaseIndexProcessor:
         response.iter_bytes.return_value = [b"a" * (3 * 1024 * 1024)]
 
         with patch("core.rag.index_processor.index_processor_base.remote_fetcher.make_request", return_value=response):
-            assert processor._download_image("https://example.com/big-stream.png", current_user=Mock()) is None
+            assert processor._download_image("https://example.com/big-stream.png", current_user=_account()) is None
 
     def test_download_image_handles_timeout_request_and_unexpected_errors(
         self, processor: _ForwardingBaseIndexProcessor
@@ -300,27 +316,27 @@ class TestBaseIndexProcessor:
             "core.rag.index_processor.index_processor_base.remote_fetcher.make_request",
             side_effect=httpx.TimeoutException("timeout"),
         ):
-            assert processor._download_image("https://example.com/image.png", current_user=Mock()) is None
+            assert processor._download_image("https://example.com/image.png", current_user=_account()) is None
 
         with patch(
             "core.rag.index_processor.index_processor_base.remote_fetcher.make_request",
             side_effect=httpx.RequestError("bad request", request=request),
         ):
-            assert processor._download_image("https://example.com/image.png", current_user=Mock()) is None
+            assert processor._download_image("https://example.com/image.png", current_user=_account()) is None
 
         with patch(
             "core.rag.index_processor.index_processor_base.remote_fetcher.make_request",
             side_effect=RuntimeError("unexpected"),
         ):
-            assert processor._download_image("https://example.com/image.png", current_user=Mock()) is None
+            assert processor._download_image("https://example.com/image.png", current_user=_account()) is None
 
     def test_download_tool_file_returns_none_when_not_found(
         self, processor: _ForwardingBaseIndexProcessor, sqlite_session: Session
     ) -> None:
-        assert processor._download_tool_file(str(uuid4()), current_user=Mock(), session=sqlite_session) is None
+        assert processor._download_tool_file(str(uuid4()), current_user=_account(), session=sqlite_session) is None
 
     def test_download_tool_file_uploads_file_when_found(
-        self, processor: _ForwardingBaseIndexProcessor, sqlite_session: Session
+        self, processor: _ForwardingBaseIndexProcessor, sqlite_session: Session, sqlite_engine: Engine
     ) -> None:
         tool_file = ToolFile(
             user_id=str(uuid4()),
@@ -333,18 +349,19 @@ class TestBaseIndexProcessor:
         )
         sqlite_session.add(tool_file)
         sqlite_session.commit()
-        mock_db = Mock()
-        mock_db.engine = Mock()
-        upload_result = SimpleNamespace(id="upload-id")
+        upload_result = _upload(upload_id=str(uuid4()), name="tool.png")
 
         with (
-            patch("core.rag.index_processor.index_processor_base.db", mock_db),
+            patch(
+                "core.rag.index_processor.index_processor_base.db",
+                SimpleNamespace(engine=sqlite_engine),
+            ),
             patch("core.rag.index_processor.index_processor_base.storage.load_once", return_value=b"blob") as mock_load,
             patch("services.file_service.FileService") as mock_file_service,
         ):
             mock_file_service.return_value.upload_file.return_value = upload_result
-            result = processor._download_tool_file(tool_file.id, current_user=Mock(), session=sqlite_session)
+            result = processor._download_tool_file(tool_file.id, current_user=_account(), session=sqlite_session)
 
-        assert result == "upload-id"
+        assert result == upload_result.id
         mock_load.assert_called_once_with("k1")
         mock_file_service.return_value.upload_file.assert_called_once()

--- a/api/tests/unit_tests/core/repositories/test_celery_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_celery_workflow_execution_repository.py
@@ -21,19 +21,8 @@ RESOURCE_TENANT_ID = "resource-tenant-id"
 
 
 @pytest.fixture
-def mock_session_factory():
-    """Mock SQLAlchemy session factory."""
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
-
-    # Create a real sessionmaker with in-memory SQLite for testing
-    engine = create_engine("sqlite:///:memory:")
-    return sessionmaker(bind=engine)
-
-
-@pytest.fixture
-def mock_account():
-    """Mock Account user."""
+def account():
+    """Create an Account user."""
     account = Account(name="Test Account", email="test@example.com")
     account.id = str(uuid4())
     account._current_tenant = Tenant(name="Test Tenant")
@@ -42,8 +31,8 @@ def mock_account():
 
 
 @pytest.fixture
-def mock_end_user():
-    """Mock EndUser."""
+def end_user():
+    """Create an EndUser."""
     user = EndUser(
         id=str(uuid4()),
         tenant_id=str(uuid4()),
@@ -68,15 +57,15 @@ def sample_workflow_execution():
 class TestCeleryWorkflowExecutionRepository:
     """Test cases for CeleryWorkflowExecutionRepository."""
 
-    def test_init_with_sessionmaker(self, mock_session_factory, mock_account):
+    def test_init_with_sessionmaker(self, sqlite_session_factory, account):
         """Test repository initialization with sessionmaker."""
         app_id = "test-app-id"
         triggered_from = WorkflowRunTriggeredFrom.APP_RUN
 
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id=app_id,
             triggered_from=triggered_from,
         )
@@ -84,15 +73,15 @@ class TestCeleryWorkflowExecutionRepository:
         assert repo._tenant_id == RESOURCE_TENANT_ID
         assert repo._app_id == app_id
         assert repo._triggered_from == triggered_from
-        assert repo._creator_user_id == mock_account.id
+        assert repo._creator_user_id == account.id
         assert repo._creator_user_role is not None
 
-    def test_init_basic_functionality(self, mock_session_factory, mock_account):
+    def test_init_basic_functionality(self, sqlite_session_factory, account):
         """Test repository initialization basic functionality."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.DEBUGGING,
         )
@@ -102,19 +91,19 @@ class TestCeleryWorkflowExecutionRepository:
         assert repo._app_id == "test-app"
         assert repo._triggered_from == WorkflowRunTriggeredFrom.DEBUGGING
 
-    def test_init_with_end_user(self, mock_session_factory, mock_end_user):
+    def test_init_with_end_user(self, sqlite_session_factory, end_user):
         """Test repository initialization with EndUser."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_end_user,
+            user=end_user,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
 
         assert repo._tenant_id == RESOURCE_TENANT_ID
 
-    def test_init_without_tenant_id_raises_error(self, mock_session_factory):
+    def test_init_without_tenant_id_raises_error(self, sqlite_session_factory):
         """Test that initialization fails without tenant_id."""
         # Create an Account with no tenant_id.
         user = Account(name="Test Account", email="test@example.com")
@@ -122,19 +111,19 @@ class TestCeleryWorkflowExecutionRepository:
 
         with pytest.raises(ValueError, match="tenant_id is required"):
             CeleryWorkflowExecutionRepository(
-                session_factory=mock_session_factory,
+                session_factory=sqlite_session_factory,
                 tenant_id="",
                 user=user,
                 app_id="test-app",
                 triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
             )
 
-    def test_init_uses_resource_tenant_when_account_has_no_current_tenant(self, mock_session_factory):
+    def test_init_uses_resource_tenant_when_account_has_no_current_tenant(self, sqlite_session_factory):
         user = Account(name="Test Account", email="test@example.com")
         user.id = str(uuid4())
 
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=user,
             app_id="test-app",
@@ -145,12 +134,12 @@ class TestCeleryWorkflowExecutionRepository:
         assert repo._creator_user_id == user.id
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
-    def test_save_queues_celery_task(self, mock_task, mock_session_factory, mock_account, sample_workflow_execution):
+    def test_save_queues_celery_task(self, mock_task, sqlite_session_factory, account, sample_workflow_execution):
         """Test that save operation queues a Celery task without tracking."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
@@ -165,22 +154,20 @@ class TestCeleryWorkflowExecutionRepository:
         assert call_args["tenant_id"] == RESOURCE_TENANT_ID
         assert call_args["app_id"] == "test-app"
         assert call_args["triggered_from"] == WorkflowRunTriggeredFrom.APP_RUN
-        assert call_args["creator_user_id"] == mock_account.id
+        assert call_args["creator_user_id"] == account.id
 
         # Verify no task tracking occurs (no _pending_saves attribute)
         assert not hasattr(repo, "_pending_saves")
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
-    def test_save_handles_celery_failure(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_execution
-    ):
+    def test_save_handles_celery_failure(self, mock_task, sqlite_session_factory, account, sample_workflow_execution):
         """Test that save operation handles Celery task failures."""
         mock_task.delay.side_effect = Exception("Celery is down")
 
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
@@ -190,13 +177,13 @@ class TestCeleryWorkflowExecutionRepository:
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
     def test_save_operation_fire_and_forget(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_execution
+        self, mock_task, sqlite_session_factory, account, sample_workflow_execution
     ):
         """Test that save operation works in fire-and-forget mode."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
@@ -208,12 +195,12 @@ class TestCeleryWorkflowExecutionRepository:
         assert not hasattr(repo, "_pending_saves")
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
-    def test_multiple_save_operations(self, mock_task, mock_session_factory, mock_account):
+    def test_multiple_save_operations(self, mock_task, sqlite_session_factory, account):
         """Test multiple save operations work correctly."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
@@ -246,12 +233,12 @@ class TestCeleryWorkflowExecutionRepository:
         assert not hasattr(repo, "_pending_saves")
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
-    def test_save_with_different_user_types(self, mock_task, mock_session_factory, mock_end_user):
+    def test_save_with_different_user_types(self, mock_task, sqlite_session_factory, end_user):
         """Test save operation with different user types."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
-            tenant_id=mock_end_user.tenant_id,
-            user=mock_end_user,
+            session_factory=sqlite_session_factory,
+            tenant_id=end_user.tenant_id,
+            user=end_user,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
@@ -271,5 +258,5 @@ class TestCeleryWorkflowExecutionRepository:
         # Verify task was called with EndUser context
         mock_task.delay.assert_called_once()
         call_args = mock_task.delay.call_args[1]
-        assert call_args["tenant_id"] == mock_end_user.tenant_id
-        assert call_args["creator_user_id"] == mock_end_user.id
+        assert call_args["tenant_id"] == end_user.tenant_id
+        assert call_args["creator_user_id"] == end_user.id

--- a/api/tests/unit_tests/core/repositories/test_celery_workflow_node_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_celery_workflow_node_execution_repository.py
@@ -25,19 +25,8 @@ RESOURCE_TENANT_ID = "resource-tenant-id"
 
 
 @pytest.fixture
-def mock_session_factory():
-    """Mock SQLAlchemy session factory."""
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
-
-    # Create a real sessionmaker with in-memory SQLite for testing
-    engine = create_engine("sqlite:///:memory:")
-    return sessionmaker(bind=engine)
-
-
-@pytest.fixture
-def mock_account():
-    """Mock Account user."""
+def account():
+    """Create an Account user."""
     account = Account(name="Test Account", email="test@example.com")
     account.id = str(uuid4())
     account._current_tenant = Tenant(name="Test Tenant")
@@ -46,8 +35,8 @@ def mock_account():
 
 
 @pytest.fixture
-def mock_end_user():
-    """Mock EndUser."""
+def end_user():
+    """Create an EndUser."""
     user = EndUser(
         id=str(uuid4()),
         tenant_id=str(uuid4()),
@@ -76,15 +65,15 @@ def sample_workflow_node_execution():
 class TestCeleryWorkflowNodeExecutionRepository:
     """Test cases for CeleryWorkflowNodeExecutionRepository."""
 
-    def test_init_with_sessionmaker(self, mock_session_factory, mock_account):
+    def test_init_with_sessionmaker(self, sqlite_session_factory, account):
         """Test repository initialization with sessionmaker."""
         app_id = "test-app-id"
         triggered_from = WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN
 
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id=app_id,
             triggered_from=triggered_from,
         )
@@ -92,15 +81,15 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert repo._tenant_id == RESOURCE_TENANT_ID
         assert repo._app_id == app_id
         assert repo._triggered_from == triggered_from
-        assert repo._creator_user_id == mock_account.id
+        assert repo._creator_user_id == account.id
         assert repo._creator_user_role is not None
 
-    def test_init_with_cache_initialized(self, mock_session_factory, mock_account):
+    def test_init_with_cache_initialized(self, sqlite_session_factory, account):
         """Test repository initialization with cache properly initialized."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.SINGLE_STEP,
         )
@@ -108,19 +97,19 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert repo._execution_cache == {}
         assert repo._workflow_execution_mapping == {}
 
-    def test_init_with_end_user(self, mock_session_factory, mock_end_user):
+    def test_init_with_end_user(self, sqlite_session_factory, end_user):
         """Test repository initialization with EndUser."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_end_user,
+            user=end_user,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
 
         assert repo._tenant_id == RESOURCE_TENANT_ID
 
-    def test_init_without_tenant_id_raises_error(self, mock_session_factory):
+    def test_init_without_tenant_id_raises_error(self, sqlite_session_factory):
         """Test that initialization fails without tenant_id."""
         # Create an Account with no tenant_id.
         user = Account(name="Test Account", email="test@example.com")
@@ -128,19 +117,19 @@ class TestCeleryWorkflowNodeExecutionRepository:
 
         with pytest.raises(ValueError, match="tenant_id is required"):
             CeleryWorkflowNodeExecutionRepository(
-                session_factory=mock_session_factory,
+                session_factory=sqlite_session_factory,
                 tenant_id="",
                 user=user,
                 app_id="test-app",
                 triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
             )
 
-    def test_init_uses_resource_tenant_when_account_has_no_current_tenant(self, mock_session_factory):
+    def test_init_uses_resource_tenant_when_account_has_no_current_tenant(self, sqlite_session_factory):
         user = Account(name="Test Account", email="test@example.com")
         user.id = str(uuid4())
 
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=user,
             app_id="test-app",
@@ -152,13 +141,13 @@ class TestCeleryWorkflowNodeExecutionRepository:
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
     def test_save_caches_and_queues_celery_task(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_node_execution
+        self, mock_task, sqlite_session_factory, account, sample_workflow_node_execution
     ):
         """Test that save operation caches execution and queues a Celery task."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -173,7 +162,7 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert call_args["tenant_id"] == RESOURCE_TENANT_ID
         assert call_args["app_id"] == "test-app"
         assert call_args["triggered_from"] == WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN
-        assert call_args["creator_user_id"] == mock_account.id
+        assert call_args["creator_user_id"] == account.id
 
         # Verify execution is cached
         assert sample_workflow_node_execution.id in repo._execution_cache
@@ -187,12 +176,12 @@ class TestCeleryWorkflowNodeExecutionRepository:
         )
 
     def test_save_synchronously_uses_sql_repository_without_queueing(
-        self, mock_session_factory, mock_account, sample_workflow_node_execution
+        self, sqlite_session_factory, account, sample_workflow_node_execution
     ):
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -205,15 +194,15 @@ class TestCeleryWorkflowNodeExecutionRepository:
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
     def test_save_handles_celery_failure(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_node_execution
+        self, mock_task, sqlite_session_factory, account, sample_workflow_node_execution
     ):
         """Test that save operation handles Celery task failures."""
         mock_task.delay.side_effect = Exception("Celery is down")
 
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -223,13 +212,13 @@ class TestCeleryWorkflowNodeExecutionRepository:
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
     def test_get_by_workflow_execution_from_cache(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_node_execution
+        self, mock_task, sqlite_session_factory, account, sample_workflow_node_execution
     ):
         """Test that get_by_workflow_execution retrieves executions from cache."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -247,12 +236,12 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert result[0].id == sample_workflow_node_execution.id
         assert result[0] is sample_workflow_node_execution
 
-    def test_get_by_workflow_execution_without_order_config(self, mock_session_factory, mock_account):
+    def test_get_by_workflow_execution_without_order_config(self, sqlite_session_factory, account):
         """Test get_by_workflow_execution without order configuration."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -263,12 +252,12 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert len(result) == 0
 
     def test_get_by_workflow_execution_loads_persisted_executions_on_cache_miss(
-        self, mock_session_factory, mock_account, sample_workflow_node_execution
+        self, sqlite_session_factory, account, sample_workflow_node_execution
     ):
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -285,12 +274,12 @@ class TestCeleryWorkflowNodeExecutionRepository:
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
     def test_get_by_workflow_execution_merges_database_and_newer_cache(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_node_execution
+        self, mock_task, sqlite_session_factory, account, sample_workflow_node_execution
     ):
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -317,12 +306,12 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert result[1] is sample_workflow_node_execution
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
-    def test_cache_operations(self, mock_task, mock_session_factory, mock_account, sample_workflow_node_execution):
+    def test_cache_operations(self, mock_task, sqlite_session_factory, account, sample_workflow_node_execution):
         """Test cache operations work correctly."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -339,12 +328,12 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert result[0].id == sample_workflow_node_execution.id
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
-    def test_multiple_executions_same_workflow(self, mock_task, mock_session_factory, mock_account):
+    def test_multiple_executions_same_workflow(self, mock_task, sqlite_session_factory, account):
         """Test multiple executions for the same workflow."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
-            user=mock_account,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )
@@ -391,12 +380,12 @@ class TestCeleryWorkflowNodeExecutionRepository:
         assert len(result) == 2
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
-    def test_ordering_functionality(self, mock_task, mock_session_factory, mock_account):
+    def test_ordering_functionality(self, mock_task, sqlite_session_factory, account):
         """Test ordering functionality works correctly."""
         repo = CeleryWorkflowNodeExecutionRepository(
-            session_factory=mock_session_factory,
-            tenant_id=mock_account.current_tenant_id,
-            user=mock_account,
+            session_factory=sqlite_session_factory,
+            tenant_id=account.current_tenant_id,
+            user=account,
             app_id="test-app",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )

--- a/api/tests/unit_tests/services/agent/test_retirement_service.py
+++ b/api/tests/unit_tests/services/agent/test_retirement_service.py
@@ -1,6 +1,4 @@
 from contextlib import nullcontext
-from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.orm import Session
@@ -23,7 +21,6 @@ from models.agent import (
 from models.enums import AppStatus
 from models.model import App, AppMode
 from models.workflow import Workflow, WorkflowType
-from services.agent.home_snapshot_service import AgentHomeSnapshotService
 from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.agent.workspace_service import AgentWorkspaceService
 

--- a/api/tests/unit_tests/services/agent/test_retirement_service.py
+++ b/api/tests/unit_tests/services/agent/test_retirement_service.py
@@ -1,4 +1,6 @@
 from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.orm import Session
@@ -21,6 +23,7 @@ from models.agent import (
 from models.enums import AppStatus
 from models.model import App, AppMode
 from models.workflow import Workflow, WorkflowType
+from services.agent.home_snapshot_service import AgentHomeSnapshotService
 from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.agent.workspace_service import AgentWorkspaceService
 

--- a/api/tests/unit_tests/services/workflow/test_workflow_draft_variable_service.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_draft_variable_service.py
@@ -2,8 +2,7 @@ import dataclasses
 import json
 import secrets
 import uuid
-from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -14,13 +13,16 @@ from core.workflow.variable_prefixes import (
     ENVIRONMENT_VARIABLE_NODE_ID,
     SYSTEM_VARIABLE_NODE_ID,
 )
+from extensions.storage.storage_type import StorageType
 from graphon.enums import BuiltinNodeTypes
 from graphon.file import File, FileTransferMethod, FileType
 from graphon.variables.segments import StringSegment
 from graphon.variables.types import SegmentType
+from libs.datetime_utils import naive_utc_now
 from libs.uuid_utils import uuidv7
 from models.account import Account
-from models.enums import DraftVariableType
+from models.enums import CreatorUserRole, DraftVariableType
+from models.model import UploadFile
 from models.workflow import (
     Workflow,
     WorkflowDraftVariable,
@@ -28,6 +30,7 @@ from models.workflow import (
     WorkflowNodeExecutionModel,
     is_system_variable_editable,
 )
+from services.variable_truncator import TruncationResult
 from services.workflow_draft_variable_service import (
     DraftVariableSaver,
     VariableResetError,
@@ -111,7 +114,8 @@ class TestDraftVariableSaver:
             ),
         ]
 
-        mock_user = MagicMock()
+        mock_user = Account(name="Test Account", email="test@example.com")
+        mock_user.id = str(uuid.uuid4())
         test_app_id = self._get_test_app_id()
         saver = DraftVariableSaver(
             session=sqlite_session,
@@ -229,15 +233,28 @@ class TestDraftVariableSaver:
             node_execution_id="test-execution-id",
             user=mock_user,
         )
-        upload_file = SimpleNamespace(id="upload-file-id")
-        truncation_result = SimpleNamespace(result=StringSegment(value="..."), truncated=True)
+        upload_file = UploadFile(
+            tenant_id="app-tenant-id",
+            storage_type=StorageType.LOCAL,
+            key="workflow/draft-variable.txt",
+            name="draft-variable.txt",
+            size=11,
+            extension="txt",
+            mime_type="text/plain",
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by=mock_user.id,
+            created_at=naive_utc_now(),
+            used=True,
+        )
+        sqlite_session.add(upload_file)
+        sqlite_session.commit()
+        truncation_result = TruncationResult(result=StringSegment(value="..."), truncated=True)
 
         with (
             patch(
                 "services.workflow_draft_variable_service.VariableTruncator.truncate", return_value=truncation_result
             ),
             patch("services.workflow_draft_variable_service.FileService") as file_service_class,
-            patch("services.workflow_draft_variable_service.sessionmaker") as sessionmaker_mock,
         ):
             file_service_class.return_value.upload_file.return_value = upload_file
             result = saver._try_offload_large_variable("large_var", StringSegment(value="large value"))
@@ -246,9 +263,10 @@ class TestDraftVariableSaver:
         _, variable_file = result
         assert file_service_class.return_value.upload_file.call_args.kwargs["tenant_id"] == "app-tenant-id"
         assert variable_file.tenant_id == "app-tenant-id"
-        sessionmaker_mock.return_value.begin.return_value.__enter__.return_value.add.assert_called_once_with(
-            variable_file
-        )
+        sqlite_session.expire_all()
+        stored_variable_file = sqlite_session.get(WorkflowDraftVariableFile, variable_file.id)
+        assert stored_variable_file is not None
+        assert stored_variable_file.upload_file_id == upload_file.id
 
     @patch("services.workflow_draft_variable_service._batch_upsert_draft_variable", autospec=True)
     def test_save_method_integration(self, mock_batch_upsert, draft_saver):

--- a/api/tests/unit_tests/services/workflow/test_workflow_restore.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_restore.py
@@ -1,6 +1,6 @@
 import json
-from types import SimpleNamespace
 
+from models.account import Account
 from models.workflow import Workflow
 from services.workflow_restore import apply_published_workflow_snapshot_to_draft
 
@@ -61,13 +61,15 @@ def test_apply_published_workflow_snapshot_to_draft_copies_serialized_features_w
         version="2026-03-19T00:00:00",
         features=LEGACY_FEATURES,
     )
+    account = Account(name="Workflow Restorer", email="restorer@example.com")
+    account.id = "account-id"
 
     draft_workflow, is_new_draft = apply_published_workflow_snapshot_to_draft(
         tenant_id="tenant-id",
         app_id="app-id",
         source_workflow=source_workflow,
         draft_workflow=None,
-        account=SimpleNamespace(id="account-id"),
+        account=account,
         updated_at_factory=lambda: source_workflow.updated_at,
     )
 


### PR DESCRIPTION
## Summary

- migrate residual advanced-chat pipeline, MCP auth, Ops tracing, indexing, Celery repository, workflow draft-variable, restore, and Agent retirement tests to shared SQLite-backed SQLAlchemy sessions
- replace Message, MessageAgentThought, Account, Workflow, UploadFile, HumanInputContent, Dataset, and Document stand-ins with real mapped instances
- exercise committed persistence, duplicate detection, scoped-session behavior, and transaction failures through real SQLAlchemy execution
- keep app DSL tests in the dedicated DSL PR to avoid overlapping files

## Persistence coverage

- observes HumanInputContent and WorkflowDraftVariableFile writes through SQLite sessions
- uses a real scoped session for Ops trace model properties and relationships
- injects real Session objects into MCP auth and raises a database failure through a SQLAlchemy engine event
- uses the repository-wide SQLite session factory for Celery repositories
- seeds real model ownership and mapped entities for workflow restoration, indexing uploads, and Agent retirement

## Production changes

None.

## Size

330 additions, 375 deletions (705 changed lines).

## Validation

- targeted run covering all current modules (executed before the overlapping app DSL module was removed) — 171 passed
- direct final targeted run — 171 passed, 1 warning
- `make lint` — passed
- `make type-check` — pyrefly passed; mypy 1.20.2 hit its existing internal error at `api/.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- structural/text audit — no mocked SQLAlchemy Session/sessionmaker/scoped_session or mapped-model stand-ins remain in the changed modules; MCP session mocks are external MCP ClientSession objects
- full test suite not run, per request
