### PR TITLE
test: migrate application DSL sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_dsl_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_dsl_service.py
@@ -11,7 +11,7 @@ import json
 from collections.abc import Generator
 from contextlib import contextmanager
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock, Mock, call
 
 import pytest
@@ -93,6 +93,27 @@ def _workflow(session: Session, pipeline: Pipeline, *, graph: dict[str, Any] | N
     pipeline.workflow_id = workflow.id
     session.add(workflow)
     session.commit()
+    return workflow
+
+
+def _workflow_for_dependencies(
+    *, graph: dict[str, Any], environment_variables: list[LLMEnvironmentVariable] | None = None
+) -> Workflow:
+    workflow = Workflow(
+        id="workflow-dependencies",
+        tenant_id="tenant-1",
+        app_id="pipeline-1",
+        type=WorkflowType.RAG_PIPELINE,
+        kind=WorkflowKind.STANDARD,
+        version=Workflow.VERSION_DRAFT,
+        graph=json.dumps(graph),
+        features="{}",
+        created_by="account-1",
+        environment_variables=[],
+        conversation_variables=[],
+        rag_pipeline_variables=[],
+    )
+    workflow.environment_variables = environment_variables or []
     return workflow
 
 
@@ -240,8 +261,8 @@ def test_extract_dependencies_from_model_config_covers_models_rerankers_and_tool
 def test_extract_workflow_dependencies_uses_llm_environment_variable_provider(
     monkeypatch: pytest.MonkeyPatch, service: RagPipelineDslService
 ) -> None:
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _workflow_for_dependencies(
+        graph={
             "nodes": [
                 {
                     "id": "llm-node",
@@ -271,7 +292,7 @@ def test_extract_workflow_dependencies_uses_llm_environment_variable_provider(
         analyze_dependency,
     )
 
-    result = service._extract_dependencies_from_workflow(cast(Workflow, workflow))
+    result = service._extract_dependencies_from_workflow(workflow)
 
     assert result == ["new-provider"]
     analyze_dependency.assert_called_once_with("new-provider")
@@ -283,8 +304,8 @@ def test_extract_workflow_dependencies_tolerates_unresolved_llm_environment_refe
     service: RagPipelineDslService,
     model_selector: list[str],
 ) -> None:
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _workflow_for_dependencies(
+        graph={
             "nodes": [
                 {
                     "id": "llm-node",
@@ -300,7 +321,6 @@ def test_extract_workflow_dependencies_tolerates_unresolved_llm_environment_refe
                 }
             ]
         },
-        environment_variables=[],
     )
     analyze_dependency = Mock(side_effect=lambda provider: provider)
     monkeypatch.setattr(
@@ -309,7 +329,7 @@ def test_extract_workflow_dependencies_tolerates_unresolved_llm_environment_refe
         analyze_dependency,
     )
 
-    result = service._extract_dependencies_from_workflow(cast(Workflow, workflow))
+    result = service._extract_dependencies_from_workflow(workflow)
 
     assert result == ["old-provider"]
     analyze_dependency.assert_called_once_with("old-provider")

--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_transform_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_transform_service.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import cast
 
 import pytest
 from pytest_mock import MockerFixture
@@ -45,6 +44,18 @@ def _document(**overrides: object) -> Document:
     }
     values.update(overrides)
     return Document(**values)
+
+
+def _pipeline(*, pipeline_id: str = "p-new", tenant_id: str = "t1") -> Pipeline:
+    pipeline = Pipeline(
+        tenant_id=tenant_id,
+        name="Pipeline",
+        description="",
+        created_by="user-1",
+        updated_by="user-1",
+    )
+    pipeline.id = pipeline_id
+    return pipeline
 
 
 def _upload_file(*, file_id: str = "file-1", tenant_id: str = "tenant-1") -> UploadFile:
@@ -257,14 +268,11 @@ def test_transform_dataset_calls_empty_pipeline_when_no_doc_form(
 
 def test_deal_knowledge_index_high_quality_sets_embedding(mocker: MockerFixture) -> None:
     service = RagPipelineTransformService()
-    dataset = cast(
-        Dataset,
-        SimpleNamespace(
-            embedding_model="text-embedding-ada-002",
-            embedding_model_provider="openai",
-            retrieval_model=None,
-            summary_index_setting=None,
-        ),
+    dataset = _dataset(
+        embedding_model="text-embedding-ada-002",
+        embedding_model_provider="openai",
+        retrieval_model=None,
+        summary_index_setting=None,
     )
     node = {
         "data": {
@@ -388,7 +396,7 @@ def test_transform_dataset_full_flow(mocker: MockerFixture, sqlite_session: Sess
     mocker.patch.object(service, "_deal_dependencies")
     mocker.patch.object(service, "_deal_document_data")
 
-    pipeline = SimpleNamespace(id="p-new")
+    pipeline = _pipeline()
     create_pipeline = mocker.patch.object(service, "_create_pipeline", return_value=pipeline)
 
     result = service.transform_dataset(dataset, "user-1", sqlite_session)
@@ -425,7 +433,7 @@ def test_transform_dataset_raises_for_unsupported_doc_form_after_pipeline_create
     sqlite_session.commit()
     mocker.patch.object(service, "_get_transform_yaml", return_value={"workflow": {"graph": {"nodes": []}}})
     mocker.patch.object(service, "_deal_dependencies")
-    mocker.patch.object(service, "_create_pipeline", return_value=SimpleNamespace(id="p-new"))
+    mocker.patch.object(service, "_create_pipeline", return_value=_pipeline())
 
     with pytest.raises(ValueError, match="Unsupported doc form"):
         service.transform_dataset(dataset, "user-1", sqlite_session)

--- a/api/tests/unit_tests/services/test_app_dsl_service.py
+++ b/api/tests/unit_tests/services/test_app_dsl_service.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import cast
@@ -10,9 +11,9 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from core.rbac import RBACPermission, RBACResourceScope
 from core.workflow.llm_environment_variable import LLMEnvironmentVariable
-from models import App, AppMode
+from models import Account, App, AppMode, Tenant
 from models.model import AppModelConfig, AppModelConfigDict, IconType
-from models.workflow import Workflow
+from models.workflow import Workflow, WorkflowType
 from services.app_dsl_service import AppDslService, PendingData
 from services.entities.dsl_entities import ImportStatus
 from services.errors.account import NoPermissionError
@@ -53,9 +54,59 @@ def _persist_overwrite_target(session: Session, *, maintainer: str = _OTHER_ACCO
     return app
 
 
+def _account(*, account_id: str = "account-1", tenant_id: str = "tenant-1") -> Account:
+    account = Account(name="DSL author", email=f"{account_id}@example.com")
+    account.id = account_id
+    tenant = Tenant(name="DSL workspace")
+    tenant.id = tenant_id
+    account._current_tenant = tenant
+    return account
+
+
+def _app(
+    *,
+    app_id: str = "11111111-1111-1111-1111-111111111111",
+    tenant_id: str = "33333333-3333-3333-3333-333333333333",
+    mode: AppMode = AppMode.CHAT,
+    app_model_config_id: str | None = None,
+) -> App:
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        app_model_config_id=app_model_config_id,
+        name="Existing app",
+        description="",
+        mode=mode,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=0,
+        use_icon_as_answer_icon=False,
+    )
+
+
+def _workflow(
+    *, graph: dict[str, object], environment_variables: list[LLMEnvironmentVariable] | None = None
+) -> Workflow:
+    workflow = Workflow(
+        id="workflow-1",
+        tenant_id="tenant-1",
+        app_id="app-1",
+        type=WorkflowType.WORKFLOW,
+        version="draft",
+        graph=json.dumps(graph),
+        _features="{}",
+        created_by="account-1",
+    )
+    workflow.environment_variables = environment_variables or []
+    return workflow
+
+
 def test_extract_workflow_dependencies_uses_llm_environment_variable_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _workflow(
+        graph={
             "nodes": [
                 {
                     "id": "llm-node",
@@ -84,7 +135,7 @@ def test_extract_workflow_dependencies_uses_llm_environment_variable_provider(mo
         analyze_dependency,
     )
 
-    result = AppDslService._extract_dependencies_from_workflow(cast(Workflow, workflow))
+    result = AppDslService._extract_dependencies_from_workflow(workflow)
 
     assert result == ["new-provider"]
     analyze_dependency.assert_called_once_with("new-provider")
@@ -94,8 +145,8 @@ def test_extract_workflow_dependencies_uses_llm_environment_variable_provider(mo
 def test_extract_workflow_dependencies_tolerates_unresolved_llm_environment_reference(
     monkeypatch: pytest.MonkeyPatch, model_selector: list[str]
 ) -> None:
-    workflow = SimpleNamespace(
-        graph_dict={
+    workflow = _workflow(
+        graph={
             "nodes": [
                 {
                     "id": "llm-node",
@@ -111,7 +162,6 @@ def test_extract_workflow_dependencies_tolerates_unresolved_llm_environment_refe
                 }
             ]
         },
-        environment_variables=[],
     )
     analyze_dependency = Mock(side_effect=lambda provider: provider)
     monkeypatch.setattr(
@@ -119,7 +169,7 @@ def test_extract_workflow_dependencies_tolerates_unresolved_llm_environment_refe
         analyze_dependency,
     )
 
-    result = AppDslService._extract_dependencies_from_workflow(cast(Workflow, workflow))
+    result = AppDslService._extract_dependencies_from_workflow(workflow)
 
     assert result == ["old-provider"]
     analyze_dependency.assert_called_once_with("old-provider")
@@ -130,7 +180,7 @@ def test_import_app_rejects_oversized_yaml_content_before_parsing(
 ) -> None:
     monkeypatch.setattr("services.app_dsl_service.DSL_MAX_SIZE", 3)
     service = AppDslService(session=unbound_session)
-    account = Mock(current_tenant_id="tenant-1")
+    account = _account()
 
     result = service.import_app(account=account, import_mode="yaml-content", yaml_content="你你")
 
@@ -150,7 +200,7 @@ def test_import_app_rejects_oversized_yaml_url_bytes_before_decode(
     service = AppDslService(session=unbound_session)
 
     result = service.import_app(
-        account=Mock(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode="yaml-url",
         yaml_url="https://example.com/app.yaml",
     )
@@ -170,7 +220,7 @@ def test_import_app_returns_decode_error_for_invalid_yaml_url_bytes(
     service = AppDslService(session=unbound_session)
 
     result = service.import_app(
-        account=Mock(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode="yaml-url",
         yaml_url="https://example.com/app.yaml",
     )
@@ -280,7 +330,7 @@ def test_pending_import_is_scoped_to_its_owner(monkeypatch: pytest.MonkeyPatch, 
         lambda key, _expiry, value: pending_imports.__setitem__(key, value),
     )
     service = AppDslService(session=unbound_session)
-    creator = Mock(id="account-1", current_tenant_id="tenant-1")
+    creator = _account()
 
     pending = service.import_app(
         account=creator,
@@ -300,12 +350,12 @@ def test_pending_import_is_scoped_to_its_owner(monkeypatch: pytest.MonkeyPatch, 
     monkeypatch.setattr(
         service,
         "_create_or_update_app",
-        Mock(return_value=Mock(id="app-1", mode=AppMode.WORKFLOW)),
+        Mock(return_value=_app(app_id="app-1", mode=AppMode.WORKFLOW)),
     )
 
     for other_account in (
-        Mock(id="account-1", current_tenant_id="tenant-2"),
-        Mock(id="account-2", current_tenant_id="tenant-1"),
+        _account(tenant_id="tenant-2"),
+        _account(account_id="account-2"),
     ):
         assert service.confirm_import(import_id=pending.id, account=other_account).status == ImportStatus.FAILED
 
@@ -357,25 +407,13 @@ def test_create_or_update_app_loads_existing_model_config_with_service_session(
         arrange_session.add(app_model_config)
         arrange_session.commit()
         app_model_config_id = app_model_config.id
-    app = cast(
-        App,
-        SimpleNamespace(
-            id="11111111-1111-1111-1111-111111111111",
-            tenant_id="33333333-3333-3333-3333-333333333333",
-            app_model_config_id=app_model_config_id,
-            name="Existing app",
-            description="",
-            icon_type=IconType.EMOJI,
-            icon="robot",
-            icon_background="#FFFFFF",
-        ),
-    )
+    app = _app(app_model_config_id=app_model_config_id)
 
     with sqlite_session_factory() as service_session:
         result = AppDslService(session=service_session)._create_or_update_app(
             app=app,
             data={"app": {"mode": AppMode.CHAT}, "model_config": {"model": {}}},
-            account=Mock(id="account-1"),
+            account=_account(),
         )
 
         assert result is app
@@ -399,25 +437,13 @@ def test_create_or_update_app_flushes_new_model_config_before_signal(
     signal = Mock()
     signal.send.side_effect = record_signal
     monkeypatch.setattr("services.app_dsl_service.app_model_config_was_updated", signal)
-    app = cast(
-        App,
-        SimpleNamespace(
-            id="11111111-1111-1111-1111-111111111111",
-            tenant_id="33333333-3333-3333-3333-333333333333",
-            app_model_config_id=None,
-            name="Existing app",
-            description="",
-            icon_type=IconType.EMOJI,
-            icon="robot",
-            icon_background="#FFFFFF",
-        ),
-    )
+    app = _app()
 
     try:
         AppDslService(session=sqlite_session)._create_or_update_app(
             app=app,
             data={"app": {"mode": AppMode.CHAT}, "model_config": {"model": {}}},
-            account=Mock(id="22222222-2222-2222-2222-222222222222"),
+            account=_account(account_id="22222222-2222-2222-2222-222222222222"),
         )
     finally:
         event.remove(sqlite_session, "after_flush", record_flush)
@@ -504,21 +530,7 @@ def test_export_dsl_loads_model_config_and_annotation_reply_with_request_session
         "services.app_dsl_service.DependenciesAnalysisService.generate_dependencies",
         Mock(return_value=[]),
     )
-    app = cast(
-        App,
-        SimpleNamespace(
-            id="11111111-1111-1111-1111-111111111111",
-            tenant_id="33333333-3333-3333-3333-333333333333",
-            app_model_config_id=app_model_config_id,
-            mode=AppMode.CHAT,
-            name="Chat app",
-            icon_type=IconType.EMOJI,
-            icon="robot",
-            icon_background="#FFFFFF",
-            description="",
-            use_icon_as_answer_icon=False,
-        ),
-    )
+    app = _app(app_model_config_id=app_model_config_id)
 
     with sqlite_session_factory() as service_session:
         exported = AppDslService.export_dsl(app, session=service_session)
@@ -536,7 +548,7 @@ def test_ensure_agent_manage_permission_noops_when_rbac_disabled(
     check = Mock()
     monkeypatch.setattr("services.app_dsl_service.RBACService.CheckAccess.check", check)
 
-    AppDslService._ensure_agent_manage_permission(Mock(id="account-1", current_tenant_id="tenant-1"))
+    AppDslService._ensure_agent_manage_permission(_account())
 
     check.assert_not_called()
 
@@ -548,7 +560,7 @@ def test_ensure_agent_manage_permission_allows_agent_manager(
     check = Mock(return_value=True)
     monkeypatch.setattr("services.app_dsl_service.RBACService.CheckAccess.check", check)
 
-    AppDslService._ensure_agent_manage_permission(Mock(id="account-1", current_tenant_id="tenant-1"))
+    AppDslService._ensure_agent_manage_permission(_account())
 
     check.assert_called_once_with("tenant-1", "account-1", scene=RBACPermission.AGENT_MANAGE)
 
@@ -560,7 +572,7 @@ def test_ensure_agent_manage_permission_rejects_without_agent_manage(
     monkeypatch.setattr("services.app_dsl_service.RBACService.CheckAccess.check", Mock(return_value=False))
 
     with pytest.raises(NoPermissionError):
-        AppDslService._ensure_agent_manage_permission(Mock(id="account-1", current_tenant_id="tenant-1"))
+        AppDslService._ensure_agent_manage_permission(_account())
 
 
 def test_create_or_update_app_gates_agent_mode_before_creation(
@@ -576,7 +588,7 @@ def test_create_or_update_app_gates_agent_mode_before_creation(
         service._create_or_update_app(
             app=None,
             data={"app": {"mode": "agent", "name": "Gated agent"}},
-            account=Mock(id="account-1", current_tenant_id="tenant-1"),
+            account=_account(),
         )
 
     assert not unbound_session.in_transaction()
@@ -593,7 +605,7 @@ def test_import_app_reraises_permission_denial_instead_of_failed_result(
 
     with pytest.raises(NoPermissionError):
         service.import_app(
-            account=Mock(id="account-1", current_tenant_id="tenant-1"),
+            account=_account(),
             import_mode="yaml-content",
             yaml_content="app:\n  mode: agent\n  name: Denied agent\n",
         )
@@ -601,18 +613,20 @@ def test_import_app_reraises_permission_denial_instead_of_failed_result(
     assert not unbound_session.in_transaction()
 
 
-def test_append_workflow_export_data_reports_missing_selected_workflow(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_append_workflow_export_data_reports_missing_selected_workflow(
+    monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+) -> None:
     workflow_id = "11111111-1111-4111-8111-111111111111"
     workflow_service = Mock()
     workflow_service.get_draft_workflow.return_value = None
     monkeypatch.setattr("services.app_dsl_service.WorkflowService", Mock(return_value=workflow_service))
-    app = cast(App, SimpleNamespace(id="app-1", tenant_id="tenant-1"))
+    app = _app(app_id="app-1", tenant_id="tenant-1")
 
     with pytest.raises(WorkflowNotFoundError, match=f"Workflow version not found. Workflow ID: {workflow_id}"):
         AppDslService._append_workflow_export_data(
             export_data={},
             app_model=app,
             include_secret=False,
-            session=Mock(),
+            session=unbound_session,
             workflow_id=workflow_id,
         )

--- a/api/tests/unit_tests/services/test_snippet_dsl_service.py
+++ b/api/tests/unit_tests/services/test_snippet_dsl_service.py
@@ -1,9 +1,15 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.orm import Session
 
 from graphon.nodes import BuiltinNodeTypes
+from models import Account, Tenant
+from models.snippet import CustomizedSnippet, SnippetType
+from models.workflow import Workflow, WorkflowType
 from services.snippet_dsl_service import (
     ImportMode,
     ImportStatus,
@@ -11,6 +17,62 @@ from services.snippet_dsl_service import (
     SnippetPendingData,
     _check_version_compatibility,
 )
+
+SQLITE_MODELS = (CustomizedSnippet,)
+pytestmark = [
+    pytest.mark.usefixtures("sqlite_session"),
+    pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True),
+]
+
+
+@pytest.fixture
+def service(sqlite_session: Session) -> SnippetDslService:
+    """Create the service with a real caller-owned SQLite session."""
+    return SnippetDslService(session=sqlite_session)
+
+
+def _account(*, account_id: str = "account-1", tenant_id: str = "tenant-1") -> Account:
+    account = Account(name="Snippet author", email=f"{account_id}@example.com")
+    account.id = account_id
+    tenant = Tenant(name="Snippet workspace")
+    tenant.id = tenant_id
+    account._current_tenant = tenant
+    return account
+
+
+def _snippet(
+    *,
+    snippet_id: str = "snippet-1",
+    tenant_id: str = "tenant-1",
+    name: str = "Snippet",
+    description: str | None = None,
+    snippet_type: SnippetType = SnippetType.NODE,
+    icon_info: dict | None = None,
+    input_fields: list[dict] | None = None,
+) -> CustomizedSnippet:
+    return CustomizedSnippet(
+        id=snippet_id,
+        tenant_id=tenant_id,
+        name=name,
+        description=description,
+        type=snippet_type.value,
+        icon_info=icon_info,
+        input_fields=json.dumps(input_fields) if input_fields else None,
+        created_by="account-1",
+    )
+
+
+def _workflow(*, graph: dict | None = None) -> Workflow:
+    return Workflow(
+        id="workflow-1",
+        tenant_id="tenant-1",
+        app_id="snippet-1",
+        type=WorkflowType.WORKFLOW,
+        version="draft",
+        graph=json.dumps(graph or {"nodes": [], "edges": []}),
+        _features="{}",
+        created_by="account-1",
+    )
 
 
 @pytest.mark.parametrize(
@@ -29,18 +91,14 @@ def test_check_version_compatibility_returns_pending_for_older_major() -> None:
     assert _check_version_compatibility("0.0.9") == ImportStatus.COMPLETED_WITH_WARNINGS
 
 
-def test_import_snippet_rejects_invalid_mode():
-    service = SnippetDslService(session=SimpleNamespace())
-
+def test_import_snippet_rejects_invalid_mode(service: SnippetDslService):
     with pytest.raises(ValueError, match="Invalid import_mode"):
-        service.import_snippet(account=SimpleNamespace(current_tenant_id="tenant-1"), import_mode="bad-mode")
+        service.import_snippet(account=_account(), import_mode="bad-mode")
 
 
-def test_import_snippet_requires_yaml_content():
-    service = SnippetDslService(session=SimpleNamespace())
-
+def test_import_snippet_requires_yaml_content(service: SnippetDslService):
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
     )
 
@@ -48,11 +106,9 @@ def test_import_snippet_requires_yaml_content():
     assert result.error == "yaml_content is required when import_mode is yaml-content"
 
 
-def test_import_snippet_requires_yaml_url() -> None:
-    service = SnippetDslService(session=SimpleNamespace())
-
+def test_import_snippet_requires_yaml_url(service: SnippetDslService) -> None:
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_URL.value,
     )
 
@@ -60,11 +116,9 @@ def test_import_snippet_requires_yaml_url() -> None:
     assert result.error == "yaml_url is required when import_mode is yaml-url"
 
 
-def test_import_snippet_rejects_invalid_yaml_url_scheme() -> None:
-    service = SnippetDslService(session=SimpleNamespace())
-
+def test_import_snippet_rejects_invalid_yaml_url_scheme(service: SnippetDslService) -> None:
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_URL.value,
         yaml_url="file:///tmp/snippet.yaml",
     )
@@ -73,15 +127,16 @@ def test_import_snippet_rejects_invalid_yaml_url_scheme() -> None:
     assert result.error == "Invalid URL scheme, only http and https are allowed"
 
 
-def test_import_snippet_returns_failed_when_yaml_url_fetch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
-    service = SnippetDslService(session=SimpleNamespace())
+def test_import_snippet_returns_failed_when_yaml_url_fetch_fails(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(
         "services.snippet_dsl_service.ssrf_proxy.get",
         Mock(return_value=SimpleNamespace(status_code=404, text="not found")),
     )
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_URL.value,
         yaml_url="https://example.com/snippet.yaml",
     )
@@ -90,8 +145,9 @@ def test_import_snippet_returns_failed_when_yaml_url_fetch_fails(monkeypatch: py
     assert result.error == "Failed to fetch YAML from URL: 404"
 
 
-def test_import_snippet_rejects_oversized_yaml_url_content(monkeypatch: pytest.MonkeyPatch) -> None:
-    service = SnippetDslService(session=SimpleNamespace())
+def test_import_snippet_rejects_oversized_yaml_url_content(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("services.snippet_dsl_service.DSL_MAX_SIZE", 3)
     monkeypatch.setattr(
         "services.snippet_dsl_service.ssrf_proxy.get",
@@ -99,7 +155,7 @@ def test_import_snippet_rejects_oversized_yaml_url_content(monkeypatch: pytest.M
     )
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_URL.value,
         yaml_url="https://example.com/snippet.yaml",
     )
@@ -108,8 +164,9 @@ def test_import_snippet_rejects_oversized_yaml_url_content(monkeypatch: pytest.M
     assert "YAML content size exceeds maximum limit" in result.error
 
 
-def test_import_snippet_rejects_oversized_yaml_url_bytes_before_decode(monkeypatch: pytest.MonkeyPatch) -> None:
-    service = SnippetDslService(session=SimpleNamespace())
+def test_import_snippet_rejects_oversized_yaml_url_bytes_before_decode(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("services.snippet_dsl_service.DSL_MAX_SIZE", 1)
     monkeypatch.setattr(
         "services.snippet_dsl_service.ssrf_proxy.get",
@@ -117,7 +174,7 @@ def test_import_snippet_rejects_oversized_yaml_url_bytes_before_decode(monkeypat
     )
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_URL.value,
         yaml_url="https://example.com/snippet.yaml",
     )
@@ -127,16 +184,15 @@ def test_import_snippet_rejects_oversized_yaml_url_bytes_before_decode(monkeypat
 
 
 def test_import_snippet_returns_decode_error_for_invalid_yaml_url_bytes(
-    monkeypatch: pytest.MonkeyPatch,
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    service = SnippetDslService(session=SimpleNamespace())
     monkeypatch.setattr(
         "services.snippet_dsl_service.ssrf_proxy.get",
         Mock(return_value=SimpleNamespace(status_code=200, content=b"\xff")),
     )
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_URL.value,
         yaml_url="https://example.com/snippet.yaml",
     )
@@ -145,15 +201,16 @@ def test_import_snippet_returns_decode_error_for_invalid_yaml_url_bytes(
     assert "utf-8" in result.error
 
 
-def test_import_snippet_returns_failed_when_yaml_url_fetch_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    service = SnippetDslService(session=SimpleNamespace())
+def test_import_snippet_returns_failed_when_yaml_url_fetch_raises(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(
         "services.snippet_dsl_service.ssrf_proxy.get",
         Mock(side_effect=RuntimeError("network down")),
     )
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_URL.value,
         yaml_url="https://example.com/snippet.yaml",
     )
@@ -162,12 +219,13 @@ def test_import_snippet_returns_failed_when_yaml_url_fetch_raises(monkeypatch: p
     assert result.error == "Failed to fetch YAML from URL: network down"
 
 
-def test_import_snippet_rejects_oversized_yaml_content(monkeypatch: pytest.MonkeyPatch) -> None:
-    service = SnippetDslService(session=SimpleNamespace())
+def test_import_snippet_rejects_oversized_yaml_content(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("services.snippet_dsl_service.DSL_MAX_SIZE", 1)
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content="é",
     )
@@ -188,11 +246,9 @@ def test_import_snippet_rejects_oversized_yaml_content(monkeypatch: pytest.Monke
         ("version: 0.1.0\nkind: snippet\n", "Missing snippet data in YAML content"),
     ],
 )
-def test_import_snippet_rejects_invalid_yaml_shapes(yaml_content, expected_error) -> None:
-    service = SnippetDslService(session=SimpleNamespace())
-
+def test_import_snippet_rejects_invalid_yaml_shapes(service: SnippetDslService, yaml_content, expected_error) -> None:
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content=yaml_content,
     )
@@ -201,11 +257,9 @@ def test_import_snippet_rejects_invalid_yaml_shapes(yaml_content, expected_error
     assert expected_error in result.error
 
 
-def test_import_snippet_returns_failed_for_invalid_version_type() -> None:
-    service = SnippetDslService(session=SimpleNamespace(rollback=Mock()))
-
+def test_import_snippet_returns_failed_for_invalid_version_type(service: SnippetDslService) -> None:
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content="version: 1\nkind: snippet\nsnippet:\n  name: Bad Version\n",
     )
@@ -214,11 +268,9 @@ def test_import_snippet_returns_failed_for_invalid_version_type() -> None:
     assert "Invalid version type" in result.error
 
 
-def test_import_snippet_returns_failed_for_invalid_yaml_syntax() -> None:
-    service = SnippetDslService(session=SimpleNamespace())
-
+def test_import_snippet_returns_failed_for_invalid_yaml_syntax(service: SnippetDslService) -> None:
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content="kind: snippet\nsnippet: [",
     )
@@ -227,8 +279,7 @@ def test_import_snippet_returns_failed_for_invalid_yaml_syntax() -> None:
     assert result.error.startswith("Invalid YAML format:")
 
 
-def test_import_snippet_rejects_forbidden_nodes():
-    service = SnippetDslService(session=SimpleNamespace())
+def test_import_snippet_rejects_forbidden_nodes(service: SnippetDslService):
     yaml_content = """
 version: 0.3.0
 kind: snippet
@@ -244,7 +295,7 @@ workflow:
 """
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content=yaml_content,
     )
@@ -253,8 +304,7 @@ workflow:
     assert result.error == "Snippet cannot contain the following node types: start"
 
 
-def test_import_snippet_stores_pending_data_for_newer_dsl(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(scalar=Mock(return_value=None)))
+def test_import_snippet_stores_pending_data_for_newer_dsl(service: SnippetDslService, monkeypatch: pytest.MonkeyPatch):
     setex = Mock()
     monkeypatch.setattr("services.snippet_dsl_service.redis_client.setex", setex)
     yaml_content = """
@@ -269,7 +319,7 @@ workflow:
 """
 
     result = service.import_snippet(
-        account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content=yaml_content,
         name="Override",
@@ -286,8 +336,7 @@ workflow:
     assert pending.description == "Override description"
 
 
-def test_import_snippet_returns_failed_when_update_target_missing():
-    service = SnippetDslService(session=SimpleNamespace(scalar=Mock(return_value=None)))
+def test_import_snippet_returns_failed_when_update_target_missing(service: SnippetDslService):
     yaml_content = """
 version: 0.1.0
 kind: snippet
@@ -300,7 +349,7 @@ workflow:
 """
 
     result = service.import_snippet(
-        account=SimpleNamespace(current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content=yaml_content,
         snippet_id="missing-snippet",
@@ -310,9 +359,10 @@ workflow:
     assert result.error == "Snippet not found"
 
 
-def test_import_snippet_passes_dependencies_to_create_or_update(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(scalar=Mock(return_value=None)))
-    snippet = SimpleNamespace(id="snippet-1")
+def test_import_snippet_passes_dependencies_to_create_or_update(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
+    snippet = _snippet()
     create_or_update = Mock(return_value=snippet)
     monkeypatch.setattr(service, "_create_or_update_snippet", create_or_update)
     yaml_content = """
@@ -331,7 +381,7 @@ workflow:
 """
 
     result = service.import_snippet(
-        account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content=yaml_content,
     )
@@ -342,50 +392,50 @@ workflow:
     assert dependencies[0].value.plugin_unique_identifier == "langgenius/openai:0.0.1"
 
 
-def test_import_snippet_rolls_back_when_create_or_update_raises(monkeypatch: pytest.MonkeyPatch):
-    session = SimpleNamespace(scalar=Mock(return_value=None), rollback=Mock())
-    service = SnippetDslService(session=session)
+def test_import_snippet_rolls_back_when_create_or_update_raises(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+):
+    rollback_events: list[str] = []
+    event.listen(sqlite_session, "after_rollback", lambda _session: rollback_events.append("rollback"))
+    sqlite_session.begin()
     monkeypatch.setattr(service, "_create_or_update_snippet", Mock(side_effect=RuntimeError("boom")))
 
     result = service.import_snippet(
-        account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1"),
+        account=_account(),
         import_mode=ImportMode.YAML_CONTENT.value,
         yaml_content="version: 0.1.0\nkind: snippet\nsnippet:\n  name: Bad\n",
     )
 
     assert result.status == ImportStatus.FAILED
     assert result.error == "boom"
-    session.rollback.assert_called_once()
+    assert rollback_events == ["rollback"]
 
 
-def test_confirm_import_returns_failed_when_pending_data_missing(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace())
+def test_confirm_import_returns_failed_when_pending_data_missing(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
     monkeypatch.setattr("services.snippet_dsl_service.redis_client.get", Mock(return_value=None))
 
-    result = service.confirm_import(
-        import_id="missing", account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1")
-    )
+    result = service.confirm_import(import_id="missing", account=_account())
 
     assert result.status == ImportStatus.FAILED
     assert result.error == "Import information expired or does not exist"
 
 
-def test_confirm_import_returns_failed_for_invalid_pending_payload(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace())
+def test_confirm_import_returns_failed_for_invalid_pending_payload(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
     monkeypatch.setattr("services.snippet_dsl_service.redis_client.get", Mock(return_value=object()))
 
-    result = service.confirm_import(
-        import_id="bad", account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1")
-    )
+    result = service.confirm_import(import_id="bad", account=_account())
 
     assert result.status == ImportStatus.FAILED
     assert result.error == "Invalid import information"
 
 
-def test_confirm_import_is_scoped_to_its_owner(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(scalar=Mock(return_value=None)))
-    account = SimpleNamespace(id="account-1", current_tenant_id="tenant-1")
-    snippet = SimpleNamespace(id="snippet-new")
+def test_confirm_import_is_scoped_to_its_owner(service: SnippetDslService, monkeypatch: pytest.MonkeyPatch):
+    account = _account()
+    snippet = _snippet(snippet_id="snippet-new")
     yaml_content = """
 version: 9.0.0
 kind: snippet
@@ -417,8 +467,8 @@ workflow:
     monkeypatch.setattr("services.snippet_dsl_service.redis_client.delete", redis_delete)
 
     for other_account in (
-        SimpleNamespace(id="account-1", current_tenant_id="tenant-2"),
-        SimpleNamespace(id="account-2", current_tenant_id="tenant-1"),
+        _account(tenant_id="tenant-2"),
+        _account(account_id="account-2"),
     ):
         assert service.confirm_import(import_id="import-1", account=other_account).status == ImportStatus.FAILED
 
@@ -437,8 +487,9 @@ workflow:
     redis_delete.assert_called_once_with(redis_key)
 
 
-def test_confirm_import_returns_failed_for_non_mapping_yaml(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace())
+def test_confirm_import_returns_failed_for_non_mapping_yaml(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
     pending = SnippetPendingData(
         import_mode="yaml-content",
         yaml_content="- item",
@@ -446,17 +497,17 @@ def test_confirm_import_returns_failed_for_non_mapping_yaml(monkeypatch: pytest.
     )
     monkeypatch.setattr("services.snippet_dsl_service.redis_client.get", Mock(return_value=pending.model_dump_json()))
 
-    result = service.confirm_import(
-        import_id="import-1", account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1")
-    )
+    result = service.confirm_import(import_id="import-1", account=_account())
 
     assert result.status == ImportStatus.FAILED
     assert result.error == "Invalid YAML format: expected a dictionary"
 
 
-def test_confirm_import_returns_failed_when_create_or_update_raises(monkeypatch: pytest.MonkeyPatch):
-    session = SimpleNamespace(scalar=Mock(return_value=None), rollback=Mock())
-    service = SnippetDslService(session=session)
+def test_confirm_import_returns_failed_when_create_or_update_raises(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+):
+    rollback_events: list[str] = []
+    event.listen(sqlite_session, "after_rollback", lambda _session: rollback_events.append("rollback"))
     pending = SnippetPendingData(
         import_mode="yaml-content",
         yaml_content="version: 0.1.0\nkind: snippet\nsnippet:\n  name: Bad\n",
@@ -467,29 +518,29 @@ def test_confirm_import_returns_failed_when_create_or_update_raises(monkeypatch:
 
     result = service.confirm_import(
         import_id="import-1",
-        account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1"),
+        account=_account(),
     )
 
     assert result.status == ImportStatus.FAILED
     assert result.error == "boom"
-    session.rollback.assert_called_once()
+    assert rollback_events == ["rollback"]
 
 
-def test_check_dependencies_returns_empty_without_draft_workflow(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(get_bind=Mock()))
+def test_check_dependencies_returns_empty_without_draft_workflow(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
     monkeypatch.setattr(
         "services.snippet_dsl_service.SnippetService",
         lambda *_args, **_kwargs: SimpleNamespace(get_draft_workflow=Mock(return_value=None)),
     )
 
-    result = service.check_dependencies(SimpleNamespace(id="snippet-1", tenant_id="tenant-1"))
+    result = service.check_dependencies(_snippet())
 
     assert result.leaked_dependencies == []
 
 
-def test_check_dependencies_returns_generated_dependencies(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(get_bind=Mock()))
-    workflow = SimpleNamespace(graph_dict={"nodes": []})
+def test_check_dependencies_returns_generated_dependencies(service: SnippetDslService, monkeypatch: pytest.MonkeyPatch):
+    workflow = _workflow()
     leaked_dependencies = [
         {
             "type": "marketplace",
@@ -506,29 +557,25 @@ def test_check_dependencies_returns_generated_dependencies(monkeypatch: pytest.M
         Mock(return_value=leaked_dependencies),
     )
 
-    result = service.check_dependencies(SimpleNamespace(id="snippet-1", tenant_id="tenant-1"))
+    result = service.check_dependencies(_snippet())
 
     assert result.leaked_dependencies[0].value.plugin_unique_identifier == "langgenius/openai:0.0.1"
 
 
-def test_create_or_update_snippet_updates_existing_snippet_and_syncs_workflow(monkeypatch: pytest.MonkeyPatch):
-    snippet = SimpleNamespace(
-        id="snippet-1",
-        tenant_id="tenant-1",
+def test_create_or_update_snippet_updates_existing_snippet_and_syncs_workflow(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+):
+    snippet = _snippet(
         name="Old",
         description="Old",
-        type="node",
         icon_info=None,
-        input_fields=None,
-        updated_by=None,
-        updated_at=None,
     )
-    session = SimpleNamespace(add=Mock(), flush=Mock(), commit=Mock(), get_bind=Mock())
-    service = SnippetDslService(session=session)
-    draft_workflow = SimpleNamespace(unique_hash="hash-1")
+    sqlite_session.add(snippet)
+    sqlite_session.commit()
+    draft_workflow = _workflow()
     snippet_service = SimpleNamespace(
         get_draft_workflow=Mock(return_value=draft_workflow),
-        sync_draft_workflow=Mock(),
+        sync_draft_workflow=Mock(return_value=draft_workflow),
     )
     monkeypatch.setattr("services.snippet_dsl_service.SnippetService", lambda *_args, **_kwargs: snippet_service)
     monkeypatch.setattr(
@@ -557,7 +604,7 @@ def test_create_or_update_snippet_updates_existing_snippet_and_syncs_workflow(mo
             },
             "workflow": {"graph": {"nodes": [], "edges": []}},
         },
-        account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1"),
+        account=_account(),
     )
 
     assert result is snippet
@@ -565,7 +612,10 @@ def test_create_or_update_snippet_updates_existing_snippet_and_syncs_workflow(mo
     assert snippet.type == "node"
     assert snippet.icon_info == {"icon": "x"}
     snippet_service.sync_draft_workflow.assert_called_once()
-    session.commit.assert_called_once()
+    assert not sqlite_session.in_transaction()
+    persisted = sqlite_session.get(CustomizedSnippet, snippet.id)
+    assert persisted is not None
+    assert persisted.name == "New"
     retire_unowned.assert_called_once_with(
         tenant_id="tenant-1",
         agent_ids={"retired-agent"},
@@ -573,10 +623,13 @@ def test_create_or_update_snippet_updates_existing_snippet_and_syncs_workflow(mo
     )
 
 
-def test_create_or_update_snippet_creates_new_snippet_and_flushes(monkeypatch: pytest.MonkeyPatch):
-    session = SimpleNamespace(add=Mock(), flush=Mock(), commit=Mock(), get_bind=Mock())
-    service = SnippetDslService(session=session)
-    snippet_service = SimpleNamespace(get_draft_workflow=Mock(return_value=None), sync_draft_workflow=Mock())
+def test_create_or_update_snippet_creates_new_snippet_and_flushes(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+):
+    snippet_service = SimpleNamespace(
+        get_draft_workflow=Mock(return_value=None),
+        sync_draft_workflow=Mock(return_value=_workflow()),
+    )
     monkeypatch.setattr("services.snippet_dsl_service.SnippetService", lambda *_args, **_kwargs: snippet_service)
     monkeypatch.setattr(
         "services.snippet_dsl_service.WorkflowAgentPublishService.sync_agent_bindings_for_draft",
@@ -598,41 +651,33 @@ def test_create_or_update_snippet_creates_new_snippet_and_flushes(monkeypatch: p
             },
             "workflow": {"graph": {"nodes": [], "edges": []}},
         },
-        account=SimpleNamespace(id="account-1", current_tenant_id="tenant-1"),
+        account=_account(),
     )
 
     assert result.name == "New Snippet"
     assert result.type == "group"
-    session.add.assert_called_once_with(result)
-    session.flush.assert_called_once()
+    assert sqlite_session.get(CustomizedSnippet, result.id) is result
     snippet_service.sync_draft_workflow.assert_called_once()
-    session.commit.assert_called_once()
+    assert not sqlite_session.in_transaction()
 
 
-def test_export_snippet_dsl_raises_without_draft_workflow(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(get_bind=Mock()))
+def test_export_snippet_dsl_raises_without_draft_workflow(service: SnippetDslService, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         "services.snippet_dsl_service.SnippetService",
         lambda *_args, **_kwargs: SimpleNamespace(get_draft_workflow=Mock(return_value=None)),
     )
 
     with pytest.raises(ValueError, match="Missing draft workflow"):
-        service.export_snippet_dsl(SimpleNamespace())
+        service.export_snippet_dsl(_snippet())
 
 
-def test_export_snippet_dsl_returns_yaml(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(get_bind=Mock()))
-    workflow = SimpleNamespace(
-        to_dict=Mock(return_value={"graph": {"nodes": []}}),
-        graph_dict={"nodes": []},
-    )
-    snippet = SimpleNamespace(
-        tenant_id="tenant-1",
+def test_export_snippet_dsl_returns_yaml(service: SnippetDslService, monkeypatch: pytest.MonkeyPatch):
+    workflow = _workflow()
+    snippet = _snippet(
         name="Exported",
         description=None,
-        type="node",
         icon_info=None,
-        input_fields_list=[{"variable": "query"}],
+        input_fields=[{"variable": "query"}],
     )
     monkeypatch.setattr(
         "services.snippet_dsl_service.SnippetService",
@@ -650,20 +695,11 @@ def test_export_snippet_dsl_returns_yaml(monkeypatch: pytest.MonkeyPatch):
     assert "input_fields:" in result
 
 
-def test_export_snippet_dsl_uses_requested_published_workflow(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace(get_bind=Mock()))
-    workflow = SimpleNamespace(
-        to_dict=Mock(return_value={"graph": {"nodes": []}}),
-        graph_dict={"nodes": []},
-    )
-    snippet = SimpleNamespace(
-        tenant_id="tenant-1",
-        name="Exported",
-        description=None,
-        type="node",
-        icon_info=None,
-        input_fields_list=[],
-    )
+def test_export_snippet_dsl_uses_requested_published_workflow(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
+    workflow = _workflow(graph={"nodes": [], "edges": []})
+    snippet = _snippet(name="Exported")
     get_published_workflow_by_id = Mock(return_value=workflow)
     get_draft_workflow = Mock()
     monkeypatch.setattr(
@@ -684,8 +720,9 @@ def test_export_snippet_dsl_uses_requested_published_workflow(monkeypatch: pytes
     get_draft_workflow.assert_not_called()
 
 
-def test_append_workflow_export_data_filters_credentials_and_extracts_dependencies(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace())
+def test_append_workflow_export_data_filters_credentials_and_extracts_dependencies(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
     workflow_dict = {
         "graph": {
             "nodes": [
@@ -718,10 +755,7 @@ def test_append_workflow_export_data_filters_credentials_and_extracts_dependenci
         "environment_variables": [{"name": "SECRET"}],
         "conversation_variables": [{"name": "memory"}],
     }
-    workflow = SimpleNamespace(
-        to_dict=Mock(return_value=workflow_dict),
-        graph_dict=workflow_dict["graph"],
-    )
+    workflow = _workflow(graph=workflow_dict["graph"])
     monkeypatch.setattr(
         "services.snippet_dsl_service.DependenciesAnalysisService.generate_dependencies",
         Mock(return_value=[]),
@@ -730,7 +764,7 @@ def test_append_workflow_export_data_filters_credentials_and_extracts_dependenci
 
     service._append_workflow_export_data(
         export_data=export_data,
-        snippet=SimpleNamespace(tenant_id="tenant-1"),
+        snippet=_snippet(),
         workflow=workflow,
         include_secret=False,
     )
@@ -742,8 +776,9 @@ def test_append_workflow_export_data_filters_credentials_and_extracts_dependenci
     assert "credential_id" not in nodes[2]["data"]["agent_parameters"]["tools"]["value"][0]
 
 
-def test_append_workflow_export_data_rewrites_knowledge_dataset_ids(monkeypatch: pytest.MonkeyPatch):
-    service = SnippetDslService(session=SimpleNamespace())
+def test_append_workflow_export_data_rewrites_knowledge_dataset_ids(
+    service: SnippetDslService, monkeypatch: pytest.MonkeyPatch
+):
     workflow_dict = {
         "graph": {
             "nodes": [
@@ -756,7 +791,7 @@ def test_append_workflow_export_data_rewrites_knowledge_dataset_ids(monkeypatch:
             ]
         },
     }
-    workflow = SimpleNamespace(to_dict=Mock(return_value=workflow_dict), graph_dict=workflow_dict["graph"])
+    workflow = _workflow(graph=workflow_dict["graph"])
     monkeypatch.setattr(
         service,
         "_encrypt_dataset_id",
@@ -770,7 +805,7 @@ def test_append_workflow_export_data_rewrites_knowledge_dataset_ids(monkeypatch:
 
     service._append_workflow_export_data(
         export_data=export_data,
-        snippet=SimpleNamespace(tenant_id="tenant-1"),
+        snippet=_snippet(),
         workflow=workflow,
         include_secret=True,
     )

--- a/api/tests/unit_tests/services/workflow/test_workflow_converter_additional.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_converter_additional.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -45,15 +45,36 @@ def converter() -> WorkflowConverter:
 
 
 def _app_model(**kwargs: Any) -> App:
-    return cast(App, SimpleNamespace(**kwargs))
+    defaults: dict[str, Any] = {
+        "id": "app-1",
+        "tenant_id": "tenant-1",
+        "name": "Source App",
+        "description": "",
+        "mode": AppMode.CHAT,
+        "enable_site": True,
+        "enable_api": True,
+        "max_active_requests": 0,
+    }
+    defaults.update(kwargs)
+    return App(**defaults)
 
 
 def _account(**kwargs: Any) -> Account:
-    return cast(Account, SimpleNamespace(**kwargs))
+    account_id = kwargs.pop("id", "account-1")
+    account = Account(
+        name=kwargs.pop("name", "Converter user"),
+        email=kwargs.pop("email", "user@example.com"),
+        **kwargs,
+    )
+    account.id = account_id
+    return account
 
 
 def _app_model_config(**kwargs: Any) -> AppModelConfig:
-    return cast(AppModelConfig, SimpleNamespace(**kwargs))
+    config_id = kwargs.pop("id", "config-1")
+    config = AppModelConfig(app_id=kwargs.pop("app_id", "app-1"), **kwargs)
+    config.id = config_id
+    return config
 
 
 def _build_start_graph() -> dict[str, Any]:
@@ -94,10 +115,7 @@ def test__convert_to_start_node(default_variables: list[VariableEntity]) -> None
 def test__convert_to_http_request_node_for_chatbot(
     default_variables: list[VariableEntity], unbound_session: Session
 ) -> None:
-    app_model = MagicMock()
-    app_model.id = "app_id"
-    app_model.tenant_id = "tenant_id"
-    app_model.mode = AppMode.CHAT
+    app_model = _app_model(id="app_id", tenant_id="tenant_id", mode=AppMode.CHAT)
 
     extension = APIBasedExtension(
         tenant_id="tenant_id",
@@ -139,10 +157,7 @@ def test__convert_to_http_request_node_for_chatbot(
 def test__convert_to_http_request_node_for_workflow_app(
     default_variables: list[VariableEntity], unbound_session: Session
 ) -> None:
-    app_model = MagicMock()
-    app_model.id = "app_id"
-    app_model.tenant_id = "tenant_id"
-    app_model.mode = AppMode.WORKFLOW
+    app_model = _app_model(id="app_id", tenant_id="tenant_id", mode=AppMode.WORKFLOW)
 
     extension = APIBasedExtension(
         tenant_id="tenant_id",
@@ -593,7 +608,7 @@ def test_convert_app_model_config_to_workflow_should_build_workflow_mode_with_en
 def test_convert_to_app_config_should_route_to_correct_manager(
     converter: WorkflowConverter,
     monkeypatch: pytest.MonkeyPatch,
-    unbound_session: Session,
+    sqlite_session: Session,
 ) -> None:
     agent_result = SimpleNamespace(kind="agent")
     chat_result = SimpleNamespace(kind="chat")
@@ -606,47 +621,61 @@ def test_convert_to_app_config_should_route_to_correct_manager(
     monkeypatch.setattr(converter_module.ChatAppConfigManager, "get_app_config", chat_get_app_config)
     monkeypatch.setattr(converter_module.CompletionAppConfigManager, "get_app_config", completion_get_app_config)
     monkeypatch.setattr(converter_module, "load_annotation_reply_config", load_annotation_reply)
-    agent_mode_app = _app_model(mode=AppMode.AGENT_CHAT, is_agent_with_session=MagicMock(return_value=False))
-    agent_flag_app = _app_model(mode=AppMode.CHAT, is_agent_with_session=MagicMock(return_value=True))
-    chat_app = _app_model(mode=AppMode.CHAT, is_agent_with_session=MagicMock(return_value=False))
-    completion_app = _app_model(mode=AppMode.COMPLETION, is_agent_with_session=MagicMock(return_value=False))
+    agent_mode_app = _app_model(id="app-1", mode=AppMode.AGENT_CHAT, app_model_config_id="cfg-1")
+    agent_flag_app = _app_model(id="app-2", mode=AppMode.CHAT, app_model_config_id="cfg-2")
+    chat_app = _app_model(id="app-3", mode=AppMode.CHAT, app_model_config_id="cfg-3")
+    completion_app = _app_model(id="app-4", mode=AppMode.COMPLETION, app_model_config_id="cfg-4")
     agent_mode_config = _app_model_config(id="cfg-1", app_id="app-1")
-    agent_flag_config = _app_model_config(id="cfg-2", app_id="app-2")
+    agent_flag_config = _app_model_config(
+        id="cfg-2", app_id="app-2", agent_mode=json.dumps({"enabled": True, "strategy": "react"})
+    )
     chat_config = _app_model_config(id="cfg-3", app_id="app-3")
     completion_config = _app_model_config(id="cfg-4", app_id="app-4")
+    sqlite_session.add_all(
+        [
+            agent_mode_app,
+            agent_flag_app,
+            chat_app,
+            completion_app,
+            agent_mode_config,
+            agent_flag_config,
+            chat_config,
+            completion_config,
+        ]
+    )
+    sqlite_session.commit()
 
     from_agent_mode = converter._convert_to_app_config(
         app_model=agent_mode_app,
         app_model_config=agent_mode_config,
-        session=unbound_session,
+        session=sqlite_session,
     )
     from_agent_flag = converter._convert_to_app_config(
         app_model=agent_flag_app,
         app_model_config=agent_flag_config,
-        session=unbound_session,
+        session=sqlite_session,
     )
     from_chat_mode = converter._convert_to_app_config(
         app_model=chat_app,
         app_model_config=chat_config,
-        session=unbound_session,
+        session=sqlite_session,
     )
     from_completion_mode = converter._convert_to_app_config(
         app_model=completion_app,
         app_model_config=completion_config,
-        session=unbound_session,
+        session=sqlite_session,
     )
 
     assert from_agent_mode is agent_result
     assert from_agent_flag is agent_result
     assert from_chat_mode is chat_result
     assert from_completion_mode is completion_result
-    agent_flag_app.is_agent_with_session.assert_called_once_with(session=unbound_session)
     load_annotation_reply.assert_has_calls(
         [
-            call(unbound_session, "app-1"),
-            call(unbound_session, "app-2"),
-            call(unbound_session, "app-3"),
-            call(unbound_session, "app-4"),
+            call(sqlite_session, "app-1"),
+            call(sqlite_session, "app-2"),
+            call(sqlite_session, "app-3"),
+            call(sqlite_session, "app-4"),
         ]
     )
     assert all(
@@ -659,7 +688,7 @@ def test_convert_to_app_config_should_route_to_correct_manager(
 def test_convert_to_app_config_should_raise_for_invalid_app_mode(
     converter: WorkflowConverter, unbound_session: Session
 ) -> None:
-    app_model = _app_model(mode=AppMode.WORKFLOW, is_agent_with_session=MagicMock(return_value=False))
+    app_model = _app_model(mode=AppMode.WORKFLOW)
 
     with pytest.raises(ValueError, match="Invalid app mode"):
         converter._convert_to_app_config(
@@ -845,25 +874,35 @@ def test_graph_helpers_should_create_edges_append_nodes_and_choose_mode(converte
 
 def test_get_api_based_extension_should_raise_when_extension_not_found(
     converter: WorkflowConverter,
-    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
 ) -> None:
-    db_session = SimpleNamespace(scalar=MagicMock(return_value=None))
-
     with pytest.raises(ValueError, match="API Based Extension not found"):
-        converter._get_api_based_extension(tenant_id="tenant-1", api_based_extension_id="ext-1", session=db_session)
-    db_session.scalar.assert_called_once()
+        converter._get_api_based_extension(tenant_id="tenant-1", api_based_extension_id="ext-1", session=sqlite_session)
 
 
 def test_get_api_based_extension_should_return_entity_when_found(
     converter: WorkflowConverter,
-    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
 ) -> None:
-    extension = SimpleNamespace(id="ext-1")
-    db_session = SimpleNamespace(scalar=MagicMock(return_value=extension))
+    extension = APIBasedExtension(
+        tenant_id="tenant-1",
+        name="API extension",
+        api_key="encrypted",
+        api_endpoint="https://example.com",
+    )
+    extension.id = "ext-1"
+    decoy = APIBasedExtension(
+        tenant_id="other-tenant",
+        name="Other tenant API extension",
+        api_key="encrypted",
+        api_endpoint="https://example.com",
+    )
+    decoy.id = "ext-other"
+    sqlite_session.add_all([extension, decoy])
+    sqlite_session.commit()
 
     result = converter._get_api_based_extension(
-        tenant_id="tenant-1", api_based_extension_id="ext-1", session=db_session
+        tenant_id="tenant-1", api_based_extension_id="ext-1", session=sqlite_session
     )
 
     assert result is extension
-    db_session.scalar.assert_called_once()


### PR DESCRIPTION
## Summary

- replace fake sessions in snippet DSL tests with the caller-owned SQLite session fixture
- replace App, Account, Tenant, AppModelConfig, CustomizedSnippet, Workflow, Dataset, Pipeline, and APIBasedExtension stand-ins with real mapped instances
- exercise scoped snippet/app/extension lookups, persisted create/update behavior, workflow conversion, RAG pipeline dependency extraction, and transaction rollback through SQLAlchemy
- retain mocks for Redis, HTTP responses, plugin analysis/installers, signals, config DTOs, and service collaborators

No production changes were required.

## Persistence coverage

- snippet import confirmation enforces tenant/account ownership with real account/tenant chains
- snippet create/update commits mapped rows; exception paths observe real rollback events
- workflow conversion persists real workflow/app records and scopes API extension lookup with a cross-tenant decoy
- app DSL model-config reads and signal ordering use real mapped App and AppModelConfig instances
- RAG pipeline DSL and transform helpers use real Workflow, Dataset, Pipeline, Account, and Tenant instances

## Size

403 additions, 271 deletions (674 changed lines). This is an atomic DSL-focused residual cluster; splitting the modules further would leave partial migrations in the same behavior family.

## Validation

- snippet DSL: 38 passed
- workflow converter additional: 30 passed
- app DSL: 22 passed
- RAG pipeline DSL: 38 passed
- RAG pipeline transform: 32 passed
- changed-file structural audit — no SQLAlchemy session doubles or mapped-model stand-ins
- `make lint` — passed
- `make type-check` — pyrefly passed after correcting a test annotation; mypy 1.20.2 hit an internal error in `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`

The full test suite was not run, per request.