### PR TITLE
test: migrate console app response sessions and ORM models to SQLite

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -63,7 +63,7 @@ from services.app_service import (
 )
 from services.enterprise import rbac_service as enterprise_rbac_service
 from services.enterprise.enterprise_service import EnterpriseService
-from services.entities.dsl_entities import DslImportWarning, ImportMode, ImportStatus
+from services.entities.dsl_entities import DslImportWarning, ImportStatus
 from services.entities.knowledge_entities.knowledge_entities import (
     DataSource,
     InfoList,
@@ -987,12 +987,11 @@ class AppCopyApi(Resource):
         # The role of the current user in the ta table must be admin, owner, or editor
 
         import_service = AppDslService(session)
-        yaml_content = import_service.export_dsl(app_model=app_model, session=session, include_secret=True)
         try:
-            result = import_service.import_app(
+            result, app = import_service.copy_app(
+                app_model=app_model,
                 account=current_user,
-                import_mode=ImportMode.YAML_CONTENT,
-                yaml_content=yaml_content,
+                tenant_id=current_tenant_id,
                 name=req_data.name,
                 description=req_data.description,
                 icon_type=req_data.icon_type,
@@ -1002,28 +1001,9 @@ class AppCopyApi(Resource):
         except NoPermissionError as e:
             raise Forbidden(str(e))
         if result.status == ImportStatus.FAILED:
-            session.rollback()
             return dump_response(AppImportResponse, result), 400
         if result.status == ImportStatus.PENDING:
-            session.rollback()
             return dump_response(AppImportResponse, result), 202
-        session.commit()
-
-        # Inherit web app permission from original app
-        if result.app_id and SystemFeatureService.is_webapp_auth_enabled():
-            try:
-                # Get the original app's access mode
-                original_settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_model.id)
-                access_mode = original_settings.access_mode
-            except Exception:
-                # If original app has no settings (old app), default to public to match fallback behavior
-                access_mode = "public"
-
-            # Apply the same access mode to the copied app
-            EnterpriseService.WebAppAuth.update_app_access_mode(result.app_id, access_mode)
-
-        stmt = select(App).where(App.id == result.app_id)
-        app = session.scalar(stmt)
         if not app:
             raise NotFound("App not found")
 

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -972,66 +972,73 @@ class AppCopyApi(Resource):
     @rbac_permission_required(RBACCheck(RBACPermission.APP_CREATE_AND_MANAGEMENT, PlainApp()))
     @with_current_user
     @with_current_tenant_id
+    @with_session
     @get_app_model(mode=None)
     @model_validate(CopyAppPayload)
-    def post(self, req_data: CopyAppPayload, current_tenant_id: str, current_user: Account, app_model: App):
+    def post(
+        self,
+        req_data: CopyAppPayload,
+        session: Session,
+        current_tenant_id: str,
+        current_user: Account,
+        app_model: App,
+    ):
         """Copy app"""
         # The role of the current user in the ta table must be admin, owner, or editor
 
-        with Session(db.engine, expire_on_commit=False) as session:
-            import_service = AppDslService(session)
-            yaml_content = import_service.export_dsl(app_model=app_model, session=session, include_secret=True)
-            try:
-                result = import_service.import_app(
-                    account=current_user,
-                    import_mode=ImportMode.YAML_CONTENT,
-                    yaml_content=yaml_content,
-                    name=req_data.name,
-                    description=req_data.description,
-                    icon_type=req_data.icon_type,
-                    icon=req_data.icon,
-                    icon_background=req_data.icon_background,
-                )
-            except NoPermissionError as e:
-                raise Forbidden(str(e))
-            if result.status == ImportStatus.FAILED:
-                session.rollback()
-                return dump_response(AppImportResponse, result), 400
-            if result.status == ImportStatus.PENDING:
-                session.rollback()
-                return dump_response(AppImportResponse, result), 202
-            session.commit()
-
-            # Inherit web app permission from original app
-            if result.app_id and SystemFeatureService.is_webapp_auth_enabled():
-                try:
-                    # Get the original app's access mode
-                    original_settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_model.id)
-                    access_mode = original_settings.access_mode
-                except Exception:
-                    # If original app has no settings (old app), default to public to match fallback behavior
-                    access_mode = "public"
-
-                # Apply the same access mode to the copied app
-                EnterpriseService.WebAppAuth.update_app_access_mode(result.app_id, access_mode)
-
-            stmt = select(App).where(App.id == result.app_id)
-            app = session.scalar(stmt)
-            if not app:
-                raise NotFound("App not found")
-
-            permission_keys_map = enterprise_rbac_service.RBACService.AppPermissions.batch_get(
-                current_tenant_id,
-                current_user.id,
-                [str(app.id)],
-                session=session,
+        import_service = AppDslService(session)
+        yaml_content = import_service.export_dsl(app_model=app_model, session=session, include_secret=True)
+        try:
+            result = import_service.import_app(
+                account=current_user,
+                import_mode=ImportMode.YAML_CONTENT,
+                yaml_content=yaml_content,
+                name=req_data.name,
+                description=req_data.description,
+                icon_type=req_data.icon_type,
+                icon=req_data.icon,
+                icon_background=req_data.icon_background,
             )
-            response_model = AppDetailWithSite.model_validate(
-                app,
-                from_attributes=True,
-                context={"session": session},
-            ).model_copy(update={"permission_keys": permission_keys_map.get(str(app.id), [])})
-            return response_model.model_dump(mode="json"), 201
+        except NoPermissionError as e:
+            raise Forbidden(str(e))
+        if result.status == ImportStatus.FAILED:
+            session.rollback()
+            return dump_response(AppImportResponse, result), 400
+        if result.status == ImportStatus.PENDING:
+            session.rollback()
+            return dump_response(AppImportResponse, result), 202
+        session.commit()
+
+        # Inherit web app permission from original app
+        if result.app_id and SystemFeatureService.is_webapp_auth_enabled():
+            try:
+                # Get the original app's access mode
+                original_settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_model.id)
+                access_mode = original_settings.access_mode
+            except Exception:
+                # If original app has no settings (old app), default to public to match fallback behavior
+                access_mode = "public"
+
+            # Apply the same access mode to the copied app
+            EnterpriseService.WebAppAuth.update_app_access_mode(result.app_id, access_mode)
+
+        stmt = select(App).where(App.id == result.app_id)
+        app = session.scalar(stmt)
+        if not app:
+            raise NotFound("App not found")
+
+        permission_keys_map = enterprise_rbac_service.RBACService.AppPermissions.batch_get(
+            current_tenant_id,
+            current_user.id,
+            [str(app.id)],
+            session=session,
+        )
+        response_model = AppDetailWithSite.model_validate(
+            app,
+            from_attributes=True,
+            context={"session": session},
+        ).model_copy(update={"permission_keys": permission_keys_map.get(str(app.id), [])})
+        return response_model.model_dump(mode="json"), 201
 
 
 @console_ns.route("/apps/<uuid:app_id>/export")

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -52,6 +52,7 @@ from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.agent.workflow_publish_service import WorkflowAgentPublishService
 from services.dsl_content import DSL_MAX_SIZE, dsl_content_size
 from services.dsl_version import check_version_compatibility
+from services.enterprise.enterprise_service import EnterpriseService
 from services.enterprise.rbac_service import RBACService
 from services.entities.dsl_entities import (
     CheckDependenciesResult,
@@ -68,6 +69,7 @@ from services.icon_configuration import (
     is_valid_image_icon,
 )
 from services.plugin.dependencies_analysis import DependenciesAnalysisService
+from services.system_feature_service import SystemFeatureService
 from services.workflow_draft_variable_service import WorkflowDraftVariableService
 from services.workflow_service import WorkflowService
 
@@ -113,6 +115,55 @@ class AppDslService:
     def __init__(self, session: Session):
         self._session = session
         self._warnings = []
+
+    def copy_app(
+        self,
+        *,
+        app_model: App,
+        account: Account,
+        tenant_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        icon_type: str | None = None,
+        icon: str | None = None,
+        icon_background: str | None = None,
+    ) -> tuple[Import, App | None]:
+        """Copy an app, finalizing the import before inheriting external access settings.
+
+        Failed and pending imports roll back the current transaction. Completed
+        imports commit before external I/O, then load the copy in the caller's tenant.
+        """
+        if app_model.tenant_id != tenant_id or account.current_tenant_id != tenant_id:
+            raise NoPermissionError("App does not belong to the current workspace")
+
+        original_app_id = app_model.id
+        yaml_content = self.export_dsl(app_model=app_model, session=self._session, include_secret=True)
+        result = self.import_app(
+            account=account,
+            import_mode=ImportMode.YAML_CONTENT,
+            yaml_content=yaml_content,
+            name=name,
+            description=description,
+            icon_type=icon_type,
+            icon=icon,
+            icon_background=icon_background,
+        )
+        if result.status in {ImportStatus.FAILED, ImportStatus.PENDING}:
+            self._session.rollback()
+            return result, None
+        self._session.commit()
+
+        if result.app_id and SystemFeatureService.is_webapp_auth_enabled():
+            try:
+                original_settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(original_app_id)
+                access_mode = original_settings.access_mode
+            except Exception:
+                # Old apps without settings default to public, matching the access fallback.
+                access_mode = "public"
+            EnterpriseService.WebAppAuth.update_app_access_mode(result.app_id, access_mode)
+
+        app = self._session.scalar(select(App).where(App.id == result.app_id, App.tenant_id == tenant_id))
+        return result, app
 
     def import_app(
         self,

--- a/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
@@ -14,12 +14,14 @@ import pytest
 from flask import Flask
 from flask.views import MethodView
 from pydantic import ValidationError
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from werkzeug.datastructures import MultiDict
 
-from models.model import App, AppMode, IconType
+from models.account import Account
+from models.enums import CustomizeTokenStrategy, TagType
+from models.model import App, AppMode, AppModelConfig, IconType, Site, Tag, TagBinding
 from models.workflow import Workflow, WorkflowType
+from services.app_service import RecentAppListItem
 
 # kombu references MethodView as a global when importing celery/kombu pools.
 if not hasattr(builtins, "MethodView"):
@@ -180,25 +182,111 @@ def _ts(hour: int = 12) -> datetime:
     return datetime(2024, 1, 1, hour, 0, 0)
 
 
-def _dummy_model_config():
-    return SimpleNamespace(
-        model_dict={"provider": "openai", "name": "gpt-4o"},
-        pre_prompt="hello",
-        created_by="config-author",
-        created_at=_ts(9),
-        updated_by="config-editor",
-        updated_at=_ts(10),
+TENANT_ID = "00000000-0000-0000-0000-000000000001"
+APP_ID = "00000000-0000-0000-0000-000000000101"
+ACCOUNT_ID = "00000000-0000-0000-0000-000000000201"
+CONFIG_ID = "00000000-0000-0000-0000-000000000301"
+WORKFLOW_ID = "00000000-0000-0000-0000-000000000401"
+SITE_ID = "00000000-0000-0000-0000-000000000501"
+TAG_ID = "00000000-0000-0000-0000-000000000601"
+
+
+def _account(*, account_id: str = ACCOUNT_ID) -> Account:
+    account = Account(name="Creator", email=f"{account_id}@example.com")
+    account.id = account_id
+    return account
+
+
+def _app(
+    *,
+    app_id: str = APP_ID,
+    tenant_id: str = TENANT_ID,
+    name: str = "My App",
+    description: str = "Summary",
+    mode: AppMode = AppMode.CHAT,
+    icon_type: IconType | None = IconType.IMAGE,
+    icon: str | None = "icon-key",
+    created_at: datetime | None = None,
+) -> App:
+    timestamp = created_at or _ts()
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        name=name,
+        description=description,
+        mode=mode,
+        icon_type=icon_type,
+        icon=icon,
+        icon_background="#fff",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=0,
+        created_at=timestamp,
+        updated_at=timestamp,
     )
 
 
-def _dummy_workflow():
-    return SimpleNamespace(
-        id="wf-1",
-        created_by="workflow-author",
+def _workflow(*, app_id: str = APP_ID, tenant_id: str = TENANT_ID) -> Workflow:
+    return Workflow(
+        id=WORKFLOW_ID,
+        tenant_id=tenant_id,
+        app_id=app_id,
+        type=WorkflowType.CHAT,
+        version=Workflow.VERSION_DRAFT,
+        graph=json.dumps({"nodes": [], "edges": []}),
+        features=json.dumps({}),
+        created_by=ACCOUNT_ID,
         created_at=_ts(8),
-        updated_by="workflow-editor",
+        updated_by=ACCOUNT_ID,
         updated_at=_ts(9),
+        environment_variables=[],
+        conversation_variables=[],
     )
+
+
+def _persist_response_graph(session: Session) -> App:
+    app = _app(description="Description")
+    app.created_by = ACCOUNT_ID
+    app.app_model_config_id = CONFIG_ID
+    app.workflow_id = WORKFLOW_ID
+    app.access_mode = "private"
+    app.create_user_name = "Creator"
+    app.has_draft_trigger = True
+    app.permission_keys = ["app.acl.view_layout"]
+
+    model_config = AppModelConfig(
+        app_id=APP_ID,
+        model=json.dumps({"provider": "openai", "name": "gpt-4o"}),
+        pre_prompt="hello",
+        created_by=ACCOUNT_ID,
+        updated_by=ACCOUNT_ID,
+    )
+    model_config.id = CONFIG_ID
+    model_config.created_at = _ts(9)
+    model_config.updated_at = _ts(10)
+
+    site = Site(
+        id=SITE_ID,
+        app_id=APP_ID,
+        code="site-code",
+        title="Public Site",
+        icon_type=IconType.IMAGE,
+        icon="site-icon",
+        icon_background="#fff",
+        description="Site description",
+        default_language="en-US",
+        input_placeholder="Ask anything",
+        customize_token_strategy=CustomizeTokenStrategy.NOT_ALLOW,
+        created_at=_ts(14),
+        updated_at=_ts(14),
+    )
+    tag = Tag(tenant_id=TENANT_ID, type=TagType.APP, name="Utilities", created_by=ACCOUNT_ID)
+    tag.id = TAG_ID
+    binding = TagBinding(tenant_id=TENANT_ID, tag_id=TAG_ID, target_id=APP_ID, created_by=ACCOUNT_ID)
+
+    session.add_all([_account(), app, model_config, _workflow(), site, tag, binding])
+    session.commit()
+    return app
 
 
 def test_app_list_query_reads_repeated_tag_ids(app_module):
@@ -336,175 +424,128 @@ def test_create_app_endpoint_rejects_agent_mode(app_module):
         app_module.CreateAppPayload.model_validate({"name": "Iris", "mode": "agent", "description": "Agent app"})
 
 
-def test_app_partial_serialization_uses_aliases(app_models):
+def test_app_partial_serialization_uses_aliases(app_models, sqlite_session: Session):
     AppPartial = app_models.AppPartial
-    created_at = _ts()
-    app_obj = SimpleNamespace(
-        id="app-1",
-        name="My App",
-        desc_or_prompt="Prompt snippet",
-        mode_compatible_with_agent="chat",
-        icon_type="image",
-        icon="icon-key",
-        icon_background="#fff",
-        app_model_config=_dummy_model_config(),
-        workflow=_dummy_workflow(),
-        created_by="creator",
-        created_at=created_at,
-        updated_by="editor",
-        updated_at=created_at,
-        tags=[SimpleNamespace(id="tag-1", name="Utilities", type="app")],
-        access_mode="private",
-        create_user_name="Creator",
-        author_name="Author",
-        has_draft_trigger=True,
-        permission_keys=["app.acl.view_layout"],
-        role="Should stay agent-only",
-    )
+    app_obj = _persist_response_graph(sqlite_session)
+    app_obj.description = "Prompt snippet"
 
-    serialized = AppPartial.model_validate(app_obj, from_attributes=True).model_dump(mode="json")
+    serialized = AppPartial.model_validate(
+        app_obj,
+        from_attributes=True,
+        context={"session": sqlite_session},
+    ).model_dump(mode="json")
 
     assert serialized["description"] == "Prompt snippet"
     assert serialized["mode"] == "chat"
     assert serialized["icon_url"] == "signed:icon-key"
-    assert serialized["created_at"] == int(created_at.timestamp())
-    assert serialized["updated_at"] == int(created_at.timestamp())
+    assert serialized["created_at"] == int(app_obj.created_at.timestamp())
+    assert serialized["updated_at"] == int(app_obj.updated_at.timestamp())
     assert serialized["model_config"]["model"] == {"provider": "openai", "name": "gpt-4o"}
-    assert serialized["workflow"]["id"] == "wf-1"
+    assert serialized["workflow"]["id"] == WORKFLOW_ID
     assert serialized["tags"][0]["name"] == "Utilities"
     assert serialized["permission_keys"] == ["app.acl.view_layout"]
     assert "role" not in serialized
 
 
-def test_app_detail_with_site_includes_nested_serialization(app_models):
+def test_app_detail_with_site_includes_nested_serialization(
+    app: Flask,
+    app_models,
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
+):
     AppDetailWithSite = app_models.AppDetailWithSite
-    timestamp = _ts(14)
-    site = SimpleNamespace(
-        code="site-code",
-        title="Public Site",
-        icon_type="image",
-        icon="site-icon",
-        input_placeholder="Ask anything",
-        created_at=timestamp,
-        updated_at=timestamp,
-    )
-    app_obj = SimpleNamespace(
-        id="app-2",
-        name="Detailed App",
-        description="Desc",
-        mode_compatible_with_agent="advanced-chat",
-        icon_type="image",
-        icon="detail-icon",
-        icon_background="#123456",
-        enable_site=True,
-        enable_api=True,
-        app_model_config={
-            "opening_statement": "hi",
-            "model": {"provider": "openai", "name": "gpt-4o"},
-            "retriever_resource": {"enabled": True},
-        },
-        workflow=_dummy_workflow(),
-        tracing={"enabled": True},
-        use_icon_as_answer_icon=True,
-        created_by="creator",
-        created_at=timestamp,
-        updated_by="editor",
-        updated_at=timestamp,
-        access_mode="public",
-        tags=[SimpleNamespace(id="tag-2", name="Prod", type="app")],
-        permission_keys=["app.acl.view_layout", "app.acl.edit"],
-        api_base_url="https://api.example.com/v1",
-        max_active_requests=5,
-        deleted_tools=[{"type": "api", "tool_name": "search", "provider_id": "prov"}],
-        site=site,
-        bound_agent_id="agent-1",
-        role="Should stay agent-only",
-    )
+    app_obj = _persist_response_graph(sqlite_session)
+    app_obj.name = "Detailed App"
+    app_obj.description = "Desc"
+    app_obj.mode = AppMode.ADVANCED_CHAT
+    app_obj.icon = "detail-icon"
+    app_obj.icon_background = "#123456"
+    app_obj.use_icon_as_answer_icon = True
+    app_obj.max_active_requests = 5
+    app_obj.access_mode = "public"
+    app_obj.permission_keys = ["app.acl.view_layout", "app.acl.edit"]
+    model_config = sqlite_session.get(AppModelConfig, CONFIG_ID)
+    assert model_config is not None
+    model_config.opening_statement = "hi"
+    model_config.retriever_resource = json.dumps({"enabled": True})
+    monkeypatch.setattr("services.app_service.load_annotation_reply_config", lambda _session, _app_id: {})
 
-    serialized = AppDetailWithSite.model_validate(app_obj, from_attributes=True).model_dump(mode="json")
+    with app.test_request_context("/"):
+        serialized = AppDetailWithSite.model_validate(
+            app_obj,
+            from_attributes=True,
+            context={"session": sqlite_session},
+        ).model_dump(mode="json")
 
     assert serialized["icon_url"] == "signed:detail-icon"
     assert serialized["model_config"]["retriever_resource"] == {"enabled": True}
-    assert serialized["deleted_tools"][0]["tool_name"] == "search"
+    assert serialized["deleted_tools"] == []
     assert serialized["site"]["icon_url"] == "signed:site-icon"
     assert serialized["site"]["input_placeholder"] == "Ask anything"
-    assert serialized["site"]["created_at"] == int(timestamp.timestamp())
+    assert serialized["site"]["created_at"] == int(_ts(14).timestamp())
     assert serialized["permission_keys"] == ["app.acl.view_layout", "app.acl.edit"]
-    assert serialized["bound_agent_id"] == "agent-1"
+    assert serialized["bound_agent_id"] is None
     assert "role" not in serialized
 
 
 def test_app_response_view_uses_the_caller_session_for_query_backed_fields(
-    app_module, monkeypatch, unbound_session: Session
+    app_module, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
 ):
-    app_obj = MagicMock()
-    app_model_config = SimpleNamespace(app_id="app-1")
-    app_obj.desc_or_prompt_with_session.return_value = "Description"
-    app_obj.site_with_session.return_value = SimpleNamespace(id="site-1")
-    app_obj.app_model_config_with_session.return_value = app_model_config
-    app_obj.workflow_with_session.return_value = SimpleNamespace(id="workflow-1")
-    app_obj.bound_agent_id_with_session.return_value = "agent-1"
-    app_obj.mode_compatible_with_agent_with_session.return_value = "agent"
-    app_obj.deleted_tools_with_session.return_value = []
-    app_obj.tags_with_session.return_value = []
-    app_obj.author_name_with_session.return_value = "Author"
+    app_obj = _persist_response_graph(sqlite_session)
+    decoy_tenant_id = "00000000-0000-0000-0000-000000000002"
+    decoy_tag = Tag(tenant_id=decoy_tenant_id, type=TagType.APP, name="Decoy", created_by=ACCOUNT_ID)
+    decoy_tag.id = "00000000-0000-0000-0000-000000000602"
+    sqlite_session.add_all(
+        [
+            decoy_tag,
+            TagBinding(
+                tenant_id=decoy_tenant_id,
+                tag_id=decoy_tag.id,
+                target_id=APP_ID,
+                created_by=ACCOUNT_ID,
+            ),
+        ]
+    )
+    sqlite_session.commit()
     load_annotation_reply = MagicMock(return_value={"enabled": False})
     monkeypatch.setattr("services.app_service.load_annotation_reply_config", load_annotation_reply)
 
-    view = app_module.AppResponseView(app_obj, session=unbound_session)
+    view = app_module.AppResponseView(app_obj, session=sqlite_session)
     site = view.site
     workflow = view.workflow
     model_config = view.app_model_config
 
     assert view.desc_or_prompt == "Description"
     assert site is not None
-    assert site.id == "site-1"
+    assert site.id == SITE_ID
     assert workflow is not None
-    assert workflow.id == "workflow-1"
-    assert view.bound_agent_id == "agent-1"
-    assert view.mode_compatible_with_agent == "agent"
+    assert workflow.id == WORKFLOW_ID
+    assert view.bound_agent_id is None
+    assert view.mode_compatible_with_agent == "chat"
     assert view.deleted_tools == []
-    assert view.tags == []
-    assert view.author_name == "Author"
+    assert [tag.name for tag in view.tags] == ["Utilities"]
+    assert view.author_name == "Creator"
     assert model_config is not None
     assert model_config.annotation_reply_dict == {"enabled": False}
-    for method in (
-        app_obj.desc_or_prompt_with_session,
-        app_obj.site_with_session,
-        app_obj.app_model_config_with_session,
-        app_obj.workflow_with_session,
-        app_obj.bound_agent_id_with_session,
-        app_obj.mode_compatible_with_agent_with_session,
-        app_obj.deleted_tools_with_session,
-        app_obj.tags_with_session,
-        app_obj.author_name_with_session,
-    ):
-        method.assert_called_once_with(session=unbound_session)
-    load_annotation_reply.assert_called_once_with(unbound_session, "app-1")
+    load_annotation_reply.assert_called_once_with(sqlite_session, APP_ID)
 
 
-def test_app_pagination_aliases_per_page_and_has_next(app_models):
+def test_app_pagination_aliases_per_page_and_has_next(app_models, sqlite_session: Session):
     AppPagination = app_models.AppPagination
-    item_one = SimpleNamespace(
-        id="app-10",
+    item_one = _app(
+        app_id="00000000-0000-0000-0000-000000000110",
         name="Paginated One",
-        desc_or_prompt="Summary",
-        mode_compatible_with_agent="chat",
-        icon_type="image",
         icon="first-icon",
         created_at=_ts(15),
-        updated_at=_ts(15),
-        permission_keys=["app.acl.edit"],
     )
-    item_two = SimpleNamespace(
-        id="app-11",
+    item_one.permission_keys = ["app.acl.edit"]
+    item_two = _app(
+        app_id="00000000-0000-0000-0000-000000000111",
         name="Paginated Two",
-        desc_or_prompt="Summary",
-        mode_compatible_with_agent="agent-chat",
-        icon_type="emoji",
+        mode=AppMode.AGENT_CHAT,
+        icon_type=IconType.EMOJI,
         icon="🙂",
         created_at=_ts(16),
-        updated_at=_ts(16),
     )
     pagination = SimpleNamespace(
         page=2,
@@ -514,7 +555,11 @@ def test_app_pagination_aliases_per_page_and_has_next(app_models):
         items=[item_one, item_two],
     )
 
-    serialized = AppPagination.model_validate(pagination, from_attributes=True).model_dump(mode="json")
+    serialized = AppPagination.model_validate(
+        pagination,
+        from_attributes=True,
+        context={"session": sqlite_session},
+    ).model_dump(mode="json")
 
     assert serialized["page"] == 2
     assert serialized["limit"] == 10
@@ -529,16 +574,14 @@ def test_app_list_uses_injected_session_for_draft_workflows(
     app_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     sqlite_session: Session,
-    unbound_session: Session,
 ) -> None:
     api = app_module.AppListApi()
     method = _unwrap(api.get)
-    app_item = SimpleNamespace(
-        id="app-1",
+    app_item = _app(
+        app_id="app-1",
+        tenant_id="tenant-1",
         name="Workflow App",
-        desc_or_prompt="Summary",
-        mode="workflow",
-        mode_compatible_with_agent="workflow",
+        mode=AppMode.WORKFLOW,
     )
     app_pagination = SimpleNamespace(page=1, per_page=20, total=1, has_next=False, items=[app_item])
     workflow = Workflow(
@@ -583,8 +626,6 @@ def test_app_list_uses_injected_session_for_draft_workflows(
         "get",
         get_permissions,
     )
-    monkeypatch.setattr(app_module, "db", SimpleNamespace(session=unbound_session))
-
     with app.test_request_context("/console/api/apps?page=1&limit=20", method="GET"):
         response, status = method("tenant-1", "user-1", sqlite_session)
 
@@ -595,21 +636,19 @@ def test_app_list_uses_injected_session_for_draft_workflows(
 
 
 def test_app_create_api_attaches_permission_keys(
-    app, app_module, unbound_session: Session, config_overrides: Callable[..., None]
+    app, app_module, sqlite_session: Session, config_overrides: Callable[..., None]
 ):
     config_overrides(RBAC_ENABLED=True)
     method = app_module.AppListApi.post
     while hasattr(method, "__wrapped__"):
         method = method.__wrapped__
 
-    app_obj = SimpleNamespace(
-        id="app-new",
+    app_obj = _app(
+        app_id="app-new",
+        tenant_id="tenant-1",
         name="Created App",
         description="Summary",
-        mode_compatible_with_agent="advanced-chat",
-        enable_site=True,
-        enable_api=True,
-        permission_keys=[],
+        mode=AppMode.ADVANCED_CHAT,
     )
 
     with app.test_request_context("/apps", method="POST", json={}):
@@ -642,9 +681,9 @@ def test_app_create_api_attaches_permission_keys(
                     description="Summary",
                     mode="advanced-chat",
                 ),
-                unbound_session,
+                sqlite_session,
                 "tenant-1",
-                SimpleNamespace(id="acct-1"),
+                _account(account_id="acct-1"),
             )
 
     assert status == 201
@@ -659,15 +698,11 @@ def test_app_list_api_attaches_permission_keys(
     while hasattr(method, "__wrapped__"):
         method = method.__wrapped__
 
-    app_obj = SimpleNamespace(
-        id="app-1",
+    app_obj = _app(
+        app_id="app-1",
+        tenant_id="tenant-1",
         name="List App",
-        desc_or_prompt="Summary",
-        mode_compatible_with_agent="chat",
-        mode="chat",
         created_at=_ts(15),
-        updated_at=_ts(15),
-        permission_keys=[],
     )
     pagination = SimpleNamespace(page=1, per_page=20, total=1, has_next=False, items=[app_obj])
     get_paginate_apps = MagicMock(return_value=pagination)
@@ -725,10 +760,10 @@ def test_recent_app_list_api_returns_only_home_card_fields(
     while hasattr(method, "__wrapped__"):
         method = method.__wrapped__
 
-    recent_app = SimpleNamespace(
+    recent_app = RecentAppListItem(
         id="app-1",
         name="Recent App",
-        icon_type="emoji",
+        icon_type=IconType.EMOJI,
         icon="🚀",
         icon_background="#FFFFFF",
         mode="chat",
@@ -974,21 +1009,18 @@ def test_app_list_api_returns_no_apps_without_workspace_or_resource_view_permiss
 
 
 def test_app_detail_api_attaches_current_user_permission_keys(
-    app, app_module, unbound_session: Session, config_overrides: Callable[..., None]
+    app, app_module, sqlite_session: Session, config_overrides: Callable[..., None]
 ):
     config_overrides(RBAC_ENABLED=True)
     method = app_module.AppApi.get
     while hasattr(method, "__wrapped__"):
         method = method.__wrapped__
 
-    app_obj = SimpleNamespace(
-        id="app-1",
+    app_obj = _app(
+        app_id="app-1",
+        tenant_id="tenant-1",
         name="Detail App",
         description="Summary",
-        mode_compatible_with_agent="chat",
-        enable_site=True,
-        enable_api=True,
-        permission_keys=[],
     )
 
     with app.test_request_context("/apps/app-1"):
@@ -1025,14 +1057,14 @@ def test_app_detail_api_attaches_current_user_permission_keys(
 
             resp = method(
                 app_module.AppApi(),
-                unbound_session,
+                sqlite_session,
                 "tenant-1",
-                SimpleNamespace(id="acct-1"),
+                _account(account_id="acct-1"),
                 app_model=app_obj,
             )
 
-    get_app.assert_called_once_with(app_obj, session=unbound_session)
-    get_permissions.assert_called_once_with("tenant-1", "acct-1", app_id="app-1", session=unbound_session)
+    get_app.assert_called_once_with(app_obj, session=sqlite_session)
+    get_permissions.assert_called_once_with("tenant-1", "acct-1", app_id="app-1", session=sqlite_session)
     assert resp["permission_keys"] == [
         "app.acl.view_layout",
         "app.acl.edit",
@@ -1045,7 +1077,6 @@ def test_app_copy_api_attaches_permission_keys(
     app,
     app_module,
     sqlite_session: Session,
-    sqlite_engine: Engine,
     config_overrides: Callable[..., None],
 ):
     config_overrides(RBAC_ENABLED=True)
@@ -1085,7 +1116,6 @@ def test_app_copy_api_attaches_permission_keys(
                 "is_webapp_auth_enabled",
                 lambda: False,
             )
-            monkeypatch.setattr(app_module, "db", SimpleNamespace(engine=sqlite_engine))
             monkeypatch.setattr(
                 app_module.enterprise_rbac_service.RBACService.AppPermissions,
                 "batch_get",
@@ -1095,9 +1125,10 @@ def test_app_copy_api_attaches_permission_keys(
             resp, status = method(
                 app_module.AppCopyApi(),
                 app_module.CopyAppPayload(),
+                sqlite_session,
                 "tenant-1",
-                SimpleNamespace(id="acct-1"),
-                app_model=SimpleNamespace(id="app-original"),
+                _account(account_id="acct-1"),
+                app_model=_app(app_id="app-original", tenant_id="tenant-1"),
             )
 
     assert status == 201

--- a/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
@@ -128,6 +128,8 @@ def app_module():
             "OpsTraceManager": _OpsTraceManager,
             "TraceQueueManager": object,
             "TraceTask": object,
+            "TracingProviderConfigEntry": dict,
+            "provider_config_map": {},
         },
     )
 
@@ -277,9 +279,9 @@ def _persist_response_graph(session: Session) -> App:
         default_language="en-US",
         input_placeholder="Ask anything",
         customize_token_strategy=CustomizeTokenStrategy.NOT_ALLOW,
-        created_at=_ts(14),
-        updated_at=_ts(14),
     )
+    site.created_at = _ts(14)
+    site.updated_at = _ts(14)
     tag = Tag(tenant_id=TENANT_ID, type=TagType.APP, name="Utilities", created_by=ACCOUNT_ID)
     tag.id = TAG_ID
     binding = TagBinding(tenant_id=TENANT_ID, tag_id=TAG_ID, target_id=APP_ID, created_by=ACCOUNT_ID)
@@ -1107,8 +1109,7 @@ def test_app_copy_api_attaches_permission_keys(
                 app_module,
                 "AppDslService",
                 lambda *_args, **_kwargs: SimpleNamespace(
-                    export_dsl=lambda **_kwargs: "dsl",
-                    import_app=lambda **_kwargs: import_result,
+                    copy_app=lambda **_kwargs: (import_result, app_obj),
                 ),
             )
             monkeypatch.setattr(

--- a/api/tests/unit_tests/controllers/console/app/test_message_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_message_api.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from inspect import unwrap
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,8 +11,37 @@ from sqlalchemy.orm import Session
 
 from controllers.console.app import message as message_module
 from core.app.entities.app_invoke_entities import InvokeFrom
-from models.enums import ConversationFromSource
-from models.model import AppMode, Conversation, Message
+from models.account import Account
+from models.enums import ConversationFromSource, CreatorUserRole, FeedbackFromSource, FeedbackRating
+from models.model import (
+    App,
+    AppAnnotationHitHistory,
+    AppMode,
+    Conversation,
+    Message,
+    MessageAgentThought,
+    MessageAnnotation,
+    MessageFeedback,
+)
+
+
+def _account() -> Account:
+    account = Account(name="Account", email="account@example.com")
+    account.id = "account-1"
+    return account
+
+
+def _app(*, app_id: str = "app-1") -> App:
+    return App(
+        id=app_id,
+        tenant_id="tenant-1",
+        name="Chat App",
+        description="",
+        mode=AppMode.CHAT,
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=0,
+    )
 
 
 def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1") -> Message:
@@ -59,7 +87,7 @@ def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1"
         app_mode=AppMode.CHAT,
     )
     message.id = message_id
-    session.add_all([conversation, message])
+    session.add_all([_account(), _app(app_id=app_id), conversation, message])
     session.flush()
     return message
 
@@ -68,8 +96,8 @@ def test_app_message_routes_pass_injected_session(
     app: Flask, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
 ) -> None:
     session = unbound_session
-    current_user = SimpleNamespace(id="account-1")
-    app_model = SimpleNamespace(id="app-1", mode="chat")
+    current_user = _account()
+    app_model = _app()
     message_id = "550e8400-e29b-41d4-a716-446655440000"
     list_messages = MagicMock(return_value={"data": []})
     update_feedback = MagicMock(return_value={"result": "success"})
@@ -109,10 +137,17 @@ def test_app_message_routes_pass_injected_session(
 
 def test_update_message_feedback_commits_injected_session(app: Flask, sqlite_session: Session) -> None:
     message_id = "550e8400-e29b-41d4-a716-446655440000"
-    feedback = SimpleNamespace(rating="dislike", content=None)
-    get_admin_feedback = MagicMock(return_value=feedback)
     message = _persist_message(sqlite_session, message_id=message_id)
-    message.admin_feedback_with_session = get_admin_feedback
+    feedback = MessageFeedback(
+        app_id=message.app_id,
+        conversation_id=message.conversation_id,
+        message_id=message.id,
+        rating=FeedbackRating.DISLIKE,
+        from_source=FeedbackFromSource.ADMIN,
+        from_account_id="account-1",
+    )
+    sqlite_session.add(feedback)
+    sqlite_session.commit()
     session = sqlite_session
     commits: list[str] = []
     event.listen(session, "after_commit", lambda _session: commits.append("commit"))
@@ -125,14 +160,15 @@ def test_update_message_feedback_commits_injected_session(app: Flask, sqlite_ses
                 content="helpful",
             ),
             session=session,
-            current_user=SimpleNamespace(id="account-1"),
-            app_model=SimpleNamespace(id="app-1"),
+            current_user=_account(),
+            app_model=_app(),
         )
 
     assert result == {"result": "success"}
-    assert feedback.rating == "like"
-    assert feedback.content == "helpful"
-    get_admin_feedback.assert_called_once_with(session=session)
+    updated_feedback = sqlite_session.get(MessageFeedback, feedback.id)
+    assert updated_feedback is not None
+    assert updated_feedback.rating == FeedbackRating.LIKE
+    assert updated_feedback.content == "helpful"
     assert commits == ["commit"]
 
 
@@ -148,7 +184,7 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
 
     result = message_module._get_message_detail(
         session=session,
-        app_model=SimpleNamespace(id="app-1"),
+        app_model=_app(),
         message_id=message_id,
     )
 
@@ -156,48 +192,64 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
     response_source_factory.assert_called_once_with(message, session=session)
 
 
-def test_message_response_source_uses_caller_session_for_nested_fields(unbound_session: Session) -> None:
-    session = unbound_session
-    account = object()
-    feedback = MagicMock()
-    feedback.from_account_with_session.return_value = account
-    annotation = MagicMock()
-    annotation.account_with_session.return_value = account
-    annotation.annotation_create_account_with_session.return_value = account
-    thought = object()
-    message_file = {"id": "file-1"}
-    message = MagicMock()
-    message.inputs_with_session.return_value = {"topic": "support"}
-    message.user_feedback_with_session.return_value = feedback
-    message.feedbacks_with_session.return_value = [feedback]
-    message.annotation_with_session.return_value = annotation
-    message.annotation_hit_history_with_session.return_value = annotation
-    message.agent_thoughts_with_session.return_value = [thought]
-    message.message_files_with_session.return_value = [message_file]
+def test_message_response_source_uses_caller_session_for_nested_fields(sqlite_session: Session) -> None:
+    session = sqlite_session
+    message_id = "550e8400-e29b-41d4-a716-446655440000"
+    message = _persist_message(sqlite_session, message_id=message_id)
+    message.inputs = {"topic": "support"}
+    feedback = MessageFeedback(
+        app_id=message.app_id,
+        conversation_id=message.conversation_id,
+        message_id=message.id,
+        rating=FeedbackRating.LIKE,
+        from_source=FeedbackFromSource.USER,
+        from_account_id="account-1",
+    )
+    annotation = MessageAnnotation(
+        app_id=message.app_id,
+        question="Question",
+        content="Answer",
+        account_id="account-1",
+        conversation_id=message.conversation_id,
+        message_id=message.id,
+    )
+    annotation.id = "annotation-1"
+    annotation_hit = AppAnnotationHitHistory(
+        app_id=message.app_id,
+        annotation_id=annotation.id,
+        source="annotation",
+        question="Question",
+        account_id="account-1",
+        score=0.0,
+        message_id=message.id,
+        annotation_question="Question",
+        annotation_content="Answer",
+    )
+    thought = MessageAgentThought(
+        message_id=message.id,
+        position=1,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-1",
+        thought="Consider the request",
+        tool_labels_str="{}",
+        tool_meta_str="{}",
+    )
+    sqlite_session.add_all([feedback, annotation, annotation_hit, thought])
+    sqlite_session.commit()
 
     source = message_module.MessageResponseSource(message, session=session)
 
     assert source.inputs == {"topic": "support"}
     assert source.user_feedback is feedback
-    assert source.feedbacks[0].from_account is account
+    assert source.feedbacks[0].from_account.id == "account-1"
     annotation_source = source.annotation
     assert annotation_source is not None
-    assert annotation_source.account is account
+    assert annotation_source.account.id == "account-1"
     annotation_hit_history_source = source.annotation_hit_history
     assert annotation_hit_history_source is not None
-    assert annotation_hit_history_source.annotation_create_account is account
+    assert annotation_hit_history_source.annotation_create_account.id == "account-1"
     assert source.agent_thoughts == [thought]
-    assert source.message_files == [message_file]
-    message.inputs_with_session.assert_called_once_with(session=session)
-    message.user_feedback_with_session.assert_called_once_with(session=session)
-    message.feedbacks_with_session.assert_called_once_with(session=session)
-    message.annotation_with_session.assert_called_once_with(session=session)
-    message.annotation_hit_history_with_session.assert_called_once_with(session=session)
-    message.agent_thoughts_with_session.assert_called_once_with(session=session)
-    message.message_files_with_session.assert_called_once_with(session=session)
-    feedback.from_account_with_session.assert_called_once_with(session=session)
-    annotation.account_with_session.assert_called_once_with(session=session)
-    annotation.annotation_create_account_with_session.assert_called_once_with(session=session)
+    assert source.message_files == []
 
 
 def test_chat_messages_query_valid(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/api/tests/unit_tests/services/test_app_dsl_service.py
+++ b/api/tests/unit_tests/services/test_app_dsl_service.py
@@ -14,10 +14,12 @@ from core.workflow.llm_environment_variable import LLMEnvironmentVariable
 from models import Account, App, AppMode, Tenant
 from models.model import AppModelConfig, AppModelConfigDict, IconType
 from models.workflow import Workflow, WorkflowType
-from services.app_dsl_service import AppDslService, PendingData
+from services.app_dsl_service import AppDslService, Import, PendingData
+from services.enterprise.enterprise_service import EnterpriseService
 from services.entities.dsl_entities import ImportStatus
 from services.errors.account import NoPermissionError
 from services.errors.app import WorkflowNotFoundError
+from services.system_feature_service import SystemFeatureService
 from tests.unit_tests.config_override import apply_config_overrides
 
 _OVERWRITE_APP_ID = "11111111-1111-4111-8111-111111111111"
@@ -103,6 +105,90 @@ def _workflow(
     )
     workflow.environment_variables = environment_variables or []
     return workflow
+
+
+@pytest.mark.parametrize("status", [ImportStatus.FAILED, ImportStatus.PENDING])
+def test_copy_app_rolls_back_incomplete_import(
+    sqlite_session: Session, monkeypatch: pytest.MonkeyPatch, status: ImportStatus
+) -> None:
+    original = _persist_overwrite_target(sqlite_session)
+    service = AppDslService(sqlite_session)
+    monkeypatch.setattr(service, "export_dsl", Mock(return_value="dsl"))
+
+    def import_app(**_kwargs: object) -> Import:
+        original.name = "Uncommitted change"
+        sqlite_session.flush()
+        return Import(id="import-1", status=status)
+
+    monkeypatch.setattr(service, "import_app", import_app)
+    auth_enabled = Mock()
+    monkeypatch.setattr(SystemFeatureService, "is_webapp_auth_enabled", auth_enabled)
+
+    result, copied = service.copy_app(app_model=original, account=_account(tenant_id=_TENANT_ID), tenant_id=_TENANT_ID)
+
+    assert result.status == status
+    assert copied is None
+    assert original.name == "Target"
+    auth_enabled.assert_not_called()
+
+
+@pytest.mark.parametrize("status", [ImportStatus.COMPLETED, ImportStatus.COMPLETED_WITH_WARNINGS])
+@pytest.mark.parametrize("missing_settings", [False, True])
+def test_copy_app_commits_before_inheriting_access(
+    sqlite_session: Session, monkeypatch: pytest.MonkeyPatch, status: ImportStatus, missing_settings: bool
+) -> None:
+    original = _persist_overwrite_target(sqlite_session)
+    service = AppDslService(sqlite_session)
+    monkeypatch.setattr(service, "export_dsl", Mock(return_value="dsl"))
+    copied_id = "55555555-5555-4555-8555-555555555555"
+
+    def import_app(**_kwargs: object) -> Import:
+        sqlite_session.add(_app(app_id=copied_id, tenant_id=_TENANT_ID))
+        return Import(id="import-1", status=status, app_id=copied_id)
+
+    def get_access_mode(app_id: str) -> SimpleNamespace:
+        assert not sqlite_session.in_transaction()
+        assert app_id == _OVERWRITE_APP_ID
+        if missing_settings:
+            raise ValueError("No settings")
+        return SimpleNamespace(access_mode="private")
+
+    def update_access_mode(app_id: str, access_mode: str) -> None:
+        assert not sqlite_session.in_transaction()
+        assert app_id == copied_id
+        assert access_mode == ("public" if missing_settings else "private")
+
+    monkeypatch.setattr(service, "import_app", import_app)
+    monkeypatch.setattr(SystemFeatureService, "is_webapp_auth_enabled", lambda: True)
+    monkeypatch.setattr(EnterpriseService.WebAppAuth, "get_app_access_mode_by_id", get_access_mode)
+    update_access = Mock(side_effect=update_access_mode)
+    monkeypatch.setattr(EnterpriseService.WebAppAuth, "update_app_access_mode", update_access)
+
+    result, copied = service.copy_app(app_model=original, account=_account(tenant_id=_TENANT_ID), tenant_id=_TENANT_ID)
+
+    assert result.status == status
+    assert copied is not None
+    assert copied.id == copied_id
+    update_access.assert_called_once()
+
+
+def test_copy_app_scopes_result_to_current_tenant(sqlite_session: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+    original = _persist_overwrite_target(sqlite_session)
+    foreign_app = _app(tenant_id="66666666-6666-4666-8666-666666666666", app_id=_OTHER_ACCOUNT_ID)
+    sqlite_session.add(foreign_app)
+    sqlite_session.commit()
+    service = AppDslService(sqlite_session)
+    monkeypatch.setattr(service, "export_dsl", Mock(return_value="dsl"))
+    monkeypatch.setattr(
+        service,
+        "import_app",
+        Mock(return_value=Import(id="import-1", status=ImportStatus.COMPLETED, app_id=foreign_app.id)),
+    )
+    monkeypatch.setattr(SystemFeatureService, "is_webapp_auth_enabled", lambda: False)
+
+    _, copied = service.copy_app(app_model=original, account=_account(tenant_id=_TENANT_ID), tenant_id=_TENANT_ID)
+
+    assert copied is None
 
 
 def test_extract_workflow_dependencies_uses_llm_environment_variable_provider(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- replace console app response test stand-ins with real `App`, `AppModelConfig`, `Workflow`, `Site`, `Tag`, `TagBinding`, `Account`, `Message`, `MessageFeedback`, `MessageAnnotation`, and `MessageAgentThought` models
- persist complete SQLite graphs for app response serialization, tenant-scoped tag lookup, nested message response fields, feedback updates, and workflow trigger enrichment
- retain mocks only for services, feature/RBAC DTOs, task dispatch, and response helpers
- move `AppCopyApi` onto the existing controller-owned `with_session` lifecycle instead of constructing a session directly from `db.engine`

## Motivation

The response tests previously bypassed SQLAlchemy behavior with `SimpleNamespace` and `MagicMock` objects. Real models now exercise mapped enums, server/on-update timestamps, relationship queries, tenant filtering, and nested response serialization through caller-owned SQLite sessions.

## Persistence coverage

- app/config/workflow/site/tag/account ownership graph, including a wrong-tenant tag decoy
- real response-model query paths for description, model config, workflow, site, tags, author, agent compatibility, and deleted tools
- persisted conversation/message/feedback/annotation/hit-history/agent-thought graph
- feedback update commit observed through a SQLAlchemy session event and verified from the mapped row
- copied app lookup and response serialization through the injected SQLite session

## Production correction

`AppCopyApi.post` now uses `@with_session` and receives the request-owned `Session`. This removes its direct `Session(db.engine)` construction while preserving its commit/rollback behavior and public HTTP interface.

## Size

3 files, 372 additions and 281 deletions (653 changed lines).

## Validation

- `make test TARGET_TESTS='./api/tests/unit_tests/controllers/console/app/test_app_response_models.py ./api/tests/unit_tests/controllers/console/app/test_message_api.py'`: 46 passed
- `make lint`: passed
- `make type-check`: could not complete because mypy 1.20.2 raised an internal error in `typeshed/stdlib/zipimport.pyi:17`; no project type error was reported
- structural audit: no mocked SQLAlchemy session/factory or stubbed mapped entity remains in the changed test modules; remaining mocks are services, loaders, task dispatch, and non-ORM DTOs
- full test suite not run per request
