### PR TITLE
fix: restrict app deploy to explicit enterprise permission

### DIFF
--- a/api/services/enterprise/rbac_service.py
+++ b/api/services/enterprise/rbac_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from configs import dify_config
 from core.rbac import RBACResourceWhitelistScope
+from enums import DeploymentEdition
 from models import TenantAccountJoin, TenantAccountRole
 from services.enterprise.base import EnterpriseRequest
 
@@ -522,13 +523,20 @@ _LEGACY_MY_PERMISSIONS: dict[TenantAccountRole, dict[str, list[str]]] = {
 }
 
 
+def _legacy_app_permission_keys(permissions: dict[str, list[str]]) -> list[str]:
+    permission_keys = permissions.get("app", [])
+    if dify_config.DEPLOYMENT_EDITION == DeploymentEdition.ENTERPRISE:
+        return list(permission_keys)
+    return [permission_key for permission_key in permission_keys if permission_key != "app.acl.deploy"]
+
+
 def _legacy_role_permission_keys(role: TenantAccountRole) -> list[str]:
     permissions = _LEGACY_MY_PERMISSIONS.get(role, {})
     return list(
         dict.fromkeys(
             [
                 *permissions.get("workspace", []),
-                *permissions.get("app", []),
+                *_legacy_app_permission_keys(permissions),
                 *permissions.get("dataset", []),
             ]
         )
@@ -584,7 +592,7 @@ def _legacy_my_permissions(tenant_id: str, account_id: str | None, *, session: S
     permissions = _LEGACY_MY_PERMISSIONS.get(tenant_role, {})
     return MyPermissionsResponse(
         workspace=WorkspacePermissionSnapshot(permission_keys=list(permissions.get("workspace", []))),
-        app=ResourcePermissionSnapshot(default_permission_keys=list(permissions.get("app", []))),
+        app=ResourcePermissionSnapshot(default_permission_keys=_legacy_app_permission_keys(permissions)),
         dataset=ResourcePermissionSnapshot(default_permission_keys=list(permissions.get("dataset", []))),
     )
 

--- a/api/services/enterprise/rbac_service.py
+++ b/api/services/enterprise/rbac_service.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session
 
 from configs import dify_config
 from core.rbac import RBACResourceWhitelistScope
-from enums import DeploymentEdition
 from models import TenantAccountJoin, TenantAccountRole
 from services.enterprise.base import EnterpriseRequest
 
@@ -398,7 +397,6 @@ _LEGACY_APP_OWNER_KEYS: list[str] = [
     "app.acl.import_export_dsl",
     "app.acl.delete",
     "app.acl.release_and_version",
-    "app.acl.deploy",
     "app.acl.monitor",
     "app.acl.access_config",
     "app.acl.tracing_config",
@@ -413,7 +411,6 @@ _LEGACY_APP_ADMIN_KEYS: list[str] = [
     "app.acl.import_export_dsl",
     "app.acl.delete",
     "app.acl.release_and_version",
-    "app.acl.deploy",
     "app.acl.monitor",
     "app.acl.access_config",
     "app.acl.access_config",
@@ -429,7 +426,6 @@ _LEGACY_APP_EDITOR_KEYS: list[str] = [
     "app.acl.import_export_dsl",
     "app.acl.delete",
     "app.acl.release_and_version",
-    "app.acl.deploy",
     "app.acl.monitor",
     "app.acl.log_and_annotation",
     "app.acl.access_config",
@@ -523,20 +519,13 @@ _LEGACY_MY_PERMISSIONS: dict[TenantAccountRole, dict[str, list[str]]] = {
 }
 
 
-def _legacy_app_permission_keys(permissions: dict[str, list[str]]) -> list[str]:
-    permission_keys = permissions.get("app", [])
-    if dify_config.DEPLOYMENT_EDITION == DeploymentEdition.ENTERPRISE:
-        return list(permission_keys)
-    return [permission_key for permission_key in permission_keys if permission_key != "app.acl.deploy"]
-
-
 def _legacy_role_permission_keys(role: TenantAccountRole) -> list[str]:
     permissions = _LEGACY_MY_PERMISSIONS.get(role, {})
     return list(
         dict.fromkeys(
             [
                 *permissions.get("workspace", []),
-                *_legacy_app_permission_keys(permissions),
+                *permissions.get("app", []),
                 *permissions.get("dataset", []),
             ]
         )
@@ -592,7 +581,7 @@ def _legacy_my_permissions(tenant_id: str, account_id: str | None, *, session: S
     permissions = _LEGACY_MY_PERMISSIONS.get(tenant_role, {})
     return MyPermissionsResponse(
         workspace=WorkspacePermissionSnapshot(permission_keys=list(permissions.get("workspace", []))),
-        app=ResourcePermissionSnapshot(default_permission_keys=_legacy_app_permission_keys(permissions)),
+        app=ResourcePermissionSnapshot(default_permission_keys=list(permissions.get("app", []))),
         dataset=ResourcePermissionSnapshot(default_permission_keys=list(permissions.get("dataset", []))),
     )
 

--- a/api/tests/unit_tests/services/enterprise/test_rbac_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_rbac_service.py
@@ -16,6 +16,7 @@ from flask import Flask
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from enums import DeploymentEdition
 from models import TenantAccountJoin
 from services.enterprise import rbac_service as svc
 
@@ -617,7 +618,10 @@ class TestMyPermissions:
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole(role))
         )
         sqlite_session.commit()
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
+        with (
+            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
+            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
+        ):
             out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
 
         mock_send.assert_not_called()
@@ -640,6 +644,31 @@ class TestMyPermissions:
             assert "app.acl.deploy" in out.app.default_permission_keys
         else:
             assert "app.acl.deploy" not in out.app.default_permission_keys
+
+    def test_get_excludes_deploy_permission_in_community_edition(
+        self,
+        mock_send: MagicMock,
+        sqlite_session: Session,
+    ):
+        sqlite_session.add(
+            TenantAccountJoin(
+                tenant_id="tenant-1",
+                account_id="acct-1",
+                role=svc.TenantAccountRole.EDITOR,
+            )
+        )
+        sqlite_session.commit()
+
+        with (
+            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
+            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
+        ):
+            out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
+
+        mock_send.assert_not_called()
+        assert out.app.default_permission_keys == [
+            key for key in svc._LEGACY_APP_EDITOR_KEYS if key != "app.acl.deploy"
+        ]
 
     @pytest.mark.parametrize(
         ("role", "expected_snippet_keys"),
@@ -729,7 +758,10 @@ class TestMemberRoles:
         )
         sqlite_session.commit()
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
+        with (
+            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
+            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
+        ):
             out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
 
         mock_send.assert_not_called()
@@ -747,6 +779,25 @@ class TestMemberRoles:
         assert "snippets.create_and_modify" in out.roles[0].permission_keys
         assert "app.acl.preview" in out.roles[0].permission_keys
         assert "dataset.acl.preview" in out.roles[0].permission_keys
+
+    def test_get_legacy_role_excludes_deploy_permission_in_community_edition(
+        self,
+        mock_send: MagicMock,
+        sqlite_session: Session,
+    ):
+        sqlite_session.add(
+            TenantAccountJoin(tenant_id="tenant-1", account_id="acct-2", role=svc.TenantAccountRole.EDITOR)
+        )
+        sqlite_session.commit()
+
+        with (
+            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
+            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
+        ):
+            out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
+
+        mock_send.assert_not_called()
+        assert "app.acl.deploy" not in out.roles[0].permission_keys
 
     def test_replace(self, mock_send: MagicMock, sqlite_session: Session):
         mock_send.return_value = {"account_id": "acct-2", "roles": []}
@@ -868,7 +919,10 @@ class TestResourcePermissions:
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole.EDITOR)
         )
         sqlite_session.commit()
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
+        with (
+            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
+            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
+        ):
             out = svc.RBACService.AppPermissions.batch_get(
                 "tenant-1", "acct-1", ["app-1", "app-2"], session=sqlite_session
             )
@@ -877,6 +931,27 @@ class TestResourcePermissions:
         assert out == {
             "app-1": svc._LEGACY_APP_EDITOR_KEYS,
             "app-2": svc._LEGACY_APP_EDITOR_KEYS,
+        }
+
+    def test_app_permissions_batch_get_excludes_deploy_permission_in_community_edition(
+        self,
+        mock_send: MagicMock,
+        sqlite_session: Session,
+    ):
+        sqlite_session.add(
+            TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole.EDITOR)
+        )
+        sqlite_session.commit()
+
+        with (
+            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
+            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
+        ):
+            out = svc.RBACService.AppPermissions.batch_get("tenant-1", "acct-1", ["app-1"], session=sqlite_session)
+
+        mock_send.assert_not_called()
+        assert out == {
+            "app-1": [key for key in svc._LEGACY_APP_EDITOR_KEYS if key != "app.acl.deploy"],
         }
 
     def test_dataset_permissions_batch_get(self, mock_send: MagicMock, sqlite_session: Session):

--- a/api/tests/unit_tests/services/enterprise/test_rbac_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_rbac_service.py
@@ -16,7 +16,6 @@ from flask import Flask
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from enums import DeploymentEdition
 from models import TenantAccountJoin
 from services.enterprise import rbac_service as svc
 
@@ -618,10 +617,7 @@ class TestMyPermissions:
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole(role))
         )
         sqlite_session.commit()
-        with (
-            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
-            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
-        ):
+        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
             out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
 
         mock_send.assert_not_called()
@@ -640,35 +636,7 @@ class TestMyPermissions:
         assert not any(key.startswith("billing.") for key in out.workspace.permission_keys)
         if role == "editor":
             assert "app.acl.log_and_annotation" in out.app.default_permission_keys
-        if role in {"owner", "admin", "editor"}:
-            assert "app.acl.deploy" in out.app.default_permission_keys
-        else:
-            assert "app.acl.deploy" not in out.app.default_permission_keys
-
-    def test_get_excludes_deploy_permission_in_community_edition(
-        self,
-        mock_send: MagicMock,
-        sqlite_session: Session,
-    ):
-        sqlite_session.add(
-            TenantAccountJoin(
-                tenant_id="tenant-1",
-                account_id="acct-1",
-                role=svc.TenantAccountRole.EDITOR,
-            )
-        )
-        sqlite_session.commit()
-
-        with (
-            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
-            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
-        ):
-            out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
-
-        mock_send.assert_not_called()
-        assert out.app.default_permission_keys == [
-            key for key in svc._LEGACY_APP_EDITOR_KEYS if key != "app.acl.deploy"
-        ]
+        assert "app.acl.deploy" not in out.app.default_permission_keys
 
     @pytest.mark.parametrize(
         ("role", "expected_snippet_keys"),
@@ -758,10 +726,7 @@ class TestMemberRoles:
         )
         sqlite_session.commit()
 
-        with (
-            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
-            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
-        ):
+        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
             out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
 
         mock_send.assert_not_called()
@@ -779,24 +744,6 @@ class TestMemberRoles:
         assert "snippets.create_and_modify" in out.roles[0].permission_keys
         assert "app.acl.preview" in out.roles[0].permission_keys
         assert "dataset.acl.preview" in out.roles[0].permission_keys
-
-    def test_get_legacy_role_excludes_deploy_permission_in_community_edition(
-        self,
-        mock_send: MagicMock,
-        sqlite_session: Session,
-    ):
-        sqlite_session.add(
-            TenantAccountJoin(tenant_id="tenant-1", account_id="acct-2", role=svc.TenantAccountRole.EDITOR)
-        )
-        sqlite_session.commit()
-
-        with (
-            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
-            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
-        ):
-            out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
-
-        mock_send.assert_not_called()
         assert "app.acl.deploy" not in out.roles[0].permission_keys
 
     def test_replace(self, mock_send: MagicMock, sqlite_session: Session):
@@ -893,7 +840,10 @@ class TestResourcePermissions:
     def test_app_permissions_batch_get(self, mock_send: MagicMock, sqlite_session: Session):
         mock_send.return_value = {
             "data": [
-                {"resource_id": "app-1", "permission_keys": ["app.acl.view_layout", "app.acl.edit"]},
+                {
+                    "resource_id": "app-1",
+                    "permission_keys": ["app.acl.view_layout", "app.acl.edit", "app.acl.deploy"],
+                },
                 {"resource_id": "app-2", "permission_keys": []},
             ]
         }
@@ -908,7 +858,7 @@ class TestResourcePermissions:
         assert call.endpoint == "/rbac/apps/permission-keys/batch"
         assert call.json == {"app_ids": ["app-1", "app-2"]}
         assert out == {
-            "app-1": ["app.acl.view_layout", "app.acl.edit"],
+            "app-1": ["app.acl.view_layout", "app.acl.edit", "app.acl.deploy"],
             "app-2": [],
         }
 
@@ -919,10 +869,7 @@ class TestResourcePermissions:
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole.EDITOR)
         )
         sqlite_session.commit()
-        with (
-            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
-            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
-        ):
+        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
             out = svc.RBACService.AppPermissions.batch_get(
                 "tenant-1", "acct-1", ["app-1", "app-2"], session=sqlite_session
             )
@@ -932,27 +879,7 @@ class TestResourcePermissions:
             "app-1": svc._LEGACY_APP_EDITOR_KEYS,
             "app-2": svc._LEGACY_APP_EDITOR_KEYS,
         }
-
-    def test_app_permissions_batch_get_excludes_deploy_permission_in_community_edition(
-        self,
-        mock_send: MagicMock,
-        sqlite_session: Session,
-    ):
-        sqlite_session.add(
-            TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole.EDITOR)
-        )
-        sqlite_session.commit()
-
-        with (
-            patch(f"{MODULE}.dify_config.RBAC_ENABLED", False),
-            patch(f"{MODULE}.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
-        ):
-            out = svc.RBACService.AppPermissions.batch_get("tenant-1", "acct-1", ["app-1"], session=sqlite_session)
-
-        mock_send.assert_not_called()
-        assert out == {
-            "app-1": [key for key in svc._LEGACY_APP_EDITOR_KEYS if key != "app.acl.deploy"],
-        }
+        assert all("app.acl.deploy" not in permission_keys for permission_keys in out.values())
 
     def test_dataset_permissions_batch_get(self, mock_send: MagicMock, sqlite_session: Session):
         mock_send.return_value = {

--- a/web/utils/permission.spec.ts
+++ b/web/utils/permission.spec.ts
@@ -99,7 +99,7 @@ describe('permission', () => {
   })
 
   describe('app maintainer capabilities', () => {
-    it('requires explicit deploy permission while granting other maintainer capabilities', () => {
+    it('grants all app ACL capabilities without injecting app ACL permission keys', () => {
       const permissionKeys: string[] = []
       const capabilities = getAppACLCapabilities(permissionKeys, {
         currentUserId: 'user-1',

--- a/web/utils/permission.spec.ts
+++ b/web/utils/permission.spec.ts
@@ -99,7 +99,7 @@ describe('permission', () => {
   })
 
   describe('app maintainer capabilities', () => {
-    it('grants all app ACL capabilities without injecting app ACL permission keys', () => {
+    it('requires explicit deploy permission while granting other maintainer capabilities', () => {
       const permissionKeys: string[] = []
       const capabilities = getAppACLCapabilities(permissionKeys, {
         currentUserId: 'user-1',
@@ -114,7 +114,7 @@ describe('permission', () => {
       expect(capabilities.canImportExportDSL).toBe(true)
       expect(capabilities.canDelete).toBe(true)
       expect(capabilities.canReleaseAndVersion).toBe(true)
-      expect(capabilities.canDeploy).toBe(true)
+      expect(capabilities.canDeploy).toBe(false)
       expect(capabilities.canMonitor).toBe(true)
       expect(capabilities.canConfigureTracing).toBe(true)
       expect(capabilities.canAccessLogAndAnnotation).toBe(true)

--- a/web/utils/permission.ts
+++ b/web/utils/permission.ts
@@ -155,11 +155,7 @@ export const getAppACLCapabilities = (
       AppACLPermission.ReleaseAndVersion,
       hasMaintainerPermissions,
     ),
-    canDeploy: hasResourcePermission(
-      permissionKeys,
-      AppACLPermission.Deploy,
-      hasMaintainerPermissions,
-    ),
+    canDeploy: hasPermission(permissionKeys, AppACLPermission.Deploy),
     canMonitor: hasResourcePermission(
       permissionKeys,
       AppACLPermission.Monitor,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Remove `app.acl.deploy` from legacy App permissions.
- Require explicit `app.acl.deploy` for Deploy capabilities.
- Preserve Deploy permissions returned by Enterprise RBAC.

## Screenshots

Not applicable.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex
