### PR TITLE
test: migrate residual service and task ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_workflow_node_execution_repository.py
+++ b/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_workflow_node_execution_repository.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +8,12 @@ from extensions.logstore.repositories.logstore_workflow_node_execution_repositor
 )
 from models.account import Account
 from models.workflow import WorkflowNodeExecutionTriggeredFrom
+
+
+def _make_account() -> Account:
+    account = Account(name="Logstore User", email="logstore@example.com")
+    account.id = "account-1"
+    return account
 
 
 def test_save_synchronously_writes_sql_when_dual_write_is_disabled(
@@ -26,7 +30,7 @@ def test_save_synchronously_writes_sql_when_dual_write_is_disabled(
         repository = LogstoreWorkflowNodeExecutionRepository(
             session_factory=sqlite_session_factory,
             tenant_id="tenant-1",
-            user=cast(Account, SimpleNamespace(id="account-1")),
+            user=_make_account(),
             app_id="app-1",
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
         )

--- a/api/tests/unit_tests/services/rag_pipeline/test_pipeline_generate_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_pipeline_generate_service.py
@@ -1,6 +1,3 @@
-from types import SimpleNamespace
-from typing import cast
-
 import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import Session
@@ -9,7 +6,8 @@ from core.app.entities.app_invoke_entities import InvokeFrom
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from models.dataset import Dataset, Document, Pipeline
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus
-from models.model import Account, App, EndUser
+from models.model import Account, App, AppMode, EndUser
+from models.workflow import Workflow, WorkflowType
 from services.dataset_ref_service import DatasetRefService
 from services.rag_pipeline.pipeline_generate_service import PipelineGenerateService
 
@@ -18,6 +16,36 @@ def _make_pipeline(*, tenant_id: str = "tenant-1") -> Pipeline:
     pipeline = Pipeline(tenant_id=tenant_id, name="Pipeline", description="")
     pipeline.id = "pipeline-1"
     return pipeline
+
+
+def _make_account(*, account_id: str = "user-1") -> Account:
+    account = Account(name="Pipeline User", email=f"{account_id}@example.com")
+    account.id = account_id
+    return account
+
+
+def _make_app(*, max_active_requests: int) -> App:
+    return App(
+        tenant_id="tenant-1",
+        name="Pipeline App",
+        mode=AppMode.RAG_PIPELINE,
+        enable_site=False,
+        enable_api=False,
+        max_active_requests=max_active_requests,
+    )
+
+
+def _make_workflow(*, workflow_id: str = "wf-1") -> Workflow:
+    return Workflow(
+        id=workflow_id,
+        tenant_id="tenant-1",
+        app_id="pipeline-1",
+        type=WorkflowType.RAG_PIPELINE,
+        version=Workflow.VERSION_DRAFT,
+        graph="{}",
+        features="{}",
+        created_by="user-1",
+    )
 
 
 def _make_dataset(*, dataset_id: str = "dataset-1", tenant_id: str = "tenant-1") -> Dataset:
@@ -52,7 +80,7 @@ def test_get_max_active_requests_uses_smallest_non_zero_limit(mocker: MockerFixt
     mocker.patch("services.rag_pipeline.pipeline_generate_service.dify_config.APP_DEFAULT_ACTIVE_REQUESTS", 5)
     mocker.patch("services.rag_pipeline.pipeline_generate_service.dify_config.APP_MAX_ACTIVE_REQUESTS", 3)
 
-    app_model = cast(App, SimpleNamespace(max_active_requests=10))
+    app_model = _make_app(max_active_requests=10)
 
     result = PipelineGenerateService._get_max_active_requests(app_model)
 
@@ -63,7 +91,7 @@ def test_get_max_active_requests_returns_zero_when_all_unlimited(mocker: MockerF
     mocker.patch("services.rag_pipeline.pipeline_generate_service.dify_config.APP_DEFAULT_ACTIVE_REQUESTS", 0)
     mocker.patch("services.rag_pipeline.pipeline_generate_service.dify_config.APP_MAX_ACTIVE_REQUESTS", 0)
 
-    app_model = cast(App, SimpleNamespace(max_active_requests=0))
+    app_model = _make_app(max_active_requests=0)
 
     result = PipelineGenerateService._get_max_active_requests(app_model)
 
@@ -75,7 +103,7 @@ def test_get_max_active_requests_returns_zero_when_all_unlimited(mocker: MockerF
     [
         (InvokeFrom.DEBUGGER, None, "Workflow not initialized"),
         (InvokeFrom.WEB_APP, None, "Workflow not published"),
-        (InvokeFrom.DEBUGGER, SimpleNamespace(id="wf-1"), None),
+        (InvokeFrom.DEBUGGER, _make_workflow(), None),
     ],
 )
 def test_get_workflow(mocker: MockerFixture, invoke_from, workflow, expected_error, sqlite_session: Session) -> None:
@@ -84,7 +112,7 @@ def test_get_workflow(mocker: MockerFixture, invoke_from, workflow, expected_err
     rag_pipeline_service.get_draft_workflow.return_value = workflow
     rag_pipeline_service.get_published_workflow.return_value = workflow
 
-    pipeline = cast(Pipeline, SimpleNamespace(id="pipeline-1"))
+    pipeline = _make_pipeline()
     session = sqlite_session
 
     if expected_error:
@@ -98,19 +126,14 @@ def test_get_workflow(mocker: MockerFixture, invoke_from, workflow, expected_err
 def test_generate_updates_document_status_and_returns_event_stream(
     mocker: MockerFixture, sqlite_session: Session
 ) -> None:
-    dataset = cast(Dataset, SimpleNamespace(id="dataset-1", tenant_id="tenant-1"))
-    pipeline = cast(
-        Pipeline,
-        SimpleNamespace(
-            id="pipeline-1",
-            tenant_id="tenant-1",
-            retrieve_dataset=mocker.Mock(return_value=dataset),
-        ),
-    )
-    user = cast(Account | EndUser, SimpleNamespace(id="user-1"))
+    dataset = _make_dataset()
+    pipeline = _make_pipeline()
+    sqlite_session.add_all([dataset, pipeline])
+    sqlite_session.commit()
+    user: Account | EndUser = _make_account()
     args = {"original_document_id": "doc-1", "query": "hello"}
 
-    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=SimpleNamespace(id="wf-1"))
+    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=_make_workflow())
     update_status_mock = mocker.patch.object(PipelineGenerateService, "update_document_status")
 
     generator_cls = mocker.patch("services.rag_pipeline.pipeline_generate_service.PipelineGenerator")
@@ -137,22 +160,17 @@ def test_generate_updates_document_status_and_returns_event_stream(
 
 
 def test_generate_rejects_pipeline_dataset_from_another_tenant(mocker: MockerFixture, sqlite_session: Session) -> None:
-    dataset = cast(Dataset, SimpleNamespace(id="dataset-1", tenant_id="tenant-2"))
-    pipeline = cast(
-        Pipeline,
-        SimpleNamespace(
-            id="pipeline-1",
-            tenant_id="tenant-1",
-            retrieve_dataset=mocker.Mock(return_value=dataset),
-        ),
-    )
-    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=SimpleNamespace(id="wf-1"))
+    dataset = _make_dataset(tenant_id="tenant-2")
+    pipeline = _make_pipeline()
+    sqlite_session.add_all([dataset, pipeline])
+    sqlite_session.commit()
+    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=_make_workflow())
     update_status_mock = mocker.patch.object(PipelineGenerateService, "update_document_status")
 
     with pytest.raises(ValueError, match="Pipeline dataset is required"):
         PipelineGenerateService.generate(
             pipeline=pipeline,
-            user=cast(Account, SimpleNamespace(id="user-1")),
+            user=_make_account(),
             args={"original_document_id": "doc-1"},
             invoke_from=InvokeFrom.WEB_APP,
             session=sqlite_session,
@@ -170,13 +188,13 @@ def test_generate_rejects_original_document_outside_pipeline_dataset_before_disp
     outside_document = _make_document(document_id="foreign-doc", dataset_id="other-dataset", tenant_id="tenant-2")
     sqlite_session.add_all([dataset, pipeline, outside_document])
     sqlite_session.commit()
-    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=SimpleNamespace(id="wf-1"))
+    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=_make_workflow())
     generator_cls = mocker.patch("services.rag_pipeline.pipeline_generate_service.PipelineGenerator")
 
     with pytest.raises(ValueError, match="Pipeline document not found"):
         PipelineGenerateService.generate(
             pipeline=pipeline,
-            user=cast(Account, SimpleNamespace(id="user-1")),
+            user=_make_account(),
             args={"original_document_id": "foreign-doc"},
             invoke_from=InvokeFrom.PUBLISHED_PIPELINE,
             session=sqlite_session,
@@ -212,7 +230,7 @@ def test_update_document_status_rejects_document_outside_owner(
     document_dataset_id: str,
     sqlite_session: Session,
 ) -> None:
-    dataset = cast(Dataset, SimpleNamespace(id="dataset-1", tenant_id="tenant-1"))
+    dataset = _make_dataset()
     dataset_ref = DatasetRefService.create_dataset_ref(dataset)
     document_ref = DatasetRefService.create_document_ref_from_id(dataset_ref, "doc-1")
     outside_document = _make_document(tenant_id=document_tenant_id, dataset_id=document_dataset_id)
@@ -230,15 +248,16 @@ def test_update_document_status_rejects_document_outside_owner(
 
 
 def test_generate_single_iteration_delegates(mocker: MockerFixture, sqlite_session: Session) -> None:
-    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=SimpleNamespace(id="wf-1"))
+    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=_make_workflow())
 
     generator_cls = mocker.patch("services.rag_pipeline.pipeline_generate_service.PipelineGenerator")
     generator_instance = generator_cls.return_value
     generator_instance.single_iteration_generate.return_value = "raw-iter"
     generator_cls.convert_to_event_stream.return_value = "stream-iter"
 
-    pipeline = cast(Pipeline, SimpleNamespace(id="p1"))
-    user = cast(Account, SimpleNamespace(id="u1"))
+    pipeline = _make_pipeline()
+    pipeline.id = "p1"
+    user = _make_account(account_id="u1")
     session = sqlite_session
 
     result = PipelineGenerateService.generate_single_iteration(pipeline, user, "node-1", {"key": "val"}, session)
@@ -252,15 +271,16 @@ def test_generate_single_iteration_delegates(mocker: MockerFixture, sqlite_sessi
 
 
 def test_generate_single_loop_delegates(mocker: MockerFixture, sqlite_session: Session) -> None:
-    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=SimpleNamespace(id="wf-1"))
+    mocker.patch.object(PipelineGenerateService, "_get_workflow", return_value=_make_workflow())
 
     generator_cls = mocker.patch("services.rag_pipeline.pipeline_generate_service.PipelineGenerator")
     generator_instance = generator_cls.return_value
     generator_instance.single_loop_generate.return_value = "raw-loop"
     generator_cls.convert_to_event_stream.return_value = "stream-loop"
 
-    pipeline = cast(Pipeline, SimpleNamespace(id="p1"))
-    user = cast(Account, SimpleNamespace(id="u1"))
+    pipeline = _make_pipeline()
+    pipeline.id = "p1"
+    user = _make_account(account_id="u1")
     session = sqlite_session
 
     result = PipelineGenerateService.generate_single_loop(pipeline, user, "node-1", {"key": "val"}, session)

--- a/api/tests/unit_tests/services/test_credential_permission_service.py
+++ b/api/tests/unit_tests/services/test_credential_permission_service.py
@@ -4,8 +4,6 @@ Tests the visibility filtering logic, partial-member read path,
 and admin bypass behavior.
 """
 
-from types import SimpleNamespace
-from typing import cast
 from uuid import uuid4
 
 import pytest
@@ -13,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from core.plugin.entities.plugin_daemon import CredentialType as TriggerCredentialType
-from models.account import Account
+from models.account import Account, TenantAccountRole
 from models.credential_permission import CredentialPermission, CredentialType
 from models.enums import PermissionEnum
 from models.trigger import TriggerSubscription
@@ -62,7 +60,10 @@ def _subscription(
 
 
 def _user(user_id: str, *, is_admin: bool) -> Account:
-    return cast(Account, SimpleNamespace(id=user_id, is_admin_or_owner=is_admin))
+    user = Account(name="Credential User", email=f"{user_id}@example.com")
+    user.id = user_id
+    user.role = TenantAccountRole.ADMIN if is_admin else TenantAccountRole.NORMAL
+    return user
 
 
 class TestGetPartialMemberList:

--- a/api/tests/unit_tests/services/test_workflow_run_service.py
+++ b/api/tests/unit_tests/services/test_workflow_run_service.py
@@ -2,15 +2,18 @@
 
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import Engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
-from models import Account, App, EndUser, Message, WorkflowRunTriggeredFrom
-from models.enums import ConversationFromSource
+from graphon.enums import WorkflowExecutionStatus
+from models import Account, App, EndUser, Message, WorkflowRun, WorkflowRunTriggeredFrom, WorkflowType
+from models.account import Tenant
+from models.enums import ConversationFromSource, CreatorUserRole, EndUserType
+from models.model import AppMode
 from services import workflow_run_service as service_module
 from services.workflow_run_service import WorkflowRunService
 
@@ -27,21 +30,53 @@ def repository_factory_mocks(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock
     return node_repo, workflow_run_repo, factory
 
 
-@pytest.fixture
-def sqlalchemy_session_factory(sqlite_engine: Engine) -> sessionmaker[Session]:
-    return sessionmaker(bind=sqlite_engine, expire_on_commit=False)
+def _app_model(*, app_id: str = "app-1", tenant_id: str = "tenant-1") -> App:
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        name="Workflow App",
+        mode=AppMode.ADVANCED_CHAT,
+        enable_site=False,
+        enable_api=False,
+    )
 
 
-def _app_model(**kwargs: Any) -> App:
-    return cast(App, SimpleNamespace(**kwargs))
+def _account(*, account_id: str = "account-1", current_tenant_id: str | None = "tenant-1") -> Account:
+    account = Account(name="Workflow User", email=f"{account_id}@example.com")
+    account.id = account_id
+    if current_tenant_id is not None:
+        tenant = Tenant(name="Workflow Tenant")
+        tenant.id = current_tenant_id
+        account._current_tenant = tenant
+    return account
 
 
-def _account(**kwargs: Any) -> Account:
-    return cast(Account, SimpleNamespace(**kwargs))
+def _end_user(*, end_user_id: str = "end-user-1", tenant_id: str = "tenant-1") -> EndUser:
+    return EndUser(
+        id=end_user_id,
+        tenant_id=tenant_id,
+        type=EndUserType.SERVICE_API,
+        session_id=f"session-{end_user_id}",
+    )
 
 
-def _end_user(**kwargs: Any) -> EndUser:
-    return cast(EndUser, SimpleNamespace(**kwargs))
+def _workflow_run(
+    *, run_id: str = "run-1", status: WorkflowExecutionStatus = WorkflowExecutionStatus.SUCCEEDED
+) -> WorkflowRun:
+    return WorkflowRun(
+        id=run_id,
+        tenant_id="tenant-1",
+        app_id="app-1",
+        workflow_id="workflow-1",
+        type=WorkflowType.CHAT,
+        triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+        version="1",
+        graph="{}",
+        inputs="{}",
+        status=status,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-1",
+    )
 
 
 def _message(*, message_id: str, workflow_run_id: str, conversation_id: str) -> Message:
@@ -91,28 +126,28 @@ class TestWorkflowRunServiceInitialization:
     def test___init___should_keep_provided_sessionmaker_and_create_repositories(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
         node_repo, workflow_run_repo, factory = repository_factory_mocks
 
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
 
-        assert service._session_factory is sqlalchemy_session_factory
+        assert service._session_factory is sqlite_session_factory
         assert service._node_execution_service_repo is node_repo
         assert service._workflow_run_repo is workflow_run_repo
-        factory.create_api_workflow_node_execution_repository.assert_called_once_with(sqlalchemy_session_factory)
-        factory.create_api_workflow_run_repository.assert_called_once_with(sqlalchemy_session_factory)
+        factory.create_api_workflow_node_execution_repository.assert_called_once_with(sqlite_session_factory)
+        factory.create_api_workflow_run_repository.assert_called_once_with(sqlite_session_factory)
 
 
 class TestWorkflowRunServiceQueries:
     def test_get_paginate_workflow_runs_should_forward_filters_and_parse_limit(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
         _, workflow_run_repo, _ = repository_factory_mocks
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", id="app-1")
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
         expected = MagicMock(name="pagination")
         workflow_run_repo.get_paginated_workflow_runs.return_value = expected
         args = {"limit": "7", "last_id": "last-1", "status": "succeeded"}
@@ -138,13 +173,13 @@ class TestWorkflowRunServiceQueries:
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
         monkeypatch: pytest.MonkeyPatch,
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
         sqlite_session: Session,
     ) -> None:
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", id="app-1")
-        run_with_message = SimpleNamespace(id="run-1", status="running")
-        run_without_message = SimpleNamespace(id="run-2", status="succeeded")
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
+        run_with_message = _workflow_run(status=WorkflowExecutionStatus.RUNNING)
+        run_without_message = _workflow_run(run_id="run-2")
         pagination = SimpleNamespace(data=[run_with_message, run_without_message])
         monkeypatch.setattr(service, "get_paginate_workflow_runs", MagicMock(return_value=pagination))
 
@@ -166,7 +201,7 @@ class TestWorkflowRunServiceQueries:
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
         monkeypatch: pytest.MonkeyPatch,
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
         sqlite_session: Session,
     ) -> None:
         """Messages must load with a constant query count regardless of run count.
@@ -174,9 +209,9 @@ class TestWorkflowRunServiceQueries:
         Previously the deprecated WorkflowRun.message property issued one query per
         run (N+1); they are now batch-loaded in a single query.
         """
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", id="app-1")
-        runs = [SimpleNamespace(id=f"run-{i}", status="succeeded") for i in range(5)]
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
+        runs = [_workflow_run(run_id=f"run-{i}") for i in range(5)]
         pagination = SimpleNamespace(data=runs)
         monkeypatch.setattr(service, "get_paginate_workflow_runs", MagicMock(return_value=pagination))
 
@@ -192,19 +227,18 @@ class TestWorkflowRunServiceQueries:
             service.get_paginate_advanced_chat_workflow_runs(app_model=app_model, args={})
         finally:
             event.remove(engine, "before_cursor_execute", count_message_query)
-
         assert all(not hasattr(run, "message_id") for run in runs)
         assert message_query_count == 1
 
     def test_get_workflow_run_should_delegate_to_repository_by_tenant_and_app(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
         _, workflow_run_repo, _ = repository_factory_mocks
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", id="app-1")
-        expected = MagicMock(name="workflow_run")
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
+        expected = _workflow_run()
         workflow_run_repo.get_workflow_run_by_id.return_value = expected
 
         result = service.get_workflow_run(app_model=app_model, run_id="run-1")
@@ -219,11 +253,11 @@ class TestWorkflowRunServiceQueries:
     def test_get_workflow_runs_count_should_forward_optional_filters(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
         _, workflow_run_repo, _ = repository_factory_mocks
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", id="app-1")
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
         expected = {"total": 3, "succeeded": 2}
         workflow_run_repo.get_workflow_runs_count.return_value = expected
 
@@ -247,11 +281,11 @@ class TestWorkflowRunServiceQueries:
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
         monkeypatch: pytest.MonkeyPatch,
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
         monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=None))
-        app_model = _app_model(id="app-1")
+        app_model = _app_model(app_id="app-1")
         user = _account(current_tenant_id="tenant-1")
 
         result = service.get_workflow_run_node_executions(app_model=app_model, run_id="run-1", user=user)
@@ -262,19 +296,13 @@ class TestWorkflowRunServiceQueries:
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
         monkeypatch: pytest.MonkeyPatch,
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
         node_repo, _, _ = repository_factory_mocks
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=SimpleNamespace(id="run-1")))
-
-        class FakeEndUser:
-            def __init__(self, tenant_id: str) -> None:
-                self.tenant_id = tenant_id
-
-        monkeypatch.setattr(service_module, "EndUser", FakeEndUser)
-        user = cast(EndUser, FakeEndUser(tenant_id="tenant-end-user"))
-        app_model = _app_model(id="app-1")
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=_workflow_run()))
+        user = _end_user(tenant_id="tenant-end-user")
+        app_model = _app_model(app_id="app-1")
         expected_executions = [SimpleNamespace(id="exec-1")]
         expected_traces = [SimpleNamespace(id="exec-1:retry:1")]
         node_repo.get_executions_by_workflow_run.return_value = expected_executions
@@ -295,12 +323,12 @@ class TestWorkflowRunServiceQueries:
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
         monkeypatch: pytest.MonkeyPatch,
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
         node_repo, _, _ = repository_factory_mocks
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=SimpleNamespace(id="run-1")))
-        app_model = _app_model(id="app-1")
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=_workflow_run()))
+        app_model = _app_model(app_id="app-1")
         user = _account(current_tenant_id="tenant-account")
         expected_executions = [SimpleNamespace(id="exec-1"), SimpleNamespace(id="exec-2")]
         expected_traces = [SimpleNamespace(id="exec-1:retry:1"), SimpleNamespace(id="exec-1")]
@@ -322,11 +350,11 @@ class TestWorkflowRunServiceQueries:
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
         monkeypatch: pytest.MonkeyPatch,
-        sqlalchemy_session_factory: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
     ) -> None:
-        service = WorkflowRunService(session_factory=sqlalchemy_session_factory)
-        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=SimpleNamespace(id="run-1")))
-        app_model = _app_model(id="app-1")
+        service = WorkflowRunService(session_factory=sqlite_session_factory)
+        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=_workflow_run()))
+        app_model = _app_model(app_id="app-1")
         user = _account(current_tenant_id=None)
 
         with pytest.raises(ValueError, match="tenant_id cannot be None"):

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -19,7 +19,6 @@ from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity,
 from graphon.entities import WorkflowStartReason
 from graphon.enums import WorkflowExecutionStatus
 from models.account import Account
-from models.base import TypeBase
 from models.enums import ConversationFromSource, CreatorUserRole, WorkflowRunTriggeredFrom
 from models.model import App, AppMode, Conversation, Message
 from models.workflow import Workflow, WorkflowRun, WorkflowType
@@ -78,13 +77,88 @@ def _published_payloads(topic: MagicMock) -> list[dict[str, object] | str]:
     return [_decode_published_payload(call.args[0]) for call in topic.publish.call_args_list]
 
 
-@pytest.fixture
-def sqlite_session_factory(sqlite_engine: Engine) -> sessionmaker[Session]:
-    tables = [
-        TypeBase.metadata.tables[model.__tablename__] for model in (App, Workflow, WorkflowRun, Conversation, Message)
-    ]
-    TypeBase.metadata.create_all(sqlite_engine, tables=tables)
-    return sessionmaker(bind=sqlite_engine, expire_on_commit=False)
+def _make_account(*, account_id: str = "account-id") -> Account:
+    account = Account(name="Workflow Runner", email=f"{account_id}@example.com")
+    account.id = account_id
+    return account
+
+
+def _make_app(*, app_id: str = "app-id", tenant_id: str = "resource-tenant-id") -> App:
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        name="Test App",
+        mode=AppMode.ADVANCED_CHAT,
+        enable_site=True,
+        enable_api=True,
+    )
+
+
+def _make_workflow(*, workflow_id: str = "workflow-id", app_id: str = "app-id") -> Workflow:
+    return Workflow(
+        id=workflow_id,
+        tenant_id="resource-tenant-id",
+        app_id=app_id,
+        type=WorkflowType.CHAT,
+        version=Workflow.VERSION_DRAFT,
+        graph="{}",
+        features="{}",
+        created_by="workflow-owner",
+        environment_variables=[],
+        conversation_variables=[],
+        rag_pipeline_variables=[],
+    )
+
+
+def _make_conversation(*, conversation_id: str = "conversation-id", app_id: str = "app-id") -> Conversation:
+    return Conversation(
+        id=conversation_id,
+        app_id=app_id,
+        mode=AppMode.ADVANCED_CHAT,
+        name="Test Conversation",
+        inputs={},
+        from_source=ConversationFromSource.API,
+    )
+
+
+def _make_message(*, conversation_id: str = "conversation-id", workflow_run_id: str = "workflow-run-id") -> Message:
+    return Message(
+        id="message-id",
+        app_id="app-id",
+        conversation_id=conversation_id,
+        inputs={},
+        query="query",
+        message={"role": "user", "content": "query"},
+        answer="answer",
+        message_unit_price=Decimal(0),
+        answer_unit_price=Decimal(0),
+        currency="USD",
+        from_source=ConversationFromSource.API,
+        workflow_run_id=workflow_run_id,
+    )
+
+
+def _make_workflow_run(
+    *,
+    workflow_run_id: str = "workflow-run-id",
+    workflow_id: str = "workflow-id",
+    created_by: str = "account-id",
+    tenant_id: str = "resource-tenant-id",
+) -> WorkflowRun:
+    return WorkflowRun(
+        id=workflow_run_id,
+        tenant_id=tenant_id,
+        app_id="app-id",
+        workflow_id=workflow_id,
+        type=WorkflowType.CHAT,
+        triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+        version=Workflow.VERSION_DRAFT,
+        graph="{}",
+        inputs="{}",
+        status=WorkflowExecutionStatus.RUNNING,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by=created_by,
+    )
 
 
 def _persist_app_and_workflow(session_factory: sessionmaker[Session]) -> None:
@@ -600,7 +674,7 @@ def test_app_runner_streaming_failure_publishes_started_then_failed_workflow_fin
     _persist_app_and_workflow(sqlite_session_factory)
     runner = _AppRunner(session_factory=sqlite_session_factory, exec_params=exec_params)
 
-    monkeypatch.setattr(runner, "_resolve_user", lambda: MagicMock())
+    monkeypatch.setattr(runner, "_resolve_user", _make_account)
     monkeypatch.setattr(runner, "_setup_flask_context", lambda _user: nullcontext())
     monkeypatch.setattr(runner, "_run_app", lambda **_kwargs: (_ for _ in ()).throw(ValueError("Invalid upload file")))
 
@@ -667,11 +741,7 @@ def test_resolve_account_for_run_without_switching_tenant(sqlite_session: Sessio
     account.id = account_id
     sqlite_session.add(account)
     sqlite_session.commit()
-    workflow_run = MagicMock(
-        created_by_role=CreatorUserRole.ACCOUNT,
-        created_by=account_id,
-        tenant_id="resource-tenant-id",
-    )
+    workflow_run = _make_workflow_run(created_by=account_id)
 
     resolved_user = workflow_execute_task_module._resolve_user_for_run(sqlite_session, workflow_run)
 
@@ -698,7 +768,7 @@ def test_app_runner_streaming_failure_keeps_existing_pre_runtime_helper_behavior
     _persist_app_and_workflow(sqlite_session_factory)
     runner = _AppRunner(session_factory=sqlite_session_factory, exec_params=exec_params)
 
-    monkeypatch.setattr(runner, "_resolve_user", lambda: MagicMock())
+    monkeypatch.setattr(runner, "_resolve_user", _make_account)
     monkeypatch.setattr(runner, "_setup_flask_context", lambda _user: nullcontext())
     monkeypatch.setattr(runner, "_run_app", lambda **_kwargs: (_ for _ in ()).throw(ValueError("Invalid upload file")))
     monkeypatch.setattr(
@@ -734,7 +804,7 @@ def test_app_runner_streaming_success_calls_publish_streaming_response_with_full
     response_stream = _single_event_generator({"event": "message"})
     publish_streaming_response = MagicMock()
 
-    monkeypatch.setattr(runner, "_resolve_user", lambda: MagicMock())
+    monkeypatch.setattr(runner, "_resolve_user", _make_account)
     monkeypatch.setattr(runner, "_setup_flask_context", lambda _user: nullcontext())
     monkeypatch.setattr(runner, "_run_app", lambda **_kwargs: response_stream)
     monkeypatch.setattr(
@@ -793,7 +863,7 @@ def test_resume_app_execution_queries_message_by_conversation_and_workflow_run(
     )
 
     monkeypatch.setattr(
-        "tasks.app_generate.workflow_execute_task._resolve_user_for_run", lambda *_args, **_kwargs: MagicMock()
+        "tasks.app_generate.workflow_execute_task._resolve_user_for_run", lambda *_args, **_kwargs: _make_account()
     )
     resume_advanced_chat = MagicMock()
     monkeypatch.setattr("tasks.app_generate.workflow_execute_task._resume_advanced_chat", resume_advanced_chat)
@@ -841,7 +911,7 @@ def test_resume_app_execution_returns_early_when_advanced_chat_missing_conversat
     )
 
     monkeypatch.setattr(
-        "tasks.app_generate.workflow_execute_task._resolve_user_for_run", lambda *_args, **_kwargs: MagicMock()
+        "tasks.app_generate.workflow_execute_task._resolve_user_for_run", lambda *_args, **_kwargs: _make_account()
     )
     resume_advanced_chat = MagicMock()
     monkeypatch.setattr("tasks.app_generate.workflow_execute_task._resume_advanced_chat", resume_advanced_chat)
@@ -859,7 +929,7 @@ def test_resume_advanced_chat_publishes_events_for_originally_blocking_runs(
 ):
     generate_entity = _build_advanced_chat_generate_entity(conversation_id="conversation-id")
     generate_entity.stream = False
-    workflow = SimpleNamespace(id="workflow-id", created_by="workflow-owner")
+    workflow = _make_workflow()
 
     generator_instance = MagicMock()
     response_stream = _single_event_generator({"event": "message"})
@@ -882,18 +952,18 @@ def test_resume_advanced_chat_publishes_events_for_originally_blocking_runs(
         lambda **kwargs: MagicMock(),
     )
     _resume_advanced_chat(
-        app_model=SimpleNamespace(id="app-id", tenant_id="resource-tenant-id"),
+        app_model=_make_app(),
         workflow=workflow,
-        user=MagicMock(),
-        conversation=SimpleNamespace(id="conversation-id"),
-        message=MagicMock(),
+        user=_make_account(),
+        conversation=_make_conversation(),
+        message=_make_message(),
         generate_entity=generate_entity,
         graph_runtime_state=MagicMock(),
         response_stream_filter=MagicMock(),
         session_factory=sqlite_session_factory,
         pause_state_config=MagicMock(),
         workflow_run_id="workflow-run-id",
-        workflow_run=SimpleNamespace(triggered_from="app_run"),
+        workflow_run=_make_workflow_run(),
         session=sqlite_session,
     )
 
@@ -915,7 +985,7 @@ def test_resume_workflow_publishes_events_for_originally_blocking_runs(
     sqlite_session_factory: sessionmaker[Session],
 ):
     generate_entity = _build_workflow_generate_entity(stream=False)
-    workflow = SimpleNamespace(id="workflow-id", created_by="workflow-owner")
+    workflow = _make_workflow()
 
     generator_instance = MagicMock()
     response_stream = _single_event_generator({"event": "workflow_finished"})
@@ -941,16 +1011,16 @@ def test_resume_workflow_publishes_events_for_originally_blocking_runs(
     pause_entity = MagicMock()
 
     _resume_workflow(
-        app_model=SimpleNamespace(id="app-id", tenant_id="resource-tenant-id"),
+        app_model=_make_app(),
         workflow=workflow,
-        user=MagicMock(),
+        user=_make_account(),
         generate_entity=generate_entity,
         graph_runtime_state=MagicMock(),
         response_stream_filter=MagicMock(),
         session_factory=sqlite_session_factory,
         pause_state_config=MagicMock(),
         workflow_run_id="workflow-run-id",
-        workflow_run=SimpleNamespace(triggered_from="app_run"),
+        workflow_run=_make_workflow_run(),
         workflow_run_repo=workflow_run_repo,
         pause_entity=pause_entity,
     )
@@ -973,7 +1043,7 @@ def test_resume_workflow_ignores_missing_old_pause_after_repause(
     sqlite_session_factory: sessionmaker[Session],
 ):
     generate_entity = _build_workflow_generate_entity(stream=False)
-    workflow = SimpleNamespace(id="workflow-id", created_by="workflow-owner")
+    workflow = _make_workflow()
 
     generator_instance = MagicMock()
     response_stream = _single_event_generator({"event": "workflow_paused"})
@@ -1000,16 +1070,16 @@ def test_resume_workflow_ignores_missing_old_pause_after_repause(
     pause_entity = MagicMock()
 
     _resume_workflow(
-        app_model=SimpleNamespace(id="app-id", tenant_id="resource-tenant-id"),
+        app_model=_make_app(),
         workflow=workflow,
-        user=MagicMock(),
+        user=_make_account(),
         generate_entity=generate_entity,
         graph_runtime_state=MagicMock(),
         response_stream_filter=MagicMock(),
         session_factory=sqlite_session_factory,
         pause_state_config=MagicMock(),
         workflow_run_id="workflow-run-id",
-        workflow_run=SimpleNamespace(triggered_from="app_run"),
+        workflow_run=_make_workflow_run(),
         workflow_run_repo=workflow_run_repo,
         pause_entity=pause_entity,
     )


### PR DESCRIPTION
## Summary

- replace mapped app, workflow, workflow-run, account, end-user, pipeline, dataset, conversation, and message stand-ins in residual task/service tests with real ORM instances
- use the shared SQLite session factory for workflow execution tasks and workflow-run services
- persist pipeline/dataset ownership chains so cross-tenant document and dataset behavior executes through real queries
- retain mocks only for repositories, stream/generator collaborators, logstore domain objects, and other non-ORM dependencies

No production changes.

## Size

397 changed lines: 260 additions, 137 deletions.

## Validation

- `make test TARGET_TESTS="./api/tests/unit_tests/tasks/test_workflow_execute_task.py ./api/tests/unit_tests/extensions/logstore/repositories/test_logstore_workflow_node_execution_repository.py ./api/tests/unit_tests/services/test_workflow_run_service.py ./api/tests/unit_tests/services/test_credential_permission_service.py ./api/tests/unit_tests/services/rag_pipeline/test_pipeline_generate_service.py"` — 69 passed
- `make lint` — passed
- `make type-check` — pyrefly reported no project errors; mypy 1.20.2 terminated with its existing internal error at `typeshed/stdlib/zipimport.pyi:17`
- scoped audit found no remaining mapped-model stand-ins or SQLAlchemy session/factory doubles in the changed tests

Per request, the full test suite was not run.