### PR TITLE
fix(web): restore app deletion autofill and knowledge scope label

### DIFF
--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -1,5 +1,6 @@
 import type { AppPartial } from '@dify/contracts/api/console/apps/types.gen'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { STEP_BY_STEP_TOUR_TARGETS } from '@/app/components/step-by-step-tour/target-registry'
 import { AccessMode } from '@/models/access-control'
@@ -883,6 +884,24 @@ describe('AppCard', () => {
       fireEvent.click(getOperationsTrigger())
       fireEvent.click(await screen.findByRole('menuitem', { name: 'common.operation.delete' }))
       expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+    })
+
+    it('should autofill the app name for delete confirmation', async () => {
+      const user = userEvent.setup()
+      render(<AppCard app={mockApp} />)
+
+      await user.click(getOperationsTrigger())
+      await user.click(await screen.findByRole('menuitem', { name: 'common.operation.delete' }))
+
+      const deleteInput = await screen.findByRole('textbox')
+      const confirmButton = screen.getByRole('button', { name: 'common.operation.confirm' })
+
+      expect(confirmButton).toBeDisabled()
+
+      await user.click(screen.getByRole('button', { name: 'common.operation.fill' }))
+
+      expect(deleteInput).toHaveValue(mockApp.name)
+      expect(confirmButton).toBeEnabled()
     })
 
     it('should close confirm dialog when cancel is clicked', async () => {

--- a/web/app/components/apps/app-card/action-bar/index.tsx
+++ b/web/app/components/apps/app-card/action-bar/index.tsx
@@ -516,15 +516,24 @@ export const AppCardActionBar = memo(
                       }}
                     />
                   </FieldLabel>
-                  <FieldControl
-                    type="text"
-                    autoComplete="off"
-                    spellCheck={false}
-                    placeholder={t(($) => $.deleteAppConfirmInputPlaceholder, { ns: 'app' })}
-                    value={confirmDeleteInput}
-                    onValueChange={setConfirmDeleteInput}
-                    className="border-components-input-border-hover bg-components-input-bg-normal focus:border-components-input-border-active focus:bg-components-input-bg-active"
-                  />
+                  <div className="relative">
+                    <FieldControl
+                      type="text"
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder={t(($) => $.deleteAppConfirmInputPlaceholder, { ns: 'app' })}
+                      value={confirmDeleteInput}
+                      onValueChange={setConfirmDeleteInput}
+                      className="border-components-input-border-hover bg-components-input-bg-normal pr-20 focus:border-components-input-border-active focus:bg-components-input-bg-active"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setConfirmDeleteInput(app.name)}
+                      className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full bg-black/6 px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/10"
+                    >
+                      {t(($) => $['operation.fill'], { ns: 'common' })}
+                    </button>
+                  </div>
                 </Field>
               </div>
               <AlertDialogActions>

--- a/web/app/components/apps/app-card/action-bar/index.tsx
+++ b/web/app/components/apps/app-card/action-bar/index.tsx
@@ -529,7 +529,7 @@ export const AppCardActionBar = memo(
                     <button
                       type="button"
                       onClick={() => setConfirmDeleteInput(app.name)}
-                      className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full bg-black/6 px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/10"
+                      className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full bg-black/6 px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/10 focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
                     >
                       {t(($) => $['operation.fill'], { ns: 'common' })}
                     </button>

--- a/web/app/components/goto-anything/__tests__/index.spec.tsx
+++ b/web/app/components/goto-anything/__tests__/index.spec.tsx
@@ -443,6 +443,23 @@ describe('GotoAnything', () => {
       expect(input).toHaveValue('test query')
     })
 
+    it('should show the localized description for the knowledge scope', async () => {
+      const user = userEvent.setup()
+      renderGotoAnything(<GotoAnything />)
+      triggerSearchShortcut()
+      const input = await screen.findByRole('combobox', {
+        name: 'app.gotoAnything.searchTitle',
+      })
+
+      await user.type(input, '@')
+
+      expect(
+        screen.getByRole('option', {
+          name: /@kb app\.gotoAnything\.actions\.searchKnowledgeBasesDesc/,
+        }),
+      ).toBeInTheDocument()
+    })
+
     it('should not search providers with a stale scope prefix', async () => {
       const user = userEvent.setup()
       matchActionMock.mockImplementation((query: string) =>

--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -79,7 +79,7 @@ const slashCommandDescriptionKeys = {
 const actionDescriptionKeys = {
   '@app': 'gotoAnything.actions.searchApplicationsDesc',
   '@plugin': 'gotoAnything.actions.searchPluginsDesc',
-  '@knowledge': 'gotoAnything.actions.searchKnowledgeBasesDesc',
+  '@kb': 'gotoAnything.actions.searchKnowledgeBasesDesc',
   '@node': 'gotoAnything.actions.searchWorkflowNodesDesc',
 } as const
 


### PR DESCRIPTION
## Summary

- Restore the Autofill action in the Studio app-card deletion dialog.
- Reuse the existing localized action and confirmation state so one click enters the exact app name and enables deletion.
- Restore the localized knowledge scope description in Goto Anything instead of rendering `undefined` beside `@kb`.
- Add React Testing Library regression coverage for both missing UI behaviors.

The Autofill control was originally added in #37263. During the Studio app-list refactor in #40109, the app-card deletion field lost its relative wrapper and Autofill button while the app-detail version remained intact.

The knowledge scope regression came from looking up action descriptions by each option's shortcut while registering the knowledge description under `@knowledge` instead of its displayed shortcut, `@kb`.

Fixes #40582

## Screenshots

N/A — both restored interactions are covered by focused component regression tests.

## Validation

- `cd web && pnpm exec vp test run app/components/apps/__tests__/app-card.spec.tsx app/components/goto-anything/__tests__/index.spec.tsx` — 105 tests passed
- `pnpm check` — 0 errors
- `pnpm exec vp staged` from the repository root — passed for all changed files

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the relevant frontend lint and static checks.

From Codex