### PR TITLE
test: migrate advanced chat generator sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import contextmanager
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from pydantic import BaseModel, ValidationError
+from sqlalchemy import Engine, event
 from sqlalchemy.orm import Session
 
 from constants import UUID_NIL
@@ -21,9 +24,88 @@ from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity, InvokeFrom
 from core.ops.ops_trace_manager import TraceQueueManager
 from libs.datetime_utils import naive_utc_now
-from models.enums import MessageStatus
-from models.model import AppMode
+from models.account import Account
+from models.enums import ConversationFromSource, EndUserType, MessageStatus
+from models.model import App, AppMode, Conversation, EndUser, Message
+from models.workflow import Workflow, WorkflowType
 from tests.unit_tests.config_override import apply_config_overrides
+
+
+def _make_app(*, app_id: str = "app", tenant_id: str = "tenant") -> App:
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        name="Advanced Chat App",
+        mode=AppMode.ADVANCED_CHAT,
+        enable_site=False,
+        enable_api=False,
+    )
+
+
+def _make_workflow(
+    *,
+    workflow_id: str = "workflow-id",
+    tenant_id: str = "tenant",
+    app_id: str = "app",
+    features: dict[str, object] | None = None,
+) -> Workflow:
+    return Workflow(
+        id=workflow_id,
+        tenant_id=tenant_id,
+        app_id=app_id,
+        type=WorkflowType.CHAT,
+        version=Workflow.VERSION_DRAFT,
+        graph="{}",
+        features=json.dumps(features or {}),
+        created_by="user",
+    )
+
+
+def _make_account(*, account_id: str = "user-id") -> Account:
+    account = Account(name="Advanced Chat User", email=f"{account_id}@example.com")
+    account.id = account_id
+    return account
+
+
+def _make_end_user(*, end_user_id: str = "end-user-id", session_id: str = "session-id") -> EndUser:
+    return EndUser(
+        id=end_user_id,
+        tenant_id="tenant",
+        app_id="app",
+        type=EndUserType.BROWSER,
+        session_id=session_id,
+    )
+
+
+def _make_conversation(*, conversation_id: str = "conversation-id", app_id: str = "app") -> Conversation:
+    return Conversation(
+        id=conversation_id,
+        app_id=app_id,
+        mode=AppMode.ADVANCED_CHAT,
+        name="Advanced Chat Conversation",
+        inputs={},
+        from_source=ConversationFromSource.API,
+    )
+
+
+def _make_message(
+    *, message_id: str = "message-id", conversation_id: str = "conversation-id", app_id: str = "app"
+) -> Message:
+    return Message(
+        id=message_id,
+        app_id=app_id,
+        conversation_id=conversation_id,
+        inputs={},
+        query="hello",
+        message={},
+        answer="",
+        status=MessageStatus.NORMAL,
+        message_unit_price=Decimal(0),
+        answer_unit_price=Decimal(0),
+        currency="USD",
+        from_source=ConversationFromSource.API,
+        created_at=naive_utc_now(),
+    )
 
 
 class TestAdvancedChatAppGeneratorValidation:
@@ -32,9 +114,9 @@ class TestAdvancedChatAppGeneratorValidation:
 
         with pytest.raises(ValueError, match="query is required"):
             generator.generate(
-                app_model=SimpleNamespace(),
-                workflow=SimpleNamespace(),
-                user=SimpleNamespace(),
+                app_model=_make_app(),
+                workflow=_make_workflow(),
+                user=_make_account(),
                 args={"inputs": {}},
                 invoke_from=InvokeFrom.WEB_APP,
                 workflow_run_id="run-id",
@@ -47,9 +129,9 @@ class TestAdvancedChatAppGeneratorValidation:
 
         with pytest.raises(ValueError, match="query must be a string"):
             generator.generate(
-                app_model=SimpleNamespace(),
-                workflow=SimpleNamespace(),
-                user=SimpleNamespace(),
+                app_model=_make_app(),
+                workflow=_make_workflow(),
+                user=_make_account(),
                 args={"inputs": {}, "query": 123},
                 invoke_from=InvokeFrom.WEB_APP,
                 workflow_run_id="run-id",
@@ -62,10 +144,10 @@ class TestAdvancedChatAppGeneratorValidation:
 
         with pytest.raises(ValueError, match="node_id is required"):
             generator.single_iteration_generate(
-                app_model=SimpleNamespace(),
-                workflow=SimpleNamespace(),
+                app_model=_make_app(),
+                workflow=_make_workflow(),
                 node_id="",
-                user=SimpleNamespace(),
+                user=_make_account(),
                 args={"inputs": {}},
                 streaming=False,
                 session=unbound_session,
@@ -73,10 +155,10 @@ class TestAdvancedChatAppGeneratorValidation:
 
         with pytest.raises(ValueError, match="inputs is required"):
             generator.single_iteration_generate(
-                app_model=SimpleNamespace(),
-                workflow=SimpleNamespace(),
+                app_model=_make_app(),
+                workflow=_make_workflow(),
                 node_id="node",
-                user=SimpleNamespace(),
+                user=_make_account(),
                 args={},
                 streaming=False,
                 session=unbound_session,
@@ -87,10 +169,10 @@ class TestAdvancedChatAppGeneratorValidation:
 
         with pytest.raises(ValueError, match="node_id is required"):
             generator.single_loop_generate(
-                app_model=SimpleNamespace(),
-                workflow=SimpleNamespace(),
+                app_model=_make_app(),
+                workflow=_make_workflow(),
                 node_id="",
-                user=SimpleNamespace(),
+                user=_make_account(),
                 args=SimpleNamespace(inputs={}),
                 streaming=False,
                 session=unbound_session,
@@ -98,10 +180,10 @@ class TestAdvancedChatAppGeneratorValidation:
 
         with pytest.raises(ValueError, match="inputs is required"):
             generator.single_loop_generate(
-                app_model=SimpleNamespace(),
-                workflow=SimpleNamespace(),
+                app_model=_make_app(),
+                workflow=_make_workflow(),
                 node_id="node",
-                user=SimpleNamespace(),
+                user=_make_account(),
                 args=SimpleNamespace(inputs=None),
                 streaming=False,
                 session=unbound_session,
@@ -120,11 +202,13 @@ class TestAdvancedChatAppGeneratorInternals:
             workflow_id="workflow-id",
         )
 
-    def test_generate_loads_conversation_and_files(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
+    def test_generate_loads_conversation_and_files(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
 
-        conversation = SimpleNamespace(id="conversation-id")
+        conversation = _make_conversation()
         built_files: list[object] = []
         build_files_called = {"called": False}
         captured: dict[str, object] = {}
@@ -157,10 +241,7 @@ class TestAdvancedChatAppGeneratorInternals:
         )
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=lambda: SimpleNamespace(close=lambda: None)),
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.sessionmaker", lambda **kwargs: SimpleNamespace()
+            SimpleNamespace(engine=sqlite_engine, session=unbound_session),
         )
         monkeypatch.setattr(generator, "_prepare_user_inputs", lambda **kwargs: kwargs["user_inputs"])
 
@@ -187,8 +268,8 @@ class TestAdvancedChatAppGeneratorInternals:
         user.id = "user-id"
 
         result = generator.generate(
-            app_model=SimpleNamespace(id="app", tenant_id="tenant"),
-            workflow=SimpleNamespace(features_dict={}),
+            app_model=_make_app(),
+            workflow=_make_workflow(),
             user=user,
             args={
                 "query": "hello",
@@ -238,11 +319,11 @@ class TestAdvancedChatAppGeneratorInternals:
         monkeypatch.setattr(generator, "_generate", _fake_generate)
 
         result = generator.resume(
-            app_model=SimpleNamespace(id="app-id"),
-            workflow=SimpleNamespace(),
-            user=SimpleNamespace(id="end-user-id", session_id="session-id"),
-            conversation=SimpleNamespace(id="conversation-id"),
-            message=SimpleNamespace(id="message-id"),
+            app_model=_make_app(app_id="app-id"),
+            workflow=_make_workflow(),
+            user=_make_end_user(),
+            conversation=_make_conversation(),
+            message=_make_message(),
             session=unbound_session,
             application_generate_entity=application_generate_entity,
             workflow_execution_repository=SimpleNamespace(),
@@ -257,7 +338,7 @@ class TestAdvancedChatAppGeneratorInternals:
         assert captured_graph_runtime_state is not None
 
     def test_single_iteration_generate_builds_debug_task(
-        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session, sqlite_engine: Engine
     ):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
@@ -265,7 +346,7 @@ class TestAdvancedChatAppGeneratorInternals:
         prefill_calls: list[object] = []
         draft_sessions: list[object] = []
         var_loader = SimpleNamespace(loader="draft")
-        workflow = SimpleNamespace(id="workflow-id")
+        workflow = _make_workflow()
         session = unbound_session
 
         monkeypatch.setattr(
@@ -282,11 +363,8 @@ class TestAdvancedChatAppGeneratorInternals:
         )
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.DraftVarLoader", lambda **kwargs: var_loader)
         monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.sessionmaker", lambda **kwargs: SimpleNamespace()
-        )
-        monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=lambda: SimpleNamespace()),
+            SimpleNamespace(engine=sqlite_engine, session=unbound_session),
         )
 
         class _DraftVarService:
@@ -305,10 +383,10 @@ class TestAdvancedChatAppGeneratorInternals:
         monkeypatch.setattr(generator, "_generate", _fake_generate)
 
         result = generator.single_iteration_generate(
-            app_model=SimpleNamespace(id="app", tenant_id="tenant"),
+            app_model=_make_app(),
             workflow=workflow,
             node_id="node-1",
-            user=SimpleNamespace(id="user-id"),
+            user=_make_account(),
             args={"inputs": {"foo": "bar"}, "trace_session_id": "session-1"},
             streaming=False,
             session=session,
@@ -322,14 +400,16 @@ class TestAdvancedChatAppGeneratorInternals:
         assert captured["application_generate_entity"].single_iteration_run.node_id == "node-1"
         assert captured["application_generate_entity"].extras["trace_session_id"] == "session-1"
 
-    def test_single_loop_generate_builds_debug_task(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
+    def test_single_loop_generate_builds_debug_task(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
         captured: dict[str, object] = {}
         prefill_calls: list[object] = []
         draft_sessions: list[object] = []
         var_loader = SimpleNamespace(loader="draft")
-        workflow = SimpleNamespace(id="workflow-id")
+        workflow = _make_workflow()
         session = unbound_session
 
         monkeypatch.setattr(
@@ -346,11 +426,8 @@ class TestAdvancedChatAppGeneratorInternals:
         )
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.DraftVarLoader", lambda **kwargs: var_loader)
         monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.sessionmaker", lambda **kwargs: SimpleNamespace()
-        )
-        monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=lambda: SimpleNamespace()),
+            SimpleNamespace(engine=sqlite_engine, session=unbound_session),
         )
 
         class _DraftVarService:
@@ -369,10 +446,10 @@ class TestAdvancedChatAppGeneratorInternals:
         monkeypatch.setattr(generator, "_generate", _fake_generate)
 
         result = generator.single_loop_generate(
-            app_model=SimpleNamespace(id="app", tenant_id="tenant"),
+            app_model=_make_app(),
             workflow=workflow,
             node_id="node-2",
-            user=SimpleNamespace(id="user-id"),
+            user=_make_account(),
             args=SimpleNamespace(inputs={"foo": "bar"}, trace_session_id="session-1"),
             streaming=False,
             session=session,
@@ -386,7 +463,9 @@ class TestAdvancedChatAppGeneratorInternals:
         assert captured["application_generate_entity"].single_loop_run.node_id == "node-2"
         assert captured["application_generate_entity"].extras["trace_session_id"] == "session-1"
 
-    def test_generate_internal_flow_initial_conversation_with_pause_layer(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_internal_flow_initial_conversation_with_pause_layer(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         generator._dialogue_count = 0
         app_config = self._build_app_config()
@@ -405,16 +484,19 @@ class TestAdvancedChatAppGeneratorInternals:
             workflow_run_id="run-id",
         )
 
-        workflow = SimpleNamespace(id="wf-1", tenant_id="tenant", features={"feature": True}, features_dict={})
-        conversation = SimpleNamespace(id="conv-1", mode=AppMode.ADVANCED_CHAT, override_model_configs=None)
-        message = SimpleNamespace(
-            id="msg-1",
-            query="hello",
-            created_at=naive_utc_now(),
-            status=MessageStatus.NORMAL,
-            answer="",
-        )
-        db_session = SimpleNamespace(commit=MagicMock(), refresh=MagicMock(), close=MagicMock())
+        app = _make_app()
+        workflow = _make_workflow(workflow_id="wf-1", features={"feature": True})
+        conversation = _make_conversation(conversation_id="conv-1")
+        message = _make_message(message_id="msg-1", conversation_id=conversation.id)
+        sqlite_session.add_all([app, workflow, conversation, message])
+        sqlite_session.commit()
+        commit_count = 0
+
+        def _record_commit(session: Session) -> None:
+            nonlocal commit_count
+            commit_count += 1
+
+        event.listen(sqlite_session, "after_commit", _record_commit)
         captured: dict[str, object] = {}
         thread_data: dict[str, object] = {}
         init_records = MagicMock(return_value=(conversation, message))
@@ -455,7 +537,8 @@ class TestAdvancedChatAppGeneratorInternals:
 
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.threading.Thread", _Thread)
         monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.db", SimpleNamespace(engine=object(), session=db_session)
+            "core.app.apps.advanced_chat.app_generator.db",
+            SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
         )
         monkeypatch.setattr(generator, "_get_draft_var_saver_factory", lambda *args, **kwargs: "draft-factory")
         monkeypatch.setattr(
@@ -472,10 +555,10 @@ class TestAdvancedChatAppGeneratorInternals:
 
         response = generator._generate(
             workflow=workflow,
-            user=SimpleNamespace(id="user"),
+            user=_make_account(account_id="user"),
             invoke_from=InvokeFrom.WEB_APP,
             application_generate_entity=application_generate_entity,
-            session=db_session,
+            session=sqlite_session,
             workflow_execution_repository=SimpleNamespace(),
             workflow_node_execution_repository=SimpleNamespace(),
             conversation=None,
@@ -490,17 +573,18 @@ class TestAdvancedChatAppGeneratorInternals:
         assert thread_data["join_timeout"] == 300
         assert "pause-layer" in thread_data["kwargs"]["graph_engine_layers"]
         assert generator._dialogue_count == 3
-        assert init_records.call_args.kwargs["session"] is db_session
-        get_thread_messages_length.assert_called_once_with(conversation.id, session=db_session)
-        db_session.commit.assert_called_once()
-        db_session.refresh.assert_called_once_with(conversation)
-        db_session.close.assert_called_once()
+        assert init_records.call_args.kwargs["session"] is sqlite_session
+        get_thread_messages_length.assert_called_once_with(conversation.id, session=sqlite_session)
+        assert commit_count == 1
+        assert json.loads(conversation.override_model_configs) == {"feature": True}
         assert captured["draft_var_saver_factory"] == "draft-factory"
         assert isinstance(captured["workflow"], WorkflowSnapshot)
         assert isinstance(captured["conversation"], ConversationSnapshot)
         assert isinstance(captured["message"], MessageSnapshot)
 
-    def test_generate_internal_flow_with_existing_records_skips_init(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_internal_flow_with_existing_records_skips_init(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         generator._dialogue_count = 0
         app_config = self._build_app_config()
@@ -519,16 +603,19 @@ class TestAdvancedChatAppGeneratorInternals:
             workflow_run_id="run-id",
         )
 
-        workflow = SimpleNamespace(id="wf-2", tenant_id="tenant", features={}, features_dict={})
-        conversation = SimpleNamespace(id="conv-2", mode=AppMode.ADVANCED_CHAT, override_model_configs=None)
-        message = SimpleNamespace(
-            id="msg-2",
-            query="hello",
-            created_at=naive_utc_now(),
-            status=MessageStatus.NORMAL,
-            answer="",
-        )
-        db_session = SimpleNamespace(close=MagicMock(), commit=MagicMock(), refresh=MagicMock())
+        app = _make_app()
+        workflow = _make_workflow(workflow_id="wf-2")
+        conversation = _make_conversation(conversation_id="conv-2")
+        message = _make_message(message_id="msg-2", conversation_id=conversation.id)
+        sqlite_session.add_all([app, workflow, conversation, message])
+        sqlite_session.commit()
+        commit_count = 0
+
+        def _record_commit(session: Session) -> None:
+            nonlocal commit_count
+            commit_count += 1
+
+        event.listen(sqlite_session, "after_commit", _record_commit)
         init_records = MagicMock()
         get_thread_messages_length = MagicMock(return_value=0)
         thread_data: dict[str, object] = {}
@@ -564,7 +651,8 @@ class TestAdvancedChatAppGeneratorInternals:
 
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.threading.Thread", _Thread)
         monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.db", SimpleNamespace(engine=object(), session=db_session)
+            "core.app.apps.advanced_chat.app_generator.db",
+            SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
         )
         monkeypatch.setattr(generator, "_get_draft_var_saver_factory", lambda *args, **kwargs: "draft-factory")
         monkeypatch.setattr(
@@ -579,10 +667,10 @@ class TestAdvancedChatAppGeneratorInternals:
 
         response = generator._generate(
             workflow=workflow,
-            user=SimpleNamespace(id="user"),
+            user=_make_account(account_id="user"),
             invoke_from=InvokeFrom.WEB_APP,
             application_generate_entity=application_generate_entity,
-            session=db_session,
+            session=sqlite_session,
             workflow_execution_repository=SimpleNamespace(),
             workflow_node_execution_repository=SimpleNamespace(),
             conversation=conversation,
@@ -592,15 +680,15 @@ class TestAdvancedChatAppGeneratorInternals:
 
         assert response == {"raw": True}
         init_records.assert_not_called()
-        get_thread_messages_length.assert_called_once_with(conversation.id, session=db_session)
+        get_thread_messages_length.assert_called_once_with(conversation.id, session=sqlite_session)
         assert thread_data["started"] is True
         assert thread_data["joined"] is True
         assert thread_data["join_timeout"] == 300
-        db_session.commit.assert_not_called()
-        db_session.refresh.assert_not_called()
-        db_session.close.assert_called_once()
+        assert commit_count == 0
 
-    def test_generate_worker_raises_when_workflow_not_found(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_worker_raises_when_workflow_not_found(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         generator._dialogue_count = 1
         app_config = self._build_app_config()
@@ -619,8 +707,8 @@ class TestAdvancedChatAppGeneratorInternals:
             workflow_run_id="run-id",
         )
 
-        generator._get_conversation = MagicMock(return_value=SimpleNamespace(id="conv"))
-        generator._get_message = MagicMock(return_value=SimpleNamespace(id="msg"))
+        generator._get_conversation = MagicMock(return_value=_make_conversation(conversation_id="conv"))
+        generator._get_message = MagicMock(return_value=_make_message(message_id="msg", conversation_id="conv"))
 
         @contextmanager
         def _fake_context(*args, **kwargs):
@@ -628,20 +716,9 @@ class TestAdvancedChatAppGeneratorInternals:
 
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.preserve_flask_contexts", _fake_context)
 
-        class _Session:
-            def __init__(self, *args, **kwargs):
-                self.scalar = MagicMock(return_value=None)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.Session", _Session)
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
+            SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
         )
 
         with pytest.raises(ValueError, match="Workflow not found"):
@@ -659,7 +736,9 @@ class TestAdvancedChatAppGeneratorInternals:
                 graph_runtime_state=None,
             )
 
-    def test_generate_worker_raises_when_app_not_found_for_internal_call(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_worker_raises_when_app_not_found_for_internal_call(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         generator._dialogue_count = 1
         app_config = self._build_app_config()
@@ -678,8 +757,10 @@ class TestAdvancedChatAppGeneratorInternals:
             workflow_run_id="run-id",
         )
 
-        generator._get_conversation = MagicMock(return_value=SimpleNamespace(id="conv"))
-        generator._get_message = MagicMock(return_value=SimpleNamespace(id="msg"))
+        generator._get_conversation = MagicMock(return_value=_make_conversation(conversation_id="conv"))
+        generator._get_message = MagicMock(return_value=_make_message(message_id="msg", conversation_id="conv"))
+        sqlite_session.add(_make_workflow())
+        sqlite_session.commit()
 
         @contextmanager
         def _fake_context(*args, **kwargs):
@@ -687,25 +768,9 @@ class TestAdvancedChatAppGeneratorInternals:
 
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.preserve_flask_contexts", _fake_context)
 
-        class _Session:
-            def __init__(self, *args, **kwargs):
-                self.scalar = MagicMock(
-                    side_effect=[
-                        SimpleNamespace(id="workflow-id", tenant_id="tenant", app_id="app"),
-                        None,
-                    ]
-                )
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.Session", _Session)
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
+            SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
         )
 
         with pytest.raises(ValueError, match="App not found"):
@@ -723,7 +788,9 @@ class TestAdvancedChatAppGeneratorInternals:
                 graph_runtime_state=None,
             )
 
-    def test_generate_worker_handles_stopped_error(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_worker_handles_stopped_error(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         generator._dialogue_count = 1
         app_config = self._build_app_config()
@@ -743,8 +810,8 @@ class TestAdvancedChatAppGeneratorInternals:
         )
 
         queue_manager = MagicMock()
-        generator._get_conversation = MagicMock(return_value=SimpleNamespace(id="conv"))
-        generator._get_message = MagicMock(return_value=SimpleNamespace(id="msg"))
+        generator._get_conversation = MagicMock(return_value=_make_conversation(conversation_id="conv"))
+        generator._get_message = MagicMock(return_value=_make_message(message_id="msg", conversation_id="conv"))
 
         @contextmanager
         def _fake_context(*args, **kwargs):
@@ -752,22 +819,8 @@ class TestAdvancedChatAppGeneratorInternals:
 
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.preserve_flask_contexts", _fake_context)
 
-        workflow = SimpleNamespace(id="workflow-id", tenant_id="tenant", app_id="app")
-
-        class _Session:
-            def __init__(self, *args, **kwargs):
-                self.scalar = MagicMock(
-                    side_effect=[
-                        workflow,
-                        SimpleNamespace(id="app"),
-                    ]
-                )
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
+        sqlite_session.add_all([_make_app(), _make_workflow()])
+        sqlite_session.commit()
 
         class _Runner:
             def __init__(self, **kwargs):
@@ -776,13 +829,12 @@ class TestAdvancedChatAppGeneratorInternals:
             def run(self):
                 raise GenerateTaskStoppedError()
 
-        monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.Session", _Session)
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.AdvancedChatAppRunner", _Runner)
         restore_workflow_run_graph = MagicMock()
         monkeypatch.setattr(generator, "_restore_workflow_run_graph", restore_workflow_run_graph)
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
+            SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
         )
 
         generator._generate_worker(
@@ -800,10 +852,12 @@ class TestAdvancedChatAppGeneratorInternals:
         )
 
         queue_manager.publish_error.assert_not_called()
-        assert restore_workflow_run_graph.call_args.kwargs["workflow"] is workflow
+        assert restore_workflow_run_graph.call_args.kwargs["workflow"].id == "workflow-id"
         assert restore_workflow_run_graph.call_args.kwargs["workflow_run_id"] == "run-id"
 
-    def test_generate_worker_handles_validation_error(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_worker_handles_validation_error(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         generator._dialogue_count = 1
         app_config = self._build_app_config()
@@ -833,29 +887,16 @@ class TestAdvancedChatAppGeneratorInternals:
             raise AssertionError("validation error should be created")
 
         queue_manager = MagicMock()
-        generator._get_conversation = MagicMock(return_value=SimpleNamespace(id="conv"))
-        generator._get_message = MagicMock(return_value=SimpleNamespace(id="msg"))
+        generator._get_conversation = MagicMock(return_value=_make_conversation(conversation_id="conv"))
+        generator._get_message = MagicMock(return_value=_make_message(message_id="msg", conversation_id="conv"))
+        sqlite_session.add_all([_make_app(), _make_workflow()])
+        sqlite_session.commit()
 
         @contextmanager
         def _fake_context(*args, **kwargs):
             yield
 
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.preserve_flask_contexts", _fake_context)
-
-        class _Session:
-            def __init__(self, *args, **kwargs):
-                self.scalar = MagicMock(
-                    side_effect=[
-                        SimpleNamespace(id="workflow-id", tenant_id="tenant", app_id="app"),
-                        SimpleNamespace(id="app"),
-                    ]
-                )
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
 
         class _Runner:
             def __init__(self, **kwargs):
@@ -864,11 +905,10 @@ class TestAdvancedChatAppGeneratorInternals:
             def run(self):
                 raise validation_error
 
-        monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.Session", _Session)
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.AdvancedChatAppRunner", _Runner)
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
+            SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
         )
 
         generator._generate_worker(
@@ -887,8 +927,12 @@ class TestAdvancedChatAppGeneratorInternals:
 
         queue_manager.publish_error.assert_called_once()
 
-    def test_generate_worker_handles_value_and_unknown_errors(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_worker_handles_value_and_unknown_errors(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         app_config = self._build_app_config()
+        sqlite_session.add_all([_make_app(), _make_workflow()])
+        sqlite_session.commit()
 
         @contextmanager
         def _fake_context(*args, **kwargs):
@@ -922,26 +966,10 @@ class TestAdvancedChatAppGeneratorInternals:
             )
 
             queue_manager = MagicMock()
-            generator._get_conversation = MagicMock(return_value=SimpleNamespace(id="conv"))
-            generator._get_message = MagicMock(return_value=SimpleNamespace(id="msg"))
-
-            class _Session:
-                def __init__(self, *args, **kwargs):
-                    self.scalar = MagicMock(
-                        side_effect=[
-                            SimpleNamespace(id="workflow-id", tenant_id="tenant", app_id="app"),
-                            SimpleNamespace(id="app"),
-                        ]
-                    )
-
-                def __enter__(self):
-                    return self
-
-                def __exit__(self, exc_type, exc, tb):
-                    return False
+            generator._get_conversation = MagicMock(return_value=_make_conversation(conversation_id="conv"))
+            generator._get_message = MagicMock(return_value=_make_message(message_id="msg", conversation_id="conv"))
 
             monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.preserve_flask_contexts", _fake_context)
-            monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.Session", _Session)
             monkeypatch.setattr(
                 "core.app.apps.advanced_chat.app_generator.AdvancedChatAppRunner",
                 _make_runner(raised_error),
@@ -949,7 +977,7 @@ class TestAdvancedChatAppGeneratorInternals:
             apply_config_overrides(monkeypatch, DEBUG=True)
             monkeypatch.setattr(
                 "core.app.apps.advanced_chat.app_generator.db",
-                SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
+                SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
             )
 
             generator._generate_worker(
@@ -1019,7 +1047,7 @@ class TestAdvancedChatAppGeneratorInternals:
                     status=MessageStatus.NORMAL,
                     answer="",
                 ),
-                user=SimpleNamespace(),
+                user=_make_account(),
                 draft_var_saver_factory=lambda **kwargs: None,
                 stream=False,
             )
@@ -1067,14 +1095,16 @@ class TestAdvancedChatAppGeneratorInternals:
                         status=MessageStatus.NORMAL,
                         answer="",
                     ),
-                    user=SimpleNamespace(),
+                    user=_make_account(),
                     draft_var_saver_factory=lambda **kwargs: None,
                     stream=False,
                 )
 
         assert "Failed to process generate task pipeline, conversation_id: conv" in caplog.messages
 
-    def test_generate_worker_handles_invoke_auth_error(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_worker_handles_invoke_auth_error(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session, sqlite_engine: Engine
+    ):
         generator = AdvancedChatAppGenerator()
         generator._dialogue_count = 1
 
@@ -1102,8 +1132,10 @@ class TestAdvancedChatAppGeneratorInternals:
 
         queue_manager = MagicMock()
 
-        generator._get_conversation = MagicMock(return_value=SimpleNamespace(id="conv", mode=AppMode.ADVANCED_CHAT))
-        generator._get_message = MagicMock(return_value=SimpleNamespace(id="msg"))
+        generator._get_conversation = MagicMock(return_value=_make_conversation(conversation_id="conv"))
+        generator._get_message = MagicMock(return_value=_make_message(message_id="msg", conversation_id="conv"))
+        sqlite_session.add_all([_make_app(), _make_workflow(), _make_end_user()])
+        sqlite_session.commit()
 
         class _Runner:
             def __init__(self, **kwargs) -> None:
@@ -1122,26 +1154,9 @@ class TestAdvancedChatAppGeneratorInternals:
 
         monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.preserve_flask_contexts", _fake_context)
 
-        class _Session:
-            def __init__(self, *args, **kwargs):
-                self.scalar = MagicMock(
-                    side_effect=[
-                        SimpleNamespace(id="workflow-id", tenant_id="tenant", app_id="app"),
-                        SimpleNamespace(id="end-user-id", session_id="session-id"),
-                        SimpleNamespace(id="app"),
-                    ]
-                )
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.Session", _Session)
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
+            SimpleNamespace(engine=sqlite_engine, session=sqlite_session),
         )
 
         generator._generate_worker(
@@ -1160,88 +1175,8 @@ class TestAdvancedChatAppGeneratorInternals:
 
         assert queue_manager.publish_error.called
 
-    def test_generate_debugger_enables_retrieve_source(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
-        generator = AdvancedChatAppGenerator()
-
-        app_config = WorkflowUIBasedAppConfig(
-            tenant_id="tenant",
-            app_id="app",
-            app_mode=AppMode.ADVANCED_CHAT,
-            additional_features=AppAdditionalFeatures(),
-            variables=[],
-            workflow_id="workflow-id",
-        )
-
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.AdvancedChatAppConfigManager.get_app_config",
-            lambda app_model, workflow: app_config,
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.FileUploadConfigManager.convert",
-            lambda features_dict, is_vision=False: None,
-        )
-        DummyTraceQueueManager = type(
-            "_DummyTraceQueueManager",
-            (TraceQueueManager,),
-            {
-                "__init__": lambda self, app_id=None, user_id=None: (
-                    setattr(self, "app_id", app_id) or setattr(self, "user_id", user_id)
-                )
-            },
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.TraceQueueManager",
-            DummyTraceQueueManager,
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.DifyCoreRepositoryFactory.create_workflow_execution_repository",
-            lambda **kwargs: SimpleNamespace(),
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.DifyCoreRepositoryFactory.create_workflow_node_execution_repository",
-            lambda **kwargs: SimpleNamespace(),
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.sessionmaker",
-            lambda **kwargs: SimpleNamespace(),
-        )
-
-        captured = {}
-
-        def _fake_generate(**kwargs):
-            captured.update(kwargs)
-            return {"ok": True}
-
-        monkeypatch.setattr(generator, "_generate", _fake_generate)
-
-        app_model = SimpleNamespace(id="app", tenant_id="tenant")
-        workflow = SimpleNamespace(features_dict={})
-        from models import Account
-
-        user = Account(name="Tester", email="tester@example.com")
-        user.id = "user"
-
-        result = generator.generate(
-            app_model=app_model,
-            workflow=workflow,
-            user=user,
-            args={"query": "hello\x00", "inputs": {}},
-            invoke_from=InvokeFrom.DEBUGGER,
-            workflow_run_id="run-id",
-            streaming=False,
-            session=unbound_session,
-        )
-
-        assert result == {"ok": True}
-        assert app_config.additional_features.show_retrieve_source is True
-        assert captured["application_generate_entity"].query == "hello"
-
-    def test_generate_service_api_sets_parent_message_id(
-        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    def test_generate_debugger_enables_retrieve_source(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session, sqlite_engine: Engine
     ):
         generator = AdvancedChatAppGenerator()
 
@@ -1285,11 +1220,7 @@ class TestAdvancedChatAppGeneratorInternals:
         )
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.db",
-            SimpleNamespace(engine=object(), session=SimpleNamespace(close=lambda: None)),
-        )
-        monkeypatch.setattr(
-            "core.app.apps.advanced_chat.app_generator.sessionmaker",
-            lambda **kwargs: SimpleNamespace(),
+            SimpleNamespace(engine=sqlite_engine, session=unbound_session),
         )
 
         captured = {}
@@ -1300,12 +1231,84 @@ class TestAdvancedChatAppGeneratorInternals:
 
         monkeypatch.setattr(generator, "_generate", _fake_generate)
 
-        app_model = SimpleNamespace(id="app", tenant_id="tenant")
-        workflow = SimpleNamespace(features_dict={})
-        from models.model import EndUser
+        app_model = _make_app()
+        workflow = _make_workflow()
+        user = _make_account(account_id="user")
 
-        user = EndUser(tenant_id="tenant", type="session", name="tester", session_id="session")
-        user.id = "end-user"
+        result = generator.generate(
+            app_model=app_model,
+            workflow=workflow,
+            user=user,
+            args={"query": "hello\x00", "inputs": {}},
+            invoke_from=InvokeFrom.DEBUGGER,
+            workflow_run_id="run-id",
+            streaming=False,
+            session=unbound_session,
+        )
+
+        assert result == {"ok": True}
+        assert app_config.additional_features.show_retrieve_source is True
+        assert captured["application_generate_entity"].query == "hello"
+
+    def test_generate_service_api_sets_parent_message_id(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session, sqlite_engine: Engine
+    ):
+        generator = AdvancedChatAppGenerator()
+
+        app_config = WorkflowUIBasedAppConfig(
+            tenant_id="tenant",
+            app_id="app",
+            app_mode=AppMode.ADVANCED_CHAT,
+            additional_features=AppAdditionalFeatures(),
+            variables=[],
+            workflow_id="workflow-id",
+        )
+
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.AdvancedChatAppConfigManager.get_app_config",
+            lambda app_model, workflow: app_config,
+        )
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.FileUploadConfigManager.convert",
+            lambda features_dict, is_vision=False: None,
+        )
+        DummyTraceQueueManager = type(
+            "_DummyTraceQueueManager",
+            (TraceQueueManager,),
+            {
+                "__init__": lambda self, app_id=None, user_id=None: (
+                    setattr(self, "app_id", app_id) or setattr(self, "user_id", user_id)
+                )
+            },
+        )
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.TraceQueueManager",
+            DummyTraceQueueManager,
+        )
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.DifyCoreRepositoryFactory.create_workflow_execution_repository",
+            lambda **kwargs: SimpleNamespace(),
+        )
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.DifyCoreRepositoryFactory.create_workflow_node_execution_repository",
+            lambda **kwargs: SimpleNamespace(),
+        )
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.db",
+            SimpleNamespace(engine=sqlite_engine, session=unbound_session),
+        )
+
+        captured = {}
+
+        def _fake_generate(**kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+        monkeypatch.setattr(generator, "_generate", _fake_generate)
+
+        app_model = _make_app()
+        workflow = _make_workflow()
+        user = _make_end_user(end_user_id="end-user", session_id="session")
 
         generator.generate(
             app_model=app_model,
@@ -1376,11 +1379,11 @@ class TestAdvancedChatAppGeneratorResume:
         monkeypatch.setattr(generator, "_generate", _fake_generate)
 
         result = generator.resume(
-            app_model=SimpleNamespace(id="app-id"),
-            workflow=SimpleNamespace(),
-            user=SimpleNamespace(id="end-user-id", session_id="session-id"),
-            conversation=SimpleNamespace(id="conversation-id"),
-            message=SimpleNamespace(id="message-id"),
+            app_model=_make_app(app_id="app-id"),
+            workflow=_make_workflow(),
+            user=_make_end_user(),
+            conversation=_make_conversation(),
+            message=_make_message(),
             session=unbound_session,
             application_generate_entity=application_generate_entity,
             workflow_execution_repository=SimpleNamespace(),
@@ -1424,11 +1427,11 @@ class TestAdvancedChatAppGeneratorResume:
         monkeypatch.setattr(generator, "_generate", _fake_generate)
 
         result = generator.resume(
-            app_model=SimpleNamespace(id="app-id"),
-            workflow=SimpleNamespace(),
-            user=SimpleNamespace(id="end-user-id", session_id="session-id"),
-            conversation=SimpleNamespace(id="conversation-id"),
-            message=SimpleNamespace(id="message-id"),
+            app_model=_make_app(app_id="app-id"),
+            workflow=_make_workflow(),
+            user=_make_end_user(),
+            conversation=_make_conversation(),
+            message=_make_message(),
             session=unbound_session,
             application_generate_entity=application_generate_entity,
             workflow_execution_repository=SimpleNamespace(),


### PR DESCRIPTION
## Summary
- replace advanced-chat generator sessionmaker and Session doubles with real SQLite-backed sessions and engine bindings
- replace App, Workflow, Account, EndUser, Conversation, and Message stand-ins with mapped model instances
- persist worker lookup chains and verify first-conversation commits through SQLAlchemy events

## Real persistence coverage
- workflow/app/end-user lookup and missing-row behavior
- initial conversation commit/refresh behavior and stored override configuration
- existing-record paths without redundant commits

## Production fixes
None.

## Changed lines
243 additions, 240 deletions (483 total). This is one atomic test module.

## Validation
- `make test TARGET_TESTS=./api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py` — 22 passed
- `make lint` — passed
- `make type-check` — pyrefly completed without project errors; mypy 1.20.2 hit the known internal error at `typeshed/stdlib/zipimport.pyi:17`
- focused session/model-double audit — no remaining SQLAlchemy session/factory doubles or mapped-model stand-ins in the module

The full test suite was intentionally not run per request.