### PR TITLE
fix(agent-v2): stop dropping non-vision attachments from agent chat (#40179)

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/chat.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/chat.spec.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, ReactNode } from 'react'
 import type { AgentPreviewChatController } from '../chat-conversation'
+import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import type { SpeechToTextTarget } from '@/app/components/base/voice-input/types'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
@@ -44,7 +45,7 @@ vi.mock('@/next/dynamic', async () => {
     default: () =>
       function MockChat(props: {
         answerActionPosition?: 'auto' | 'below'
-        onSend: (message: string) => unknown
+        onSend: (message: string, files?: FileEntity[]) => unknown
         onStopResponding: () => void
         sendButtonLabel?: string
         sendButtonLoading?: boolean
@@ -99,6 +100,26 @@ vi.mock('@/next/dynamic', async () => {
               }}
             >
               send
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setSent(true)
+                sendResultRef.current = props.onSend('read this file', [
+                  {
+                    id: 'file-1',
+                    name: 'brief.docx',
+                    size: 1024,
+                    type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    progress: 100,
+                    transferMethod: TransferMethod.local_file,
+                    supportFileType: 'document',
+                    uploadedId: 'uploaded-file-1',
+                  },
+                ])
+              }}
+            >
+              send with document
             </button>
             <button type="button" onClick={props.onStopResponding}>
               stop
@@ -688,6 +709,21 @@ describe('AgentPreviewChat', () => {
     )
     expect(screen.getByRole('textbox', { name: 'chat draft' })).toHaveValue(
       'Keep this footer draft',
+    )
+  })
+
+  it('should deliver non-image attachments even when the selected model does not support vision', async () => {
+    renderPreviewChat()
+
+    fireEvent.click(screen.getByRole('button', { name: 'send with document' }))
+
+    await waitFor(() => expect(handleSendMock).toHaveBeenCalledTimes(1))
+    expect(handleSendMock).toHaveBeenCalledWith(
+      'agent/agent-1/chat-messages',
+      expect.objectContaining({
+        files: [expect.objectContaining({ id: 'file-1', name: 'brief.docx' })],
+      }),
+      expect.any(Object),
     )
   })
 

--- a/web/features/agent-v2/agent-detail/configure/components/preview/chat-conversation.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/chat-conversation.tsx
@@ -18,12 +18,10 @@ import { useCallback, useImperativeHandle, useLayoutEffect, useRef, useState } f
 import { AgentRosterResponseContent } from '@/app/components/base/chat/chat/answer/agent-roster-response-content'
 import { useChat } from '@/app/components/base/chat/chat/hooks'
 import { getLastAnswer, isValidGeneratedAnswer } from '@/app/components/base/chat/utils'
-import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
-import { useTextGenerationCurrentProviderAndModelAndModelList } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import { userProfileAtom } from '@/context/account-state'
 import dynamic from '@/next/dynamic'
 import { consoleClient, consoleQuery } from '@/service/client'
-import { buildChatConfig, getAgentSoulInputs, getAgentSoulInputsForm } from './chat-config'
+import { getAgentSoulInputs, getAgentSoulInputsForm } from './chat-config'
 
 const Chat = dynamic(() => import('@/app/components/base/chat/chat'), { ssr: false })
 
@@ -77,7 +75,7 @@ export function AgentPreviewChatConversation({
   clearChatList,
   config,
   conversationId,
-  currentModel,
+  currentModel: _currentModel,
   draftType,
   initialChatTree,
   inputs,
@@ -128,8 +126,6 @@ export function AgentPreviewChatConversation({
     sendInterruptedRef.current = true
     onSendInterrupted?.()
   }, [onSendInterrupted])
-  const { textGenerationModelList } =
-    useTextGenerationCurrentProviderAndModelAndModelList(currentModel)
   const {
     chatList,
     setTargetMessageId,
@@ -171,21 +167,6 @@ export function AgentPreviewChatConversation({
         const runtimeInputs = preparedAgentSoulConfig
           ? getAgentSoulInputs(runtimeInputsForm)
           : inputs
-        const runtimeConfig = preparedAgentSoulConfig
-          ? buildChatConfig({
-              agentSoulConfig: runtimeAgentSoulConfig,
-              currentModel: undefined,
-              prompt: runtimeAgentSoulConfig?.prompt?.system_prompt ?? '',
-            })
-          : config
-
-        const currentProvider = textGenerationModelList.find(
-          (item) => item.provider === runtimeConfig.model.provider,
-        )
-        const selectedModel = currentProvider?.models.find(
-          (model) => model.model === runtimeConfig.model.name,
-        )
-        const supportVision = selectedModel?.features?.includes(ModelFeatureEnum.vision)
         const data: Record<string, unknown> = {
           query: message,
           inputs: runtimeInputs,
@@ -195,7 +176,7 @@ export function AgentPreviewChatConversation({
         }
         if (draftType) data.draft_type = draftType
 
-        if (files?.length && supportVision) data.files = files
+        if (files?.length) data.files = files
 
         sendMessage({
           agentId,
@@ -253,7 +234,6 @@ export function AgentPreviewChatConversation({
       agentId,
       agentSoulConfig,
       chatList,
-      config,
       conversationId,
       draftType,
       handleSend,
@@ -266,7 +246,6 @@ export function AgentPreviewChatConversation({
       onSaveDraftBeforeRun,
       queryClient,
       sendMessage,
-      textGenerationModelList,
     ],
   )
 


### PR DESCRIPTION
## Summary
Cherry-pick of #40179 onto `release/e-1.16.1`.

Agent V2 previously gated all file delivery on `data.files` behind `supportVision`, so DOCX/PDF/TXT uploads were silently discarded whenever the selected model did not advertise vision. Vision only governs direct image interpretation by the LLM and should not gate whether files reach the Agent sandbox.

## Conflict notes
`chat-conversation.tsx` conflicted against unrelated userProfile/i18n drift that hasn't landed on `release/e-1.16.1` yet (jotai `userProfileAtom` vs. react-query `userProfileQueryOptions`). Resolved by keeping the release branch's existing pattern and applying only the vision-gating fix. Diff stat matches the original PR exactly (2 files changed, +40/-25).

## Test plan
- [x] `pnpm vitest run features/agent-v2/agent-detail/configure/components/preview/__tests__/chat.spec.tsx` — 34/34 passing, including the new non-vision-attachment regression test