### PR TITLE
fix: serialize annotation reply jobs per app

### DIFF
--- a/api/extensions/ext_redis.py
+++ b/api/extensions/ext_redis.py
@@ -34,6 +34,13 @@ from libs.broadcast_channel.redis.streams_channel import StreamsBroadcastChannel
 
 logger = logging.getLogger(__name__)
 
+_COMPARE_AND_DELETE_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+end
+return 0
+"""
+
 
 _normalize_redis_key_prefix = normalize_redis_key_prefix
 _serialize_redis_name = serialize_redis_name
@@ -146,6 +153,15 @@ class RedisClientWrapper:
 
     def getdel(self, name: str | bytes) -> Any:
         return self._require_client().getdel(_serialize_redis_name_arg(name, self._get_prefix()))
+
+    def compare_and_delete(self, name: str | bytes, expected_value: str | bytes) -> Any:
+        client = cast(Any, self._require_client())
+        return client.eval(
+            _COMPARE_AND_DELETE_SCRIPT,
+            1,
+            _serialize_redis_name_arg(name, self._get_prefix()),
+            expected_value,
+        )
 
     def lock(
         self,

--- a/api/services/annotation_job_service.py
+++ b/api/services/annotation_job_service.py
@@ -1,0 +1,137 @@
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from werkzeug.exceptions import Conflict
+
+AnnotationReplyAction = Literal["enable", "disable"]
+
+ANNOTATION_REPLY_JOB_TTL_SECONDS = 7200
+ANNOTATION_REPLY_JOB_RESULT_TTL_SECONDS = 600
+
+
+class AnnotationReplyJobRedisClient(Protocol):
+    def get(self, name: str) -> bytes | str | None: ...
+
+    def set(self, name: str, value: str, *, nx: bool = False, ex: int | None = None) -> object: ...
+
+    def setex(self, name: str, time: int, value: str) -> object: ...
+
+    def delete(self, name: str) -> object: ...
+
+    def compare_and_delete(self, name: str, expected_value: str) -> object: ...
+
+
+@dataclass(frozen=True)
+class AnnotationReplyJob:
+    action: AnnotationReplyAction
+    app_id: str
+    job_id: str
+
+    @property
+    def lock_key(self) -> str:
+        return f"app_annotation_job:{self.app_id}"
+
+    @property
+    def status_key(self) -> str:
+        return f"{self.action}_app_annotation_job_{self.job_id}"
+
+    @property
+    def error_key(self) -> str:
+        return f"{self.action}_app_annotation_error_{self.job_id}"
+
+    @property
+    def lock_value(self) -> str:
+        return f"{self.action}:{self.job_id}"
+
+
+class AnnotationReplyJobCoordinator:
+    def __init__(self, redis_client: AnnotationReplyJobRedisClient):
+        self._redis_client = redis_client
+
+    @staticmethod
+    def _decode(value: bytes | str) -> str:
+        return value.decode() if isinstance(value, bytes) else value
+
+    def acquire(self, job: AnnotationReplyJob) -> str | None:
+        if self._redis_client.set(
+            job.lock_key,
+            job.lock_value,
+            nx=True,
+            ex=ANNOTATION_REPLY_JOB_TTL_SECONDS,
+        ):
+            self._initialize_status(job)
+            return None
+
+        running_value = self._redis_client.get(job.lock_key)
+        if running_value is None:
+            if self._redis_client.set(
+                job.lock_key,
+                job.lock_value,
+                nx=True,
+                ex=ANNOTATION_REPLY_JOB_TTL_SECONDS,
+            ):
+                self._initialize_status(job)
+                return None
+            running_value = self._redis_client.get(job.lock_key)
+
+        if running_value is None:
+            raise Conflict("An annotation reply job is already running for this app.")
+
+        running_action, separator, running_job_id = self._decode(running_value).partition(":")
+        if separator and running_action == job.action and running_job_id:
+            return running_job_id
+
+        raise Conflict("An annotation reply job is already running for this app.")
+
+    def _initialize_status(self, job: AnnotationReplyJob) -> None:
+        try:
+            self._redis_client.set(job.status_key, "waiting", ex=ANNOTATION_REPLY_JOB_TTL_SECONDS)
+        except Exception:
+            self._release(job)
+            raise
+
+    def start(self, job: AnnotationReplyJob) -> bool:
+        running_value = self._redis_client.get(job.lock_key)
+        if running_value is None or self._decode(running_value) != job.lock_value:
+            self._redis_client.setex(
+                job.status_key,
+                ANNOTATION_REPLY_JOB_RESULT_TTL_SECONDS,
+                "error",
+            )
+            self._redis_client.setex(
+                job.error_key,
+                ANNOTATION_REPLY_JOB_RESULT_TTL_SECONDS,
+                "Job no longer owns the application lock",
+            )
+            return False
+
+        self._redis_client.set(job.status_key, "processing", ex=ANNOTATION_REPLY_JOB_TTL_SECONDS)
+        return True
+
+    def complete(self, job: AnnotationReplyJob) -> None:
+        self._redis_client.setex(
+            job.status_key,
+            ANNOTATION_REPLY_JOB_RESULT_TTL_SECONDS,
+            "completed",
+        )
+        self._release(job)
+
+    def fail(self, job: AnnotationReplyJob, error: str) -> None:
+        self._redis_client.setex(
+            job.status_key,
+            ANNOTATION_REPLY_JOB_RESULT_TTL_SECONDS,
+            "error",
+        )
+        self._redis_client.setex(
+            job.error_key,
+            ANNOTATION_REPLY_JOB_RESULT_TTL_SECONDS,
+            error,
+        )
+        self._release(job)
+
+    def _release(self, job: AnnotationReplyJob) -> None:
+        self._redis_client.compare_and_delete(job.lock_key, job.lock_value)
+
+    def abandon(self, job: AnnotationReplyJob) -> None:
+        self._release(job)
+        self._redis_client.delete(job.status_key)

--- a/api/services/annotation_job_service.py
+++ b/api/services/annotation_job_service.py
@@ -16,7 +16,7 @@ class AnnotationReplyJobRedisClient(Protocol):
 
     def setex(self, name: str, time: int, value: str) -> object: ...
 
-    def delete(self, name: str) -> object: ...
+    def delete(self, *names: str) -> object: ...
 
     def compare_and_delete(self, name: str, expected_value: str) -> object: ...
 
@@ -45,7 +45,7 @@ class AnnotationReplyJob:
 
 
 class AnnotationReplyJobCoordinator:
-    def __init__(self, redis_client: AnnotationReplyJobRedisClient):
+    def __init__(self, redis_client: AnnotationReplyJobRedisClient) -> None:
         self._redis_client = redis_client
 
     @staticmethod

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -15,6 +15,7 @@ from libs.login import current_account_with_tenant
 from libs.pagination import paginate_query
 from models.dataset import DatasetCollectionBinding
 from models.model import App, AppAnnotationHitHistory, AppAnnotationSetting, Message, MessageAnnotation
+from services.annotation_job_service import AnnotationReplyJob, AnnotationReplyJobCoordinator
 from services.app_ref_service import AnnotationRef, AppRef
 from services.feature_service import FeatureService
 from tasks.annotation.add_annotation_to_index_task import add_annotation_to_index_task
@@ -176,42 +177,44 @@ class AppAnnotationService:
 
     @classmethod
     def enable_app_annotation(cls, args: EnableAnnotationArgs, app_id: str) -> AnnotationJobStatusDict:
-        enable_app_annotation_key = f"enable_app_annotation_{str(app_id)}"
-        cache_result = redis_client.get(enable_app_annotation_key)
-        if cache_result is not None:
-            return {"job_id": cache_result, "job_status": "processing"}
-
-        # async job
         job_id = str(uuid.uuid4())
-        enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
-        # send batch add segments task
-        redis_client.setnx(enable_app_annotation_job_key, "waiting")
-        current_user, current_tenant_id = current_account_with_tenant()
-        enable_annotation_reply_task.delay(
-            str(job_id),
-            app_id,
-            current_user.id,
-            current_tenant_id,
-            args["score_threshold"],
-            args["embedding_provider_name"],
-            args["embedding_model_name"],
-        )
+        job = AnnotationReplyJob(action="enable", app_id=app_id, job_id=job_id)
+        coordinator = AnnotationReplyJobCoordinator(redis_client)
+        running_job_id = coordinator.acquire(job)
+        if running_job_id is not None:
+            return {"job_id": running_job_id, "job_status": "processing"}
+
+        try:
+            current_user, current_tenant_id = current_account_with_tenant()
+            enable_annotation_reply_task.delay(
+                str(job_id),
+                app_id,
+                current_user.id,
+                current_tenant_id,
+                args["score_threshold"],
+                args["embedding_provider_name"],
+                args["embedding_model_name"],
+            )
+        except Exception:
+            coordinator.abandon(job)
+            raise
         return {"job_id": job_id, "job_status": "waiting"}
 
     @classmethod
     def disable_app_annotation(cls, app_id: str) -> AnnotationJobStatusDict:
         _, current_tenant_id = current_account_with_tenant()
-        disable_app_annotation_key = f"disable_app_annotation_{str(app_id)}"
-        cache_result = redis_client.get(disable_app_annotation_key)
-        if cache_result is not None:
-            return {"job_id": cache_result, "job_status": "processing"}
-
-        # async job
         job_id = str(uuid.uuid4())
-        disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
-        # send batch add segments task
-        redis_client.setnx(disable_app_annotation_job_key, "waiting")
-        disable_annotation_reply_task.delay(str(job_id), app_id, current_tenant_id)
+        job = AnnotationReplyJob(action="disable", app_id=app_id, job_id=job_id)
+        coordinator = AnnotationReplyJobCoordinator(redis_client)
+        running_job_id = coordinator.acquire(job)
+        if running_job_id is not None:
+            return {"job_id": running_job_id, "job_status": "processing"}
+
+        try:
+            disable_annotation_reply_task.delay(str(job_id), app_id, current_tenant_id)
+        except Exception:
+            coordinator.abandon(job)
+            raise
         return {"job_id": job_id, "job_status": "waiting"}
 
     @classmethod

--- a/api/tasks/annotation/disable_annotation_reply_task.py
+++ b/api/tasks/annotation/disable_annotation_reply_task.py
@@ -11,6 +11,7 @@ from core.rag.index_processor.constant.index_type import IndexTechniqueType
 from extensions.ext_redis import redis_client
 from models.dataset import Dataset
 from models.model import App, AppAnnotationSetting, MessageAnnotation
+from services.annotation_job_service import AnnotationReplyJob, AnnotationReplyJobCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -22,28 +23,31 @@ def disable_annotation_reply_task(job_id: str, app_id: str, tenant_id: str):
     """
     logger.info(click.style(f"Start delete app annotations index: {app_id}", fg="green"))
     start_at = time.perf_counter()
-    # get app info
+    job = AnnotationReplyJob(action="disable", app_id=app_id, job_id=job_id)
+    coordinator = AnnotationReplyJobCoordinator(redis_client)
+    if not coordinator.start(job):
+        logger.info("Skip stale annotation reply job %s for app %s", job_id, app_id)
+        return
+
     with session_factory.create_session() as session:
-        app = session.scalar(
-            select(App).where(App.id == app_id, App.tenant_id == tenant_id, App.status == "normal").limit(1)
-        )
-        annotations_exists = session.scalar(select(exists().where(MessageAnnotation.app_id == app_id)))
-        if not app:
-            logger.info(click.style(f"App not found: {app_id}", fg="red"))
-            return
-
-        app_annotation_setting = session.scalar(
-            select(AppAnnotationSetting).where(AppAnnotationSetting.app_id == app_id).limit(1)
-        )
-
-        if not app_annotation_setting:
-            logger.info(click.style(f"App annotation setting not found: {app_id}", fg="red"))
-            return
-
-        disable_app_annotation_key = f"disable_app_annotation_{str(app_id)}"
-        disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
-
         try:
+            app = session.scalar(
+                select(App).where(App.id == app_id, App.tenant_id == tenant_id, App.status == "normal").limit(1)
+            )
+            if not app:
+                logger.info(click.style(f"App not found: {app_id}", fg="red"))
+                coordinator.fail(job, "App not found")
+                return
+
+            annotations_exists = session.scalar(select(exists().where(MessageAnnotation.app_id == app_id)))
+            app_annotation_setting = session.scalar(
+                select(AppAnnotationSetting).where(AppAnnotationSetting.app_id == app_id).limit(1)
+            )
+            if not app_annotation_setting:
+                logger.info(click.style(f"App annotation setting not found: {app_id}", fg="red"))
+                coordinator.complete(job)
+                return
+
             dataset = Dataset(
                 id=app_id,
                 tenant_id=tenant_id,
@@ -57,11 +61,11 @@ def disable_annotation_reply_task(job_id: str, app_id: str, tenant_id: str):
                     vector.delete()
             except Exception:
                 logger.exception("Delete annotation index failed when annotation deleted.")
-            redis_client.setex(disable_app_annotation_job_key, 600, "completed")
 
             # delete annotation setting
             session.delete(app_annotation_setting)
             session.commit()
+            coordinator.complete(job)
 
             end_at = time.perf_counter()
             logger.info(
@@ -72,8 +76,5 @@ def disable_annotation_reply_task(job_id: str, app_id: str, tenant_id: str):
             )
         except Exception as e:
             logger.exception("Annotation batch deleted index failed")
-            redis_client.setex(disable_app_annotation_job_key, 600, "error")
-            disable_app_annotation_error_key = f"disable_app_annotation_error_{str(job_id)}"
-            redis_client.setex(disable_app_annotation_error_key, 600, str(e))
-        finally:
-            redis_client.delete(disable_app_annotation_key)
+            session.rollback()
+            coordinator.fail(job, str(e))

--- a/api/tasks/annotation/enable_annotation_reply_task.py
+++ b/api/tasks/annotation/enable_annotation_reply_task.py
@@ -14,6 +14,7 @@ from libs.datetime_utils import naive_utc_now
 from models.dataset import Dataset
 from models.enums import CollectionBindingType
 from models.model import App, AppAnnotationSetting, MessageAnnotation
+from services.annotation_job_service import AnnotationReplyJob, AnnotationReplyJobCoordinator
 from services.dataset_service import DatasetCollectionBindingService
 
 logger = logging.getLogger(__name__)
@@ -34,21 +35,23 @@ def enable_annotation_reply_task(
     """
     logger.info(click.style(f"Start add app annotation to index: {app_id}", fg="green"))
     start_at = time.perf_counter()
-    # get app info
+    job = AnnotationReplyJob(action="enable", app_id=app_id, job_id=job_id)
+    coordinator = AnnotationReplyJobCoordinator(redis_client)
+    if not coordinator.start(job):
+        logger.info("Skip stale annotation reply job %s for app %s", job_id, app_id)
+        return
+
     with session_factory.create_session() as session:
-        app = session.scalar(
-            select(App).where(App.id == app_id, App.tenant_id == tenant_id, App.status == "normal").limit(1)
-        )
-
-        if not app:
-            logger.info(click.style(f"App not found: {app_id}", fg="red"))
-            return
-
-        annotations = session.scalars(select(MessageAnnotation).where(MessageAnnotation.app_id == app_id)).all()
-        enable_app_annotation_key = f"enable_app_annotation_{str(app_id)}"
-        enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
-
         try:
+            app = session.scalar(
+                select(App).where(App.id == app_id, App.tenant_id == tenant_id, App.status == "normal").limit(1)
+            )
+            if not app:
+                logger.info(click.style(f"App not found: {app_id}", fg="red"))
+                coordinator.fail(job, "App not found")
+                return
+
+            annotations = session.scalars(select(MessageAnnotation).where(MessageAnnotation.app_id == app_id)).all()
             documents = []
             dataset_collection_binding = DatasetCollectionBindingService.get_dataset_collection_binding(
                 embedding_provider_name, embedding_model_name, session, CollectionBindingType.ANNOTATION
@@ -120,7 +123,7 @@ def enable_annotation_reply_task(
                     logger.info(click.style(f"Delete annotation index error: {str(e)}", fg="red"))
                 vector.create(documents)
             session.commit()
-            redis_client.setex(enable_app_annotation_job_key, 600, "completed")
+            coordinator.complete(job)
             end_at = time.perf_counter()
             logger.info(
                 click.style(
@@ -130,9 +133,5 @@ def enable_annotation_reply_task(
             )
         except Exception as e:
             logger.exception("Annotation batch created index failed")
-            redis_client.setex(enable_app_annotation_job_key, 600, "error")
-            enable_app_annotation_error_key = f"enable_app_annotation_error_{str(job_id)}"
-            redis_client.setex(enable_app_annotation_error_key, 600, str(e))
             session.rollback()
-        finally:
-            redis_client.delete(enable_app_annotation_key)
+            coordinator.fail(job, str(e))

--- a/api/tests/test_containers_integration_tests/services/test_annotation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_annotation_service.py
@@ -714,8 +714,8 @@ class TestAnnotationService:
         from extensions.ext_redis import redis_client
 
         cached_job_id = fake.uuid4()
-        enable_app_annotation_key = f"enable_app_annotation_{app.id}"
-        redis_client.set(enable_app_annotation_key, cached_job_id)
+        annotation_job_key = f"app_annotation_job:{app.id}"
+        redis_client.set(annotation_job_key, f"enable:{cached_job_id}")
 
         # Setup enable arguments
         enable_args = {
@@ -728,14 +728,14 @@ class TestAnnotationService:
         result = AppAnnotationService.enable_app_annotation(enable_args, app.id)
 
         # Verify cached result
-        assert cached_job_id == result["job_id"].decode("utf-8")
+        assert cached_job_id == result["job_id"]
         assert result["job_status"] == "processing"
 
         # Verify task was not called again
         mock_external_service_dependencies["enable_task"].delay.assert_not_called()
 
         # Clean up
-        redis_client.delete(enable_app_annotation_key)
+        redis_client.delete(annotation_job_key)
 
     def test_get_annotation_hit_histories_success(
         self, db_session_with_containers: Session, mock_external_service_dependencies

--- a/api/tests/unit_tests/extensions/test_redis.py
+++ b/api/tests/unit_tests/extensions/test_redis.py
@@ -188,6 +188,20 @@ class TestRedisClientWrapperKeyPrefix:
         assert args == ("enterprise-a:resource-lock",)
         assert kwargs["timeout"] == 10
 
+    def test_wrapper_compare_and_delete_prefixes_key(self):
+        mock_client = MagicMock()
+        wrapper = RedisClientWrapper()
+        wrapper.initialize(mock_client)
+
+        with patch("extensions.ext_redis.dify_config") as mock_config:
+            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
+
+            wrapper.compare_and_delete("resource-lock", "owner-1")
+
+        mock_client.eval.assert_called_once()
+        args = mock_client.eval.call_args.args
+        assert args[1:] == (1, "enterprise-a:resource-lock", "owner-1")
+
     def test_wrapper_hash_operations_prefix_key_name(self):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()

--- a/api/tests/unit_tests/services/test_annotation_job_service.py
+++ b/api/tests/unit_tests/services/test_annotation_job_service.py
@@ -8,29 +8,30 @@ class _FakeRedis:
         self.values: dict[str, str] = {}
         self.fail_status_write = False
 
-    def get(self, key: str) -> str | None:
-        return self.values.get(key)
+    def get(self, name: str) -> str | None:
+        return self.values.get(name)
 
-    def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
+    def set(self, name: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
         del ex
-        if self.fail_status_write and key.startswith(("enable_app_annotation_job_", "disable_app_annotation_job_")):
+        if self.fail_status_write and name.startswith(("enable_app_annotation_job_", "disable_app_annotation_job_")):
             raise RuntimeError("redis write failed")
-        if nx and key in self.values:
+        if nx and name in self.values:
             return False
-        self.values[key] = value
+        self.values[name] = value
         return True
 
-    def setex(self, key: str, _ttl: int, value: str) -> bool:
-        self.values[key] = value
+    def setex(self, name: str, time: int, value: str) -> bool:
+        del time
+        self.values[name] = value
         return True
 
-    def delete(self, key: str) -> int:
-        return int(self.values.pop(key, None) is not None)
+    def delete(self, *names: str) -> int:
+        return sum(self.values.pop(name, None) is not None for name in names)
 
-    def compare_and_delete(self, key: str, expected_value: str) -> int:
-        if self.values.get(key) != expected_value:
+    def compare_and_delete(self, name: str, expected_value: str) -> int:
+        if self.values.get(name) != expected_value:
             return 0
-        del self.values[key]
+        del self.values[name]
         return 1
 
 

--- a/api/tests/unit_tests/services/test_annotation_job_service.py
+++ b/api/tests/unit_tests/services/test_annotation_job_service.py
@@ -1,0 +1,56 @@
+import pytest
+
+from services.annotation_job_service import AnnotationReplyJob, AnnotationReplyJobCoordinator
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.fail_status_write = False
+
+    def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
+        del ex
+        if self.fail_status_write and key.startswith(("enable_app_annotation_job_", "disable_app_annotation_job_")):
+            raise RuntimeError("redis write failed")
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    def setex(self, key: str, _ttl: int, value: str) -> bool:
+        self.values[key] = value
+        return True
+
+    def delete(self, key: str) -> int:
+        return int(self.values.pop(key, None) is not None)
+
+    def compare_and_delete(self, key: str, expected_value: str) -> int:
+        if self.values.get(key) != expected_value:
+            return 0
+        del self.values[key]
+        return 1
+
+
+def test_acquire_releases_lock_when_initial_status_cannot_be_written() -> None:
+    redis = _FakeRedis()
+    redis.fail_status_write = True
+    job = AnnotationReplyJob(action="enable", app_id="app-1", job_id="job-1")
+
+    with pytest.raises(RuntimeError, match="redis write failed"):
+        AnnotationReplyJobCoordinator(redis).acquire(job)
+
+    assert job.lock_key not in redis.values
+
+
+def test_old_job_cannot_release_lock_owned_by_new_job() -> None:
+    redis = _FakeRedis()
+    old_job = AnnotationReplyJob(action="enable", app_id="app-1", job_id="old-job")
+    new_job = AnnotationReplyJob(action="disable", app_id="app-1", job_id="new-job")
+    redis.values[new_job.lock_key] = new_job.lock_value
+
+    AnnotationReplyJobCoordinator(redis).fail(old_job, "late failure")
+
+    assert redis.values[new_job.lock_key] == new_job.lock_value

--- a/api/tests/unit_tests/services/test_annotation_service.py
+++ b/api/tests/unit_tests/services/test_annotation_service.py
@@ -11,12 +11,37 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 from werkzeug.datastructures import FileStorage
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import Conflict, NotFound
 
+import services.annotation_service as annotation_service_module
 from models.dataset import DatasetCollectionBinding
 from models.model import App, AppAnnotationHitHistory, AppAnnotationSetting, Message, MessageAnnotation
 from services.annotation_service import AppAnnotationService
 from services.app_ref_service import AnnotationRef, AppRef
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
+        del ex
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    def delete(self, key: str) -> int:
+        return int(self.values.pop(key, None) is not None)
+
+    def compare_and_delete(self, key: str, expected_value: str) -> int:
+        if self.values.get(key) != expected_value:
+            return 0
+        del self.values[key]
+        return 1
 
 
 def _make_app(app_id: str = "app-1", tenant_id: str = "tenant-1") -> App:
@@ -275,6 +300,79 @@ class TestAppAnnotationServiceUpInsert:
 class TestAppAnnotationServiceEnableDisable:
     """Test suite for enable/disable app annotation."""
 
+    def test_enable_app_annotation_should_reuse_running_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Repeated enable requests should observe the same in-flight job."""
+        args = {"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"}
+        current_user = _make_user("user-1")
+        task = MagicMock()
+        redis = _FakeRedis()
+
+        monkeypatch.setattr(annotation_service_module, "redis_client", redis)
+        monkeypatch.setattr(annotation_service_module, "enable_annotation_reply_task", task)
+        monkeypatch.setattr(
+            annotation_service_module,
+            "current_account_with_tenant",
+            lambda: (current_user, "tenant-1"),
+        )
+
+        with patch.object(annotation_service_module.uuid, "uuid4", side_effect=["job-1", "job-2"]):
+            first = AppAnnotationService.enable_app_annotation(args, "app-1")
+            second = AppAnnotationService.enable_app_annotation(args, "app-1")
+
+        assert first == {"job_id": "job-1", "job_status": "waiting"}
+        assert second == {"job_id": "job-1", "job_status": "processing"}
+        task.delay.assert_called_once()
+
+    def test_disable_app_annotation_should_reject_running_enable_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Enable and disable operations for one app must not run at the same time."""
+        args = {"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"}
+        current_user = _make_user("user-1")
+        enable_task = MagicMock()
+        disable_task = MagicMock()
+        redis = _FakeRedis()
+
+        monkeypatch.setattr(annotation_service_module, "redis_client", redis)
+        monkeypatch.setattr(annotation_service_module, "enable_annotation_reply_task", enable_task)
+        monkeypatch.setattr(annotation_service_module, "disable_annotation_reply_task", disable_task)
+        monkeypatch.setattr(
+            annotation_service_module,
+            "current_account_with_tenant",
+            lambda: (current_user, "tenant-1"),
+        )
+
+        with patch.object(annotation_service_module.uuid, "uuid4", side_effect=["enable-job", "disable-job"]):
+            AppAnnotationService.enable_app_annotation(args, "app-1")
+            with pytest.raises(Conflict, match="already running"):
+                AppAnnotationService.disable_app_annotation("app-1")
+
+        disable_task.delay.assert_not_called()
+
+    def test_enable_app_annotation_should_allow_retry_when_enqueue_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A broker failure must not leave the app blocked by a job that was never queued."""
+        args = {"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"}
+        current_user = _make_user("user-1")
+        task = MagicMock()
+        task.delay.side_effect = RuntimeError("broker unavailable")
+        redis = _FakeRedis()
+
+        monkeypatch.setattr(annotation_service_module, "redis_client", redis)
+        monkeypatch.setattr(annotation_service_module, "enable_annotation_reply_task", task)
+        monkeypatch.setattr(
+            annotation_service_module,
+            "current_account_with_tenant",
+            lambda: (current_user, "tenant-1"),
+        )
+
+        with patch.object(annotation_service_module.uuid, "uuid4", side_effect=["failed-job", "retry-job"]):
+            with pytest.raises(RuntimeError, match="broker unavailable"):
+                AppAnnotationService.enable_app_annotation(args, "app-1")
+
+            task.delay.side_effect = None
+            retry = AppAnnotationService.enable_app_annotation(args, "app-1")
+
+        assert retry == {"job_id": "retry-job", "job_status": "waiting"}
+        assert task.delay.call_count == 2
+
     def test_enable_app_annotation_should_return_processing_when_cache_hit(self) -> None:
         """Test cache hit returns processing status."""
         # Arrange
@@ -284,7 +382,8 @@ class TestAppAnnotationServiceEnableDisable:
             patch("services.annotation_service.redis_client") as mock_redis,
             patch("services.annotation_service.enable_annotation_reply_task") as mock_task,
         ):
-            mock_redis.get.return_value = "job-1"
+            mock_redis.set.return_value = False
+            mock_redis.get.return_value = "enable:job-1"
 
             # Act
             result = AppAnnotationService.enable_app_annotation(args, "app-1")
@@ -306,14 +405,15 @@ class TestAppAnnotationServiceEnableDisable:
             patch("services.annotation_service.uuid.uuid4", return_value="uuid-1"),
             patch("services.annotation_service.enable_annotation_reply_task") as mock_task,
         ):
-            mock_redis.get.return_value = None
+            mock_redis.set.return_value = True
 
             # Act
             result = AppAnnotationService.enable_app_annotation(args, "app-1")
 
             # Assert
             assert result == {"job_id": "uuid-1", "job_status": "waiting"}
-            mock_redis.setnx.assert_called_once_with("enable_app_annotation_job_uuid-1", "waiting")
+            mock_redis.set.assert_any_call("app_annotation_job:app-1", "enable:uuid-1", nx=True, ex=7200)
+            mock_redis.set.assert_any_call("enable_app_annotation_job_uuid-1", "waiting", ex=7200)
             mock_task.delay.assert_called_once_with(
                 "uuid-1",
                 "app-1",
@@ -333,7 +433,8 @@ class TestAppAnnotationServiceEnableDisable:
             patch("services.annotation_service.current_account_with_tenant", return_value=(_make_user(), tenant_id)),
             patch("services.annotation_service.disable_annotation_reply_task") as mock_task,
         ):
-            mock_redis.get.return_value = "job-2"
+            mock_redis.set.return_value = False
+            mock_redis.get.return_value = "disable:job-2"
 
             # Act
             result = AppAnnotationService.disable_app_annotation("app-1")
@@ -353,14 +454,15 @@ class TestAppAnnotationServiceEnableDisable:
             patch("services.annotation_service.uuid.uuid4", return_value="uuid-2"),
             patch("services.annotation_service.disable_annotation_reply_task") as mock_task,
         ):
-            mock_redis.get.return_value = None
+            mock_redis.set.return_value = True
 
             # Act
             result = AppAnnotationService.disable_app_annotation("app-1")
 
             # Assert
             assert result == {"job_id": "uuid-2", "job_status": "waiting"}
-            mock_redis.setnx.assert_called_once_with("disable_app_annotation_job_uuid-2", "waiting")
+            mock_redis.set.assert_any_call("app_annotation_job:app-1", "disable:uuid-2", nx=True, ex=7200)
+            mock_redis.set.assert_any_call("disable_app_annotation_job_uuid-2", "waiting", ex=7200)
             mock_task.delay.assert_called_once_with("uuid-2", "app-1", tenant_id)
 
 

--- a/api/tests/unit_tests/services/test_annotation_service.py
+++ b/api/tests/unit_tests/services/test_annotation_service.py
@@ -24,23 +24,28 @@ class _FakeRedis:
     def __init__(self) -> None:
         self.values: dict[str, str] = {}
 
-    def get(self, key: str) -> str | None:
-        return self.values.get(key)
+    def get(self, name: str) -> str | None:
+        return self.values.get(name)
 
-    def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
+    def set(self, name: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
         del ex
-        if nx and key in self.values:
+        if nx and name in self.values:
             return False
-        self.values[key] = value
+        self.values[name] = value
         return True
 
-    def delete(self, key: str) -> int:
-        return int(self.values.pop(key, None) is not None)
+    def setex(self, name: str, time: int, value: str) -> bool:
+        del time
+        self.values[name] = value
+        return True
 
-    def compare_and_delete(self, key: str, expected_value: str) -> int:
-        if self.values.get(key) != expected_value:
+    def delete(self, *names: str) -> int:
+        return sum(self.values.pop(name, None) is not None for name in names)
+
+    def compare_and_delete(self, name: str, expected_value: str) -> int:
+        if self.values.get(name) != expected_value:
             return 0
-        del self.values[key]
+        del self.values[name]
         return 1
 
 

--- a/api/tests/unit_tests/tasks/test_annotation_reply_tasks.py
+++ b/api/tests/unit_tests/tasks/test_annotation_reply_tasks.py
@@ -1,0 +1,141 @@
+from unittest.mock import MagicMock, patch
+
+import tasks.annotation.disable_annotation_reply_task as disable_task_module
+import tasks.annotation.enable_annotation_reply_task as enable_task_module
+
+
+class _FakeRedis:
+    def __init__(self, values: dict[str, str]):
+        self.values = values
+
+    def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
+        del ex
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    def setex(self, key: str, _ttl: int, value: str) -> bool:
+        self.values[key] = value
+        return True
+
+    def delete(self, key: str) -> int:
+        return int(self.values.pop(key, None) is not None)
+
+    def compare_and_delete(self, key: str, expected_value: str) -> int:
+        if self.values.get(key) != expected_value:
+            return 0
+        del self.values[key]
+        return 1
+
+
+def test_enable_annotation_reply_marks_missing_app_as_error() -> None:
+    redis = _FakeRedis(
+        {
+            "app_annotation_job:app-1": "enable:job-1",
+            "enable_app_annotation_job_job-1": "waiting",
+        }
+    )
+    session = MagicMock()
+    session.scalar.return_value = None
+    session_factory = MagicMock()
+    session_factory.create_session.return_value.__enter__.return_value = session
+
+    with (
+        patch.object(enable_task_module, "redis_client", redis),
+        patch.object(enable_task_module, "session_factory", session_factory),
+    ):
+        enable_task_module.enable_annotation_reply_task.run(
+            "job-1",
+            "app-1",
+            "user-1",
+            "tenant-1",
+            0.5,
+            "provider",
+            "model",
+        )
+
+    assert redis.values["enable_app_annotation_job_job-1"] == "error"
+    assert redis.values["enable_app_annotation_error_job-1"] == "App not found"
+    assert "app_annotation_job:app-1" not in redis.values
+
+
+def test_disable_annotation_reply_completes_when_setting_is_already_absent() -> None:
+    redis = _FakeRedis(
+        {
+            "app_annotation_job:app-1": "disable:job-1",
+            "disable_app_annotation_job_job-1": "waiting",
+        }
+    )
+    session = MagicMock()
+    session.scalar.side_effect = [object(), False, None]
+    session_factory = MagicMock()
+    session_factory.create_session.return_value.__enter__.return_value = session
+
+    with (
+        patch.object(disable_task_module, "redis_client", redis),
+        patch.object(disable_task_module, "session_factory", session_factory),
+    ):
+        disable_task_module.disable_annotation_reply_task.run("job-1", "app-1", "tenant-1")
+
+    assert redis.values["disable_app_annotation_job_job-1"] == "completed"
+    assert "app_annotation_job:app-1" not in redis.values
+
+
+def test_enable_annotation_reply_releases_job_when_app_lookup_fails() -> None:
+    redis = _FakeRedis(
+        {
+            "app_annotation_job:app-1": "enable:job-1",
+            "enable_app_annotation_job_job-1": "waiting",
+        }
+    )
+    session = MagicMock()
+    session.scalar.side_effect = RuntimeError("database unavailable")
+    session_factory = MagicMock()
+    session_factory.create_session.return_value.__enter__.return_value = session
+
+    with (
+        patch.object(enable_task_module, "redis_client", redis),
+        patch.object(enable_task_module, "session_factory", session_factory),
+    ):
+        enable_task_module.enable_annotation_reply_task.run(
+            "job-1",
+            "app-1",
+            "user-1",
+            "tenant-1",
+            0.5,
+            "provider",
+            "model",
+        )
+
+    assert redis.values["enable_app_annotation_job_job-1"] == "error"
+    assert redis.values["enable_app_annotation_error_job-1"] == "database unavailable"
+    assert "app_annotation_job:app-1" not in redis.values
+    session.rollback.assert_called_once()
+
+
+def test_disable_annotation_reply_releases_job_when_app_lookup_fails() -> None:
+    redis = _FakeRedis(
+        {
+            "app_annotation_job:app-1": "disable:job-1",
+            "disable_app_annotation_job_job-1": "waiting",
+        }
+    )
+    session = MagicMock()
+    session.scalar.side_effect = RuntimeError("database unavailable")
+    session_factory = MagicMock()
+    session_factory.create_session.return_value.__enter__.return_value = session
+
+    with (
+        patch.object(disable_task_module, "redis_client", redis),
+        patch.object(disable_task_module, "session_factory", session_factory),
+    ):
+        disable_task_module.disable_annotation_reply_task.run("job-1", "app-1", "tenant-1")
+
+    assert redis.values["disable_app_annotation_job_job-1"] == "error"
+    assert redis.values["disable_app_annotation_error_job-1"] == "database unavailable"
+    assert "app_annotation_job:app-1" not in redis.values
+    session.rollback.assert_called_once()

--- a/api/tests/unit_tests/tasks/test_annotation_reply_tasks.py
+++ b/api/tests/unit_tests/tasks/test_annotation_reply_tasks.py
@@ -5,30 +5,31 @@ import tasks.annotation.enable_annotation_reply_task as enable_task_module
 
 
 class _FakeRedis:
-    def __init__(self, values: dict[str, str]):
+    def __init__(self, values: dict[str, str]) -> None:
         self.values = values
 
-    def get(self, key: str) -> str | None:
-        return self.values.get(key)
+    def get(self, name: str) -> str | None:
+        return self.values.get(name)
 
-    def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
+    def set(self, name: str, value: str, *, nx: bool = False, ex: int | None = None) -> bool:
         del ex
-        if nx and key in self.values:
+        if nx and name in self.values:
             return False
-        self.values[key] = value
+        self.values[name] = value
         return True
 
-    def setex(self, key: str, _ttl: int, value: str) -> bool:
-        self.values[key] = value
+    def setex(self, name: str, time: int, value: str) -> bool:
+        del time
+        self.values[name] = value
         return True
 
-    def delete(self, key: str) -> int:
-        return int(self.values.pop(key, None) is not None)
+    def delete(self, *names: str) -> int:
+        return sum(self.values.pop(name, None) is not None for name in names)
 
-    def compare_and_delete(self, key: str, expected_value: str) -> int:
-        if self.values.get(key) != expected_value:
+    def compare_and_delete(self, name: str, expected_value: str) -> int:
+        if self.values.get(name) != expected_value:
             return 0
-        del self.values[key]
+        del self.values[name]
         return 1
 
 


### PR DESCRIPTION
## Summary

- serialize annotation reply enable and disable jobs with one application-scoped lock
- reuse an in-flight job for repeated requests and reject conflicting operations
- keep job status and lock cleanup consistent across enqueue failures, missing records, database errors, completion, and failure
- add prefix-aware atomic lock release to avoid deleting a newer job's lock

Fixes #40595

## Screenshots

Not applicable. This is a backend-only change.

## Testing

- [x] Related unit tests (82 passed)
- [x] Ruff format and lint checks
- [x] Mypy checks for changed backend source files
- [x] Pyrefly checks for changed backend source files

## Checklist

- [x] I've added tests for the introduced behavior and kept the change atomic.
- [x] No documentation update is required.
