### PR TITLE
test: migrate human input sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/console/test_human_input_form.py
+++ b/api/tests/unit_tests/controllers/console/test_human_input_form.py
@@ -8,9 +8,11 @@ from unittest.mock import ANY, Mock
 
 import pytest
 from flask import Flask, Response
+from sqlalchemy import Engine
 
 from controllers.common.errors import NotFoundError
 from controllers.common.human_input import HumanInputFormSubmitPayload
+from controllers.console import human_input_form as human_input_form_module
 from controllers.console.human_input_form import (
     ConsoleHumanInputFormApi,
     ConsoleWorkflowEventsApi,
@@ -19,10 +21,62 @@ from controllers.console.human_input_form import (
     _jsonify_form_definition,
 )
 from core.workflow.human_input_policy import HumanInputSurface
+from graphon.enums import WorkflowExecutionStatus, WorkflowType
+from models import Account
 from models.account import AccountStatus
-from models.enums import CreatorUserRole
+from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.human_input import RecipientType
-from models.model import AppMode
+from models.model import App, AppMode
+from models.workflow import WorkflowRun
+
+
+@pytest.fixture(autouse=True)
+def bind_console_human_input_database(sqlite_engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bind controller-owned service factories to the isolated SQLite engine."""
+    monkeypatch.setattr(human_input_form_module, "db", SimpleNamespace(engine=sqlite_engine))
+
+
+def _account(*, account_id: str = "user-1") -> Account:
+    account = Account(name="Console User", email=f"{account_id}@example.com", status=AccountStatus.ACTIVE)
+    account.id = account_id
+    return account
+
+
+def _app() -> App:
+    return App(
+        id="app-1",
+        tenant_id="t1",
+        name="Human Input App",
+        description="",
+        mode=AppMode.WORKFLOW,
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=0,
+    )
+
+
+def _workflow_run(
+    *,
+    created_by_role: CreatorUserRole = CreatorUserRole.ACCOUNT,
+    created_by: str = "user-1",
+    finished_at: datetime | None = None,
+) -> WorkflowRun:
+    return WorkflowRun(
+        id="run-1",
+        tenant_id="t1",
+        app_id="app-1",
+        workflow_id="workflow-1",
+        type=WorkflowType.WORKFLOW,
+        triggered_from=WorkflowRunTriggeredFrom.DEBUGGING,
+        version="draft",
+        graph="{}",
+        inputs="{}",
+        status=WorkflowExecutionStatus.SUCCEEDED if finished_at else WorkflowExecutionStatus.RUNNING,
+        created_by_role=created_by_role,
+        created_by=created_by,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        finished_at=finished_at,
+    )
 
 
 def test_jsonify_form_definition() -> None:
@@ -57,7 +111,6 @@ def test_get_form_definition_success(app: Flask, monkeypatch: pytest.MonkeyPatch
             return form
 
     monkeypatch.setattr("controllers.console.human_input_form.HumanInputService", _ServiceStub)
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleHumanInputFormApi()
     handler = unwrap(api.get)
@@ -78,7 +131,6 @@ def test_get_form_definition_not_found(app: Flask, monkeypatch: pytest.MonkeyPat
             return None
 
     monkeypatch.setattr("controllers.console.human_input_form.HumanInputService", _ServiceStub)
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleHumanInputFormApi()
     handler = unwrap(api.get)
@@ -99,7 +151,6 @@ def test_post_form_invalid_recipient_type(app: Flask, monkeypatch: pytest.Monkey
             return form
 
     monkeypatch.setattr("controllers.console.human_input_form.HumanInputService", _ServiceStub)
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleHumanInputFormApi()
     handler = unwrap(api.post)
@@ -114,7 +165,7 @@ def test_post_form_invalid_recipient_type(app: Flask, monkeypatch: pytest.Monkey
                 api,
                 HumanInputFormSubmitPayload.model_validate({"inputs": {"content": "ok"}, "action": "approve"}),
                 "tenant-1",
-                SimpleNamespace(id="user-1"),
+                _account(),
                 form_token="token",
             )
 
@@ -130,7 +181,6 @@ def test_post_form_rejects_webapp_recipient_type(app: Flask, monkeypatch: pytest
             return form
 
     monkeypatch.setattr("controllers.console.human_input_form.HumanInputService", _ServiceStub)
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleHumanInputFormApi()
     handler = unwrap(api.post)
@@ -145,7 +195,7 @@ def test_post_form_rejects_webapp_recipient_type(app: Flask, monkeypatch: pytest
                 api,
                 HumanInputFormSubmitPayload.model_validate({"inputs": {"content": "ok"}, "action": "approve"}),
                 "tenant-1",
-                SimpleNamespace(id="user-1"),
+                _account(),
                 form_token="token",
             )
 
@@ -165,7 +215,6 @@ def test_post_form_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
             submit_mock(**kwargs)
 
     monkeypatch.setattr("controllers.console.human_input_form.HumanInputService", _ServiceStub)
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleHumanInputFormApi()
     handler = unwrap(api.post)
@@ -179,7 +228,7 @@ def test_post_form_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
             api,
             HumanInputFormSubmitPayload.model_validate({"inputs": {"content": "ok"}, "action": "approve"}),
             "tenant-1",
-            SimpleNamespace(id="user-1"),
+            _account(),
             form_token="token",
         )
 
@@ -190,7 +239,7 @@ def test_post_form_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
 def test_post_form_decorated_success_validates_request_body(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     submit_mock = Mock()
     form = SimpleNamespace(tenant_id="tenant-1", recipient_type=RecipientType.CONSOLE)
-    current_user = SimpleNamespace(id="user-1", status=AccountStatus.ACTIVE)
+    current_user = _account()
 
     class _ServiceStub:
         def __init__(self, *_args, **_kwargs):
@@ -207,7 +256,6 @@ def test_post_form_decorated_success_validates_request_body(app: Flask, monkeypa
         "controllers.console.wraps.current_account_with_tenant",
         lambda: (current_user, "tenant-1"),
     )
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
     monkeypatch.setattr("libs.login.dify_config.LOGIN_DISABLED", True)
 
     with app.test_request_context(
@@ -237,23 +285,17 @@ def test_workflow_events_not_found(app: Flask, monkeypatch: pytest.MonkeyPatch) 
         "create_api_workflow_run_repository",
         lambda *_args, **_kwargs: _RepoStub(),
     )
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleWorkflowEventsApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/console/api/workflow/run/events", method="GET"):
         with pytest.raises(NotFoundError):
-            handler(api, "t1", SimpleNamespace(id="u1"), workflow_run_id="run-1")
+            handler(api, "t1", _account(account_id="u1"), workflow_run_id="run-1")
 
 
 def test_workflow_events_requires_account(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow_run = SimpleNamespace(
-        id="run-1",
-        created_by_role=CreatorUserRole.END_USER,
-        created_by="user-1",
-        tenant_id="t1",
-    )
+    workflow_run = _workflow_run(created_by_role=CreatorUserRole.END_USER)
 
     class _RepoStub:
         def get_workflow_run_by_id_and_tenant_id(self, **_kwargs):
@@ -264,23 +306,17 @@ def test_workflow_events_requires_account(app: Flask, monkeypatch: pytest.Monkey
         "create_api_workflow_run_repository",
         lambda *_args, **_kwargs: _RepoStub(),
     )
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleWorkflowEventsApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/console/api/workflow/run/events", method="GET"):
         with pytest.raises(NotFoundError):
-            handler(api, "t1", SimpleNamespace(id="u1"), workflow_run_id="run-1")
+            handler(api, "t1", _account(account_id="u1"), workflow_run_id="run-1")
 
 
 def test_workflow_events_requires_creator(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow_run = SimpleNamespace(
-        id="run-1",
-        created_by_role=CreatorUserRole.ACCOUNT,
-        created_by="user-2",
-        tenant_id="t1",
-    )
+    workflow_run = _workflow_run(created_by="user-2")
 
     class _RepoStub:
         def get_workflow_run_by_id_and_tenant_id(self, **_kwargs):
@@ -291,26 +327,18 @@ def test_workflow_events_requires_creator(app: Flask, monkeypatch: pytest.Monkey
         "create_api_workflow_run_repository",
         lambda *_args, **_kwargs: _RepoStub(),
     )
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleWorkflowEventsApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/console/api/workflow/run/events", method="GET"):
         with pytest.raises(NotFoundError):
-            handler(api, "t1", SimpleNamespace(id="u1"), workflow_run_id="run-1")
+            handler(api, "t1", _account(account_id="u1"), workflow_run_id="run-1")
 
 
 def test_workflow_events_finished(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow_run = SimpleNamespace(
-        id="run-1",
-        created_by_role=CreatorUserRole.ACCOUNT,
-        created_by="user-1",
-        tenant_id="t1",
-        app_id="app-1",
-        finished_at=datetime(2024, 1, 1, tzinfo=UTC),
-    )
-    app_model = SimpleNamespace(mode=AppMode.WORKFLOW)
+    workflow_run = _workflow_run(finished_at=datetime(2024, 1, 1, tzinfo=UTC))
+    app_model = _app()
 
     class _RepoStub:
         def get_workflow_run_by_id_and_tenant_id(self, **_kwargs):
@@ -335,28 +363,20 @@ def test_workflow_events_finished(app: Flask, monkeypatch: pytest.MonkeyPatch) -
         "workflow_run_result_to_finish_response",
         lambda **_kwargs: response_obj,
     )
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleWorkflowEventsApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/console/api/workflow/run/events", method="GET"):
-        response = handler(api, "t1", SimpleNamespace(id="user-1"), workflow_run_id="run-1")
+        response = handler(api, "t1", _account(), workflow_run_id="run-1")
 
     assert response.mimetype == "text/event-stream"
     assert "data" in response.get_data(as_text=True)
 
 
 def test_workflow_events_snapshot_can_continue_across_pauses(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    workflow_run = SimpleNamespace(
-        id="run-1",
-        created_by_role=CreatorUserRole.ACCOUNT,
-        created_by="user-1",
-        tenant_id="t1",
-        app_id="app-1",
-        finished_at=None,
-    )
-    app_model = SimpleNamespace(mode=AppMode.WORKFLOW)
+    workflow_run = _workflow_run()
+    app_model = _app()
 
     class _RepoStub:
         def get_workflow_run_by_id_and_tenant_id(self, **_kwargs):
@@ -383,7 +403,6 @@ def test_workflow_events_snapshot_can_continue_across_pauses(app: Flask, monkeyp
         "controllers.console.human_input_form.build_workflow_event_stream",
         snapshot_builder,
     )
-    monkeypatch.setattr("controllers.console.human_input_form.db", SimpleNamespace(engine=object()))
 
     api = ConsoleWorkflowEventsApi()
     handler = unwrap(api.get)
@@ -392,7 +411,7 @@ def test_workflow_events_snapshot_can_continue_across_pauses(app: Flask, monkeyp
         "/console/api/workflow/run-1/events?include_state_snapshot=true&continue_on_pause=true",
         method="GET",
     ):
-        response = handler(api, "t1", SimpleNamespace(id="user-1"), workflow_run_id="run-1")
+        response = handler(api, "t1", _account(), workflow_run_id="run-1")
 
     assert response.get_data(as_text=True) == "data: snapshot\n\n"
     snapshot_builder.assert_called_once_with(

--- a/api/tests/unit_tests/services/test_human_input_file_upload_service.py
+++ b/api/tests/unit_tests/services/test_human_input_file_upload_service.py
@@ -194,6 +194,13 @@ def _create_service(
     )
 
 
+def _get_workflow_run(session_maker) -> WorkflowRun:
+    with session_maker() as session:
+        workflow_run = session.get(WorkflowRun, "00000000-0000-0000-0000-000000000012")
+    assert workflow_run is not None
+    return workflow_run
+
+
 def test_issue_upload_token_persists_token_without_technical_end_user(
     monkeypatch: pytest.MonkeyPatch,
     session_maker,
@@ -217,12 +224,7 @@ def test_validate_upload_token_returns_account_owner_and_record_file_link(sessio
     form_id, recipient_id, created_by = _create_waiting_form(session_maker, created_by_role=CreatorUserRole.ACCOUNT)
     token = _create_service(session_maker).issue_upload_token("form-token-1")
     workflow_run_repository = MagicMock()
-    workflow_run_repository.get_workflow_run_by_id.return_value = SimpleNamespace(
-        tenant_id="00000000-0000-0000-0000-000000000010",
-        app_id="00000000-0000-0000-0000-000000000011",
-        created_by_role=CreatorUserRole.ACCOUNT,
-        created_by=created_by,
-    )
+    workflow_run_repository.get_workflow_run_by_id.return_value = _get_workflow_run(session_maker)
 
     context = HumanInputFileUploadService(
         session_maker,
@@ -257,12 +259,7 @@ def test_validate_upload_token_returns_end_user_owner(session_maker) -> None:
     form_id, recipient_id, created_by = _create_waiting_form(session_maker, created_by_role=CreatorUserRole.END_USER)
     token = _create_service(session_maker).issue_upload_token("form-token-1")
     workflow_run_repository = MagicMock()
-    workflow_run_repository.get_workflow_run_by_id.return_value = SimpleNamespace(
-        tenant_id="00000000-0000-0000-0000-000000000010",
-        app_id="00000000-0000-0000-0000-000000000011",
-        created_by_role=CreatorUserRole.END_USER,
-        created_by=created_by,
-    )
+    workflow_run_repository.get_workflow_run_by_id.return_value = _get_workflow_run(session_maker)
 
     context = HumanInputFileUploadService(
         session_maker,

--- a/api/tests/unit_tests/services/test_human_input_service.py
+++ b/api/tests/unit_tests/services/test_human_input_service.py
@@ -32,6 +32,7 @@ from graphon.runtime import GraphRuntimeState, VariablePool
 from libs.datetime_utils import naive_utc_now
 from models.human_input import RecipientType
 from models.model import App, AppMode
+from models.workflow import WorkflowRun
 from services.human_input_service import (
     Form,
     FormExpiredError,
@@ -53,6 +54,10 @@ def _make_app(mode: AppMode) -> App:
         enable_api=True,
         max_active_requests=0,
     )
+
+
+def _workflow_run() -> WorkflowRun:
+    return WorkflowRun(id="workflow-run-id", app_id="app-id")
 
 
 @pytest.fixture
@@ -93,8 +98,7 @@ def test_enqueue_resume_dispatches_task_for_workflow(
 ) -> None:
     service = HumanInputService(sqlite_session_factory)
 
-    workflow_run = MagicMock()
-    workflow_run.app_id = "app-id"
+    workflow_run = _workflow_run()
 
     workflow_run_repo = MagicMock()
     workflow_run_repo.get_workflow_run_by_id_without_tenant.return_value = workflow_run
@@ -138,8 +142,7 @@ def test_enqueue_resume_dispatches_task_for_advanced_chat(
 ) -> None:
     service = HumanInputService(sqlite_session_factory)
 
-    workflow_run = MagicMock()
-    workflow_run.app_id = "app-id"
+    workflow_run = _workflow_run()
 
     workflow_run_repo = MagicMock()
     workflow_run_repo.get_workflow_run_by_id_without_tenant.return_value = workflow_run
@@ -166,8 +169,7 @@ def test_enqueue_resume_skips_unsupported_app_mode(
 ) -> None:
     service = HumanInputService(sqlite_session_factory)
 
-    workflow_run = MagicMock()
-    workflow_run.app_id = "app-id"
+    workflow_run = _workflow_run()
 
     workflow_run_repo = MagicMock()
     workflow_run_repo.get_workflow_run_by_id_without_tenant.return_value = workflow_run
@@ -671,8 +673,7 @@ def test_enqueue_resume_app_not_found(
 ) -> None:
     service = HumanInputService(sqlite_session_factory)
 
-    workflow_run = MagicMock()
-    workflow_run.app_id = "app-id"
+    workflow_run = _workflow_run()
 
     workflow_run_repo = MagicMock()
     workflow_run_repo.get_workflow_run_by_id_without_tenant.return_value = workflow_run


### PR DESCRIPTION
## Summary
- replace console human-input Account, App, and WorkflowRun stand-ins with mapped models
- bind controller-owned HumanInputService construction to the isolated SQLite engine
- return real persisted WorkflowRun rows from mocked repository boundaries in upload-owner tests
- retain repository and task mocks as non-ORM collaborators

## Real persistence coverage
- console workflow event authorization now evaluates real WorkflowRun creator roles and real Account identities
- workflow app-mode selection uses a mapped App
- upload-token ownership tests load the actual WorkflowRun persisted by their SQLite fixture
- enqueue-resume tests pass mapped WorkflowRun rows while querying mapped App rows from SQLite

## Production fixes
- none

## Size
- 89 additions, 72 deletions (161 changed lines)
- intentionally small atomic residual; related OpenAPI and web modules are owned by existing independent PRs and were not modified

## Validation
- targeted `make test` for the three changed modules — 52 passed
- `make lint` — passed
- `make type-check` — blocked by existing mypy 1.20.2 internal error at `typeshed/stdlib/zipimport.pyi:17`
- focused audit — remaining workflow-run repository mocks are non-SQLAlchemy repository interfaces; their returned mapped rows are real
- full test suite not run, per explicit request