### PR TITLE
fix(api): point SSRF-blocked error message at the correct dify issue

### DIFF
--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -260,7 +260,7 @@ def make_request(
                         f"(e.g. SSRF_PROXY_ALLOW_PRIVATE_IPS=172.21.0.0/16 to "
                         f"allow 172.21.0.0/16). The URL resolves to a private, "
                         f"loopback, link-local, or otherwise non-public network "
-                        f"address. See https://github.com/infiniflow/ragflow/issues/38443."
+                        f"address. See https://github.com/langgenius/dify/issues/38443."
                     )
 
             if response.status_code not in STATUS_FORCELIST or max_retries == 0:

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -399,8 +399,9 @@ def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
     # The remediation hint must include a concrete example, otherwise users
     # still have to grep the squid config to figure out the syntax.
     assert "172.21.0.0/16" in msg
-    # And it must point to the issue so maintainers can find context.
-    assert "issues/38443" in msg
+    # And it must point to the dify issue so maintainers can find context
+    # (not some other project's tracker with a coincidentally matching number).
+    assert "https://github.com/langgenius/dify/issues/38443" in msg
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

While investigating #40601 (HTTP Request node failing with `[Errno -3] Temporary failure in name resolution` for a LAN address), I found that the actionable `ToolSSRFError` raised in `api/core/helper/ssrf_proxy.py` when Squid denies a private-network request points users to the wrong GitHub repository.

The message says:

```
See https://github.com/infiniflow/ragflow/issues/38443.
```

`infiniflow/ragflow` is an unrelated project. The intended reference is dify's own issue, [langgenius/dify#38443](https://github.com/langgenius/dify/issues/38443) ("http request is blocked by SSRF protection"), which was the original report that motivated adding this actionable error message (#39867). Anyone who hits this SSRF block and follows the link in the error message currently lands on a different project's tracker instead of the context that explains the fix (`SSRF_PROXY_ALLOW_PRIVATE_IPS` / `SSRF_PROXY_ALLOW_PRIVATE_DOMAINS`).

This PR corrects the URL to `https://github.com/langgenius/dify/issues/38443` and strengthens the regression test to assert on the full URL (previously it only checked for the substring `"issues/38443"`, which passed even with the wrong org/repo).

Related to #40601 — that issue's root cause is Dify's deny-by-default SSRF proxy policy (introduced in 1.15.0), which is expected behavior once the appropriate `SSRF_PROXY_ALLOW_PRIVATE_IPS`/`SSRF_PROXY_ALLOW_PRIVATE_DOMAINS` env vars are set; this PR fixes a small but concrete bug found in the exact code path that's supposed to guide users through that configuration.

## Test plan

- Updated `test_squid_block_raises_actionable_tool_ssrf_error` in `api/tests/unit_tests/core/helper/test_ssrf_proxy.py` to assert the full correct URL.
- Confirmed the strengthened assertion fails against the pre-fix code:

  ```
  $ git checkout HEAD~1 -- api/core/helper/ssrf_proxy.py
  $ uv run --project api python3 -m pytest api/tests/unit_tests/core/helper/test_ssrf_proxy.py -k test_squid_block_raises_actionable_tool_ssrf_error -o addopts=""
  FAILED ... assert 'https://github.com/langgenius/dify/issues/38443' in "...See https://github.com/infiniflow/ragflow/issues/38443."
  $ git checkout HEAD -- api/core/helper/ssrf_proxy.py
  ```

- Full suite after restoring the fix:

  ```
  $ uv run --project api python3 -m pytest api/tests/unit_tests/core/helper/test_ssrf_proxy.py -o addopts=""
  36 passed, 1 warning in 2.88s
  ```

- Lint:

  ```
  $ uv run --project api --dev ruff check api/core/helper/ssrf_proxy.py api/tests/unit_tests/core/helper/test_ssrf_proxy.py
  All checks passed!
  $ uv run --project api --dev ruff format --check api/core/helper/ssrf_proxy.py api/tests/unit_tests/core/helper/test_ssrf_proxy.py
  2 files already formatted
  ```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `ruff check` / `ruff format --check` (backend) targeted at the changed files; full `make type-check` was not run since this change only touches a string literal and a test assertion with no typing impact.

From Claude
