### PR TITLE
fix(rbac): grant member access when a dataset is created with documents or opened to the workspace

### DIFF
--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services
+from configs import dify_config
 from controllers.common.controller_schemas import DocumentBatchDownloadZipPayload
 from controllers.common.fields import SimpleResultMessageResponse, SimpleResultResponse, UrlResponse
 from controllers.common.schema import register_response_schema_models, register_schema_models
@@ -54,13 +55,16 @@ from libs.helper import dump_response, to_timestamp
 from libs.login import login_required
 from libs.pagination import paginate_query
 from models import Account, Document, DocumentSegment, UploadFile
-from models.dataset import DocumentPipelineExecutionLog
+from models.dataset import DatasetPermissionEnum, DocumentPipelineExecutionLog
 from models.enums import IndexingStatus, ProcessRuleMode, SegmentStatus
 from services.dataset_ref_service import DatasetRefService
 from services.dataset_service import DatasetService, DocumentService
+from services.enterprise import rbac_service as enterprise_rbac_service
+from services.enterprise.rbac_service import RBACResourceWhitelistScope, ReplaceMemberBindings
 from services.entities.knowledge_entities.knowledge_entities import KnowledgeConfig, ProcessRule, RetrievalModel
 from services.file_service import FileService
 from tasks.generate_summary_index_task import generate_summary_index_task
+from tasks.initialize_created_app_rbac_access_task import initialize_created_app_rbac_access_task
 
 from ..app.error import (
     ProviderModelCurrentlyNotSupportError,
@@ -660,6 +664,21 @@ class DatasetInitApi(Resource):
             raise ProviderQuotaExceededError()
         except ModelCurrentlyNotSupportError:
             raise ProviderModelCurrentlyNotSupportError()
+
+        if dify_config.RBAC_ENABLED:
+            dataset.permission = DatasetPermissionEnum.ALL_TEAM
+        else:
+            dataset.permission = DatasetPermissionEnum.ONLY_ME
+        session.flush()
+
+        if dify_config.RBAC_ENABLED:
+            enterprise_rbac_service.RBACService.DatasetAccess.replace_whitelist(
+                current_tenant_id,
+                current_user.id,
+                dataset.id,
+                ReplaceMemberBindings(scope=RBACResourceWhitelistScope.ALL),
+            )
+            initialize_created_app_rbac_access_task.delay(current_tenant_id, current_user.id, dataset_id=dataset.id)
 
         return dump_response(
             DatasetAndDocumentResponse,

--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -703,14 +703,17 @@ class RBACDatasetWhitelistApi(Resource):
     def put(self, dataset_id):
         tenant_id, account_id = _current_ids()
         request = _payload(_ResourceAccessScopeRequest)
-        return _dump(
-            svc.RBACService.DatasetAccess.replace_whitelist(
-                tenant_id,
-                account_id,
-                str(dataset_id),
-                svc.ReplaceMemberBindings(scope=request.scope.value),
-            )
+        result = svc.RBACService.DatasetAccess.replace_whitelist(
+            tenant_id,
+            account_id,
+            str(dataset_id),
+            svc.ReplaceMemberBindings(scope=request.scope.value),
         )
+        # Widening the scope only records it: the members still need the default access policy
+        # before they can reach the dataset, same as the app whitelist route above.
+        if dify_config.RBAC_ENABLED and request.scope is RBACResourceWhitelistScope.ALL:
+            initialize_created_app_rbac_access_task.delay(tenant_id, account_id, dataset_id=str(dataset_id))
+        return _dump(result)
 
 
 @console_ns.route("/workspaces/current/rbac/datasets/<uuid:dataset_id>/user-access-policies")

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
@@ -38,9 +38,10 @@ from controllers.console.datasets.error import (
 )
 from core.entities.knowledge_entities import IndexingEstimate
 from core.rag.index_processor.constant.index_type import IndexStructureType
-from models.dataset import Dataset
+from models.dataset import Dataset, DatasetPermissionEnum
 from models.dataset import Document as DatasetDocument
 from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus
+from services.enterprise.rbac_service import RBACResourceWhitelistScope, ReplaceMemberBindings
 
 
 def make_serializable_document(**overrides):
@@ -476,6 +477,7 @@ class TestDatasetInitApi:
         with (
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
+            patch("controllers.console.datasets.datasets_document.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.console.datasets.datasets_document.DocumentService.document_create_args_validate",
                 return_value=None,
@@ -484,6 +486,12 @@ class TestDatasetInitApi:
                 "controllers.console.datasets.datasets_document.DocumentService.save_document_without_dataset_id",
                 return_value=(created_dataset, [created_document], "batch-init"),
             ),
+            patch(
+                "controllers.console.datasets.datasets_document.enterprise_rbac_service.RBACService.DatasetAccess.replace_whitelist"
+            ) as replace_whitelist,
+            patch(
+                "controllers.console.datasets.datasets_document.initialize_created_app_rbac_access_task"
+            ) as initialize_rbac_task,
         ):
             response = method(api, session, tenant_id, user)
         assert response["dataset"]["id"] == "ds-1"
@@ -491,6 +499,14 @@ class TestDatasetInitApi:
         assert response["documents"][0]["data_source_info"] == {}
         assert response["documents"][0]["doc_metadata"] == []
         assert response["batch"] == "batch-init"
+        assert created_dataset.permission == DatasetPermissionEnum.ALL_TEAM
+        replace_whitelist.assert_called_once_with(
+            tenant_id,
+            user.id,
+            created_dataset.id,
+            ReplaceMemberBindings(scope=RBACResourceWhitelistScope.ALL),
+        )
+        initialize_rbac_task.delay.assert_called_once_with(tenant_id, user.id, dataset_id=created_dataset.id)
 
 
 class TestDocumentApi:

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -281,6 +281,46 @@ class TestResourceAccessScopeBindings:
 
         mock_sync_task.delay.assert_called_once_with("tenant-1", "acct-actor", "app-1")
 
+    def test_dataset_whitelist_all_schedules_member_policy_sync(self, app):
+        # Widening a dataset to the whole workspace only records the scope; without granting the
+        # default policy to the current members nobody actually gains access.
+        with (
+            app.test_request_context(
+                "/workspaces/current/rbac/datasets/dataset-1/whitelist",
+                method="PUT",
+                json={"scope": "all"},
+            ),
+            patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-actor")),
+            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", True),
+            patch(
+                "controllers.console.workspace.rbac.svc.RBACService.DatasetAccess.replace_whitelist",
+                return_value=rbac_mod.svc.ResourceWhitelist(),
+            ),
+            patch("controllers.console.workspace.rbac.initialize_created_app_rbac_access_task") as mock_sync_task,
+        ):
+            inspect.unwrap(rbac_mod.RBACDatasetWhitelistApi.put)(rbac_mod.RBACDatasetWhitelistApi(), "dataset-1")
+
+        mock_sync_task.delay.assert_called_once_with("tenant-1", "acct-actor", dataset_id="dataset-1")
+
+    def test_dataset_whitelist_specific_does_not_schedule_member_policy_sync(self, app):
+        with (
+            app.test_request_context(
+                "/workspaces/current/rbac/datasets/dataset-1/whitelist",
+                method="PUT",
+                json={"scope": "specific"},
+            ),
+            patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-actor")),
+            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", True),
+            patch(
+                "controllers.console.workspace.rbac.svc.RBACService.DatasetAccess.replace_whitelist",
+                return_value=rbac_mod.svc.ResourceWhitelist(),
+            ),
+            patch("controllers.console.workspace.rbac.initialize_created_app_rbac_access_task") as mock_sync_task,
+        ):
+            inspect.unwrap(rbac_mod.RBACDatasetWhitelistApi.put)(rbac_mod.RBACDatasetWhitelistApi(), "dataset-1")
+
+        mock_sync_task.delay.assert_not_called()
+
     def test_app_user_access_policy_assignment_forwards_ids(self, app):
         with (
             app.test_request_context(


### PR DESCRIPTION
## Summary

Backport of #40599 and #39735 to `release/e-1.16.1`. Both fix the same class of RBAC gap: a dataset ends up visible to the whole workspace on paper, but the members never receive the access policy that actually lets them reach it.

- **#40599** — `DatasetInitApi` (create a dataset *with* documents) never ran the RBAC bootstrap that the empty-dataset path runs. The created dataset now gets `ALL_TEAM` permission when RBAC is enabled (`ONLY_ME` otherwise), its whitelist is replaced with `scope=ALL`, and `initialize_created_app_rbac_access_task` is dispatched to grant the member policies.
- **#39735** — `RBACDatasetWhitelistApi.put` recorded a widened scope but stopped there. When RBAC is enabled and the scope is set to `ALL`, it now dispatches the same task, matching what the app whitelist route on this branch already does.

Together these mean a dataset created with documents, or later opened to the workspace, no longer requires adding members one at a time.

Cherry-picked in merge order (#40599 then #39735 — they are consecutive commits on `main`).

### Backport notes

- **`api/controllers/console/datasets/datasets_document.py`** — the upstream change uses `dify_config.RBAC_ENABLED`, but on `main` that module already imported `dify_config` for several other call sites that do not exist on this branch. Cherry-picking applied the usage without the import, which would have raised `NameError` when the endpoint was hit with RBAC enabled. `from configs import dify_config` was added, and folded into the #40599 commit so that commit stands on its own.
- **`api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py`** — the import hunk conflicted. Only `services.enterprise.rbac_service` was taken; the conflict also offered `services.dataset_ref_service` and `services.vector_space_admission_service`, which are unchanged context on `main` unrelated to #40599 (and `vector_space_admission_service` does not exist on this branch at all).
- `api/controllers/console/workspace/rbac.py` applied cleanly; `dify_config`, `RBACResourceWhitelistScope`, and `initialize_created_app_rbac_access_task` were already imported there.

## Screenshots

| Before | After |
|--------|-------|
| Dataset created with documents defaults to specified-members only; widening to all members lists nobody, so members must be added by hand | Dataset created with documents defaults to all team members with policies granted; widening an existing dataset to all members grants them too |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] Backend checks run on the changed files: `ruff format --check`, `ruff check`, and `mypy` all clean. `api/tests/unit_tests/controllers/console` passes (1811 tests). No frontend changes.
