### PR TITLE
refactor(ui): adopt icon button in close controls

### DIFF
--- a/packages/dify-ui/README.md
+++ b/packages/dify-ui/README.md
@@ -107,6 +107,10 @@ Every icon button must have an `aria-label` or `aria-labelledby`; a tooltip is o
 
 `IconButton` preserves Base UI Button's `render`, `nativeButton`, event, and ref composition.
 
+Do not layer `IconButton` over compound controls that already own button behavior and a specialized recipe, such as Number Field increment/decrement, Combobox clear, or Pagination navigation. Those controls keep their Base UI owner and domain-specific styling.
+
+Dify-authored icon-only compound parts, such as dialog, drawer, and toast close controls, also keep their own Base UI semantic part. They reuse the private icon-button visual recipe directly instead of rendering the public `IconButton` component, so dependency direction and DOM ownership stay unchanged.
+
 ## Segmented control contract
 
 `SegmentedControl` is Dify's design-system primitive for mode, filter, and view selection. It is built on Base UI `ToggleGroup` + `Toggle`, so use `Tabs` instead when the UI needs `tablist` / `tabpanel` semantics.

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -3,6 +3,7 @@
 import type * as React from 'react'
 import { Dialog as BaseDialog } from '@base-ui/react/dialog'
 import { cn } from '../cn'
+import { iconButtonVariants } from '../icon-button/variants'
 import { modalBackdropClassName, modalPopupAnimationClassName } from '../overlay-shared'
 
 const Dialog = BaseDialog.Root
@@ -66,11 +67,12 @@ function DialogCloseButton({
       aria-label={ariaLabel}
       {...props}
       className={cn(
-        'absolute inset-e-6 top-6 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-2xl hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+        iconButtonVariants({ size: 'sm' }),
+        'absolute inset-e-6 top-6 z-10 rounded-2xl disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
     >
-      <span aria-hidden="true" className="i-ri-close-line h-4 w-4 text-text-tertiary" />
+      <span aria-hidden="true" className="i-ri-close-line size-4 text-text-tertiary" />
     </BaseDialog.Close>
   )
 }

--- a/packages/dify-ui/src/drawer/index.tsx
+++ b/packages/dify-ui/src/drawer/index.tsx
@@ -3,6 +3,7 @@
 import type * as React from 'react'
 import { Drawer as BaseDrawer } from '@base-ui/react/drawer'
 import { cn } from '../cn'
+import { iconButtonVariants } from '../icon-button/variants'
 
 const Drawer = BaseDrawer.Root
 const DrawerProvider = BaseDrawer.Provider
@@ -119,12 +120,13 @@ function DrawerCloseButton({
       type={type}
       aria-label={ariaLabel}
       className={cn(
-        'flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg text-text-tertiary outline-hidden hover:bg-state-base-hover hover:text-text-secondary focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid disabled:cursor-not-allowed disabled:opacity-50',
+        iconButtonVariants({ size: 'lg' }),
+        'focus-visible:bg-state-base-hover disabled:cursor-not-allowed disabled:opacity-50 data-disabled:text-text-tertiary',
         className,
       )}
       {...props}
     >
-      {children ?? <span aria-hidden="true" className="i-ri-close-line h-4 w-4" />}
+      {children ?? <span aria-hidden="true" className="i-ri-close-line size-4" />}
     </BaseDrawer.Close>
   )
 }

--- a/packages/dify-ui/src/kbd/index.stories.tsx
+++ b/packages/dify-ui/src/kbd/index.stories.tsx
@@ -9,6 +9,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '../context-menu'
+import { IconButton } from '../icon-button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../tooltip'
 
 const meta = {
@@ -169,13 +170,9 @@ export const InTooltip: Story = {
     <Tooltip open>
       <TooltipTrigger
         render={
-          <button
-            type="button"
-            aria-label="Collapse sidebar"
-            className="inline-flex size-8 items-center justify-center rounded-lg border border-divider-subtle bg-components-button-secondary-bg text-text-secondary shadow-xs focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
-          >
+          <IconButton aria-label="Collapse sidebar" size="lg" variant="secondary">
             <span aria-hidden className="i-ri-sidebar-fold-line size-4" />
-          </button>
+          </IconButton>
         }
       />
       <TooltipContent className="flex items-center gap-1">

--- a/packages/dify-ui/src/toast/index.tsx
+++ b/packages/dify-ui/src/toast/index.tsx
@@ -9,6 +9,7 @@ import type {
 import type * as React from 'react'
 import { Toast as BaseToast } from '@base-ui/react/toast'
 import { cn } from '../cn'
+import { iconButtonVariants } from '../icon-button/variants'
 
 type ToastData = Record<string, never>
 type ToastToneStyle = {
@@ -234,10 +235,11 @@ function ToastCard({ toast: toastItem }: { toast: ToastObject<ToastData> }) {
             <BaseToast.Close
               aria-label={toastCloseLabel}
               className={cn(
-                'flex h-5 w-5 items-center justify-center rounded-md hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+                iconButtonVariants({ size: 'sm' }),
+                'focus-visible:bg-state-base-hover disabled:cursor-not-allowed disabled:opacity-50',
               )}
             >
-              <span aria-hidden="true" className="i-ri-close-line h-4 w-4 text-text-tertiary" />
+              <span aria-hidden="true" className="i-ri-close-line size-4 text-text-tertiary" />
             </BaseToast.Close>
           </div>
         </BaseToast.Content>

--- a/packages/dify-ui/src/tooltip/index.stories.tsx
+++ b/packages/dify-ui/src/tooltip/index.stories.tsx
@@ -2,9 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { TooltipContentProps } from '.'
 import * as React from 'react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '.'
+import { IconButton as DifyIconButton } from '../icon-button'
 
-const iconButtonClassName =
-  'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-divider-subtle bg-components-button-secondary-bg text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 const triggerButtonClassName =
   'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 
@@ -56,9 +55,9 @@ export const IconButton: Story = {
         <Tooltip key={label}>
           <TooltipTrigger
             render={
-              <button type="button" aria-label={label} className={iconButtonClassName}>
-                <span aria-hidden className={`${icon} h-4 w-4`} />
-              </button>
+              <DifyIconButton aria-label={label} size="lg" variant="secondary">
+                <span aria-hidden className={`${icon} size-4`} />
+              </DifyIconButton>
             }
           />
           <TooltipContent>{label}</TooltipContent>
@@ -130,9 +129,9 @@ const PlacementsDemo = () => {
       <Tooltip open>
         <TooltipTrigger
           render={
-            <button type="button" aria-label="Placement anchor" className={iconButtonClassName}>
-              <span aria-hidden className="i-ri-pushpin-line h-4 w-4" />
-            </button>
+            <DifyIconButton aria-label="Placement anchor" size="lg" variant="secondary">
+              <span aria-hidden className="i-ri-pushpin-line size-4" />
+            </DifyIconButton>
           }
         />
         <TooltipContent placement={placement}>{`placement="${placement}"`}</TooltipContent>
@@ -167,13 +166,9 @@ const DelayDemo = () => (
         <Tooltip>
           <TooltipTrigger
             render={
-              <button
-                type="button"
-                aria-label={`${label} (${delay}ms)`}
-                className={iconButtonClassName}
-              >
-                <span aria-hidden className="i-ri-timer-line h-4 w-4" />
-              </button>
+              <DifyIconButton aria-label={`${label} (${delay}ms)`} size="lg" variant="secondary">
+                <span aria-hidden className="i-ri-timer-line size-4" />
+              </DifyIconButton>
             }
           />
           <TooltipContent>{`${label} (${delay}ms)`}</TooltipContent>


### PR DESCRIPTION
## Summary

- Reuse the private IconButton visual recipe for Dialog, Drawer, and Toast close parts.
- Keep each overlay primitive as the semantic owner instead of making overlays depend on the public IconButton component.
- Preserve existing close-control geometry and colors while adding the shared focus-visible treatment.

## Verification

- Dify UI type check
- Dify UI unit tests
- Dify UI Storybook tests

Depends on #40616
Stack: 2/13

From Codex