### PR TITLE
fix(dify-agent): clarify shell working spaces

### DIFF
--- a/dify-agent/src/dify_agent/layers/shell/layer.py
+++ b/dify-agent/src/dify_agent/layers/shell/layer.py
@@ -265,8 +265,7 @@ class DifyShellLayer(PydanticAILayer[DifyShellLayerDeps, object, DifyShellLayerC
     def _build_prefix_prompt(self) -> str:
         execution_context = self.deps.execution_context
         is_build_draft = (
-            execution_context is not None
-            and execution_context.config.agent_config_version_kind == "build_draft"
+            execution_context is not None and execution_context.config.agent_config_version_kind == "build_draft"
         )
         working_location_prompt = (
             _BUILD_DRAFT_WORKING_LOCATION_PROMPT if is_build_draft else _DEFAULT_WORKING_LOCATION_PROMPT

--- a/dify-agent/src/dify_agent/layers/shell/layer.py
+++ b/dify-agent/src/dify_agent/layers/shell/layer.py
@@ -106,13 +106,11 @@ Installed CLI:
 - Use the generated `dify-agent ... --help` output in the config prompt for exact command syntax.
 - Do not install or recreate the `dify-agent` CLI.
 
-Workspace persistence rules:
+Filesystem spaces:
 
-- The current workspace cwd is stable across runs for the current product session.
-- Workspace files are working data, not Agent configuration, and are removed when that product session ends.
-- In build mode, config changes persist only after you run the matching `dify-agent config ...` mutation command.
-- Shell file edits alone do not save Agent config files, skills, env, or notes.
-- In non-build modes, local shell changes are not a persistence mechanism for Agent configuration.
+- `$HOME` is the system space.
+- The current working directory (`cwd`) is the temporary working space. Relative paths resolve from here.
+- Store temporary files under `<cwd>/.tmp` (normally `./.tmp`). Do not use `/tmp`.
 
 shell_run script rules:
 
@@ -153,6 +151,14 @@ from rich import print
 response = httpx.get("https://example.com", timeout=10)
 print(f"[green]status:[/green] {response.status_code}")
 [end script]"""
+_BUILD_DRAFT_WORKING_LOCATION_PROMPT = """Working location:
+
+- Prefer `$HOME` for work and changes intended for the system space.
+- Use `cwd` for scratch files, intermediate results, and other temporary work."""
+_DEFAULT_WORKING_LOCATION_PROMPT = """Working location:
+
+- Prefer `cwd` for your work.
+- Changes in `$HOME` or `cwd` do not update the saved Agent state."""
 _SHELL_LAYER_SUFFIX_PROMPT = """Environment variables may contain API keys, tokens, or credentials.
 You may refer to environment variable names when needed."""
 
@@ -239,7 +245,7 @@ class DifyShellLayer(PydanticAILayer[DifyShellLayerDeps, object, DifyShellLayerC
     @property
     @override
     def prefix_prompts(self) -> Sequence[PydanticAIPrompt[object]]:
-        return [_shell_layer_prefix_prompt]
+        return [self._build_prefix_prompt]
 
     @property
     @override
@@ -255,6 +261,17 @@ class DifyShellLayer(PydanticAILayer[DifyShellLayerDeps, object, DifyShellLayerC
             Tool(self._tool_input, name="shell_input"),
             Tool(self._tool_interrupt, name="shell_interrupt"),
         ]
+
+    def _build_prefix_prompt(self) -> str:
+        execution_context = self.deps.execution_context
+        is_build_draft = (
+            execution_context is not None
+            and execution_context.config.agent_config_version_kind == "build_draft"
+        )
+        working_location_prompt = (
+            _BUILD_DRAFT_WORKING_LOCATION_PROMPT if is_build_draft else _DEFAULT_WORKING_LOCATION_PROMPT
+        )
+        return f"{_SHELL_LAYER_PREFIX_PROMPT}\n\n{working_location_prompt}"
 
     @override
     async def on_context_create(self) -> None:
@@ -574,10 +591,6 @@ async def render_prompt_observation_from_result(
         truncated_in_middle=result.truncated or output_exceeds_edge_budget,
     )
     return ShellPromptObservation(text=text, output_path=output_path, offset=offset)
-
-
-def _shell_layer_prefix_prompt() -> str:
-    return _SHELL_LAYER_PREFIX_PROMPT
 
 
 def _shell_layer_suffix_prompt() -> str:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Describe `$HOME` as the system space and the current working directory as the temporary working space in the Shell system prompt.
- Direct temporary files to `<cwd>/.tmp` instead of `/tmp`.
- Prefer `$HOME` for build-draft work intended for the system space, while keeping scratch and intermediate data in `cwd`.
- Prefer `cwd` in other modes and clarify that changes in either location do not update the saved Agent state.

Issue: N/A — scoped Dify Agent system-prompt clarification.

## Impact

Agents receive explicit, mode-aware guidance about where to place system changes, ordinary work, and temporary files. The prompt no longer exposes internal resource-lifecycle concepts when explaining these spaces.

Runtime paths, filesystem lifecycle, Shell tool behavior, saved Agent state, and public protocol contracts are unchanged.

## Validation

- Existing Shell layer tests: 34 passed.
- Ruff check for the modified Shell layer: passed.
- Changed-file basedpyright: 0 errors, 0 warnings, and 0 notes.
- `git diff --check`: passed.

## Screenshots

N/A — system-prompt wording only.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

****This PR is made with gpt-5.6-sol (codex), while I'm responsible for all the changes.****