### PR TITLE
test: migrate residual user ORM stand-ins to real models

### DIFF
--- a/api/tests/unit_tests/controllers/console/workspace/test_plugin.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_plugin.py
@@ -1428,7 +1428,7 @@ class TestPluginChangeAutoUpgradeApi:
         api = PluginChangeAutoUpgradeApi()
         method = unwrap(api.post)
 
-        user = MagicMock(is_admin_or_owner=True)
+        user = _account()
 
         payload = {
             "category": TenantPluginAutoUpgradeCategory.TOOL.value,

--- a/api/tests/unit_tests/controllers/console/workspace/test_plugin.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_plugin.py
@@ -77,6 +77,7 @@ from models.account import (
     TenantAccountRole,
     TenantPluginAutoUpgradeCategory,
     TenantPluginAutoUpgradeMode,
+    TenantPluginAutoUpgradeStrategy,
     TenantPluginAutoUpgradeStrategySetting,
     TenantPluginDebugPermission,
     TenantPluginInstallPermission,
@@ -1455,7 +1456,8 @@ class TestPluginFetchAutoUpgradeApi:
         api = PluginFetchAutoUpgradeApi()
         method = unwrap(api.get)
 
-        auto_upgrade = MagicMock(
+        auto_upgrade = TenantPluginAutoUpgradeStrategy(
+            tenant_id="t1",
             category=TenantPluginAutoUpgradeCategory.TOOL,
             strategy_setting=TenantPluginAutoUpgradeStrategySetting.FIX_ONLY,
             upgrade_time_of_day=1,

--- a/api/tests/unit_tests/core/datasource/test_file_upload.py
+++ b/api/tests/unit_tests/core/datasource/test_file_upload.py
@@ -120,7 +120,6 @@ Run with coverage: pytest api/tests/unit_tests/core/datasource/test_file_upload.
 import hashlib  # For SHA3-256 hashing of file content
 import os  # For file path operations
 import uuid  # For generating unique identifiers
-from unittest.mock import Mock  # For mocking dependencies
 
 # Third-party imports
 import pytest  # Testing framework
@@ -686,12 +685,11 @@ class TestUserRoleHandling:
     def test_creator_role_detection_account(self):
         """Test creator role detection for Account user."""
         # Arrange
-        user = Mock()
-        user.__class__.__name__ = "Account"
-
-        # Act
         from models import Account
 
+        user = Account(name="Test User", email="user@example.com")
+
+        # Act
         is_account = isinstance(user, Account) or user.__class__.__name__ == "Account"
         role = CreatorUserRole.ACCOUNT if is_account else CreatorUserRole.END_USER
 
@@ -701,12 +699,17 @@ class TestUserRoleHandling:
     def test_creator_role_detection_end_user(self):
         """Test creator role detection for EndUser."""
         # Arrange
-        user = Mock()
-        user.__class__.__name__ = "EndUser"
+        from models import Account, EndUser
+        from models.model import EndUserType
+
+        user = EndUser(
+            tenant_id="tenant-1",
+            app_id="app-1",
+            type=EndUserType.SERVICE_API,
+            session_id="session-1",
+        )
 
         # Act
-        from models import Account
-
         is_account = isinstance(user, Account) or user.__class__.__name__ == "Account"
         role = CreatorUserRole.ACCOUNT if is_account else CreatorUserRole.END_USER
 

--- a/api/tests/unit_tests/services/test_datasource_provider_service.py
+++ b/api/tests/unit_tests/services/test_datasource_provider_service.py
@@ -143,9 +143,9 @@ class TestDatasourceProviderService:
 
     @pytest.fixture
     def mock_user(self):
-        u = MagicMock()
-        u.id = "uid-1"
-        return u
+        user = Account(name="Test User", email="user@example.com")
+        user.id = "uid-1"
+        return user
 
     # -----------------------------------------------------------------------
     # get_current_user (lines 27-40)
@@ -153,24 +153,26 @@ class TestDatasourceProviderService:
 
     def test_should_return_proxy_when_current_object_is_account(self):
         with patch("libs.login.current_user", new_callable=MagicMock) as proxy:
-            user_obj = MagicMock()
-            user_obj.__class__ = Account
+            user_obj = Account(name="Test User", email="user@example.com")
             proxy._get_current_object.return_value = user_obj
             assert get_current_user() is proxy
 
     def test_should_return_proxy_when_current_object_is_enduser(self):
         with patch("libs.login.current_user", new_callable=MagicMock) as proxy:
-            user_obj = MagicMock()
-            user_obj.__class__ = EndUser
+            user_obj = EndUser(
+                tenant_id="tenant-1",
+                app_id="app-1",
+                type="service-api",
+                session_id="session-1",
+            )
             proxy._get_current_object.return_value = user_obj
             assert get_current_user() is proxy
 
     def test_should_return_proxy_when_get_current_object_raises_attribute_error(self):
         """AttributeError from LocalProxy falls back to the proxy itself."""
-        with patch("libs.login.current_user", new_callable=MagicMock) as proxy:
-            proxy._get_current_object.side_effect = AttributeError("no attr")
-            proxy.__class__ = Account  # make the proxy itself satisfy isinstance
-            assert get_current_user() is proxy
+        account = Account(name="Test User", email="user@example.com")
+        with patch("libs.login.current_user", account):
+            assert get_current_user() is account
 
     def test_should_raise_type_error_when_user_is_not_account_or_enduser(self):
         with patch("libs.login.current_user", new_callable=MagicMock) as proxy:

--- a/api/tests/unit_tests/services/test_workflow_collaboration_service.py
+++ b/api/tests/unit_tests/services/test_workflow_collaboration_service.py
@@ -8,6 +8,7 @@ from socketio.exceptions import TimeoutError as SocketIOTimeoutError
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 
+from models.account import Account, Tenant
 from models.base import TypeBase
 from models.model import App, AppMode, IconType
 from repositories.workflow_collaboration_repository import WorkflowCollaborationRepository
@@ -130,11 +131,12 @@ class TestWorkflowCollaborationService:
 
     def test_repr_and_save_socket_identity(self, service: tuple[WorkflowCollaborationService, Mock, Mock]) -> None:
         collaboration_service, _repository, socketio = service
-        user = Mock()
+        user = Account(name="Jane", email="jane@example.com")
         user.id = "u-1"
-        user.name = "Jane"
         user.avatar = "avatar.png"
-        user.current_tenant_id = "t-1"
+        tenant = Tenant(name="Tenant")
+        tenant.id = "t-1"
+        user._current_tenant = tenant
 
         assert "WorkflowCollaborationService" in repr(collaboration_service)
 

--- a/api/tests/unit_tests/services/tools/test_mcp_tools_transform.py
+++ b/api/tests/unit_tests/services/tools/test_mcp_tools_transform.py
@@ -9,16 +9,15 @@ from core.mcp.types import Tool as MCPTool
 from core.tools.entities.api_entities import ToolApiEntity, ToolProviderApiEntity
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_entities import ToolParameter, ToolProviderType
+from models.account import Account
 from models.tools import MCPToolProvider
 from services.tools.tools_transform_service import ToolTransformService
 
 
 @pytest.fixture
 def mock_user():
-    """Provides a mock user object."""
-    user = Mock()
-    user.name = "Test User"
-    return user
+    """Provides a real mapped account returned by the provider lookup."""
+    return Account(name="Test User", email="user@example.com")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- replace remaining Account and EndUser stand-ins in plugin, datasource, collaboration, and MCP transform tests with mapped model instances
- replace the plugin auto-upgrade service result with a real `TenantPluginAutoUpgradeStrategy`
- exercise role and strategy serialization through actual mapped classes
- retain mocks for login proxies, sockets, plugin clients, and other non-ORM collaborators

## Model coverage

- validates Account and EndUser identity/type branching with real mapped classes
- supplies real Account tenant context to workflow collaboration serialization
- uses a real transient plugin strategy for the pure response-serialization path

## Scope

- 5 test files
- 37 additions, 29 deletions (66 changed lines)
- no production changes

## Validation

- targeted affected modules — 327 passed
- focused plugin auto-upgrade controller class — 2 passed
- focused mapped-user/strategy stand-in audit passed
- `make lint` passed
- `make type-check` reached the existing mypy 1.20.2 internal error at `typeshed/stdlib/zipimport.pyi:17`
- full test suite not run, per request
