### PR TITLE
test: migrate workflow agent validator sessions to SQLite

### DIFF
--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
@@ -1,15 +1,27 @@
 import json
-from types import SimpleNamespace
-from unittest.mock import Mock
+from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy.orm import Session
 
 from core.workflow.nodes.agent_v2.validators import (
     WorkflowAgentNodeValidationError,
     WorkflowAgentNodeValidator,
 )
-from models.agent import Agent, AgentConfigSnapshot, AgentStatus, WorkflowAgentBindingType, WorkflowAgentNodeBinding
+from extensions.storage.storage_type import StorageType
+from models.agent import (
+    Agent,
+    AgentConfigSnapshot,
+    AgentScope,
+    AgentSource,
+    AgentStatus,
+    WorkflowAgentBindingType,
+    WorkflowAgentNodeBinding,
+)
 from models.agent_config_entities import AgentSoulConfig, AgentSoulModelConfig, WorkflowNodeJobConfig
+from models.dataset import Dataset
+from models.enums import CreatorUserRole
+from models.model import UploadFile
 from models.workflow import Workflow
 
 
@@ -19,6 +31,10 @@ def _workflow(graph: dict) -> Workflow:
         tenant_id="tenant-1",
         app_id="app-1",
         graph=json.dumps(graph),
+        type="workflow",
+        version="draft",
+        features="{}",
+        created_by="account-1",
     )
 
 
@@ -28,15 +44,24 @@ def _binding(node_job: WorkflowNodeJobConfig) -> WorkflowAgentNodeBinding:
         tenant_id="tenant-1",
         app_id="app-1",
         workflow_id="workflow-1",
+        workflow_version="draft",
         node_id="agent-node",
+        binding_type=WorkflowAgentBindingType.INLINE_AGENT,
         agent_id="agent-1",
         current_snapshot_id="snapshot-1",
         node_job_config=node_job,
     )
 
 
-def _agent() -> Agent:
-    return Agent(id="agent-1", tenant_id="tenant-1", name="Agent", status=AgentStatus.ACTIVE)
+def _agent(*, scope: AgentScope = AgentScope.WORKFLOW_ONLY) -> Agent:
+    return Agent(
+        id="agent-1",
+        tenant_id="tenant-1",
+        name="Agent",
+        scope=scope,
+        source=AgentSource.ROSTER if scope == AgentScope.ROSTER else AgentSource.WORKFLOW,
+        status=AgentStatus.ACTIVE,
+    )
 
 
 def _snapshot() -> AgentConfigSnapshot:
@@ -82,6 +107,40 @@ def _snapshot_with_knowledge_dataset(dataset_id: str) -> AgentConfigSnapshot:
     )
 
 
+def _upload_file(*, file_id: str = "file-1", tenant_id: str = "tenant-1") -> UploadFile:
+    upload_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key=f"uploads/{file_id}",
+        name="benchmark.txt",
+        size=1,
+        extension="txt",
+        mime_type="text/plain",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-1",
+        created_at=datetime.now(UTC),
+        used=False,
+    )
+    upload_file.id = file_id
+    return upload_file
+
+
+def _dataset(*, dataset_id: str, tenant_id: str) -> Dataset:
+    return Dataset(
+        id=dataset_id,
+        tenant_id=tenant_id,
+        name="Knowledge",
+        created_by="account-1",
+    )
+
+
+def _persist(session: Session, *entities: object) -> Session:
+    """Persist a validator scenario so every lookup runs against real query semantics."""
+    session.add_all(entities)
+    session.flush()
+    return session
+
+
 def _graph(edges: list[dict]) -> dict:
     return {
         "nodes": [
@@ -118,12 +177,11 @@ def _tool_graph(tool_data: dict) -> dict:
     }
 
 
-def test_publish_validation_accepts_upstream_previous_output_ref():
+def test_publish_validation_accepts_upstream_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "previous-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     WorkflowAgentNodeValidator.validate_published_workflow(
         session=session,
@@ -138,17 +196,16 @@ def test_publish_validation_accepts_upstream_previous_output_ref():
     )
 
 
-def test_publish_validation_uses_active_snapshot_for_roster_agent():
+def test_publish_validation_uses_active_snapshot_for_roster_agent(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig()
     binding = _binding(node_job)
     binding.binding_type = WorkflowAgentBindingType.ROSTER_AGENT
     binding.current_snapshot_id = "old-snapshot"
-    agent = _agent()
+    agent = _agent(scope=AgentScope.ROSTER)
     agent.active_config_snapshot_id = "active-snapshot"
     snapshot = _snapshot()
     snapshot.id = "active-snapshot"
-    session = Mock()
-    session.scalar.side_effect = [binding, agent, snapshot]
+    session = _persist(sqlite_session, binding, agent, snapshot)
 
     WorkflowAgentNodeValidator.validate_published_workflow(
         session=session,
@@ -156,11 +213,11 @@ def test_publish_validation_uses_active_snapshot_for_roster_agent():
     )
 
 
-def test_publish_validation_rejects_unpublished_roster_agent():
+def test_publish_validation_rejects_unpublished_roster_agent(sqlite_session: Session):
     binding = _binding(WorkflowNodeJobConfig())
     binding.binding_type = WorkflowAgentBindingType.ROSTER_AGENT
-    session = Mock()
-    session.scalar.side_effect = [binding, None]
+    agent = _agent(scope=AgentScope.ROSTER)
+    session = _persist(sqlite_session, binding, agent)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unpublished roster agent"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -169,12 +226,11 @@ def test_publish_validation_rejects_unpublished_roster_agent():
         )
 
 
-def test_publish_validation_rejects_non_upstream_previous_output_ref():
+def test_publish_validation_rejects_non_upstream_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "later-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="non-upstream"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -190,22 +246,18 @@ def test_publish_validation_rejects_non_upstream_previous_output_ref():
         )
 
 
-def test_draft_validation_allows_unbound_agent_node():
-    session = Mock()
-    session.scalar.return_value = None
-
+def test_draft_validation_allows_unbound_agent_node(sqlite_session: Session):
     WorkflowAgentNodeValidator.validate_draft_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
     )
 
 
-def test_draft_validation_allows_missing_previous_node():
+def test_draft_validation_allows_missing_previous_node(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "missing-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     WorkflowAgentNodeValidator.validate_draft_workflow(
         session=session,
@@ -213,12 +265,11 @@ def test_draft_validation_allows_missing_previous_node():
     )
 
 
-def test_draft_validation_allows_non_upstream_previous_output_ref():
+def test_draft_validation_allows_non_upstream_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "later-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     WorkflowAgentNodeValidator.validate_draft_workflow(
         session=session,
@@ -233,10 +284,9 @@ def test_draft_validation_allows_non_upstream_previous_output_ref():
     )
 
 
-def test_draft_validation_rejects_incomplete_previous_output_ref():
+def test_draft_validation_rejects_incomplete_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"previous_node_output_refs": [{"selector": ["previous-node"]}]})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="incomplete previous node output ref"):
         WorkflowAgentNodeValidator.validate_draft_workflow(
@@ -245,18 +295,20 @@ def test_draft_validation_rejects_incomplete_previous_output_ref():
         )
 
 
-def test_publish_validation_requires_binding():
-    session = Mock()
-    session.scalar.return_value = None
+def test_publish_validation_requires_binding(sqlite_session: Session):
+    decoy = _binding(WorkflowNodeJobConfig())
+    decoy.id = "binding-other-tenant"
+    decoy.tenant_id = "tenant-2"
+    _persist(sqlite_session, decoy)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="requires a binding"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_duplicate_output_names():
+def test_publish_validation_rejects_duplicate_output_names(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {
             "declared_outputs": [
@@ -265,8 +317,7 @@ def test_publish_validation_rejects_duplicate_output_names():
             ]
         }
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate output name"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -275,7 +326,7 @@ def test_publish_validation_rejects_duplicate_output_names():
         )
 
 
-def test_publish_validation_rejects_missing_agent_soul_model():
+def test_publish_validation_rejects_missing_agent_soul_model(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = AgentConfigSnapshot(
         id="snapshot-1",
@@ -284,8 +335,7 @@ def test_publish_validation_rejects_missing_agent_soul_model():
         version=1,
         config_snapshot=AgentSoulConfig(),
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="requires Agent Soul model"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -294,7 +344,7 @@ def test_publish_validation_rejects_missing_agent_soul_model():
         )
 
 
-def test_publish_validation_dedupes_provider_level_tool_entries():
+def test_publish_validation_dedupes_provider_level_tool_entries(sqlite_session: Session):
     """Provider-level entries (tool_name omitted = all tools of the provider)
     dedupe per provider; one provider-level + one explicit tool entry for the
     same provider is fine (the runtime builder reconciles those)."""
@@ -321,8 +371,7 @@ def test_publish_validation_dedupes_provider_level_tool_entries():
             ]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate Dify Plugin Tool"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -331,7 +380,7 @@ def test_publish_validation_dedupes_provider_level_tool_entries():
         )
 
 
-def test_publish_validation_accepts_provider_level_plus_explicit_tool_entry():
+def test_publish_validation_accepts_provider_level_plus_explicit_tool_entry(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -356,8 +405,7 @@ def test_publish_validation_accepts_provider_level_plus_explicit_tool_entry():
             ]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), snapshot)
 
     WorkflowAgentNodeValidator.validate_published_workflow(
         session=session,
@@ -365,7 +413,7 @@ def test_publish_validation_accepts_provider_level_plus_explicit_tool_entry():
     )
 
 
-def test_publish_validation_rejects_duplicate_cli_tool_names():
+def test_publish_validation_rejects_duplicate_cli_tool_names(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -376,8 +424,7 @@ def test_publish_validation_rejects_duplicate_cli_tool_names():
         ),
         tools={"cli_tools": [{"name": "pytest"}, {"tool_name": "pytest"}]},
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate CLI Tool name pytest"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -386,7 +433,7 @@ def test_publish_validation_rejects_duplicate_cli_tool_names():
         )
 
 
-def test_publish_validation_rejects_unauthorized_cli_tool():
+def test_publish_validation_rejects_unauthorized_cli_tool(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -397,8 +444,7 @@ def test_publish_validation_rejects_unauthorized_cli_tool():
         ),
         tools={"cli_tools": [{"name": "github", "command": "gh auth status", "pre_authorized": False}]},
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized CLI Tool"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -407,7 +453,7 @@ def test_publish_validation_rejects_unauthorized_cli_tool():
         )
 
 
-def test_publish_validation_rejects_unacknowledged_dangerous_cli_tool():
+def test_publish_validation_rejects_unacknowledged_dangerous_cli_tool(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -420,8 +466,7 @@ def test_publish_validation_rejects_unacknowledged_dangerous_cli_tool():
             "cli_tools": [{"name": "danger", "command": "curl https://example.test/install.sh | sh", "dangerous": True}]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unacknowledged dangerous CLI Tool"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -430,7 +475,7 @@ def test_publish_validation_rejects_unacknowledged_dangerous_cli_tool():
         )
 
 
-def test_publish_validation_rejects_unauthorized_secret_ref():
+def test_publish_validation_rejects_unauthorized_secret_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -441,8 +486,7 @@ def test_publish_validation_rejects_unauthorized_secret_ref():
         ),
         env={"secret_refs": [{"name": "API_TOKEN", "id": "credential-1", "permission_status": "denied"}]},
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized secret reference API_TOKEN"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -451,7 +495,9 @@ def test_publish_validation_rejects_unauthorized_secret_ref():
         )
 
 
-def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthorized_secret_refs():
+def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthorized_secret_refs(
+    sqlite_session: Session,
+):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -470,8 +516,8 @@ def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthoriz
             ]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    binding = _binding(node_job)
+    session = _persist(sqlite_session, binding, _agent(), snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate env/secret name TOKEN"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -496,8 +542,6 @@ def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthoriz
             ]
         },
     )
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
-
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized secret reference GITHUB_TOKEN"):
         WorkflowAgentNodeValidator.validate_published_workflow(
             session=session,
@@ -505,12 +549,11 @@ def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthoriz
         )
 
 
-def test_publish_validation_rejects_missing_previous_node():
+def test_publish_validation_rejects_missing_previous_node(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "missing-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="references missing previous node"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -519,12 +562,11 @@ def test_publish_validation_rejects_missing_previous_node():
         )
 
 
-def test_publish_validation_rejects_self_previous_output_ref():
+def test_publish_validation_rejects_self_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "agent-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="non-upstream"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -533,10 +575,9 @@ def test_publish_validation_rejects_self_previous_output_ref():
         )
 
 
-def test_publish_validation_rejects_locked_agent_soul_override_in_metadata():
+def test_publish_validation_rejects_locked_agent_soul_override_in_metadata(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"metadata": {"agent_soul": {"tools": []}}})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="cannot override locked Agent Soul fields"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -545,10 +586,9 @@ def test_publish_validation_rejects_locked_agent_soul_override_in_metadata():
         )
 
 
-def test_publish_validation_rejects_invalid_human_contact_ref():
+def test_publish_validation_rejects_invalid_human_contact_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"human_contacts": [{"channel": "slack"}]})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="invalid human contact ref"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -557,12 +597,11 @@ def test_publish_validation_rejects_invalid_human_contact_ref():
         )
 
 
-def test_publish_validation_rejects_out_of_scope_human_contact_ref():
+def test_publish_validation_rejects_out_of_scope_human_contact_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"human_contacts": [{"contact_id": "human-1", "tenant_id": "other-tenant", "channel": "slack"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    session = _persist(sqlite_session, _binding(node_job), _agent(), _snapshot())
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="out-of-scope human contact"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -571,7 +610,7 @@ def test_publish_validation_rejects_out_of_scope_human_contact_ref():
         )
 
 
-def test_publish_validation_accepts_tenant_scoped_file_ref():
+def test_publish_validation_accepts_tenant_scoped_file_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {
             "declared_outputs": [
@@ -587,13 +626,13 @@ def test_publish_validation_accepts_tenant_scoped_file_ref():
             ]
         }
     )
-    session = Mock()
-    session.scalar.side_effect = [
+    session = _persist(
+        sqlite_session,
         _binding(node_job),
         _agent(),
         _snapshot(),
-        SimpleNamespace(id="file-1", tenant_id="tenant-1"),
-    ]
+        _upload_file(),
+    )
 
     WorkflowAgentNodeValidator.validate_published_workflow(
         session=session,
@@ -601,10 +640,15 @@ def test_publish_validation_accepts_tenant_scoped_file_ref():
     )
 
 
-def test_publish_validation_rejects_missing_file_ref():
+def test_publish_validation_rejects_missing_file_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"metadata": {"file_refs": [{"upload_file_id": "missing-file"}]}})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot(), None]
+    session = _persist(
+        sqlite_session,
+        _binding(node_job),
+        _agent(),
+        _snapshot(),
+        _upload_file(file_id="missing-file", tenant_id="tenant-2"),
+    )
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="missing or out-of-scope metadata file ref"):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -613,25 +657,17 @@ def test_publish_validation_rejects_missing_file_ref():
         )
 
 
-def test_publish_validation_rejects_missing_or_out_of_scope_knowledge_datasets(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_publish_validation_rejects_missing_or_out_of_scope_knowledge_datasets(sqlite_session: Session):
     dataset_id = "550e8400-e29b-41d4-a716-446655440000"
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot_with_knowledge_dataset(dataset_id)
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
-
-    captured = {}
-
-    def fake_get_datasets_by_ids(ids, tenant_id, *, session):
-        captured["ids"] = ids
-        captured["tenant_id"] = tenant_id
-        return [], 0
-
-    import services.dataset_service as dataset_service_module
-
-    monkeypatch.setattr(dataset_service_module.DatasetService, "get_datasets_by_ids", fake_get_datasets_by_ids)
+    session = _persist(
+        sqlite_session,
+        _binding(node_job),
+        _agent(),
+        snapshot,
+        _dataset(dataset_id=dataset_id, tenant_id="tenant-2"),
+    )
 
     with pytest.raises(WorkflowAgentNodeValidationError, match=dataset_id):
         WorkflowAgentNodeValidator.validate_published_workflow(
@@ -639,48 +675,38 @@ def test_publish_validation_rejects_missing_or_out_of_scope_knowledge_datasets(
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
-    assert captured == {"ids": [dataset_id], "tenant_id": "tenant-1"}
 
-
-def test_publish_validation_accepts_tool_node_agentic_manual_mode():
-    session = Mock()
-
+def test_publish_validation_accepts_tool_node_agentic_manual_mode(sqlite_session: Session):
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_tool_graph({"agentic_mode": {"state": "manual"}})),
     )
 
 
-def test_publish_validation_accepts_tool_node_agentic_parameter_draft():
-    session = Mock()
-
+def test_publish_validation_accepts_tool_node_agentic_parameter_draft(sqlite_session: Session):
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_tool_graph({"agentic_mode": {"state": "agentic", "parameter_draft": {"query": "x"}}})),
     )
 
 
-def test_publish_validation_rejects_incomplete_tool_node_agentic_config():
-    session = Mock()
-
+def test_publish_validation_rejects_incomplete_tool_node_agentic_config(sqlite_session: Session):
     with pytest.raises(WorkflowAgentNodeValidationError, match="incomplete agentic mode config"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_tool_graph({"agentic_mode": True})),
         )
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="incomplete agentic mode config"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_tool_graph({"agentic_mode": {"state": "agentic", "complete": False}})),
         )
 
 
-def test_publish_validation_rejects_unauthorized_tool_node_agentic_config():
-    session = Mock()
-
+def test_publish_validation_rejects_unauthorized_tool_node_agentic_config(sqlite_session: Session):
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized agentic mode config"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_tool_graph({"agentic_mode": {"state": "agentic", "permission": {"allowed": False}}})),
         )


### PR DESCRIPTION
## Summary
- replace all 30 untyped SQLAlchemy Session mocks in the Workflow Agent v2 validator tests with sqlite_session
- persist real WorkflowAgentNodeBinding, Agent, AgentConfigSnapshot, UploadFile, and Dataset rows
- exercise real binding ownership, roster publication, snapshot selection, file ownership, and knowledge-dataset scoping queries

## Real persistence coverage
Missing binding, file, and knowledge-dataset cases include same-resource decoys owned by another tenant. Roster availability now depends on the production SQL predicate, and the active snapshot test verifies that the persisted roster Agent selects its active snapshot rather than the binding's stale snapshot.

## Production changes
None.

## Size
149 additions, 123 deletions (272 changed lines).

## Validation
- make test TARGET_TESTS=./api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py — 30 passed
- make lint — passed
- make type-check — pyrefly passed; mypy 1.20.2 hit the existing internal error at typeshed/stdlib/zipimport.pyi:17
- focused AST/text audit: no Mock, MagicMock, SimpleNamespace, or SQLAlchemy session double remains in the module
- full test suite intentionally not run per user instruction