### PR TITLE
test: migrate file controller ORM models to real entities

### DIFF
--- a/api/tests/unit_tests/controllers/files/test_image_preview.py
+++ b/api/tests/unit_tests/controllers/files/test_image_preview.py
@@ -1,4 +1,5 @@
 import types
+from datetime import UTC, datetime
 from inspect import unwrap
 from unittest.mock import patch
 
@@ -6,6 +7,9 @@ import pytest
 from werkzeug.exceptions import NotFound
 
 import controllers.files.image_preview as module
+from extensions.storage.storage_type import StorageType
+from models.enums import CreatorUserRole
+from models.model import UploadFile
 
 
 @pytest.fixture(autouse=True)
@@ -18,12 +22,24 @@ def mock_db():
     module.db = fake_db
 
 
-class DummyUploadFile:
-    def __init__(self, mime_type="text/plain", size=10, name="test.txt", extension="txt"):
-        self.mime_type = mime_type
-        self.size = size
-        self.name = name
-        self.extension = extension
+def _upload_file(
+    *, mime_type: str = "text/plain", size: int = 10, name: str = "test.txt", extension: str = "txt"
+) -> UploadFile:
+    upload_file = UploadFile(
+        tenant_id="tenant-1",
+        storage_type=StorageType.LOCAL,
+        key="uploads/file-id",
+        name=name,
+        size=size,
+        extension=extension,
+        mime_type=mime_type,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-1",
+        created_at=datetime.now(UTC),
+        used=False,
+    )
+    upload_file.id = "file-id"
+    return upload_file
 
 
 def fake_request(args: dict):
@@ -90,7 +106,7 @@ class TestFilePreviewApi:
         )
 
         generator = iter([b"data"])
-        upload_file = DummyUploadFile(
+        upload_file = _upload_file(
             mime_type="application/pdf",
             size=100,
             name="doc.pdf",
@@ -134,7 +150,7 @@ class TestFilePreviewApi:
         )
 
         generator = iter([b"<svg></svg>"])
-        upload_file = DummyUploadFile(
+        upload_file = _upload_file(
             mime_type=mime_type,
             size=11,
             name=name,
@@ -167,7 +183,7 @@ class TestFilePreviewApi:
         )
 
         generator = iter([b"<script>alert(1)</script>"])
-        upload_file = DummyUploadFile(
+        upload_file = _upload_file(
             mime_type="text/html",
             size=25,
             name="unsafe.html",
@@ -201,7 +217,7 @@ class TestFilePreviewApi:
         )
 
         generator = iter([b"data"])
-        upload_file = DummyUploadFile(
+        upload_file = _upload_file(
             mime_type="application/pdf",
             name="doc.pdf",
             extension="pdf",

--- a/api/tests/unit_tests/controllers/files/test_upload.py
+++ b/api/tests/unit_tests/controllers/files/test_upload.py
@@ -12,6 +12,9 @@ import controllers.files.upload as module
 from core.workflow.file_reference import build_file_reference
 from models import Account, TenantAccountJoin
 from models.account import AccountStatus
+from models.enums import EndUserType
+from models.model import EndUser
+from models.tools import ToolFile
 
 
 def fake_request(args: dict, file=None):
@@ -37,9 +40,13 @@ def _persist_account_memberships(session: Session) -> None:
     session.commit()
 
 
-class DummyUser:
-    def __init__(self, user_id="user-1"):
-        self.id = user_id
+def _end_user(user_id: str = "user-1") -> EndUser:
+    return EndUser(
+        id=user_id,
+        tenant_id="tenant-1",
+        type=EndUserType.SERVICE_API,
+        session_id="session-1",
+    )
 
 
 class DummyFile:
@@ -63,22 +70,24 @@ class RecordingStream(io.BytesIO):
         return super().read(*args, **kwargs)
 
 
-class DummyToolFile:
-    def __init__(self, name="test.txt", mimetype="text/plain"):
-        self.id = "file-id"
-        self.name = name
-        self.size = 10
-        self.mimetype = mimetype
-        self.original_url = "http://original"
-        self.user_id = "user-1"
-        self.tenant_id = "tenant-1"
-        self.conversation_id = None
-        self.file_key = "file-key"
+def _tool_file(*, name: str = "test.txt", mimetype: str = "text/plain") -> ToolFile:
+    tool_file = ToolFile(
+        user_id="user-1",
+        tenant_id="tenant-1",
+        conversation_id=None,
+        file_key="file-key",
+        mimetype=mimetype,
+        original_url="http://original",
+        name=name,
+        size=10,
+    )
+    tool_file.id = "file-id"
+    return tool_file
 
 
 class TestPluginUploadFileApi:
     @patch.object(module, "verify_plugin_file_signature", return_value=True)
-    @patch.object(module, "get_user", return_value=DummyUser())
+    @patch.object(module, "get_user", return_value=_end_user())
     @patch.object(module, "ToolFileManager")
     def test_success_upload(
         self,
@@ -101,7 +110,7 @@ class TestPluginUploadFileApi:
         )
 
         tool_file_manager_instance = mock_tool_file_manager.return_value
-        tool_file_manager_instance.create_file_by_raw.return_value = DummyToolFile(
+        tool_file_manager_instance.create_file_by_raw.return_value = _tool_file(
             name="report.docx",
             mimetype="application/octet-stream",
         )
@@ -165,7 +174,7 @@ class TestPluginUploadFileApi:
         )
         tool_file_manager = mock_tool_file_manager.return_value
         tool_file_manager.create_file_by_raw.side_effect = lambda **_kwargs: (
-            events.append("storage-create-file") or DummyToolFile(name="report.pdf", mimetype="application/pdf")
+            events.append("storage-create-file") or _tool_file(name="report.pdf", mimetype="application/pdf")
         )
         mock_tool_file_manager.sign_file.return_value = "signed-url"
 
@@ -273,7 +282,7 @@ class TestPluginUploadFileApi:
         with pytest.raises(Forbidden):
             post_fn(api)
 
-    @patch.object(module, "get_user", return_value=DummyUser())
+    @patch.object(module, "get_user", return_value=_end_user())
     @patch.object(module, "verify_plugin_file_signature", return_value=False)
     def test_invalid_signature(self, mock_verify, mock_get_user):
         dummy_file = DummyFile()
@@ -295,7 +304,7 @@ class TestPluginUploadFileApi:
         with pytest.raises(Forbidden):
             post_fn(api)
 
-    @patch.object(module, "get_user", return_value=DummyUser())
+    @patch.object(module, "get_user", return_value=_end_user())
     @patch.object(module, "verify_plugin_file_signature", return_value=True)
     @patch.object(module, "ToolFileManager")
     def test_file_too_large(
@@ -327,7 +336,7 @@ class TestPluginUploadFileApi:
         with pytest.raises(module.FileTooLargeError):
             post_fn(api)
 
-    @patch.object(module, "get_user", return_value=DummyUser())
+    @patch.object(module, "get_user", return_value=_end_user())
     @patch.object(module, "verify_plugin_file_signature", return_value=True)
     @patch.object(module, "ToolFileManager")
     def test_unsupported_file_type(

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py
@@ -5,42 +5,40 @@ Unit tests for Service API knowledge pipeline file-upload serialization.
 from datetime import UTC, datetime
 
 from controllers.service_api.dataset.rag_pipeline.rag_pipeline_workflow import PipelineUploadFileResponse
+from extensions.storage.storage_type import StorageType
 from libs.helper import dump_response
+from models.enums import CreatorUserRole
+from models.model import UploadFile
 
 
-class FakeUploadFile:
-    id: str
-    name: str
-    size: int
-    extension: str
-    mime_type: str
-    created_by: str
-    created_at: datetime | None
+def _upload_file(*, created_at: datetime) -> UploadFile:
+    upload_file = UploadFile(
+        tenant_id="tenant-1",
+        storage_type=StorageType.LOCAL,
+        key="uploads/file-1",
+        name="test.pdf",
+        size=123,
+        extension="pdf",
+        mime_type="application/pdf",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-1",
+        created_at=created_at,
+        used=False,
+    )
+    upload_file.id = "file-1"
+    return upload_file
 
 
 def test_file_upload_created_at_is_isoformat_string():
     created_at = datetime(2026, 2, 8, 12, 0, 0, tzinfo=UTC)
-    upload_file = FakeUploadFile()
-    upload_file.id = "file-1"
-    upload_file.name = "test.pdf"
-    upload_file.size = 123
-    upload_file.extension = "pdf"
-    upload_file.mime_type = "application/pdf"
-    upload_file.created_by = "account-1"
-    upload_file.created_at = created_at
+    upload_file = _upload_file(created_at=created_at)
 
     result = dump_response(PipelineUploadFileResponse, upload_file)
     assert result["created_at"] == created_at.isoformat()
 
 
 def test_file_upload_created_at_none_serializes_to_null():
-    upload_file = FakeUploadFile()
-    upload_file.id = "file-1"
-    upload_file.name = "test.pdf"
-    upload_file.size = 123
-    upload_file.extension = "pdf"
-    upload_file.mime_type = "application/pdf"
-    upload_file.created_by = "account-1"
+    upload_file = _upload_file(created_at=datetime(2026, 2, 8, 12, 0, 0, tzinfo=UTC))
     upload_file.created_at = None
 
     result = dump_response(PipelineUploadFileResponse, upload_file)


### PR DESCRIPTION
## Summary
- replace hand-written EndUser, ToolFile, and UploadFile stand-ins with real mapped model instances
- cover plugin upload response construction, file preview metadata, and Service API pipeline upload serialization with production ORM properties
- retain request, storage-manager, and graph File DTO doubles because those are non-ORM boundaries

## Real ORM coverage
The controller and serializer behaviors only consume mapped attributes and do not query the database, so real transient model instances are used. Existing account membership tests in the same upload module continue to persist owned and decoy rows through sqlite_session.

## Production changes
None.

## Size
76 additions, 53 deletions (129 changed lines).

## Validation
- make test TARGET_TESTS='./api/tests/unit_tests/controllers/files/test_upload.py ./api/tests/unit_tests/controllers/files/test_image_preview.py ./api/tests/unit_tests/controllers/service_api/dataset/test_rag_pipeline_file_upload_serialization.py' — 17 passed
- make lint — passed
- make type-check — pyrefly passed; mypy 1.20.2 hit the existing internal error at typeshed/stdlib/zipimport.pyi:17
- focused class audit: no Dummy/Fake stand-in for EndUser, ToolFile, or UploadFile remains in these modules
- full test suite intentionally not run per user instruction