### PR TITLE
test: migrate OpenAPI and tool-file ORM entities

### DIFF
--- a/api/tests/unit_tests/controllers/openapi/test_app_describe_builder.py
+++ b/api/tests/unit_tests/controllers/openapi/test_app_describe_builder.py
@@ -1,4 +1,4 @@
-from types import SimpleNamespace
+from datetime import datetime
 from unittest.mock import MagicMock
 
 from sqlalchemy.orm import Session
@@ -6,25 +6,20 @@ from sqlalchemy.orm import Session
 from controllers.openapi._input_schema import EMPTY_INPUT_SCHEMA
 from controllers.openapi.apps import _EMPTY_PARAMETERS, build_app_describe_response
 from controllers.service_api.app.error import AppUnavailableError
+from models.model import App, AppMode
 
 
-class _FakeApp(SimpleNamespace):
-    pass
-
-
-def _app() -> _FakeApp:
-    from datetime import datetime
-
-    return _FakeApp(
+def _app() -> App:
+    app = App(
         id="11111111-1111-1111-1111-111111111111",
+        tenant_id="tenant-1",
         name="Demo",
-        mode="chat",
+        mode=AppMode.CHAT,
         description="d",
-        tags=[],
-        author_name="me",
-        updated_at=datetime(2026, 1, 1),
         enable_api=True,
     )
+    app.updated_at = datetime(2026, 1, 1)
+    return app
 
 
 def test_fields_none_returns_all_blocks(monkeypatch, unbound_session: Session):

--- a/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
+++ b/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
@@ -4,13 +4,7 @@ import pytest
 
 import core.tools.utils.message_transformer as mt
 from core.tools.entities.tool_entities import ToolInvokeMessage
-
-
-class _FakeToolFile:
-    def __init__(self, mimetype: str, name: str | None):
-        self.id = "fake-tool-file-id"
-        self.mimetype = mimetype
-        self.name = name or "fake-tool-file.bin"
+from models.tools import ToolFile
 
 
 class _FakeToolFileManager:
@@ -39,7 +33,17 @@ class _FakeToolFileManager:
             "mimetype": mimetype,
             "filename": filename,
         }
-        return _FakeToolFile(mimetype, filename)
+        tool_file = ToolFile(
+            user_id=user_id,
+            tenant_id=tenant_id,
+            conversation_id=conversation_id,
+            file_key="tools/fake-tool-file-id",
+            mimetype=mimetype,
+            name=filename or "fake-tool-file.bin",
+            size=len(file_binary),
+        )
+        tool_file.id = "fake-tool-file-id"
+        return tool_file
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- replace the OpenAPI app-describe SimpleNamespace subclass with a real App model
- make the message transformer's fake storage manager return a real mapped ToolFile
- retain unbound_session for describe paths whose downstream parameter/schema builders are mocked

## Real ORM coverage
Both affected paths consume mapped attributes without database reads, so real transient entities are sufficient. The ToolFile manager remains a non-ORM boundary double used to capture uploaded bytes and metadata.

## Production changes
None.

## Size
20 additions, 21 deletions (41 changed lines).

## Validation
- make test TARGET_TESTS='./api/tests/unit_tests/controllers/openapi/test_app_describe_builder.py ./api/tests/unit_tests/core/tools/utils/test_message_transformer.py' — 8 passed
- make lint — passed
- make type-check — pyrefly passed; mypy 1.20.2 hit the existing internal error at typeshed/stdlib/zipimport.pyi:17
- focused class audit: no fake App or ToolFile model remains in these modules
- full test suite intentionally not run per user instruction