### PR TITLE
refactor(web): migrate app card icon controls

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -9,6 +9,7 @@
 - User-facing strings must use `web/i18n/en-US/` keys. When adding or renaming a key, update every supported locale with the correct localized value.
 - For new backend calls and migrated surfaces, use generated `consoleQuery` / `consoleClient` APIs from `@/service/client`. Do not add handwritten REST helpers or DTO mirrors, mock-backed app state, or direct edits to generated contracts.
 - Prefer `@langgenius/dify-ui/*` primitives, data attributes, and design tokens. Preserve a visible focus indicator on the final focusable element.
+- Use `Button` for actions with visible text and `IconButton` for icon-only actions. Every `IconButton` needs an `aria-label` or `aria-labelledby`; compose Menu, Popover, Toggle, and Collapsible through `render` so those primitives keep ownership of their state.
 - Follow `docs/overlay.md` for overlay selection and migration. Migrate a legacy overlay only when the current behavior change actually involves that overlay boundary.
 - For custom SVG icons, follow `../packages/iconify-collections/README.md`; do not add generated React icons under `app/components/base/icons/src/`.
 - `docs/test.md` is the single source of truth for frontend automated-test policy. Skills may route and execute that policy but must not redefine it.

--- a/web/README.md
+++ b/web/README.md
@@ -132,12 +132,6 @@ vp test run
 
 If a test fails only in CI, inspect the failing job and reproduce it locally when possible. A rerun can help identify a flaky test, but it does not replace diagnosing or reporting the failure.
 
-### Example Code
-
-If you are not familiar with writing tests, refer to:
-
-- [index.spec.tsx] - Component test example
-
 ## Documentation
 
 Visit <https://docs.dify.ai> to view the full documentation.
@@ -155,7 +149,6 @@ The Dify community can be found on [Discord community], where you can ask questi
 [Storybook]: https://storybook.js.org
 [Vite+]: https://viteplus.dev
 [Vitest]: https://vitest.dev
-[index.spec.tsx]: ./app/components/base/action-button/__tests__/index.spec.tsx
 [pnpm]: https://pnpm.io
 [vinext]: https://github.com/cloudflare/vinext
 [web/docs/test.md]: ./docs/test.md

--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -682,9 +682,13 @@ describe('AppCard', () => {
     })
 
     it('should star the app from the card action without navigating', async () => {
+      const user = userEvent.setup()
       render(<AppCard app={mockApp} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'app.studio.starApp' }))
+      const starToggle = screen.getByRole('button', { name: 'app.studio.starApp' })
+      expect(starToggle).toHaveAttribute('aria-pressed', 'false')
+
+      await user.click(starToggle)
 
       await waitFor(() => {
         expect(mockStarAppMutation).toHaveBeenCalledWith({
@@ -695,10 +699,14 @@ describe('AppCard', () => {
     })
 
     it('should unstar the app from the filled star action', async () => {
+      const user = userEvent.setup()
       const starredApp = createMockApp({ is_starred: true })
       render(<AppCard app={starredApp} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'app.studio.unstarApp' }))
+      const starToggle = screen.getByRole('button', { name: 'app.studio.starApp' })
+      expect(starToggle).toHaveAttribute('aria-pressed', 'true')
+
+      await user.click(starToggle)
 
       await waitFor(() => {
         expect(mockUnstarAppMutation).toHaveBeenCalledWith({
@@ -724,13 +732,15 @@ describe('AppCard', () => {
     })
 
     it('should show edit option when dropdown menu is opened', async () => {
+      const user = userEvent.setup()
       render(<AppCard app={mockApp} />)
 
-      fireEvent.click(getOperationsTrigger())
+      await user.click(getOperationsTrigger())
 
       await waitFor(() => {
         expect(screen.getByText('app.editApp')).toBeInTheDocument()
       })
+      expect(mockPush).not.toHaveBeenCalled()
     })
 
     it('should show duplicate option when dropdown menu is opened', async () => {

--- a/web/app/components/apps/app-card/action-bar/index.tsx
+++ b/web/app/components/apps/app-card/action-bar/index.tsx
@@ -4,7 +4,7 @@ import type {
   AppPartial,
   EnvironmentVariableItemResponse,
 } from '@dify/contracts/api/console/apps/types.gen'
-import type { FormEventHandler, MouseEvent } from 'react'
+import type { FormEventHandler } from 'react'
 import type { DuplicateAppModalProps } from '@/app/components/app/duplicate-modal'
 import type { CreateAppModalProps } from '@/app/components/explore/create-app-modal'
 import { zIconType } from '@dify/contracts/api/console/apps/zod.gen'
@@ -24,7 +24,9 @@ import {
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import { Field, FieldControl, FieldLabel } from '@langgenius/dify-ui/field'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
+import { Toggle } from '@langgenius/dify-ui/toggle'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
@@ -311,13 +313,10 @@ export const AppCardActionBar = memo(
     }
 
     const handleToggleStar = useCallback(
-      (e: MouseEvent<HTMLButtonElement>) => {
-        e.stopPropagation()
-        e.preventDefault()
-
+      (pressed: boolean) => {
         if (isTogglingStar) return
 
-        const mutateStar = app.is_starred ? unstarApp : starApp
+        const mutateStar = pressed ? starApp : unstarApp
         try {
           mutateStar(
             { params: { app_id: app.id } },
@@ -338,7 +337,7 @@ export const AppCardActionBar = memo(
           )
         }
       },
-      [app.id, app.is_starred, isTogglingStar, starApp, t, unstarApp],
+      [app.id, isTogglingStar, starApp, t, unstarApp],
     )
 
     const shouldShowEditOption = appACLCapabilities.canEdit
@@ -359,6 +358,7 @@ export const AppCardActionBar = memo(
     const starActionLabel = app.is_starred
       ? t(($) => $['studio.unstarApp'], { ns: 'app' })
       : t(($) => $['studio.starApp'], { ns: 'app' })
+    const starToggleLabel = t(($) => $['studio.starApp'], { ns: 'app' })
 
     return (
       <>
@@ -374,21 +374,23 @@ export const AppCardActionBar = memo(
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <button
-                    type="button"
-                    aria-label={starActionLabel}
+                  <Toggle
+                    pressed={app.is_starred}
                     disabled={isTogglingStar}
-                    className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-70"
-                    onClick={handleToggleStar}
-                  >
-                    <StarIcon
-                      aria-hidden
-                      className={cn(
-                        app.is_starred ? 'text-text-warning-secondary' : 'text-text-tertiary',
-                        'size-4.5',
-                      )}
-                    />
-                  </button>
+                    onPressedChange={handleToggleStar}
+                    render={
+                      <IconButton
+                        size="lg"
+                        aria-label={starToggleLabel}
+                        className="group disabled:opacity-70"
+                      >
+                        <StarIcon
+                          aria-hidden
+                          className="size-4.5 text-text-tertiary group-data-pressed:text-text-warning-secondary"
+                        />
+                      </IconButton>
+                    }
+                  />
                 }
               />
               <TooltipContent>{starActionLabel}</TooltipContent>
@@ -400,33 +402,32 @@ export const AppCardActionBar = memo(
                 onOpenChange={setIsOperationsMenuOpen}
               >
                 <DropdownMenuTrigger
-                  aria-label={
-                    isExporting
-                      ? t(($) => $['operation.exporting'], { ns: 'common' })
-                      : t(($) => $['operation.moreActionsFor'], {
-                          ns: 'common',
-                          name: app.name,
-                        })
+                  render={
+                    <IconButton
+                      size="lg"
+                      aria-label={
+                        isExporting
+                          ? t(($) => $['operation.exporting'], { ns: 'common' })
+                          : t(($) => $['operation.moreActionsFor'], {
+                              ns: 'common',
+                              name: app.name,
+                            })
+                      }
+                      disabled={isExporting}
+                      className="data-popup-open:bg-state-base-hover"
+                    >
+                      <span
+                        aria-hidden
+                        className={cn(
+                          'size-4.5 text-text-tertiary',
+                          isExporting
+                            ? 'i-ri-loader-2-line animate-spin motion-reduce:animate-none'
+                            : 'i-ri-more-fill',
+                        )}
+                      />
+                    </IconButton>
                   }
-                  disabled={isExporting}
-                  className={cn(
-                    'flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed data-popup-open:bg-state-base-hover',
-                  )}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    e.preventDefault()
-                  }}
-                >
-                  <span
-                    aria-hidden
-                    className={cn(
-                      'h-4.5 w-4.5 text-text-tertiary',
-                      isExporting
-                        ? 'i-ri-loader-2-line animate-spin motion-reduce:animate-none'
-                        : 'i-ri-more-fill',
-                    )}
-                  />
-                </DropdownMenuTrigger>
+                />
                 <DropdownMenuContent
                   placement="bottom-end"
                   sideOffset={4}

--- a/web/app/components/base/chat/chat-with-history/sidebar/__tests__/operation.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/__tests__/operation.spec.tsx
@@ -36,11 +36,6 @@ describe('Operation', () => {
     expect(screen.getByText('explore.sidebar.action.pin')).toBeInTheDocument()
   })
 
-  it('should apply active state to ActionButton', () => {
-    render(<Operation {...defaultProps} isActive={true} />)
-    expect(getTrigger()).toBeInTheDocument()
-  })
-
   it('should call togglePin when pin/unpin is clicked', async () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} />)

--- a/web/app/components/base/chat/chat/answer/__tests__/operation.spec.tsx
+++ b/web/app/components/base/chat/chat/answer/__tests__/operation.spec.tsx
@@ -885,21 +885,6 @@ describe('Operation', () => {
         screen.getByTestId('operation-bar').querySelectorAll('.i-ri-thumb-up-line').length,
       ).toBe(0)
     })
-
-    it('should render action buttons with Default state when feedback rating is undefined', () => {
-      // Setting a malformed feedback object with no rating but triggers the wrapper to see undefined fallbacks
-      const item = {
-        ...baseItem,
-        feedback: {} as unknown as Record<string, unknown>,
-        adminFeedback: {} as unknown as Record<string, unknown>,
-      } as ChatItem
-      renderOperation({ ...baseProps, item })
-      // Since it renders the 'else' block for hasAdminFeedback (which is false due to !)
-      // the like/dislike regular ActionButtons should hit the Default state
-      // Since it renders the 'else' block for hasAdminFeedback (which is false due to !)
-      // the like/dislike regular ActionButtons should hit the Default state
-      expect(screen.getByTestId('operation-bar'))!.toBeInTheDocument()
-    })
   })
 
   describe('Positioning and layout', () => {

--- a/web/app/components/base/copy-feedback/index.stories.tsx
+++ b/web/app/components/base/copy-feedback/index.stories.tsx
@@ -8,8 +8,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component:
-          'Copy-to-clipboard button that shows instant feedback and a tooltip. Includes the original ActionButton wrapper and the newer ghost-button variant.',
+        component: 'Copy-to-clipboard icon buttons that show instant feedback and a tooltip.',
       },
     },
   },

--- a/web/app/components/base/file-uploader/file-uploader-in-attachment/__tests__/index.spec.tsx
+++ b/web/app/components/base/file-uploader/file-uploader-in-attachment/__tests__/index.spec.tsx
@@ -196,7 +196,7 @@ describe('FileUploaderInAttachmentWrapper', () => {
       />,
     )
 
-    // ReplayLine is inside ActionButton (a <button>) with data-icon attribute
+    // ReplayLine is inside an icon button with a data-icon attribute.
     const replayIcon = container.querySelector('svg[data-icon="ReplayLine"]')
     const replayBtn = replayIcon!.closest('button')
     fireEvent.click(replayBtn!)

--- a/web/app/components/base/new-audio-button/index.stories.tsx
+++ b/web/app/components/base/new-audio-button/index.stories.tsx
@@ -14,7 +14,7 @@ const StoryWrapper = (props: ComponentProps<typeof AudioBtn>) => {
   return (
     <div className="flex items-center justify-center space-x-3">
       <AudioBtn {...props} />
-      <span className="text-xs text-gray-500">Audio toggle using ActionButton styling</span>
+      <span className="text-xs text-gray-500">Audio toggle using IconButton styling</span>
     </div>
   )
 }
@@ -28,7 +28,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Updated audio playback trigger styled with `ActionButton`. Behaves like the legacy audio button but adopts the new button design system.',
+          'Audio playback trigger using the shared IconButton shape and a feature-owned active state.',
       },
     },
     nextjs: {

--- a/web/features/agent-v2/agent-detail/configure/README.md
+++ b/web/features/agent-v2/agent-detail/configure/README.md
@@ -17,7 +17,6 @@ Owns the Agent V2 configure runtime used by the Agent App configure page and wor
 ## External Modules
 
 - app/components/base/chat
-- app/components/base/action-button
 - app/components/base/app-icon
 - app/components/base/features
 - app/components/base/file-uploader


### PR DESCRIPTION
## Summary

- Migrate the app-card star control to controlled Toggle rendered as IconButton.
- Migrate the adjacent more-actions trigger to Menu rendered as IconButton.
- Remove redundant event cancellation after verifying both controls are siblings of the card link, and preserve 32px geometry, radius, hover, pressed, disabled, and popup-open visuals.

## Verification

- App-card focused tests
- Web type check
- Web production build
- Repository formatting and lint checks

Depends on #40651
Stack: 13/13

From Codex