### PR TITLE
test: migrate residual controller ORM identities to real models

### DIFF
--- a/api/tests/unit_tests/controllers/console/datasets/test_data_source_notion_apis.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_data_source_notion_apis.py
@@ -19,7 +19,26 @@ from controllers.console.datasets.data_source import (
     NotionEstimatePayload,
 )
 from core.rag.index_processor.constant.index_type import IndexStructureType
-from models import Account
+from models import Account, Dataset, Document
+from models.dataset import DataSourceType, DocumentCreatedFrom
+
+
+def _dataset() -> Dataset:
+    return Dataset(id="ds-1", tenant_id="tenant-1", name="Dataset", created_by="u1")
+
+
+def _document() -> Document:
+    return Document(
+        id="d1",
+        tenant_id="tenant-1",
+        dataset_id="ds-1",
+        position=1,
+        data_source_type=DataSourceType.NOTION_IMPORT,
+        batch="batch-1",
+        name="Notion page",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="u1",
+    )
 
 
 @pytest.fixture
@@ -97,11 +116,11 @@ class TestDataSourceNotionDatasetSyncApi:
             app.test_request_context("/"),
             patch(
                 "controllers.console.datasets.data_source.DatasetService.get_dataset",
-                return_value=MagicMock(),
+                return_value=_dataset(),
             ),
             patch(
                 "controllers.console.datasets.data_source.DocumentService.get_document_by_dataset_id",
-                return_value=[MagicMock(id="d1")],
+                return_value=[_document()],
             ),
             patch(
                 "controllers.console.datasets.data_source.document_indexing_sync_task.delay",
@@ -138,11 +157,11 @@ class TestDataSourceNotionDocumentSyncApi:
             app.test_request_context("/"),
             patch(
                 "controllers.console.datasets.data_source.DatasetService.get_dataset",
-                return_value=MagicMock(),
+                return_value=_dataset(),
             ),
             patch(
                 "controllers.console.datasets.data_source.DocumentService.get_document",
-                return_value=MagicMock(),
+                return_value=_document(),
             ),
             patch(
                 "controllers.console.datasets.data_source.document_indexing_sync_task.delay",
@@ -162,7 +181,7 @@ class TestDataSourceNotionDocumentSyncApi:
             app.test_request_context("/"),
             patch(
                 "controllers.console.datasets.data_source.DatasetService.get_dataset",
-                return_value=MagicMock(),
+                return_value=_dataset(),
             ),
             patch(
                 "controllers.console.datasets.data_source.DocumentService.get_document",

--- a/api/tests/unit_tests/controllers/console/tag/test_tags.py
+++ b/api/tests/unit_tests/controllers/console/tag/test_tags.py
@@ -198,7 +198,7 @@ class TestTagListApi:
                 patch("controllers.console.tag.tags.dify_config.RBAC_ENABLED", True),
                 patch(
                     "controllers.console.tag.tags.current_account_with_tenant",
-                    return_value=(SimpleNamespace(id="user-1"), "tenant-1"),
+                    return_value=(admin_user, "tenant-1"),
                 ),
                 patch("controllers.console.tag.tags.enforce_rbac_access") as enforce_mock,
                 patch(
@@ -301,7 +301,7 @@ class TestTagUpdateDeleteApi:
             patch("controllers.console.tag.tags.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.console.tag.tags.current_account_with_tenant",
-                return_value=(SimpleNamespace(id="user-1"), "tenant-1"),
+                return_value=(admin_user, "tenant-1"),
             ),
             patch("controllers.console.tag.tags.enforce_rbac_access") as enforce_mock,
             patch("controllers.console.tag.tags.TagService.delete_tag") as delete_mock,
@@ -346,7 +346,7 @@ class TestTagUpdateDeleteApi:
             patch("controllers.console.tag.tags.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.console.tag.tags.current_account_with_tenant",
-                return_value=(SimpleNamespace(id="user-1"), "tenant-1"),
+                return_value=(admin_user, "tenant-1"),
             ),
             patch("controllers.console.tag.tags.enforce_rbac_access") as enforce_mock,
             patch("controllers.console.tag.tags.TagService.delete_tag") as delete_mock,

--- a/api/tests/unit_tests/controllers/console/workspace/test_models.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_models.py
@@ -1,5 +1,4 @@
 from inspect import unwrap
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +27,13 @@ from controllers.console.workspace.models import (
 )
 from graphon.model_runtime.entities.model_entities import ModelType
 from graphon.model_runtime.errors.validate import CredentialsValidateFailedError
+from models import Account
+
+
+def _account() -> Account:
+    account = Account(name="Model User", email="model-user@example.com")
+    account.id = "u1"
+    return account
 
 
 class TestDefaultModelApi:
@@ -191,7 +197,7 @@ class TestModelProviderModelCredentialApi:
                 api,
                 ParserGetCredentials(model="gpt-4", model_type=ModelType.LLM),
                 "tenant1",
-                SimpleNamespace(id="u1"),
+                _account(),
                 "openai",
             )
 
@@ -232,7 +238,7 @@ class TestModelProviderModelCredentialApi:
                 api,
                 ParserGetCredentials(model="gpt", model_type=ModelType.LLM),
                 "t1",
-                SimpleNamespace(id="u1"),
+                _account(),
                 "openai",
             )
 

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -16,7 +16,6 @@ changes.
 from __future__ import annotations
 
 import inspect
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +27,7 @@ from configs import dify_config
 from controllers.console.workspace import rbac as rbac_mod
 from controllers.console.workspace.rbac import _RolesListQuery
 from enums import DeploymentEdition
+from models import Account
 
 
 @pytest.fixture
@@ -42,16 +42,22 @@ def _enabled(enabled: bool):
     return patch("controllers.console.workspace.rbac.dify_config.DEPLOYMENT_EDITION", deployment_edition)
 
 
+def _account() -> Account:
+    account = Account(name="RBAC User", email="rbac@example.com")
+    account.id = "acct-1"
+    return account
+
+
 class TestCurrentIds:
     def test_rejects_missing_tenant(self):
         with patch("controllers.console.workspace.rbac.current_account_with_tenant") as mock_user:
-            mock_user.return_value = (SimpleNamespace(id="acct-1"), None)
+            mock_user.return_value = (_account(), None)
             with pytest.raises(NotFound):
                 rbac_mod._current_ids()
 
     def test_returns_tuple(self):
         with patch("controllers.console.workspace.rbac.current_account_with_tenant") as mock_user:
-            mock_user.return_value = (SimpleNamespace(id="acct-1"), "tenant-1")
+            mock_user.return_value = (_account(), "tenant-1")
             assert rbac_mod._current_ids() == ("tenant-1", "acct-1")
 
 
@@ -553,7 +559,7 @@ class TestWorkspaceRbacGuards:
             patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.common.wraps.current_account_with_tenant",
-                return_value=(SimpleNamespace(id="acct-1"), "tenant-1"),
+                return_value=(_account(), "tenant-1"),
             ),
             patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
             patch("controllers.console.workspace.rbac.svc.RBACService.Roles.create") as mock_create,
@@ -574,7 +580,7 @@ class TestWorkspaceRbacGuards:
             patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.common.wraps.current_account_with_tenant",
-                return_value=(SimpleNamespace(id="acct-1"), "tenant-1"),
+                return_value=(_account(), "tenant-1"),
             ),
             patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
             patch("controllers.console.workspace.rbac.svc.RBACService.AccessPolicies.create") as mock_create,

--- a/api/tests/unit_tests/controllers/web/test_wraps.py
+++ b/api/tests/unit_tests/controllers/web/test_wraps.py
@@ -4,6 +4,7 @@ import pytest
 from werkzeug.exceptions import Unauthorized
 
 from core.logging.context import clear_request_context, get_identity_context
+from models import App, EndUser
 
 
 @pytest.fixture(autouse=True)
@@ -16,8 +17,8 @@ def _reset_logging_context():
 def test_validate_jwt_token_sets_logging_identity_before_view() -> None:
     from controllers.web import wraps
 
-    app_model = mock.Mock()
-    end_user = mock.Mock(id="end-user-id", tenant_id="tenant-id", type=None)
+    app_model = App(id="app-id", tenant_id="tenant-id")
+    end_user = EndUser(id="end-user-id", tenant_id="tenant-id", type=None)
     clear_request_context()
 
     @wraps.validate_jwt_token


### PR DESCRIPTION
## Summary
- replace namespace accounts in tag, workspace RBAC, and model-provider controllers with real `Account` instances
- replace mocked Notion-sync `Dataset` and `Document` results with real mapped entities
- replace mocked web-auth `App` and `EndUser` identities with real mapped entities

## Real persistence coverage
These controller paths consume identity and resource fields without querying relationships, so real transient ORM instances are used as the production contracts permit. Existing SQLite sessions continue to cover the controller database boundary.

## Production fixes
None.

## Size
51 additions, 19 deletions.

## Validation
- focused pytest over the five changed modules — 86 passed
- targeted `make test` over the five changed modules — 86 passed
- `make lint` — passed
- `make type-check` — pyrefly completed; mypy 1.20.2 hit its existing internal error at `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- `git diff --check` — passed

The full test suite was not run, per request.
