### PR TITLE
test: migrate RAG dataset ORM contracts to real models

### DIFF
--- a/api/tests/unit_tests/core/rag/datasource/keyword/test_keyword_base.py
+++ b/api/tests/unit_tests/core/rag/datasource/keyword/test_keyword_base.py
@@ -6,6 +6,11 @@ from sqlalchemy.orm import Session
 
 from core.rag.datasource.keyword.keyword_base import BaseKeyword
 from core.rag.models.document import Document
+from models import Dataset
+
+
+def _dataset() -> Dataset:
+    return Dataset(id="dataset-1", tenant_id="tenant-1", name="Dataset", created_by="account-1")
 
 
 class _KeywordThatRaises(BaseKeyword):
@@ -65,7 +70,7 @@ class _KeywordForHelpers(BaseKeyword):
 
 
 def test_abstract_methods_raise_not_implemented(unbound_session: Session):
-    keyword = _KeywordThatRaises(SimpleNamespace(id="dataset-1"))
+    keyword = _KeywordThatRaises(_dataset())
     session = unbound_session
 
     with pytest.raises(NotImplementedError):
@@ -88,7 +93,7 @@ def test_abstract_methods_raise_not_implemented(unbound_session: Session):
 
 
 def test_filter_duplicate_texts_removes_existing_doc_ids(unbound_session: Session):
-    keyword = _KeywordForHelpers(SimpleNamespace(id="dataset-1"), existing_ids={"duplicate"})
+    keyword = _KeywordForHelpers(_dataset(), existing_ids={"duplicate"})
     texts = [
         Document(page_content="keep", metadata={"doc_id": "keep"}),
         Document(page_content="duplicate", metadata={"doc_id": "duplicate"}),
@@ -102,7 +107,7 @@ def test_filter_duplicate_texts_removes_existing_doc_ids(unbound_session: Sessio
 
 
 def test_get_uuids_returns_only_docs_with_metadata():
-    keyword = _KeywordForHelpers(SimpleNamespace(id="dataset-1"))
+    keyword = _KeywordForHelpers(_dataset())
     texts = [
         Document(page_content="doc-1", metadata={"doc_id": "doc-1"}),
         Document(page_content="doc-2", metadata={"doc_id": "doc-2"}),

--- a/api/tests/unit_tests/core/rag/docstore/test_dataset_docstore.py
+++ b/api/tests/unit_tests/core/rag/docstore/test_dataset_docstore.py
@@ -139,11 +139,10 @@ class TestDatasetDocumentStoreSerialization(_UsesSQLiteSession):
         """Test deserialization from dictionary."""
 
         config_dict = {
-            "dataset": MagicMock(spec=["id"]),
+            "dataset": _dataset(),
             "user_id": "test-user",
             "document_id": "test-doc",
         }
-        config_dict["dataset"].id = "ds-123"
 
         store = DatasetDocumentStore.from_dict(config_dict)
 


### PR DESCRIPTION
## Summary
- pass real mapped `Dataset` instances to `BaseKeyword`
- deserialize `DatasetDocumentStore` configuration with a real mapped dataset
- retain mocks only for the non-ORM RAG document DTO error path

## Real persistence coverage
These helpers only read dataset identity fields, so real transient ORM instances provide the mapped contract without unnecessary database writes. Existing document-store mutation tests continue to use SQLite sessions.

## Production fixes
None.

## Size
9 additions, 5 deletions.

## Validation
- focused pytest over both changed modules — 37 passed
- targeted `make test` over both changed modules — 37 passed
- `make lint` — passed
- `make type-check` — pyrefly completed; mypy 1.20.2 hit its existing internal error at `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- `git diff --check` — passed

The full test suite was not run, per request.
