### PR TITLE
test: migrate OpenTelemetry ORM identities to real models

### DIFF
--- a/api/tests/unit_tests/extensions/otel/conftest.py
+++ b/api/tests/unit_tests/extensions/otel/conftest.py
@@ -7,13 +7,15 @@ Provides:
 - Test data factories
 """
 
-from unittest.mock import MagicMock, create_autospec
+from unittest.mock import MagicMock
 
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import set_tracer_provider
+
+from models import Account, App, EndUser
 
 
 @pytest.fixture
@@ -42,31 +44,22 @@ def tracer_provider_with_memory_exporter(memory_span_exporter):
 
 @pytest.fixture
 def mock_app_model():
-    """Create a mock App model."""
-    app = MagicMock()
-    app.id = "test-app-id"
-    app.tenant_id = "test-tenant-id"
-    return app
+    """Create a real transient App model."""
+    return App(id="test-app-id", tenant_id="test-tenant-id")
 
 
 @pytest.fixture
 def mock_account_user():
-    """Create a mock Account user."""
-    from models.model import Account
-
-    user = create_autospec(Account, instance=True)
+    """Create a real transient Account user."""
+    user = Account(name="Test User", email="otel@example.com")
     user.id = "test-user-id"
     return user
 
 
 @pytest.fixture
 def mock_end_user():
-    """Create a mock EndUser."""
-    from models.model import EndUser
-
-    user = create_autospec(EndUser, instance=True)
-    user.id = "test-end-user-id"
-    return user
+    """Create a real transient EndUser."""
+    return EndUser(id="test-end-user-id", tenant_id="test-tenant-id")
 
 
 @pytest.fixture

--- a/api/tests/unit_tests/extensions/otel/test_runtime.py
+++ b/api/tests/unit_tests/extensions/otel/test_runtime.py
@@ -5,6 +5,13 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
 from core.logging.context import clear_request_context
+from models import Account
+
+
+def _user() -> Account:
+    user = Account(name="Test User", email="otel@example.com")
+    user.id = "user-id"
+    return user
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +26,7 @@ def test_on_user_loaded_does_not_write_to_non_recording_span() -> None:
 
     span = mock.MagicMock()
     span.is_recording.return_value = False
-    user = mock.Mock(id="user-id")
+    user = _user()
 
     with (
         mock.patch.object(runtime.dify_config, "ENABLE_OTEL", True),
@@ -39,7 +46,7 @@ def test_on_user_loaded_sets_attributes_on_recording_span() -> None:
 
     span = mock.MagicMock()
     span.is_recording.return_value = True
-    user = mock.Mock(id="user-id")
+    user = _user()
 
     with (
         mock.patch.object(runtime.dify_config, "ENABLE_OTEL", True),
@@ -62,7 +69,7 @@ def test_on_user_loaded_ignores_ended_sdk_span(caplog) -> None:
     tracer_provider = TracerProvider()
     span = tracer_provider.get_tracer(__name__).start_span("ended")
     span.end()
-    user = mock.Mock(id="user-id")
+    user = _user()
 
     with (
         trace.use_span(span, end_on_exit=False),


### PR DESCRIPTION
## Summary
- replace mocked OpenTelemetry `App`, `Account`, and `EndUser` fixtures with real mapped models
- replace mocked Flask-login user event payloads with real transient accounts
- retain mocks for spans, exporters, and runner/service boundaries

## Real persistence coverage
The tracing paths only read identity fields, so real transient ORM instances provide the mapped contracts without unnecessary database access.

## Production fixes
None.

## Size
19 additions, 19 deletions.

## Validation
- `uv run pytest tests/unit_tests/extensions/otel --no-cov -q -x` — 46 passed
- `make test TARGET_TESTS=./api/tests/unit_tests/extensions/otel` — 46 passed
- `make lint` — passed
- `make type-check` — pyrefly completed; mypy 1.20.2 hit its existing internal error at `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- `git diff --check` — passed

The full test suite was not run, per request.
