### PR TITLE
test: migrate workflow variable ORM model to real entity

### DIFF
--- a/api/tests/unit_tests/core/app/app_config/workflow_ui_based_app/test_workflow_ui_based_app_manager.py
+++ b/api/tests/unit_tests/core/app/app_config/workflow_ui_based_app/test_workflow_ui_based_app_manager.py
@@ -1,9 +1,22 @@
+import json
+
 import pytest
 from pytest_mock import MockerFixture
 
 from core.app.app_config.workflow_ui_based_app.variables.manager import (
     WorkflowVariablesConfigManager,
 )
+from models.workflow import Workflow, WorkflowType
+
+
+def _rag_variable(variable: str, belong_to_node_id: str) -> dict[str, object]:
+    return {
+        "variable": variable,
+        "belong_to_node_id": belong_to_node_id,
+        "type": "text-input",
+        "label": variable,
+    }
+
 
 # =============================
 # Fixtures
@@ -12,8 +25,19 @@ from core.app.app_config.workflow_ui_based_app.variables.manager import (
 
 @pytest.fixture
 def mock_workflow(mocker: MockerFixture):
-    workflow = mocker.MagicMock()
-    workflow.graph_dict = {"nodes": []}
+    workflow = Workflow.new(
+        tenant_id="tenant-1",
+        app_id="app-1",
+        type=WorkflowType.WORKFLOW,
+        version=Workflow.VERSION_DRAFT,
+        graph=json.dumps({"nodes": []}),
+        features="{}",
+        created_by="account-1",
+        environment_variables=[],
+        conversation_variables=[],
+        rag_pipeline_variables=[],
+    )
+    mocker.patch.object(workflow, "user_input_form")
     return workflow
 
 
@@ -76,8 +100,6 @@ class TestWorkflowVariablesConfigManagerConvert:
 
     def test_convert_normalizes_json_schema_string_to_dict(self, mock_workflow, mock_variable_entity):
         """Regression test for #36766: json_schema stored as a JSON string."""
-        import json
-
         schema_dict = {"type": "object", "properties": {"name": {"type": "string"}}}
         input_variables = [
             {
@@ -174,7 +196,7 @@ class TestWorkflowVariablesConfigManagerConvertRag:
 
     def test_rag_pipeline_none(self, mock_workflow):
         # Arrange
-        mock_workflow.rag_pipeline_variables = None
+        mock_workflow._rag_pipeline_variables = None
 
         # Act
         result = WorkflowVariablesConfigManager.convert_rag_pipeline_variable(mock_workflow, "node1")
@@ -185,9 +207,9 @@ class TestWorkflowVariablesConfigManagerConvertRag:
     def test_no_matching_node_keeps_all(self, mock_workflow, mock_rag_entity):
         # Arrange
         mock_workflow.rag_pipeline_variables = [
-            {"variable": "var1", "belong_to_node_id": "node1"},
+            _rag_variable("var1", "node1"),
         ]
-        mock_workflow.graph_dict = {"nodes": []}
+        mock_workflow.graph = json.dumps({"nodes": []})
         mock_rag_entity.model_validate.side_effect = lambda x: {"validated": x}
 
         # Act
@@ -199,18 +221,20 @@ class TestWorkflowVariablesConfigManagerConvertRag:
     def test_string_pattern_removes_variable(self, mock_workflow, mock_rag_entity):
         # Arrange
         mock_workflow.rag_pipeline_variables = [
-            {"variable": "var1", "belong_to_node_id": "node1"},
-            {"variable": "var2", "belong_to_node_id": "node1"},
+            _rag_variable("var1", "node1"),
+            _rag_variable("var2", "node1"),
         ]
 
-        mock_workflow.graph_dict = {
-            "nodes": [
-                {
-                    "id": "node1",
-                    "data": {"datasource_parameters": {"param1": {"value": "{{#parent.var1#}}"}}},
-                }
-            ]
-        }
+        mock_workflow.graph = json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "node1",
+                        "data": {"datasource_parameters": {"param1": {"value": "{{#parent.var1#}}"}}},
+                    }
+                ]
+            }
+        )
 
         mock_rag_entity.model_validate.side_effect = lambda x: {"validated": x}
 
@@ -224,18 +248,20 @@ class TestWorkflowVariablesConfigManagerConvertRag:
     def test_list_value_removes_variable(self, mock_workflow, mock_rag_entity):
         # Arrange
         mock_workflow.rag_pipeline_variables = [
-            {"variable": "var1", "belong_to_node_id": "node1"},
-            {"variable": "var2", "belong_to_node_id": "node1"},
+            _rag_variable("var1", "node1"),
+            _rag_variable("var2", "node1"),
         ]
 
-        mock_workflow.graph_dict = {
-            "nodes": [
-                {
-                    "id": "node1",
-                    "data": {"datasource_parameters": {"param1": {"value": ["x", "var1"]}}},
-                }
-            ]
-        }
+        mock_workflow.graph = json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "node1",
+                        "data": {"datasource_parameters": {"param1": {"value": ["x", "var1"]}}},
+                    }
+                ]
+            }
+        )
 
         mock_rag_entity.model_validate.side_effect = lambda x: {"validated": x}
 
@@ -257,9 +283,9 @@ class TestWorkflowVariablesConfigManagerConvertRag:
     def test_belong_to_node_filtering(self, mock_workflow, mock_rag_entity, belong_to_node_id, expected_count):
         # Arrange
         mock_workflow.rag_pipeline_variables = [
-            {"variable": "var1", "belong_to_node_id": belong_to_node_id},
+            _rag_variable("var1", belong_to_node_id),
         ]
-        mock_workflow.graph_dict = {"nodes": []}
+        mock_workflow.graph = json.dumps({"nodes": []})
         mock_rag_entity.model_validate.side_effect = lambda x: {"validated": x}
 
         # Act
@@ -271,17 +297,19 @@ class TestWorkflowVariablesConfigManagerConvertRag:
     def test_invalid_pattern_does_not_remove(self, mock_workflow, mock_rag_entity):
         # Arrange
         mock_workflow.rag_pipeline_variables = [
-            {"variable": "var1", "belong_to_node_id": "node1"},
+            _rag_variable("var1", "node1"),
         ]
 
-        mock_workflow.graph_dict = {
-            "nodes": [
-                {
-                    "id": "node1",
-                    "data": {"datasource_parameters": {"param1": {"value": "invalid_pattern"}}},
-                }
-            ]
-        }
+        mock_workflow.graph = json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "node1",
+                        "data": {"datasource_parameters": {"param1": {"value": "invalid_pattern"}}},
+                    }
+                ]
+            }
+        )
 
         mock_rag_entity.model_validate.side_effect = lambda x: {"validated": x}
 
@@ -294,9 +322,9 @@ class TestWorkflowVariablesConfigManagerConvertRag:
     def test_validation_error_propagates(self, mock_workflow, mock_rag_entity):
         # Arrange
         mock_workflow.rag_pipeline_variables = [
-            {"variable": "var1", "belong_to_node_id": "node1"},
+            _rag_variable("var1", "node1"),
         ]
-        mock_workflow.graph_dict = {"nodes": []}
+        mock_workflow.graph = json.dumps({"nodes": []})
         mock_rag_entity.model_validate.side_effect = RuntimeError("validation failed")
 
         # Act & Assert


### PR DESCRIPTION
## Summary
- replace the workflow `MagicMock` fixture with a real `Workflow.new(...)` model
- exercise the model's real graph JSON and RAG pipeline variable serialization
- keep method mocks only around the isolated input-form and Pydantic conversion boundaries

## Real persistence coverage
The manager only reads workflow properties, so a real transient mapped workflow is sufficient. Test RAG variables now satisfy the model's actual validation contract and graph inputs flow through the mapped JSON property.

## Production fixes
None.

## Size
68 additions, 40 deletions.

## Validation
- focused pytest — 18 passed
- targeted `make test` — 18 passed
- `make lint` — passed
- `make type-check` — pyrefly completed; mypy 1.20.2 hit its existing internal error at `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- `git diff --check` — passed

The full test suite was not run, per request.
