### PR TITLE
test: migrate residual session factories to shared SQLite

### DIFF
--- a/api/tests/unit_tests/commands/test_data_migration_commands.py
+++ b/api/tests/unit_tests/commands/test_data_migration_commands.py
@@ -108,7 +108,6 @@ def test_export_command_uses_cli_owned_session(monkeypatch, tmp_path: Path, sqli
             captured["path"] = path
             captured["overwrite"] = overwrite
 
-    monkeypatch.setattr(data_migration.session_factory, "create_session", lambda: Session(sqlite_engine))
     monkeypatch.setattr(data_migration, "MigrationExportService", FakeMigrationExportService)
     monkeypatch.setattr(data_migration, "MigrationPackageService", FakeMigrationPackageService)
 
@@ -153,7 +152,6 @@ def test_import_command_uses_cli_owned_session(monkeypatch, tmp_path: Path, sqli
             captured["path"] = path
             return package
 
-    monkeypatch.setattr(data_migration.session_factory, "create_session", lambda: Session(sqlite_engine))
     monkeypatch.setattr(data_migration, "MigrationImportService", FakeMigrationImportService)
     monkeypatch.setattr(data_migration, "MigrationPackageService", FakeMigrationPackageService)
 

--- a/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
+++ b/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
@@ -22,14 +22,14 @@ import json
 import uuid
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from flask import Flask
 from flask.views import MethodView
 from pydantic import ValidationError
-from sqlalchemy import Engine, select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest, NotFound, UnprocessableEntity
 
 from controllers.openapi import bp as openapi_bp
@@ -45,7 +45,6 @@ from controllers.openapi.workspaces import (
 from libs.oauth_bearer import AuthContext, Scope, SubjectType, TokenType, reset_auth_ctx, set_auth_ctx
 from models import Account, Tenant, TenantAccountJoin
 from models.account import AccountStatus, TenantAccountRole, TenantStatus
-from models.base import TypeBase
 from services.account_service import TenantService as RealTenantService
 from services.errors.account import (
     AccountAlreadyInTenantError,
@@ -92,14 +91,8 @@ def openapi_app() -> Flask:
 
 
 @pytest.fixture
-def database_session(sqlite_engine: Engine):
-    models = (Account, Tenant, TenantAccountJoin)
-    tables = [model.metadata.tables[model.__tablename__] for model in models]
-    TypeBase.metadata.create_all(sqlite_engine, tables=tables)
-    session_maker = sessionmaker(bind=sqlite_engine, expire_on_commit=False)
-    factory = SimpleNamespace(get_session_maker=lambda: session_maker, create_session=session_maker)
-    with patch("controllers.common.session.session_factory", factory), session_maker() as session:
-        yield session
+def database_session(sqlite_session: Session):
+    return sqlite_session
 
 
 def _rule(app: Flask, path: str):


### PR DESCRIPTION
## Summary
- remove the fabricated OpenAPI `SimpleNamespace` session factory
- remove CLI migration `create_session` lambda stubs
- use the autouse shared SQLite session factory for production-owned session creation

## Real persistence coverage
OpenAPI workspace tests now share the canonical `sqlite_session`, while migration commands open and close their own sessions through the actual production factory bound by the unit-test fixture.

## Production fixes
None.

## Size
5 additions, 14 deletions.

## Validation
- focused pytest over both changed modules — 40 passed
- targeted `make test` over both changed modules — 40 passed
- `make lint` — passed
- `make type-check` — pyrefly completed; mypy 1.20.2 hit its existing internal error at `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- `git diff --check` — passed

The full test suite was not run, per request.
