### PR TITLE
feat(otel): emit gen_ai.response.model on LLM node spans

### DIFF
--- a/api/extensions/otel/parser/llm.py
+++ b/api/extensions/otel/parser/llm.py
@@ -119,6 +119,10 @@ class LLMNodeOTelParser:
 
         if model_name:
             span.set_attribute(LLMAttributes.REQUEST_MODEL, model_name)
+            # Dify does not surface the provider-returned model separately, so
+            # response.model is set on the instrumentation's best knowledge,
+            # as permitted by the GenAI semantic conventions.
+            span.set_attribute(LLMAttributes.RESPONSE_MODEL, model_name)
         if model_provider:
             span.set_attribute(LLMAttributes.PROVIDER_NAME, model_provider)
 

--- a/api/extensions/otel/semconv/gen_ai.py
+++ b/api/extensions/otel/semconv/gen_ai.py
@@ -68,7 +68,10 @@ class LLMAttributes:
     """LLM operation attribute keys."""
 
     REQUEST_MODEL = "gen_ai.request.model"
-    """Model identifier."""
+    """Model identifier requested by the caller."""
+
+    RESPONSE_MODEL = "gen_ai.response.model"
+    """Model identifier that generated the response."""
 
     PROVIDER_NAME = "gen_ai.provider.name"
     """Provider name."""

--- a/api/tests/unit_tests/extensions/otel/parser/test_llm.py
+++ b/api/tests/unit_tests/extensions/otel/parser/test_llm.py
@@ -1,0 +1,29 @@
+"""Tests for LLMNodeOTelParser GenAI attribute mapping."""
+
+from unittest.mock import MagicMock, patch
+
+from extensions.otel.parser.llm import LLMNodeOTelParser
+from extensions.otel.semconv.gen_ai import LLMAttributes
+
+
+class TestLLMNodeOTelParserModelAttributes:
+    def test_response_model_is_set_alongside_request_model(self) -> None:
+        """gen_ai.response.model must be emitted so backends can group by model."""
+        with patch("extensions.otel.parser.llm.DefaultNodeOTelParser"):
+            parser = LLMNodeOTelParser()
+
+        span = MagicMock()
+        result_event = MagicMock()
+        result_event.node_run_result.process_data = {
+            "model_name": "gpt-4o",
+            "model_provider": "openai",
+        }
+        result_event.node_run_result.outputs = {"text": "hello", "finish_reason": "stop"}
+
+        parser.parse(node=MagicMock(), span=span, error=None, result_event=result_event)
+
+        recorded = {call.args[0]: call.args[1] for call in span.set_attribute.call_args_list}
+
+        assert recorded[LLMAttributes.REQUEST_MODEL] == "gpt-4o"
+        assert recorded[LLMAttributes.RESPONSE_MODEL] == "gpt-4o"
+        assert recorded[LLMAttributes.PROVIDER_NAME] == "openai"


### PR DESCRIPTION
## Summary

Fixes #40635

The native OTel instrumentation sets `gen_ai.request.model` on LLM node spans
but never sets `gen_ai.response.model`, which is a first-class attribute in the
OpenTelemetry GenAI semantic conventions registry. Several observability
backends key their GenAI model-level aggregations on `gen_ai.response.model`
specifically, so model breakdown views can render empty for Dify workloads even
though otherwise-correct GenAI spans are emitted.

This change is **purely additive** — no existing attribute is renamed or
removed — so it is backward-compatible with all current consumers (Langfuse,
Arize Phoenix, Opik) and does not require an `OTEL_SEMCONV_STABILITY_OPT_IN`
gate.

**Known limitation:** Dify derives the model name from
`process_data["model_name"]`, which is the *requested* model. The
provider-returned model (`LLMResult.model`) is not surfaced in `NodeRunResult`.
The spec permits setting `gen_ai.response.model` on the instrumentation's best
knowledge, so this is valid today; the complete fix would be for `graphon` to
expose `LLMResult.model`. Happy to open a follow-up if maintainers agree.

## Screenshots

N/A — backend-only change. Span attribute effect:

|             Before                |                                  After                                  |
|-----------------------------------|-------------------------------------------------------------------------|
| `gen_ai.request.model = "gpt-4o"` | `gen_ai.request.model = "gpt-4o"`<br>`gen_ai.response.model = "gpt-4o"` |

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods
