### PR TITLE
test: migrate residual dataset and archive ORM models

### DIFF
--- a/api/tests/unit_tests/services/agent/test_composer_candidates.py
+++ b/api/tests/unit_tests/services/agent/test_composer_candidates.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 from fields.agent_fields import AgentComposerCandidatesResponse
 from models.agent_config_entities import AgentSoulConfig, DeclaredOutputConfig, DeclaredOutputType
+from models.dataset import Dataset
 from services.agent.composer_candidates import (
     MAX_CANDIDATES_PER_LIST,
     previous_node_output_candidates,
@@ -142,9 +141,16 @@ def _soul() -> AgentSoulConfig:
 
 
 def test_soul_candidates_lists_configured_items_only():
+    dataset = Dataset(
+        id="ds-1",
+        tenant_id="tenant-1",
+        name="产品手册",
+        description="desc",
+        created_by="account-1",
+    )
     lists, truncated = soul_candidates(
         agent_soul=_soul(),
-        dataset_lookup=lambda ids: {"ds-1": SimpleNamespace(name="产品手册", description="desc")},
+        dataset_lookup=lambda ids: {"ds-1": dataset},
         workspace_tools_loader=lambda: [
             {"id": "tavily/tavily_search", "name": "tavily_search", "provider": "tavily", "plugin_id": "lg/tavily"}
         ],

--- a/api/tests/unit_tests/services/retention/workflow_run/test_bundle_archive_maintenance.py
+++ b/api/tests/unit_tests/services/retention/workflow_run/test_bundle_archive_maintenance.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, call, patch
 
@@ -112,6 +111,13 @@ def _bundle_model(entry: ArchiveBundleCatalogEntry) -> WorkflowRunArchiveBundle:
         archived_at=datetime.datetime(2026, 1, 1),
     )
     bundle.id = entry.catalog_id
+    return bundle
+
+
+def _cursor_bundle(*, year: int, tenant_id: str) -> WorkflowRunArchiveBundle:
+    bundle = _bundle_model(_catalog_entry())
+    bundle.year = year
+    bundle.tenant_id = tenant_id
     return bundle
 
 
@@ -291,31 +297,26 @@ def test_catalog_shard_preflight_uses_requested_tenant_scope(
     [
         (None, None, "does not exist"),
         (
-            SimpleNamespace(year=2024, month=3, tenant_id=TENANT_ID),
+            _cursor_bundle(year=2024, tenant_id=TENANT_ID),
             None,
             "requested archive month",
         ),
         (
-            SimpleNamespace(year=2025, month=3, tenant_id="other-tenant"),
+            _cursor_bundle(year=2025, tenant_id="other-tenant"),
             [TENANT_ID],
             "requested tenant scope",
         ),
     ],
 )
 def test_catalog_discovery_rejects_cursor_outside_requested_scope(
-    cursor_bundle: SimpleNamespace | None,
+    cursor_bundle: WorkflowRunArchiveBundle | None,
     tenant_ids: list[str] | None,
     error_message: str,
     sqlite_session_factory: sessionmaker[Session],
     sqlite_session: Session,
 ) -> None:
     if cursor_bundle is not None:
-        entry = _catalog_entry()
-        stored = _bundle_model(entry)
-        stored.year = cursor_bundle.year
-        stored.month = cursor_bundle.month
-        stored.tenant_id = cursor_bundle.tenant_id
-        sqlite_session.add(stored)
+        sqlite_session.add(cursor_bundle)
         sqlite_session.commit()
     maintenance = WorkflowRunBundleArchiveMaintenance(
         storage=cast(MagicMock, MagicMock()),


### PR DESCRIPTION
## Summary
- return a real mapped `Dataset` from the agent composer lookup
- use real `WorkflowRunArchiveBundle` cursor rows in archive catalog validation
- remove the remaining namespaces that semantically represented mapped records

## Real persistence coverage
The composer path only reads dataset display fields and therefore uses a real transient dataset. Archive cursor tests persist real bundle rows to SQLite before the production query validates month and tenant scope.

## Production fixes
None.

## Size
20 additions, 13 deletions.

## Validation
- focused pytest over both changed modules — 31 passed
- targeted `make test` over both changed modules — 31 passed
- `make lint` — passed
- `make type-check` — pyrefly completed; mypy 1.20.2 hit its existing internal error at `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- `git diff --check` — passed

The full test suite was not run, per request.
