### PR TITLE
test: migrate API workflow pause ORM models to real entities

### DIFF
--- a/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py
+++ b/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from types import SimpleNamespace
 
 from core.workflow.nodes.human_input.entities import FormDefinition, ParagraphInputConfig, UserActionConfig
 from core.workflow.nodes.human_input.enums import FormInputType
 from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
 from graphon.entities.pause_reason import HitlRequired, PauseReasonType
-from models.human_input import RecipientType
-from models.workflow import WorkflowPauseReason
+from models.human_input import HumanInputForm, HumanInputFormRecipient, RecipientType
+from models.workflow import WorkflowPause, WorkflowPauseReason
 from repositories.sqlalchemy_api_workflow_run_repository import (
     _build_human_input_required_reason,
     _PrivateWorkflowPauseEntity,
 )
 
 
-def _build_form_model() -> SimpleNamespace:
+def _build_form_model() -> HumanInputForm:
     expiration_time = datetime(2024, 1, 1, tzinfo=UTC)
     definition = FormDefinition(
         form_content="content",
@@ -27,17 +26,36 @@ def _build_form_model() -> SimpleNamespace:
         node_title="Ask Name",
         display_in_ui=True,
     )
-    return SimpleNamespace(
-        id="form-1",
+    form = HumanInputForm(
+        tenant_id="tenant-1",
+        app_id="app-1",
+        workflow_run_id="run-1",
         node_id="node-1",
         form_definition=definition.model_dump_json(),
         rendered_content="rendered",
         expiration_time=expiration_time,
     )
+    form.id = "form-1"
+    return form
 
 
-def _build_reason_model() -> SimpleNamespace:
-    return SimpleNamespace(form_id="form-1", node_id="node-1")
+def _build_reason_model() -> WorkflowPauseReason:
+    return WorkflowPauseReason(
+        pause_id="pause-1",
+        type_=PauseReasonType.HITL_REQUIRED,
+        form_id="form-1",
+        node_id="node-1",
+    )
+
+
+def _recipient(recipient_type: RecipientType, access_token: str) -> HumanInputFormRecipient:
+    return HumanInputFormRecipient(
+        form_id="form-1",
+        delivery_id=f"delivery-{recipient_type.value}",
+        recipient_type=recipient_type,
+        recipient_payload="{}",
+        access_token=access_token,
+    )
 
 
 def test_build_human_input_required_reason_prefers_standalone_web_app_token() -> None:
@@ -45,9 +63,9 @@ def test_build_human_input_required_reason_prefers_standalone_web_app_token() ->
         _build_reason_model(),
         _build_form_model(),
         [
-            SimpleNamespace(recipient_type=RecipientType.BACKSTAGE, access_token="btok"),
-            SimpleNamespace(recipient_type=RecipientType.CONSOLE, access_token="ctok"),
-            SimpleNamespace(recipient_type=RecipientType.STANDALONE_WEB_APP, access_token="wtok"),
+            _recipient(RecipientType.BACKSTAGE, "btok"),
+            _recipient(RecipientType.CONSOLE, "ctok"),
+            _recipient(RecipientType.STANDALONE_WEB_APP, "wtok"),
         ],
     )
 
@@ -62,8 +80,8 @@ def test_build_human_input_required_reason_falls_back_to_console_token() -> None
         _build_reason_model(),
         _build_form_model(),
         [
-            SimpleNamespace(recipient_type=RecipientType.BACKSTAGE, access_token="btok"),
-            SimpleNamespace(recipient_type=RecipientType.CONSOLE, access_token="ctok"),
+            _recipient(RecipientType.BACKSTAGE, "btok"),
+            _recipient(RecipientType.CONSOLE, "ctok"),
         ],
     )
 
@@ -117,13 +135,14 @@ def test_private_workflow_pause_entity_preserves_list_shaped_pause_reasons() -> 
             node_title="Ask Name",
         )
     ]
+    pause_model = WorkflowPause(
+        workflow_id="workflow-1",
+        workflow_run_id="run-1",
+        state_object_key="pause-state",
+    )
+    pause_model.id = "pause-1"
     entity = _PrivateWorkflowPauseEntity(
-        pause_model=SimpleNamespace(
-            id="pause-1",
-            workflow_run_id="run-1",
-            resumed_at=None,
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-        ),
+        pause_model=pause_model,
         reason_models=[],
         pause_reasons=pause_reasons,
     )


### PR DESCRIPTION
## Summary

- replace `SimpleNamespace` stand-ins for API workflow pause models with real mapped SQLAlchemy entities
- exercise human-input form, recipient, pause reason, and workflow pause conversion using their production model contracts
- keep these objects transient because the tests cover pure conversion/property behavior and perform no database access

## Motivation

These repository unit tests passed object-shaped stand-ins into helpers whose interfaces require mapped ORM models. Real model instances keep the tests aligned with SQLAlchemy mappings and expose constructor/property contract drift.

## Persistence coverage

No persistence is required for this behavior cluster: the tested helpers only read initialized mapped attributes. The tests now use real transient `HumanInputForm`, `HumanInputFormRecipient`, `WorkflowPauseReason`, and `WorkflowPause` instances.

## Production changes

None.

## Size

- 38 additions, 19 deletions

## Validation

- `make test TARGET_TESTS=./api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py` — 5 passed
- `make lint` — passed
- `make type-check` — pyrefly passed; mypy 1.20.2 hit its existing internal error at `.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- full test suite not run, per request
