### PR TITLE
fix(workflow): align human input timeout handle

### DIFF
--- a/api/core/workflow/nodes/human_input/callback.py
+++ b/api/core/workflow/nodes/human_input/callback.py
@@ -68,7 +68,7 @@ class DifyHITLCallback:
     _OUTPUT_FIELD_ACTION_ID = "__action_id"
     _OUTPUT_FIELD_ACTION_VALUE = "__action_value"
     _OUTPUT_FIELD_RENDERED_CONTENT = "__rendered_content"
-    _TIMEOUT_HANDLE = "__timeout__"
+    _TIMEOUT_HANDLE = "__timeout"
 
     def __init__(
         self,

--- a/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
+++ b/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
@@ -264,4 +264,4 @@ def test_human_input_node_emits_timeout_event_before_succeeded():
 
     assert isinstance(events[0], NodeRunStartedEvent)
     assert isinstance(events[1], NodeRunSucceededEvent)
-    assert events[1].node_run_result.edge_source_handle == "__timeout__"
+    assert events[1].node_run_result.edge_source_handle == "__timeout"


### PR DESCRIPTION
## Summary

- restore the Human Input backend timeout handle to `__timeout`
- align the focused runtime regression assertion with the frontend and persisted workflow DSL contract

## Why

The workflow editor and preview nodes expose their timeout edge with `handleId=__timeout`, while `DifyHITLCallback` returned `selected_handle=__timeout__`. The extra trailing underscores prevent an expired Human Input node from selecting its configured timeout edge.

Fixes #40459

## Validation

- `python -m py_compile api/core/workflow/nodes/human_input/callback.py api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py`
- verified current `main` uses `handleId=__timeout` in the workflow editor, workflow preview, and frontend node tests
- verified the focused backend test asserts the runtime `edge_source_handle`
- full pytest suite not run locally because this contribution was prepared from a sparse source snapshot; CI is expected to run the repository test environment

## AI disclosure

Codex assisted with issue discovery, repository inspection, and implementation. I reviewed the change and validation results.