### PR TITLE
fix(api): add missing RBAC permission checks to workspace RBAC console endpoints

### DIFF
--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -838,6 +838,9 @@ class RBACDatasetMemberBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/apps/access-policy")
 class RBACWorkspaceAppMatrixApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.WorkspaceAccessMatrix.__name__])
     def get(self):
         tenant_id, account_id = _current_ids()
@@ -850,6 +853,9 @@ class RBACWorkspaceAppMatrixApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/apps/access-policies/<uuid:policy_id>/role-bindings")
 class RBACWorkspaceAppRoleBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.RoleBindingsResponse.__name__])
     def get(self, policy_id):
         tenant_id, account_id = _current_ids()
@@ -859,6 +865,9 @@ class RBACWorkspaceAppRoleBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/apps/access-policies/<uuid:policy_id>/bindings")
 class RBACWorkspaceAppBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.expect(console_ns.models[_ReplaceBindingsRequest.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.AccessMatrixItem.__name__])
     def put(self, policy_id):
@@ -877,6 +886,9 @@ class RBACWorkspaceAppBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/apps/access-policies/<uuid:policy_id>/member-bindings")
 class RBACWorkspaceAppMemberBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.MemberBindingsResponse.__name__])
     def get(self, policy_id):
         tenant_id, account_id = _current_ids()
@@ -886,6 +898,9 @@ class RBACWorkspaceAppMemberBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/datasets/access-policy")
 class RBACWorkspaceDatasetMatrixApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.WorkspaceAccessMatrix.__name__])
     def get(self):
         tenant_id, account_id = _current_ids()
@@ -898,6 +913,9 @@ class RBACWorkspaceDatasetMatrixApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/datasets/access-policies/<uuid:policy_id>/role-bindings")
 class RBACWorkspaceDatasetRoleBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.RoleBindingsResponse.__name__])
     def get(self, policy_id):
         tenant_id, account_id = _current_ids()
@@ -907,6 +925,9 @@ class RBACWorkspaceDatasetRoleBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/datasets/access-policies/<uuid:policy_id>/bindings")
 class RBACWorkspaceDatasetBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.expect(console_ns.models[_ReplaceBindingsRequest.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.AccessMatrixItem.__name__])
     def put(self, policy_id):
@@ -925,6 +946,9 @@ class RBACWorkspaceDatasetBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/workspace/datasets/access-policies/<uuid:policy_id>/member-bindings")
 class RBACWorkspaceDatasetMemberBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.MemberBindingsResponse.__name__])
     def get(self, policy_id):
         tenant_id, account_id = _current_ids()

--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -11,7 +11,13 @@ from werkzeug.exceptions import NotFound
 from configs import dify_config
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
-from controllers.console.wraps import RBACPermission, RBACResourceScope, model_validate, rbac_permission_required
+from controllers.console.wraps import (
+    RBACPermission,
+    RBACResourceScope,
+    is_admin_or_owner_required,
+    model_validate,
+    rbac_permission_required,
+)
 from core.db.session_factory import session_factory
 from core.rbac import RBACResourceWhitelistScope
 from enums import DeploymentEdition
@@ -979,12 +985,19 @@ register_schema_models(console_ns, _ReplaceMemberRolesRequest)
 @console_ns.route("/workspaces/current/rbac/members/<uuid:member_id>/rbac-roles")
 class RBACMemberRolesApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_MEMBER_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.MemberRolesResponse.__name__])
     def get(self, member_id):
         tenant_id, account_id = _current_ids()
         return _dump(svc.RBACService.MemberRoles.get(tenant_id, account_id, str(member_id), session=db.session()))
 
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_MEMBER_MANAGE, resource_required=False
+    )
     @console_ns.expect(console_ns.models[_ReplaceMemberRolesRequest.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.MemberRolesResponse.__name__])
     def put(self, member_id):
@@ -1004,6 +1017,9 @@ class RBACMemberRolesApi(Resource):
 @console_ns.route("/workspaces/current/rbac/roles/<uuid:role_id>/members")
 class ListMembersByRole(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[_MembersInRoleList.__name__])
     def get(self, role_id):
         tenant_id, account_id = _current_ids()

--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -260,6 +260,9 @@ def _legacy_workspace_roles(
 @console_ns.route("/workspaces/current/rbac/role-permissions/catalog")
 class RBACWorkspaceCatalogApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.PermissionCatalogResponse.__name__])
     def get(self):
         tenant_id, account_id = _current_ids()
@@ -269,6 +272,9 @@ class RBACWorkspaceCatalogApi(Resource):
 @console_ns.route("/workspaces/current/rbac/role-permissions/catalog/app")
 class RBACAppCatalogApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.PermissionCatalogResponse.__name__])
     def get(self):
         tenant_id, account_id = _current_ids()
@@ -278,6 +284,9 @@ class RBACAppCatalogApi(Resource):
 @console_ns.route("/workspaces/current/rbac/role-permissions/catalog/dataset")
 class RBACDatasetCatalogApi(Resource):
     @login_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.WORKSPACE_ROLE_MANAGE, resource_required=False
+    )
     @console_ns.response(200, "Success", console_ns.models[svc.PermissionCatalogResponse.__name__])
     def get(self):
         tenant_id, account_id = _current_ids()

--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -607,6 +607,7 @@ class RBACMyPermissionsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/apps/<uuid:app_id>/access-policy")
 class RBACAppMatrixApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.doc(params=query_params_from_model(_AccessControlLanguageQuery))
     @console_ns.response(200, "Success", console_ns.models[svc.AppAccessMatrix.__name__])
     def get(self, app_id):
@@ -619,12 +620,14 @@ class RBACAppMatrixApi(Resource):
 @console_ns.route("/workspaces/current/rbac/apps/<uuid:app_id>/whitelist")
 class RBACAppWhitelistApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.response(200, "Success", console_ns.models[svc.ResourceWhitelist.__name__])
     def get(self, app_id):
         tenant_id, account_id = _current_ids()
         return _dump(svc.RBACService.AppAccess.whitelist(tenant_id, account_id, str(app_id)))
 
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.expect(console_ns.models[_ResourceAccessScopeRequest.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.ResourceWhitelist.__name__])
     def put(self, app_id):
@@ -644,6 +647,7 @@ class RBACAppWhitelistApi(Resource):
 @console_ns.route("/workspaces/current/rbac/apps/<uuid:app_id>/user-access-policies")
 class RBACAppUserAccessPoliciesApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.doc(params=query_params_from_model(_AccessControlLanguageQuery))
     @console_ns.response(200, "Success", console_ns.models[svc.ResourceUserAccessPoliciesResponse.__name__])
     def get(self, app_id):
@@ -656,6 +660,7 @@ class RBACAppUserAccessPoliciesApi(Resource):
 @console_ns.route("/workspaces/current/rbac/apps/<uuid:app_id>/users/<uuid:target_account_id>/access-policies")
 class RBACAppUserAccessPolicyAssignmentApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.expect(console_ns.models[svc.ReplaceUserAccessPolicies.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.ReplaceUserAccessPoliciesResponse.__name__])
     def put(self, app_id, target_account_id):
@@ -675,6 +680,7 @@ class RBACAppUserAccessPolicyAssignmentApi(Resource):
 @console_ns.route("/workspaces/current/rbac/apps/<uuid:app_id>/access-policies/<uuid:policy_id>/role-bindings")
 class RBACAppRoleBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.response(200, "Success", console_ns.models[svc.RoleBindingsResponse.__name__])
     def get(self, app_id, policy_id):
         tenant_id, account_id = _current_ids()
@@ -684,12 +690,14 @@ class RBACAppRoleBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/apps/<uuid:app_id>/access-policies/<string:policy_id>/member-bindings")
 class RBACAppMemberBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.response(200, "Success", console_ns.models[svc.MemberBindingsResponse.__name__])
     def get(self, app_id, policy_id):
         tenant_id, account_id = _current_ids()
         return _dump(svc.RBACService.AppAccess.list_member_bindings(tenant_id, account_id, str(app_id), str(policy_id)))
 
     @login_required
+    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_ACCESS_CONFIG)
     @console_ns.expect(console_ns.models[_DeleteMemberBindingsRequest.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.MemberBindingsResponse.__name__])
     def delete(self, app_id, policy_id):

--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -721,6 +721,7 @@ class RBACAppMemberBindingsApi(Resource):
 @console_ns.route("/workspaces/current/rbac/datasets/<uuid:dataset_id>/access-policy")
 class RBACDatasetMatrixApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.doc(params=query_params_from_model(_AccessControlLanguageQuery))
     @console_ns.response(200, "Success", console_ns.models[svc.DatasetAccessMatrix.__name__])
     def get(self, dataset_id):
@@ -733,12 +734,14 @@ class RBACDatasetMatrixApi(Resource):
 @console_ns.route("/workspaces/current/rbac/datasets/<uuid:dataset_id>/whitelist")
 class RBACDatasetWhitelistApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.response(200, "Success", console_ns.models[svc.ResourceWhitelist.__name__])
     def get(self, dataset_id):
         tenant_id, account_id = _current_ids()
         return _dump(svc.RBACService.DatasetAccess.whitelist(tenant_id, account_id, str(dataset_id)))
 
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.expect(console_ns.models[_ResourceAccessScopeRequest.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.ResourceWhitelist.__name__])
     def put(self, dataset_id):
@@ -760,6 +763,7 @@ class RBACDatasetWhitelistApi(Resource):
 @console_ns.route("/workspaces/current/rbac/datasets/<uuid:dataset_id>/user-access-policies")
 class RBACDatasetUserAccessPoliciesApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.doc(params=query_params_from_model(_AccessControlLanguageQuery))
     @console_ns.response(200, "Success", console_ns.models[svc.ResourceUserAccessPoliciesResponse.__name__])
     def get(self, dataset_id):
@@ -772,6 +776,7 @@ class RBACDatasetUserAccessPoliciesApi(Resource):
 @console_ns.route("/workspaces/current/rbac/datasets/<uuid:dataset_id>/users/<uuid:target_account_id>/access-policies")
 class RBACDatasetUserAccessPolicyAssignmentApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.expect(console_ns.models[svc.ReplaceUserAccessPolicies.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.ReplaceUserAccessPoliciesResponse.__name__])
     def put(self, dataset_id, target_account_id):
@@ -791,6 +796,7 @@ class RBACDatasetUserAccessPolicyAssignmentApi(Resource):
 @console_ns.route("/workspaces/current/rbac/datasets/<uuid:dataset_id>/access-policies/<uuid:policy_id>/role-bindings")
 class RBACDatasetRoleBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.response(200, "Success", console_ns.models[svc.RoleBindingsResponse.__name__])
     def get(self, dataset_id, policy_id):
         tenant_id, account_id = _current_ids()
@@ -804,6 +810,7 @@ class RBACDatasetRoleBindingsApi(Resource):
 )
 class RBACDatasetMemberBindingsApi(Resource):
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.response(200, "Success", console_ns.models[svc.MemberBindingsResponse.__name__])
     def get(self, dataset_id, policy_id):
         tenant_id, account_id = _current_ids()
@@ -812,6 +819,7 @@ class RBACDatasetMemberBindingsApi(Resource):
         )
 
     @login_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_ACCESS_CONFIG)
     @console_ns.expect(console_ns.models[_DeleteMemberBindingsRequest.__name__])
     @console_ns.response(200, "Success", console_ns.models[svc.MemberBindingsResponse.__name__])
     def delete(self, dataset_id, policy_id):

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -639,9 +639,7 @@ class TestWorkspaceRbacGuards:
             ),
             patch("controllers.common.wraps._is_resource_owned_by_current_user", return_value=False),
             patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
-            patch(
-                "controllers.console.workspace.rbac.svc.RBACService.DatasetAccess.replace_whitelist"
-            ) as mock_replace,
+            patch("controllers.console.workspace.rbac.svc.RBACService.DatasetAccess.replace_whitelist") as mock_replace,
         ):
             with pytest.raises(Forbidden):
                 rbac_mod.RBACDatasetWhitelistApi().put(dataset_id="ds-1")

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -623,6 +623,30 @@ class TestWorkspaceRbacGuards:
 
         mock_replace.assert_not_called()
 
+    def test_dataset_whitelist_replace_requires_dataset_access_config(self, app):
+        with (
+            app.test_request_context(
+                "/workspaces/current/rbac/datasets/ds-1/whitelist",
+                method="PUT",
+                json={"scope": "all"},
+            ),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
+            patch(
+                "controllers.common.wraps.current_account_with_tenant",
+                return_value=(SimpleNamespace(id="acct-1"), "tenant-1"),
+            ),
+            patch("controllers.common.wraps._is_resource_owned_by_current_user", return_value=False),
+            patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
+            patch(
+                "controllers.console.workspace.rbac.svc.RBACService.DatasetAccess.replace_whitelist"
+            ) as mock_replace,
+        ):
+            with pytest.raises(Forbidden):
+                rbac_mod.RBACDatasetWhitelistApi().put(dataset_id="ds-1")
+
+        mock_replace.assert_not_called()
+
 
 class TestDumpHelper:
     def test_dump_returns_plain_dict(self):

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -601,6 +601,28 @@ class TestWorkspaceRbacGuards:
 
         mock_catalog.assert_not_called()
 
+    def test_app_whitelist_replace_requires_app_access_config(self, app):
+        with (
+            app.test_request_context(
+                "/workspaces/current/rbac/apps/app-1/whitelist",
+                method="PUT",
+                json={"scope": "all"},
+            ),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
+            patch(
+                "controllers.common.wraps.current_account_with_tenant",
+                return_value=(SimpleNamespace(id="acct-1"), "tenant-1"),
+            ),
+            patch("controllers.common.wraps._is_resource_owned_by_current_user", return_value=False),
+            patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
+            patch("controllers.console.workspace.rbac.svc.RBACService.AppAccess.replace_whitelist") as mock_replace,
+        ):
+            with pytest.raises(Forbidden):
+                rbac_mod.RBACAppWhitelistApi().put(app_id="app-1")
+
+        mock_replace.assert_not_called()
+
 
 class TestDumpHelper:
     def test_dump_returns_plain_dict(self):

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -28,6 +28,7 @@ from configs import dify_config
 from controllers.console.workspace import rbac as rbac_mod
 from controllers.console.workspace.rbac import _RolesListQuery
 from enums import DeploymentEdition
+from models.account import Account, TenantAccountRole
 
 
 @pytest.fixture
@@ -667,6 +668,50 @@ class TestWorkspaceRbacGuards:
         ):
             with pytest.raises(Forbidden):
                 rbac_mod.RBACWorkspaceAppBindingsApi().put(policy_id="policy-1")
+
+        mock_replace.assert_not_called()
+
+    def test_member_role_replace_requires_member_manage(self, app):
+        with (
+            app.test_request_context(
+                "/workspaces/current/rbac/members/member-1/rbac-roles",
+                method="PUT",
+                json={"role_ids": ["role-owner"]},
+            ),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
+            patch(
+                "controllers.common.wraps.current_account_with_tenant",
+                return_value=(SimpleNamespace(id="acct-1"), "tenant-1"),
+            ),
+            patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
+            patch("controllers.console.workspace.rbac.svc.RBACService.MemberRoles.replace") as mock_replace,
+        ):
+            with pytest.raises(Forbidden):
+                rbac_mod.RBACMemberRolesApi().put(member_id="member-1")
+
+        mock_replace.assert_not_called()
+
+    def test_member_role_replace_requires_admin_when_rbac_disabled(self, app):
+        # `rbac_permission_required` is inert when RBAC is off, so the legacy admin guard is the
+        # only thing standing between a normal member and `TenantAccountJoin.role`.
+        normal_member = Account(name="Normal", email="normal@example.com")
+        normal_member.role = TenantAccountRole.NORMAL
+
+        with (
+            app.test_request_context(
+                "/workspaces/current/rbac/members/member-1/rbac-roles",
+                method="PUT",
+                json={"role_ids": ["owner"]},
+            ),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", False),
+            patch("libs.login._get_user", return_value=normal_member),
+            patch("controllers.console.workspace.rbac.svc.RBACService.MemberRoles.replace") as mock_replace,
+        ):
+            assert normal_member.is_admin_or_owner is False
+            with pytest.raises(Forbidden):
+                rbac_mod.RBACMemberRolesApi().put(member_id="member-1")
 
         mock_replace.assert_not_called()
 

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -647,6 +647,29 @@ class TestWorkspaceRbacGuards:
 
         mock_replace.assert_not_called()
 
+    def test_workspace_app_bindings_replace_requires_workspace_role_manage(self, app):
+        with (
+            app.test_request_context(
+                "/workspaces/current/rbac/workspace/apps/access-policies/policy-1/bindings",
+                method="PUT",
+                json={"role_ids": [], "account_ids": []},
+            ),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
+            patch(
+                "controllers.common.wraps.current_account_with_tenant",
+                return_value=(SimpleNamespace(id="acct-1"), "tenant-1"),
+            ),
+            patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
+            patch(
+                "controllers.console.workspace.rbac.svc.RBACService.WorkspaceAccess.replace_app_bindings"
+            ) as mock_replace,
+        ):
+            with pytest.raises(Forbidden):
+                rbac_mod.RBACWorkspaceAppBindingsApi().put(policy_id="policy-1")
+
+        mock_replace.assert_not_called()
+
 
 class TestDumpHelper:
     def test_dump_returns_plain_dict(self):

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -584,6 +584,23 @@ class TestWorkspaceRbacGuards:
 
         mock_create.assert_not_called()
 
+    def test_workspace_catalog_requires_workspace_role_manage(self, app):
+        with (
+            app.test_request_context("/workspaces/current/rbac/role-permissions/catalog"),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
+            patch(
+                "controllers.common.wraps.current_account_with_tenant",
+                return_value=(SimpleNamespace(id="acct-1"), "tenant-1"),
+            ),
+            patch("controllers.common.wraps.RBACService.CheckAccess.check", return_value=False),
+            patch("controllers.console.workspace.rbac.svc.RBACService.Catalog.workspace") as mock_catalog,
+        ):
+            with pytest.raises(Forbidden):
+                rbac_mod.RBACWorkspaceCatalogApi().get()
+
+        mock_catalog.assert_not_called()
+
 
 class TestDumpHelper:
     def test_dump_returns_plain_dict(self):


### PR DESCRIPTION
## Summary

`api/controllers/console/workspace/rbac.py` exposes 45 request handlers. Only 14 carried a permission check — the remaining 31 were reachable by any authenticated workspace member, including the endpoints that read and mutate RBAC configuration itself.

This adds the existing `@rbac_permission_required` decorator to 30 of them. The permission point for each group matches what the frontend already gates the corresponding UI surface on, so no working UI should begin receiving 403s.

| Group | Handlers | Permission |
| ----- | -------- | ---------- |
| Permission catalogs | 3 | `workspace.role.manage` |
| Per-app access config | 8 | `app.acl.access_config` |
| Per-dataset access config | 8 | `dataset.acl.access_config` |
| Workspace-level default bindings | 8 | `workspace.role.manage` |
| Member role read/write | 2 | `workspace.member.manage` |
| Members-in-a-role listing | 1 | `workspace.role.manage` |

`GET /workspaces/current/rbac/my-permissions` is deliberately left ungated — it returns the caller's own permission snapshot and every member must be able to call it. It is the only handler in the file without a check.

### The non-RBAC path

`PUT /workspaces/current/rbac/members/<member_id>/rbac-roles` also gets `@is_admin_or_owner_required`. `@rbac_permission_required` is a no-op when `RBAC_ENABLED` is `False`, and this handler has a legacy branch that writes `TenantAccountJoin.role` directly. The two decorators are complementary — exactly one is active at a time.

### Scope

Decorators and one import line. No changes to shared decorator code, no refactoring.

## Tests

Six guard tests added to the existing `TestWorkspaceRbacGuards` class, following that class's established convention (the 14 already-gated handlers share 2 representative tests; the module docstring explains why full decorator-stack happy paths belong in e2e).

Coverage of all 30 handlers is asserted structurally rather than per-handler — a source-level check confirms `RBACMyPermissionsApi.get` is the only remaining ungated handler (`gated=44 ungated=1`).

- `api/tests/unit_tests/controllers/console/workspace/test_rbac.py` — 43 passed (37 before this change)
- `api/tests/unit_tests/controllers` — 3773 passed, 1 skipped

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods

`make lint` is clean. On `make type-check`, `mypy` reports `Success: no issues found in 1671 source files`, but the `pyrefly` step fails before `mypy` runs with:

```
No Python files matched pattern `api/tests/test_containers_integration_tests`
```

This reproduces identically on an unmodified checkout of the base commit, so it is pre-existing and unrelated to this change. Flagging it because it means `make type-check` currently never reaches `mypy` locally.
