### PR TITLE
fix: hide knowledge retrieval from Agent V2 configuration

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/__tests__/agent-prompt-editor.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/__tests__/agent-prompt-editor.spec.tsx
@@ -487,6 +487,11 @@ describe('AgentPromptEditor', () => {
       expect(
         screen.getByRole('button', { name: /agentDetail\.configure\.skills\.label/i }),
       ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', {
+          name: /agentDetail\.configure\.knowledgeRetrieval\.label/i,
+        }),
+      ).not.toBeInTheDocument()
     })
 
     it.each(['Review/', 'Use https:/', 'path/to/'])(

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@langgenius/dify-ui/scroll-area'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { ENABLE_AGENT_KNOWLEDGE_RETRIEVAL } from '@/features/agent-v2/agent-detail/configure/feature-flags'
 import { AgentOrchestrateAddActionsProvider } from './add-actions'
 import { AgentAdvancedSettings } from './advanced'
 import { AgentOrchestrateBottomActions } from './bottom-actions'
@@ -164,7 +165,7 @@ export function AgentOrchestratePanel({
                       <AgentSkills />
                       <AgentFiles />
                       <AgentTools />
-                      <AgentKnowledgeRetrieval />
+                      {ENABLE_AGENT_KNOWLEDGE_RETRIEVAL && <AgentKnowledgeRetrieval />}
                       <AgentAdvancedSettings />
                     </AgentBuildDraftChangedKeysProvider>
                   </AgentOrchestrateAddActionsProvider>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/prompt-editor/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/prompt-editor/index.tsx
@@ -43,7 +43,10 @@ import {
   addProviderToolsAtom,
   agentComposerToolsAtom,
 } from '@/features/agent-v2/agent-composer/store-modules/tools'
-import { ENABLE_AGENT_CLI_TOOLS } from '@/features/agent-v2/agent-detail/configure/feature-flags'
+import {
+  ENABLE_AGENT_CLI_TOOLS,
+  ENABLE_AGENT_KNOWLEDGE_RETRIEVAL,
+} from '@/features/agent-v2/agent-detail/configure/feature-flags'
 import { useAgentOrchestrateAddActions } from '../add-actions-context'
 import { AgentConfigureTipContent } from '../common/tip-content'
 import { useAgentConfigFiles, useAgentConfigSkills } from '../config-context'
@@ -987,11 +990,15 @@ export function AgentPromptEditor() {
       label: t(($) => $['agentDetail.configure.tools.label']),
       icon: 'i-ri-box-3-line',
     },
-    {
-      key: 'knowledge',
-      label: t(($) => $['agentDetail.configure.knowledgeRetrieval.label']),
-      icon: 'i-ri-book-open-line',
-    },
+    ...(ENABLE_AGENT_KNOWLEDGE_RETRIEVAL
+      ? [
+          {
+            key: 'knowledge' as const,
+            label: t(($) => $['agentDetail.configure.knowledgeRetrieval.label']),
+            icon: 'i-ri-book-open-line',
+          },
+        ]
+      : []),
   ]
   const handleOpenSlashMenuCategory = (view: Exclude<SlashMenuView, 'main'>) => {
     parentSlashMenuItemIndexRef.current = Math.max(

--- a/web/features/agent-v2/agent-detail/configure/feature-flags.ts
+++ b/web/features/agent-v2/agent-detail/configure/feature-flags.ts
@@ -1,2 +1,3 @@
 export const ENABLE_AGENT_CLI_TOOLS = false
 export const ENABLE_AGENT_CONTENT_MODERATION = false
+export const ENABLE_AGENT_KNOWLEDGE_RETRIEVAL = false


### PR DESCRIPTION
## Summary

- Hide unsupported knowledge retrieval controls from roster and inline Agent V2 configuration panels behind a temporary feature flag.
- Remove the Knowledge category from the prompt editor slash menu and add regression coverage for the hidden entry.

Fixes DIFY-2884

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.