### PR TITLE
fix: update Agent advanced settings copy

### DIFF
--- a/web/i18n/ar-TN/agent-v-2.json
+++ b/web/i18n/ar-TN/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "العقد",
   "agentDetail.access.workflow.table.version": "الإصدار",
   "agentDetail.access.workflow.title": "وصول سير العمل",
-  "agentDetail.configure.advancedSettings.description": "للمستخدمين المتقدمين. متغيرات البيئة، sandbox والذاكرة.",
+  "agentDetail.configure.advancedSettings.description": "للمستخدمين المتقدمين، مثل متغيرات البيئة.",
   "agentDetail.configure.advancedSettings.envEditor.add": "إضافة متغير بيئة",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "حذف {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "إخفاء قيمة {{key}}",

--- a/web/i18n/de-DE/agent-v-2.json
+++ b/web/i18n/de-DE/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Knoten",
   "agentDetail.access.workflow.table.version": "Version",
   "agentDetail.access.workflow.title": "Workflow-Zugriff",
-  "agentDetail.configure.advancedSettings.description": "Für erfahrene Nutzer. Umgebungsvariablen, Sandbox und Speicher.",
+  "agentDetail.configure.advancedSettings.description": "Für erfahrene Nutzer, z. B. Umgebungsvariablen.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Umgebungsvariable hinzufügen",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "{{key}} löschen",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Wert von {{key}} verbergen",

--- a/web/i18n/en-US/agent-v-2.json
+++ b/web/i18n/en-US/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Nodes",
   "agentDetail.access.workflow.table.version": "Version",
   "agentDetail.access.workflow.title": "Workflow access",
-  "agentDetail.configure.advancedSettings.description": "For power users. Env vars, sandbox & memory.",
+  "agentDetail.configure.advancedSettings.description": "For power users, such as environment variables.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Add environment variable",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Delete {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Hide {{key}} value",

--- a/web/i18n/es-ES/agent-v-2.json
+++ b/web/i18n/es-ES/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Nodos",
   "agentDetail.access.workflow.table.version": "Versión",
   "agentDetail.access.workflow.title": "Acceso por flujo de trabajo",
-  "agentDetail.configure.advancedSettings.description": "Para usuarios avanzados. Variables de entorno, sandbox y memoria.",
+  "agentDetail.configure.advancedSettings.description": "Para usuarios avanzados, como las variables de entorno.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Agregar variable de entorno",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Eliminar {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Ocultar valor de {{key}}",

--- a/web/i18n/fa-IR/agent-v-2.json
+++ b/web/i18n/fa-IR/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "گره‌ها",
   "agentDetail.access.workflow.table.version": "نسخه",
   "agentDetail.access.workflow.title": "دسترسی گردش کار",
-  "agentDetail.configure.advancedSettings.description": "برای کاربران حرفه‌ای. متغیرهای محیطی، sandbox و حافظه.",
+  "agentDetail.configure.advancedSettings.description": "برای کاربران حرفه‌ای، مانند متغیرهای محیطی.",
   "agentDetail.configure.advancedSettings.envEditor.add": "افزودن متغیر محیطی",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "حذف {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "پنهان کردن مقدار {{key}}",

--- a/web/i18n/fr-FR/agent-v-2.json
+++ b/web/i18n/fr-FR/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Nœuds",
   "agentDetail.access.workflow.table.version": "Version",
   "agentDetail.access.workflow.title": "Accès par workflow",
-  "agentDetail.configure.advancedSettings.description": "Pour les utilisateurs avancés. Variables d’environnement, sandbox et mémoire.",
+  "agentDetail.configure.advancedSettings.description": "Pour les utilisateurs avancés, par exemple les variables d’environnement.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Ajouter une variable d’environnement",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Supprimer {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Masquer la valeur de {{key}}",

--- a/web/i18n/hi-IN/agent-v-2.json
+++ b/web/i18n/hi-IN/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "नोड",
   "agentDetail.access.workflow.table.version": "संस्करण",
   "agentDetail.access.workflow.title": "वर्कफ़्लो एक्सेस",
-  "agentDetail.configure.advancedSettings.description": "उन्नत उपयोगकर्ताओं के लिए। पर्यावरण चर, सैंडबॉक्स और मेमोरी।",
+  "agentDetail.configure.advancedSettings.description": "उन्नत उपयोगकर्ताओं के लिए, जैसे पर्यावरण चर।",
   "agentDetail.configure.advancedSettings.envEditor.add": "पर्यावरण चर जोड़ें",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "{{key}} हटाएँ",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "{{key}} मान छुपाएँ",

--- a/web/i18n/id-ID/agent-v-2.json
+++ b/web/i18n/id-ID/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Simpul",
   "agentDetail.access.workflow.table.version": "Versi",
   "agentDetail.access.workflow.title": "Akses alur kerja",
-  "agentDetail.configure.advancedSettings.description": "Untuk pengguna mahir. Variabel lingkungan, sandbox & memori.",
+  "agentDetail.configure.advancedSettings.description": "Untuk pengguna mahir, seperti variabel lingkungan.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Tambahkan variabel lingkungan",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Hapus {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Sembunyikan nilai {{key}}",

--- a/web/i18n/it-IT/agent-v-2.json
+++ b/web/i18n/it-IT/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Nodi",
   "agentDetail.access.workflow.table.version": "Versione",
   "agentDetail.access.workflow.title": "Accesso tramite workflow",
-  "agentDetail.configure.advancedSettings.description": "Per utenti avanzati. Variabili d’ambiente, sandbox e memoria.",
+  "agentDetail.configure.advancedSettings.description": "Per utenti avanzati, ad esempio le variabili d’ambiente.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Aggiungi variabile d’ambiente",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Elimina {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Nascondi valore di {{key}}",

--- a/web/i18n/ja-JP/agent-v-2.json
+++ b/web/i18n/ja-JP/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "ノード",
   "agentDetail.access.workflow.table.version": "バージョン",
   "agentDetail.access.workflow.title": "ワークフローアクセス",
-  "agentDetail.configure.advancedSettings.description": "上級ユーザー向け。環境変数、サンドボックスとメモリ。",
+  "agentDetail.configure.advancedSettings.description": "上級ユーザー向け（環境変数など）。",
   "agentDetail.configure.advancedSettings.envEditor.add": "環境変数を追加",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "{{key}} を削除",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "{{key}} の値を隠す",

--- a/web/i18n/ko-KR/agent-v-2.json
+++ b/web/i18n/ko-KR/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "노드",
   "agentDetail.access.workflow.table.version": "버전",
   "agentDetail.access.workflow.title": "워크플로 액세스",
-  "agentDetail.configure.advancedSettings.description": "고급 사용자용. 환경 변수, 샌드박스 및 메모리.",
+  "agentDetail.configure.advancedSettings.description": "고급 사용자용(예: 환경 변수).",
   "agentDetail.configure.advancedSettings.envEditor.add": "환경 변수 추가",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "{{key}} 삭제",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "{{key}} 값 숨기기",

--- a/web/i18n/lo-LA/agent-v-2.json
+++ b/web/i18n/lo-LA/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "ໂນດ",
   "agentDetail.access.workflow.table.version": "ເວີຊັນ",
   "agentDetail.access.workflow.title": "ການເຂົ້າເຖິງເວີກໂຟລ",
-  "agentDetail.configure.advancedSettings.description": "ສຳລັບຜູ້ໃຊ້ລະດັບສູງ: ຕົວປ່ຽນສະພາບແວດລ້ອມ, ແຊນບ໋ອກຊ໌ ແລະ ໜ່ວຍຄວາມຈຳ.",
+  "agentDetail.configure.advancedSettings.description": "ສຳລັບຜູ້ໃຊ້ລະດັບສູງ ເຊັ່ນ ຕົວປ່ຽນສະພາບແວດລ້ອມ.",
   "agentDetail.configure.advancedSettings.envEditor.add": "ເພີ່ມຕົວປ່ຽນສະພາບແວດລ້ອມ",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "ລຶບ {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "ເຊື່ອງຄ່າ {{key}}",

--- a/web/i18n/nl-NL/agent-v-2.json
+++ b/web/i18n/nl-NL/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Knooppunten",
   "agentDetail.access.workflow.table.version": "Versie",
   "agentDetail.access.workflow.title": "Workflowtoegang",
-  "agentDetail.configure.advancedSettings.description": "Voor gevorderde gebruikers. Omgevingsvariabelen, sandbox en geheugen.",
+  "agentDetail.configure.advancedSettings.description": "Voor gevorderde gebruikers, zoals omgevingsvariabelen.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Omgevingsvariabele toevoegen",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "{{key}} verwijderen",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Waarde van {{key}} verbergen",

--- a/web/i18n/pl-PL/agent-v-2.json
+++ b/web/i18n/pl-PL/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Węzły",
   "agentDetail.access.workflow.table.version": "Wersja",
   "agentDetail.access.workflow.title": "Dostęp do workflow",
-  "agentDetail.configure.advancedSettings.description": "Dla zaawansowanych użytkowników. Zmienne środowiskowe, sandbox i pamięć.",
+  "agentDetail.configure.advancedSettings.description": "Dla zaawansowanych użytkowników, np. zmienne środowiskowe.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Dodaj zmienną środowiskową",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Usuń {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Ukryj wartość {{key}}",

--- a/web/i18n/pt-BR/agent-v-2.json
+++ b/web/i18n/pt-BR/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Nós",
   "agentDetail.access.workflow.table.version": "Versão",
   "agentDetail.access.workflow.title": "Acesso por workflow",
-  "agentDetail.configure.advancedSettings.description": "Para usuários avançados. Variáveis de ambiente, sandbox e memória.",
+  "agentDetail.configure.advancedSettings.description": "Para usuários avançados, como variáveis de ambiente.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Adicionar variável de ambiente",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Excluir {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Ocultar valor de {{key}}",

--- a/web/i18n/ro-RO/agent-v-2.json
+++ b/web/i18n/ro-RO/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Noduri",
   "agentDetail.access.workflow.table.version": "Versiune",
   "agentDetail.access.workflow.title": "Acces prin workflow",
-  "agentDetail.configure.advancedSettings.description": "Pentru utilizatori avansați. Variabile de mediu, sandbox și memorie.",
+  "agentDetail.configure.advancedSettings.description": "Pentru utilizatori avansați, cum ar fi variabilele de mediu.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Adaugă variabilă de mediu",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Șterge {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Ascunde valoarea {{key}}",

--- a/web/i18n/ru-RU/agent-v-2.json
+++ b/web/i18n/ru-RU/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Узлы",
   "agentDetail.access.workflow.table.version": "Версия",
   "agentDetail.access.workflow.title": "Доступ к рабочему процессу",
-  "agentDetail.configure.advancedSettings.description": "Для опытных пользователей. Переменные окружения, песочница и память.",
+  "agentDetail.configure.advancedSettings.description": "Для опытных пользователей, например переменные окружения.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Добавить переменную окружения",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Удалить {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Скрыть значение {{key}}",

--- a/web/i18n/sl-SI/agent-v-2.json
+++ b/web/i18n/sl-SI/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Vozlišča",
   "agentDetail.access.workflow.table.version": "Različica",
   "agentDetail.access.workflow.title": "Dostop do poteka dela",
-  "agentDetail.configure.advancedSettings.description": "Za napredne uporabnike. Okoljske spremenljivke, sandbox in pomnilnik.",
+  "agentDetail.configure.advancedSettings.description": "Za napredne uporabnike, na primer okoljske spremenljivke.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Dodaj okoljsko spremenljivko",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Izbriši {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Skrij vrednost {{key}}",

--- a/web/i18n/th-TH/agent-v-2.json
+++ b/web/i18n/th-TH/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "โหนด",
   "agentDetail.access.workflow.table.version": "เวอร์ชัน",
   "agentDetail.access.workflow.title": "การเข้าถึงเวิร์กโฟลว์",
-  "agentDetail.configure.advancedSettings.description": "สำหรับผู้ใช้ขั้นสูง ตัวแปรสภาพแวดล้อม แซนด์บ็อกซ์ และหน่วยความจำ",
+  "agentDetail.configure.advancedSettings.description": "สำหรับผู้ใช้ขั้นสูง เช่น ตัวแปรสภาพแวดล้อม",
   "agentDetail.configure.advancedSettings.envEditor.add": "เพิ่มตัวแปรสภาพแวดล้อม",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "ลบ {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "ซ่อนค่า {{key}}",

--- a/web/i18n/tr-TR/agent-v-2.json
+++ b/web/i18n/tr-TR/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Düğümler",
   "agentDetail.access.workflow.table.version": "Sürüm",
   "agentDetail.access.workflow.title": "İş akışı erişimi",
-  "agentDetail.configure.advancedSettings.description": "Güç kullanıcıları için. Çevre değişkenleri, sandbox ve bellek.",
+  "agentDetail.configure.advancedSettings.description": "Güç kullanıcıları için, ör. ortam değişkenleri.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Çevre değişkeni ekle",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "{{key}} sil",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "{{key}} değerini gizle",

--- a/web/i18n/uk-UA/agent-v-2.json
+++ b/web/i18n/uk-UA/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Вузли",
   "agentDetail.access.workflow.table.version": "Версія",
   "agentDetail.access.workflow.title": "Доступ до робочого процесу",
-  "agentDetail.configure.advancedSettings.description": "Для досвідчених користувачів. Змінні середовища, пісочниця та пам'ять.",
+  "agentDetail.configure.advancedSettings.description": "Для досвідчених користувачів, наприклад змінні середовища.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Додати змінну середовища",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Видалити {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Сховати значення {{key}}",

--- a/web/i18n/vi-VN/agent-v-2.json
+++ b/web/i18n/vi-VN/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "Nút",
   "agentDetail.access.workflow.table.version": "Phiên bản",
   "agentDetail.access.workflow.title": "Truy cập quy trình làm việc",
-  "agentDetail.configure.advancedSettings.description": "Dành cho người dùng nâng cao. Biến môi trường, sandbox và bộ nhớ.",
+  "agentDetail.configure.advancedSettings.description": "Dành cho người dùng nâng cao, chẳng hạn như biến môi trường.",
   "agentDetail.configure.advancedSettings.envEditor.add": "Thêm biến môi trường",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "Xóa {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "Ẩn giá trị của {{key}}",

--- a/web/i18n/zh-Hans/agent-v-2.json
+++ b/web/i18n/zh-Hans/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "节点",
   "agentDetail.access.workflow.table.version": "版本",
   "agentDetail.access.workflow.title": "工作流访问",
-  "agentDetail.configure.advancedSettings.description": "面向高级用户。环境变量、沙箱与记忆。",
+  "agentDetail.configure.advancedSettings.description": "面向高级用户，如环境变量。",
   "agentDetail.configure.advancedSettings.envEditor.add": "添加环境变量",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "删除 {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "隐藏 {{key}} 的值",

--- a/web/i18n/zh-Hant/agent-v-2.json
+++ b/web/i18n/zh-Hant/agent-v-2.json
@@ -38,7 +38,7 @@
   "agentDetail.access.workflow.table.nodes": "節點",
   "agentDetail.access.workflow.table.version": "版本",
   "agentDetail.access.workflow.title": "工作流程存取",
-  "agentDetail.configure.advancedSettings.description": "面向進階使用者。環境變數、沙箱與記憶。",
+  "agentDetail.configure.advancedSettings.description": "面向進階使用者，如環境變數。",
   "agentDetail.configure.advancedSettings.envEditor.add": "新增環境變數",
   "agentDetail.configure.advancedSettings.envEditor.deleteVariable": "刪除 {{key}}",
   "agentDetail.configure.advancedSettings.envEditor.hideValue": "隱藏 {{key}} 的值",


### PR DESCRIPTION
## Summary

- Update the Agent V2 advanced settings description to reference environment variables without mentioning sandbox or memory.
- Keep the revised copy consistent across all 24 supported locales.

Fixes DIFY-2891

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.