### PR TITLE
fix(ci): always report required style checks

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -394,10 +394,10 @@ jobs:
   style-check:
     name: Style Check
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
     uses: ./.github/workflows/style.yml
     with:
       base-rev: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+      skip-checks: ${{ needs.pre_job.outputs.should_skip == 'true' }}
 
   vdb-tests-run:
     name: Run VDB Tests

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,6 +6,11 @@ on:
       base-rev:
         required: true
         type: string
+      skip-checks:
+        description: Create the required check runs without repeating previously successful work.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   checks: write
@@ -15,6 +20,7 @@ permissions:
 jobs:
   python-style:
     name: Python Style
+    if: ${{ !inputs.skip-checks }}
     runs-on: depot-ubuntu-24.04
 
     steps:
@@ -79,6 +85,7 @@ jobs:
 
   web-style:
     name: Web Style
+    if: ${{ !inputs.skip-checks }}
     runs-on: depot-ubuntu-24.04
     defaults:
       run:
@@ -138,6 +145,7 @@ jobs:
 
   ts-common-style:
     name: TS Common
+    if: ${{ !inputs.skip-checks }}
     runs-on: depot-ubuntu-24.04-4
     permissions:
       checks: write
@@ -181,6 +189,7 @@ jobs:
 
   superlinter:
     name: SuperLinter
+    if: ${{ !inputs.skip-checks }}
     runs-on: depot-ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## What changed

- Always instantiate the reusable Style Check workflow for the current commit.
- Forward the duplicate-check result as a typed boolean input.
- Keep the four required Style Check jobs and names unchanged, while marking those jobs skipped when identical work has already passed.

## Why

After a stacked PR rebase, the duplicate checker can reuse a successful run from another SHA and set `should_skip=true`. Main CI previously skipped the entire reusable Style Check workflow, so the new PR head never created:

- `Style Check / Python Style`
- `Style Check / Web Style`
- `Style Check / SuperLinter`
- `Style Check / TS Common`

The main branch ruleset still expected those contexts, leaving the PR permanently blocked at “Waiting for status to be reported”.

Other required test families already preserve their current-SHA contexts when duplicate work is skipped. This change gives Style Check the same contract without repeating its lint and type-check work.

## Validation

- `vp fmt .github/workflows/main-ci.yml .github/workflows/style.yml --check`
- `git diff --check`
- Parsed both workflow files and verified the reusable call, boolean input, four stable job names, and duplicate gates
- GitHub Actions normal path: all four Style Check jobs completed successfully
- Duplicate path: the reusable workflow is still instantiated; `skip-checks=true` skips the four jobs at job level, so GitHub creates the same required contexts without repeating their work