### PR TITLE
fix(api): fallback when plugin category list route is unavailable

### DIFF
--- a/api/core/plugin/impl/plugin.py
+++ b/api/core/plugin/impl/plugin.py
@@ -22,6 +22,7 @@ from core.plugin.entities.plugin_daemon import (
     PluginReadmeResponse,
 )
 from core.plugin.impl.base import BasePluginClient
+from core.plugin.impl.exc import PluginDaemonClientSideError
 from models.provider_ids import GenericProviderID
 
 
@@ -98,18 +99,56 @@ class PluginInstaller(BasePluginClient):
         tags: Sequence[str] = (),
         language: str = "en_US",
     ) -> PluginListWithoutTotalResponse:
-        return self._request_with_plugin_daemon_response(
-            "GET",
-            f"plugin/{tenant_id}/management/{category.value}/list",
-            PluginListWithoutTotalResponse,
-            params={
-                "page": page,
-                "page_size": page_size,
-                "response_type": "paged",
-                "query": query,
-                "tags": list(tags),
-                "language": language,
-            },
+        try:
+            return self._request_with_plugin_daemon_response(
+                "GET",
+                f"plugin/{tenant_id}/management/{category.value}/list",
+                PluginListWithoutTotalResponse,
+                params={
+                    "page": page,
+                    "page_size": page_size,
+                    "response_type": "paged",
+                    "query": query,
+                    "tags": list(tags),
+                    "language": language,
+                },
+            )
+        except PluginDaemonClientSideError as e:
+            if not self._is_plugin_category_route_missing(e):
+                raise
+            return self._list_plugins_by_category_from_management_list(tenant_id, category, page, page_size)
+
+    def _is_plugin_category_route_missing(self, error: PluginDaemonClientSideError) -> bool:
+        description = error.description.lower()
+        return "404" in description or "not found" in description
+
+    def _list_plugins_by_category_from_management_list(
+        self,
+        tenant_id: str,
+        category: PluginCategory,
+        page: int,
+        page_size: int,
+    ) -> PluginListWithoutTotalResponse:
+        normalized_page = max(page, 1)
+        normalized_page_size = max(page_size, 1)
+        start = (normalized_page - 1) * normalized_page_size
+        end = start + normalized_page_size
+        fallback_page = 1
+        fallback_page_size = max(normalized_page_size, 256)
+        matched_plugins: list[PluginEntity] = []
+
+        while True:
+            plugins = self.list_plugins_with_total(tenant_id, fallback_page, fallback_page_size)
+            matched_plugins.extend(plugin for plugin in plugins.list if plugin.declaration.category == category)
+            if len(matched_plugins) > end:
+                break
+            if fallback_page * fallback_page_size >= plugins.total or not plugins.list:
+                break
+            fallback_page += 1
+
+        return PluginListWithoutTotalResponse(
+            list=matched_plugins[start:end],
+            has_more=len(matched_plugins) > end,
         )
 
     def upload_pkg(

--- a/api/tests/unit_tests/core/plugin/impl/test_plugin_client_impl.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_plugin_client_impl.py
@@ -1,0 +1,49 @@
+from core.plugin.entities.plugin import PluginCategory, PluginDeclaration, PluginEntity
+from core.plugin.entities.plugin_daemon import PluginListResponse, PluginListWithoutTotalResponse
+from core.plugin.impl.exc import PluginDaemonClientSideError
+from core.plugin.impl.plugin import PluginInstaller
+
+
+def _plugin_entity(plugin_id: str, category: PluginCategory) -> PluginEntity:
+    return PluginEntity.model_construct(
+        plugin_id=plugin_id,
+        declaration=PluginDeclaration.model_construct(category=category),
+    )
+
+
+class TestPluginInstaller:
+    def test_list_plugins_by_category_falls_back_to_management_list_when_category_route_missing(self, mocker):
+        client = PluginInstaller()
+        model_plugin = _plugin_entity("model-plugin", PluginCategory.Model)
+        tool_plugin = _plugin_entity("tool-plugin", PluginCategory.Tool)
+        request_mock = mocker.patch.object(
+            client,
+            "_request_with_plugin_daemon_response",
+            side_effect=[
+                PluginDaemonClientSideError("Client error '404 Not Found' for url"),
+                PluginListResponse.model_construct(list=[model_plugin, tool_plugin], total=2),
+            ],
+        )
+
+        result = client.list_plugins_by_category("tenant-1", PluginCategory.Model, page=1, page_size=100)
+
+        assert result.list == [model_plugin]
+        assert result.has_more is False
+        assert request_mock.call_args_list[0].args[:3] == (
+            "GET",
+            "plugin/tenant-1/management/model/list",
+            PluginListWithoutTotalResponse,
+        )
+        assert request_mock.call_args_list[0].kwargs["params"] == {
+            "page": 1,
+            "page_size": 100,
+            "response_type": "paged",
+            "query": "",
+            "tags": [],
+            "language": "en_US",
+        }
+        assert request_mock.call_args_list[1].args[:3] == (
+            "GET",
+            "plugin/tenant-1/management/list",
+            PluginListResponse,
+        )


### PR DESCRIPTION
## Summary

Fixes #40683

This PR adds a compatibility fallback for plugin daemons that do not provide the category-specific plugin list route:

```text
/plugin/{tenant_id}/management/{category}/list
```

The API still uses the category-specific route as the primary path. If that route returns 404, it falls back to the generic plugin list route:

```text
/plugin/{tenant_id}/management/list
```

and filters plugins by `declaration.category` on the API side.

A focused unit test was added for the fallback behavior.

## Screenshots

N/A. Backend compatibility fix.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Verification performed locally:

```text
git diff --check
python syntax check for changed Python files
```

Targeted pytest and pre-commit lint were attempted locally, but dependency setup failed while building `llvmlite==0.47.0` because LLVM CMake configuration was not available in the local macOS environment.
```