### PR TITLE
fix: route MCP provider credential lookup away from builtin auth (fix #40612)

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/__tests__/tool-provider-catalog.spec.ts
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/tool-provider-catalog.spec.ts
@@ -1,0 +1,58 @@
+import type { ToolWithProvider } from '@/app/components/workflow/types'
+import { describe, expect, it } from 'vitest'
+import { CollectionType } from '@/app/components/tools/types'
+import { getProviderCredentialType } from '../tool-provider-catalog'
+
+const baseCollection = {
+  name: 'provider',
+  author: 'Author',
+  description: { en_US: 'Desc', zh_Hans: '描述' },
+  icon: '',
+  label: { en_US: 'Provider', zh_Hans: '提供方' },
+  team_credentials: {},
+  is_team_authorization: false,
+  allow_delete: false,
+  labels: [],
+  meta: { version: '0.0.1' },
+  tools: [],
+} satisfies Omit<ToolWithProvider, 'id' | 'type'>
+
+const builtInProvider = {
+  ...baseCollection,
+  id: 'builtin/org/provider',
+  type: CollectionType.builtIn,
+} satisfies ToolWithProvider
+
+const mcpProvider = {
+  ...baseCollection,
+  id: 'mcp-server-id',
+  type: CollectionType.mcp,
+} satisfies ToolWithProvider
+
+describe('getProviderCredentialType', () => {
+  it('returns api-key for a builtIn provider that has stored team credentials', () => {
+    const provider = { ...builtInProvider, team_credentials: { api_key: 'secret' } }
+
+    expect(getProviderCredentialType(provider)).toBe('api-key')
+  })
+
+  it('returns oauth2 for a builtIn provider that supports delete and has no team credentials', () => {
+    const provider = { ...builtInProvider, allow_delete: true }
+
+    expect(getProviderCredentialType(provider)).toBe('oauth2')
+  })
+
+  it('does not classify an MCP provider with stored team credentials as api-key', () => {
+    const provider = { ...mcpProvider, team_credentials: { server_token: 'secret' } }
+
+    expect(getProviderCredentialType(provider)).toBeUndefined()
+  })
+
+  it('returns undefined for an MCP provider without team credentials', () => {
+    expect(getProviderCredentialType(mcpProvider)).toBeUndefined()
+  })
+
+  it('returns undefined when no provider is given', () => {
+    expect(getProviderCredentialType(undefined)).toBeUndefined()
+  })
+})

--- a/web/features/agent-v2/agent-detail/configure/tool-provider-catalog.ts
+++ b/web/features/agent-v2/agent-detail/configure/tool-provider-catalog.ts
@@ -201,7 +201,11 @@ export function getProviderCredentialType(
 ): AgentProviderTool['credentialType'] {
   if (!provider) return undefined
 
-  if (Object.keys(provider.team_credentials ?? {}).length > 0) return 'api-key'
+  if (
+    provider.type === CollectionType.builtIn &&
+    Object.keys(provider.team_credentials ?? {}).length > 0
+  )
+    return 'api-key'
 
   if (provider.type === CollectionType.builtIn && provider.allow_delete) return 'oauth2'
 


### PR DESCRIPTION
## Summary

Fixes #40612.

`getProviderCredentialType` (in `web/features/agent-v2/agent-detail/configure/tool-provider-catalog.ts`) classified any tool provider with stored `team_credentials` as credential type `api-key`, checking `team_credentials` before `provider.type`. An MCP provider that had stored team credentials was therefore misclassified as `api-key`, which routed it into the plugin-auth UI path and set `credentialVariant: 'unauthorized'`. `UnauthorizedCredentialStatus` then mounts `usePluginAuth`, whose `useGetApi` always builds URLs like `/workspaces/current/tool-provider/builtin/<provider>/credential/info`. For an MCP server, `<provider>` is the MCP server id (not a builtin/plugin provider id), so the backend returns 500.

## Root cause

The `team_credentials` check in `getProviderCredentialType` was not scoped to builtin providers, so any provider type (including `mcp`) with stored team credentials resolved to `'api-key'`.

## Fix

Scope the `team_credentials` → `'api-key'` classification to `CollectionType.builtIn` only, mirroring the existing `oauth2` branch. MCP (and `custom`/`workflow`/`model`) providers now resolve to no credential type, so they no longer enter the plugin-auth path.

## Testing

- Added `web/features/agent-v2/agent-detail/configure/__tests__/tool-provider-catalog.spec.ts` covering `getProviderCredentialType` for builtin (api-key / oauth2) and MCP (with/without team_credentials) providers.
- RED: before the fix, the MCP-with-team_credentials case returned `'api-key'` and the test failed (`expected 'api-key' to be undefined`).
- GREEN: after the fix, the focused spec passes (5/5).
- Regression: `pnpm --config.verifyDepsBeforeRun=false test configure` → 26 files, 379 tests passed.

Note: this addresses the primary root cause (credential-type misclassification). The related hardening suggested in the issue — adding an `isBuiltinProvider` guard on the `UnauthorizedCredentialStatus` render path in `provider-tool/item.tsx` so non-builtin providers short-circuit before `usePluginAuth` mounts — was intentionally left out of this PR to keep the change atomic and scoped to the actual 500 trigger; it can be a follow-up if maintainers want defense-in-depth.

From Claude
