### PR TITLE
fix(web): avoid builtin credential lookup for MCP agent tools

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/__tests__/index.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/__tests__/index.spec.tsx
@@ -21,6 +21,7 @@ import { AgentTools } from '../index'
 
 const toolProviderState = vi.hoisted(() => ({
   builtInTools: [] as ToolWithProvider[] | undefined,
+  mcpTools: [] as ToolWithProvider[] | undefined,
 }))
 const pluginAuthState = vi.hoisted(() => ({
   canOAuth: true as boolean | undefined,
@@ -28,6 +29,7 @@ const pluginAuthState = vi.hoisted(() => ({
   credentials: [] as Credential[],
   notAllowCustomCredential: false,
   invalidPluginCredentialInfo: vi.fn(),
+  usePluginAuth: vi.fn(),
 }))
 const pluginInstallState = vi.hoisted(() => ({
   manifest: undefined as
@@ -123,10 +125,13 @@ vi.mock('@/app/components/plugins/plugin-auth/authorize/add-oauth-button', () =>
 }))
 
 vi.mock('@/app/components/plugins/plugin-auth/hooks/use-plugin-auth', () => ({
-  usePluginAuth: () => ({
-    ...pluginAuthState,
-    isAuthorized: pluginAuthState.credentials.length > 0,
-  }),
+  usePluginAuth: (...args: unknown[]) => {
+    pluginAuthState.usePluginAuth(...args)
+    return {
+      ...pluginAuthState,
+      isAuthorized: pluginAuthState.credentials.length > 0,
+    }
+  },
 }))
 
 vi.mock('@/hooks/use-credential-permissions', () => ({
@@ -155,7 +160,7 @@ vi.mock('@/service/use-tools', () => ({
   useAllBuiltInTools: () => ({ data: toolProviderState.builtInTools }),
   useAllCustomTools: () => ({ data: [] }),
   useAllWorkflowTools: () => ({ data: [] }),
-  useAllMCPTools: () => ({ data: [] }),
+  useAllMCPTools: () => ({ data: toolProviderState.mcpTools }),
   useInvalidateAllBuiltInTools: () => pluginInstallState.invalidateBuiltInTools,
   useInvalidToolsByType: () => vi.fn(),
 }))
@@ -378,6 +383,63 @@ const duckDuckGoProvider = {
   ],
 } satisfies ToolWithProvider
 
+const mcpProvider = {
+  ...googleProvider,
+  id: 'tapd-server-test',
+  name: 'tapd-server-test',
+  author: 'TAPD',
+  label: {
+    en_US: 'TAPD MCP',
+    zh_Hans: 'TAPD MCP',
+  },
+  type: CollectionType.mcp,
+  team_credentials: {
+    access_token: 'configured',
+  },
+  is_team_authorization: true,
+  allow_delete: false,
+  tools: [
+    {
+      name: 'get_story',
+      author: 'TAPD',
+      label: {
+        en_US: 'Get TAPD Story',
+        zh_Hans: 'Get TAPD Story',
+      },
+      description: {
+        en_US: 'Get a TAPD story.',
+        zh_Hans: 'Get a TAPD story.',
+      },
+      parameters: [],
+      labels: [],
+      output_schema: {},
+    },
+  ],
+} satisfies ToolWithProvider
+
+const reflectedUnauthorizedMCPDraft = {
+  ...defaultAgentSoulConfigFormState,
+  tools: [
+    {
+      id: 'tapd-server-test',
+      kind: 'provider',
+      name: 'tapd-server-test',
+      iconClassName: 'i-custom-public-other-default-tool-icon text-text-tertiary',
+      providerType: CollectionType.mcp,
+      credentialType: 'unauthorized',
+      credentialVariant: 'unauthorized',
+      actions: [
+        {
+          id: 'tapd-server-test:get_story',
+          name: 'get_story',
+          toolName: 'get_story',
+          description: '',
+        },
+      ],
+    },
+  ],
+} satisfies AgentSoulConfigFormState
+
 function renderAgentTools(initialDraft: AgentSoulConfigFormState = agentToolsDraft) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -450,10 +512,12 @@ describe('AgentTools', () => {
     cleanup()
     vi.clearAllMocks()
     toolProviderState.builtInTools = []
+    toolProviderState.mcpTools = []
     pluginAuthState.canOAuth = true
     pluginAuthState.canApiKey = false
     pluginAuthState.credentials = []
     pluginAuthState.notAllowCustomCredential = false
+    pluginAuthState.usePluginAuth.mockReset()
     pluginInstallState.manifest = undefined
     pluginInstallState.fallbackManifest = undefined
     pluginInstallState.invalidateBuiltInTools.mockResolvedValue(undefined)
@@ -698,6 +762,59 @@ describe('AgentTools', () => {
         }),
       ).toBeInTheDocument()
       expect(screen.queryByText('tools.notAuthorized')).not.toBeInTheDocument()
+    })
+
+    it('should not request plugin credentials for an authorized MCP provider', async () => {
+      const user = userEvent.setup()
+      toolProviderState.mcpTools = [mcpProvider]
+
+      renderAgentTools(reflectedUnauthorizedMCPDraft)
+
+      expect(screen.getByRole('button', { name: 'TAPD MCP' })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'tools.notAuthorized' })).not.toBeInTheDocument()
+      expect(pluginAuthState.usePluginAuth).not.toHaveBeenCalled()
+
+      await user.click(screen.getByRole('button', { name: 'TAPD MCP' }))
+
+      expect(screen.getByText('Get TAPD Story')).toBeInTheDocument()
+    })
+
+    it('should not request plugin credentials while the MCP provider catalog is loading', () => {
+      toolProviderState.mcpTools = undefined
+
+      renderAgentTools(reflectedUnauthorizedMCPDraft)
+
+      expect(screen.getByRole('button', { name: 'tapd-server-test' })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'tools.notAuthorized' })).not.toBeInTheDocument()
+      expect(pluginAuthState.usePluginAuth).not.toHaveBeenCalled()
+    })
+
+    it('should preserve plugin credential authorization actions', () => {
+      toolProviderState.builtInTools = [
+        {
+          ...googleProvider,
+          id: 'langgenius/google/google',
+          name: 'google',
+          plugin_id: 'langgenius/google',
+          type: 'plugin',
+          team_credentials: {
+            api_key: 'configured',
+          },
+          is_team_authorization: false,
+          allow_delete: false,
+        },
+      ]
+
+      renderAgentTools(reflectedUninstalledPluginDraft)
+
+      expect(screen.getByRole('button', { name: 'tools.notAuthorized' })).toBeInTheDocument()
+      expect(pluginAuthState.usePluginAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'langgenius/google/google',
+          providerType: 'plugin',
+        }),
+        true,
+      )
     })
 
     it('should keep provider credential metadata display-only without dirtying the composer draft', () => {

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
@@ -19,7 +19,6 @@ import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AuthCategory, Authorized, usePluginAuth } from '@/app/components/plugins/plugin-auth'
 import AuthorizedInNode from '@/app/components/plugins/plugin-auth/authorized-in-node'
-import { CollectionType } from '@/app/components/tools/types'
 import BlockIcon from '@/app/components/workflow/block-icon'
 import { InstallPluginButton } from '@/app/components/workflow/nodes/_base/components/install-plugin-button'
 import { BlockEnum } from '@/app/components/workflow/types'
@@ -27,6 +26,7 @@ import useTheme from '@/hooks/use-theme'
 import { usePluginManifestInfo } from '@/service/use-plugins'
 import { Theme } from '@/types/app'
 import { getIconFromMarketPlace } from '@/utils/get-icon'
+import { supportsAgentPluginCredentials } from '../../../../tool-provider-catalog'
 import { useAgentOrchestrateReadOnly } from '../../read-only-context'
 
 function ProviderIcon({
@@ -162,7 +162,8 @@ function CredentialStatus({
     credentialType?: AgentProviderTool['credentialType'],
   ) => void
 }) {
-  const canSwitchCredential = tool.providerType === CollectionType.builtIn && tool.allowDelete
+  const supportsPluginCredentials = supportsAgentPluginCredentials(tool.providerType)
+  const canSwitchCredential = supportsPluginCredentials && tool.allowDelete
   const handleAuthorizationItemClick = useCallback(
     (id: string) => {
       onCredentialChange(
@@ -180,6 +181,8 @@ function CredentialStatus({
   )
 
   if (tool.credentialVariant === 'none') return null
+
+  if (!supportsPluginCredentials) return null
 
   if (tool.credentialVariant === 'unauthorized') {
     return <UnauthorizedCredentialStatus tool={tool} onCredentialChange={onCredentialChange} />

--- a/web/features/agent-v2/agent-detail/configure/tool-provider-catalog.ts
+++ b/web/features/agent-v2/agent-detail/configure/tool-provider-catalog.ts
@@ -201,11 +201,19 @@ export function getProviderCredentialType(
 ): AgentProviderTool['credentialType'] {
   if (!provider) return undefined
 
+  if (!supportsAgentPluginCredentials(provider.type)) return undefined
+
   if (Object.keys(provider.team_credentials ?? {}).length > 0) return 'api-key'
 
-  if (provider.type === CollectionType.builtIn && provider.allow_delete) return 'oauth2'
+  if (provider.allow_delete) return 'oauth2'
 
   return undefined
+}
+
+export function supportsAgentPluginCredentials(
+  providerType: AgentProviderTool['providerType'] | ToolWithProvider['type'],
+) {
+  return providerType === CollectionType.builtIn || providerType === 'plugin'
 }
 
 export function getProviderCredentialVariant(


### PR DESCRIPTION
## Summary

- prevent Agent v2 MCP tools from entering the builtin/plugin credential authorization flow
- classify plugin-style credential metadata only for provider types that support the builtin/plugin credential API
- guard the credential UI so stale MCP `unauthorized` metadata cannot mount `usePluginAuth`, including while the MCP catalog is loading
- preserve credential authorization and switching for builtin and plugin providers
- add regression coverage for authorized MCP tools, stale MCP drafts, catalog loading, and legitimate plugin credentials

Fixes #40612

Related: #40686 addresses the provider catalog classification; this PR also covers the stale-draft and catalog-loading UI path.

## Screenshots

N/A — this fixes credential routing and network behavior without introducing a visual UI change.

## Tests

- `pnpm exec vp test run features/agent-v2/agent-detail/configure/components/orchestrate/tools/__tests__/index.spec.tsx` — 18 passed
- `pnpm exec vp test run features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx --test-timeout=15000` — 46 passed
- `pnpm --dir web type-check` — passed
- `pnpm --dir web lint:tss` — 5961 passed
- scoped `vp check` for the three changed files — passed
- `pnpm exec vp staged` from the repository root — passed

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
