### PR TITLE
fix(ci): prevent false failures from superseded runs

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -15,8 +15,10 @@ permissions:
   statuses: write
 
 concurrency:
-  group: main-ci-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
-  cancel-in-progress: true
+  # Pull request deduplication is owned by skip-duplicate-actions so pre_job can
+  # publish should_skip before required status finalizers run.
+  group: main-ci-${{ github.event.merge_group.head_sha || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'merge_group' }}
 
 jobs:
   pre_job:


### PR DESCRIPTION
## Summary

- let skip-duplicate-actions own pull request deduplication
- retain native concurrency cancellation for merge-group runs
- keep all required-check finalizers and path selection unchanged

## Root cause

Pull request runs were deduplicated by both GitHub concurrency and skip-duplicate-actions. Native concurrency could cancel pre_job before it published should_skip, while the always-running required-check finalizers interpreted the missing output and cancelled skip jobs as failures. This produced immediate false-red required checks even when the surviving run was healthy.

## Validation

- vp fmt .github/workflows/main-ci.yml --check
- YAML parse check
- concurrency ownership contract check, including all seven required finalizers
- git diff --check
- [full same-head run](https://github.com/langgenius/dify/actions/runs/31672315939): completed successfully
- [concurrent duplicate run](https://github.com/langgenius/dify/actions/runs/31672335206): skip-duplicate-actions reported the same files were checked by the older run, published should_skip, and all required finalizers completed successfully

The duplicate scenario was reproduced by reopening this draft without changing its head SHA. Neither run was cancelled by pull request concurrency.