### PR TITLE
chore: remove scope selection from the agent environment editor

### DIFF
--- a/e2e/features/step-definitions/agent-v2/advanced-settings.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/advanced-settings.steps.ts
@@ -53,6 +53,9 @@ Then(
     await expect(envEditor.getByRole('button', { name: 'Add environment variable' })).toBeVisible()
     await expect(envEditor.getByText('Key', { exact: true })).toBeVisible()
     await expect(envEditor.getByText('Value', { exact: true })).toBeVisible()
-    await expect(envEditor.getByText('Scope', { exact: true })).toBeVisible()
+    await expect(envEditor.getByText('Scope', { exact: true })).toHaveCount(0)
+    await expect(
+      envEditor.getByRole('combobox', { name: 'Select environment variable scope' }),
+    ).toHaveCount(0)
   },
 )

--- a/e2e/features/step-definitions/agent-v2/configure-helpers.ts
+++ b/e2e/features/step-definitions/agent-v2/configure-helpers.ts
@@ -224,7 +224,6 @@ export const expectAgentEnvVariableRows = async (
   for (const variableRow of variableRows) {
     await expect(variableRow.getByRole('textbox', { name: 'Key' })).toHaveValue(key)
     await expect(variableRow.getByRole('textbox', { name: 'Value' })).toHaveValue(value)
-    await expect(variableRow.getByText('Plain', { exact: true })).toBeVisible()
   }
 }
 

--- a/e2e/features/step-definitions/agent-v2/env-editor.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/env-editor.steps.ts
@@ -27,7 +27,6 @@ When(
     await advancedSettings
       .getByRole('textbox', { name: 'Value' })
       .fill(agentBuilderFixedInputs.envPlainValue)
-    await expect(advancedSettings.getByText('Plain', { exact: true })).toBeVisible()
   },
 )
 
@@ -61,7 +60,6 @@ When(
     await savedVariableRow
       .getByRole('textbox', { name: 'Value' })
       .fill(agentBuilderFixedInputs.envModeValue)
-    await expect(advancedSettings.getByText('Plain', { exact: true })).toHaveCount(2)
   },
 )
 
@@ -249,7 +247,6 @@ Then(
       agentBuilderFixedInputs.envModeKey,
       agentBuilderFixedInputs.envModeValue,
     )
-    await expect(advancedSettings.getByText('Plain', { exact: true })).toHaveCount(2)
   },
 )
 
@@ -264,7 +261,6 @@ Then(
       agentBuilderFixedInputs.envModeValue,
     )
     await expectAgentEnvVariableAbsent(advancedSettings, agentBuilderFixedInputs.envPlainKey)
-    await expect(advancedSettings.getByText('Plain', { exact: true })).toHaveCount(1)
   },
 )
 
@@ -284,7 +280,6 @@ Then(
     await expect(variableRow.getByRole('textbox', { name: 'Value' })).toHaveValue(
       agentBuilderFixedInputs.envPlainValue,
     )
-    await expect(variableRow.getByText('Plain', { exact: true })).toBeVisible()
     await expect(page.getByRole('button', { name: /^Build$/i })).toBeVisible()
   },
 )

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/__tests__/env.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/__tests__/env.spec.tsx
@@ -85,6 +85,19 @@ describe('AgentEnvEditor', () => {
   })
 
   describe('User Interactions', () => {
+    it('should only expose plain environment variables', () => {
+      renderAgentEnvEditor()
+
+      expect(
+        screen.queryByText('agentV2.agentDetail.configure.advancedSettings.envEditor.scopeColumn'),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('combobox', {
+          name: 'agentV2.agentDetail.configure.advancedSettings.envEditor.scopeSelector',
+        }),
+      ).not.toBeInTheDocument()
+    })
+
     it('should edit the initial environment variable row directly', async () => {
       const user = userEvent.setup()
       renderAgentEnvEditor()

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/env.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/env.tsx
@@ -26,6 +26,7 @@ import {
   setEnvVariableScopeAtom,
   setEnvVariableValueAtom,
 } from '@/features/agent-v2/agent-composer/store-modules/env'
+import { ENABLE_AGENT_SECRET_ENV_VARIABLES } from '@/features/agent-v2/agent-detail/configure/feature-flags'
 import { checkKeys } from '@/utils/var'
 import { ConfigureSection } from '../common/section'
 import { AgentConfigureTipContent } from '../common/tip-content'
@@ -591,6 +592,7 @@ export function AgentEnvEditor() {
         onScopeChange={updateVariableScope}
         onValueChange={updateVariableValue}
         showDraftRow={false}
+        showScope={ENABLE_AGENT_SECRET_ENV_VARIABLES}
       />
     </ConfigureSection>
   )

--- a/web/features/agent-v2/agent-detail/configure/feature-flags.ts
+++ b/web/features/agent-v2/agent-detail/configure/feature-flags.ts
@@ -1,3 +1,4 @@
 export const ENABLE_AGENT_CLI_TOOLS = false
 export const ENABLE_AGENT_CONTENT_MODERATION = false
 export const ENABLE_AGENT_KNOWLEDGE_RETRIEVAL = false
+export const ENABLE_AGENT_SECRET_ENV_VARIABLES = false


### PR DESCRIPTION
## Summary

- Hide Agent v2 environment variable scope controls behind a disabled secret-support flag so new and imported entries remain plain.
- Update component and E2E assertions for the plain-only editor while retaining persistence coverage.

Fixes DIFY-2895

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.