### PR TITLE
fix(web): fall back to local editing when collaboration runtime fails to load

### DIFF
--- a/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts
@@ -49,11 +49,10 @@ describe('CollaborationManager CRDT runtime loading', () => {
     expect(manager.isConnected()).toBe(false)
   })
 
-  it('does not create connection state when the runtime fails to load and allows a retry', async () => {
+  it('falls back to local editing instead of leaving the UI stuck when the runtime fails to load', async () => {
     const { CollaborationManager, webSocketClient } = await loadCollaborationModules()
     const manager = new CollaborationManager()
     const runtimeError = new Error('runtime-load-failed')
-    const retryError = new Error('runtime-retry-failed')
     const loadRuntimeSpy = vi
       .spyOn(
         manager as unknown as {
@@ -62,19 +61,17 @@ describe('CollaborationManager CRDT runtime loading', () => {
         'loadCrdtRuntime',
       )
       .mockRejectedValueOnce(runtimeError)
-      .mockRejectedValueOnce(retryError)
     const connectSpy = vi.spyOn(webSocketClient, 'connect')
 
-    await expect(manager.connect('app-runtime-failure')).rejects.toBe(runtimeError)
+    const connectionId = await manager.connect('app-runtime-failure')
 
     expect(loadRuntimeSpy).toHaveBeenCalledTimes(1)
     expect(connectSpy).not.toHaveBeenCalled()
     expect(manager.isConnected()).toBe(false)
+    expect(manager.canApplyLocalGraphMutation()).toBe(true)
+    expect(manager.canPersistLocalGraph()).toBe(true)
 
-    await expect(manager.connect('app-runtime-failure')).rejects.toBe(retryError)
-
-    expect(loadRuntimeSpy).toHaveBeenCalledTimes(2)
-    expect(connectSpy).not.toHaveBeenCalled()
+    manager.disconnect(connectionId)
   })
 
   it('initializes one session for concurrent consumers of the same app', async () => {

--- a/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts
@@ -74,6 +74,33 @@ describe('CollaborationManager CRDT runtime loading', () => {
     manager.disconnect(connectionId)
   })
 
+  it('keeps editing blocked when the runtime fails to load on a configured socket URL', async () => {
+    const { CollaborationManager } = await loadCollaborationModules()
+    const websocketManager = await import('../websocket-manager')
+    vi.spyOn(websocketManager, 'isDefaultSocketUrl').mockReturnValue(false)
+    const manager = new CollaborationManager()
+    const runtimeError = new Error('runtime-load-failed')
+    const loadRuntimeSpy = vi
+      .spyOn(
+        manager as unknown as {
+          loadCrdtRuntime: () => Promise<(typeof import('../crdt-runtime'))['crdtRuntime']>
+        },
+        'loadCrdtRuntime',
+      )
+      .mockRejectedValueOnce(runtimeError)
+    const connectSpy = vi.spyOn(websocketManager.webSocketClient, 'connect')
+
+    const connectionId = await manager.connect('app-runtime-failure-configured-socket')
+
+    expect(loadRuntimeSpy).toHaveBeenCalledTimes(1)
+    expect(connectSpy).not.toHaveBeenCalled()
+    expect(manager.isConnected()).toBe(false)
+    expect(manager.canApplyLocalGraphMutation()).toBe(false)
+    expect(manager.canPersistLocalGraph()).toBe(false)
+
+    manager.disconnect(connectionId)
+  })
+
   it('initializes one session for concurrent consumers of the same app', async () => {
     const { CollaborationManager, webSocketClient } = await loadCollaborationModules()
     const manager = new CollaborationManager()

--- a/web/app/components/workflow/collaboration/core/collaboration-manager.ts
+++ b/web/app/components/workflow/collaboration/core/collaboration-manager.ts
@@ -664,7 +664,20 @@ export class CollaborationManager {
     }
     const connectGeneration = this.connectGeneration
 
-    if (!this.crdtRuntime) await this.ensureCrdtRuntime()
+    if (!this.crdtRuntime) {
+      try {
+        await this.ensureCrdtRuntime()
+      } catch (error) {
+        console.error('Failed to load collaboration runtime, falling back to local editing:', error)
+        if (connectGeneration === this.connectGeneration && this.targetAppId === appId) {
+          this.currentAppId = appId
+          this.localDraftFallbackActive = true
+          this.activeConnections.add(connectionId)
+          this.emitGraphReadyState()
+        }
+        return connectionId
+      }
+    }
 
     if (connectGeneration !== this.connectGeneration || this.targetAppId !== appId)
       return connectionId

--- a/web/app/components/workflow/collaboration/core/collaboration-manager.ts
+++ b/web/app/components/workflow/collaboration/core/collaboration-manager.ts
@@ -671,7 +671,11 @@ export class CollaborationManager {
         console.error('Failed to load collaboration runtime, falling back to local editing:', error)
         if (connectGeneration === this.connectGeneration && this.targetAppId === appId) {
           this.currentAppId = appId
-          this.localDraftFallbackActive = true
+          // Mirrors activateLocalDraftFallback(): only degrade to local-only editing on the
+          // default self-hosted socket URL. A configured (Cloud/Enterprise) socket implies a real
+          // collaboration server may have other users editing live, so editing stays blocked here.
+          if (isDefaultSocketUrl() && !this.hasEstablishedConnection)
+            this.localDraftFallbackActive = true
           this.activeConnections.add(connectionId)
           this.emitGraphReadyState()
         }


### PR DESCRIPTION
## Summary

Fixes #40720.

`CollaborationManager.connect()` loads the CRDT runtime (the `loro-crdt`
WASM module) before doing anything else. When that load fails — e.g. an
offline/air-gapped deployment that can't fetch the WASM asset, or a
browser that can't run it — `connect()` rejected, and the promise
rejection was only `console.error`'d by the caller
(`useCollaboration`'s `initCollaboration`). No socket was created and
`graphReadyChange` was never emitted, so the "Syncing data, just a few
seconds" overlay in `workflow-main.tsx` — which is only hidden once the
collaboration graph reports ready — stayed up forever. That left the
chatflow/workflow canvas permanently blocked, matching the report:
publish failing behind a WASM console error on an older browser, and
the sync overlay never clearing on a newer one.

There's already an established fallback for this class of problem:
`activateLocalDraftFallback`, used when the collaboration socket itself
fails to connect (`connect_error`), degrades the app to plain
non-collaborative editing/saving via `localDraftFallbackActive` — but
only on the default self-hosted socket URL (`isDefaultSocketUrl()`).
On a configured (Cloud/Enterprise) socket URL, a real collaboration
server may have other users editing the same workflow live, so that
path deliberately keeps editing blocked rather than risking a local
HTTP-draft save clobbering a concurrent CRDT edit from someone else.

This change reuses the same fallback flag for the CRDT-runtime-load-
failure path, gated behind the same `isDefaultSocketUrl()` check: on
the default socket URL, `connect()` activates the local fallback and
emits the graph-ready state, unblocking the canvas and letting edits/
publishes go through the normal (non-collaborative) draft-sync
endpoint instead of hanging indefinitely. On a configured socket URL,
editing stays blocked (matching the existing `connect_error` behavior
for that topology) rather than silently allowing local-only edits that
could lose a concurrent collaborator's changes.

## Changes

- `web/app/components/workflow/collaboration/core/collaboration-manager.ts`:
  catch the CRDT runtime load failure in `connect()` and activate the
  existing local-draft fallback — gated behind `isDefaultSocketUrl()`
  and `!hasEstablishedConnection`, mirroring `activateLocalDraftFallback` —
  instead of letting the rejection propagate unhandled.
- `web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts`:
  updated the runtime-load-failure test to assert the new fallback
  behavior on the default socket URL (`connect()` resolves, local graph
  mutation/persistence is allowed), and added a new test asserting
  editing stays blocked when the runtime fails to load on a configured
  (non-default) socket URL.

## Test plan

- Confirmed the new "configured socket URL" test fails on the pre-fix
  code (unconditional fallback activation, no `isDefaultSocketUrl()`
  gate):

  ```
  ❯ app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts (6 tests | 1 failed)
       × keeps editing blocked when the runtime fails to load on a configured socket URL
    AssertionError: expected true to be false // Object.is equality
     ❯ …/collaboration-manager.runtime-loading.spec.ts:98:50
  ```

- With the fix, the full collaboration test suite passes:

  ```
  $ pnpm vp test app/components/workflow/collaboration
   Test Files  10 passed (10)
        Tests  99 passed (99)
  ```

- `vp check` (format + lint + types) passes clean on both changed files:

  ```
  $ vp check web/app/components/workflow/collaboration/core/collaboration-manager.ts \
             web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts
  pass: All 2 files are correctly formatted
  pass: Found no warnings, lint errors, or type errors in 2 files
  ```

## Disclosure

This PR was drafted with AI assistance (Claude); I reviewed the diff, ran the tests locally, and verified the regression test fails without the fix and passes with it.
