### PR TITLE
fix(api): enforce edit and RBAC permissions on dataset API key GET endpoint (#40740)

### DIFF
--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -278,6 +278,8 @@ class DatasetApiKeyListResource(BaseApiKeyListResource):
     @console_ns.doc(params={"resource_id": "Dataset ID"})
     @console_ns.response(200, "API keys retrieved successfully", console_ns.models[ApiKeyList.__name__])
     @with_current_tenant_id
+    @edit_permission_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_API_KEY_MANAGE)
     @with_session(write=False)
     def get(self, session: Session, current_tenant_id: str, resource_id: UUID) -> dict[str, object]:
         """Get all API keys for a dataset"""

--- a/api/tests/unit_tests/controllers/console/test_apikey.py
+++ b/api/tests/unit_tests/controllers/console/test_apikey.py
@@ -18,6 +18,7 @@ from controllers.console.apikey import (
     AppApiKeyListResource,
     BaseApiKeyListResource,
     BaseApiKeyResource,
+    DatasetApiKeyListResource,
 )
 from controllers.console.datasets.datasets import DatasetApiKeyApi
 from core.rbac import RBACPermission, RBACResourceScope
@@ -268,6 +269,10 @@ def test_api_key_lists_require_matching_rbac_permission() -> None:
             lambda: DatasetApiKeyApi().get(),
             [(RBACResourceScope.DATASET, RBACPermission.DATASET_API_KEY_MANAGE, False)],
         ),
+        (
+            lambda: DatasetApiKeyListResource().get(resource_id=api_id),
+            [(RBACResourceScope.DATASET, RBACPermission.DATASET_API_KEY_MANAGE, True)],
+        ),
     ]
 
     with (
@@ -316,6 +321,7 @@ def test_api_key_lists_reject_legacy_read_only_members() -> None:
             lambda: AppApiKeyListResource().get(resource_id=api_id),
             lambda: AgentApiKeyListApi().get(agent_id=api_id),
             lambda: DatasetApiKeyApi().get(),
+            lambda: DatasetApiKeyListResource().get(resource_id=api_id),
         ):
             with pytest.raises(Forbidden):
                 invoke()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #40740

The `GET /console/api/datasets/<dataset_id>/api-keys` endpoint in `DatasetApiKeyListResource` was missing authorization decorators:
- `@edit_permission_required`
- `@rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_API_KEY_MANAGE)`

Without these decorators, any authenticated tenant member—even read-only members lacking dataset edit or API key management permissions—could call the `GET` endpoint and retrieve all secret dataset API keys (`ds-...`).

### Changes:
1. Added `@edit_permission_required` and `@rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_API_KEY_MANAGE)` to `DatasetApiKeyListResource.get` in `api/controllers/console/apikey.py`.
2. Added unit test assertions in `api/tests/unit_tests/controllers/console/test_apikey.py` to ensure legacy edit permission checks and RBAC permission gates are enforced for `DatasetApiKeyListResource.get`.

## Screenshots

N/A (Backend permission fix)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
