### PR TITLE
fix: handle long text URLs in webscraper

### DIFF
--- a/api/core/rag/extractor/extract_processor.py
+++ b/api/core/rag/extractor/extract_processor.py
@@ -132,7 +132,6 @@ class ExtractProcessor:
                     storage.download(upload_file.key, file_path)
                 input_file = Path(file_path)
                 file_extension = input_file.suffix.lower()
-                assert upload_file is not None, "upload_file is required"
                 etl_type = dify_config.ETL_TYPE
                 extractor: BaseExtractor | None = None
                 if etl_type == "Unstructured":
@@ -140,6 +139,7 @@ class ExtractProcessor:
                     unstructured_api_key = dify_config.UNSTRUCTURED_API_KEY or ""
 
                     if file_extension in {".xlsx", ".xls"}:
+                        assert upload_file is not None, "upload_file is required"
                         extractor = ExcelExtractor(
                             file_path,
                             upload_file.tenant_id,
@@ -187,6 +187,7 @@ class ExtractProcessor:
                         extractor = TextExtractor(file_path, autodetect_encoding=True)
                 else:
                     if file_extension in {".xlsx", ".xls"}:
+                        assert upload_file is not None, "upload_file is required"
                         extractor = ExcelExtractor(
                             file_path,
                             upload_file.tenant_id,

--- a/api/tests/unit_tests/core/rag/extractor/test_extract_processor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_extract_processor.py
@@ -118,6 +118,16 @@ class TestExtractProcessorLoaders:
         assert len(docs) == 2
         assert text == "u1\nu2"
 
+    def test_load_from_url_extracts_long_text_without_upload_file(self, monkeypatch: pytest.MonkeyPatch):
+        content = "a" * 100_000
+        response = SimpleNamespace(headers={"Content-Type": "text/plain"}, content=content.encode())
+        monkeypatch.setattr(processor_module.remote_fetcher, "make_request", lambda *args, **kwargs: response)
+        monkeypatch.setattr(processor_module.dify_config, "ETL_TYPE", "SelfHosted")
+
+        text = ExtractProcessor.load_from_url("https://example.com/response.txt", return_text=True)
+
+        assert text == content
+
 
 class TestExtractProcessorFileRouting:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fix webscraper failures for long plain-text URL responses by allowing temporary local files to be extracted without an `UploadFile`. Keep upload metadata validation scoped to extractors that require tenant context, and add regression coverage for a 100,000-character response.

No matching open issue was found for this error.

## Screenshots

<img width="338" height="320" alt="image" src="https://github.com/user-attachments/assets/0fad02f7-1b09-46ea-823e-4fcd33b38862" />

N/A — backend-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods