### PR TITLE
fix(web): skip lifecycle scripts in Docker install

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -31,7 +31,7 @@ COPY packages /app/packages
 RUN corepack install
 
 # Install workspace dependencies for the Docker build environment.
-RUN VITE_GIT_HOOKS=0 pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # build resources
 FROM base AS builder


### PR DESCRIPTION
## Summary

- skip install-time lifecycle scripts in the Web Docker dependency layer
- prevent the development-only root `prepare: vp config` from requiring Git during image builds
- keep development checkout hook setup unchanged

## Context

The Vite+ 0.2.9 upgrade exposed an invalid boundary in the Web Dockerfile. A full `pnpm install` runs the root `prepare` script, but `vp config` configures repository-local hooks and agent integration. The manifest-only Docker dependency layer has neither a Git checkout nor a Git binary, and none of that setup contributes to the Web production build.

pnpm's documented `--ignore-scripts` option is the narrow container boundary here. The Dockerfile explicitly runs the actual application builds later with `pnpm build && pnpm build:vinext`; install-time repository setup is unnecessary. This also avoids adding Git to an intermediate image solely to let `vp config` determine that no `.git` directory exists.

The same manifest-only dependency context installed all 11 workspace projects successfully with `--ignore-scripts`. PR CI then completed the full Web Docker image build successfully on both amd64 and arm64.