### PR TITLE
fix(agent): return conflict for duplicate creation

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -599,6 +599,7 @@ class AgentAppListApi(Resource):
 
     @console_ns.expect(console_ns.models[AgentAppCreatePayload.__name__])
     @console_ns.response(201, "Agent app created successfully", console_ns.models[AgentAppDetailWithSite.__name__])
+    @console_ns.response(409, "Agent name already exists")
     @console_ns.response(403, "Insufficient permissions")
     @console_ns.response(400, "Invalid request parameters")
     @setup_required

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -331,6 +331,7 @@ Check if activation token is valid
 | 201 | Agent app created successfully | **application/json**: [AgentAppDetailWithSite](#agentappdetailwithsite)<br> |
 | 400 | Invalid request parameters |  |
 | 403 | Insufficient permissions |  |
+| 409 | Agent name already exists |  |
 
 ### [GET] /agent/invite-options
 #### Parameters

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -624,17 +624,21 @@ class AppService:
             from services.agent.roster_service import AgentRosterService
 
             icon_type = AgentIconType(params.icon_type) if params.icon_type else None
-            AgentRosterService(session).create_backing_agent_for_app(
-                tenant_id=tenant_id,
-                account_id=account.id,
-                app_id=app.id,
-                name=params.name,
-                description=params.description or "",
-                role=params.agent_role,
-                icon_type=icon_type,
-                icon=params.icon,
-                icon_background=params.icon_background,
-            )
+            try:
+                AgentRosterService(session).create_backing_agent_for_app(
+                    tenant_id=tenant_id,
+                    account_id=account.id,
+                    app_id=app.id,
+                    name=params.name,
+                    description=params.description or "",
+                    role=params.agent_role,
+                    icon_type=icon_type,
+                    icon=params.icon,
+                    icon_background=params.icon_background,
+                )
+            except IntegrityError as exc:
+                session.rollback()
+                raise AgentNameConflictError() from exc
 
         session.flush()
 

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import event
+from sqlalchemy import event, select
 from sqlalchemy.orm import Session
 
 from enums import DeploymentEdition
@@ -124,6 +124,36 @@ class TestCreateAppTransactionBoundary:
 
         assert phase_events == ["commit", "signal", "commit", "external"]
         assert sqlite_session.get(App, app.id) is app
+
+    def test_duplicate_agent_name_rolls_back_and_raises_conflict(self, sqlite_session: Session) -> None:
+        account = _persist_account(sqlite_session)
+        tenant_id = account.current_tenant_id or ""
+        existing_agent = Agent(
+            tenant_id=tenant_id,
+            name="Existing Agent",
+            description="existing",
+            role="",
+            scope=AgentScope.ROSTER,
+            source=AgentSource.ROSTER,
+            status=AgentStatus.ACTIVE,
+        )
+        sqlite_session.add(existing_agent)
+        sqlite_session.commit()
+        rollback_events: list[str] = []
+        event.listen(sqlite_session, "after_rollback", lambda _session: rollback_events.append("rollback"))
+
+        with pytest.raises(AgentNameConflictError):
+            AppService().create_app(
+                tenant_id,
+                CreateAppParams(name="Existing Agent", mode=AppMode.AGENT.value),
+                account,
+                session=sqlite_session,
+            )
+
+        assert rollback_events == ["rollback"]
+        assert sqlite_session.scalars(select(App).where(App.tenant_id == tenant_id)).all() == []
+        assert sqlite_session.scalars(select(AppModelConfig)).all() == []
+        assert sqlite_session.get(Agent, existing_agent.id) is existing_agent
 
     def test_falls_back_when_default_model_schema_is_unavailable(self, sqlite_session: Session) -> None:
         account = _persist_account(sqlite_session)

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -2039,6 +2039,7 @@ export type PostAgentData = {
 export type PostAgentErrors = {
   400: unknown
   403: unknown
+  409: unknown
 }
 
 export type PostAgentResponses = {


### PR DESCRIPTION
## Summary

- map duplicate backing Agent names to the existing `AgentNameConflictError` contract
- roll back the atomic Agent App creation transaction before returning HTTP 409
- document the conflict response and cover rollback without orphan App rows

## Verification

- `31 passed` in `tests/unit_tests/services/test_app_service.py`
- `6 passed` for related Agent duplicate-name/model tests
- Ruff check and format check passed
- Pyrefly reported no diagnostics for the changed production files
- deployed revision `ab41571b28` to dev and verified create/read/copy/update/delete/name-reuse through real console APIs
- duplicate create/copy/update return `409 agent_name_conflict_error`; database counts remain unchanged after failed requests

Linear: https://linear.app/dify/issue/DIFY-2899/创建现有同名的-agent接口会报-inter-server-error