### PR TITLE
fix: preserve successful last run status after page restore

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/workflow-panel/last-run/__tests__/index.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/workflow-panel/last-run/__tests__/index.spec.tsx
@@ -237,4 +237,40 @@ describe('LastRun', () => {
 
     expect(screen.getByTestId('result-panel')).toHaveTextContent(NodeRunningStatus.Succeeded)
   })
+
+  it('should restore a completed last run when refreshing the canvas loses its transient status', () => {
+    mockUseLastRun.mockReturnValue({
+      data: {
+        status: NodeRunningStatus.Succeeded,
+      },
+      isFetching: false,
+      error: undefined,
+    })
+
+    const props = {
+      appId: 'app-1',
+      nodeId: 'node-1',
+      canSingleRun: true,
+      isRunAfterSingleRun: true,
+      updateNodeRunningStatus,
+      onSingleRunClicked,
+    }
+    const { rerender } = render(<LastRun {...props} runningStatus={NodeRunningStatus.Running} />)
+    rerender(<LastRun {...props} runningStatus={NodeRunningStatus.Succeeded} />)
+
+    act(() => {
+      visibilityState = 'hidden'
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    rerender(<LastRun {...props} runningStatus={NodeRunningStatus.NotStart} />)
+    expect(screen.getByTestId('result-panel')).toHaveTextContent(NodeRunningStatus.Succeeded)
+
+    act(() => {
+      visibilityState = 'visible'
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(screen.getByTestId('result-panel')).toHaveTextContent(NodeRunningStatus.Succeeded)
+    expect(updateNodeRunningStatus).toHaveBeenCalledWith(NodeRunningStatus.Succeeded)
+  })
 })

--- a/web/app/components/workflow/nodes/_base/components/workflow-panel/last-run/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/workflow-panel/last-run/index.tsx
@@ -4,7 +4,7 @@ import type { ResultPanelProps } from '@/app/components/workflow/run/result-pane
 import type { NodeTracing } from '@/types/workflow'
 import { RiLoader2Line } from '@remixicon/react'
 import * as React from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useHooksStore } from '@/app/components/workflow/hooks-store'
 import ResultPanel from '@/app/components/workflow/run/result-panel'
 import { NodeRunningStatus } from '@/app/components/workflow/types'
@@ -67,27 +67,22 @@ const LastRun: FC<Props> = ({
     nodeId,
     canRunLastRun,
   )
-  const isRunning = useMemo(() => {
-    if (isPaused) return false
-
-    if (!isRunAfterSingleRun) return isFetching
-    return [NodeRunningStatus.Running, NodeRunningStatus.NotStart].includes(
-      oneStepRunRunningStatus!,
-    )
-  }, [isFetching, isPaused, isRunAfterSingleRun, oneStepRunRunningStatus])
+  const hasAuthoritativeLastRun = canRunLastRun && !!lastRunResult
+  const isRunning =
+    !isPaused &&
+    (isRunAfterSingleRun
+      ? !hasAuthoritativeLastRun &&
+        [NodeRunningStatus.Running, NodeRunningStatus.NotStart].includes(oneStepRunRunningStatus!)
+      : isFetching)
 
   const noLastRun = (error as any)?.status === 404
   const runResult = (canRunLastRun ? lastRunResult : singleRunResult) || lastRunResult || {}
 
-  const resolvedStatus = useMemo(() => {
-    if (isPaused) return NodeRunningStatus.Stopped
-
-    if (oneStepRunRunningStatus === NodeRunningStatus.Stopped) return NodeRunningStatus.Stopped
-
-    if (oneStepRunRunningStatus === NodeRunningStatus.Listening) return NodeRunningStatus.Listening
-
-    return (runResult as any).status || otherResultPanelProps.status
-  }, [isPaused, oneStepRunRunningStatus, runResult, otherResultPanelProps.status])
+  let resolvedStatus = (runResult as any).status || otherResultPanelProps.status
+  if (isPaused || oneStepRunRunningStatus === NodeRunningStatus.Stopped)
+    resolvedStatus = NodeRunningStatus.Stopped
+  else if (oneStepRunRunningStatus === NodeRunningStatus.Listening)
+    resolvedStatus = NodeRunningStatus.Listening
 
   const resetHidePageStatus = useCallback(() => {
     setPageHasHide(false)
@@ -95,15 +90,21 @@ const LastRun: FC<Props> = ({
     setHidePageOneStepFinishedStatus(null)
   }, [])
   useEffect(() => {
-    if (
-      pageShowed &&
-      hidePageOneStepFinishedStatus &&
-      (!oneStepRunRunningStatus || oneStepRunRunningStatus === NodeRunningStatus.NotStart)
-    ) {
+    if (!pageShowed || !hidePageOneStepFinishedStatus) return
+
+    if (!oneStepRunRunningStatus || oneStepRunRunningStatus === NodeRunningStatus.NotStart) {
       updateNodeRunningStatus(hidePageOneStepFinishedStatus)
-      resetHidePageStatus()
+      return
     }
-  }, [isOneStepRunSucceed, isOneStepRunFailed, oneStepRunRunningStatus])
+
+    resetHidePageStatus()
+  }, [
+    hidePageOneStepFinishedStatus,
+    oneStepRunRunningStatus,
+    pageShowed,
+    resetHidePageStatus,
+    updateNodeRunningStatus,
+  ])
 
   useEffect(() => {
     if ([NodeRunningStatus.Succeeded, NodeRunningStatus.Failed].includes(oneStepRunRunningStatus!))
@@ -112,7 +113,7 @@ const LastRun: FC<Props> = ({
 
   useEffect(() => {
     resetHidePageStatus()
-  }, [nodeId])
+  }, [nodeId, resetHidePageStatus])
 
   const handlePageVisibilityChange = useCallback(() => {
     if (document.visibilityState === 'hidden') setPageHasHide(true)


### PR DESCRIPTION
## Summary

- Keep completed last-run results authoritative when a workflow canvas refresh clears transient node status.
- Restore the terminal single-run status after returning to the page and add regression coverage for the visibility-change flow.

Fixes FPRD-115

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.