### PR TITLE
fix(api): support audio/x-m4a for ASR

### DIFF
--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -49,7 +49,7 @@ class AudioApi(Resource):
         summary="Convert Audio to Text",
         description=(
             "Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, "
-            "`audio/wav`, and `audio/amr`. File size limit is `30 MB`."
+            "`audio/x-m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`."
         ),
         tags=["TTS"],
         responses={
@@ -76,7 +76,7 @@ class AudioApi(Resource):
             include_user=True,
             file_description=(
                 "Audio file to transcribe. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, "
-                "`audio/wav`, and `audio/amr`. File size limit is `30 MB`."
+                "`audio/x-m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`."
             ),
         ),
     )

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -265,7 +265,7 @@ Updates the question and answer of an existing annotation.
 ### [POST] /audio-to-text
 **Convert Audio to Text**
 
-Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`.
+Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/x-m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`.
 
 #### Request Body
 

--- a/api/services/audio_service.py
+++ b/api/services/audio_service.py
@@ -30,6 +30,9 @@ from services.workflow_service import WorkflowService
 
 FILE_SIZE = 30
 FILE_SIZE_LIMIT = FILE_SIZE * 1024 * 1024
+_ASR_MIME_TYPE_ALIASES = {
+    "audio/x-m4a": "audio/m4a",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -130,8 +133,8 @@ class AudioService:
         if file is None:
             raise NoAudioUploadedServiceError()
 
-        extension = file.mimetype
-        if extension not in [f"audio/{ext}" for ext in AUDIO_EXTENSIONS]:
+        mimetype = _ASR_MIME_TYPE_ALIASES.get(file.mimetype, file.mimetype)
+        if mimetype not in [f"audio/{ext}" for ext in AUDIO_EXTENSIONS]:
             raise UnsupportedAudioTypeServiceError()
 
         file_content = file.stream.read()

--- a/api/tests/unit_tests/controllers/test_swagger.py
+++ b/api/tests/unit_tests/controllers/test_swagger.py
@@ -350,7 +350,7 @@ def test_service_openapi_documents_app_multipart_contracts(monkeypatch: pytest.M
             assert schema["properties"]["file"] == {
                 "description": (
                     "Audio file to transcribe. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, "
-                    "`audio/wav`, and `audio/amr`. File size limit is `30 MB`."
+                    "`audio/x-m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`."
                 ),
                 "format": "binary",
                 "type": "string",

--- a/api/tests/unit_tests/services/test_audio_service.py
+++ b/api/tests/unit_tests/services/test_audio_service.py
@@ -254,6 +254,26 @@ class TestAudioServiceASR:
         mock_model_manager_class.assert_called_once_with(tenant_id=app.tenant_id, user_id="user-123")
 
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    def test_transcript_asr_accepts_x_m4a_mimetype(
+        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
+    ):
+        """Test that the x-m4a MIME alias follows the normal m4a transcription flow."""
+        # Arrange
+        app_model_config = factory.create_app_model_config_mock(speech_to_text_dict={"enabled": True})
+        app = factory.create_app_mock(mode=AppMode.CHAT, app_model_config=app_model_config)
+        file = factory.create_file_storage_mock(filename="audio.m4a", mimetype="audio/x-m4a")
+        mock_model_instance = MagicMock()
+        mock_model_instance.invoke_speech2text.return_value = "M4A transcript"
+        mock_model_manager_class.return_value.get_default_model_instance.return_value = mock_model_instance
+
+        # Act
+        result = AudioService.transcript_asr(app_model=app, file=file, session=self.session)
+
+        # Assert
+        assert result == {"text": "M4A transcript"}
+        mock_model_instance.invoke_speech2text.assert_called_once()
+
+    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_asr_success_advanced_chat_mode(
         self, mock_model_manager_class, factory: AudioServiceTestDataFactory
     ):

--- a/packages/contracts/generated/api/service/orpc.gen.ts
+++ b/packages/contracts/generated/api/service/orpc.gen.ts
@@ -419,12 +419,12 @@ export const apps = {
 /**
  * Convert Audio to Text
  *
- * Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`.
+ * Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/x-m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`.
  */
 export const post3 = oc
   .route({
     description:
-      'Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`.',
+      'Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/x-m4a`, `audio/wav`, and `audio/amr`. File size limit is `30 MB`.',
     inputStructure: 'detailed',
     method: 'POST',
     operationId: 'postAudioToText',


### PR DESCRIPTION
## Summary

- Normalize `audio/x-m4a` to the canonical `audio/m4a` MIME type before ASR validation.
- Preserve the existing audio MIME allowlist for all other file types.
- Document `audio/x-m4a` support in the Service API OpenAPI description.
- Add regression coverage to verify that `audio/x-m4a` uploads follow the normal speech-to-text flow.

## Motivation and Context

Some clients, particularly iOS and React Native applications, identify valid `.m4a` recordings as `audio/x-m4a`.

Dify currently validates uploaded audio using an exact MIME type allowlist. The allowlist accepts `audio/m4a`, but not its commonly used `audio/x-m4a` alias. Consequently, valid M4A recordings may be rejected with HTTP 415 before reaching the configured speech-to-text provider.

This change normalizes only the `audio/x-m4a` alias to `audio/m4a`, allowing these recordings to reuse the existing M4A validation and transcription flow. It does not broaden ASR support to arbitrary `audio/*` MIME types.

## Screenshots

N/A — this is a backend-only change.

## Verification

- [x] Added a focused regression test for `audio/x-m4a`.
- [x] Updated the OpenAPI contract assertion.
- [x] Python AST syntax check passed.
- [x] `git diff --check` passed.
- [ ] `make lint`, `make type-check`, and the targeted unit tests should be run before merge.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed if there was no previous discussion or associated issue.
- [x] I added a test for the introduced behavior and kept the change atomic.
- [x] I updated the Service API OpenAPI description accordingly.
- [ ] I ran `make lint && make type-check`.

From Codex