### PR TITLE
fix(web): prevent long segment summaries from shrinking the editor

### DIFF
--- a/web/app/components/datasets/documents/detail/completed/common/__tests__/summary-text.spec.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/__tests__/summary-text.spec.tsx
@@ -26,6 +26,11 @@ describe('SummaryText', () => {
     expect(screen.getByTestId('textarea')).toHaveValue('My summary')
   })
 
+  it('should cap the auto-growing summary field', () => {
+    render(<SummaryText />)
+    expect(screen.getByTestId('textarea')).toHaveAttribute('maxRows', '6')
+  })
+
   it('should render empty string when value is undefined', () => {
     render(<SummaryText onChange={onChange} />)
     expect(screen.getByTestId('textarea')).toHaveValue('')

--- a/web/app/components/datasets/documents/detail/completed/common/summary-text.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/summary-text.tsx
@@ -22,6 +22,7 @@ const SummaryText = ({ value, onChange, disabled }: SummaryTextProps) => {
         )}
         placeholder={t(($) => $['segment.summaryPlaceholder'], { ns: 'datasetDocuments' })}
         minRows={1}
+        maxRows={6}
         value={value ?? ''}
         onChange={(e) => onChange?.(e.target.value)}
         disabled={disabled}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Limit the segment summary textarea to six auto-growing rows and let it scroll internally after the limit is reached. This prevents long summaries from consuming the non-fullscreen drawer height and compressing the editable segment content area.

Fixes #40779

## Screenshots

Not applicable. This is a layout behavior fix without a visual asset change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Verification

- `pnpm --filter dify-web exec vp test app/components/datasets/documents/detail/completed/common/__tests__ --run`
  - 7 test files passed
  - 119 tests passed
- `pnpm --filter dify-web type-check` passed
- Pre-commit `vp check --fix` passed

From Codex