### PR TITLE
fix(api): protect custom OAuth client deletion

### DIFF
--- a/api/controllers/console/datasets/rag_pipeline/datasource_auth.py
+++ b/api/controllers/console/datasets/rag_pipeline/datasource_auth.py
@@ -436,6 +436,8 @@ class DatasourceAuthOauthCustomClient(Resource):
     @setup_required
     @login_required
     @account_initialization_required
+    @edit_permission_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
     @with_current_tenant_id
     def delete(self, current_tenant_id: str, provider_id: str):

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1268,6 +1268,8 @@ class ToolOAuthCustomClient(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
     def delete(self, current_tenant_id: str, provider: str):

--- a/api/tests/unit_tests/controllers/console/test_oauth_custom_client_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_oauth_custom_client_permissions.py
@@ -1,0 +1,28 @@
+from inspect import getclosurevars, unwrap
+from types import FunctionType
+
+import pytest
+
+from controllers.common.wraps import RBACPermission, RBACResourceScope
+from controllers.console.datasets.rag_pipeline.datasource_auth import DatasourceAuthOauthCustomClient
+from controllers.console.workspace.tool_providers import ToolOAuthCustomClient
+
+
+@pytest.mark.parametrize(
+    ("method", "legacy_gate", "resource_type"),
+    [
+        (ToolOAuthCustomClient.delete, "is_admin_or_owner_required", RBACResourceScope.WORKSPACE),
+        (DatasourceAuthOauthCustomClient.delete, "edit_permission_required", RBACResourceScope.DATASET),
+    ],
+)
+def test_custom_oauth_client_delete_requires_management_permission(
+    method: FunctionType, legacy_gate: str, resource_type: RBACResourceScope
+) -> None:
+    legacy_wrapper = unwrap(method, stop=lambda wrapper: legacy_gate in wrapper.__code__.co_qualname)
+    assert legacy_gate in legacy_wrapper.__code__.co_qualname
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == resource_type
+    assert rbac_config["scene"] == RBACPermission.CREDENTIAL_MANAGE
+    assert rbac_config["resource_required"] is False


### PR DESCRIPTION
## Summary

- Require Tool custom OAuth client deletion to pass the admin-or-owner and workspace CREDENTIAL_MANAGE gates already used by creation.
- Require Datasource custom OAuth client deletion to pass the editor and dataset CREDENTIAL_MANAGE gates already used by creation.
- Keep masked OAuth client read paths unchanged.

Refs #37986

## Verification

- Added a parameterized authorization contract test for both DELETE routes.
- Confirmed both existing authorized deletion tests still pass.
- Ran targeted Ruff, Pyrefly, and mypy checks.
- Ran the response contract lint and staged getattr check.

## Screenshots

Not applicable.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Codex
