### PR TITLE
fix(web): show plugin error message instead of the raw error envelope in toasts

### DIFF
--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -40,6 +40,7 @@ import {
 } from '@/config'
 import { asyncRunSafe } from '@/utils'
 import { isClient } from '@/utils/client'
+import { parsePluginErrorString } from '@/utils/error-parser'
 import { resolveLoginRedirectTarget } from '@/utils/login-redirect'
 import { basePath } from '@/utils/var'
 import { base, ContentType, getBaseOptions } from './fetch'
@@ -654,7 +655,7 @@ export const ssePost = async (
             void reportStreamResponseError(res, onError, onNotifyError)
           } else {
             res.json().then((data) => {
-              toast.error(data.message || 'Server Error')
+              toast.error(parsePluginErrorString(data.message || 'Server Error'))
             })
             onError?.('Server Error')
           }
@@ -820,7 +821,7 @@ export const sseGet = async (
             void reportStreamResponseError(res, onError, onNotifyError)
           } else {
             res.json().then((data) => {
-              toast.error(data.message || 'Server Error')
+              toast.error(parsePluginErrorString(data.message || 'Server Error'))
             })
             onError?.('Server Error')
           }

--- a/web/service/fetch.ts
+++ b/web/service/fetch.ts
@@ -14,6 +14,7 @@ import {
   PUBLIC_API_PREFIX,
   WEB_APP_SHARE_CODE_HEADER_NAME,
 } from '@/config'
+import { parsePluginErrorString } from '@/utils/error-parser'
 import { getWebAppPublicApiPath, resolveWebAppAddress } from './webapp-address'
 import { getWebAppAccessToken, getWebAppPassport } from './webapp-auth'
 
@@ -78,7 +79,7 @@ const afterResponseErrorCode = (otherOptions: IOtherOptions): AfterResponseHook 
       const shouldNotifyError = response.status !== 401 && errorData && !otherOptions.silent
 
       const errorMessage = errorData?.message || errorData?.error
-      if (shouldNotifyError && errorMessage) toast.error(errorMessage)
+      if (shouldNotifyError && errorMessage) toast.error(parsePluginErrorString(errorMessage))
 
       if (response.status === 403 && errorData?.code === 'already_setup')
         globalThis.location.href = `${globalThis.location.origin}/signin`

--- a/web/utils/__tests__/error-parser.spec.ts
+++ b/web/utils/__tests__/error-parser.spec.ts
@@ -1,0 +1,50 @@
+import { parsePluginErrorMessage, parsePluginErrorString } from '../error-parser'
+
+describe('parsePluginErrorString', () => {
+  it('extracts the inner message from a PluginInvokeError envelope', () => {
+    const raw =
+      'req_id: a7ce6eaf14 PluginInvokeError: {"args":{},"error_type":"ToolProviderCredentialValidationError","message":"Invalid Apify API Token. Please check the token and try again."}'
+    expect(parsePluginErrorString(raw)).toBe(
+      'Invalid Apify API Token. Please check the token and try again.',
+    )
+  })
+
+  it('falls back to error_type when the envelope has no message', () => {
+    const raw = 'req_id: abc PluginInvokeError: {"args":{},"error_type":"ToolProviderError"}'
+    expect(parsePluginErrorString(raw)).toBe('ToolProviderError')
+  })
+
+  it('returns the input unchanged when it is not a plugin envelope', () => {
+    expect(parsePluginErrorString('plain error message')).toBe('plain error message')
+  })
+
+  it('returns the input unchanged when the envelope JSON is malformed', () => {
+    const raw = 'req_id: abc PluginInvokeError: {not-json'
+    expect(parsePluginErrorString(raw)).toBe(raw)
+  })
+})
+
+describe('parsePluginErrorMessage', () => {
+  it('parses the envelope from an error-like object', async () => {
+    const error = {
+      message:
+        'req_id: a7ce6eaf14 PluginInvokeError: {"args":{},"error_type":"ToolProviderCredentialValidationError","message":"Bad credentials"}',
+    }
+    await expect(parsePluginErrorMessage(error)).resolves.toBe('Bad credentials')
+  })
+
+  it('parses the envelope from a Response body message', async () => {
+    const response = new Response(
+      JSON.stringify({
+        message:
+          'req_id: a7ce6eaf14 PluginInvokeError: {"args":{},"error_type":"ToolProviderCredentialValidationError","message":"Bad credentials"}',
+      }),
+      { status: 400 },
+    )
+    await expect(parsePluginErrorMessage(response)).resolves.toBe('Bad credentials')
+  })
+
+  it('returns plain messages unchanged', async () => {
+    await expect(parsePluginErrorMessage(new Error('boom'))).resolves.toBe('boom')
+  })
+})

--- a/web/utils/error-parser.ts
+++ b/web/utils/error-parser.ts
@@ -1,4 +1,34 @@
 /**
+ * Extract the human-readable message from a PluginInvokeError envelope string.
+ *
+ * The plugin daemon wraps every exception into a JSON envelope, which the backend
+ * then stringifies into error responses:
+ *   "req_id: xxx PluginInvokeError: {\"args\":{},\"error_type\":\"ToolProviderCredentialValidationError\",\"message\":\"Invalid token\"}"
+ * Toasts should show the inner `message`, not the raw envelope.
+ *
+ * Returns the input unchanged when it is not a plugin envelope.
+ */
+export const parsePluginErrorString = (rawMessage: string): string => {
+  // Use greedy match .+ to capture the complete JSON object with nested braces
+  const pluginErrorPattern = /PluginInvokeError:\s*(\{.+\})/
+  const match = pluginErrorPattern.exec(rawMessage)
+
+  if (match) {
+    try {
+      const errorData = JSON.parse(match[1]!)
+      // Return the inner message if exists
+      if (errorData.message) return errorData.message
+      // Fallback to error_type if message not available
+      if (errorData.error_type) return errorData.error_type
+    } catch (parseError) {
+      console.warn('Failed to parse plugin error JSON:', parseError)
+    }
+  }
+
+  return rawMessage
+}
+
+/**
  * Parse plugin error message from nested error structure
  * Extracts the real error message from PluginInvokeError JSON string
  *
@@ -24,24 +54,5 @@ export const parsePluginErrorMessage = async (error: any): Promise<string> => {
     rawMessage = error?.message || error?.toString() || 'Unknown error'
   }
 
-  console.log('rawMessage', rawMessage)
-
-  // Try to extract nested JSON from PluginInvokeError
-  // Use greedy match .+ to capture the complete JSON object with nested braces
-  const pluginErrorPattern = /PluginInvokeError:\s*(\{.+\})/
-  const match = pluginErrorPattern.exec(rawMessage)
-
-  if (match) {
-    try {
-      const errorData = JSON.parse(match[1]!)
-      // Return the inner message if exists
-      if (errorData.message) return errorData.message
-      // Fallback to error_type if message not available
-      if (errorData.error_type) return errorData.error_type
-    } catch (parseError) {
-      console.warn('Failed to parse plugin error JSON:', parseError)
-    }
-  }
-
-  return rawMessage
+  return parsePluginErrorString(rawMessage)
 }


### PR DESCRIPTION
## Summary

Fixes #40487

When a plugin call fails (e.g. credential validation), the plugin daemon wraps the exception in a JSON envelope and the backend stringifies it into the error response `message`:

```
req_id: a7ce6eaf14 PluginInvokeError: {"args":{},"error_type":"ToolProviderCredentialValidationError","message":"Invalid Apify API Token. Please check the token and try again."}
```

Every toast displayed this raw envelope, burying the human-readable `message` meant for the user. This PR parses the envelope before toasting, so the toast shows only the message; `req_id`/`error_type` remain in the rejected error for diagnostics.

Since every plugin error flows through these paths, this fixes the error UX for all plugins at once:

- `web/service/fetch.ts` `afterResponseErrorCode` — the global ky hook that toasts non-2xx JSON API errors (covers tool/agent/workflow/data-source credential modals)
- `web/service/base.ts` — the two SSE non-2xx branches (ssePost/sseGet)

The existing `parsePluginErrorMessage` helper is reused; its string-parsing core is extracted into a synchronous `parsePluginErrorString` for the toast paths, and a leftover debug `console.log` is removed. Non-envelope messages pass through unchanged.

## Screenshots

| Before | After |
|--------|-------|
| `req_id: a7ce6eaf14 PluginInvokeError: {"args":{},"error_type":"ToolProviderCredentialValidationError","message":"Invalid Apify API Token..."}` | `Invalid Apify API Token. Please check the token and try again.` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/eslint` and `dev/type-check` locally to appease the lint gods

Verified locally: new `web/utils/__tests__/error-parser.spec.ts` (7/7), `service/base.spec.ts` + `service/plugins.spec.ts` (25/25), `tsc --noEmit` clean.