### PR TITLE
fix(api): protect workspace credential mutations

### DIFF
--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -36,6 +36,7 @@ from ..wraps import (
     RBACPermission,
     RBACResourceScope,
     account_initialization_required,
+    is_admin_or_owner_required,
     model_validate,
     rbac_permission_required,
     setup_required,
@@ -187,6 +188,8 @@ class DataSourceApi(Resource):
 
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
     @with_current_tenant_id

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -580,6 +580,8 @@ class ToolBuiltinProviderAddApi(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_CREATE, resource_required=False)
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -1,0 +1,28 @@
+from inspect import getclosurevars, unwrap
+from types import FunctionType
+
+import pytest
+
+from controllers.common.wraps import RBACPermission, RBACResourceScope
+from controllers.console.datasets.data_source import DataSourceApi
+from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddApi
+
+
+@pytest.mark.parametrize(
+    ("method", "permission"),
+    [
+        (ToolBuiltinProviderAddApi.post, RBACPermission.CREDENTIAL_CREATE),
+        (DataSourceApi.patch, RBACPermission.CREDENTIAL_MANAGE),
+    ],
+)
+def test_workspace_credential_mutations_require_management_permission(
+    method: FunctionType, permission: RBACPermission
+) -> None:
+    legacy_wrapper = unwrap(method, stop=lambda wrapper: "is_admin_or_owner_required" in wrapper.__code__.co_qualname)
+    assert "is_admin_or_owner_required" in legacy_wrapper.__code__.co_qualname
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
+    assert rbac_config["scene"] == permission
+    assert rbac_config["resource_required"] is False

--- a/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
@@ -336,6 +336,7 @@ def test_builtin_provider_add_passes_payload(
     app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
 ):
     user = _mock_account()
+    user.role = TenantAccountRole.ADMIN
     _set_current_account(monkeypatch, controller_module, user, "tenant-456")
 
     service_mock = MagicMock(return_value={"result": "success"})


### PR DESCRIPTION
## Summary

- Require builtin tool credential creation to pass the admin-or-owner and workspace CREDENTIAL_CREATE gates.
- Require legacy datasource binding enable and disable to pass the admin-or-owner and workspace CREDENTIAL_MANAGE gates.
- Keep read routes, service behavior, payloads, and responses unchanged.

Refs #37986

## Verification

- Added a parameterized authorization contract test for both mutation routes.
- Confirmed all 36 related controller tests pass.
- Ran targeted Ruff, Pyrefly, and mypy checks.
- Ran the response contract lint and no-new-getattr check.

## Screenshots

Not applicable.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I added a test for each introduced change and kept this as a single atomic change.
- [ ] I updated the documentation accordingly.
- [ ] I ran make lint and make type-check for the full backend.

From Codex