### PR TITLE
fix(api): re-sign tool file URLs that are not markdown links

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1656,16 +1656,21 @@ class Message(Base):
         if not self.answer:
             return self.answer
 
-        pattern = r"\[!?.*?\]\((((http|https):\/\/.+)?\/files\/(tools\/)?[\w-]+.*?timestamp=.*&nonce=.*&sign=.*)\)"
+        # Match the signed file URL itself rather than the markdown that may surround it, so bare,
+        # backticked and fenced occurrences are re-signed too. `url_char` stops the match at the
+        # delimiters that can terminate a URL in an answer (whitespace, markdown link/quote chars).
+        url_char = r"[^\s)\]`\"'<>]"
+        pattern = (
+            rf"(?:https?://{url_char}+)?/files/(?:tools/)?"
+            rf"{url_char}*?timestamp={url_char}*?nonce={url_char}*?sign={url_char}*"
+        )
         matches = re.findall(pattern, self.answer)
 
         if not matches:
             return self.answer
 
-        urls = [match[0] for match in matches]
-
         # remove duplicate urls
-        urls = list(set(urls))
+        urls = list(set(matches))
 
         if not urls:
             return self.answer

--- a/api/tests/unit_tests/models/test_model.py
+++ b/api/tests/unit_tests/models/test_model.py
@@ -86,6 +86,50 @@ def test_image_preview_misspelled_not_replaced():
     assert out == original
 
 
+def test_bare_file_preview_url_replaced():
+    """
+    A file-preview URL that is not wrapped in markdown must still be re-signed.
+    """
+    upload_id = "bare-1"
+    url = f"http://api:5001/files/{upload_id}/file-preview?timestamp=111&nonce=222&sign=333"
+    msg = Message(answer=f"Download:\n{url}")
+
+    out = msg.re_sign_file_url_answer
+    assert f"https://signed.example/{upload_id}" in out
+    assert "http://api:5001" not in out
+
+
+def test_backticked_tool_file_url_replaced(monkeypatch: pytest.MonkeyPatch):
+    """
+    A tool file URL inside backticks must be re-signed, including the internal host.
+    """
+    model_module = importlib.import_module("models.model")
+    monkeypatch.setattr(
+        model_module,
+        "sign_tool_file",
+        lambda tool_file_id, extension: f"https://signed.example/tools/{tool_file_id}{extension}",
+    )
+
+    tool_file_id = "5c465079-d1ee-c17e-f8fd-000000000001"
+    url = f"http://api:5001/files/tools/{tool_file_id}.txt?timestamp=111&nonce=222&sign=333"
+    msg = Message(answer=f"Download:\n`{url}`")
+
+    out = msg.re_sign_file_url_answer
+    assert out == f"Download:\n`https://signed.example/tools/{tool_file_id}.txt`"
+
+
+def test_multiple_bare_urls_replaced_independently():
+    """
+    Two bare URLs in one answer must each be re-signed, not collapsed into one greedy match.
+    """
+    first = "/files/multi-a/file-preview?timestamp=1&nonce=2&sign=3"
+    second = "/files/multi-b/file-preview?timestamp=4&nonce=5&sign=6"
+    msg = Message(answer=f"first {first} then {second}")
+
+    out = msg.re_sign_file_url_answer
+    assert out == "first https://signed.example/multi-a then https://signed.example/multi-b"
+
+
 def _build_local_file_mapping(record_id: str, *, tenant_id: str | None = None) -> dict[str, object]:
     mapping: dict[str, object] = {
         "dify_model_identity": FILE_MODEL_IDENTITY,


### PR DESCRIPTION
## Summary

Fixes #40788

`Message.re_sign_file_url_answer` is what rewrites stored signed file URLs to
`FILES_URL` with a fresh timestamp on every read. It is bound to the `answer`
field of both the Service API and console message schemas
(`fields/message_fields.py`, `fields/conversation_fields.py`).

Its regex required the URL to be wrapped in a markdown link:

```
\[!?.*?\]\((((http|https)://.+)?/files/(tools/)?[\w-]+.*?timestamp=.*&nonce=.*&sign=.*)\)
```

Whether an agent's answer contains `[download](http://api:5001/files/tools/...)`
or a bare/backticked URL is entirely up to the model. When it isn't a markdown
link the pattern finds no match, the method returns `self.answer` untouched, and
the client receives the raw `INTERNAL_FILES_URL` host — unresolvable outside the
compose network — still carrying its original timestamp, already counting down
against `FILES_ACCESS_TIMEOUT`.

This matches the URL itself instead of the markdown that happens to surround it:

```python
url_char = r"[^\s)\]`\"'<>]"
pattern = (
    rf"(?:https?://{url_char}+)?/files/(?:tools/)?"
    rf"{url_char}*?timestamp={url_char}*?nonce={url_char}*?sign={url_char}*"
)
```

`url_char` bounds the match at the characters that terminate a URL inside an
answer — whitespace, `)`, `]`, backtick, quotes, angle brackets. That boundary
is what makes dropping the markdown wrapper safe: the old pattern's greedy
`.*&nonce=.*&sign=.*` only terminated because the closing `)` anchored it, so
without a bound two URLs in one answer would collapse into a single bogus match.
Markdown links still match exactly as before, since `)` ends the URL either way.

`re.findall` now returns whole matches rather than group tuples, so the
`match[0]` extraction is no longer needed. Everything downstream — tool-file-id
extraction, `sign_tool_file` / `file_helpers.get_signed_file_url`, the
`as_attachment` passthrough, and the final `str.replace` — is unchanged and
already operated on a plain URL string, so it handles bare, backticked, fenced
and markdown occurrences uniformly.

### Scope

Read path only. The issue also notes that `ToolFileManager.sign_file` lacks the
`for_external` switch that `core/tools/signature.py::sign_tool_file` has. That is
left alone deliberately: #39952 already reworked URL production for the Agent CLI,
whereas stored messages are re-signed through this property on *every* read, so
existing conversations keep serving internal hostnames even after upgrading. This
fixes that half.

### Tests

Added to `api/tests/unit_tests/models/test_model.py`:

- `test_bare_file_preview_url_replaced` — unwrapped URL with an internal host
- `test_backticked_tool_file_url_replaced` — tool file URL inside backticks
- `test_multiple_bare_urls_replaced_independently` — two URLs in one answer are
  re-signed separately rather than swallowed by one greedy match

All three produce zero matches against the previous regex, so they fail without
this change. The four existing tests — including both misspelled-endpoint cases
that must *not* be rewritten — still pass; they exercise the inner
`file-preview` / `image-preview` patterns, which are untouched.

- `make test TARGET_TESTS=./api/tests/unit_tests/models/test_model.py` → 10 passed
- `make lint` → clean
- `make type-check` → no issues found in 1677 source files

## Screenshots

Not applicable — backend-only change with no UI surface.

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods