### PR TITLE
refactor(controllers/web): dep-inject payloads with @model_validate

### DIFF
--- a/api/controllers/web/message.py
+++ b/api/controllers/web/message.py
@@ -2,7 +2,6 @@ import logging
 from typing import Literal
 from uuid import UUID
 
-from flask import request
 from pydantic import BaseModel, Field, TypeAdapter
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import InternalServerError, NotFound
@@ -11,6 +10,7 @@ from controllers.common.controller_schemas import MessageFeedbackPayload, Messag
 from controllers.common.fields import GeneratedAppResponse
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console.app.wraps import with_session
+from controllers.console.wraps import model_validate
 from controllers.web import web_ns
 from controllers.web.error import (
     AppMoreLikeThisDisabledError,
@@ -77,13 +77,11 @@ class MessageListApi(WebApiResource):
         }
     )
     @web_ns.response(200, "Success", web_ns.models[WebMessageInfiniteScrollPagination.__name__])
-    def get(self, app_model: App, end_user: EndUser):
+    @model_validate(MessageListQuery)
+    def get(self, query: MessageListQuery, app_model: App, end_user: EndUser):
         app_mode = AppMode.value_of(app_model.mode)
         if app_mode not in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT, AppMode.AGENT}:
             raise NotChatAppError()
-
-        raw_args = request.args.to_dict()
-        query = MessageListQuery.model_validate(raw_args)
 
         try:
             session = db.session()
@@ -134,10 +132,9 @@ class MessageFeedbackApi(WebApiResource):
     )
     @web_ns.response(200, "Feedback submitted successfully", web_ns.models[ResultResponse.__name__])
     @web_ns.expect(web_ns.models[MessageFeedbackPayload.__name__])
-    def post(self, app_model: App, end_user: EndUser, message_id: UUID):
+    @model_validate(MessageFeedbackPayload)
+    def post(self, payload: MessageFeedbackPayload, app_model: App, end_user: EndUser, message_id: UUID):
         message_id_str = str(message_id)
-
-        payload = MessageFeedbackPayload.model_validate(web_ns.payload or {})
 
         try:
             MessageService.create_feedback(
@@ -171,14 +168,19 @@ class MessageMoreLikeThisApi(WebApiResource):
     )
     @web_ns.response(200, "Success", web_ns.models[GeneratedAppResponse.__name__])
     @with_session
-    def get(self, session: Session, app_model: App, end_user: EndUser, message_id: UUID):
+    @model_validate(MessageMoreLikeThisQuery)
+    def get(
+        self,
+        query: MessageMoreLikeThisQuery,
+        session: Session,
+        app_model: App,
+        end_user: EndUser,
+        message_id: UUID,
+    ):
         if app_model.mode != "completion":
             raise NotCompletionAppError()
 
         message_id_str = str(message_id)
-
-        raw_args = request.args.to_dict()
-        query = MessageMoreLikeThisQuery.model_validate(raw_args)
 
         streaming = query.response_mode == "streaming"
 

--- a/api/controllers/web/saved_message.py
+++ b/api/controllers/web/saved_message.py
@@ -1,11 +1,11 @@
 from uuid import UUID
 
-from flask import request
 from pydantic import TypeAdapter
 from werkzeug.exceptions import NotFound
 
 from controllers.common.controller_schemas import SavedMessageCreatePayload, SavedMessageListQuery
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
+from controllers.console.wraps import model_validate
 from controllers.web import web_ns
 from controllers.web.error import NotCompletionAppError
 from controllers.web.wraps import WebApiResource
@@ -36,12 +36,10 @@ class SavedMessageListApi(WebApiResource):
         }
     )
     @web_ns.response(200, "Success", web_ns.models[SavedMessageInfiniteScrollPagination.__name__])
-    def get(self, app_model: App, end_user: EndUser):
+    @model_validate(SavedMessageListQuery)
+    def get(self, query: SavedMessageListQuery, app_model: App, end_user: EndUser):
         if app_model.mode != "completion":
             raise NotCompletionAppError()
-
-        raw_args = request.args.to_dict()
-        query = SavedMessageListQuery.model_validate(raw_args)
 
         session = db.session()
         pagination = SavedMessageService.pagination_by_last_id(
@@ -75,11 +73,10 @@ class SavedMessageListApi(WebApiResource):
     )
     @web_ns.response(200, "Message saved successfully", web_ns.models[ResultResponse.__name__])
     @web_ns.expect(web_ns.models[SavedMessageCreatePayload.__name__])
-    def post(self, app_model: App, end_user: EndUser):
+    @model_validate(SavedMessageCreatePayload)
+    def post(self, payload: SavedMessageCreatePayload, app_model: App, end_user: EndUser):
         if app_model.mode != "completion":
             raise NotCompletionAppError()
-
-        payload = SavedMessageCreatePayload.model_validate(web_ns.payload or {})
 
         try:
             SavedMessageService.save(app_model, end_user, payload.message_id, session=db.session())

--- a/api/tests/unit_tests/controllers/web/test_message_endpoints.py
+++ b/api/tests/unit_tests/controllers/web/test_message_endpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -9,6 +10,7 @@ import pytest
 from flask import Flask
 from werkzeug.exceptions import NotFound
 
+from controllers.common.controller_schemas import MessageFeedbackPayload
 from controllers.web.error import (
     AppMoreLikeThisDisabledError,
     NotChatAppError,
@@ -17,6 +19,7 @@ from controllers.web.error import (
 from controllers.web.message import (
     MessageFeedbackApi,
     MessageMoreLikeThisApi,
+    MessageMoreLikeThisQuery,
     MessageSuggestedQuestionApi,
 )
 from models.enums import EndUserType
@@ -42,30 +45,35 @@ def _end_user() -> EndUser:
     )
 
 
+# The @model_validate and @with_session decorators wrap the handlers; tests
+# call the undecorated function so they can pass a pydantic payload / a fake
+# session directly.
+_feedback_post = inspect.unwrap(MessageFeedbackApi.post)
+_more_like_this_get = inspect.unwrap(MessageMoreLikeThisApi.get)
+
+
 # ---------------------------------------------------------------------------
 # MessageFeedbackApi
 # ---------------------------------------------------------------------------
 class TestMessageFeedbackApi:
     @patch("controllers.web.message.MessageService.create_feedback")
-    @patch("controllers.web.message.web_ns")
-    def test_feedback_success(self, mock_ns: MagicMock, mock_create: MagicMock, app: Flask) -> None:
-        mock_ns.payload = {"rating": "like", "content": "great"}
+    def test_feedback_success(self, mock_create: MagicMock, app: Flask) -> None:
+        payload = MessageFeedbackPayload.model_validate({"rating": "like", "content": "great"})
         msg_id = uuid4()
 
         with app.test_request_context(f"/messages/{msg_id}/feedbacks", method="POST"):
-            result = MessageFeedbackApi().post(_chat_app(), _end_user(), msg_id)
+            result = _feedback_post(MessageFeedbackApi(), payload, _chat_app(), _end_user(), msg_id)
 
         assert result == {"result": "success"}
         mock_create.assert_called_once()
 
     @patch("controllers.web.message.MessageService.create_feedback")
-    @patch("controllers.web.message.web_ns")
-    def test_feedback_null_rating(self, mock_ns: MagicMock, mock_create: MagicMock, app: Flask) -> None:
-        mock_ns.payload = {"rating": None}
+    def test_feedback_null_rating(self, mock_create: MagicMock, app: Flask) -> None:
+        payload = MessageFeedbackPayload.model_validate({"rating": None})
         msg_id = uuid4()
 
         with app.test_request_context(f"/messages/{msg_id}/feedbacks", method="POST"):
-            result = MessageFeedbackApi().post(_chat_app(), _end_user(), msg_id)
+            result = _feedback_post(MessageFeedbackApi(), payload, _chat_app(), _end_user(), msg_id)
 
         assert result == {"result": "success"}
 
@@ -73,14 +81,13 @@ class TestMessageFeedbackApi:
         "controllers.web.message.MessageService.create_feedback",
         side_effect=MessageNotExistsError(),
     )
-    @patch("controllers.web.message.web_ns")
-    def test_feedback_message_not_found(self, mock_ns: MagicMock, mock_create: MagicMock, app: Flask) -> None:
-        mock_ns.payload = {"rating": "dislike"}
+    def test_feedback_message_not_found(self, mock_create: MagicMock, app: Flask) -> None:
+        payload = MessageFeedbackPayload.model_validate({"rating": "dislike"})
         msg_id = uuid4()
 
         with app.test_request_context(f"/messages/{msg_id}/feedbacks", method="POST"):
             with pytest.raises(NotFound, match="Message Not Exists"):
-                MessageFeedbackApi().post(_chat_app(), _end_user(), msg_id)
+                _feedback_post(MessageFeedbackApi(), payload, _chat_app(), _end_user(), msg_id)
 
 
 # ---------------------------------------------------------------------------
@@ -89,18 +96,24 @@ class TestMessageFeedbackApi:
 class TestMessageMoreLikeThisApi:
     def test_wrong_mode_raises(self, app: Flask) -> None:
         msg_id = uuid4()
+        query = MessageMoreLikeThisQuery.model_validate({"response_mode": "blocking"})
+        session = MagicMock()
         with app.test_request_context(f"/messages/{msg_id}/more-like-this?response_mode=blocking"):
             with pytest.raises(NotCompletionAppError):
-                MessageMoreLikeThisApi().get(_chat_app(), _end_user(), msg_id)
+                _more_like_this_get(MessageMoreLikeThisApi(), query, session, _chat_app(), _end_user(), msg_id)
 
     @patch("controllers.web.message.helper.compact_generate_response", return_value={"answer": "similar"})
     @patch("controllers.web.message.AppGenerateService.generate_more_like_this")
     def test_happy_path(self, mock_gen: MagicMock, mock_compact: MagicMock, app: Flask) -> None:
         msg_id = uuid4()
         mock_gen.return_value = "response"
+        query = MessageMoreLikeThisQuery.model_validate({"response_mode": "blocking"})
+        session = MagicMock()
 
         with app.test_request_context(f"/messages/{msg_id}/more-like-this?response_mode=blocking"):
-            result = MessageMoreLikeThisApi().get(_completion_app(), _end_user(), msg_id)
+            result = _more_like_this_get(
+                MessageMoreLikeThisApi(), query, session, _completion_app(), _end_user(), msg_id
+            )
 
         assert result == {"answer": "similar"}
 
@@ -110,9 +123,11 @@ class TestMessageMoreLikeThisApi:
     )
     def test_message_not_found(self, mock_gen: MagicMock, app: Flask) -> None:
         msg_id = uuid4()
+        query = MessageMoreLikeThisQuery.model_validate({"response_mode": "blocking"})
+        session = MagicMock()
         with app.test_request_context(f"/messages/{msg_id}/more-like-this?response_mode=blocking"):
             with pytest.raises(NotFound, match="Message Not Exists"):
-                MessageMoreLikeThisApi().get(_completion_app(), _end_user(), msg_id)
+                _more_like_this_get(MessageMoreLikeThisApi(), query, session, _completion_app(), _end_user(), msg_id)
 
     @patch(
         "controllers.web.message.AppGenerateService.generate_more_like_this",
@@ -120,9 +135,11 @@ class TestMessageMoreLikeThisApi:
     )
     def test_feature_disabled(self, mock_gen: MagicMock, app: Flask) -> None:
         msg_id = uuid4()
+        query = MessageMoreLikeThisQuery.model_validate({"response_mode": "blocking"})
+        session = MagicMock()
         with app.test_request_context(f"/messages/{msg_id}/more-like-this?response_mode=blocking"):
             with pytest.raises(AppMoreLikeThisDisabledError):
-                MessageMoreLikeThisApi().get(_completion_app(), _end_user(), msg_id)
+                _more_like_this_get(MessageMoreLikeThisApi(), query, session, _completion_app(), _end_user(), msg_id)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/controllers/web/test_message_list.py
+++ b/api/tests/unit_tests/controllers/web/test_message_list.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import inspect
 import uuid
 from datetime import datetime
 from types import ModuleType, SimpleNamespace
@@ -13,6 +14,7 @@ import pytest
 from flask import Flask
 from flask.views import MethodView
 
+from controllers.common.controller_schemas import MessageListQuery
 from core.entities.execution_extra_content import HumanInputContent
 
 # Ensure flask_restx.api finds MethodView during import.
@@ -156,7 +158,8 @@ def test_message_list_mapping(app: Flask) -> None:
         patch.object(message_module.MessageService, "pagination_by_first_id", return_value=pagination) as mock_page,
         app.test_request_context(f"/messages?conversation_id={conversation_id}&limit=20"),
     ):
-        response = MessageListApi().get(app_model, end_user)
+        query = MessageListQuery.model_validate({"conversation_id": conversation_id, "limit": 20})
+        response = inspect.unwrap(MessageListApi.get)(MessageListApi(), query, app_model, end_user)
 
     mock_page.assert_called_once_with(app_model, end_user, conversation_id, None, 20, session=ANY)
     assert response["limit"] == 20

--- a/api/tests/unit_tests/controllers/web/test_saved_message.py
+++ b/api/tests/unit_tests/controllers/web/test_saved_message.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -10,6 +11,7 @@ import pytest
 from flask import Flask
 from werkzeug.exceptions import NotFound
 
+from controllers.common.controller_schemas import SavedMessageCreatePayload, SavedMessageListQuery
 from controllers.web.error import NotCompletionAppError
 from controllers.web.saved_message import SavedMessageApi, SavedMessageListApi
 from models.enums import EndUserType
@@ -34,21 +36,30 @@ def _end_user() -> EndUser:
     )
 
 
+# The @model_validate decorator wraps the handler; tests call the undecorated
+# function so they can pass the validated pydantic payload directly and skip
+# the flask request-parsing step.
+_list_get = inspect.unwrap(SavedMessageListApi.get)
+_list_post = inspect.unwrap(SavedMessageListApi.post)
+
+
 # ---------------------------------------------------------------------------
 # SavedMessageListApi (GET)
 # ---------------------------------------------------------------------------
 class TestSavedMessageListApiGet:
     def test_non_completion_mode_raises(self, app: Flask) -> None:
+        query = SavedMessageListQuery.model_validate({})
         with app.test_request_context("/saved-messages"):
             with pytest.raises(NotCompletionAppError):
-                SavedMessageListApi().get(_chat_app(), _end_user())
+                _list_get(SavedMessageListApi(), query, _chat_app(), _end_user())
 
     @patch("controllers.web.saved_message.SavedMessageService.pagination_by_last_id")
     def test_happy_path(self, mock_paginate: MagicMock, app: Flask) -> None:
         mock_paginate.return_value = SimpleNamespace(limit=20, has_more=False, data=[])
+        query = SavedMessageListQuery.model_validate({"limit": 20})
 
         with app.test_request_context("/saved-messages?limit=20"):
-            result = SavedMessageListApi().get(_completion_app(), _end_user())
+            result = _list_get(SavedMessageListApi(), query, _completion_app(), _end_user())
 
         assert result["limit"] == 20
         assert result["has_more"] is False
@@ -59,29 +70,27 @@ class TestSavedMessageListApiGet:
 # ---------------------------------------------------------------------------
 class TestSavedMessageListApiPost:
     def test_non_completion_mode_raises(self, app: Flask) -> None:
+        payload = SavedMessageCreatePayload.model_validate({"message_id": str(uuid4())})
         with app.test_request_context("/saved-messages", method="POST"):
             with pytest.raises(NotCompletionAppError):
-                SavedMessageListApi().post(_chat_app(), _end_user())
+                _list_post(SavedMessageListApi(), payload, _chat_app(), _end_user())
 
     @patch("controllers.web.saved_message.SavedMessageService.save")
-    @patch("controllers.web.saved_message.web_ns")
-    def test_save_success(self, mock_ns: MagicMock, mock_save: MagicMock, app: Flask) -> None:
-        msg_id = str(uuid4())
-        mock_ns.payload = {"message_id": msg_id}
+    def test_save_success(self, mock_save: MagicMock, app: Flask) -> None:
+        payload = SavedMessageCreatePayload.model_validate({"message_id": str(uuid4())})
 
         with app.test_request_context("/saved-messages", method="POST"):
-            result = SavedMessageListApi().post(_completion_app(), _end_user())
+            result = _list_post(SavedMessageListApi(), payload, _completion_app(), _end_user())
 
         assert result["result"] == "success"
 
     @patch("controllers.web.saved_message.SavedMessageService.save", side_effect=MessageNotExistsError())
-    @patch("controllers.web.saved_message.web_ns")
-    def test_save_not_found(self, mock_ns: MagicMock, mock_save: MagicMock, app: Flask) -> None:
-        mock_ns.payload = {"message_id": str(uuid4())}
+    def test_save_not_found(self, mock_save: MagicMock, app: Flask) -> None:
+        payload = SavedMessageCreatePayload.model_validate({"message_id": str(uuid4())})
 
         with app.test_request_context("/saved-messages", method="POST"):
             with pytest.raises(NotFound, match="Message Not Exists"):
-                SavedMessageListApi().post(_completion_app(), _end_user())
+                _list_post(SavedMessageListApi(), payload, _completion_app(), _end_user())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 1. Associated issue: #36659.

## Summary

 #36659

Extends the `@model_validate` dependency-injection decorator pattern (already used across the console/explore controllers, e.g. `controllers/web/human_input_form.py`) to the remaining `controllers/web` handlers that still parse their Pydantic schema inline from `request.args`/`web_ns.payload`:

- `SavedMessageListApi.get` / `.post` (`controllers/web/saved_message.py`)
- `MessageListApi.get`, `MessageFeedbackApi.post`, `MessageMoreLikeThisApi.get` (`controllers/web/message.py`)

Each handler now receives its validated query/payload model as a parameter via `@model_validate(Schema)`, composing with the existing `@with_session` decorator where present (`MessageMoreLikeThisApi.get`), instead of calling `Schema.model_validate(...)` manually inside the function body. This removes the now-unused `flask.request` import from both files and keeps validation error handling centralized in the shared decorator rather than duplicated per-handler.

No behavior change: request parsing, validation errors, and response shapes are identical before/after — this is purely a mechanical refactor to the existing dep-injection pattern, matching the approach requested in the issue.

## Testing

- Rewrote/extended the unit tests for the migrated handlers to call the undecorated function directly (`inspect.unwrap`) with an explicitly-constructed validated model, so tests no longer depend on Flask's request-parsing path:
  - `api/tests/unit_tests/controllers/web/test_saved_message.py`
  - `api/tests/unit_tests/controllers/web/test_message_endpoints.py`
  - `api/tests/unit_tests/controllers/web/test_message_list.py`
- Full local verification (see `AGENTS.md`: backend integration tests are CI-only, not run locally):
  - `uv run --project api pytest tests/unit_tests/controllers/web/` → **233 passed**
  - `make lint` → clean (ruff format/check, response-contract lint, import-linter, dotenv-linter)
  - `make type-check` → clean (pyrefly + mypy, 1677 source files, no issues)

## Screenshots

| Before | After |
| ------ | ----- |
| N/A — backend-only controller refactor, no UI change | N/A — backend-only controller refactor, no UI change |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods. No frontend files changed, so `vp staged` (frontend) is not applicable.

From Claude Code
