### PR TITLE
fix: replace bare except with except Exception in core agent, storage and vector backends

### DIFF
--- a/api/core/agent/output_parser/cot_output_parser.py
+++ b/api/core/agent/output_parser/cot_output_parser.py
@@ -49,7 +49,7 @@ class CotAgentOutputParser:
                     json_text = re.sub(r"^[a-zA-Z]+\n", "", block.strip(), flags=re.MULTILINE)
                     json_blocks.append(json.loads(json_text, strict=False))
                 return json_blocks
-            except:
+            except Exception:
                 return []
 
         code_block_cache = ""

--- a/api/extensions/storage/aws_s3_storage.py
+++ b/api/extensions/storage/aws_s3_storage.py
@@ -86,7 +86,7 @@ class AwsS3Storage(BaseStorage):
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=filename)
             return True
-        except:
+        except Exception:
             return False
 
     @override

--- a/api/extensions/storage/oracle_oci_storage.py
+++ b/api/extensions/storage/oracle_oci_storage.py
@@ -58,7 +58,7 @@ class OracleOCIStorage(BaseStorage):
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=filename)
             return True
-        except:
+        except Exception:
             return False
 
     @override

--- a/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_openapi.py
+++ b/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_openapi.py
@@ -66,7 +66,7 @@ class AnalyticdbVectorOpenAPI:
         try:
             from alibabacloud_gpdb20160503.client import Client  # type: ignore
             from alibabacloud_tea_openapi import models as open_api_models  # type: ignore
-        except:
+        except Exception:
             raise ImportError(_import_err_msg)
         self._collection_name = collection_name.lower()
         self.config = config

--- a/api/providers/vdb/vdb-lindorm/src/dify_vdb_lindorm/lindorm_vector.py
+++ b/api/providers/vdb/vdb-lindorm/src/dify_vdb_lindorm/lindorm_vector.py
@@ -248,7 +248,7 @@ class LindormVectorStore(BaseVector):
                 params["routing"] = self._routing
             self._client.get(index=self._collection_name, id=id, params=params)
             return True
-        except:
+        except Exception:
             return False
 
     @override

--- a/api/providers/vdb/vdb-opensearch/src/dify_vdb_opensearch/opensearch_vector.py
+++ b/api/providers/vdb/vdb-opensearch/src/dify_vdb_opensearch/opensearch_vector.py
@@ -191,7 +191,7 @@ class OpenSearchVector(BaseVector):
         try:
             self._client.get(index=self._collection_name.lower(), id=id)
             return True
-        except:
+        except Exception:
             return False
 
     @override

--- a/api/services/quota_service.py
+++ b/api/services/quota_service.py
@@ -20,7 +20,7 @@ class QuotaCharge:
         try:
             do_work()
             charge.commit()   # Confirm consumption
-        except:
+        except Exception:
             charge.refund()   # Release frozen quota
 
     If neither commit() nor refund() is called, the billing system's

--- a/api/services/trigger/webhook_service.py
+++ b/api/services/trigger/webhook_service.py
@@ -881,7 +881,7 @@ class WebhookService:
                     response_data = {"message": response_body}
             else:
                 response_data = {"status": "success", "message": "Webhook processed successfully"}
-        except:
+        except Exception:
             response_data = {"message": response_body or "Webhook processed successfully"}
 
         return response_data, status_code


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in 8 spots across the core agent output parser, S3/OCI storage, AnalyticDB/Lindorm/OpenSearch vector backends, quota service and webhook service — same intended behavior (failure fallbacks and refunds), but KeyboardInterrupt/SystemExit are no longer intercepted first. Verified: `python -m py_compile` passes on all touched files; zero bare excepts remain under api/.