### PR TITLE
fix(api): bound connect phase to 3.0s in auth credential validation clients

### DIFF
--- a/api/services/auth/firecrawl/firecrawl.py
+++ b/api/services/auth/firecrawl/firecrawl.py
@@ -7,7 +7,7 @@ from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
 # Explicit bounded timeout for credential-validation requests so a slow or
 # hanging Firecrawl endpoint cannot block the worker indefinitely.
-_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0)
+_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
 
 
 class FirecrawlAuth(ApiKeyAuthBase):

--- a/api/services/auth/jina/jina.py
+++ b/api/services/auth/jina/jina.py
@@ -9,7 +9,7 @@ from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 _http_client: httpx.Client = get_pooled_http_client(
     "auth:jina",
     lambda: httpx.Client(
-        timeout=httpx.Timeout(10.0),
+        timeout=httpx.Timeout(10.0, connect=3.0),
         limits=httpx.Limits(max_keepalive_connections=50, max_connections=100),
     ),
 )

--- a/api/services/auth/watercrawl/watercrawl.py
+++ b/api/services/auth/watercrawl/watercrawl.py
@@ -8,7 +8,7 @@ from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
 # Explicit bounded timeout for credential-validation requests so a slow or
 # hanging WaterCrawl endpoint cannot block the worker indefinitely.
-_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0)
+_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
 
 
 class WatercrawlAuth(ApiKeyAuthBase):

--- a/api/tests/unit_tests/services/auth/test_firecrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_firecrawl_auth.py
@@ -86,7 +86,7 @@ class TestFirecrawlAuth:
             "https://api.firecrawl.dev/v1/crawl",
             headers={"Content-Type": "application/json", "Authorization": "Bearer test_api_key_123"},
             json=expected_data,
-            timeout=httpx.Timeout(10.0),
+            timeout=httpx.Timeout(10.0, connect=3.0),
         )
 
     @pytest.mark.parametrize(
@@ -206,3 +206,24 @@ class TestFirecrawlAuth:
 
         # Verify the timeout exception is raised with original message
         assert "timed out" in str(exc_info.value)
+
+    def test_credential_timeout_bounds_connect_phase(self):
+        """Credential-validation timeout should bound the connect phase to 3.0s."""
+        from services.auth.firecrawl.firecrawl import _CREDENTIAL_TIMEOUT
+
+        assert _CREDENTIAL_TIMEOUT.connect == 3.0
+        assert _CREDENTIAL_TIMEOUT.read == 10.0
+
+    @patch("services.auth.firecrawl.firecrawl.httpx.post", autospec=True)
+    def test_post_request_passes_credential_timeout_with_connect(self, mock_post: MagicMock):
+        """`_post_request` should forward the connect-bounded timeout to httpx.post."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        credentials = {"auth_type": "bearer", "config": {"api_key": "test_api_key_123"}}
+        FirecrawlAuth(credentials).validate_credentials()
+
+        passed_timeout = mock_post.call_args.kwargs["timeout"]
+        assert passed_timeout.connect == 3.0
+        assert passed_timeout.read == 10.0

--- a/api/tests/unit_tests/services/auth/test_firecrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_firecrawl_auth.py
@@ -208,7 +208,7 @@ class TestFirecrawlAuth:
         assert "timed out" in str(exc_info.value)
 
     def test_credential_timeout_bounds_connect_phase(self):
-        """Credential-validation timeout should bound the connect phase to 3.0s."""
+        """Test that the credential timeout bounds the connect phase to 3.0s"""
         from services.auth.firecrawl.firecrawl import _CREDENTIAL_TIMEOUT
 
         assert _CREDENTIAL_TIMEOUT.connect == 3.0
@@ -216,7 +216,7 @@ class TestFirecrawlAuth:
 
     @patch("services.auth.firecrawl.firecrawl.httpx.post", autospec=True)
     def test_post_request_passes_credential_timeout_with_connect(self, mock_post: MagicMock):
-        """`_post_request` should forward the connect-bounded timeout to httpx.post."""
+        """Test that _post_request forwards the connect-bounded timeout to httpx.post"""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_post.return_value = mock_response

--- a/api/tests/unit_tests/services/auth/test_jina_auth.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth.py
@@ -187,7 +187,7 @@ class TestJinaAuth:
         assert "super_secret_key_12345" not in str(exc_info.value)
 
     def test_pooled_http_client_bounds_connect_phase(self):
-        """Pooled Jina client should have a 3.0s connect timeout on its Timeout object."""
+        """Test that the pooled Jina client has a 3.0s connect timeout"""
         from services.auth.jina.jina import _http_client
 
         assert _http_client.timeout.connect == 3.0

--- a/api/tests/unit_tests/services/auth/test_jina_auth.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth.py
@@ -185,3 +185,10 @@ class TestJinaAuth:
         with pytest.raises(ValueError) as exc_info:
             JinaAuth({"auth_type": "basic", "config": {"api_key": "super_secret_key_12345"}})
         assert "super_secret_key_12345" not in str(exc_info.value)
+
+    def test_pooled_http_client_bounds_connect_phase(self):
+        """Pooled Jina client should have a 3.0s connect timeout on its Timeout object."""
+        from services.auth.jina.jina import _http_client
+
+        assert _http_client.timeout.connect == 3.0
+        assert _http_client.timeout.read == 10.0

--- a/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
@@ -77,7 +77,7 @@ class TestWatercrawlAuth:
         mock_get.assert_called_once_with(
             "https://app.watercrawl.dev/api/v1/core/crawl-requests/",
             headers={"Content-Type": "application/json", "X-API-KEY": "test_api_key_123"},
-            timeout=httpx.Timeout(10.0),
+            timeout=httpx.Timeout(10.0, connect=3.0),
         )
 
     @pytest.mark.parametrize(
@@ -217,3 +217,24 @@ class TestWatercrawlAuth:
 
         # Verify the timeout exception is raised with original message
         assert "timed out" in str(exc_info.value)
+
+    def test_credential_timeout_bounds_connect_phase(self):
+        """Credential-validation timeout should bound the connect phase to 3.0s."""
+        from services.auth.watercrawl.watercrawl import _CREDENTIAL_TIMEOUT
+
+        assert _CREDENTIAL_TIMEOUT.connect == 3.0
+        assert _CREDENTIAL_TIMEOUT.read == 10.0
+
+    @patch("services.auth.watercrawl.watercrawl.httpx.get", autospec=True)
+    def test_get_request_passes_credential_timeout_with_connect(self, mock_get):
+        """`_get_request` should forward the connect-bounded timeout to httpx.get."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        credentials = {"auth_type": "x-api-key", "config": {"api_key": "test_api_key_123"}}
+        WatercrawlAuth(credentials).validate_credentials()
+
+        passed_timeout = mock_get.call_args.kwargs["timeout"]
+        assert passed_timeout.connect == 3.0
+        assert passed_timeout.read == 10.0

--- a/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
@@ -219,7 +219,7 @@ class TestWatercrawlAuth:
         assert "timed out" in str(exc_info.value)
 
     def test_credential_timeout_bounds_connect_phase(self):
-        """Credential-validation timeout should bound the connect phase to 3.0s."""
+        """Test that the credential timeout bounds the connect phase to 3.0s"""
         from services.auth.watercrawl.watercrawl import _CREDENTIAL_TIMEOUT
 
         assert _CREDENTIAL_TIMEOUT.connect == 3.0
@@ -227,7 +227,7 @@ class TestWatercrawlAuth:
 
     @patch("services.auth.watercrawl.watercrawl.httpx.get", autospec=True)
     def test_get_request_passes_credential_timeout_with_connect(self, mock_get):
-        """`_get_request` should forward the connect-bounded timeout to httpx.get."""
+        """Test that _get_request forwards the connect-bounded timeout to httpx.get"""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_get.return_value = mock_response


### PR DESCRIPTION
## Problem

The three outbound credential-validation clients in `api/services/auth/` (`watercrawl`, `firecrawl`, `jina/jina`) all use a plain `httpx.Timeout(10.0)` for their validation requests. That leaves the **connect** phase on httpx's 5s default and the read/write/pool phases at 10s. A slow or unreachable remote endpoint can keep the worker waiting up to 10s per credential check before failing.

The same `api/services/` directory already has the tighter pattern:

```python
# api/services/operation_service.py:6
OPERATION_REQUEST_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
```

## Fix

Add an explicit `connect=3.0` to all three auth client timeouts so unreachable endpoints fail in ≤3s instead of up to 10s, matching the shape already used elsewhere in `services/`.

```python
# before
_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0)
# after
_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
```

```python
# before
timeout=httpx.Timeout(10.0),
# after
timeout=httpx.Timeout(10.0, connect=3.0),
```

## Scope

3 source files (one-line each), 3 test files (new assertions + update two existing test calls that hardcoded the old timeout):

| File | Change |
|------|--------|
| `api/services/auth/watercrawl/watercrawl.py` | `httpx.Timeout(10.0)` → `httpx.Timeout(10.0, connect=3.0)` |
| `api/services/auth/firecrawl/firecrawl.py` | same |
| `api/services/auth/jina/jina.py` | same, on pooled client constructor |
| `api/tests/unit_tests/services/auth/test_watercrawl_auth.py` | update existing assertion + add 2 new tests |
| `api/tests/unit_tests/services/auth/test_firecrawl_auth.py` | update existing assertion + add 2 new tests |
| `api/tests/unit_tests/services/auth/test_jina_auth.py` | add 1 new test |

Fixes #40802

## Out of scope (tracked separately)

- `api/services/auth/jina.py` is the orphan file shadowed by the `jina/` package. It still uses the old `httpx.Timeout(10.0)`. Deleting the orphan (or unifying the two) is a separate cleanup that touches test fixture and the duplicate-file situation.
- The wider `connect=` gap across `api/core/` (e.g. `api/core/rag/extractor/watercrawl/client.py:235` and `api/core/helper/creators.py:23` use a bare integer `timeout=30` without a connect timeout) is a different code area and a separate fix.

## Testing

- 69 tests in `test_watercrawl_auth.py`, `test_firecrawl_auth.py`, `test_jina_auth.py` pass locally (`--noconftest`).
- 4 new tests added (2 for watercrawl, 2 for firecrawl, 1 for jina; 1 is parametrized equivalent in firecrawl). One existing test in watercrawl and one in firecrawl that hardcoded the old timeout are updated to assert the new one.
- `ruff check` and `ruff format --check` clean on `services/auth/` and the corresponding test directory.
- `pyrefly check services/auth/` reports 0 diagnostics.

## Risks

The connect timeout is 3.0s versus httpx's 5.0s default. If any of the three remote providers has a real connect latency > 3s under normal operation, the validation will start failing. This is unlikely for the well-known Jina, Firecrawl, and WaterCrawl APIs, and the existing read=10s budget still bounds the total request.

## Backward compatibility

Public API of `JinaAuth`, `FirecrawlAuth`, `WatercrawlAuth` is unchanged. Only the internal timeout shape changes.
