### PR TITLE
fix(api): bound connect phase to 5.0s in two api/core/ outbound timeouts

### DIFF
--- a/api/core/helper/creators.py
+++ b/api/core/helper/creators.py
@@ -17,10 +17,12 @@ logger = logging.getLogger(__name__)
 
 creators_platform_api_url = URL(str(dify_config.CREATORS_PLATFORM_API_URL))
 
+_CREATORS_REQUEST_TIMEOUT: httpx.Timeout = httpx.Timeout(30.0, connect=5.0)
+
 
 def upload_dsl(dsl_file_bytes: bytes, filename: str = "template.yaml") -> str:
     url = str(creators_platform_api_url / "api/v1/templates/anonymous-upload")
-    response = httpx.post(url, files={"file": (filename, dsl_file_bytes)}, timeout=30)
+    response = httpx.post(url, files={"file": (filename, dsl_file_bytes)}, timeout=_CREATORS_REQUEST_TIMEOUT)
     response.raise_for_status()
     data = response.json()
     claim_code = data.get("data", {}).get("claim_code")

--- a/api/core/rag/extractor/watercrawl/client.py
+++ b/api/core/rag/extractor/watercrawl/client.py
@@ -232,7 +232,7 @@ class WaterCrawlAPIClient(BaseAPIClient):
                 return event_data["data"]
 
     def download_result(self, result_object: dict[str, Any]):
-        response = httpx.get(result_object["result"], timeout=30)
+        response = httpx.get(result_object["result"], timeout=WATERCRAWL_REQUEST_TIMEOUT)
         try:
             response.raise_for_status()
             result_object["result"] = response.json()

--- a/api/tests/unit_tests/core/helper/test_creators.py
+++ b/api/tests/unit_tests/core/helper/test_creators.py
@@ -32,7 +32,17 @@ class TestUploadDSL:
         mock_post.assert_called_once()
         call_kwargs = mock_post.call_args
         assert "anonymous-upload" in call_kwargs.args[0]
-        assert call_kwargs.kwargs["timeout"] == 30
+        timeout = call_kwargs.kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 5.0
+        assert timeout.read == 30.0
+
+    def test_creators_request_timeout_bounds_connect_phase(self):
+        """Module-level _CREATORS_REQUEST_TIMEOUT should bound the connect phase to 5.0s."""
+        from core.helper.creators import _CREATORS_REQUEST_TIMEOUT
+
+        assert _CREATORS_REQUEST_TIMEOUT.connect == 5.0
+        assert _CREATORS_REQUEST_TIMEOUT.read == 30.0
 
     @patch("core.helper.creators.httpx.post")
     def test_raises_on_missing_claim_code(self, mock_post):

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 import core.rag.extractor.watercrawl.client as client_module
@@ -301,7 +302,10 @@ class TestWaterCrawlAPIClient:
         result = client.download_result({"result": "https://example.com/result.json"})
 
         assert result["result"] == {"markdown": "body"}
-        assert captured["timeout"] is not None
+        timeout = captured["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 5.0
+        assert timeout.read == 30.0
         response.close.assert_called_once()
 
 


### PR DESCRIPTION
## Problem

Two outbound HTTP calls in `api/core/` use a bare integer `timeout=30` instead of a `httpx.Timeout` object with a separate connect cap. A bare integer sets the read timeout to 30s and lets the connect phase default to httpx's 5s, but the two phases share the same 30s budget. So a slow or unreachable endpoint can keep a worker waiting up to 30s before failing.

The adjacent `api/core/rag/extractor/watercrawl/client.py:15` already has the tighter pattern:

```python
WATERCRAWL_REQUEST_TIMEOUT: httpx.Timeout = httpx.Timeout(30.0, connect=5.0)
```

The two sites below are the only remaining `timeout=30`-style calls in `api/` that don't use a `httpx.Timeout` object.

## Fix

```python
# api/core/rag/extractor/watercrawl/client.py
# before
def download_result(self, result_object):
    response = httpx.get(result_object["result"], timeout=30)
# after
def download_result(self, result_object):
    response = httpx.get(result_object["result"], timeout=WATERCRAWL_REQUEST_TIMEOUT)
```

```python
# api/core/helper/creators.py
# before
def upload_dsl(dsl_file_bytes, filename="template.yaml"):
    response = httpx.post(url, files={...}, timeout=30)
# after
_CREATORS_REQUEST_TIMEOUT: httpx.Timeout = httpx.Timeout(30.0, connect=5.0)

def upload_dsl(dsl_file_bytes, filename="template.yaml"):
    response = httpx.post(url, files={...}, timeout=_CREATORS_REQUEST_TIMEOUT)
```

The watercrawl site reuses the existing module-level `WATERCRAWL_REQUEST_TIMEOUT` from cycle 6 (#39860). The creators site gets a new `_CREATORS_REQUEST_TIMEOUT` constant in the same naming convention.

Fixes #40806

## Scope

2 source files (1 line each + 3-line constant in creators.py), 2 test files (existing assertion + new constant test):

| File | Change |
|------|--------|
| `api/core/rag/extractor/watercrawl/client.py` | reuse existing `WATERCRAWL_REQUEST_TIMEOUT` constant |
| `api/core/helper/creators.py` | new `_CREATORS_REQUEST_TIMEOUT` constant + use it |
| `api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py` | extend `test_download_result_fetches_json_and_closes` to assert `timeout.connect == 5.0`, `timeout.read == 30.0` (was just `is not None`); add `import httpx` |
| `api/tests/unit_tests/core/helper/test_creators.py` | update `test_returns_claim_code` to assert the new shape; add `test_creators_request_timeout_bounds_connect_phase` |

## Out of scope

- The orphan `api/services/auth/jina.py` (separate cleanup, mentioned in cycle 14 #40803 PR body).
- The `api/services/auth/jina.py` 179-line standalone test `test_jina_auth_standalone_module.py`.
- The wider PEP 3134 sweep (cycle 13 #40738 covered 13 sites; upstream #40801 is the opposite direction).

## Testing

- 41 tests in `test_watercrawl.py` and `test_creators.py` pass locally (`--noconftest`).
- 1 test updated in `test_watercrawl.py` to assert the new `httpx.Timeout` shape.
- 1 test updated + 1 new test added in `test_creators.py`.
- `ruff check` and `ruff format --check` clean on all 4 files.
- `pyrefly check` 0 diagnostics on the 2 source files.

## Pre-existing test issues (not introduced by this PR)

While running the wider `tests/unit_tests/core/helper/` directory, 9 tests in `test_model_provider_cache.py`, `test_provider_cache.py`, and `test_tool_parameter_cache.py` fail with `RuntimeError: Redis client is not initialized. Call init_app first.` Confirmed pre-existing on clean `upstream/main @ 8031ea6d73` without my changes — these tests require a live Redis in the test env, which is not available locally. Not related to this PR.

## Risks

The 5s connect timeout matches the existing `WATERCRAWL_REQUEST_TIMEOUT` constant. If `creators.dify.dev` has a real connect latency > 5s under normal operation, the upload will start failing. Unlikely; the read=30s budget still bounds the total request.

## Backward compatibility

The public API of `WaterCrawlAPIClient.download_result` and `core.helper.creators.upload_dsl` is unchanged. Only the internal timeout shape changes (bare `int 30` → `httpx.Timeout(30.0, connect=5.0)`).
