### PR TITLE
fix(extension): chain original exception in APIBasedExtensionRequestor per PEP 3134

### DIFF
--- a/api/core/extension/api_based_extension_requestor.py
+++ b/api/core/extension/api_based_extension_requestor.py
@@ -41,10 +41,10 @@ class APIBasedExtensionRequestor:
                     json={"point": point.value, "params": params},
                     headers=headers,
                 )
-        except httpx.TimeoutException:
-            raise ValueError("request timeout")
-        except httpx.RequestError:
-            raise ValueError("request connection error")
+        except httpx.TimeoutException as e:
+            raise ValueError("request timeout") from e
+        except httpx.RequestError as e:
+            raise ValueError("request connection error") from e
 
         if response.status_code != 200:
             raise ValueError(f"request error, status_code: {response.status_code}, content: {response.text[:100]}")

--- a/api/tests/unit_tests/core/extension/test_api_based_extension_requestor.py
+++ b/api/tests/unit_tests/core/extension/test_api_based_extension_requestor.py
@@ -89,22 +89,28 @@ def test_request_timeout(mocker: MockerFixture):
     mock_client = mocker.MagicMock()
     mock_client_instance = mock_client.__enter__.return_value
     mocker.patch("httpx.Client", return_value=mock_client)
-    mock_client_instance.request.side_effect = httpx.TimeoutException("timeout")
+    original = httpx.TimeoutException("timeout")
+    mock_client_instance.request.side_effect = original
 
     requestor = APIBasedExtensionRequestor(api_endpoint="http://example.com", api_key="test_key")
-    with pytest.raises(ValueError, match="request timeout"):
+    with pytest.raises(ValueError, match="request timeout") as exc_info:
         requestor.request(APIBasedExtensionPoint.PING, {})
+
+    assert exc_info.value.__cause__ is original
 
 
 def test_request_connection_error(mocker: MockerFixture):
     mock_client = mocker.MagicMock()
     mock_client_instance = mock_client.__enter__.return_value
     mocker.patch("httpx.Client", return_value=mock_client)
-    mock_client_instance.request.side_effect = httpx.RequestError("error")
+    original = httpx.RequestError("error")
+    mock_client_instance.request.side_effect = original
 
     requestor = APIBasedExtensionRequestor(api_endpoint="http://example.com", api_key="test_key")
-    with pytest.raises(ValueError, match="request connection error"):
+    with pytest.raises(ValueError, match="request connection error") as exc_info:
         requestor.request(APIBasedExtensionPoint.PING, {})
+
+    assert exc_info.value.__cause__ is original
 
 
 def test_request_error_status_code(mocker: MockerFixture):


### PR DESCRIPTION
## Problem

The two `except` blocks in `api/core/extension/api_based_extension_requestor.py::APIBasedExtensionRequestor.request` re-raise `httpx.TimeoutException` and `httpx.RequestError` as `ValueError` without preserving the original exception chain. The new `ValueError` replaces the original in the traceback, so a caller catching the original `httpx.TimeoutException` or `httpx.RequestError` (or anyone inspecting `__cause__` for log forensics) never sees it.

PEP 3134 — `raise … from …` to chain the original — is the codebase convention (see #40738 for the 13-site sweep in cycle 13). The two sites here were on the deferred list in that PR's body because the work was already 13 sites.

## Fix

Two-line source change:

```python
# api/core/extension/api_based_extension_requestor.py
-        except httpx.TimeoutException:
-            raise ValueError("request timeout")
+        except httpx.TimeoutException as e:
+            raise ValueError("request timeout") from e
-        except httpx.RequestError:
-            raise ValueError("request connection error")
+        except httpx.RequestError as e:
+            raise ValueError("request connection error") from e
```

Plus two test extensions asserting `__cause__` is the original `httpx.TimeoutException` / `httpx.RequestError`.

Fixes #40809

## Scope

2 files: 1 source (`+4/-4`), 1 test (`+10/-4`).

| File | Change |
|------|--------|
| `api/core/extension/api_based_extension_requestor.py` | `as e` / `from e` on both sites |
| `api/tests/unit_tests/core/extension/test_api_based_extension_requestor.py` | capture `exc_info` in both tests; assert `__cause__` is the original httpx exception |

## Out of scope (deferred)

- The wider PEP 3134 sweep across `api/` (392 candidate sites from a cycle-13 audit). Most of these are not in code paths I can verify locally; deferred to a future dedicated PR or series.
- The upstream #40801 commit (opposite direction — replacing `except Exception: raise X` with explicit no-chain raises in some core backends) does not affect this fix because the two sites here already have a clear cause type.

## Testing

- 7/7 tests in `test_api_based_extension_requestor.py` pass locally (`--noconftest`).
- 2 tests (`test_request_timeout`, `test_request_connection_error`) extended to assert `__cause__` is the original httpx exception.
- `ruff check` and `ruff format --check` clean on the 2 files.
- `pyrefly check` 0 diagnostics on the source file.

## Backward compatibility

The raised exception type and message are unchanged. Only the chain metadata (`__cause__`) is added. No public API change.

## Risks

None. The change is metadata-only at the exception layer. The chain is constructed in CPython at raise time; the cost is one extra frame reference.
