### PR TITLE
docs: fix pipeline_generator docstrings to reference pipeline instead of app_model

### DIFF
--- a/api/core/app/apps/pipeline/pipeline_generator.py
+++ b/api/core/app/apps/pipeline/pipeline_generator.py
@@ -388,7 +388,7 @@ class PipelineGenerator(BaseAppGenerator):
         """
         Generate App response.
 
-        :param app_model: App
+        :param pipeline: Pipeline
         :param workflow: Workflow
         :param node_id: the node id
         :param user: account or end user
@@ -490,7 +490,7 @@ class PipelineGenerator(BaseAppGenerator):
         """
         Generate App response.
 
-        :param app_model: App
+        :param pipeline: Pipeline
         :param workflow: Workflow
         :param node_id: the node id
         :param user: account or end user


### PR DESCRIPTION
Fixes #40811

## Summary

Two docstrings in `pipeline_generator.py` documented a `:param app_model:` that the methods don't accept — the real first parameter is `pipeline: Pipeline`. These methods were copied from `WorkflowAppGenerator` (which does take `app_model`), but the docstrings were never updated after the first parameter was changed to `pipeline`.

Updated both `:param app_model: App` entries to `:param pipeline: Pipeline` in `single_iteration_generate` and `single_loop_generate`.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods