### PR TITLE
refactor(models): migrate workflow models to TypeBase

### DIFF
--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 from collections.abc import Generator, Mapping, Sequence
+from dataclasses import field
 from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional, TypedDict, cast
@@ -73,8 +74,8 @@ from .base import Base, DefaultFieldsDCMixin, TypeBase
 from .engine import db
 from .enums import CreatorUserRole, DraftVariableType, ExecutionOffLoadType, WorkflowRunTriggeredFrom
 
-# UploadFile uses TypeBase while workflow execution offload models use Base, so relationships
-# must target the class object directly instead of relying on string lookup across registries.
+# UploadFile and workflow execution models use a separate declarative registry from the
+# excluded offload model, so cross-registry relationships target class objects directly.
 from .model import UploadFile
 from .types import EnumText, LongText, StringUUID
 from .utils.file_input_compat import (
@@ -174,7 +175,7 @@ class _InvalidGraphDefinitionError(Exception):
     pass
 
 
-class Workflow(Base):  # bug
+class Workflow(TypeBase):
     """
     Workflow, for `Workflow App` and `Chat App workflow mode`.
 
@@ -220,41 +221,64 @@ class Workflow(Base):  # bug
         ),
     )
 
-    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    type: Mapped[WorkflowType] = mapped_column(EnumText(WorkflowType, length=255), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False, default=None)
+    app_id: Mapped[str] = mapped_column(StringUUID, nullable=False, default=None)
+    type: Mapped[WorkflowType] = mapped_column(EnumText(WorkflowType, length=255), nullable=False, default=None)
     kind: Mapped[WorkflowKind | None] = mapped_column(
         EnumText(WorkflowKind, length=255),
         nullable=True,
         default=WorkflowKind.STANDARD,
         server_default=sa.text("'standard'"),
     )
-    version: Mapped[str] = mapped_column(String(255), nullable=False)
+    version: Mapped[str] = mapped_column(String(255), nullable=False, default=None)
+    id: Mapped[str] = mapped_column(
+        StringUUID,
+        insert_default=lambda: str(uuid4()),
+        default_factory=lambda: str(uuid4()),
+    )
     # User-facing version number, unique and monotonically increasing within an app, displayed as `#N`.
     # NULL for draft workflows and for versions published before numbering was introduced.
     version_number: Mapped[int | None] = mapped_column(sa.Integer, nullable=True, default=None)
     marked_name: Mapped[str] = mapped_column(String(255), default="", server_default="")
     marked_comment: Mapped[str] = mapped_column(String(255), default="", server_default="")
-    graph: Mapped[str] = mapped_column(LongText)
-    _features: Mapped[str] = mapped_column("features", LongText)
-    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by: Mapped[str | None] = mapped_column(StringUUID)
+    graph: Mapped[str] = mapped_column(LongText, default=None)
+    _features: Mapped[Any] = mapped_column("features", LongText, default=None)
+    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False, default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        insert_default=naive_utc_now,
+        default_factory=naive_utc_now,
+        server_default=func.current_timestamp(),
+        init=False,
+    )
+    updated_by: Mapped[str | None] = mapped_column(StringUUID, default=None)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=func.current_timestamp(),
+        insert_default=naive_utc_now,
+        default_factory=naive_utc_now,
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
+        init=False,
     )
-    _environment_variables: Mapped[str] = mapped_column("environment_variables", LongText, nullable=False, default="{}")
-    _conversation_variables: Mapped[str] = mapped_column(
+    _environment_variables: Mapped[Any] = mapped_column("environment_variables", LongText, nullable=False, default="{}")
+    _conversation_variables: Mapped[Any] = mapped_column(
         "conversation_variables", LongText, nullable=False, default="{}"
     )
-    _rag_pipeline_variables: Mapped[str] = mapped_column(
+    _rag_pipeline_variables: Mapped[Any] = mapped_column(
         "rag_pipeline_variables", LongText, nullable=False, default="{}"
     )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._environment_variables, str):
+            environment_variables = self._environment_variables
+            self._environment_variables = "{}"
+            self.environment_variables = environment_variables
+        if not isinstance(self._conversation_variables, str):
+            self.conversation_variables = self._conversation_variables
+        if not isinstance(self._rag_pipeline_variables, str):
+            self.rag_pipeline_variables = self._rag_pipeline_variables
 
     VERSION_DRAFT = "draft"
 
@@ -746,7 +770,7 @@ class Workflow(Base):  # bug
         return str(d)
 
 
-class WorkflowVersionCounter(Base):
+class WorkflowVersionCounter(TypeBase):
     """Monotonic per-app allocator for `Workflow.version_number`.
 
     One row per app, holding the highest number handed out so far. Numbers are never
@@ -787,7 +811,7 @@ class WorkflowRunDict(TypedDict):
     exceptions_count: int
 
 
-class WorkflowRun(Base):
+class WorkflowRun(TypeBase):
     """
     Workflow Run
 
@@ -832,30 +856,38 @@ class WorkflowRun(Base):
         sa.Index("workflow_run_created_at_id_idx", "created_at", "id"),
     )
 
-    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    tenant_id: Mapped[str] = mapped_column(StringUUID)
-    app_id: Mapped[str] = mapped_column(StringUUID)
-
-    workflow_id: Mapped[str] = mapped_column(StringUUID)
-    type: Mapped[WorkflowType] = mapped_column(EnumText(WorkflowType, length=255))
-    triggered_from: Mapped[WorkflowRunTriggeredFrom] = mapped_column(EnumText(WorkflowRunTriggeredFrom, length=255))
-    version: Mapped[str] = mapped_column(String(255))
-    graph: Mapped[str | None] = mapped_column(LongText)
-    inputs: Mapped[str | None] = mapped_column(LongText)
+    tenant_id: Mapped[str] = mapped_column(StringUUID, default=None)
+    app_id: Mapped[str] = mapped_column(StringUUID, default=None)
+    workflow_id: Mapped[str] = mapped_column(StringUUID, default=None)
+    type: Mapped[WorkflowType] = mapped_column(EnumText(WorkflowType, length=255), default=None)
+    triggered_from: Mapped[WorkflowRunTriggeredFrom] = mapped_column(
+        EnumText(WorkflowRunTriggeredFrom, length=255), default=None
+    )
+    version: Mapped[str] = mapped_column(String(255), default=None)
     status: Mapped[WorkflowExecutionStatus] = mapped_column(
         EnumText(WorkflowExecutionStatus, length=255),
         nullable=False,
+        default=None,
     )
+    created_by_role: Mapped[CreatorUserRole] = mapped_column(EnumText(CreatorUserRole, length=255), default=None)
+    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False, default=None)
+    id: Mapped[str] = mapped_column(
+        StringUUID,
+        insert_default=lambda: str(uuid4()),
+        default_factory=lambda: str(uuid4()),
+    )
+    graph: Mapped[str | None] = mapped_column(LongText, default=None)
+    inputs: Mapped[str | None] = mapped_column(LongText, default=None)
     outputs: Mapped[str | None] = mapped_column(LongText, default="{}")
-    error: Mapped[str | None] = mapped_column(LongText)
-    elapsed_time: Mapped[float] = mapped_column(sa.Float, nullable=False, server_default=sa.text("0"))
-    total_tokens: Mapped[int] = mapped_column(sa.BigInteger, server_default=sa.text("0"))
-    total_steps: Mapped[int] = mapped_column(sa.Integer, server_default=sa.text("0"), nullable=True)
-    created_by_role: Mapped[CreatorUserRole] = mapped_column(EnumText(CreatorUserRole, length=255))  # account, end_user
-    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
-    finished_at: Mapped[datetime | None] = mapped_column(DateTime)
-    exceptions_count: Mapped[int] = mapped_column(sa.Integer, server_default=sa.text("0"), nullable=True)
+    error: Mapped[str | None] = mapped_column(LongText, default=None)
+    elapsed_time: Mapped[float] = mapped_column(sa.Float, nullable=False, server_default=sa.text("0"), default=0)
+    total_tokens: Mapped[int] = mapped_column(sa.BigInteger, server_default=sa.text("0"), default=0)
+    total_steps: Mapped[int] = mapped_column(sa.Integer, server_default=sa.text("0"), nullable=True, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.current_timestamp(), init=False
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
+    exceptions_count: Mapped[int] = mapped_column(sa.Integer, server_default=sa.text("0"), nullable=True, default=0)
 
     pause: Mapped[Optional["WorkflowPause"]] = orm.relationship(
         lambda: WorkflowPause,
@@ -864,6 +896,7 @@ class WorkflowRun(Base):
         # require explicit preloading.
         lazy="raise",
         back_populates="workflow_run",
+        init=False,
     )
 
     @property
@@ -932,28 +965,29 @@ class WorkflowRun(Base):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "WorkflowRun":
-        return cls(
-            id=data.get("id"),
-            tenant_id=data.get("tenant_id"),
-            app_id=data.get("app_id"),
-            workflow_id=data.get("workflow_id"),
-            type=data.get("type"),
-            triggered_from=data.get("triggered_from"),
-            version=data.get("version"),
+        workflow_run = cls(
+            id=data["id"],
+            tenant_id=data["tenant_id"],
+            app_id=data["app_id"],
+            workflow_id=data["workflow_id"],
+            type=data["type"],
+            triggered_from=data["triggered_from"],
+            version=data["version"],
             graph=json.dumps(data.get("graph")),
             inputs=json.dumps(data.get("inputs")),
-            status=data.get("status"),
+            status=data["status"],
             outputs=json.dumps(data.get("outputs")),
             error=data.get("error"),
-            elapsed_time=data.get("elapsed_time"),
-            total_tokens=data.get("total_tokens"),
-            total_steps=data.get("total_steps"),
-            created_by_role=data.get("created_by_role"),
-            created_by=data.get("created_by"),
-            created_at=data.get("created_at"),
+            elapsed_time=data["elapsed_time"],
+            total_tokens=data["total_tokens"],
+            total_steps=data["total_steps"],
+            created_by_role=data["created_by_role"],
+            created_by=data["created_by"],
             finished_at=data.get("finished_at"),
-            exceptions_count=data.get("exceptions_count"),
+            exceptions_count=data["exceptions_count"],
         )
+        workflow_run.created_at = data["created_at"]
+        return workflow_run
 
 
 class WorkflowNodeExecutionTriggeredFrom(StrEnum):
@@ -966,7 +1000,7 @@ class WorkflowNodeExecutionTriggeredFrom(StrEnum):
     RAG_PIPELINE_RUN = "rag-pipeline-run"
 
 
-class WorkflowNodeExecutionModel(Base):  # This model is expected to have `offload_data` preloaded in most cases.
+class WorkflowNodeExecutionModel(TypeBase):  # This model is expected to have `offload_data` preloaded in most cases.
     """
     Workflow Node Execution
 
@@ -1047,39 +1081,48 @@ class WorkflowNodeExecutionModel(Base):  # This model is expected to have `offlo
         ),
     )
 
-    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    tenant_id: Mapped[str] = mapped_column(StringUUID)
-    app_id: Mapped[str] = mapped_column(StringUUID)
-    workflow_id: Mapped[str] = mapped_column(StringUUID)
+    tenant_id: Mapped[str] = mapped_column(StringUUID, default=None)
+    app_id: Mapped[str] = mapped_column(StringUUID, default=None)
+    workflow_id: Mapped[str] = mapped_column(StringUUID, default=None)
     triggered_from: Mapped[WorkflowNodeExecutionTriggeredFrom] = mapped_column(
-        EnumText(WorkflowNodeExecutionTriggeredFrom, length=255)
+        EnumText(WorkflowNodeExecutionTriggeredFrom, length=255), default=None
     )
-    workflow_run_id: Mapped[str | None] = mapped_column(StringUUID)
-    index: Mapped[int] = mapped_column(sa.Integer)
-    predecessor_node_id: Mapped[str | None] = mapped_column(String(255))
-    node_execution_id: Mapped[str | None] = mapped_column(String(255))
-    node_id: Mapped[str] = mapped_column(String(255))
-    node_type: Mapped[str] = mapped_column(String(255))
-    title: Mapped[str] = mapped_column(String(255))
-    agent_workspace_binding_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
-    inputs: Mapped[str | None] = mapped_column(LongText)
-    process_data: Mapped[str | None] = mapped_column(LongText)
-    outputs: Mapped[str | None] = mapped_column(LongText)
-    status: Mapped[WorkflowNodeExecutionStatus] = mapped_column(EnumText(WorkflowNodeExecutionStatus, length=255))
-    error: Mapped[str | None] = mapped_column(LongText)
-    elapsed_time: Mapped[float] = mapped_column(sa.Float, server_default=sa.text("0"))
-    execution_metadata: Mapped[str | None] = mapped_column(LongText)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    created_by_role: Mapped[CreatorUserRole] = mapped_column(EnumText(CreatorUserRole, length=255))
-    created_by: Mapped[str] = mapped_column(StringUUID)
-    finished_at: Mapped[datetime | None] = mapped_column(DateTime)
+    index: Mapped[int] = mapped_column(sa.Integer, default=None)
+    node_id: Mapped[str] = mapped_column(String(255), default=None)
+    node_type: Mapped[str] = mapped_column(String(255), default=None)
+    title: Mapped[str] = mapped_column(String(255), default=None)
+    status: Mapped[WorkflowNodeExecutionStatus] = mapped_column(
+        EnumText(WorkflowNodeExecutionStatus, length=255), default=None
+    )
+    created_by_role: Mapped[CreatorUserRole] = mapped_column(EnumText(CreatorUserRole, length=255), default=None)
+    created_by: Mapped[str] = mapped_column(StringUUID, default=None)
+    id: Mapped[str] = mapped_column(
+        StringUUID,
+        insert_default=lambda: str(uuid4()),
+        default_factory=lambda: str(uuid4()),
+    )
+    workflow_run_id: Mapped[str | None] = mapped_column(StringUUID, default=None)
+    predecessor_node_id: Mapped[str | None] = mapped_column(String(255), default=None)
+    node_execution_id: Mapped[str | None] = mapped_column(String(255), default=None)
+    agent_workspace_binding_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
+    inputs: Mapped[str | None] = mapped_column(LongText, default=None)
+    process_data: Mapped[str | None] = mapped_column(LongText, default=None)
+    outputs: Mapped[str | None] = mapped_column(LongText, default=None)
+    error: Mapped[str | None] = mapped_column(LongText, default=None)
+    elapsed_time: Mapped[float] = mapped_column(sa.Float, server_default=sa.text("0"), default=0)
+    execution_metadata: Mapped[str | None] = mapped_column(LongText, default=None)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp(), init=False)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
 
     offload_data: Mapped[list["WorkflowNodeExecutionOffload"]] = orm.relationship(
-        "WorkflowNodeExecutionOffload",
-        primaryjoin="WorkflowNodeExecutionModel.id == foreign(WorkflowNodeExecutionOffload.node_execution_id)",
+        lambda: WorkflowNodeExecutionOffload,
+        primaryjoin=lambda: (
+            WorkflowNodeExecutionModel.id == orm.foreign(WorkflowNodeExecutionOffload.node_execution_id)
+        ),
         uselist=True,
         lazy="raise",
         back_populates="execution",
+        init=False,
     )
 
     @staticmethod
@@ -1273,10 +1316,13 @@ class WorkflowNodeExecutionOffload(Base):
     file_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
 
     execution: Mapped[WorkflowNodeExecutionModel] = orm.relationship(
+        lambda: WorkflowNodeExecutionModel,
         foreign_keys=[node_execution_id],
         lazy="raise",
         uselist=False,
-        primaryjoin="WorkflowNodeExecutionOffload.node_execution_id == WorkflowNodeExecutionModel.id",
+        primaryjoin=lambda: (
+            orm.foreign(WorkflowNodeExecutionOffload.node_execution_id) == WorkflowNodeExecutionModel.id
+        ),
         back_populates="offload_data",
     )
 
@@ -1553,7 +1599,7 @@ class ConversationVariable(TypeBase):
 _EDITABLE_SYSTEM_VARIABLE = frozenset(("query", "files"))
 
 
-class WorkflowDraftVariable(Base):
+class WorkflowDraftVariable(TypeBase):
     """`WorkflowDraftVariable` record variables and outputs generated during
     debugging workflow or chatflow.
 
@@ -1582,25 +1628,35 @@ class WorkflowDraftVariable(Base):
     __allow_unmapped__ = True
 
     # id is the unique identifier of a draft variable.
-    id: Mapped[str] = mapped_column(StringUUID, primary_key=True, default=lambda: str(uuid4()))
+    id: Mapped[str] = mapped_column(
+        StringUUID,
+        primary_key=True,
+        insert_default=lambda: str(uuid4()),
+        default_factory=lambda: str(uuid4()),
+        init=False,
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=naive_utc_now,
+        insert_default=naive_utc_now,
+        default_factory=naive_utc_now,
         server_default=func.current_timestamp(),
+        init=False,
     )
 
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
-        default=naive_utc_now,
+        insert_default=naive_utc_now,
+        default_factory=naive_utc_now,
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
+        init=False,
     )
 
     # "`app_id` maps to the `id` field in the `model.App` model."
-    app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
+    app_id: Mapped[str] = mapped_column(StringUUID, nullable=False, default=None)
     # Owner of this draft variable.
     #
     # This field is nullable during migration and will be migrated to NOT NULL
@@ -1627,18 +1683,18 @@ class WorkflowDraftVariable(Base):
     #
     # However, there's one caveat. The id of the first "Answer" node in chatflow is "answer". (Other
     # "Answer" node conform the rules above.)
-    node_id: Mapped[str] = mapped_column(sa.String(255), nullable=False, name="node_id")
+    node_id: Mapped[str] = mapped_column(sa.String(255), nullable=False, name="node_id", default=None)
 
     # From `VARIABLE_PATTERN`, we may conclude that the length of a top level variable is less than
     # 80 chars.
-    name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    name: Mapped[str] = mapped_column(sa.String(255), nullable=False, default=None)
     description: Mapped[str] = mapped_column(
         sa.String(255),
         default="",
         nullable=False,
     )
 
-    selector: Mapped[str] = mapped_column(sa.String(255), nullable=False, name="selector")
+    selector: Mapped[str] = mapped_column(sa.String(255), nullable=False, name="selector", default=None)
 
     # The data type of this variable's value
     #
@@ -1646,12 +1702,12 @@ class WorkflowDraftVariable(Base):
     # which may differ from the original value's type. Typically, they are the same,
     # but in cases where the structurally truncated  value still exceeds the size limit,
     # text slicing is applied, and the `value_type` is converted to `STRING`.
-    value_type: Mapped[SegmentType] = mapped_column(EnumText(SegmentType, length=20))
+    value_type: Mapped[SegmentType] = mapped_column(EnumText(SegmentType, length=20), default=None)
 
     # The variable's value serialized as a JSON string
     #
     # If the variable is offloaded, `value` contains a truncated version, not the full original value.
-    value: Mapped[str] = mapped_column(LongText, nullable=False, name="value")
+    value: Mapped[str] = mapped_column(LongText, nullable=False, name="value", default=None)
 
     # Controls whether the variable should be displayed in the variable inspection panel
     visible: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=True)
@@ -1691,14 +1747,14 @@ class WorkflowDraftVariable(Base):
         ),
     )
 
-    # WorkflowDraftVariableFile uses TypeBase while WorkflowDraftVariable uses Base, so the relationship
-    # must resolve the class object lazily instead of relying on string lookup across registries.
+    # Resolve lazily because WorkflowDraftVariableFile is declared later in this module.
     variable_file: Mapped[Optional["WorkflowDraftVariableFile"]] = orm.relationship(
         lambda: WorkflowDraftVariableFile,
         foreign_keys=[file_id],
         lazy="raise",
         uselist=False,
         primaryjoin=lambda: orm.foreign(WorkflowDraftVariable.file_id) == WorkflowDraftVariableFile.id,
+        init=False,
     )
 
     # Cache for deserialized value
@@ -1712,20 +1768,7 @@ class WorkflowDraftVariable(Base):
     #
     # Use double underscore prefix for better encapsulation,
     # making this attribute harder to access from outside the class.
-    __value: Segment | None
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """
-        The constructor of `WorkflowDraftVariable` is not intended for
-        direct use outside this file. Its solo purpose is setup private state
-        used by the model instance.
-
-        Please use the factory methods
-        (`new_conversation_variable`, `new_sys_variable`, `new_node_variable`)
-        defined below to create instances of this class.
-        """
-        super().__init__(*args, **kwargs)
-        self.__value = None
+    __value: Segment | None = field(default=None, init=False, repr=False)
 
     @orm.reconstructor
     def _init_on_load(self):

--- a/api/services/rag_pipeline/rag_pipeline.py
+++ b/api/services/rag_pipeline/rag_pipeline.py
@@ -384,14 +384,14 @@ class RagPipelineService:
             workflow = Workflow(
                 tenant_id=pipeline.tenant_id,
                 app_id=pipeline.id,
-                features="{}",
-                type=WorkflowType.RAG_PIPELINE.value,
+                _features="{}",
+                type=WorkflowType.RAG_PIPELINE,
                 version="draft",
                 graph=json.dumps(graph),
                 created_by=account.id,
-                environment_variables=environment_variables,
-                conversation_variables=conversation_variables,
-                rag_pipeline_variables=rag_pipeline_variables,
+                _environment_variables=environment_variables,
+                _conversation_variables=conversation_variables,
+                _rag_pipeline_variables=rag_pipeline_variables,
             )
             self._session.add(workflow)
             self._session.flush()

--- a/api/services/rag_pipeline/rag_pipeline_dsl_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_dsl_service.py
@@ -617,14 +617,14 @@ class RagPipelineDslService:
             workflow = Workflow(
                 tenant_id=pipeline.tenant_id,
                 app_id=pipeline.id,
-                features="{}",
+                _features="{}",
                 type=WorkflowType.RAG_PIPELINE,
                 version="draft",
                 graph=json.dumps(graph),
                 created_by=account.id,
-                environment_variables=environment_variables,
-                conversation_variables=conversation_variables,
-                rag_pipeline_variables=rag_pipeline_variables_list,
+                _environment_variables=environment_variables,
+                _conversation_variables=conversation_variables,
+                _rag_pipeline_variables=rag_pipeline_variables_list,
             )
             self._session.add(workflow)
             self._session.flush()

--- a/api/services/rag_pipeline/rag_pipeline_transform_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_transform_service.py
@@ -249,26 +249,26 @@ class RagPipelineTransformService:
         draft_workflow = Workflow(
             tenant_id=pipeline.tenant_id,
             app_id=pipeline.id,
-            features="{}",
+            _features="{}",
             type=WorkflowType.RAG_PIPELINE,
             version="draft",
             graph=json.dumps(graph),
             created_by=account_id,
-            environment_variables=environment_variables,
-            conversation_variables=conversation_variables,
-            rag_pipeline_variables=rag_pipeline_variables_list,
+            _environment_variables=environment_variables,
+            _conversation_variables=conversation_variables,
+            _rag_pipeline_variables=rag_pipeline_variables_list,
         )
         published_workflow = Workflow(
             tenant_id=pipeline.tenant_id,
             app_id=pipeline.id,
-            features="{}",
+            _features="{}",
             type=WorkflowType.RAG_PIPELINE,
             version=str(datetime.now(UTC).replace(tzinfo=None)),
             graph=json.dumps(graph),
             created_by=account_id,
-            environment_variables=environment_variables,
-            conversation_variables=conversation_variables,
-            rag_pipeline_variables=rag_pipeline_variables_list,
+            _environment_variables=environment_variables,
+            _conversation_variables=conversation_variables,
+            _rag_pipeline_variables=rag_pipeline_variables_list,
         )
         session.add(draft_workflow)
         session.add(published_workflow)

--- a/api/services/snippet_service.py
+++ b/api/services/snippet_service.py
@@ -577,14 +577,14 @@ class SnippetService:
             workflow = Workflow(
                 tenant_id=snippet.tenant_id,
                 app_id=snippet.id,
-                features="{}",
+                _features="{}",
                 type=WorkflowType.WORKFLOW,
                 kind=WorkflowKind.SNIPPET,
                 version="draft",
                 graph=json.dumps(graph),
                 created_by=account.id,
-                environment_variables=[],
-                conversation_variables=[],
+                _environment_variables=[],
+                _conversation_variables=[],
             )
         else:
             # Update existing draft workflow

--- a/api/services/workflow/workflow_converter.py
+++ b/api/services/workflow/workflow_converter.py
@@ -224,13 +224,13 @@ class WorkflowConverter:
         workflow = Workflow(
             tenant_id=app_model.tenant_id,
             app_id=app_model.id,
-            type=WorkflowType.from_app_mode(new_app_mode).value,
+            type=WorkflowType.from_app_mode(new_app_mode),
             version=Workflow.VERSION_DRAFT,
             graph=json.dumps(graph),
-            features=json.dumps(features),
+            _features=json.dumps(features),
             created_by=account_id,
-            environment_variables=[],
-            conversation_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
         )
 
         session.add(workflow)

--- a/api/services/workflow_restore.py
+++ b/api/services/workflow_restore.py
@@ -34,16 +34,14 @@ def apply_published_workflow_snapshot_to_draft(
     the published source row before the caller commits.
     """
     if not draft_workflow:
-        workflow_type = (
-            source_workflow.type.value if isinstance(source_workflow.type, WorkflowType) else source_workflow.type
-        )
+        workflow_type = WorkflowType(source_workflow.type)
         draft_workflow = Workflow(
             tenant_id=tenant_id,
             app_id=app_id,
             type=workflow_type,
             version=Workflow.VERSION_DRAFT,
             graph=source_workflow.graph,
-            features=source_workflow.serialized_features,
+            _features=source_workflow.serialized_features,
             created_by=account.id,
         )
         draft_workflow.copy_serialized_variable_storage_from(source_workflow)

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -461,13 +461,13 @@ class WorkflowService:
             workflow = Workflow(
                 tenant_id=app_model.tenant_id,
                 app_id=app_model.id,
-                type=WorkflowType.from_app_mode(app_model.mode).value,
+                type=WorkflowType.from_app_mode(app_model.mode),
                 version=Workflow.VERSION_DRAFT,
                 graph=json.dumps(graph),
-                features=json.dumps(features),
+                _features=json.dumps(features),
                 created_by=account.id,
-                environment_variables=initial_environment_variables,
-                conversation_variables=conversation_variables,
+                _environment_variables=initial_environment_variables,
+                _conversation_variables=conversation_variables,
             )
             session.add(workflow)
         # update draft workflow if found

--- a/api/tasks/trigger_processing_tasks.py
+++ b/api/tasks/trigger_processing_tasks.py
@@ -158,11 +158,11 @@ def _record_trigger_failure_log(
         app_id=workflow.app_id,
         workflow_id=workflow.id,
         type=workflow.type,
-        triggered_from=WorkflowRunTriggeredFrom.PLUGIN.value,
+        triggered_from=WorkflowRunTriggeredFrom.PLUGIN,
         version=workflow.version,
         graph=workflow.graph,
         inputs=json.dumps(failure_inputs),
-        status=WorkflowExecutionStatus.FAILED.value,
+        status=WorkflowExecutionStatus.FAILED,
         outputs="{}",
         error=error_message,
         elapsed_time=0.0,
@@ -170,10 +170,10 @@ def _record_trigger_failure_log(
         total_steps=0,
         created_by_role=created_by_role,
         created_by=created_by,
-        created_at=now,
         finished_at=now,
         exceptions_count=0,
     )
+    workflow_run.created_at = now
     session.add(workflow_run)
     session.flush()
 

--- a/api/tests/integration_tests/services/test_node_output_inspector_service.py
+++ b/api/tests/integration_tests/services/test_node_output_inspector_service.py
@@ -99,7 +99,7 @@ def _make_execution(
     index: int = 1,
 ) -> WorkflowNodeExecutionModel:
     """Build a ``WorkflowNodeExecutionModel`` row with all required fields."""
-    return WorkflowNodeExecutionModel(
+    execution = WorkflowNodeExecutionModel(
         id=str(uuid.uuid4()),
         tenant_id=tenant_id,
         app_id=app_id,
@@ -115,9 +115,10 @@ def _make_execution(
         execution_metadata=json.dumps(execution_metadata) if execution_metadata is not None else None,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=str(uuid.uuid4()),
-        created_at=datetime.now(UTC),
         finished_at=datetime.now(UTC),
     )
+    execution.created_at = datetime.now(UTC)
+    return execution
 
 
 @pytest.fixture

--- a/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/app/test_chat_conversation_status_count_api.py
@@ -98,8 +98,8 @@ def _create_workflow_run(db_session: Session, app_id: str, tenant_id: str, accou
         total_steps=0,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=account_id,
-        created_at=naive_utc_now(),
     )
+    workflow_run.created_at = naive_utc_now()
     db_session.add(workflow_run)
     db_session.commit()
     return workflow_run

--- a/api/tests/test_containers_integration_tests/controllers/web/test_human_input_form.py
+++ b/api/tests/test_containers_integration_tests/controllers/web/test_human_input_form.py
@@ -139,8 +139,8 @@ def test_get_human_input_form_resolves_runtime_select_options(
         total_steps=0,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=account.id,
-        created_at=datetime.now(UTC).replace(tzinfo=None),
     )
+    workflow_run.created_at = datetime.now(UTC).replace(tzinfo=None)
     db_session_with_containers.add(workflow_run)
     db_session_with_containers.flush()
 

--- a/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
+++ b/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
@@ -157,7 +157,7 @@ class TestPauseStatePersistenceLayerTestContainers:
             type="workflow",
             version="draft",
             graph='{"nodes": [], "edges": []}',
-            features='{"file_upload": {"enabled": false}}',
+            _features='{"file_upload": {"enabled": false}}',
             created_by=self.test_user_id,
             created_at=naive_utc_now(),
         )
@@ -502,7 +502,7 @@ class TestPauseStatePersistenceLayerTestContainers:
             type="workflow",
             version="draft",
             graph='{"nodes": [], "edges": []}',
-            features='{"file_upload": {"enabled": false}}',
+            _features='{"file_upload": {"enabled": false}}',
             created_by=different_user_id,
             created_at=naive_utc_now(),
         )

--- a/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
+++ b/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
@@ -159,8 +159,8 @@ class TestPauseStatePersistenceLayerTestContainers:
             graph='{"nodes": [], "edges": []}',
             _features='{"file_upload": {"enabled": false}}',
             created_by=self.test_user_id,
-            created_at=naive_utc_now(),
         )
+        self.test_workflow.created_at = naive_utc_now()
 
         # Create test workflow run
         self.test_workflow_run = WorkflowRun(
@@ -174,8 +174,8 @@ class TestPauseStatePersistenceLayerTestContainers:
             status=WorkflowExecutionStatus.RUNNING,
             created_by=self.test_user_id,
             created_by_role="account",
-            created_at=naive_utc_now(),
         )
+        self.test_workflow_run.created_at = naive_utc_now()
 
         # Store session and service instances
         self.session = db_session_with_containers
@@ -504,8 +504,8 @@ class TestPauseStatePersistenceLayerTestContainers:
             graph='{"nodes": [], "edges": []}',
             _features='{"file_upload": {"enabled": false}}',
             created_by=different_user_id,
-            created_at=naive_utc_now(),
         )
+        different_workflow.created_at = naive_utc_now()
 
         different_workflow_run = WorkflowRun(
             id=str(uuid.uuid4()),
@@ -518,8 +518,8 @@ class TestPauseStatePersistenceLayerTestContainers:
             status=WorkflowExecutionStatus.RUNNING,
             created_by=self.test_user_id,  # Run created by different user
             created_by_role="account",
-            created_at=naive_utc_now(),
         )
+        different_workflow_run.created_at = naive_utc_now()
 
         self.session.add(different_workflow)
         self.session.add(different_workflow_run)

--- a/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
+++ b/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
@@ -233,7 +233,7 @@ class TestHumanInputResumeNodeExecutionIntegration:
             type="workflow",
             version="draft",
             graph='{"nodes": [], "edges": []}',
-            features='{"file_upload": {"enabled": false}}',
+            _features='{"file_upload": {"enabled": false}}',
             created_by=account.id,
             created_at=naive_utc_now(),
         )

--- a/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
+++ b/api/tests/test_containers_integration_tests/core/workflow/test_human_input_resume_node_execution.py
@@ -235,8 +235,8 @@ class TestHumanInputResumeNodeExecutionIntegration:
             graph='{"nodes": [], "edges": []}',
             _features='{"file_upload": {"enabled": false}}',
             created_by=account.id,
-            created_at=naive_utc_now(),
         )
+        workflow.created_at = naive_utc_now()
         db_session_with_containers.add(workflow)
         db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/models/test_conversation_status_count.py
+++ b/api/tests/test_containers_integration_tests/models/test_conversation_status_count.py
@@ -12,7 +12,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from graphon.enums import WorkflowExecutionStatus
-from models.enums import ConversationFromSource, CustomizeTokenStrategy, InvokeFrom
+from models.enums import ConversationFromSource, CreatorUserRole, CustomizeTokenStrategy, InvokeFrom
 from models.model import App, AppMode, Conversation, Message, Site
 from models.workflow import Workflow, WorkflowRun, WorkflowRunTriggeredFrom, WorkflowType
 
@@ -89,7 +89,7 @@ class TestConversationStatusCount:
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
             version="draft",
             status=status,
-            created_by_role="account",
+            created_by_role=CreatorUserRole.ACCOUNT,
             created_by=created_by,
         )
         db_session.add(run)

--- a/api/tests/test_containers_integration_tests/models/test_workflow_node_execution_model.py
+++ b/api/tests/test_containers_integration_tests/models/test_workflow_node_execution_model.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from graphon.enums import WorkflowNodeExecutionStatus
 from models.account import Account
 from models.enums import CreatorUserRole, EndUserType
 from models.model import App, AppMode, EndUser
@@ -72,7 +73,7 @@ class TestWorkflowNodeExecutionModelCreatedBy:
         return app
 
     def _make_execution(
-        self, tenant_id: str, app_id: str, created_by_role: str, created_by: str
+        self, tenant_id: str, app_id: str, created_by_role: CreatorUserRole, created_by: str
     ) -> WorkflowNodeExecutionModel:
         return WorkflowNodeExecutionModel(
             tenant_id=tenant_id,
@@ -89,7 +90,7 @@ class TestWorkflowNodeExecutionModelCreatedBy:
             inputs=None,
             process_data=None,
             outputs=None,
-            status="succeeded",
+            status=WorkflowNodeExecutionStatus.SUCCEEDED,
             error=None,
             elapsed_time=0.0,
             execution_metadata=None,
@@ -105,7 +106,7 @@ class TestWorkflowNodeExecutionModelCreatedBy:
         execution = self._make_execution(
             tenant_id=app.tenant_id,
             app_id=app.id,
-            created_by_role=CreatorUserRole.ACCOUNT.value,
+            created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
         )
 
@@ -122,7 +123,7 @@ class TestWorkflowNodeExecutionModelCreatedBy:
         execution = self._make_execution(
             tenant_id=app.tenant_id,
             app_id=app.id,
-            created_by_role=CreatorUserRole.END_USER.value,
+            created_by_role=CreatorUserRole.END_USER,
             created_by=account.id,
         )
 
@@ -142,7 +143,7 @@ class TestWorkflowNodeExecutionModelCreatedBy:
         execution = self._make_execution(
             tenant_id=tenant_id,
             app_id=app.id,
-            created_by_role=CreatorUserRole.END_USER.value,
+            created_by_role=CreatorUserRole.END_USER,
             created_by=end_user.id,
         )
 
@@ -161,7 +162,7 @@ class TestWorkflowNodeExecutionModelCreatedBy:
         execution = self._make_execution(
             tenant_id=tenant_id,
             app_id=app.id,
-            created_by_role=CreatorUserRole.ACCOUNT.value,
+            created_by_role=CreatorUserRole.ACCOUNT,
             created_by=end_user.id,
         )
 

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py
@@ -51,11 +51,11 @@ def _create_node_execution(
         error=None,
         elapsed_time=0.0,
         execution_metadata="{}",
-        created_at=now + timedelta(seconds=created_at_offset_seconds),
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=created_by,
         finished_at=None,
     )
+    node_execution.created_at = now + timedelta(seconds=created_at_offset_seconds)
     session.add(node_execution)
     session.flush()
     return node_execution
@@ -63,10 +63,8 @@ def _create_node_execution(
 
 class TestDifyAPISQLAlchemyWorkflowNodeExecutionRepository:
     def test_load_full_process_data_returns_inline_mapping(self, db_session_with_containers: Session) -> None:
-        execution = WorkflowNodeExecutionModel(
-            process_data='{"request": "inline"}',
-            offload_data=[],
-        )
+        execution = WorkflowNodeExecutionModel(process_data='{"request": "inline"}')
+        execution.offload_data = []
         engine = db_session_with_containers.get_bind()
         assert isinstance(engine, Engine)
         repository = DifyAPISQLAlchemyWorkflowNodeExecutionRepository(sessionmaker(bind=engine, expire_on_commit=False))
@@ -78,7 +76,8 @@ class TestDifyAPISQLAlchemyWorkflowNodeExecutionRepository:
         db_session_with_containers: Session,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        execution = WorkflowNodeExecutionModel(process_data="{}", offload_data=[])
+        execution = WorkflowNodeExecutionModel(process_data="{}")
+        execution.offload_data = []
         monkeypatch.setattr(
             WorkflowNodeExecutionModel,
             "load_full_process_data",

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py
@@ -79,8 +79,8 @@ def _create_workflow_run(
         status=status,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=scope.user_id,
-        created_at=created_at or naive_utc_now(),
     )
+    workflow_run.created_at = created_at or naive_utc_now()
     session.add(workflow_run)
     session.commit()
     return workflow_run

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_node_execution_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_node_execution_repository.py
@@ -81,11 +81,11 @@ def _create_node_execution_model(
         error=None,
         elapsed_time=1.5,
         execution_metadata="{}",
-        created_at=datetime.now(),
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=str(uuid4()),
         finished_at=None,
     )
+    model.created_at = datetime.now()
     session.add(model)
     session.flush()
     return model

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_run_cleanup_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_run_cleanup_repository.py
@@ -12,7 +12,16 @@ from sqlalchemy.orm import Session, sessionmaker
 from graphon.entities.pause_reason import PauseReasonType
 from graphon.enums import WorkflowExecutionStatus, WorkflowType
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
-from models.workflow import WorkflowAppLog, WorkflowAppLogCreatedFrom, WorkflowPause, WorkflowPauseReason, WorkflowRun
+from models.workflow import (
+    WorkflowAppLog,
+    WorkflowAppLogCreatedFrom,
+    WorkflowPause,
+    WorkflowPauseReason,
+    WorkflowRun,
+)
+from models.workflow import (
+    WorkflowType as ModelWorkflowType,
+)
 from repositories.sqlalchemy_api_workflow_run_repository import DifyAPISQLAlchemyWorkflowRunRepository
 
 
@@ -40,7 +49,7 @@ def _create_workflow_run(
     created_at: datetime,
     tenant_id: str | None = None,
     workflow_id: str | None = None,
-    workflow_type: str = WorkflowType.WORKFLOW,
+    workflow_type: ModelWorkflowType = ModelWorkflowType.WORKFLOW,
 ) -> WorkflowRun:
     workflow_run = WorkflowRun(
         id=str(uuid4()),
@@ -55,8 +64,8 @@ def _create_workflow_run(
         status=status,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=scope.user_id,
-        created_at=created_at,
     )
+    workflow_run.created_at = created_at
     session.add(workflow_run)
     session.commit()
     return workflow_run
@@ -130,7 +139,7 @@ class TestGetCleanupRefsBatchByTimeRange:
             db_session_with_containers,
             scope,
             created_at=base + timedelta(minutes=1),
-            workflow_type=WorkflowType.CHAT,
+            workflow_type=ModelWorkflowType.CHAT,
         )
         _create_workflow_run(db_session_with_containers, scope, created_at=base + timedelta(minutes=3))
 

--- a/api/tests/test_containers_integration_tests/repositories/test_workflow_run_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_workflow_run_repository.py
@@ -59,8 +59,8 @@ def _create_workflow_run(
         status=status,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=scope.user_id,
-        created_at=now + created_at_offset if created_at_offset is not None else now,
     )
+    workflow_run.created_at = now + created_at_offset if created_at_offset is not None else now
     session.add(workflow_run)
     session.commit()
     return workflow_run

--- a/api/tests/test_containers_integration_tests/services/test_delete_archived_workflow_run.py
+++ b/api/tests/test_containers_integration_tests/services/test_delete_archived_workflow_run.py
@@ -66,10 +66,10 @@ class TestArchivedWorkflowRunDeletion:
             total_steps=1,
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=str(uuid4()),
-            created_at=created_at,
             finished_at=created_at,
             exceptions_count=0,
         )
+        run.created_at = created_at
         db_session_with_containers.add(run)
         db_session_with_containers.commit()
         return run

--- a/api/tests/test_containers_integration_tests/services/test_webhook_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_webhook_service.py
@@ -102,10 +102,10 @@ def test_data(
         app_id=app.id,
         type="workflow",
         graph=json.dumps(workflow_data),
-        features=json.dumps({}),
+        _features=json.dumps({}),
         created_by=account.id,
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
         version="1.0",
     )
     db_session_with_containers.add(workflow)

--- a/api/tests/test_containers_integration_tests/services/test_webhook_service_relationships.py
+++ b/api/tests/test_containers_integration_tests/services/test_webhook_service_relationships.py
@@ -113,11 +113,11 @@ class WebhookServiceRelationshipFactory:
             app_id=app.id,
             type="workflow",
             graph=json.dumps(graph),
-            features=json.dumps({}),
+            _features=json.dumps({}),
             created_by=account.id,
             updated_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
             version=version,
         )
         db_session_with_containers.add(workflow)

--- a/api/tests/test_containers_integration_tests/services/test_workflow_app_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_app_service.py
@@ -236,9 +236,9 @@ class TestWorkflowAppLogQueryService:
             total_steps=3,
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
-            created_at=datetime.now(UTC),
             finished_at=datetime.now(UTC),
         )
+        workflow_run.created_at = datetime.now(UTC)
         db_session_with_containers.add(workflow_run)
         db_session_with_containers.commit()
 
@@ -372,8 +372,8 @@ class TestWorkflowAppLogQueryService:
             outputs=json.dumps({"result": "50% discount applied", "status": "success"}),
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
-            created_at=datetime.now(UTC),
         )
+        workflow_run_1.created_at = datetime.now(UTC)
         db_session_with_containers.add(workflow_run_1)
         db_session_with_containers.flush()
 
@@ -414,8 +414,8 @@ class TestWorkflowAppLogQueryService:
             outputs=json.dumps({"result": "test_data_value found", "status": "success"}),
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
-            created_at=datetime.now(UTC),
         )
+        workflow_run_2.created_at = datetime.now(UTC)
         db_session_with_containers.add(workflow_run_2)
         db_session_with_containers.flush()
 
@@ -456,8 +456,8 @@ class TestWorkflowAppLogQueryService:
             outputs=json.dumps({"result": "100% different result", "status": "success"}),
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
-            created_at=datetime.now(UTC),
         )
+        workflow_run_4.created_at = datetime.now(UTC)
         db_session_with_containers.add(workflow_run_4)
         db_session_with_containers.flush()
 
@@ -535,9 +535,9 @@ class TestWorkflowAppLogQueryService:
                 total_steps=3,
                 created_by_role=CreatorUserRole.ACCOUNT,
                 created_by=account.id,
-                created_at=datetime.now(UTC) + timedelta(minutes=i),
                 finished_at=datetime.now(UTC) + timedelta(minutes=i + 1) if status != "running" else None,
             )
+            workflow_run.created_at = datetime.now(UTC) + timedelta(minutes=i)
             db_session_with_containers.add(workflow_run)
             db_session_with_containers.commit()
 
@@ -641,9 +641,9 @@ class TestWorkflowAppLogQueryService:
                 total_steps=3,
                 created_by_role=CreatorUserRole.ACCOUNT,
                 created_by=account.id,
-                created_at=timestamp,
                 finished_at=timestamp + timedelta(minutes=1),
             )
+            workflow_run.created_at = timestamp
             db_session_with_containers.add(workflow_run)
             db_session_with_containers.commit()
 
@@ -746,9 +746,9 @@ class TestWorkflowAppLogQueryService:
                 total_steps=3,
                 created_by_role=CreatorUserRole.ACCOUNT,
                 created_by=account.id,
-                created_at=datetime.now(UTC) + timedelta(minutes=i),
                 finished_at=datetime.now(UTC) + timedelta(minutes=i + 1),
             )
+            workflow_run.created_at = datetime.now(UTC) + timedelta(minutes=i)
             db_session_with_containers.add(workflow_run)
             db_session_with_containers.commit()
 
@@ -874,9 +874,9 @@ class TestWorkflowAppLogQueryService:
                 total_steps=3,
                 created_by_role=CreatorUserRole.ACCOUNT,
                 created_by=account.id,
-                created_at=datetime.now(UTC) + timedelta(minutes=i),
                 finished_at=datetime.now(UTC) + timedelta(minutes=i + 1),
             )
+            workflow_run.created_at = datetime.now(UTC) + timedelta(minutes=i)
             db_session_with_containers.add(workflow_run)
             db_session_with_containers.commit()
 
@@ -916,9 +916,9 @@ class TestWorkflowAppLogQueryService:
                 total_steps=3,
                 created_by_role=CreatorUserRole.END_USER,
                 created_by=end_user.id,
-                created_at=datetime.now(UTC) + timedelta(minutes=i + 10),
                 finished_at=datetime.now(UTC) + timedelta(minutes=i + 11),
             )
+            workflow_run.created_at = datetime.now(UTC) + timedelta(minutes=i + 10)
             db_session_with_containers.add(workflow_run)
             db_session_with_containers.commit()
 
@@ -1050,9 +1050,9 @@ class TestWorkflowAppLogQueryService:
             total_steps=3,
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
-            created_at=datetime.now(UTC),
             finished_at=datetime.now(UTC) + timedelta(minutes=1),
         )
+        workflow_run.created_at = datetime.now(UTC)
         db_session_with_containers.add(workflow_run)
         db_session_with_containers.commit()
 
@@ -1138,9 +1138,9 @@ class TestWorkflowAppLogQueryService:
             total_steps=0,  # Edge case: 0 steps
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
-            created_at=datetime.now(UTC),
             finished_at=datetime.now(UTC),
         )
+        workflow_run.created_at = datetime.now(UTC)
         db_session_with_containers.add(workflow_run)
         db_session_with_containers.commit()
 
@@ -1293,9 +1293,9 @@ class TestWorkflowAppLogQueryService:
                 total_steps=3,
                 created_by_role=CreatorUserRole.ACCOUNT,
                 created_by=account.id,
-                created_at=datetime.now(UTC) + timedelta(minutes=i),
                 finished_at=datetime.now(UTC) + timedelta(minutes=i + 1) if status == "succeeded" else None,
             )
+            workflow_run.created_at = datetime.now(UTC) + timedelta(minutes=i)
             db_session_with_containers.add(workflow_run)
             db_session_with_containers.flush()
 
@@ -1393,9 +1393,9 @@ class TestWorkflowAppLogQueryService:
                 total_steps=3,
                 created_by_role=CreatorUserRole.ACCOUNT,
                 created_by=account.id,
-                created_at=datetime.now(UTC) + timedelta(minutes=i),
                 finished_at=datetime.now(UTC) + timedelta(minutes=i + 1) if status != "running" else None,
             )
+            workflow_run.created_at = datetime.now(UTC) + timedelta(minutes=i)
             db_session_with_containers.add(workflow_run)
             db_session_with_containers.flush()
 
@@ -1499,9 +1499,9 @@ class TestWorkflowAppLogQueryService:
                     total_steps=3,
                     created_by_role=CreatorUserRole.ACCOUNT,
                     created_by=account.id,
-                    created_at=datetime.now(UTC) + timedelta(minutes=i * 10 + j),
                     finished_at=datetime.now(UTC) + timedelta(minutes=i * 10 + j + 1),
                 )
+                workflow_run.created_at = datetime.now(UTC) + timedelta(minutes=i * 10 + j)
                 db_session_with_containers.add(workflow_run)
                 db_session_with_containers.flush()
                 run_ids_by_app[app.id].add(workflow_run.id)

--- a/api/tests/test_containers_integration_tests/services/test_workflow_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_service.py
@@ -133,12 +133,12 @@ class TestWorkflowService:
             type=WorkflowType.WORKFLOW,
             version=Workflow.VERSION_DRAFT,
             graph=json.dumps({"nodes": [], "edges": []}),
-            features=json.dumps({"features": []}),
+            _features=json.dumps({"features": []}),
             # unique_hash is a computed property based on graph and features
             created_by=account.id,
             updated_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
         )
 
         db_session_with_containers.add(workflow)
@@ -959,11 +959,11 @@ class TestWorkflowService:
             type=WorkflowType.WORKFLOW,
             version="2026.03.19.001",
             graph=json.dumps({"nodes": [], "edges": []}),
-            features=json.dumps(legacy_features),
+            _features=json.dumps(legacy_features),
             created_by=account.id,
             updated_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
         )
         draft_workflow = Workflow(
             id=fake.uuid4(),
@@ -972,11 +972,11 @@ class TestWorkflowService:
             type=WorkflowType.WORKFLOW,
             version=Workflow.VERSION_DRAFT,
             graph=json.dumps({"nodes": [], "edges": []}),
-            features=json.dumps({}),
+            _features=json.dumps({}),
             created_by=account.id,
             updated_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
         )
         db_session_with_containers.add(published_workflow)
         db_session_with_containers.add(draft_workflow)

--- a/api/tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py
@@ -10,6 +10,7 @@ from core.tools.entities.tool_entities import WorkflowToolParameterConfiguration
 from core.tools.errors import WorkflowToolHumanInputNotSupportedError
 from models.tools import WorkflowToolProvider
 from models.workflow import Workflow as WorkflowModel
+from models.workflow import WorkflowType
 from services.account_service import AccountService, TenantService
 from services.app_service import AppService, CreateAppParams
 from services.tools.workflow_tools_manage_service import WorkflowToolManageService
@@ -111,13 +112,13 @@ class TestWorkflowToolManageService:
         workflow = WorkflowModel(
             tenant_id=tenant.id,
             app_id=app.id,
-            type="workflow",
+            type=WorkflowType.WORKFLOW,
             version="1.0.0",
             graph=json.dumps({}),
-            features=json.dumps({}),
+            _features=json.dumps({}),
             created_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
         )
 
         db_session_with_containers.add(workflow)

--- a/api/tests/test_containers_integration_tests/services/workflow/test_workflow_event_snapshot_service.py
+++ b/api/tests/test_containers_integration_tests/services/workflow/test_workflow_event_snapshot_service.py
@@ -17,10 +17,10 @@ from core.workflow.nodes.human_input.enums import HumanInputFormStatus, ValueSou
 from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
 from graphon.enums import WorkflowExecutionStatus
 from graphon.runtime import GraphRuntimeState, VariablePool
-from models.enums import CreatorUserRole
+from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.human_input import HumanInputForm
 from models.model import AppMode
-from models.workflow import WorkflowRun
+from models.workflow import WorkflowRun, WorkflowType
 from repositories.entities.workflow_pause import WorkflowPauseEntity
 from services.workflow_event_snapshot_service import _build_snapshot_events
 
@@ -89,13 +89,13 @@ def _build_resumption_context(workflow_run_id: str) -> WorkflowResumptionContext
 
 
 def _build_workflow_run(workflow_run_id: str) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id=workflow_run_id,
         tenant_id=str(uuid4()),
         app_id=str(uuid4()),
         workflow_id=str(uuid4()),
-        type="workflow",
-        triggered_from="app-run",
+        type=WorkflowType.WORKFLOW,
+        triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         version="v1",
         graph=None,
         inputs="{}",
@@ -107,8 +107,9 @@ def _build_workflow_run(workflow_run_id: str) -> WorkflowRun:
         total_steps=0,
         created_by_role=CreatorUserRole.END_USER,
         created_by=str(uuid4()),
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
+    workflow_run.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def test_build_snapshot_events_resolves_variable_select_options(db_session_with_containers: Session) -> None:

--- a/api/tests/test_containers_integration_tests/services/workflow/test_workflow_node_execution_service_repository.py
+++ b/api/tests/test_containers_integration_tests/services/workflow/test_workflow_node_execution_service_repository.py
@@ -55,11 +55,11 @@ class TestSQLAlchemyWorkflowNodeExecutionServiceRepository:
             error=None,
             elapsed_time=0.0,
             execution_metadata="{}",
-            created_at=created_at,
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=str(uuid4()),
             finished_at=None,
         )
+        execution.created_at = created_at
         db_session_with_containers.add(execution)
         db_session_with_containers.commit()
         return execution

--- a/api/tests/test_containers_integration_tests/tasks/test_mail_human_input_delivery_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_mail_human_input_delivery_task.py
@@ -134,8 +134,8 @@ def _create_workflow_pause_state(
         status=WorkflowExecutionStatus.PAUSED,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=account_id,
-        created_at=datetime.now(UTC),
     )
+    workflow_run.created_at = datetime.now(UTC)
     db_session_with_containers.add(workflow_run)
 
     runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=0.0)

--- a/api/tests/test_containers_integration_tests/tasks/test_rag_pipeline_run_tasks.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_rag_pipeline_run_tasks.py
@@ -100,13 +100,13 @@ class TestRagPipelineRunTasks:
             type="workflow",
             version="draft",
             graph="{}",
-            features="{}",
+            _features="{}",
             marked_name=fake.company(),
             marked_comment=fake.text(max_nb_chars=100),
             created_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
-            rag_pipeline_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
+            _rag_pipeline_variables=[],
         )
         db_session_with_containers.add(workflow)
         db_session_with_containers.commit()

--- a/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
+++ b/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
@@ -219,7 +219,7 @@ class TestWorkflowPauseIntegration:
             type="workflow",
             version="draft",
             graph='{"nodes": [], "edges": []}',
-            features='{"file_upload": {"enabled": false}}',
+            _features='{"file_upload": {"enabled": false}}',
             created_by=self.test_user_id,
             created_at=naive_utc_now(),
         )
@@ -727,7 +727,7 @@ class TestWorkflowPauseIntegration:
             type="workflow",
             version="draft",
             graph='{"nodes": [], "edges": []}',
-            features='{"file_upload": {"enabled": false}}',
+            _features='{"file_upload": {"enabled": false}}',
             created_by=account2.id,
             created_at=naive_utc_now(),
         )

--- a/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
+++ b/api/tests/test_containers_integration_tests/test_workflow_pause_integration.py
@@ -221,8 +221,8 @@ class TestWorkflowPauseIntegration:
             graph='{"nodes": [], "edges": []}',
             _features='{"file_upload": {"enabled": false}}',
             created_by=self.test_user_id,
-            created_at=naive_utc_now(),
         )
+        self.test_workflow.created_at = naive_utc_now()
 
         # Store session instance
         self.session = db_session_with_containers
@@ -277,8 +277,8 @@ class TestWorkflowPauseIntegration:
             status=status,
             created_by=self.test_user_id,
             created_by_role="account",
-            created_at=naive_utc_now(),
         )
+        workflow_run.created_at = naive_utc_now()
         self.session.add(workflow_run)
         self.session.commit()
         return workflow_run
@@ -729,8 +729,8 @@ class TestWorkflowPauseIntegration:
             graph='{"nodes": [], "edges": []}',
             _features='{"file_upload": {"enabled": false}}',
             created_by=account2.id,
-            created_at=naive_utc_now(),
         )
+        workflow2.created_at = naive_utc_now()
         self.session.add(workflow2)
         self.session.commit()
 
@@ -747,8 +747,8 @@ class TestWorkflowPauseIntegration:
             status=WorkflowExecutionStatus.RUNNING,
             created_by=account2.id,
             created_by_role="account",
-            created_at=naive_utc_now(),
         )
+        workflow_run2.created_at = naive_utc_now()
         self.session.add(workflow_run2)
         self.session.commit()
 

--- a/api/tests/unit_tests/commands/test_archive_workflow_runs.py
+++ b/api/tests/unit_tests/commands/test_archive_workflow_runs.py
@@ -67,28 +67,27 @@ class ArchiveDatabase:
     ) -> str:
         run_id = str(uuid4())
         with self.session_maker.begin() as session:
-            session.add(
-                WorkflowRun(
-                    id=run_id,
-                    tenant_id=tenant_id,
-                    app_id=str(uuid4()),
-                    workflow_id=str(uuid4()),
-                    type=run_type,
-                    triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
-                    version="1",
-                    graph="{}",
-                    inputs="{}",
-                    status=status,
-                    outputs="{}",
-                    error=None,
-                    elapsed_time=0,
-                    total_tokens=0,
-                    total_steps=1,
-                    created_by_role=CreatorUserRole.ACCOUNT,
-                    created_by=str(uuid4()),
-                    created_at=created_at or self.end_before - datetime.timedelta(days=1),
-                )
+            workflow_run = WorkflowRun(
+                id=run_id,
+                tenant_id=tenant_id,
+                app_id=str(uuid4()),
+                workflow_id=str(uuid4()),
+                type=run_type,
+                triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+                version="1",
+                graph="{}",
+                inputs="{}",
+                status=status,
+                outputs="{}",
+                error=None,
+                elapsed_time=0,
+                total_tokens=0,
+                total_steps=1,
+                created_by_role=CreatorUserRole.ACCOUNT,
+                created_by=str(uuid4()),
             )
+            workflow_run.created_at = created_at or self.end_before - datetime.timedelta(days=1)
+            session.add(workflow_run)
         return run_id
 
     def add_node(self, run_id: str, tenant_id: str, *, index: int) -> None:

--- a/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
@@ -548,10 +548,10 @@ def test_app_list_uses_injected_session_for_draft_workflows(
         type=WorkflowType.WORKFLOW,
         version=Workflow.VERSION_DRAFT,
         graph=json.dumps({"nodes": [{"id": "trigger-1", "data": {"type": "trigger-webhook"}}], "edges": []}),
-        features=json.dumps({}),
+        _features=json.dumps({}),
         created_by="user-1",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
     sqlite_session.add(workflow)
     sqlite_session.commit()

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_run_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_run_api.py
@@ -100,10 +100,10 @@ def _workflow_run_summary(session: Session, **overrides: object) -> WorkflowRun:
         total_steps=2,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-1",
-        created_at=created_at,
         finished_at=created_at,
         exceptions_count=0,
     )
+    workflow_run.created_at = created_at
     for name, value in overrides.items():
         setattr(workflow_run, name, value)
     workflow_run.retry_index = 0
@@ -135,11 +135,11 @@ def _workflow_run_node_execution(session: Session) -> WorkflowNodeExecutionModel
         error=None,
         elapsed_time=1.0,
         execution_metadata=json.dumps({"total_tokens": 3}),
-        created_at=created_at,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-1",
         finished_at=created_at,
     )
+    execution.created_at = created_at
     execution.offload_data = []
     session.add(execution)
     session.commit()

--- a/api/tests/unit_tests/controllers/console/app/workflow_draft_variables_test.py
+++ b/api/tests/unit_tests/controllers/console/app/workflow_draft_variables_test.py
@@ -31,15 +31,15 @@ class TestWorkflowDraftVariableFields:
         # Create mock objects with relationships pre-loaded
         mock_variable = WorkflowDraftVariable(
             file_id="test-file-id",
-            variable_file=WorkflowDraftVariableFile(
-                size=100000,
-                length=50,
-                value_type=SegmentType.OBJECT,
-                upload_file_id="test-upload-file-id",
-                tenant_id=str(uuid.uuid4()),
-                app_id=str(uuid.uuid4()),
-                user_id=str(uuid.uuid4()),
-            ),
+        )
+        mock_variable.variable_file = WorkflowDraftVariableFile(
+            size=100000,
+            length=50,
+            value_type=SegmentType.OBJECT,
+            upload_file_id="test-upload-file-id",
+            tenant_id=str(uuid.uuid4()),
+            app_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
         )
 
         # Mock the file helpers

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
@@ -53,15 +53,15 @@ def _make_workflow(**overrides: object) -> Workflow:
         marked_name="Release 1",
         marked_comment="Initial release",
         graph=json.dumps({"nodes": [], "edges": []}),
-        features=json.dumps({"file_upload": {"enabled": False}}),
+        _features=json.dumps({"file_upload": {"enabled": False}}),
         created_by=DEFAULT_WORKFLOW_CREATED_BY,
-        created_at=datetime(2024, 1, 1, 12, 0, 0),
         updated_by=None,
-        updated_at=datetime(2024, 1, 1, 12, 1, 0),
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
+    workflow.created_at = datetime(2024, 1, 1, 12, 0, 0)
+    workflow.updated_at = datetime(2024, 1, 1, 12, 1, 0)
     for key, value in overrides.items():
         setattr(workflow, key, value)
     return workflow

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow_apis.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow_apis.py
@@ -50,7 +50,7 @@ from libs.datetime_utils import naive_utc_now
 from models.account import Account, TenantAccountRole
 from models.dataset import Pipeline
 from models.enums import CreatorUserRole
-from models.workflow import Workflow, WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom
+from models.workflow import Workflow, WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom, WorkflowType
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
 
 DEFAULT_WORKFLOW_TENANT_ID = "00000000-0000-0000-0000-000000000001"
@@ -188,10 +188,32 @@ def make_node_execution(**overrides: Unpack[NodeExecutionOverrides]) -> Workflow
         "finished_at": datetime(2026, 1, 1, 0, 0, 1),
     }
     payload.update(overrides)
+    created_at = payload.pop("created_at")
     execution = WorkflowNodeExecutionModel(
+        id=payload["id"],
+        tenant_id=payload["tenant_id"],
+        app_id=payload["app_id"],
+        workflow_id=payload["workflow_id"],
         triggered_from=WorkflowNodeExecutionTriggeredFrom.RAG_PIPELINE_RUN,
-        **payload,
+        workflow_run_id=payload["workflow_run_id"],
+        index=payload["index"],
+        predecessor_node_id=payload["predecessor_node_id"],
+        node_execution_id=payload["node_execution_id"],
+        node_id=payload["node_id"],
+        node_type=payload["node_type"],
+        title=payload["title"],
+        inputs=payload["inputs"],
+        process_data=payload["process_data"],
+        outputs=payload["outputs"],
+        status=payload["status"],
+        error=payload["error"],
+        elapsed_time=payload["elapsed_time"],
+        execution_metadata=payload["execution_metadata"],
+        created_by_role=payload["created_by_role"],
+        created_by=payload["created_by"],
+        finished_at=payload["finished_at"],
     )
+    execution.created_at = created_at
     execution.offload_data = []
     return execution
 
@@ -220,7 +242,26 @@ def default_workflow_payload() -> WorkflowFactoryPayload:
 def make_workflow(**overrides: Unpack[WorkflowFactoryOverrides]) -> Workflow:
     payload = default_workflow_payload()
     payload.update(overrides)
-    return Workflow(**payload)
+    workflow = Workflow(
+        id=payload["id"],
+        tenant_id=payload["tenant_id"],
+        app_id=payload["app_id"],
+        type=WorkflowType(payload["type"]),
+        version=payload["version"],
+        marked_name=payload["marked_name"],
+        marked_comment=payload["marked_comment"],
+        graph=payload["graph"],
+        _features=payload["features"],
+        created_by=payload["created_by"],
+        updated_by=payload["updated_by"],
+        _environment_variables=payload["environment_variables"],
+        _conversation_variables=payload["conversation_variables"],
+        _rag_pipeline_variables=payload["rag_pipeline_variables"],
+    )
+    workflow.created_at = payload["created_at"]
+    if payload["updated_at"] is not None:
+        workflow.updated_at = payload["updated_at"]
+    return workflow
 
 
 def make_account(*, id: str = "account-1", role: TenantAccountRole = TenantAccountRole.EDITOR) -> Account:

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -87,11 +87,11 @@ def _persist_app(
             kind=WorkflowKind.STANDARD,
             version="1",
             graph='{"nodes":[],"edges":[]}',
-            features="{}",
+            _features="{}",
             created_by="user-1",
-            environment_variables=[],
-            conversation_variables=[],
-            rag_pipeline_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
+            _rag_pipeline_variables=[],
         )
         session.add(workflow)
         app.workflow_id = workflow.id

--- a/api/tests/unit_tests/controllers/console/test_human_input_form.py
+++ b/api/tests/unit_tests/controllers/console/test_human_input_form.py
@@ -62,7 +62,7 @@ def _workflow_run(
     created_by: str = "user-1",
     finished_at: datetime | None = None,
 ) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id="run-1",
         tenant_id="t1",
         app_id="app-1",
@@ -75,9 +75,10 @@ def _workflow_run(
         status=WorkflowExecutionStatus.SUCCEEDED if finished_at else WorkflowExecutionStatus.RUNNING,
         created_by_role=created_by_role,
         created_by=created_by,
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
         finished_at=finished_at,
     )
+    workflow_run.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def test_jsonify_form_definition() -> None:

--- a/api/tests/unit_tests/controllers/openapi/test_input_schema.py
+++ b/api/tests/unit_tests/controllers/openapi/test_input_schema.py
@@ -121,7 +121,7 @@ def _persist_app(
                 type=WorkflowType.CHAT,
                 version=Workflow.VERSION_DRAFT,
                 graph=json.dumps({"nodes": [{"id": "start", "data": {"type": "start", "variables": variables}}]}),
-                features="{}",
+                _features="{}",
                 created_by="00000000-0000-0000-0000-000000000003",
             )
             app.workflow_id = workflow.id

--- a/api/tests/unit_tests/controllers/service_api/app/test_hitl_service_api.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_hitl_service_api.py
@@ -213,7 +213,7 @@ class _FakePauseEntity(WorkflowPauseEntity):
 
 
 def _build_workflow_run(status: WorkflowExecutionStatus) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id="run-1",
         tenant_id="tenant-1",
         app_id="app-1",
@@ -231,8 +231,9 @@ def _build_workflow_run(status: WorkflowExecutionStatus) -> WorkflowRun:
         total_steps=0,
         created_by_role=CreatorUserRole.END_USER,
         created_by="user-1",
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
+    workflow_run.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def _build_snapshot(status: WorkflowNodeExecutionStatus) -> WorkflowNodeExecutionSnapshot:

--- a/api/tests/unit_tests/controllers/service_api/app/test_workflow.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_workflow.py
@@ -82,7 +82,7 @@ def _make_workflow_run(
     created_at: datetime | None = None,
     finished_at: datetime | None = None,
 ) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id=run_id,
         tenant_id=tenant_id,
         app_id=app_id,
@@ -100,10 +100,11 @@ def _make_workflow_run(
         total_steps=1,
         created_by_role=CreatorUserRole.END_USER,
         created_by="end-user-1",
-        created_at=created_at or datetime(2026, 1, 1, tzinfo=UTC),
         finished_at=finished_at or datetime(2026, 1, 1, tzinfo=UTC),
         exceptions_count=0,
     )
+    workflow_run.created_at = created_at or datetime(2026, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def _make_workflow_app_log(

--- a/api/tests/unit_tests/controllers/web/test_workflow_events.py
+++ b/api/tests/unit_tests/controllers/web/test_workflow_events.py
@@ -36,7 +36,7 @@ def _workflow_run(
     created_by: str = "eu-1",
     finished_at: datetime | None = None,
 ) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id="run-1",
         tenant_id="tenant-1",
         app_id=app_id,
@@ -54,9 +54,10 @@ def _workflow_run(
         total_steps=0,
         created_by_role=created_by_role,
         created_by=created_by,
-        created_at=datetime(2024, 1, 1),
         finished_at=finished_at,
     )
+    workflow_run.created_at = datetime(2024, 1, 1)
+    return workflow_run
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_config_manager.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_config_manager.py
@@ -18,7 +18,7 @@ def _workflow() -> Workflow:
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features=json.dumps({}),
+        _features=json.dumps({}),
         created_by="account-1",
     )
 

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
@@ -56,7 +56,7 @@ def _make_workflow(
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features=json.dumps(features or {}),
+        _features=json.dumps(features or {}),
         created_by="user",
     )
 

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_conversation_variables.py
@@ -39,7 +39,7 @@ def _runner(workflow_variables: list[object]) -> AdvancedChatAppRunner:
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="44444444-4444-4444-4444-444444444444",
     )
     workflow.conversation_variables = workflow_variables

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_input_moderation.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_input_moderation.py
@@ -49,7 +49,7 @@ def build_runner(sqlite_session: Session):
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph=json.dumps(MINIMAL_GRAPH),
-        features="{}",
+        _features="{}",
         created_by=str(uuid4()),
     )
 

--- a/api/tests/unit_tests/core/app/apps/test_pause_resume.py
+++ b/api/tests/unit_tests/core/app/apps/test_pause_resume.py
@@ -213,7 +213,7 @@ def _make_workflow() -> Workflow:
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="user",
     )
 

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_generator.py
@@ -40,11 +40,11 @@ def _workflow(
         kind=kind,
         version="1",
         graph=json.dumps({"nodes": [], "edges": []}),
-        features="{}",
+        _features="{}",
         created_by="creator",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
 
 

--- a/api/tests/unit_tests/core/app/apps/workflow/test_app_config_manager.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_app_config_manager.py
@@ -18,7 +18,7 @@ def _workflow() -> Workflow:
         type=WorkflowType.WORKFLOW,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features=json.dumps({}),
+        _features=json.dumps({}),
         created_by="account-1",
     )
 

--- a/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline.py
@@ -56,7 +56,7 @@ def _build_pipeline(run_id: str, unbound_session_factory: sessionmaker[Session])
         type=WorkflowType.WORKFLOW,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features=json.dumps({}),
+        _features=json.dumps({}),
         created_by="user-id",
     )
     user = Account(name="user", email="user@example.com")

--- a/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
@@ -67,7 +67,7 @@ def _workflow() -> Workflow:
         type=WorkflowType.WORKFLOW,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features=json.dumps({}),
+        _features=json.dumps({}),
         created_by="user",
     )
 

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -158,11 +158,11 @@ def _persist_node_execution(
         error="",
         elapsed_time=0.1,
         execution_metadata=json.dumps({"agent_log": agent_log}),
-        created_at=datetime(2026, 1, 1),
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by=str(uuid4()),
         finished_at=datetime(2026, 1, 1),
     )
+    execution.created_at = datetime(2026, 1, 1)
     database.add(execution)
     database.commit()
     return execution

--- a/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
+++ b/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
@@ -213,7 +213,7 @@ def _persist_workflow(database: Database, *, workflow_id: str) -> Workflow:
         type=WorkflowType.CHAT,
         version="1",
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account-1",
     )
     database.session.add(workflow)

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -595,9 +595,9 @@ def test_workflow_trace_reads_real_workflow_log_from_owned_session(
         total_steps=1,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="user-1",
-        created_at=datetime(2025, 2, 20, 10, 0, 0),
         finished_at=datetime(2025, 2, 20, 10, 0, 5),
     )
+    workflow_run.created_at = datetime(2025, 2, 20, 10, 0, 0)
     database.add_all([log, workflow_run])
     database.commit()
     repo = DifyAPISQLAlchemyWorkflowRunRepository(sqlite_session_factory)

--- a/api/tests/unit_tests/core/ops/test_trace_session_metadata.py
+++ b/api/tests/unit_tests/core/ops/test_trace_session_metadata.py
@@ -31,7 +31,7 @@ def _bind_trace_database(
 
 
 def _make_workflow_run() -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         workflow_id="wf-1",
         tenant_id="tenant-1",
         id="run-1",
@@ -45,7 +45,6 @@ def _make_workflow_run() -> WorkflowRun:
         error=None,
         total_tokens=0,
         total_steps=0,
-        created_at=datetime(2026, 1, 1, 0, 0, 0),
         finished_at=datetime(2026, 1, 1, 0, 0, 1),
         triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         app_id="app-1",
@@ -53,6 +52,8 @@ def _make_workflow_run() -> WorkflowRun:
         created_by="user-1",
         exceptions_count=0,
     )
+    workflow_run.created_at = datetime(2026, 1, 1, 0, 0, 0)
+    return workflow_run
 
 
 def _make_message_data():

--- a/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_execution_repository.py
@@ -188,9 +188,9 @@ class TestSQLAlchemyWorkflowExecutionRepository:
             exceptions_count=1,
             created_by_role=CreatorUserRole.ACCOUNT,
             created_by=account.id,
-            created_at=datetime.now(UTC),
             finished_at=datetime.now(UTC),
         )
+        db_model.created_at = datetime.now(UTC)
         sqlite_session.add(db_model)
         sqlite_session.commit()
         sqlite_session.expunge_all()

--- a/api/tests/unit_tests/core/repositories/test_workflow_node_execution_truncation.py
+++ b/api/tests/unit_tests/core/repositories/test_workflow_node_execution_truncation.py
@@ -160,10 +160,10 @@ class TestSQLAlchemyWorkflowNodeExecutionRepositoryTruncation:
             error=None,
             elapsed_time=1.0,
             execution_metadata="{}",
-            created_at=datetime.now(UTC),
             finished_at=None,
-            offload_data=[],
         )
+        db_model.created_at = datetime.now(UTC)
+        db_model.offload_data = []
 
         domain_model = repo._to_domain_model(db_model)
 
@@ -207,9 +207,8 @@ class TestWorkflowNodeExecutionModelTruncatedProperties:
 
     def test_truncated_properties_without_offload_data(self):
         """Test truncated properties when no offload data exists."""
-        model = WorkflowNodeExecutionModel(
-            offload_data=[],
-        )
+        model = WorkflowNodeExecutionModel()
+        model.offload_data = []
 
         assert model.inputs_truncated is False
         assert model.outputs_truncated is False

--- a/api/tests/unit_tests/core/test_file.py
+++ b/api/tests/unit_tests/core/test_file.py
@@ -34,10 +34,10 @@ def test_workflow_features_with_image():
         type="chat",
         version="1.0",
         graph="{}",
-        features=json.dumps(features),
+        _features=json.dumps(features),
         created_by="user-1",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
 
     # Get the converted features through the property

--- a/api/tests/unit_tests/enterprise/telemetry/test_draft_trace.py
+++ b/api/tests/unit_tests/enterprise/telemetry/test_draft_trace.py
@@ -27,7 +27,7 @@ def _make_execution(**overrides: object) -> WorkflowNodeExecutionModel:
     outputs = overrides.get("outputs_dict", {"answer": "world"})
     process_data = overrides.get("process_data_dict", {})
     metadata = overrides.get("execution_metadata_dict", {})
-    return WorkflowNodeExecutionModel(
+    execution = WorkflowNodeExecutionModel(
         id=cast(str, overrides.get("id", "exec-1")),
         tenant_id=cast(str, overrides.get("tenant_id", "tenant-1")),
         app_id=cast(str, overrides.get("app_id", "app-1")),
@@ -48,7 +48,6 @@ def _make_execution(**overrides: object) -> WorkflowNodeExecutionModel:
         error=cast(str | None, overrides.get("error")),
         elapsed_time=cast(float, overrides.get("elapsed_time", 1.5)),
         execution_metadata=json.dumps(metadata),
-        created_at=cast(datetime, overrides.get("created_at", datetime(2024, 1, 1, tzinfo=UTC))),
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="user-1",
         finished_at=cast(
@@ -56,6 +55,8 @@ def _make_execution(**overrides: object) -> WorkflowNodeExecutionModel:
             overrides.get("finished_at", datetime(2024, 1, 1, 0, 0, 5, tzinfo=UTC)),
         ),
     )
+    execution.created_at = cast(datetime, overrides.get("created_at", datetime(2024, 1, 1, tzinfo=UTC)))
+    return execution
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/events/event_handlers/test_delete_tool_parameters_cache_when_sync_draft_workflow.py
+++ b/api/tests/unit_tests/events/event_handlers/test_delete_tool_parameters_cache_when_sync_draft_workflow.py
@@ -6,7 +6,7 @@ from core.tools.errors import ToolProviderNotFoundError
 from events.event_handlers import delete_tool_parameters_cache_when_sync_draft_workflow as handler_module
 from graphon.nodes.tool.entities import ToolEntity, ToolProviderType
 from models.model import App, AppMode, IconType
-from models.workflow import Workflow
+from models.workflow import Workflow, WorkflowType
 
 
 def test_missing_tool_provider_does_not_log_error_traceback(
@@ -29,13 +29,13 @@ def test_missing_tool_provider_does_not_log_error_traceback(
     workflow = Workflow(
         tenant_id=app.tenant_id,
         app_id=app.id,
-        type="workflow",
+        type=WorkflowType.WORKFLOW,
         version="draft",
         graph='{"nodes": [{"id": "node-id", "data": {"type": "tool"}}]}',
-        features="{}",
+        _features="{}",
         created_by="account-id",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
     tool_entity = ToolEntity(
         provider_type=ToolProviderType.MCP,

--- a/api/tests/unit_tests/models/test_workflow.py
+++ b/api/tests/unit_tests/models/test_workflow.py
@@ -1,10 +1,12 @@
 import dataclasses
 import json
+from datetime import datetime
 from unittest import mock
 from uuid import uuid4
 
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session, configure_mappers
 
 from constants import HIDDEN_VALUE
 from core.helper import encrypter
@@ -15,13 +17,58 @@ from graphon.file import File, FileTransferMethod, FileType
 from graphon.variables import FloatVariable, IntegerVariable, SecretVariable, StringVariable
 from graphon.variables.segments import IntegerSegment, Segment
 from models.account import Account
+from models.base import Base, TypeBase
 from models.tools import WorkflowToolProvider
 from models.workflow import (
     Workflow,
     WorkflowDraftVariable,
     WorkflowNodeExecutionModel,
+    WorkflowNodeExecutionOffload,
+    WorkflowRun,
+    WorkflowVersionCounter,
     is_system_variable_editable,
 )
+
+
+def test_workflow_models_use_typebase_registry_and_generated_defaults() -> None:
+    models = (
+        Workflow,
+        WorkflowVersionCounter,
+        WorkflowRun,
+        WorkflowNodeExecutionModel,
+        WorkflowDraftVariable,
+    )
+
+    typebase_models = {mapper.class_ for mapper in TypeBase.registry.mappers}
+    base_models = {mapper.class_ for mapper in Base.registry.mappers}
+
+    assert all(model in typebase_models for model in models)
+    assert all(model not in base_models for model in models)
+
+    instances = (Workflow(), WorkflowRun(), WorkflowNodeExecutionModel(), WorkflowDraftVariable())
+    assert all(instance.id for instance in instances)
+    assert len({instance.id for instance in instances}) == len(instances)
+    assert isinstance(instances[0].created_at, datetime)
+    assert isinstance(instances[-1].created_at, datetime)
+
+
+def test_workflow_constructor_serializes_variable_collections_and_configures_offload_relationship() -> None:
+    workflow = Workflow(
+        _features="{}",
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
+    )
+
+    assert workflow._features == "{}"
+    assert json.loads(workflow._environment_variables) == {}
+    assert json.loads(workflow._conversation_variables) == {}
+    assert json.loads(workflow._rag_pipeline_variables) == {}
+
+    configure_mappers()
+    relationship = inspect(WorkflowNodeExecutionModel).relationships["offload_data"]
+    assert relationship.mapper.class_ is WorkflowNodeExecutionOffload
+    assert relationship.back_populates == "execution"
 
 
 def test_environment_variables():
@@ -34,10 +81,10 @@ def test_environment_variables():
         type="workflow",
         version="draft",
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account_id",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
 
     # Create some EnvironmentVariable instances
@@ -65,10 +112,10 @@ def test_llm_environment_variable_round_trip():
         type="workflow",
         version="draft",
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account_id",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
     variable = LLMEnvironmentVariable(
         name="for_research",
@@ -94,10 +141,10 @@ def test_update_environment_variables():
         type="workflow",
         version="draft",
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account_id",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
 
     # Create some EnvironmentVariable instances
@@ -147,10 +194,10 @@ def test_to_dict():
         type="workflow",
         version="draft",
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account_id",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
 
     # Create some EnvironmentVariable instances
@@ -188,10 +235,10 @@ def test_workflow_account_accessors_use_caller_session(sqlite_session: Session):
         type="workflow",
         version="draft",
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="created-account-id",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
         updated_by="updated-account-id",
     )
     sqlite_session.add_all([decoy_account, updated_account, workflow, created_account])
@@ -209,10 +256,10 @@ def test_workflow_tool_published_accessor_uses_caller_session(sqlite_session: Se
         type="workflow",
         version="draft",
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account_id",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
     matching_provider = WorkflowToolProvider(
         name="matching-provider",

--- a/api/tests/unit_tests/models/test_workflow_feature_compatibility.py
+++ b/api/tests/unit_tests/models/test_workflow_feature_compatibility.py
@@ -6,7 +6,7 @@ import json
 
 from pydantic import JsonValue
 
-from models import Workflow
+from models import Workflow, WorkflowType
 
 OLD_VERSION_WORKFLOW_FEATURES: dict[str, JsonValue] = {
     "file_upload": {
@@ -47,7 +47,7 @@ def test_workflow_features() -> None:
     workflow = Workflow(
         tenant_id="",
         app_id="",
-        type="",
+        type=WorkflowType.WORKFLOW,
         version="",
         graph="",
         _features=json.dumps(OLD_VERSION_WORKFLOW_FEATURES),

--- a/api/tests/unit_tests/models/test_workflow_feature_compatibility.py
+++ b/api/tests/unit_tests/models/test_workflow_feature_compatibility.py
@@ -50,10 +50,10 @@ def test_workflow_features() -> None:
         type="",
         version="",
         graph="",
-        features=json.dumps(OLD_VERSION_WORKFLOW_FEATURES),
+        _features=json.dumps(OLD_VERSION_WORKFLOW_FEATURES),
         created_by="",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
 
     assert workflow.features_dict == NEW_VERSION_WORKFLOW_FEATURES

--- a/api/tests/unit_tests/repositories/test_app_definition_query_repository.py
+++ b/api/tests/unit_tests/repositories/test_app_definition_query_repository.py
@@ -90,11 +90,11 @@ def test_get_published_parameter_config_returns_workflow_features_and_legacy_inp
             kind=WorkflowKind.STANDARD,
             version="1",
             graph=json.dumps({"nodes": [{"id": "start", "data": {"type": "start", "variables": [variable]}}]}),
-            features=json.dumps({"opening_statement": "Hello from workflow"}),
+            _features=json.dumps({"opening_statement": "Hello from workflow"}),
             created_by=_ACCOUNT_ID,
-            environment_variables=[],
-            conversation_variables=[],
-            rag_pipeline_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
+            _rag_pipeline_variables=[],
         )
         session.add(workflow)
         app.workflow_id = workflow.id
@@ -479,11 +479,11 @@ def test_get_tool_icon_sources_reads_workflow_tools(
                     ]
                 }
             ),
-            features="{}",
+            _features="{}",
             created_by=_ACCOUNT_ID,
-            environment_variables=[],
-            conversation_variables=[],
-            rag_pipeline_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
+            _rag_pipeline_variables=[],
         )
         session.add(workflow)
         app.workflow_id = workflow.id

--- a/api/tests/unit_tests/services/agent/test_agent_observability_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_observability_service.py
@@ -110,7 +110,7 @@ def _feedback(
 
 def _workflow_run(*, workflow_type: WorkflowType = WorkflowType.WORKFLOW) -> WorkflowRun:
     created_at = datetime(2026, 7, 21, 7, 0, 19)
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id="workflow-run-1",
         tenant_id="tenant-1",
         app_id="workflow-app-1",
@@ -128,9 +128,10 @@ def _workflow_run(*, workflow_type: WorkflowType = WorkflowType.WORKFLOW) -> Wor
         total_steps=1,
         created_by_role=CreatorUserRole.END_USER,
         created_by="end-user-1",
-        created_at=created_at,
         finished_at=created_at,
     )
+    workflow_run.created_at = created_at
+    return workflow_run
 
 
 def _node_execution(
@@ -139,7 +140,7 @@ def _node_execution(
     status: WorkflowNodeExecutionStatus = WorkflowNodeExecutionStatus.SUCCEEDED,
 ) -> WorkflowNodeExecutionModel:
     created_at = datetime(2026, 7, 23, 7, 0, 19, tzinfo=UTC)
-    return WorkflowNodeExecutionModel(
+    node_execution = WorkflowNodeExecutionModel(
         id=execution_id,
         tenant_id="tenant-1",
         app_id="workflow-app-1",
@@ -174,11 +175,12 @@ def _node_execution(
                 }
             }
         ),
-        created_at=created_at,
         created_by_role=CreatorUserRole.END_USER,
         created_by="end-user-1",
         finished_at=None,
     )
+    node_execution.created_at = created_at
+    return node_execution
 
 
 def _workflow_binding(

--- a/api/tests/unit_tests/services/agent/test_workflow_publish_service.py
+++ b/api/tests/unit_tests/services/agent/test_workflow_publish_service.py
@@ -30,10 +30,10 @@ def _workflow(*, workflow_id: str = "workflow-1", version: str = Workflow.VERSIO
         type=WorkflowType.WORKFLOW,
         version=version,
         graph={"nodes": [], "edges": []},
-        features={},
+        _features={},
         created_by="account-1",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
 
 

--- a/api/tests/unit_tests/services/rag_pipeline/test_pipeline_generate_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_pipeline_generate_service.py
@@ -45,7 +45,7 @@ def _make_workflow(*, workflow_id: str = "wf-1") -> Workflow:
         type=WorkflowType.RAG_PIPELINE,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="user-1",
     )
 

--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_dsl_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_dsl_service.py
@@ -84,11 +84,11 @@ def _workflow(session: Session, pipeline: Pipeline, *, graph: dict[str, Any] | N
         kind=WorkflowKind.STANDARD,
         version=Workflow.VERSION_DRAFT,
         graph=json.dumps(graph or {"nodes": [], "edges": []}),
-        features="{}",
+        _features="{}",
         created_by="account-1",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
     pipeline.workflow_id = workflow.id
     session.add(workflow)

--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_dsl_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_dsl_service.py
@@ -107,11 +107,11 @@ def _workflow_for_dependencies(
         kind=WorkflowKind.STANDARD,
         version=Workflow.VERSION_DRAFT,
         graph=json.dumps(graph),
-        features="{}",
+        _features="{}",
         created_by="account-1",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
     workflow.environment_variables = environment_variables or []
     return workflow

--- a/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
+++ b/api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_service.py
@@ -138,15 +138,15 @@ def _make_workflow(
         marked_name="",
         marked_comment="",
         graph=json.dumps(graph or {"nodes": []}),
-        features=json.dumps(features or {}),
+        _features=json.dumps(features or {}),
         created_by=created_by,
-        created_at=datetime(2024, 1, 1),
         updated_by=None,
-        updated_at=datetime(2024, 1, 1),
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=rag_pipeline_variables or [],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=rag_pipeline_variables or [],
     )
+    workflow.created_at = datetime(2024, 1, 1)
+    workflow.updated_at = datetime(2024, 1, 1)
     return workflow
 
 

--- a/api/tests/unit_tests/services/retention/workflow_run/test_restore_archived_workflow_run.py
+++ b/api/tests/unit_tests/services/retention/workflow_run/test_restore_archived_workflow_run.py
@@ -119,7 +119,9 @@ class WorkflowRunRestoreTestDataFactory:
             "exceptions_count": 0,
         }
         attrs.update(kwargs)
+        run_created_at = attrs.pop("created_at")
         run = WorkflowRun(**attrs)
+        run.created_at = run_created_at
         return run
 
     @staticmethod

--- a/api/tests/unit_tests/services/test_clear_free_plan_tenant_expired_logs.py
+++ b/api/tests/unit_tests/services/test_clear_free_plan_tenant_expired_logs.py
@@ -177,7 +177,7 @@ def _create_workflow_node_execution(
     node_id: str = "node-1",
 ) -> WorkflowNodeExecutionModel:
     """Create a real mapped node execution returned by the repository boundary."""
-    return WorkflowNodeExecutionModel(
+    execution = WorkflowNodeExecutionModel(
         id=execution_id,
         tenant_id="tenant-1",
         app_id="app-1",
@@ -198,16 +198,17 @@ def _create_workflow_node_execution(
         error=None,
         elapsed_time=0.1,
         execution_metadata="{}",
-        created_at=REAL_DATETIME(2026, 1, 1),
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-1",
         finished_at=REAL_DATETIME(2026, 1, 1, 0, 0, 1),
     )
+    execution.created_at = REAL_DATETIME(2026, 1, 1)
+    return execution
 
 
 def _create_workflow_run(run_id: str) -> WorkflowRun:
     """Create a real mapped workflow run returned by the repository boundary."""
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id=run_id,
         tenant_id="tenant-1",
         app_id="app-1",
@@ -225,10 +226,11 @@ def _create_workflow_run(run_id: str) -> WorkflowRun:
         total_steps=1,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-1",
-        created_at=REAL_DATETIME(2026, 1, 1),
         finished_at=REAL_DATETIME(2026, 1, 1, 0, 0, 1),
         exceptions_count=0,
     )
+    workflow_run.created_at = REAL_DATETIME(2026, 1, 1)
+    return workflow_run
 
 
 def _create_related_records(message_id: str) -> list[object]:

--- a/api/tests/unit_tests/services/test_snippet_generate_service.py
+++ b/api/tests/unit_tests/services/test_snippet_generate_service.py
@@ -21,11 +21,11 @@ def _workflow(graph: dict) -> Workflow:
         kind=WorkflowKind.SNIPPET,
         version=Workflow.VERSION_DRAFT,
         graph=json.dumps(graph),
-        features="{}",
+        _features="{}",
         created_by="account-1",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
 
 

--- a/api/tests/unit_tests/services/test_snippet_service.py
+++ b/api/tests/unit_tests/services/test_snippet_service.py
@@ -48,11 +48,11 @@ def _create_workflow(*, workflow_id: str, version: str, graph: dict, features: d
         kind=WorkflowKind.SNIPPET.value,
         version=version,
         graph=json.dumps(graph),
-        features=json.dumps(features),
+        _features=json.dumps(features),
         created_by="account-1",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
 
 

--- a/api/tests/unit_tests/services/test_snippet_service.py
+++ b/api/tests/unit_tests/services/test_snippet_service.py
@@ -852,11 +852,11 @@ def test_delete_snippet_keeps_agent_with_persisted_external_owner(
         type=WorkflowType.WORKFLOW,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account-1",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
     external_binding = WorkflowAgentNodeBinding(
         tenant_id=snippet.tenant_id,

--- a/api/tests/unit_tests/services/test_workflow_node_execution_trace_service.py
+++ b/api/tests/unit_tests/services/test_workflow_node_execution_trace_service.py
@@ -43,7 +43,7 @@ def _retry_attempt(retry_index: int, **overrides: object) -> dict[str, object]:
 
 
 def _execution(process_data: dict[str, object]) -> WorkflowNodeExecutionModel:
-    return WorkflowNodeExecutionModel(
+    execution = WorkflowNodeExecutionModel(
         id="exec-1",
         tenant_id="tenant-1",
         app_id="app-1",
@@ -64,11 +64,12 @@ def _execution(process_data: dict[str, object]) -> WorkflowNodeExecutionModel:
         error=None,
         elapsed_time=3.5,
         execution_metadata=json.dumps({"iteration_id": "iteration-1"}),
-        created_at=datetime(2023, 11, 14, tzinfo=UTC),
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-1",
         finished_at=datetime(2023, 11, 14, 0, 0, 4, tzinfo=UTC),
     )
+    execution.created_at = datetime(2023, 11, 14, tzinfo=UTC)
+    return execution
 
 
 def _repository(full_process_data: dict[str, object] | None) -> DifyAPIWorkflowNodeExecutionRepository:

--- a/api/tests/unit_tests/services/test_workflow_service.py
+++ b/api/tests/unit_tests/services/test_workflow_service.py
@@ -132,11 +132,11 @@ class TestWorkflowAssociatedDataFactory:
             type=workflow_type,
             version=version,
             graph=json.dumps(graph or {"nodes": [], "edges": []}),
-            features=json.dumps(features or {}),
+            _features=json.dumps(features or {}),
             created_by="user-123",
-            environment_variables=[],
-            conversation_variables=[],
-            rag_pipeline_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
+            _rag_pipeline_variables=[],
         )
         for key, value in kwargs.items():
             setattr(workflow, key, value)
@@ -804,11 +804,11 @@ class TestWorkflowService:
             type=WorkflowType.WORKFLOW,
             version="2026-03-19T00:00:00",
             graph=json.dumps(TestWorkflowAssociatedDataFactory.create_valid_workflow_graph()),
-            features=json.dumps(legacy_features),
+            _features=json.dumps(legacy_features),
             created_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
-            rag_pipeline_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
+            _rag_pipeline_variables=[],
         )
         draft_workflow = Workflow(
             id="draft-workflow-id",
@@ -817,11 +817,11 @@ class TestWorkflowService:
             type=WorkflowType.WORKFLOW,
             version=Workflow.VERSION_DRAFT,
             graph=json.dumps({"nodes": [], "edges": []}),
-            features=json.dumps({}),
+            _features=json.dumps({}),
             created_by=account.id,
-            environment_variables=[],
-            conversation_variables=[],
-            rag_pipeline_variables=[],
+            _environment_variables=[],
+            _conversation_variables=[],
+            _rag_pipeline_variables=[],
         )
         sqlite_session.add_all([source_workflow, draft_workflow])
         sqlite_session.commit()

--- a/api/tests/unit_tests/services/workflow/test_draft_var_loader_simple.py
+++ b/api/tests/unit_tests/services/workflow/test_draft_var_loader_simple.py
@@ -103,13 +103,13 @@ class TestDraftVarLoaderSimple:
         variable_file.upload_file = upload_file
 
         draft_var = WorkflowDraftVariable(
-            id="draft-var-id",
             node_id="test-node-id",
             name="test_object",
             description="test description",
             selector=json.dumps(["test-node-id", "test_object"]),
-            variable_file=variable_file,
         )
+        draft_var.id = "draft-var-id"
+        draft_var.variable_file = variable_file
 
         test_object = {"key1": "value1", "key2": 42}
         test_json_content = json.dumps(test_object, ensure_ascii=False, separators=(",", ":"))
@@ -132,9 +132,8 @@ class TestDraftVarLoaderSimple:
 
     def test_load_offloaded_variable_missing_variable_file_unit(self, draft_var_loader):
         """Test that assertion error is raised when variable_file is None."""
-        draft_var = WorkflowDraftVariable(
-            variable_file=None,
-        )
+        draft_var = WorkflowDraftVariable()
+        draft_var.variable_file = None
 
         with pytest.raises(AssertionError):
             draft_var_loader._load_offloaded_variable(draft_var)
@@ -152,9 +151,8 @@ class TestDraftVarLoaderSimple:
         )
         variable_file.upload_file = None
 
-        draft_var = WorkflowDraftVariable(
-            variable_file=variable_file,
-        )
+        draft_var = WorkflowDraftVariable()
+        draft_var.variable_file = variable_file
 
         with pytest.raises(AssertionError):
             draft_var_loader._load_offloaded_variable(draft_var)
@@ -199,13 +197,13 @@ class TestDraftVarLoaderSimple:
         variable_file.upload_file = upload_file
 
         draft_var = WorkflowDraftVariable(
-            id="draft-var-id",
             node_id="test-node-id",
             name="test_array",
             description="test array description",
             selector=json.dumps(["test-node-id", "test_array"]),
-            variable_file=variable_file,
         )
+        draft_var.id = "draft-var-id"
+        draft_var.variable_file = variable_file
 
         test_array = ["item1", 2, True]
         test_json_content = json.dumps(test_array)
@@ -251,12 +249,12 @@ class TestDraftVarLoaderSimple:
         variable_file.upload_file = upload_file
 
         draft_var = WorkflowDraftVariable(
-            id="draft-var-id",
             app_id="app-1",
             node_id="test-node-id",
             name="test_file",
             description="test file description",
         )
+        draft_var.id = "draft-var-id"
         draft_var._set_selector(["test-node-id", "test_file"])
         draft_var.variable_file = variable_file
 

--- a/api/tests/unit_tests/services/workflow/test_node_output_inspector_service.py
+++ b/api/tests/unit_tests/services/workflow/test_node_output_inspector_service.py
@@ -70,7 +70,7 @@ def _workflow_run(
     nodes: list[dict[str, Any]] | None = None,
     graph: str | None = None,
 ) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id=run_id,
         workflow_id=workflow_id,
         tenant_id=tenant_id,
@@ -88,9 +88,10 @@ def _workflow_run(
         total_steps=0,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-1",
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
         finished_at=None,
     )
+    workflow_run.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def _execution(
@@ -109,7 +110,7 @@ def _execution(
     workflow_id: str = "workflow-1",
     workflow_run_id: str = "run-1",
 ) -> WorkflowNodeExecutionModel:
-    return WorkflowNodeExecutionModel(
+    execution = WorkflowNodeExecutionModel(
         tenant_id=tenant_id,
         app_id=app_id,
         workflow_id=workflow_id,
@@ -128,11 +129,12 @@ def _execution(
         elapsed_time=0,
         execution_metadata=json.dumps(execution_metadata) if execution_metadata is not None else None,
         index=index,
-        created_at=created_at or datetime.now(UTC),
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-1",
         finished_at=finished_at,
     )
+    execution.created_at = created_at or datetime.now(UTC)
+    return execution
 
 
 def _agent_v2_node(*, node_id: str = "agent-node-1", title: str = "My Agent") -> dict[str, Any]:

--- a/api/tests/unit_tests/services/workflow/test_workflow_converter_additional.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_converter_additional.py
@@ -420,10 +420,10 @@ def test_convert_to_workflow_should_create_new_app_with_fallback_fields(
         type=WorkflowType.WORKFLOW,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="account-1",
-        environment_variables=[],
-        conversation_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
     )
     monkeypatch.setattr(converter, "convert_app_model_config_to_workflow", MagicMock(return_value=workflow))
     phase_events: list[str] = []

--- a/api/tests/unit_tests/services/workflow/test_workflow_draft_variable_service.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_draft_variable_service.py
@@ -503,7 +503,7 @@ class TestWorkflowDraftVariableService:
             assert variable.last_edited_at is None
             flush.assert_called()
             # Should return the updated variable
-            assert result == variable
+            assert result is variable
 
     def test_reset_non_editable_system_variable_raises_error(self, sqlite_session: Session):
         """Test that resetting a non-editable system variable raises an error"""
@@ -556,7 +556,7 @@ class TestWorkflowDraftVariableService:
             result = service._reset_node_var_or_sys_var(workflow, variable)
 
         # Should succeed and return the variable
-        assert result == variable
+        assert result is variable
         assert variable.last_edited_at is None
         flush.assert_called()
 
@@ -589,7 +589,7 @@ class TestWorkflowDraftVariableService:
             result = service._reset_node_var_or_sys_var(workflow, variable)
 
         # Should succeed and return the variable
-        assert result == variable
+        assert result is variable
         assert variable.last_edited_at is None
         flush.assert_called()
 

--- a/api/tests/unit_tests/services/workflow/test_workflow_event_snapshot_service.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_event_snapshot_service.py
@@ -83,7 +83,7 @@ class _FakePauseEntity(WorkflowPauseEntity):
 
 
 def _build_workflow_run(status: WorkflowExecutionStatus) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id="run-1",
         tenant_id="tenant-1",
         app_id="app-1",
@@ -101,8 +101,9 @@ def _build_workflow_run(status: WorkflowExecutionStatus) -> WorkflowRun:
         total_steps=0,
         created_by_role=CreatorUserRole.END_USER,
         created_by="user-1",
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
+    workflow_run.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def _build_snapshot(status: WorkflowNodeExecutionStatus) -> WorkflowNodeExecutionSnapshot:
@@ -208,7 +209,7 @@ def test_resolve_task_id_priority(context_task_id, buffered_task_id, expected) -
 
 
 def _build_workflow_run_additional(status: WorkflowExecutionStatus = WorkflowExecutionStatus.RUNNING) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id="run-1",
         tenant_id="tenant-1",
         app_id="app-1",
@@ -226,8 +227,9 @@ def _build_workflow_run_additional(status: WorkflowExecutionStatus = WorkflowExe
         total_steps=2,
         created_by_role=CreatorUserRole.END_USER,
         created_by="user-1",
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
+    workflow_run.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def _build_resumption_context_additional(task_id: str) -> WorkflowResumptionContext:

--- a/api/tests/unit_tests/services/workflow/test_workflow_event_snapshot_service_additional.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_event_snapshot_service_additional.py
@@ -33,7 +33,7 @@ from services.workflow_event_snapshot_service import BufferState, MessageContext
 
 
 def _build_workflow_run(status: WorkflowExecutionStatus = WorkflowExecutionStatus.RUNNING) -> WorkflowRun:
-    return WorkflowRun(
+    workflow_run = WorkflowRun(
         id="run-1",
         tenant_id="tenant-1",
         app_id="app-1",
@@ -51,8 +51,9 @@ def _build_workflow_run(status: WorkflowExecutionStatus = WorkflowExecutionStatu
         total_steps=2,
         created_by_role=CreatorUserRole.END_USER,
         created_by="user-1",
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
+    workflow_run.created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    return workflow_run
 
 
 def _build_resumption_context(task_id: str) -> WorkflowResumptionContext:

--- a/api/tests/unit_tests/services/workflow/test_workflow_restore.py
+++ b/api/tests/unit_tests/services/workflow/test_workflow_restore.py
@@ -47,11 +47,11 @@ def _create_workflow(*, workflow_id: str, version: str, features: dict[str, obje
         type="workflow",
         version=version,
         graph=json.dumps({"nodes": [], "edges": []}),
-        features=json.dumps(features),
+        _features=json.dumps(features),
         created_by="account-id",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
 
 

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -177,11 +177,11 @@ def _persist_app_and_workflow(session_factory: sessionmaker[Session]) -> None:
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="workflow-owner",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
     with session_factory.begin() as session:
         session.add_all([app, workflow])
@@ -208,11 +208,11 @@ def _persist_resumption_models(
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="workflow-owner",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
     workflow_run = WorkflowRun(
         id=workflow_run_id,

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -102,11 +102,11 @@ def _make_workflow(*, workflow_id: str = "workflow-id", app_id: str = "app-id") 
         type=WorkflowType.CHAT,
         version=Workflow.VERSION_DRAFT,
         graph="{}",
-        features="{}",
+        _features="{}",
         created_by="workflow-owner",
-        environment_variables=[],
-        conversation_variables=[],
-        rag_pipeline_variables=[],
+        _environment_variables=[],
+        _conversation_variables=[],
+        _rag_pipeline_variables=[],
     )
 
 


### PR DESCRIPTION
## Summary

- migrate `Workflow`, `WorkflowVersionCounter`, `WorkflowRun`, `WorkflowNodeExecutionModel`, and `WorkflowDraftVariable` to `TypeBase`
- preserve generated defaults and serialized variable behavior while adapting typed constructor call sites
- resolve the excluded offload model relationship across declarative registries and add focused mapper/default coverage

Refs #38564

## Validation

- `make lint`
- `./dev/pyrefly-check-local`
- `make test TARGET_TESTS="./api/tests/unit_tests/services/retention/workflow_run/test_restore_archived_workflow_run.py ./api/tests/unit_tests/services/test_workflow_service.py"` (178 passed)
- `make test` (14,764 passed, 4 skipped; controller suite 3,778 passed)

Docker-backed integration suites were not run.