### PR TITLE
refactor: migrate Dataset to TypeBase

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -163,7 +163,7 @@ from models.enums import PermissionEnum
 DatasetPermissionEnum = PermissionEnum
 
 
-class Dataset(Base):
+class Dataset(TypeBase, kw_only=True):
     __tablename__ = "datasets"
     __table_args__ = (
         sa.PrimaryKeyConstraint("id", name="dataset_pkey"),
@@ -176,41 +176,69 @@ class Dataset(Base):
     PROVIDER_LIST = ["vendor", "external", None]
     DOC_FORM_LIST = [member.value for member in IndexStructureType]
 
-    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    tenant_id: Mapped[str] = mapped_column(StringUUID)
-    name: Mapped[str] = mapped_column(String(255))
-    description = mapped_column(LongText, nullable=True)
-    provider: Mapped[str] = mapped_column(String(255), server_default=sa.text("'vendor'"))
-    permission: Mapped[DatasetPermissionEnum] = mapped_column(
+    id: Mapped[str] = mapped_column(
+        StringUUID,
+        insert_default=lambda: str(uuid4()),
+        default_factory=lambda: str(uuid4()),
+    )
+    tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False, default=cast(str, None))
+    name: Mapped[str] = mapped_column(String(255), nullable=False, default=cast(str, None))
+    description: Mapped[str | None] = mapped_column(LongText, nullable=True, default=None)
+    provider: Mapped[str] = mapped_column(
+        String(255), nullable=False, server_default=sa.text("'vendor'"), default=cast(str, None)
+    )
+    permission: Mapped[Any] = mapped_column(
         EnumText(DatasetPermissionEnum, length=255),
         server_default=sa.text("'only_me'"),
         default=DatasetPermissionEnum.ONLY_ME,
     )
-    data_source_type = mapped_column(EnumText(DataSourceType, length=255))
-    indexing_technique: Mapped[IndexTechniqueType | None] = mapped_column(EnumText(IndexTechniqueType, length=255))
-    index_struct = mapped_column(LongText, nullable=True)
-    created_by = mapped_column(StringUUID, nullable=False)
-    maintainer: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by = mapped_column(StringUUID, nullable=True)
-    updated_at = mapped_column(
-        sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+    data_source_type: Mapped[Any] = mapped_column(EnumText(DataSourceType, length=255), nullable=True, default=None)
+    indexing_technique: Mapped[Any] = mapped_column(
+        EnumText(IndexTechniqueType, length=255), nullable=True, default=None
     )
-    embedding_model = mapped_column(sa.String(255), nullable=True)
-    embedding_model_provider = mapped_column(sa.String(255), nullable=True)
-    keyword_number = mapped_column(sa.Integer, nullable=True, server_default=sa.text("10"))
-    collection_binding_id = mapped_column(StringUUID, nullable=True)
-    retrieval_model = mapped_column(AdjustedJSON, nullable=True)
-    summary_index_setting = mapped_column(AdjustedJSON, nullable=True)
-    built_in_field_enabled = mapped_column(sa.Boolean, nullable=False, server_default=sa.false())
-    icon_info = mapped_column(AdjustedJSON, nullable=True)
-    runtime_mode = mapped_column(
-        EnumText(DatasetRuntimeMode, length=255), nullable=True, server_default=sa.text("'general'")
+    index_struct: Mapped[Any] = mapped_column(LongText, nullable=True, default=None)
+    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False, default=cast(str, None))
+    maintainer: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.current_timestamp(), init=False
     )
-    pipeline_id = mapped_column(StringUUID, nullable=True)
-    chunk_structure = mapped_column(sa.String(255), nullable=True)
-    enable_api = mapped_column(sa.Boolean, nullable=False, server_default=sa.true())
-    is_multimodal = mapped_column(sa.Boolean, default=False, nullable=False, server_default=sa.false())
+    updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime,
+        nullable=False,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+        init=False,
+    )
+    embedding_model: Mapped[Any] = mapped_column(sa.String(255), nullable=True, default=None)
+    embedding_model_provider: Mapped[Any] = mapped_column(sa.String(255), nullable=True, default=None)
+    keyword_number: Mapped[Any] = mapped_column(sa.Integer, nullable=True, server_default=sa.text("10"), default=None)
+    collection_binding_id: Mapped[Any] = mapped_column(StringUUID, nullable=True, default=None)
+    retrieval_model: Mapped[Any] = mapped_column(AdjustedJSON, nullable=True, default=None)
+    summary_index_setting: Mapped[Any] = mapped_column(AdjustedJSON, nullable=True, default=None)
+    built_in_field_enabled: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, server_default=sa.false(), default=cast(bool, None)
+    )
+    icon_info: Mapped[Any] = mapped_column(AdjustedJSON, nullable=True, default=None)
+    runtime_mode: Mapped[Any] = mapped_column(
+        EnumText(DatasetRuntimeMode, length=255), nullable=True, server_default=sa.text("'general'"), default=None
+    )
+    pipeline_id: Mapped[Any] = mapped_column(StringUUID, nullable=True, default=None)
+    chunk_structure: Mapped[Any] = mapped_column(sa.String(255), nullable=True, default=None)
+    enable_api: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, server_default=sa.true(), default=cast(bool, None)
+    )
+    is_multimodal: Mapped[bool] = mapped_column(
+        sa.Boolean,
+        insert_default=False,
+        default=False,
+        nullable=False,
+        server_default=sa.false(),
+    )
+
+    @property
+    def total_documents(self) -> int:
+        return self.get_total_documents(session=db.session())
 
     def get_total_documents(self, *, session: Session) -> int:
         return self.get_document_count(session=session)

--- a/api/services/rag_pipeline/rag_pipeline_dsl_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_dsl_service.py
@@ -287,7 +287,7 @@ class RagPipelineDslService:
                         names = [dataset.name for dataset in datasets]
                         generate_name = generate_incremental_name(names, name)
                         dataset = Dataset(
-                            tenant_id=account.current_tenant_id,
+                            tenant_id=cast(str, account.current_tenant_id),
                             name=generate_name,
                             description=description,
                             icon_info={
@@ -429,7 +429,7 @@ class RagPipelineDslService:
                     knowledge_configuration = KnowledgeConfiguration.model_validate(node.get("data", {}))
                     if not dataset:
                         dataset = Dataset(
-                            tenant_id=account.current_tenant_id,
+                            tenant_id=cast(str, account.current_tenant_id),
                             name=name,
                             description=description,
                             icon_info={

--- a/api/services/rag_pipeline/rag_pipeline_transform_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_transform_service.py
@@ -311,7 +311,7 @@ class RagPipelineTransformService:
         pipeline = Pipeline(
             tenant_id=dataset.tenant_id,
             name=dataset.name,
-            description=dataset.description,
+            description=dataset.description or "",
             created_by=account_id,
         )
         session.add(pipeline)

--- a/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
@@ -159,9 +159,9 @@ class TestCleanDatasetTask:
             index_struct='{"type": "paragraph"}',
             collection_binding_id=str(uuid.uuid4()),
             created_by=account.id,
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
         )
+        dataset.created_at = datetime.now()
+        dataset.updated_at = datetime.now()
 
         db_session_with_containers.add(dataset)
         db_session_with_containers.commit()
@@ -905,9 +905,9 @@ class TestCleanDatasetTask:
             index_struct='{"type": "paragraph", "max_length": 10000}',
             collection_binding_id=str(uuid.uuid4()),
             created_by=account.id,
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
         )
+        dataset.created_at = datetime.now()
+        dataset.updated_at = datetime.now()
 
         db_session_with_containers.add(dataset)
         db_session_with_containers.commit()

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -114,7 +114,12 @@ def make_dataset(**overrides) -> Dataset:
         "is_multimodal": False,
     }
     base.update(overrides)
-    return Dataset(**base)
+    created_at = base.pop("created_at")
+    updated_at = base.pop("updated_at")
+    dataset = Dataset(**base)
+    dataset.created_at = created_at
+    dataset.updated_at = updated_at
+    return dataset
 
 
 def make_account(role: TenantAccountRole = TenantAccountRole.EDITOR) -> Account:

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -159,8 +159,8 @@ def test_trial_dataset_list_preserves_slim_dataset_fields(app: Flask, unbound_se
         data_source_type="upload_file",
         indexing_technique="high_quality",
         created_by="user-1",
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
+    dataset.created_at = datetime(2024, 1, 1, tzinfo=UTC)
     dataset.permission_keys = ["dataset.acl.readonly"]  # type: ignore[attr-defined]
     with (
         app.test_request_context("/?page=1&limit=20&ids=dataset-1"),

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
@@ -102,7 +102,11 @@ def make_dataset(
         "is_multimodal": False,
     }
     base.update(overrides)
-    dataset = Dataset(**base)
+    created_at = cast(datetime, base.pop("created_at"))
+    updated_at = cast(datetime, base.pop("updated_at"))
+    dataset = Dataset(**base)  # type: ignore[bad-argument-type]
+    dataset.created_at = created_at
+    dataset.updated_at = updated_at
     session.add(dataset)
     session.flush()
     return dataset

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import UTC, datetime
 from inspect import unwrap
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator_missing.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator_missing.py
@@ -44,13 +44,12 @@ def _model_manager() -> tuple[MagicMock, MagicMock]:
     return model_manager, model_instance
 
 
-def _dataset(*, dataset_id: str, tenant_id: str, name: str, created_at: datetime) -> Dataset:
+def _dataset(*, dataset_id: str, tenant_id: str, name: str) -> Dataset:
     return Dataset(
         id=dataset_id,
         tenant_id=tenant_id,
         name=name,
         created_by="account-id",
-        created_at=created_at,
     )
 
 

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -24,6 +24,7 @@ from core.rag.index_processor.constant.index_type import IndexStructureType, Ind
 from extensions.storage.storage_type import StorageType
 from models import dataset as dataset_module
 from models.account import Account
+from models.base import Base, TypeBase
 from models.dataset import (
     AppDatasetJoin,
     ChildChunk,
@@ -129,6 +130,16 @@ def _make_segments(document: Document, hit_counts: list[int]) -> list[DocumentSe
 
 class TestDatasetModelValidation:
     """Test suite for Dataset model validation and basic operations."""
+
+    def test_dataset_uses_typebase_registry_and_generates_ids(self):
+        generated_dataset = Dataset()
+        another_dataset = Dataset()
+        explicit_id = str(uuid4())
+
+        assert Dataset.__mapper__.registry is TypeBase.registry
+        assert Dataset.__mapper__.registry is not Base.registry
+        assert generated_dataset.id != another_dataset.id
+        assert Dataset(id=explicit_id).id == explicit_id
 
     def test_dataset_creation_with_required_fields(self):
         """Test creating a dataset with all required fields."""

--- a/api/tests/unit_tests/services/dataset_service_test_helpers.py
+++ b/api/tests/unit_tests/services/dataset_service_test_helpers.py
@@ -183,7 +183,6 @@ class DatasetServiceUnitDataFactory:
             chunk_structure=doc_form,
             enable_api=enable_api,
             updated_by=None,
-            updated_at=None,
             summary_index_setting=summary_index_setting,
             **kwargs,
         )


### PR DESCRIPTION
## Summary

- migrate Dataset from Base to TypeBase while preserving its legacy staged-construction behavior
- complete mapped annotations and keep database nullability/server defaults unchanged
- move database-managed timestamp values out of constructor call sites
- add registry and generated-ID coverage

Document remains on Base and is intentionally excluded from this change.

Related to #38564.

## Validation

- make test TARGET_TESTS="./api/tests/unit_tests/models/test_dataset_models.py" (61 passed)
- make test TARGET_TESTS="./api/tests/unit_tests/services/test_dataset_service_dataset.py" (82 passed)
- make test TARGET_TESTS="./api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py" (18 passed)
- make test TARGET_TESTS="./api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_dsl_service.py ./api/tests/unit_tests/services/rag_pipeline/test_rag_pipeline_transform_service.py" (73 passed)
- make lint
- ./dev/pyrefly-check-local

The full unit-test suite and Docker-backed integration suites were not run per request.