### PR TITLE
refactor: migrate CustomizedSnippet to TypeBase

### DIFF
--- a/api/models/snippet.py
+++ b/api/models/snippet.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import Sequence
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
 import sqlalchemy as sa
 from sqlalchemy import DateTime, String, func
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, Session, mapped_column
 from libs.uuid_utils import uuidv7
 
 from .account import Account
-from .base import Base
+from .base import TypeBase
 from .model import Tag, TagBinding
 from .types import AdjustedJSON, LongText, StringUUID
 
@@ -23,7 +23,7 @@ class SnippetType(StrEnum):
     GROUP = "group"
 
 
-class CustomizedSnippet(Base):
+class CustomizedSnippet(TypeBase, kw_only=True):
     """
     Customized Snippet Model
 
@@ -37,32 +37,50 @@ class CustomizedSnippet(Base):
         sa.Index("customized_snippet_tenant_idx", "tenant_id"),
     )
 
-    id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuidv7()))
-    tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    description: Mapped[str | None] = mapped_column(LongText, nullable=True)
-    type: Mapped[str] = mapped_column(String(50), nullable=False, server_default=sa.text("'node'"))
+    id: Mapped[str] = mapped_column(
+        StringUUID,
+        insert_default=lambda: str(uuidv7()),
+        default_factory=lambda: str(uuidv7()),
+    )
+    tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False, default=cast(str, None))
+    name: Mapped[str] = mapped_column(String(255), nullable=False, default=cast(str, None))
+    description: Mapped[str | None] = mapped_column(LongText, nullable=True, default=None)
+    type: Mapped[str] = mapped_column(
+        String(50), nullable=False, server_default=sa.text("'node'"), default=cast(str, None)
+    )
 
     # Workflow reference for published version
-    workflow_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
+    workflow_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
 
     # State flags
-    is_published: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.false())
-    version: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default=sa.text("1"))
-    use_count: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default=sa.text("0"))
+    is_published: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, server_default=sa.false(), default=cast(bool, None)
+    )
+    version: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default=sa.text("1"), default=cast(int, None)
+    )
+    use_count: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default=sa.text("0"), default=cast(int, None)
+    )
 
     # Visual customization
-    icon_info: Mapped[dict | None] = mapped_column(AdjustedJSON, nullable=True)
+    icon_info: Mapped[dict[str, Any] | None] = mapped_column(AdjustedJSON, nullable=True, default=None)
 
     # Snippet configuration (stored as JSON text)
-    input_fields: Mapped[str | None] = mapped_column(LongText, nullable=True)
+    input_fields: Mapped[str | None] = mapped_column(LongText, nullable=True, default=None)
 
     # Audit fields
-    created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.current_timestamp(), init=False
+    )
+    updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+        DateTime,
+        nullable=False,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+        init=False,
     )
 
     def get_graph_dict(self, *, session: Session) -> dict[str, Any]:

--- a/api/services/snippet_dsl_service.py
+++ b/api/services/snippet_dsl_service.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from typing import cast
 from urllib.parse import urlparse
 
 import yaml
@@ -432,7 +433,7 @@ class SnippetDslService:
         else:
             # Create new snippet
             snippet = CustomizedSnippet(
-                tenant_id=account.current_tenant_id,
+                tenant_id=cast(str, account.current_tenant_id),
                 name=snippet_name,
                 description=snippet_description,
                 type=snippet_type.value,

--- a/api/tests/unit_tests/fields/test_snippet_fields.py
+++ b/api/tests/unit_tests/fields/test_snippet_fields.py
@@ -34,10 +34,10 @@ def test_snippet_list_fields_include_author_name(sqlite_session: Session) -> Non
         is_published=False,
         icon_info=None,
         created_by="account-1",
-        created_at=datetime.fromtimestamp(1704067200, tz=UTC),
         updated_by="account-1",
-        updated_at=datetime.fromtimestamp(1704067201, tz=UTC),
     )
+    snippet.created_at = datetime.fromtimestamp(1704067200, tz=UTC)
+    snippet.updated_at = datetime.fromtimestamp(1704067201, tz=UTC)
     sqlite_session.add_all([account, snippet])
     sqlite_session.flush()
 
@@ -68,7 +68,7 @@ def populated_snippet(sqlite_session: Session) -> CustomizedSnippet:
     sqlite_session.add_all((workflow, author, editor, tag, binding))
     sqlite_session.commit()
 
-    return CustomizedSnippet(
+    snippet = CustomizedSnippet(
         id=SNIPPET_ID,
         tenant_id=TENANT_ID,
         name="Snippet",
@@ -82,9 +82,10 @@ def populated_snippet(sqlite_session: Session) -> CustomizedSnippet:
         input_fields=json.dumps([{"variable": "query"}]),
         created_by=ACCOUNT_1_ID,
         updated_by=ACCOUNT_2_ID,
-        created_at=datetime.fromtimestamp(1704067200, tz=UTC),
-        updated_at=datetime.fromtimestamp(1704067201, tz=UTC),
     )
+    snippet.created_at = datetime.fromtimestamp(1704067200, tz=UTC)
+    snippet.updated_at = datetime.fromtimestamp(1704067201, tz=UTC)
+    return snippet
 
 
 def test_snippet_response_resolves_fields_from_the_given_session(

--- a/api/tests/unit_tests/models/test_snippet.py
+++ b/api/tests/unit_tests/models/test_snippet.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from models import snippet as snippet_module
 from models.account import Account
+from models.base import Base, TypeBase
 from models.enums import TagType
 from models.model import Tag, TagBinding
 from models.snippet import CustomizedSnippet
@@ -17,6 +18,16 @@ APP_ID = "33333333-3333-3333-3333-333333333333"
 SNIPPET_ID = "44444444-4444-4444-4444-444444444444"
 ACCOUNT_1_ID = "55555555-5555-5555-5555-555555555555"
 ACCOUNT_2_ID = "55555555-5555-5555-5555-555555555556"
+
+
+def test_customized_snippet_uses_typebase_registry_and_generates_ids() -> None:
+    snippet = CustomizedSnippet()
+    another_snippet = CustomizedSnippet()
+
+    assert CustomizedSnippet.__mapper__.registry is TypeBase.registry
+    assert CustomizedSnippet.__mapper__.registry is not Base.registry
+    assert snippet.id != another_snippet.id
+    assert CustomizedSnippet(id=SNIPPET_ID).id == SNIPPET_ID
 
 
 def test_get_graph_dict_returns_empty_without_workflow_id(sqlite_session: Session) -> None:


### PR DESCRIPTION
## Summary

- migrate CustomizedSnippet from Base to TypeBase
- preserve staged and explicit-ID construction while retaining database defaults
- mark database-managed timestamps as constructor-excluded
- add registry and generated-ID coverage

Related to #38564.

## Validation

- make test TARGET_TESTS="./api/tests/unit_tests/models/test_snippet.py ./api/tests/unit_tests/services/test_snippet_service.py ./api/tests/unit_tests/services/test_snippet_dsl_service.py ./api/tests/unit_tests/services/test_snippet_generate_service.py" (100 passed)
- make test TARGET_TESTS="./api/tests/unit_tests/controllers/console/snippets ./api/tests/unit_tests/controllers/console/workspace/test_snippets.py" (59 passed)
- make lint
- ./dev/pyrefly-check-local

The full unit-test suite was not run per request.