### PR TITLE
refactor: pass db.session explicitly in instruction_modify_workflow (#37403)

### DIFF
--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -409,6 +409,7 @@ class InstructionGenerateApi(Resource):
                     model_config=req_data.model_config_data,
                     ideal_output=req_data.ideal_output,
                     workflow_service=WorkflowService(),
+                    session=session,
                 )
             return {"error": "incompatible parameters"}, 400
         except ProviderTokenNotInitError as ex:

--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -707,9 +707,8 @@ class LLMGenerator:
         model_config: ModelConfig,
         ideal_output: str | None,
         workflow_service: WorkflowServiceInterface,
+        session: Session,
     ):
-        session = db.session()
-
         app: App | None = session.scalar(select(App).where(App.id == flow_id, App.tenant_id == tenant_id).limit(1))
         if not app:
             raise ValueError("App not found.")

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -647,6 +647,7 @@ class TestLLMGenerator:
                 model_config_entity,
                 "ideal",
                 workflow_service,
+                session=database,
             )
 
     def test_instruction_modify_workflow_rejects_app_from_another_tenant(
@@ -668,6 +669,7 @@ class TestLLMGenerator:
                 model_config_entity,
                 "ideal",
                 workflow_service,
+                session=database,
             )
 
     def test_instruction_modify_workflow_requires_draft_workflow(
@@ -689,6 +691,7 @@ class TestLLMGenerator:
                 model_config_entity,
                 "ideal",
                 workflow_service,
+                session=database,
             )
 
     def test_instruction_modify_workflow_uses_last_run(
@@ -718,6 +721,7 @@ class TestLLMGenerator:
             model_config_entity,
             "ideal",
             workflow_service,
+            session=database,
         )
 
         assert result == {"modified": "workflow"}
@@ -746,6 +750,7 @@ class TestLLMGenerator:
             model_config_entity,
             "ideal",
             workflow_service,
+            session=database,
         )
 
         assert result == {"modified": "workflow"}
@@ -781,6 +786,7 @@ class TestLLMGenerator:
             model_config_entity,
             "ideal",
             workflow_service,
+            session=database,
         )
 
         assert result == {"modified": "fallback"}
@@ -805,6 +811,7 @@ class TestLLMGenerator:
             model_config_entity,
             "ideal",
             workflow_service,
+            session=database,
         )
 
         assert result == {"modified": "workflow"}


### PR DESCRIPTION
## Summary

Part of the ongoing session-injection refactor tracked in #37403. This slice targets `LLMGenerator.instruction_modify_workflow` in `api/core/llm_generator/llm_generator.py`.

Instead of calling `db.session()` internally, the method now receives an explicit `session: Session` parameter from its caller (`InstructionGenerateApi.post` in `api/controllers/console/app/generator.py`), which already has a session available from `@with_session`.

This follows the same pattern as the example PRs #37402 and #40370.

## Changes

- `api/core/llm_generator/llm_generator.py`: add `session: Session` parameter to `instruction_modify_workflow`; drop internal `db.session()` call.
- `api/controllers/console/app/generator.py`: pass `session=session` at the call site.
- `api/tests/unit_tests/core/llm_generator/test_llm_generator.py`: update the 7 call sites to pass `session=database`.

## Verification

- `pytest tests/unit_tests/core/llm_generator/test_llm_generator.py` → 47 passed
- `pytest tests/unit_tests/controllers/console/app/test_generator_api.py` → 28 passed
- `pyrefly` on the two changed source files → clean
- `mypy` on the two changed source files → no issues
- `ruff` → all checks passed

No behavioral change; this is a pure dependency-injection refactor for testability, matching the `#37403` pattern.