### PR TITLE
fix(api/controllers): cap ChildChunk content length to 16384 chars (#40825)

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 from typing import Annotated, Any, Literal, override
 from uuid import UUID
 
-from libs.helper import UUIDStrOrEmpty
 from pydantic import BaseModel, Field, GetJsonSchemaHandler, WithJsonSchema, model_validator
+
+from libs.helper import UUIDStrOrEmpty
 
 # --- Conversation schemas ---
 

--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -2,9 +2,8 @@ from copy import deepcopy
 from typing import Annotated, Any, Literal, override
 from uuid import UUID
 
-from pydantic import BaseModel, Field, GetJsonSchemaHandler, WithJsonSchema, model_validator
-
 from libs.helper import UUIDStrOrEmpty
+from pydantic import BaseModel, Field, GetJsonSchemaHandler, WithJsonSchema, model_validator
 
 # --- Conversation schemas ---
 
@@ -182,13 +181,27 @@ class WorkflowUpdatePayload(BaseModel):
 
 DOCUMENT_BATCH_DOWNLOAD_ZIP_MAX_DOCS = 100
 
+# Cap on the size of a single child chunk's text content. Generous relative to the
+# default child chunk size (~1024 tokens ≈ 4096 chars at ~4 chars/token) and the
+# existing 10000-char "very long content" test, but bounded to prevent embedding
+# cost / latency / DB-row-size abuse from a single oversized API call.
+CHILD_CHUNK_CONTENT_MAX_LENGTH = 16384
+
 
 class ChildChunkCreatePayload(BaseModel):
-    content: str = Field(description="Child chunk text content.")
+    content: str = Field(
+        ...,
+        max_length=CHILD_CHUNK_CONTENT_MAX_LENGTH,
+        description="Child chunk text content.",
+    )
 
 
 class ChildChunkUpdatePayload(BaseModel):
-    content: str = Field(description="Child chunk text content.")
+    content: str = Field(
+        ...,
+        max_length=CHILD_CHUNK_CONTENT_MAX_LENGTH,
+        description="Child chunk text content.",
+    )
 
 
 class DocumentBatchDownloadZipPayload(BaseModel):

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -19,9 +19,6 @@ import uuid
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from flask import Flask
-from werkzeug.exceptions import NotFound
-
 from controllers.service_api.dataset.segment import (
     ChildChunkApi,
     ChildChunkCreatePayload,
@@ -35,10 +32,12 @@ from controllers.service_api.dataset.segment import (
     SegmentListQuery,
 )
 from core.rag.index_processor.constant.index_type import IndexStructureType
+from flask import Flask
 from libs.datetime_utils import naive_utc_now
 from models.dataset import ChildChunk, Dataset, Document, DocumentSegment
 from models.enums import IndexingStatus, SegmentType
 from services.dataset_service import DocumentService, SegmentService
+from werkzeug.exceptions import NotFound
 
 
 def _session_factory_mock():
@@ -225,6 +224,20 @@ class TestChildChunkCreatePayload:
         payload = ChildChunkCreatePayload(content=long_content)
         assert len(payload.content) == 10000
 
+    def test_payload_accepts_content_at_max_length(self):
+        """Content at exactly the cap (16384 chars) is accepted."""
+        from controllers.common.controller_schemas import CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+        payload = ChildChunkCreatePayload(content="A" * CHILD_CHUNK_CONTENT_MAX_LENGTH)
+        assert len(payload.content) == CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+    def test_payload_rejects_content_above_max_length(self):
+        """Content one char above the cap is rejected with a validation error."""
+        from controllers.common.controller_schemas import CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+        with pytest.raises(ValueError):
+            ChildChunkCreatePayload.model_validate({"content": "A" * (CHILD_CHUNK_CONTENT_MAX_LENGTH + 1)})
+
     def test_payload_with_unicode_content(self):
         """Test payload with unicode content."""
         unicode_content = "这是中文内容 🎉 Привет мир"
@@ -287,6 +300,20 @@ class TestChildChunkUpdatePayload:
         """Test payload with empty content."""
         payload = ChildChunkUpdatePayload(content="")
         assert payload.content == ""
+
+    def test_payload_accepts_content_at_max_length(self):
+        """Content at exactly the cap (16384 chars) is accepted."""
+        from controllers.common.controller_schemas import CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+        payload = ChildChunkUpdatePayload(content="A" * CHILD_CHUNK_CONTENT_MAX_LENGTH)
+        assert len(payload.content) == CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+    def test_payload_rejects_content_above_max_length(self):
+        """Content one char above the cap is rejected with a validation error."""
+        from controllers.common.controller_schemas import CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+        with pytest.raises(ValueError):
+            ChildChunkUpdatePayload.model_validate({"content": "A" * (CHILD_CHUNK_CONTENT_MAX_LENGTH + 1)})
 
 
 class TestSegmentServiceInterface:

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -19,6 +19,9 @@ import uuid
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from flask import Flask
+from werkzeug.exceptions import NotFound
+
 from controllers.service_api.dataset.segment import (
     ChildChunkApi,
     ChildChunkCreatePayload,
@@ -32,12 +35,10 @@ from controllers.service_api.dataset.segment import (
     SegmentListQuery,
 )
 from core.rag.index_processor.constant.index_type import IndexStructureType
-from flask import Flask
 from libs.datetime_utils import naive_utc_now
 from models.dataset import ChildChunk, Dataset, Document, DocumentSegment
 from models.enums import IndexingStatus, SegmentType
 from services.dataset_service import DocumentService, SegmentService
-from werkzeug.exceptions import NotFound
 
 
 def _session_factory_mock():

--- a/packages/contracts/generated/api/console/datasets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/zod.gen.ts
@@ -217,14 +217,14 @@ export const zSegmentUpdatePayload = z.object({
  * ChildChunkCreatePayload
  */
 export const zChildChunkCreatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**
  * ChildChunkUpdatePayload
  */
 export const zChildChunkUpdatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -186,7 +186,7 @@ export const zChatRequestPayloadWithUser = z.object({
  * ChildChunkCreatePayload
  */
 export const zChildChunkCreatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**
@@ -234,7 +234,7 @@ export const zChildChunkListResponse = z.object({
  * ChildChunkUpdatePayload
  */
 export const zChildChunkUpdatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**


### PR DESCRIPTION
## Summary

Add a `max_length=16384` to `ChildChunkCreatePayload.content` and
`ChildChunkUpdatePayload.content` in `api/controllers/common/controller_schemas.py`,
plus boundary tests covering 16,384 (accepted) and 16,385 (rejected) for both
Pydantic models.

Closes #40825.

## Why

`ChildChunkCreatePayload.content` and `ChildChunkUpdatePayload.content` were
unbounded Pydantic strings, so a single service-API or console call could
hand an arbitrary-size `content` to the embedding model. Adjacent to the
`max_length` gap flagged in #39825 (TTS text), but sharper for child chunks
because:

- **Cost.** Embedding is metered (e.g. OpenAI `text-embedding-3-small` is per
  token). A multi-MB `content` produces a multi-MB embedding bill that lands
  on the tenant owner, even when the calling service-API client isn't
  authorised to spend that much.
- **Latency.** A long child chunk is embedded in one round-trip and ties up
  Celery worker capacity for the duration of the embedding call.
- **DB write amplification.** `child_chunks.content` is `LongText` (unbounded);
  a single oversized row skews the table's average row size and bloats
  backups.
- **Retrieval quality.** A child chunk much larger than the configured
  `chunk_size` defeats the parent-child chunking design.

## What changed

- One new module-level constant `CHILD_CHUNK_CONTENT_MAX_LENGTH = 16384` in
  `api/controllers/common/controller_schemas.py`, named in the same style as
  the adjacent `DOCUMENT_BATCH_DOWNLOAD_ZIP_MAX_DOCS = 100`.
- `max_length=CHILD_CHUNK_CONTENT_MAX_LENGTH` added to the `content` field on
  both `ChildChunkCreatePayload` and `ChildChunkUpdatePayload`.
- Two new boundary tests per model (one accept at the cap, one reject one
  over) in `api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py`,
  inside the existing `TestChildChunkCreatePayload` and `TestChildChunkUpdatePayload`
  classes.

The cap of 16,384 is chosen to be:

- well above the default child chunk size (~1024 tokens ≈ 4,096 chars at
  ~4 chars/token), so no real child chunk is rejected;
- ~1.6× the existing 10,000-char "very long content" test at
  `test_dataset_segment.py:222-226`, which still passes after this change.

## Test plan

- `ChildChunkCreatePayload.model_validate({"content": "A" * 16384})` succeeds.
- `ChildChunkCreatePayload.model_validate({"content": "A" * 16385})` raises
  `ValidationError`.
- `ChildChunkUpdatePayload.model_validate({"content": "A" * 16384})` succeeds.
- `ChildChunkUpdatePayload.model_validate({"content": "A" * 16385})` raises
  `ValidationError`.
- The existing 10,000-char "very long content" test (and the empty-content
  update test) still pass.
- `ruff check --config api/.ruff.toml` is clean on the two touched files
  (verified locally).

## Scope notes

Out of scope, as the issue notes:

- `MessageFeedbackPayload.content`, `ConversationRenamePayload.name`,
  `MetadataUpdatePayload.name` (same pattern, separate issues).
- Parent chunk (`Segment`) length limits.
- Embedding-side chunking policy in `core/rag/index_processor/`.

## Chore

While running `ruff check` with the project's `api/.ruff.toml` config on the
two touched files, the linter flagged two pre-existing `I001` import-sort
warnings (one per file) that already existed on `main`. I let
`ruff check --fix` tidy them so the new diff doesn't introduce any lint
errors. Happy to split that into a separate commit/PR if you'd prefer.

## Checklist

- [x] One new module-level constant + two `max_length` field args
- [x] Four new boundary tests (two per model) in the existing test classes
- [x] No migration, no schema change, no behaviour change for in-range inputs
- [x] `ruff check` clean on the two touched files
