### PR TITLE
refactor(web): replace setState-in-useEffect with adjusting-state-while-rendering

### DIFF
--- a/web/app/components/base/chat/chat/answer/workflow-process.tsx
+++ b/web/app/components/base/chat/chat/answer/workflow-process.tsx
@@ -1,6 +1,6 @@
 import type { ChatItem, WorkflowProcess } from '../../types'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import TracingPanel from '@/app/components/workflow/run/tracing-panel'
 import { WorkflowRunningStatus } from '@/app/components/workflow/types'
@@ -21,7 +21,12 @@ const WorkflowProcessItem = ({
   readonly = false,
 }: WorkflowProcessProps) => {
   const { t } = useTranslation()
+  const [prevExpand, setPrevExpand] = useState(expand)
   const [collapse, setCollapse] = useState(!expand)
+  if (prevExpand !== expand) {
+    setPrevExpand(expand)
+    setCollapse(!expand)
+  }
   const running = data.status === WorkflowRunningStatus.Running
   const succeeded = data.status === WorkflowRunningStatus.Succeeded
   const failed =
@@ -41,10 +46,6 @@ const WorkflowProcessItem = ({
   const collapsedTitle = failed
     ? data.error || latestNode?.error || latestNode?.title || fallbackTitle
     : latestNode?.title || fallbackTitle
-
-  useEffect(() => {
-    setCollapse(!expand)
-  }, [expand])
 
   if (readonly) return null
 

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
@@ -20,7 +20,12 @@ const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => 
   const linkOperatorShow = useStore((s) => s.linkOperatorShow)
   const setLinkAnchorElement = useStore((s) => s.setLinkAnchorElement)
   const setLinkOperatorShow = useStore((s) => s.setLinkOperatorShow)
+  const [prevSelectedLinkUrl, setPrevSelectedLinkUrl] = useState(selectedLinkUrl)
   const [url, setUrl] = useState(selectedLinkUrl)
+  if (prevSelectedLinkUrl !== selectedLinkUrl) {
+    setPrevSelectedLinkUrl(selectedLinkUrl)
+    setUrl(selectedLinkUrl)
+  }
   const floatingRef = useRef<HTMLDivElement | null>(null)
   const { refs, floatingStyles, elements } = useFloating({
     placement: 'top',
@@ -40,10 +45,6 @@ const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => 
   useClickAway(() => {
     handleCancelLinkEdit()
   }, [floatingRef, linkAnchorElement])
-
-  useEffect(() => {
-    setUrl(selectedLinkUrl)
-  }, [selectedLinkUrl])
 
   useEffect(() => {
     if (linkAnchorElement) refs.setReference(linkAnchorElement)


### PR DESCRIPTION
## Summary

Fixes #25194

Two components called a `useState` setter directly inside a `useEffect` to re-sync state when an external value changed. This pattern triggers `@eslint-react/hooks-extra-no-direct-set-state-in-use-effect` and causes an unnecessary extra render cycle.

**`workflow-process.tsx`** — `setCollapse(!expand)` fired in a `useEffect([expand])` to reset collapse state when the parent passed a new `expand` prop.

**`link-editor-plugin/component.tsx`** — `setUrl(selectedLinkUrl)` fired in a `useEffect([selectedLinkUrl])` to reset the input when the selected link in the store changed.

Both are replaced with React's recommended "adjusting state while rendering" pattern: track the previous external value in a `prev*` state variable, and call the setter synchronously during render when the value differs. This avoids the extra render cycle and is the correct idiomatic fix per the React docs (https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).

## Test plan

- [x] `vitest run` on `workflow-process.spec.tsx` — 14 tests pass
- [x] `vitest run` on `link-editor-plugin/__tests__/component.spec.tsx` — 3 tests pass
- [x] `vitest run` on `workflow-body.spec.tsx` (imports `WorkflowProcessItem`) — 2 tests pass
- [x] `git diff HEAD` reviewed — only intended lines changed, no debug statements