### PR TITLE
fix(web): keep Add model dialog footer visible when form overflows (cherry-pick #35490)

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -298,15 +298,15 @@ const ModelModal: FC<ModelModalProps> = ({
     <Dialog open onOpenChange={handleOpenChange}>
       <DialogContent
         backdropProps={{ forceRender: true }}
-        className="w-[640px] max-w-[640px] overflow-hidden p-0"
+        className="flex w-[640px] max-w-[640px] flex-col overflow-hidden p-0"
       >
         <DialogCloseButton className="right-5 top-5 h-8 w-8" />
-        <div className="p-6 pb-3">
+        <div className="shrink-0 p-6 pb-3">
           {modalTitle}
           {modalDesc}
           {modalModel}
         </div>
-        <div className="max-h-[calc(100vh-320px)] overflow-y-auto px-6 py-3">
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
           {
             mode === ModelModalModeEnum.configCustomModel && (
               <AuthForm
@@ -375,7 +375,7 @@ const ModelModal: FC<ModelModalProps> = ({
             )
           }
         </div>
-        <div className="flex justify-between p-6 pt-5">
+        <div className="flex shrink-0 justify-between p-6 pt-5">
           {
             (provider.help && (provider.help.title || provider.help.url))
               ? (
@@ -419,7 +419,7 @@ const ModelModal: FC<ModelModalProps> = ({
         </div>
         {
           (mode === ModelModalModeEnum.configCustomModel || mode === ModelModalModeEnum.configProviderCredential) && (
-            <div className="border-t-[0.5px] border-t-divider-regular">
+            <div className="shrink-0 border-t-[0.5px] border-t-divider-regular">
               <div className="flex items-center justify-center rounded-b-2xl bg-background-section-burn py-3 text-xs text-text-tertiary">
                 <Lock01 className="mr-1 h-3 w-3 text-text-tertiary" />
                 {t('modelProvider.encrypted.front', { ns: 'common' })}


### PR DESCRIPTION
Cherry-pick of #35490 to LTS 1.13.x branch.

## Summary
The Add model dialog's Save/Add button and encryption notice were being clipped off-screen when the form grew tall (notably when selecting the `LLM` model type via an OpenAI-API-compatible provider, which renders more fields than `Text Embedding` or `Rerank`). Switches the dialog to a flex column so the footer stays pinned and the form region scrolls within the popup's height budget.

Related: Linear ESQ1-247

## Conflict note
`web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx` had one conflicting line (`DialogCloseButton` className ordering) caused by unrelated Tailwind class-sort drift between this branch and `main` — that line was never touched by #35490. Resolved by keeping this branch's existing class order and taking only the PR's actual changes (the four `shrink-0`/`flex-1`/`min-h-0` hunks).

(cherry picked from commit 491061b8f427981c280d5da8329dcbf225988de3)