### PR TITLE
refactor(web): migrate endpoint mutations to generated contracts

### DIFF
--- a/web/service/__tests__/use-endpoints.spec.tsx
+++ b/web/service/__tests__/use-endpoints.spec.tsx
@@ -1,0 +1,139 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { renderHook } from '@/test/console/render'
+import {
+  useCreateEndpoint,
+  useDeleteEndpoint,
+  useDisableEndpoint,
+  useEnableEndpoint,
+  useUpdateEndpoint,
+} from '../use-endpoints'
+
+const { mockCreate, mockDelete, mockDisable, mockEnable, mockLegacyPost, mockUpdate } = vi.hoisted(
+  () => ({
+    mockCreate: vi.fn(),
+    mockDelete: vi.fn(),
+    mockDisable: vi.fn(),
+    mockEnable: vi.fn(),
+    mockLegacyPost: vi.fn(),
+    mockUpdate: vi.fn(),
+  }),
+)
+
+vi.mock('@/service/base', () => ({
+  get: vi.fn(),
+  post: mockLegacyPost,
+}))
+
+vi.mock('@/service/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/service/client')>()
+  return {
+    ...actual,
+    consoleClient: {
+      workspaces: {
+        current: {
+          endpoints: {
+            post: mockCreate,
+            byId: {
+              delete: mockDelete,
+              patch: mockUpdate,
+            },
+            disable: { post: mockDisable },
+            enable: { post: mockEnable },
+          },
+        },
+      },
+    },
+  }
+})
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('endpoint mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates an endpoint through the generated collection contract without mutating form state', async () => {
+    mockCreate.mockResolvedValue({ success: true })
+    const state = { name: 'My endpoint', api_key: 'secret' }
+    const { result } = renderHook(() => useCreateEndpoint({}), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ pluginUniqueID: 'plugin-1@1.0.0', state })
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      body: {
+        name: 'My endpoint',
+        plugin_unique_identifier: 'plugin-1@1.0.0',
+        settings: { api_key: 'secret' },
+      },
+    })
+    expect(state).toEqual({ name: 'My endpoint', api_key: 'secret' })
+    expect(mockLegacyPost).not.toHaveBeenCalled()
+  })
+
+  it('updates an endpoint through the generated item contract without mutating form state', async () => {
+    mockUpdate.mockResolvedValue({ success: true })
+    const state = { name: 'Renamed endpoint', region: 'us-east' }
+    const { result } = renderHook(() => useUpdateEndpoint({}), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ endpointID: 'endpoint-1', state })
+    })
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      params: { id: 'endpoint-1' },
+      body: {
+        name: 'Renamed endpoint',
+        settings: { region: 'us-east' },
+      },
+    })
+    expect(state).toEqual({ name: 'Renamed endpoint', region: 'us-east' })
+    expect(mockLegacyPost).not.toHaveBeenCalled()
+  })
+
+  it('routes endpoint state changes through their generated contracts', async () => {
+    mockDelete.mockResolvedValue({ success: true })
+    mockDisable.mockResolvedValue({ success: true })
+    mockEnable.mockResolvedValue({ success: true })
+    const { result } = renderHook(
+      () => ({
+        deleteEndpoint: useDeleteEndpoint({}),
+        disableEndpoint: useDisableEndpoint({}),
+        enableEndpoint: useEnableEndpoint({}),
+      }),
+      { wrapper: createWrapper() },
+    )
+
+    await act(async () => {
+      await result.current.deleteEndpoint.mutateAsync('endpoint-1')
+      await result.current.disableEndpoint.mutateAsync('endpoint-2')
+      await result.current.enableEndpoint.mutateAsync('endpoint-3')
+    })
+
+    expect(mockDelete).toHaveBeenCalledWith({ params: { id: 'endpoint-1' } })
+    expect(mockDisable).toHaveBeenCalledWith({ body: { endpoint_id: 'endpoint-2' } })
+    expect(mockEnable).toHaveBeenCalledWith({ body: { endpoint_id: 'endpoint-3' } })
+    expect(mockLegacyPost).not.toHaveBeenCalled()
+  })
+})

--- a/web/service/use-endpoints.ts
+++ b/web/service/use-endpoints.ts
@@ -1,8 +1,11 @@
 import type { EndpointsResponse } from '@/app/components/plugins/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { get, post } from './base'
+import { get } from './base'
+import { consoleClient, consoleQuery } from './client'
 
 const NAME_SPACE = 'endpoints'
+const endpointContract = consoleQuery.workspaces.current.endpoints
+const endpointClient = consoleClient.workspaces.current.endpoints
 
 export const useEndpointList = (pluginID: string) => {
   return useQuery({
@@ -35,16 +38,15 @@ export const useCreateEndpoint = ({
   onError?: (error: any) => void
 }) => {
   return useMutation({
-    mutationKey: [NAME_SPACE, 'create'],
+    mutationKey: endpointContract.post.mutationKey(),
     mutationFn: (payload: { pluginUniqueID: string; state: Record<string, any> }) => {
       const { pluginUniqueID, state } = payload
-      const newName = state.name
-      delete state.name
-      return post('/workspaces/current/endpoints/create', {
+      const { name, ...settings } = state
+      return endpointClient.post({
         body: {
           plugin_unique_identifier: pluginUniqueID,
-          settings: state,
-          name: newName,
+          settings,
+          name,
         },
       })
     },
@@ -61,16 +63,17 @@ export const useUpdateEndpoint = ({
   onError?: (error: any) => void
 }) => {
   return useMutation({
-    mutationKey: [NAME_SPACE, 'update'],
+    mutationKey: endpointContract.byId.patch.mutationKey(),
     mutationFn: (payload: { endpointID: string; state: Record<string, any> }) => {
       const { endpointID, state } = payload
-      const newName = state.name
-      delete state.name
-      return post('/workspaces/current/endpoints/update', {
+      const { name, ...settings } = state
+      return endpointClient.byId.patch({
+        params: {
+          id: endpointID,
+        },
         body: {
-          endpoint_id: endpointID,
-          settings: state,
-          name: newName,
+          settings,
+          name,
         },
       })
     },
@@ -87,11 +90,11 @@ export const useDeleteEndpoint = ({
   onError?: (error: any) => void
 }) => {
   return useMutation({
-    mutationKey: [NAME_SPACE, 'delete'],
+    mutationKey: endpointContract.byId.delete.mutationKey(),
     mutationFn: (endpointID: string) => {
-      return post('/workspaces/current/endpoints/delete', {
-        body: {
-          endpoint_id: endpointID,
+      return endpointClient.byId.delete({
+        params: {
+          id: endpointID,
         },
       })
     },
@@ -108,9 +111,9 @@ export const useEnableEndpoint = ({
   onError?: (error: any) => void
 }) => {
   return useMutation({
-    mutationKey: [NAME_SPACE, 'enable'],
+    mutationKey: endpointContract.enable.post.mutationKey(),
     mutationFn: (endpointID: string) => {
-      return post('/workspaces/current/endpoints/enable', {
+      return endpointClient.enable.post({
         body: {
           endpoint_id: endpointID,
         },
@@ -129,9 +132,9 @@ export const useDisableEndpoint = ({
   onError?: (error: any) => void
 }) => {
   return useMutation({
-    mutationKey: [NAME_SPACE, 'disable'],
+    mutationKey: endpointContract.disable.post.mutationKey(),
     mutationFn: (endpointID: string) => {
-      return post('/workspaces/current/endpoints/disable', {
+      return endpointClient.disable.post({
         body: {
           endpoint_id: endpointID,
         },


### PR DESCRIPTION
## Summary

- Migrate the five endpoint mutations in `web/service/use-endpoints.ts` from handwritten REST helpers to generated `consoleClient` contracts.
- Use the canonical collection/item routes for create, update, and delete while preserving the existing enable/disable behavior and callbacks.
- Keep caller-owned form state immutable when separating the endpoint name from settings.
- Add focused hook tests that exercise the public mutation API and verify requests at the network boundary.

The endpoint list query remains handwritten because its generated response currently omits the pagination fields represented by the existing frontend response type.

Part of #38351

## Screenshots

Not applicable. This is a service-layer refactor with no UI changes.

## Validation

- `vp test run service/__tests__/use-endpoints.spec.tsx` (3 tests passed)
- `vp check web/service/use-endpoints.ts web/service/__tests__/use-endpoints.spec.tsx` (no formatting, lint, or type errors)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the relevant frontend tests and Vite+ checks.

From Codex
