### PR TITLE
fix(web): let multimodal guidance height fit content

### DIFF
--- a/web/app/components/datasets/common/multimodal-retrieval-guidance/tip-card.tsx
+++ b/web/app/components/datasets/common/multimodal-retrieval-guidance/tip-card.tsx
@@ -25,7 +25,7 @@ const renderDescription = (description: string): ReactNode => {
 
 export const TipCard = ({ title, description, dismissLabel, onDismiss }: TipCardProps) => {
   return (
-    <div className="relative flex min-h-[110px] gap-3 overflow-hidden rounded-xl border border-divider-regular bg-linear-to-b from-components-chat-input-audio-bg-alt to-components-chat-input-audio-bg py-3 pr-0.75 pl-3 shadow-xs">
+    <div className="relative flex gap-3 overflow-hidden rounded-xl border border-divider-regular bg-linear-to-b from-components-chat-input-audio-bg-alt to-components-chat-input-audio-bg py-3 pr-0.75 pl-3 shadow-xs">
       <div className="relative size-9 shrink-0">
         <img
           src={PictureFrame.src}


### PR DESCRIPTION
## Summary

Fix the multimodal retrieval guidance tip card height for shorter localized copy.

The previous card used a fixed minimum height, which made short copy such as Chinese and Japanese leave unnecessary vertical whitespace. This change lets the card height follow its content while preserving the existing padding, spacing, and all copy.

## Details

- Remove the fixed `min-h-[110px]` from the multimodal retrieval guidance tip card.
- Keep all locale strings unchanged.
- Keep long-language behavior adaptive: longer translations can still wrap and expand the card naturally.

## Test Plan

- `vp fmt --check web/app/components/datasets/common/multimodal-retrieval-guidance/tip-card.tsx`
- `vp test run app/components/datasets/common/multimodal-retrieval-guidance/__tests__/index.spec.tsx`
- `vp exec tsx ./scripts/check-i18n.js`
- Checked locale description lengths across all `dataset-settings` locales to confirm the fix targets short-copy height while preserving long-copy wrapping.
- Started local dev server with `pnpm dev`; verified `http://localhost:3000/` responds with the expected auth redirect.
