### PR TITLE
test: keep integration config overrides typed

### DIFF
--- a/api/tests/unit_tests/enums/test_quota_type.py
+++ b/api/tests/unit_tests/enums/test_quota_type.py
@@ -21,28 +21,23 @@ class TestQuotaType:
 
 
 class TestQuotaService:
-    def test_reserve_outside_cloud_edition(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService"),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    @pytest.fixture(autouse=True)
+    def _cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+
+    def test_reserve_outside_cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        with patch("services.billing_service.BillingService"):
             charge = QuotaService.reserve(QuotaType.TRIGGER, "t1")
             assert charge.success is True
             assert charge.charge_id is None
 
     def test_reserve_zero_amount_raises(self):
-        with patch("services.quota_service.dify_config") as mock_cfg:
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            with pytest.raises(ValueError, match="greater than 0"):
-                QuotaService.reserve(QuotaType.TRIGGER, "t1", amount=0)
+        with pytest.raises(ValueError, match="greater than 0"):
+            QuotaService.reserve(QuotaType.TRIGGER, "t1", amount=0)
 
     def test_reserve_success(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.return_value = {"reservation_id": "rid-1", "available": 99}
 
             charge = QuotaService.reserve(QuotaType.TRIGGER, "t1", amount=1)
@@ -57,11 +52,7 @@ class TestQuotaService:
     def test_reserve_no_reservation_id_raises(self):
         from services.errors.app import QuotaExceededError
 
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.return_value = {}
 
             with pytest.raises(QuotaExceededError):
@@ -70,22 +61,14 @@ class TestQuotaService:
     def test_reserve_quota_exceeded_propagates(self):
         from services.errors.app import QuotaExceededError
 
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.side_effect = QuotaExceededError(feature="trigger", tenant_id="t1", required=1)
 
             with pytest.raises(QuotaExceededError):
                 QuotaService.reserve(QuotaType.TRIGGER, "t1")
 
     def test_reserve_api_exception_returns_unlimited(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.side_effect = RuntimeError("network")
 
             charge = QuotaService.reserve(QuotaType.TRIGGER, "t1")
@@ -93,11 +76,7 @@ class TestQuotaService:
             assert charge.charge_id is None
 
     def test_consume_calls_reserve_and_commit(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.return_value = {"reservation_id": "rid-c"}
             mock_bs.quota_commit.return_value = {}
 
@@ -105,73 +84,43 @@ class TestQuotaService:
             assert charge.success is True
             mock_bs.quota_commit.assert_called_once()
 
-    def test_check_outside_cloud_edition(self):
-        with patch("services.quota_service.dify_config") as mock_cfg:
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            assert QuotaService.check(QuotaType.TRIGGER, "t1") is True
+    def test_check_outside_cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        assert QuotaService.check(QuotaType.TRIGGER, "t1") is True
 
     def test_check_zero_amount_raises(self):
-        with patch("services.quota_service.dify_config") as mock_cfg:
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            with pytest.raises(ValueError, match="greater than 0"):
-                QuotaService.check(QuotaType.TRIGGER, "t1", amount=0)
+        with pytest.raises(ValueError, match="greater than 0"):
+            QuotaService.check(QuotaType.TRIGGER, "t1", amount=0)
 
     def test_check_sufficient_quota(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", return_value=100),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", return_value=100):
             assert QuotaService.check(QuotaType.TRIGGER, "t1", amount=50) is True
 
     def test_check_insufficient_quota(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", return_value=5),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", return_value=5):
             assert QuotaService.check(QuotaType.TRIGGER, "t1", amount=10) is False
 
     def test_check_unlimited_quota(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", return_value=-1),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", return_value=-1):
             assert QuotaService.check(QuotaType.TRIGGER, "t1", amount=999) is True
 
     def test_check_exception_returns_true(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", side_effect=RuntimeError),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", side_effect=RuntimeError):
             assert QuotaService.check(QuotaType.TRIGGER, "t1") is True
 
-    def test_release_outside_cloud_edition(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    def test_release_outside_cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        with patch("services.billing_service.BillingService") as mock_bs:
             QuotaService.release(QuotaType.TRIGGER, "rid-1", "t1", "trigger_event")
             mock_bs.quota_release.assert_not_called()
 
     def test_release_empty_reservation(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             QuotaService.release(QuotaType.TRIGGER, "", "t1", "trigger_event")
             mock_bs.quota_release.assert_not_called()
 
     def test_release_success(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_release.return_value = {}
             QuotaService.release(QuotaType.TRIGGER, "rid-1", "t1", "trigger_event")
             mock_bs.quota_release.assert_called_once_with(
@@ -179,11 +128,7 @@ class TestQuotaService:
             )
 
     def test_release_exception_swallowed(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_release.side_effect = RuntimeError("fail")
             QuotaService.release(QuotaType.TRIGGER, "rid-1", "t1", "trigger_event")
 

--- a/api/tests/unit_tests/extensions/storage/test_supabase_storage.py
+++ b/api/tests/unit_tests/extensions/storage/test_supabase_storage.py
@@ -10,105 +10,81 @@ from extensions.storage.supabase_storage import SupabaseStorage
 class TestSupabaseStorage:
     """Test suite for SupabaseStorage class."""
 
+    @pytest.fixture(autouse=True)
+    def _supabase_config(self, config_overrides) -> None:
+        config_overrides(
+            SUPABASE_URL="https://test.supabase.co",
+            SUPABASE_API_KEY="test-api-key",
+            SUPABASE_BUCKET_NAME="test-bucket",
+        )
+
     def test_init_success_with_all_config(self):
         """Test successful initialization when all required config is provided."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            # Mock bucket_exists to return True so create_bucket is not called
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
+                storage = SupabaseStorage()
 
-                # Mock bucket_exists to return True so create_bucket is not called
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
-                    storage = SupabaseStorage()
+                assert storage.bucket_name == "test-bucket"
+                mock_client_class.assert_called_once_with(
+                    supabase_url="https://test.supabase.co", supabase_key="test-api-key"
+                )
 
-                    assert storage.bucket_name == "test-bucket"
-                    mock_client_class.assert_called_once_with(
-                        supabase_url="https://test.supabase.co", supabase_key="test-api-key"
-                    )
-
-    def test_init_raises_error_when_url_missing(self):
+    def test_init_raises_error_when_url_missing(self, config_overrides):
         """Test initialization raises ValueError when SUPABASE_URL is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = None
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        config_overrides(SUPABASE_URL=None)
+        with pytest.raises(ValueError, match="SUPABASE_URL is not set"):
+            SupabaseStorage()
 
-            with pytest.raises(ValueError, match="SUPABASE_URL is not set"):
-                SupabaseStorage()
-
-    def test_init_raises_error_when_api_key_missing(self):
+    def test_init_raises_error_when_api_key_missing(self, config_overrides):
         """Test initialization raises ValueError when SUPABASE_API_KEY is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = None
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        config_overrides(SUPABASE_API_KEY=None)
+        with pytest.raises(ValueError, match="SUPABASE_API_KEY is not set"):
+            SupabaseStorage()
 
-            with pytest.raises(ValueError, match="SUPABASE_API_KEY is not set"):
-                SupabaseStorage()
-
-    def test_init_raises_error_when_bucket_name_missing(self):
+    def test_init_raises_error_when_bucket_name_missing(self, config_overrides):
         """Test initialization raises ValueError when SUPABASE_BUCKET_NAME is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = None
-
-            with pytest.raises(ValueError, match="SUPABASE_BUCKET_NAME is not set"):
-                SupabaseStorage()
+        config_overrides(SUPABASE_BUCKET_NAME=None)
+        with pytest.raises(ValueError, match="SUPABASE_BUCKET_NAME is not set"):
+            SupabaseStorage()
 
     def test_create_bucket_when_not_exists(self):
         """Test create_bucket creates bucket when it doesn't exist."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=False):
+                SupabaseStorage()
 
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=False):
-                    storage = SupabaseStorage()
-
-                    mock_client.storage.create_bucket.assert_called_once_with(id="test-bucket", name="test-bucket")
+                mock_client.storage.create_bucket.assert_called_once_with(id="test-bucket", name="test-bucket")
 
     def test_create_bucket_when_exists(self):
         """Test create_bucket does not create bucket when it already exists."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
+                SupabaseStorage()
 
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
-                    storage = SupabaseStorage()
-
-                    mock_client.storage.create_bucket.assert_not_called()
+                mock_client.storage.create_bucket.assert_not_called()
 
     @pytest.fixture
     def storage_with_mock_client(self):
         """Fixture providing SupabaseStorage with mocked client."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
-
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
-                    storage = SupabaseStorage()
-                    # Create fresh mock for each test
-                    mock_client.reset_mock()
-                    yield storage, mock_client
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
+                storage = SupabaseStorage()
+                # Create fresh mock for each test
+                mock_client.reset_mock()
+                yield storage, mock_client
 
     def test_save(self, storage_with_mock_client):
         """Test save calls client.storage.from_(bucket).upload(path, data)."""
@@ -210,63 +186,48 @@ class TestSupabaseStorage:
 
     def test_bucket_exists_returns_true_when_bucket_found(self):
         """Test bucket_exists returns True when bucket is found in list."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            mock_bucket = Mock()
+            mock_bucket.name = "test-bucket"
+            mock_client.storage.list_buckets.return_value = [mock_bucket]
+            storage = SupabaseStorage()
+            result = storage.bucket_exists()
 
-                mock_bucket = Mock()
-                mock_bucket.name = "test-bucket"
-                mock_client.storage.list_buckets.return_value = [mock_bucket]
-                storage = SupabaseStorage()
-                result = storage.bucket_exists()
-
-                assert result is True
-                assert mock_client.storage.list_buckets.call_count >= 1
+            assert result is True
+            assert mock_client.storage.list_buckets.call_count >= 1
 
     def test_bucket_exists_returns_false_when_bucket_not_found(self):
         """Test bucket_exists returns False when bucket is not found in list."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            # Mock different bucket
+            mock_bucket = Mock()
+            mock_bucket.name = "different-bucket"
+            mock_client.storage.list_buckets.return_value = [mock_bucket]
+            mock_client.storage.create_bucket = Mock()
 
-                # Mock different bucket
-                mock_bucket = Mock()
-                mock_bucket.name = "different-bucket"
-                mock_client.storage.list_buckets.return_value = [mock_bucket]
-                mock_client.storage.create_bucket = Mock()
+            storage = SupabaseStorage()
+            result = storage.bucket_exists()
 
-                storage = SupabaseStorage()
-                result = storage.bucket_exists()
-
-                assert result is False
-                assert mock_client.storage.list_buckets.call_count >= 1
+            assert result is False
+            assert mock_client.storage.list_buckets.call_count >= 1
 
     def test_bucket_exists_returns_false_when_no_buckets(self):
         """Test bucket_exists returns False when no buckets exist."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            mock_client.storage.list_buckets.return_value = []
+            mock_client.storage.create_bucket = Mock()
 
-                mock_client.storage.list_buckets.return_value = []
-                mock_client.storage.create_bucket = Mock()
+            storage = SupabaseStorage()
+            result = storage.bucket_exists()
 
-                storage = SupabaseStorage()
-                result = storage.bucket_exists()
-
-                assert result is False
-                assert mock_client.storage.list_buckets.call_count >= 1
+            assert result is False
+            assert mock_client.storage.list_buckets.call_count >= 1

--- a/api/tests/unit_tests/extensions/test_redis.py
+++ b/api/tests/unit_tests/extensions/test_redis.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
 from redis import RedisError
 from redis.retry import Retry
 
@@ -14,16 +15,30 @@ from extensions.ext_redis import (
 )
 
 
-class TestGetConnectionHealthParams:
-    @patch("extensions.ext_redis.dify_config")
-    def test_includes_all_health_params(self, mock_config):
-        mock_config.REDIS_RETRY_RETRIES = 3
-        mock_config.REDIS_RETRY_BACKOFF_BASE = 1.0
-        mock_config.REDIS_RETRY_BACKOFF_CAP = 10.0
-        mock_config.REDIS_SOCKET_TIMEOUT = 5.0
-        mock_config.REDIS_SOCKET_CONNECT_TIMEOUT = 5.0
-        mock_config.REDIS_HEALTH_CHECK_INTERVAL = 30
+@pytest.fixture(autouse=True)
+def _redis_config(config_overrides) -> None:
+    config_overrides(
+        REDIS_USERNAME=None,
+        REDIS_PASSWORD=None,
+        REDIS_DB=0,
+        REDIS_SERIALIZATION_PROTOCOL=3,
+        REDIS_ENABLE_CLIENT_SIDE_CACHE=False,
+        REDIS_RETRY_RETRIES=3,
+        REDIS_RETRY_BACKOFF_BASE=1.0,
+        REDIS_RETRY_BACKOFF_CAP=10.0,
+        REDIS_SOCKET_TIMEOUT=5.0,
+        REDIS_SOCKET_CONNECT_TIMEOUT=5.0,
+        REDIS_HEALTH_CHECK_INTERVAL=30,
+        REDIS_KEEPALIVE=True,
+        REDIS_KEEPALIVE_IDLE=60,
+        REDIS_KEEPALIVE_INTERVAL=10,
+        REDIS_KEEPALIVE_COUNT=3,
+        REDIS_KEY_PREFIX="",
+    )
 
+
+class TestGetConnectionHealthParams:
+    def test_includes_all_health_params(self):
         params = _get_connection_health_params()
 
         assert "retry" in params
@@ -38,15 +53,7 @@ class TestGetConnectionHealthParams:
 
 
 class TestGetClusterConnectionHealthParams:
-    @patch("extensions.ext_redis.dify_config")
-    def test_excludes_health_check_interval(self, mock_config):
-        mock_config.REDIS_RETRY_RETRIES = 3
-        mock_config.REDIS_RETRY_BACKOFF_BASE = 1.0
-        mock_config.REDIS_RETRY_BACKOFF_CAP = 10.0
-        mock_config.REDIS_SOCKET_TIMEOUT = 5.0
-        mock_config.REDIS_SOCKET_CONNECT_TIMEOUT = 5.0
-        mock_config.REDIS_HEALTH_CHECK_INTERVAL = 30
-
+    def test_excludes_health_check_interval(self):
         params = _get_cluster_connection_health_params()
 
         assert "retry" in params
@@ -56,24 +63,7 @@ class TestGetClusterConnectionHealthParams:
 
 
 class TestGetBaseRedisParams:
-    @patch("extensions.ext_redis.dify_config")
-    def test_includes_retry_and_health_params(self, mock_config):
-        mock_config.REDIS_USERNAME = None
-        mock_config.REDIS_PASSWORD = None
-        mock_config.REDIS_DB = 0
-        mock_config.REDIS_SERIALIZATION_PROTOCOL = 3
-        mock_config.REDIS_ENABLE_CLIENT_SIDE_CACHE = False
-        mock_config.REDIS_RETRY_RETRIES = 3
-        mock_config.REDIS_RETRY_BACKOFF_BASE = 1.0
-        mock_config.REDIS_RETRY_BACKOFF_CAP = 10.0
-        mock_config.REDIS_SOCKET_TIMEOUT = 5.0
-        mock_config.REDIS_SOCKET_CONNECT_TIMEOUT = 5.0
-        mock_config.REDIS_HEALTH_CHECK_INTERVAL = 30
-        mock_config.REDIS_KEEPALIVE = True
-        mock_config.REDIS_KEEPALIVE_IDLE = 60
-        mock_config.REDIS_KEEPALIVE_INTERVAL = 10
-        mock_config.REDIS_KEEPALIVE_COUNT = 3
-
+    def test_includes_retry_and_health_params(self):
         params = _get_base_redis_params()
 
         assert "retry" in params
@@ -149,86 +139,74 @@ class TestRedisKeyPrefixHelpers:
 
 
 class TestRedisClientWrapperKeyPrefix:
-    def test_wrapper_get_prefixes_string_keys(self):
+    def test_wrapper_get_prefixes_string_keys(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.get("oauth_state:abc")
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.get("oauth_state:abc")
 
         mock_client.get.assert_called_once_with("enterprise-a:oauth_state:abc")
 
-    def test_wrapper_delete_prefixes_multiple_keys(self):
+    def test_wrapper_delete_prefixes_multiple_keys(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.delete("key:a", "key:b")
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.delete("key:a", "key:b")
 
         mock_client.delete.assert_called_once_with("enterprise-a:key:a", "enterprise-a:key:b")
 
-    def test_wrapper_lock_prefixes_lock_name(self):
+    def test_wrapper_lock_prefixes_lock_name(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.lock("resource-lock", timeout=10)
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.lock("resource-lock", timeout=10)
 
         mock_client.lock.assert_called_once()
         args, kwargs = mock_client.lock.call_args
         assert args == ("enterprise-a:resource-lock",)
         assert kwargs["timeout"] == 10
 
-    def test_wrapper_hash_operations_prefix_key_name(self):
+    def test_wrapper_hash_operations_prefix_key_name(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.hset("hash:key", "field", "value")
-            wrapper.hgetall("hash:key")
-            wrapper.hkeys("hash:key")
-            wrapper.hexists("hash:key", "field")
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.hset("hash:key", "field", "value")
+        wrapper.hgetall("hash:key")
+        wrapper.hkeys("hash:key")
+        wrapper.hexists("hash:key", "field")
 
         mock_client.hset.assert_called_once_with("enterprise-a:hash:key", "field", "value")
         mock_client.hgetall.assert_called_once_with("enterprise-a:hash:key")
         mock_client.hkeys.assert_called_once_with("enterprise-a:hash:key")
         mock_client.hexists.assert_called_once_with("enterprise-a:hash:key", "field")
 
-    def test_wrapper_zadd_prefixes_sorted_set_name(self):
+    def test_wrapper_zadd_prefixes_sorted_set_name(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.zadd("zset:key", {"member": 1})
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.zadd("zset:key", {"member": 1})
 
         mock_client.zadd.assert_called_once()
         args, kwargs = mock_client.zadd.call_args
         assert args == ("enterprise-a:zset:key", {"member": 1})
         assert kwargs["nx"] is False
 
-    def test_wrapper_preserves_keys_when_prefix_is_empty(self):
+    def test_wrapper_preserves_keys_when_prefix_is_empty(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "   "
-
-            wrapper.get("plain:key")
+        config_overrides(REDIS_KEY_PREFIX="   ")
+        wrapper.get("plain:key")
 
         mock_client.get.assert_called_once_with("plain:key")

--- a/api/tests/unit_tests/libs/test_passport.py
+++ b/api/tests/unit_tests/libs/test_passport.py
@@ -12,18 +12,16 @@ class TestPassportService:
     """Test PassportService JWT operations"""
 
     @pytest.fixture
-    def passport_service(self):
+    def passport_service(self, config_overrides):
         """Create PassportService instance with test secret key"""
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "test-secret-key-for-testing"
-            return PassportService()
+        config_overrides(SECRET_KEY="test-secret-key-for-testing")
+        return PassportService()
 
     @pytest.fixture
-    def another_passport_service(self):
+    def another_passport_service(self, config_overrides):
         """Create another PassportService instance with different secret key"""
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "another-secret-key-for-testing"
-            return PassportService()
+        config_overrides(SECRET_KEY="another-secret-key-for-testing")
+        return PassportService()
 
     # Core functionality tests
     def test_should_issue_and_verify_token(self, passport_service):
@@ -98,10 +96,8 @@ class TestPassportService:
         payload = {"user_id": "123"}
 
         # Create token with different algorithm
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "test-secret-key-for-testing"
-            # Create token with HS512 instead of HS256
-            wrong_alg_token = jwt.encode(payload, mock_config.SECRET_KEY, algorithm="HS512")
+        # Create token with HS512 instead of HS256
+        wrong_alg_token = jwt.encode(payload, "test-secret-key-for-testing", algorithm="HS512")
 
         # Should fail because service expects HS256
         # InvalidAlgorithmError is now caught by PyJWTError handler
@@ -134,20 +130,17 @@ class TestPassportService:
         past_time = datetime.now(UTC) - timedelta(hours=1)
         payload = {"user_id": "123", "exp": past_time.timestamp()}
 
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "test-secret-key-for-testing"
-            token = jwt.encode(payload, mock_config.SECRET_KEY, algorithm="HS256")
+        token = jwt.encode(payload, "test-secret-key-for-testing", algorithm="HS256")
 
         with pytest.raises(Unauthorized) as exc_info:
             passport_service.verify(token)
         assert str(exc_info.value) == "401 Unauthorized: Token has expired."
 
     # Configuration tests
-    def test_should_use_configured_secret_key_without_policy_validation(self):
+    def test_should_use_configured_secret_key_without_policy_validation(self, config_overrides):
         """Test that policy decisions are owned by config, not PassportService."""
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "configured"
-            service = PassportService()
+        config_overrides(SECRET_KEY="configured")
+        service = PassportService()
 
         assert service.sk == "configured"
 

--- a/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
@@ -55,6 +55,15 @@ def plugin_db() -> Iterator[Session]:
             yield session
 
 
+@pytest.fixture(autouse=True)
+def _plugin_config(config_overrides) -> None:
+    config_overrides(
+        CONSOLE_API_URL="https://console.example.com",
+        MARKETPLACE_ENABLED=True,
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+    )
+
+
 class TestFetchLatestPluginVersion:
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.redis_client")
@@ -200,10 +209,7 @@ class TestCheckPluginInstallationScope:
 
 
 class TestGetPluginIconUrl:
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_constructs_url_with_params(self, mock_config):
-        mock_config.CONSOLE_API_URL = "https://console.example.com"
-
+    def test_constructs_url_with_params(self):
         url = PluginService.get_plugin_icon_url("tenant-1", "icon.svg")
 
         assert "tenant_id=tenant-1" in url
@@ -245,26 +251,20 @@ class TestIsPluginVerified:
 
 
 class TestUpgradePluginWithMarketplace:
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_raises_when_marketplace_disabled(self, mock_config):
-        mock_config.MARKETPLACE_ENABLED = False
+    def test_raises_when_marketplace_disabled(self, config_overrides):
+        config_overrides(MARKETPLACE_ENABLED=False)
 
         with pytest.raises(ValueError, match="marketplace is not enabled"):
             PluginService.upgrade_plugin_with_marketplace("t1", "old-uid", "new-uid")
 
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_raises_when_same_identifier(self, mock_config):
-        mock_config.MARKETPLACE_ENABLED = True
-
+    def test_raises_when_same_identifier(self):
         with pytest.raises(ValueError, match="same plugin"):
             PluginService.upgrade_plugin_with_marketplace("t1", "same-uid", "same-uid")
 
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_skips_download_when_already_installed(self, mock_config, mock_installer_cls, mock_fs, mock_marketplace):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_skips_download_when_already_installed(self, mock_installer_cls, mock_fs, mock_marketplace):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.return_value = MagicMock()
@@ -278,9 +278,7 @@ class TestUpgradePluginWithMarketplace:
     @patch("core.plugin.plugin_service.download_plugin_pkg")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_downloads_when_not_installed(self, mock_config, mock_installer_cls, mock_fs, mock_download):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_downloads_when_not_installed(self, mock_installer_cls, mock_fs, mock_download):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.side_effect = RuntimeError("not found")
@@ -303,11 +301,9 @@ class TestUpgradePluginWithMarketplace:
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
     def test_rejects_cached_pkg_outside_scope(
-        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace, mock_download, scope
+        self, mock_installer_cls, mock_fs, mock_marketplace, mock_download, scope
     ):
-        mock_config.MARKETPLACE_ENABLED = True
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(scope=scope)
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.return_value = MagicMock()
@@ -326,9 +322,7 @@ class TestUpgradePluginWithMarketplace:
 
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_rejects_before_touching_daemon_when_scope_is_none(self, mock_config, mock_installer_cls, mock_fs):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_rejects_before_touching_daemon_when_scope_is_none(self, mock_installer_cls, mock_fs):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(scope=PluginInstallationScope.NONE)
         installer = mock_installer_cls.return_value
 
@@ -341,11 +335,7 @@ class TestUpgradePluginWithMarketplace:
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_allows_cached_official_pkg_under_official_only(
-        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace
-    ):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_allows_cached_official_pkg_under_official_only(self, mock_installer_cls, mock_fs, mock_marketplace):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(
             scope=PluginInstallationScope.OFFICIAL_ONLY
         )
@@ -391,9 +381,8 @@ class TestUploadPkg:
 
 
 class TestInstallFromMarketplacePkg:
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_raises_when_marketplace_disabled(self, mock_config):
-        mock_config.MARKETPLACE_ENABLED = False
+    def test_raises_when_marketplace_disabled(self, config_overrides):
+        config_overrides(MARKETPLACE_ENABLED=False)
 
         with pytest.raises(ValueError, match="marketplace is not enabled"):
             PluginService.install_from_marketplace_pkg("t1", ["uid-1"])
@@ -401,9 +390,7 @@ class TestInstallFromMarketplacePkg:
     @patch("core.plugin.plugin_service.download_plugin_pkg")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_downloads_when_not_cached(self, mock_config, mock_installer_cls, mock_fs, mock_download):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_downloads_when_not_cached(self, mock_installer_cls, mock_fs, mock_download):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.side_effect = RuntimeError("not found")
@@ -423,9 +410,7 @@ class TestInstallFromMarketplacePkg:
 
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_uses_cached_when_already_downloaded(self, mock_config, mock_installer_cls: MagicMock, mock_fs: MagicMock):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_uses_cached_when_already_downloaded(self, mock_installer_cls: MagicMock, mock_fs: MagicMock):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.return_value = MagicMock()
@@ -443,9 +428,7 @@ class TestInstallFromMarketplacePkg:
     @patch("core.plugin.plugin_service.download_plugin_pkg")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_rejects_cached_pkg_outside_scope(self, mock_config, mock_installer_cls, mock_fs, mock_download):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_rejects_cached_pkg_outside_scope(self, mock_installer_cls, mock_fs, mock_download):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(
             scope=PluginInstallationScope.OFFICIAL_ONLY
         )
@@ -516,9 +499,7 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = True
 
-        with patch("core.plugin.plugin_service.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = PluginService.uninstall(tenant_id, "install-1")
+        result = PluginService.uninstall(tenant_id, "install-1")
 
         assert result is True
         installer.uninstall.assert_called_once()
@@ -579,9 +560,7 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = True
 
-        with patch("core.plugin.plugin_service.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = PluginService.uninstall(tenant_id, "install-1", preserve_credentials=True)
+        result = PluginService.uninstall(tenant_id, "install-1", preserve_credentials=True)
 
         assert result is True
         plugin_db.expire_all()
@@ -609,9 +588,7 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = False
 
-        with patch("core.plugin.plugin_service.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = PluginService.uninstall(tenant_id, "install-1")
+        result = PluginService.uninstall(tenant_id, "install-1")
 
         assert result is False
         plugin_db.expire_all()

--- a/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
+++ b/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
@@ -117,10 +117,16 @@ class TestRemoteRecommendAppRetrieval:
 
 
 class TestFetchFromDifyOfficial:
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
+    @pytest.fixture(autouse=True)
+    def _remote_config(self, config_overrides):
+        config_overrides(
+            HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN="https://example.com",
+            HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=300,
+            CONSOLE_WEB_URL="",
+        )
+
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_detail_returns_json_on_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_detail_returns_json_on_200(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"id": "app-1", "name": "Test"}
         mock_get.return_value = mock_response
@@ -130,20 +136,16 @@ class TestFetchFromDifyOfficial:
         assert result == {"id": "app-1", "name": "Test"}
         mock_get.assert_called_once()
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_detail_returns_none_on_non_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_detail_returns_none_on_non_200(self, mock_get):
         mock_get.return_value = MagicMock(status_code=404)
 
         result = RemoteRecommendAppRetrieval.fetch_recommended_app_detail_from_dify_official("app-1")
 
         assert result is None
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_preserves_remote_categories_order_on_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_apps_preserves_remote_categories_order_on_200(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {
             "recommended_apps": [],
@@ -155,19 +157,15 @@ class TestFetchFromDifyOfficial:
 
         assert result["categories"] == ["writing", "agent", "chat"]
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_raises_on_non_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_apps_raises_on_non_200(self, mock_get):
         mock_get.return_value = MagicMock(status_code=500)
 
         with pytest.raises(ValueError, match="fetch recommended apps failed"):
             RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_without_categories_key(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_apps_without_categories_key(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -177,11 +175,9 @@ class TestFetchFromDifyOfficial:
         assert "categories" not in result
         assert mock_get.call_args.kwargs["headers"] == {}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_forwards_request_origin_header(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "https://saas.dify.dev"
+    def test_apps_forwards_request_origin_header(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="https://saas.dify.dev")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -192,11 +188,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "https://cloud.example.com"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_falls_back_to_console_web_url_origin(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "https://saas.dify.dev/console"
+    def test_apps_falls_back_to_console_web_url_origin(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="https://saas.dify.dev/console")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -207,11 +201,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "https://saas.dify.dev/console"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_falls_back_to_console_web_url_without_request_context(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "http://localhost:3000/console"
+    def test_apps_falls_back_to_console_web_url_without_request_context(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="http://localhost:3000/console")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -220,11 +212,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "http://localhost:3000/console"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_uses_console_web_url_without_scheme(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "saas.dify.dev"
+    def test_apps_uses_console_web_url_without_scheme(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="saas.dify.dev")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -235,10 +225,8 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "saas.dify.dev"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_learn_dify_apps_returns_json_on_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_learn_dify_apps_returns_json_on_200(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": [{"id": "learn-dify-app"}]}
         mock_get.return_value = mock_response
@@ -248,20 +236,16 @@ class TestFetchFromDifyOfficial:
         assert result == {"recommended_apps": [{"id": "learn-dify-app"}]}
         assert mock_get.call_args.args[0] == "https://example.com/apps/learn-dify?language=en-US"
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_learn_dify_apps_raises_on_non_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_learn_dify_apps_raises_on_non_200(self, mock_get):
         mock_get.return_value = MagicMock(status_code=500)
 
         with pytest.raises(ValueError, match="fetch learn dify apps failed"):
             RemoteRecommendAppRetrieval.fetch_learn_dify_apps_from_dify_official("en-US")
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_uses_cache_for_repeated_requests(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+    def test_apps_uses_cache_for_repeated_requests(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=600)
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": [{"id": "app-1"}]}
         mock_get.return_value = mock_response
@@ -272,11 +256,9 @@ class TestFetchFromDifyOfficial:
         assert first == second == {"recommended_apps": [{"id": "app-1"}]}
         mock_get.assert_called_once()
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_does_not_cache_failed_responses(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+    def test_apps_does_not_cache_failed_responses(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=600)
         mock_get.return_value = MagicMock(status_code=500)
 
         with pytest.raises(ValueError, match="fetch recommended apps failed"):
@@ -286,11 +268,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_count == 2
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_skips_cache_when_ttl_disabled(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 0
+    def test_apps_skips_cache_when_ttl_disabled(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=0)
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -300,11 +280,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_count == 2
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_cache_isolated_by_origin_header(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+    def test_apps_cache_isolated_by_origin_header(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=600)
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response

--- a/api/tests/unit_tests/services/retention/workflow_run/test_clear_free_plan_expired_workflow_run_logs.py
+++ b/api/tests/unit_tests/services/retention/workflow_run/test_clear_free_plan_expired_workflow_run_logs.py
@@ -26,12 +26,17 @@ def mock_repo():
     return MagicMock()
 
 
+@pytest.fixture(autouse=True)
+def _cleanup_config(config_overrides):
+    config_overrides(
+        SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD=0,
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+    )
+
+
 @pytest.fixture
 def cleanup(mock_repo):
-    with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-        cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-        cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        yield WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+    return WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
 
 
 # ---------------------------------------------------------------------------
@@ -41,91 +46,68 @@ def cleanup(mock_repo):
 
 class TestWorkflowRunCleanupInit:
     def test_only_start_from_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="both set or both omitted"):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    start_from=datetime.datetime(2024, 1, 1),
-                    workflow_run_repo=mock_repo,
-                )
+        with pytest.raises(ValueError, match="both set or both omitted"):
+            WorkflowRunCleanup(
+                days=30,
+                batch_size=10,
+                start_from=datetime.datetime(2024, 1, 1),
+                workflow_run_repo=mock_repo,
+            )
 
     def test_only_end_before_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="both set or both omitted"):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    end_before=datetime.datetime(2024, 1, 1),
-                    workflow_run_repo=mock_repo,
-                )
+        with pytest.raises(ValueError, match="both set or both omitted"):
+            WorkflowRunCleanup(
+                days=30,
+                batch_size=10,
+                end_before=datetime.datetime(2024, 1, 1),
+                workflow_run_repo=mock_repo,
+            )
 
     def test_end_before_not_greater_than_start_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="end_before must be greater than start_from"):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    start_from=datetime.datetime(2024, 6, 1),
-                    end_before=datetime.datetime(2024, 1, 1),
-                    workflow_run_repo=mock_repo,
-                )
+        with pytest.raises(ValueError, match="end_before must be greater than start_from"):
+            WorkflowRunCleanup(
+                days=30,
+                batch_size=10,
+                start_from=datetime.datetime(2024, 6, 1),
+                end_before=datetime.datetime(2024, 1, 1),
+                workflow_run_repo=mock_repo,
+            )
 
     def test_equal_start_end_raises(self, mock_repo):
         dt = datetime.datetime(2024, 1, 1)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    start_from=dt,
-                    end_before=dt,
-                    workflow_run_repo=mock_repo,
-                )
-
-    def test_zero_batch_size_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="batch_size must be greater than 0"):
-                WorkflowRunCleanup(days=30, batch_size=0, workflow_run_repo=mock_repo)
-
-    def test_negative_batch_size_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError):
-                WorkflowRunCleanup(days=30, batch_size=-1, workflow_run_repo=mock_repo)
-
-    def test_valid_window_init(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 7
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            start = datetime.datetime(2024, 1, 1)
-            end = datetime.datetime(2024, 6, 1)
-            c = WorkflowRunCleanup(
+        with pytest.raises(ValueError):
+            WorkflowRunCleanup(
                 days=30,
-                batch_size=5,
-                start_from=start,
-                end_before=end,
+                batch_size=10,
+                start_from=dt,
+                end_before=dt,
                 workflow_run_repo=mock_repo,
             )
-            assert c.window_start == start
-            assert c.window_end == end
+
+    def test_zero_batch_size_raises(self, mock_repo):
+        with pytest.raises(ValueError, match="batch_size must be greater than 0"):
+            WorkflowRunCleanup(days=30, batch_size=0, workflow_run_repo=mock_repo)
+
+    def test_negative_batch_size_raises(self, mock_repo):
+        with pytest.raises(ValueError):
+            WorkflowRunCleanup(days=30, batch_size=-1, workflow_run_repo=mock_repo)
+
+    def test_valid_window_init(self, mock_repo, config_overrides):
+        config_overrides(SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD=7)
+        start = datetime.datetime(2024, 1, 1)
+        end = datetime.datetime(2024, 6, 1)
+        c = WorkflowRunCleanup(
+            days=30,
+            batch_size=5,
+            start_from=start,
+            end_before=end,
+            workflow_run_repo=mock_repo,
+        )
+        assert c.window_start == start
+        assert c.window_end == end
 
     def test_default_task_label_is_custom(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
 
         assert c._metrics._base_attributes["task_label"] == "custom"
 
@@ -219,21 +201,15 @@ class TestIsWithinGracePeriod:
 class TestGetCleanupWhitelist:
     def test_non_cloud_edition_returns_empty(self, cleanup):
         cleanup._cleanup_whitelist = None
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = cleanup._get_cleanup_whitelist()
+        result = cleanup._get_cleanup_whitelist()
         assert result == set()
 
-    def test_cloud_edition_fetches_whitelist(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_expired_subscription_cleanup_whitelist.return_value = ["t1", "t2"]
-                result = c._get_cleanup_whitelist()
+    def test_cloud_edition_fetches_whitelist(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_expired_subscription_cleanup_whitelist.return_value = ["t1", "t2"]
+            result = c._get_cleanup_whitelist()
         assert result == {"t1", "t2"}
 
     def test_cached_whitelist_returned(self, cleanup):
@@ -241,16 +217,12 @@ class TestGetCleanupWhitelist:
         result = cleanup._get_cleanup_whitelist()
         assert result == {"cached"}
 
-    def test_billing_service_error_returns_empty(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_expired_subscription_cleanup_whitelist.side_effect = Exception("error")
-                result = c._get_cleanup_whitelist()
+    def test_billing_service_error_returns_empty(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_expired_subscription_cleanup_whitelist.side_effect = Exception("error")
+            result = c._get_cleanup_whitelist()
         assert result == set()
 
 
@@ -264,68 +236,51 @@ class TestFilterFreeTenants:
         result = cleanup._filter_free_tenants(["t1", "t2"])
         assert result == {"t1", "t2"}
 
-    def test_empty_tenants_returns_empty(self, cleanup):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            result = cleanup._filter_free_tenants([])
+    def test_empty_tenants_returns_empty(self, cleanup, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        result = cleanup._filter_free_tenants([])
         assert result == set()
 
-    def test_whitelisted_tenant_excluded(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = {"t1"}
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.return_value = {
-                    "t1": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
-                    "t2": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
-                }
-                result = c._filter_free_tenants(["t1", "t2"])
+    def test_whitelisted_tenant_excluded(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = {"t1"}
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.return_value = {
+                "t1": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
+                "t2": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
+            }
+            result = c._filter_free_tenants(["t1", "t2"])
         assert "t1" not in result
         assert "t2" in result
 
-    def test_paid_tenant_excluded(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = set()
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.return_value = {
-                    "t1": {"plan": "professional", "expiration_date": -1},
-                }
-                result = c._filter_free_tenants(["t1"])
+    def test_paid_tenant_excluded(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = set()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.return_value = {
+                "t1": {"plan": "professional", "expiration_date": -1},
+            }
+            result = c._filter_free_tenants(["t1"])
         assert result == set()
 
-    def test_missing_billing_info_treats_as_non_free(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = set()
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.return_value = {}
-                result = c._filter_free_tenants(["t1"])
+    def test_missing_billing_info_treats_as_non_free(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = set()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.return_value = {}
+            result = c._filter_free_tenants(["t1"])
         assert result == set()
 
-    def test_billing_bulk_error_treats_as_non_free(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = set()
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.side_effect = Exception("fail")
-                result = c._filter_free_tenants(["t1"])
+    def test_billing_bulk_error_treats_as_non_free(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = set()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.side_effect = Exception("fail")
+            result = c._filter_free_tenants(["t1"])
         assert result == set()
 
 
@@ -336,17 +291,12 @@ class TestFilterFreeTenants:
 
 class TestRunDeleteMode:
     def _make_cleanup(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            return WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        return WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
 
     def test_no_rows_stops_immediately(self, mock_repo):
         mock_repo.get_cleanup_refs_batch_by_time_range.return_value = []
         c = self._make_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_not_called()
 
     def test_all_paid_skips_delete(self, mock_repo):
@@ -355,9 +305,7 @@ class TestRunDeleteMode:
         c = self._make_cleanup(mock_repo)
         # Override the non-Cloud default to exercise the no-deletion path.
         c._filter_free_tenants = MagicMock(return_value=set())
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_not_called()
 
     def test_runs_deleted_successfully(self, mock_repo):
@@ -373,10 +321,8 @@ class TestRunDeleteMode:
             "pause_reasons": 0,
         }
         c = self._make_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.time.sleep"):
-                c.run()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.time.sleep"):
+            c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_called_once()
 
     def test_delete_exception_reraises(self, mock_repo):
@@ -384,24 +330,19 @@ class TestRunDeleteMode:
         mock_repo.get_cleanup_refs_batch_by_time_range.side_effect = [[ref], [ref]]
         mock_repo.delete_runs_with_related_by_ids.side_effect = RuntimeError("db error")
         c = self._make_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(RuntimeError):
-                c.run()
+        with pytest.raises(RuntimeError):
+            c.run()
 
     def test_summary_with_window_start(self, mock_repo):
         mock_repo.get_cleanup_refs_batch_by_time_range.return_value = []
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c = WorkflowRunCleanup(
-                days=30,
-                batch_size=10,
-                start_from=datetime.datetime(2024, 1, 1),
-                end_before=datetime.datetime(2024, 6, 1),
-                workflow_run_repo=mock_repo,
-            )
-            c.run()
+        c = WorkflowRunCleanup(
+            days=30,
+            batch_size=10,
+            start_from=datetime.datetime(2024, 1, 1),
+            end_before=datetime.datetime(2024, 6, 1),
+            workflow_run_repo=mock_repo,
+        )
+        c.run()
 
 
 # ---------------------------------------------------------------------------
@@ -411,15 +352,12 @@ class TestRunDeleteMode:
 
 class TestRunDryRunMode:
     def _make_dry_cleanup(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            return WorkflowRunCleanup(
-                days=30,
-                batch_size=10,
-                workflow_run_repo=mock_repo,
-                dry_run=True,
-            )
+        return WorkflowRunCleanup(
+            days=30,
+            batch_size=10,
+            workflow_run_repo=mock_repo,
+            dry_run=True,
+        )
 
     def test_dry_run_no_delete_called(self, mock_repo):
         ref = make_ref("t1")
@@ -434,35 +372,28 @@ class TestRunDryRunMode:
             "pause_reasons": 0,
         }
         c = self._make_dry_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_not_called()
         mock_repo.count_runs_with_related_by_ids.assert_called_once()
 
     def test_dry_run_summary_with_window_start(self, mock_repo):
         mock_repo.get_cleanup_refs_batch_by_time_range.return_value = []
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c = WorkflowRunCleanup(
-                days=30,
-                batch_size=10,
-                start_from=datetime.datetime(2024, 1, 1),
-                end_before=datetime.datetime(2024, 6, 1),
-                workflow_run_repo=mock_repo,
-                dry_run=True,
-            )
-            c.run()
+        c = WorkflowRunCleanup(
+            days=30,
+            batch_size=10,
+            start_from=datetime.datetime(2024, 1, 1),
+            end_before=datetime.datetime(2024, 6, 1),
+            workflow_run_repo=mock_repo,
+            dry_run=True,
+        )
+        c.run()
 
     def test_dry_run_all_paid_skips_count(self, mock_repo):
         ref = make_ref("t1")
         mock_repo.get_cleanup_refs_batch_by_time_range.side_effect = [[ref], []]
         c = self._make_dry_cleanup(mock_repo)
         c._filter_free_tenants = MagicMock(return_value=set())
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.count_runs_with_related_by_ids.assert_not_called()
 
 

--- a/api/tests/unit_tests/services/test_recommended_app_service.py
+++ b/api/tests/unit_tests/services/test_recommended_app_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from typing import TypedDict, Unpack, cast
 from unittest.mock import MagicMock, patch
 
@@ -20,6 +21,15 @@ pytestmark = pytest.mark.parametrize(
     [(TrialApp, AccountTrialAppRecord, App)],
     indirect=True,
 )
+
+
+@pytest.fixture(autouse=True)
+def _recommended_app_config(config_overrides: Callable[..., None]) -> None:
+    config_overrides(
+        HOSTED_FETCH_APP_TEMPLATES_MODE="remote",
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+        ENABLE_TRIAL_APP=True,
+    )
 
 
 class RecommendedAppPayload(TypedDict, total=False):
@@ -58,14 +68,13 @@ class AppDetailKwargs(TypedDict, total=False):
     ],
 )
 def test_trial_app_policy_is_cloud_only(
-    monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     sqlite_session: Session,
     edition: DeploymentEdition,
     feature_enabled: bool,
     expected: bool,
 ) -> None:
-    monkeypatch.setattr(service_module.dify_config, "DEPLOYMENT_EDITION", edition)
-    monkeypatch.setattr(service_module.dify_config, "ENABLE_TRIAL_APP", feature_enabled)
+    config_overrides(DEPLOYMENT_EDITION=edition, ENABLE_TRIAL_APP=feature_enabled)
 
     assert RecommendedAppService.is_trial_app_enabled() is expected
 
@@ -168,11 +177,7 @@ def _persist_app(session: Session, *, name: str) -> App:
 
 class TestRecommendedAppServiceGetApps:
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
-    def test_success_with_apps(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
-    ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
+    def test_success_with_apps(self, mock_factory_class: MagicMock, sqlite_session: Session) -> None:
         expected = _apps_response()
 
         mock_instance = MagicMock()
@@ -189,11 +194,7 @@ class TestRecommendedAppServiceGetApps:
         mock_instance.get_recommended_apps_and_categories.assert_called_once_with("en-US", session=sqlite_session)
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
-    def test_fallback_to_builtin_when_empty(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
-    ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
+    def test_fallback_to_builtin_when_empty(self, mock_factory_class: MagicMock, sqlite_session: Session) -> None:
         empty_response = AppsResponse(recommended_apps=[], categories=[])
         builtin_response = _apps_response(
             recommended_apps=[{"app_id": "builtin-1", "name": "Builtin App", "category": "default"}]
@@ -214,11 +215,13 @@ class TestRecommendedAppServiceGetApps:
         mock_builtin_instance.fetch_recommended_apps_from_builtin.assert_called_once_with("en-US")
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_fallback_when_none_recommended_apps(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
+        self,
+        mock_factory_class: MagicMock,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "db"
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="db")
         none_response = AppsResponse(recommended_apps=None, categories=["test"])
         builtin_response = _apps_response()
 
@@ -236,11 +239,13 @@ class TestRecommendedAppServiceGetApps:
         mock_builtin_instance.fetch_recommended_apps_from_builtin.assert_called_once()
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_different_languages(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
+        self,
+        mock_factory_class: MagicMock,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "builtin"
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="builtin")
 
         for language in ["en-US", "zh-CN", "ja-JP", "fr-FR"]:
             lang_response = _apps_response(
@@ -256,12 +261,14 @@ class TestRecommendedAppServiceGetApps:
             mock_instance.get_recommended_apps_and_categories.assert_called_with(language, session=sqlite_session)
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_uses_correct_factory_mode(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
+        self,
+        mock_factory_class: MagicMock,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
         for mode in ["remote", "builtin", "db"]:
-            mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = mode
+            config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE=mode)
             response = _apps_response()
             mock_instance = MagicMock()
             mock_instance.get_recommended_apps_and_categories.return_value = response
@@ -310,16 +317,11 @@ class TestRecommendedAppServiceGetApp:
 
 class TestRecommendedAppServiceGetDetail:
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_returns_retrieval_detail_when_trial_disabled(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        mock_config.ENABLE_TRIAL_APP = True
         cases: list[tuple[str, RecommendedAppPayload]] = [
             (
                 "complex-app",
@@ -350,17 +352,14 @@ class TestRecommendedAppServiceGetDetail:
             mock_instance.get_recommend_app_detail.assert_called_once_with(app_id, session=sqlite_session)
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_different_modes(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        mock_config.ENABLE_TRIAL_APP = True
         for mode in ["remote", "builtin", "db"]:
-            mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = mode
+            config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE=mode)
             detail = _app_detail(app_id="test-app", name=f"App from {mode}")
             mock_instance = MagicMock()
             mock_instance.get_recommend_app_detail.return_value = detail
@@ -378,16 +377,11 @@ class TestRecommendedAppServiceGetDetail:
 
 class TestRecommendedAppServiceGetLearnDifyApps:
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_uses_configured_retrieval_source(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        mock_config.ENABLE_TRIAL_APP = True
         expected_app = RecommendedAppPayload(app_id="app-1", category="Workflow")
         mock_instance = MagicMock()
         mock_instance.get_learn_dify_apps.return_value = {
@@ -402,11 +396,13 @@ class TestRecommendedAppServiceGetLearnDifyApps:
         mock_factory_class.get_recommend_app_factory.assert_called_once_with("remote")
         mock_instance.get_learn_dify_apps.assert_called_once_with("en-US", session=sqlite_session)
 
-    @patch("services.recommended_app_service.dify_config")
     def test_sets_can_trial_when_trial_feature_enabled(
-        self, mock_config: MagicMock, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "db"
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="db")
         app = RecommendedAppPayload(app_id="app-1", category="Workflow")
         mock_retrieval_instance = MagicMock()
         mock_retrieval_instance.get_learn_dify_apps.return_value = {
@@ -514,14 +510,11 @@ class TestRecommendedAppServiceTrialFeatures:
         assert detail_result["can_trial"] is has_trial_app
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_get_detail_returns_none_before_reading_trial_flag(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
         mock_instance = MagicMock()
         mock_instance.get_recommend_app_detail.return_value = None
         mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)

--- a/api/tests/unit_tests/utils/encryption/test_system_encryption.py
+++ b/api/tests/unit_tests/utils/encryption/test_system_encryption.py
@@ -27,13 +27,12 @@ class TestSystemEncrypter:
         expected_key = hashlib.sha256(secret_key.encode()).digest()
         assert encrypter.key == expected_key
 
-    def test_init_with_none_secret_key(self):
+    def test_init_with_none_secret_key(self, config_overrides):
         """Test initialization with None secret key falls back to config"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "config_secret"
-            encrypter = SystemEncrypter(secret_key=None)
-            expected_key = hashlib.sha256(b"config_secret").digest()
-            assert encrypter.key == expected_key
+        config_overrides(SECRET_KEY="config_secret")
+        encrypter = SystemEncrypter(secret_key=None)
+        expected_key = hashlib.sha256(b"config_secret").digest()
+        assert encrypter.key == expected_key
 
     def test_init_with_empty_secret_key(self):
         """Test initialization with empty secret key"""
@@ -41,13 +40,12 @@ class TestSystemEncrypter:
         expected_key = hashlib.sha256(b"").digest()
         assert encrypter.key == expected_key
 
-    def test_init_without_secret_key_uses_config(self):
+    def test_init_without_secret_key_uses_config(self, config_overrides):
         """Test initialization without secret key uses config"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "default_secret"
-            encrypter = SystemEncrypter()
-            expected_key = hashlib.sha256(b"default_secret").digest()
-            assert encrypter.key == expected_key
+        config_overrides(SECRET_KEY="default_secret")
+        encrypter = SystemEncrypter()
+        expected_key = hashlib.sha256(b"default_secret").digest()
+        assert encrypter.key == expected_key
 
     def test_encrypt_params_basic(self):
         """Test basic parameters encryption"""
@@ -368,25 +366,23 @@ class TestFactoryFunctions:
         expected_key = hashlib.sha256(secret_key.encode()).digest()
         assert encrypter.key == expected_key
 
-    def test_create_system_encrypter_without_secret(self):
+    def test_create_system_encrypter_without_secret(self, config_overrides):
         """Test factory function without secret key"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "config_secret"
-            encrypter = create_system_encrypter()
+        config_overrides(SECRET_KEY="config_secret")
+        encrypter = create_system_encrypter()
 
-            assert isinstance(encrypter, SystemEncrypter)
-            expected_key = hashlib.sha256(b"config_secret").digest()
-            assert encrypter.key == expected_key
+        assert isinstance(encrypter, SystemEncrypter)
+        expected_key = hashlib.sha256(b"config_secret").digest()
+        assert encrypter.key == expected_key
 
-    def test_create_system_encrypter_with_none_secret(self):
+    def test_create_system_encrypter_with_none_secret(self, config_overrides):
         """Test factory function with None secret key"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "config_secret"
-            encrypter = create_system_encrypter(None)
+        config_overrides(SECRET_KEY="config_secret")
+        encrypter = create_system_encrypter(None)
 
-            assert isinstance(encrypter, SystemEncrypter)
-            expected_key = hashlib.sha256(b"config_secret").digest()
-            assert encrypter.key == expected_key
+        assert isinstance(encrypter, SystemEncrypter)
+        expected_key = hashlib.sha256(b"config_secret").digest()
+        assert encrypter.key == expected_key
 
 
 class TestGlobalEncrypterInstance:
@@ -405,19 +401,18 @@ class TestGlobalEncrypterInstance:
         assert encrypter1 is encrypter2
         assert isinstance(encrypter1, SystemEncrypter)
 
-    def test_get_system_encrypter_uses_config(self):
+    def test_get_system_encrypter_uses_config(self, config_overrides):
         """Test that global encrypter uses config"""
         # Clear the global instance first
         import core.tools.utils.system_encryption
 
         core.tools.utils.system_encryption._encrypter = None
 
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "global_secret"
-            encrypter = get_system_encrypter()
+        config_overrides(SECRET_KEY="global_secret")
+        encrypter = get_system_encrypter()
 
-            expected_key = hashlib.sha256(b"global_secret").digest()
-            assert encrypter.key == expected_key
+        expected_key = hashlib.sha256(b"global_secret").digest()
+        assert encrypter.key == expected_key
 
 
 class TestConvenienceFunctions:


### PR DESCRIPTION
## Summary

- replace whole DifyConfig mocks in recommendation and plugin service tests with typed field overrides
- centralize deterministic remote-template, marketplace, Supabase, and Redis test defaults
- keep HTTP, plugin daemon, storage client, and Redis client mocks focused on external boundaries
- remove repeated config setup and nested config patch contexts

## Stack

- depends on #40848

## Tests

- make lint
- make test TARGET_TESTS="--no-cov ./api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py ./api/tests/unit_tests/services/test_recommended_app_service.py ./api/tests/unit_tests/services/plugin/test_plugin_service_installation.py ./api/tests/unit_tests/extensions/storage/test_supabase_storage.py ./api/tests/unit_tests/extensions/test_redis.py"

From Codex