### PR TITLE
fix: suggest deepseek-v4-flash for Agent mode

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/__tests__/model-compatibility.spec.ts
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/model-compatibility.spec.ts
@@ -189,6 +189,7 @@ describe('isAgentSuggestedModel', () => {
     )
     expect(isAgentSuggestedModel(provider, createModelItem('grok-4.3'))).toBe(true)
     expect(isAgentSuggestedModel(provider, createModelItem('deepseek-v4-pro'))).toBe(true)
+    expect(isAgentSuggestedModel(provider, createModelItem('deepseek-v4-flash'))).toBe(true)
     expect(isAgentSuggestedModel(provider, createModelItem('kimi-k2.6'))).toBe(true)
     expect(isAgentSuggestedModel(provider, createModelItem('minimax-m3'))).toBe(true)
     expect(isAgentSuggestedModel(provider, createModelItem('qwen3.7-max'))).toBe(true)

--- a/web/features/agent-v2/agent-detail/configure/model-compatibility.ts
+++ b/web/features/agent-v2/agent-detail/configure/model-compatibility.ts
@@ -79,6 +79,7 @@ const agentSuggestedModelPatterns: RegExp[] = [
 
   // deepseek
   /^deepseek[ .-]v4[ .-]pro$/i,
+  /^deepseek[ .-]v4[ .-]flash$/i,
 
   // qwen
   /^qwen[ .-]?3\.7[ .-]max$/i,


### PR DESCRIPTION
Fixes #40851

## Summary

The Agent mode model selector only suggests `deepseek-v4-pro`, but the official DeepSeek provider plugin also ships `deepseek-v4-flash` with the same agent features (`tool-call`, `multi-tool-call`, `stream-tool-call` per the plugin model yaml). This adds `deepseek[ .-]v4[ .-]flash` to `agentSuggestedModelPatterns`, mirroring how both `gpt-5.5` and `gpt-5.5-pro` are suggested for OpenAI.

## Screenshots

N/A (no UI change, suggestion list only)

## Checklist

- [x] This change requires a documentation update, included: No (behavioral list only, no docs page describes the suggestion list)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly: N/A
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) — frontend test for this file not run in this environment