### PR TITLE
test: scope plugin and datasource config overrides

### DIFF
--- a/api/tests/unit_tests/controllers/console/test_workspace_members.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_members.py
@@ -35,6 +35,14 @@ def _build_feature_flags():
 
 class TestMemberInviteEmailApi:
     @pytest.fixture(autouse=True)
+    def _member_config(self, config_overrides) -> None:
+        config_overrides(
+            RBAC_ENABLED=False,
+            CONSOLE_WEB_URL="https://console.example.com",
+            DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+        )
+
+    @pytest.fixture(autouse=True)
     def _mock_member_invite_lock(self):
         with patch("controllers.console.workspace.members.redis_client.lock", return_value=nullcontext()):
             yield
@@ -51,10 +59,7 @@ class TestMemberInviteEmailApi:
         inviter = SimpleNamespace(email="Owner@Example.com", current_tenant=tenant, status="active")
 
         with (
-            patch("controllers.console.workspace.members.dify_config.RBAC_ENABLED", False),
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "https://console.example.com"),
             patch("controllers.console.workspace.members._count_new_member_invites", return_value=(1, 1)),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
         ):
             with app.test_request_context(
                 "/workspaces/current/members/invite-email",
@@ -90,26 +95,25 @@ class TestMemberInviteEmailApi:
         mock_invite_member,
         mock_get_features,
         app,
+        config_overrides,
     ):
         """When RBAC is enabled, any non-empty role string should be accepted."""
+        config_overrides(RBAC_ENABLED=True)
         mock_get_features.return_value = _build_feature_flags()
         mock_invite_member.return_value = "rbac-token"
 
         tenant = SimpleNamespace(id="tenant-1", name="Test Tenant")
 
-        with patch("controllers.console.workspace.members.dify_config") as mock_config:
-            mock_config.RBAC_ENABLED = True
-            mock_config.CONSOLE_WEB_URL = "https://console.example.com"
-            with app.test_request_context(
-                "/workspaces/current/members/invite-email",
-                method="POST",
-                json={"emails": ["user@example.com"], "role": "rbac-role-id-abc", "language": "en-US"},
-            ):
-                account = Account(name="tester", email="tester@example.com")
-                account._current_tenant = tenant
-                g._login_user = account
-                g._current_tenant = tenant
-                response, status_code = MemberInviteEmailApi().post()
+        with app.test_request_context(
+            "/workspaces/current/members/invite-email",
+            method="POST",
+            json={"emails": ["user@example.com"], "role": "rbac-role-id-abc", "language": "en-US"},
+        ):
+            account = Account(name="tester", email="tester@example.com")
+            account._current_tenant = tenant
+            g._login_user = account
+            g._current_tenant = tenant
+            response, status_code = MemberInviteEmailApi().post()
 
         assert status_code == 201
         mock_invite_member.assert_called_once()
@@ -131,20 +135,17 @@ class TestMemberInviteEmailApi:
 
         tenant = SimpleNamespace(id="tenant-1", name="Test Tenant")
 
-        with patch("controllers.console.workspace.members.dify_config") as mock_config:
-            mock_config.RBAC_ENABLED = False
-            mock_config.CONSOLE_WEB_URL = "https://console.example.com"
-            with app.test_request_context(
-                "/workspaces/current/members/invite-email",
-                method="POST",
-                json={"emails": ["user@example.com"], "role": "invalid-role", "language": "en-US"},
-            ):
-                account = Account(name="tester", email="tester@example.com")
-                account._current_tenant = tenant
-                g._login_user = account
-                g._current_tenant = tenant
-                with pytest.raises(InvalidMemberRoleError) as exc_info:
-                    MemberInviteEmailApi().post()
+        with app.test_request_context(
+            "/workspaces/current/members/invite-email",
+            method="POST",
+            json={"emails": ["user@example.com"], "role": "invalid-role", "language": "en-US"},
+        ):
+            account = Account(name="tester", email="tester@example.com")
+            account._current_tenant = tenant
+            g._login_user = account
+            g._current_tenant = tenant
+            with pytest.raises(InvalidMemberRoleError) as exc_info:
+                MemberInviteEmailApi().post()
 
         assert exc_info.value.error_code == "invalid_role"
         assert exc_info.value.data == {"code": "invalid_role", "message": "Invalid role.", "status": 400}
@@ -164,19 +165,16 @@ class TestMemberInviteEmailApi:
 
         tenant = SimpleNamespace(id="tenant-1", name="Test Tenant")
 
-        with patch("controllers.console.workspace.members.dify_config") as mock_config:
-            mock_config.RBAC_ENABLED = False
-            mock_config.CONSOLE_WEB_URL = "https://console.example.com"
-            with app.test_request_context(
-                "/workspaces/current/members/invite-email",
-                method="POST",
-                json={"emails": ["user@example.com"], "role": "owner", "language": "en-US"},
-            ):
-                account = Account(name="tester", email="tester@example.com")
-                account._current_tenant = tenant
-                g._login_user = account
-                g._current_tenant = tenant
-                with pytest.raises(InvalidMemberRoleError) as exc_info:
-                    MemberInviteEmailApi().post()
+        with app.test_request_context(
+            "/workspaces/current/members/invite-email",
+            method="POST",
+            json={"emails": ["user@example.com"], "role": "owner", "language": "en-US"},
+        ):
+            account = Account(name="tester", email="tester@example.com")
+            account._current_tenant = tenant
+            g._login_user = account
+            g._current_tenant = tenant
+            with pytest.raises(InvalidMemberRoleError) as exc_info:
+                MemberInviteEmailApi().post()
 
         assert exc_info.value.error_code == "invalid_role"

--- a/api/tests/unit_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_members.py
@@ -124,6 +124,13 @@ class TestMemberListApi:
 
 class TestMemberInviteEmailApi:
     @pytest.fixture(autouse=True)
+    def _invite_config(self, config_overrides) -> None:
+        config_overrides(
+            CONSOLE_WEB_URL="http://x",
+            DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+        )
+
+    @pytest.fixture(autouse=True)
     def _mock_member_invite_lock(self):
         with patch("controllers.console.workspace.members.redis_client.lock", return_value=nullcontext()):
             yield
@@ -151,8 +158,6 @@ class TestMemberInviteEmailApi:
             patch(
                 "controllers.console.workspace.members.RegisterService.invite_new_member", return_value="token"
             ) as mock_invite,
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "http://x"),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
         ):
             result, status = method(api, user)
 
@@ -163,7 +168,8 @@ class TestMemberInviteEmailApi:
         mock_invite.assert_called_once()
         assert mock_invite.call_args.kwargs["email"] == "a@test.com"
 
-    def test_invite_limit_exceeded(self, app: Flask):
+    def test_invite_limit_exceeded(self, app: Flask, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
@@ -182,12 +188,12 @@ class TestMemberInviteEmailApi:
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.members.FeatureService.get_features", return_value=features),
             patch("controllers.console.workspace.members._count_new_member_invites", return_value=(1, 1)),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
         ):
             with pytest.raises(WorkspaceMembersLimitExceeded):
                 method(api, user)
 
-    def test_invite_cloud_member_limit_exceeded(self, app: Flask):
+    def test_invite_cloud_member_limit_exceeded(self, app: Flask, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
@@ -208,7 +214,6 @@ class TestMemberInviteEmailApi:
             patch("controllers.console.workspace.members.FeatureService.get_features", return_value=features),
             patch("controllers.console.workspace.members._count_new_member_invites", return_value=(2, 2)),
             patch("controllers.console.workspace.members._count_current_members", return_value=9),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         ):
             with pytest.raises(WorkspaceMembersLimitExceeded):
                 method(api, user)
@@ -236,8 +241,6 @@ class TestMemberInviteEmailApi:
                 "controllers.console.workspace.members.RegisterService.invite_new_member",
                 side_effect=AccountAlreadyInTenantError(),
             ),
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "http://x"),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
         ):
             result, status = method(api, user)
 
@@ -302,14 +305,13 @@ class TestMemberInviteEmailApi:
                 "controllers.console.workspace.members.RegisterService.invite_new_member",
                 side_effect=Exception("boom"),
             ),
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "http://x"),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
         ):
             result, _ = method(api, user)
 
         assert result["invitation_results"][0]["status"] == "failed"
 
-    def test_invite_seats_limit_exceeded(self, app: Flask):
+    def test_invite_seats_limit_exceeded(self, app: Flask, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
@@ -334,7 +336,6 @@ class TestMemberInviteEmailApi:
                 return_value=license_info,
             ) as mock_get_license,
             patch("controllers.console.workspace.members.RegisterService.invite_new_member") as mock_invite,
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
         ):
             with pytest.raises(SeatsLimitExceeded):
                 method(api, user)
@@ -343,7 +344,8 @@ class TestMemberInviteEmailApi:
         license_info.seats.is_available.assert_called_once_with(2)
         mock_invite.assert_not_called()
 
-    def test_invite_existing_accounts_do_not_consume_seats(self, app: Flask):
+    def test_invite_existing_accounts_do_not_consume_seats(self, app: Flask, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
@@ -370,8 +372,6 @@ class TestMemberInviteEmailApi:
             patch(
                 "controllers.console.workspace.members.RegisterService.invite_new_member", return_value="token"
             ) as mock_invite,
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "http://x"),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
         ):
             result, status = method(api, user)
 
@@ -381,7 +381,8 @@ class TestMemberInviteEmailApi:
         license_info.seats.is_available.assert_not_called()
         assert mock_invite.call_count == 2
 
-    def test_invite_mixed_accounts_with_available_seats(self, app: Flask):
+    def test_invite_mixed_accounts_with_available_seats(self, app: Flask, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
@@ -408,8 +409,6 @@ class TestMemberInviteEmailApi:
             patch(
                 "controllers.console.workspace.members.RegisterService.invite_new_member", return_value="token"
             ) as mock_invite,
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "http://x"),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
         ):
             result, status = method(api, user)
 
@@ -444,8 +443,6 @@ class TestMemberInviteEmailApi:
                 return_value=license_info,
             ) as mock_get_license,
             patch("controllers.console.workspace.members.RegisterService.invite_new_member", return_value="token"),
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "http://x"),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
         ):
             result, status = method(api, user)
 
@@ -454,7 +451,8 @@ class TestMemberInviteEmailApi:
         mock_get_license.assert_not_called()
         license_info.seats.is_available.assert_not_called()
 
-    def test_invite_seats_error_is_reported_as_failed_result(self, app: Flask):
+    def test_invite_seats_error_is_reported_as_failed_result(self, app: Flask, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
@@ -482,8 +480,6 @@ class TestMemberInviteEmailApi:
                 "controllers.console.workspace.members.RegisterService.invite_new_member",
                 side_effect=SeatsLimitExceededError("licensed seats limit exceeded"),
             ),
-            patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "http://x"),
-            patch("controllers.console.workspace.members.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
         ):
             result, status = method(api, user)
 

--- a/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_rbac.py
@@ -37,9 +37,13 @@ def app():
     return flask_app
 
 
-def _enabled(enabled: bool):
-    deployment_edition = DeploymentEdition.ENTERPRISE if enabled else DeploymentEdition.COMMUNITY
-    return patch("controllers.console.workspace.rbac.dify_config.DEPLOYMENT_EDITION", deployment_edition)
+@pytest.fixture(autouse=True)
+def _rbac_config(config_overrides) -> None:
+    config_overrides(
+        DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE,
+        RBAC_ENABLED=True,
+        LOGIN_DISABLED=True,
+    )
 
 
 def _account() -> Account:
@@ -198,10 +202,10 @@ class TestPydanticModels:
 
 
 class TestPaginationMapping:
-    def test_roles_get_returns_legacy_compatible_roles_when_rbac_disabled(self, app):
+    def test_roles_get_returns_legacy_compatible_roles_when_rbac_disabled(self, app, config_overrides):
+        config_overrides(RBAC_ENABLED=False)
         with (
             app.test_request_context("/workspaces/current/rbac/roles?page=1&limit=2&include_owner=1"),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", False),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.Roles.list") as mock_list,
         ):
@@ -256,10 +260,10 @@ class TestPaginationMapping:
         }
         mock_list.assert_not_called()
 
-    def test_roles_get_filters_out_owner_when_include_owner_is_zero(self, app):
+    def test_roles_get_filters_out_owner_when_include_owner_is_zero(self, app, config_overrides):
+        config_overrides(RBAC_ENABLED=False)
         with (
             app.test_request_context("/workspaces/current/rbac/roles?include_owner=0"),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", False),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.Roles.list"),
         ):
@@ -268,10 +272,10 @@ class TestPaginationMapping:
         names = [r["name"] for r in response["data"]]
         assert "owner" not in names
 
-    def test_roles_get_keeps_owner_when_include_owner_is_one(self, app):
+    def test_roles_get_keeps_owner_when_include_owner_is_one(self, app, config_overrides):
+        config_overrides(RBAC_ENABLED=False)
         with (
             app.test_request_context("/workspaces/current/rbac/roles?include_owner=1"),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", False),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.Roles.list"),
         ):
@@ -283,10 +287,10 @@ class TestPaginationMapping:
         names = [r["name"] for r in response["data"]]
         assert "owner" in names
 
-    def test_roles_get_filters_out_owner_by_default(self, app):
+    def test_roles_get_filters_out_owner_by_default(self, app, config_overrides):
+        config_overrides(RBAC_ENABLED=False)
         with (
             app.test_request_context("/workspaces/current/rbac/roles"),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", False),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.Roles.list"),
         ):
@@ -298,7 +302,6 @@ class TestPaginationMapping:
     def test_roles_get_forwards_outer_pagination_params(self, app):
         with (
             app.test_request_context("/workspaces/current/rbac/roles?page=2&limit=50&reverse=true&include_owner=1"),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", True),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.Roles.list") as mock_list,
             patch("controllers.console.workspace.rbac._dump", return_value={}),
@@ -324,7 +327,6 @@ class TestResourceAccessScopeBindings:
                 json={"scope": "all"},
             ),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-actor")),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.console.workspace.rbac.svc.RBACService.AppAccess.replace_whitelist",
                 return_value=rbac_mod.svc.ResourceWhitelist(),
@@ -345,7 +347,6 @@ class TestResourceAccessScopeBindings:
                 json={"scope": "all"},
             ),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-actor")),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.console.workspace.rbac.svc.RBACService.DatasetAccess.replace_whitelist",
                 return_value=rbac_mod.svc.ResourceWhitelist(),
@@ -364,7 +365,6 @@ class TestResourceAccessScopeBindings:
                 json={"scope": "specific"},
             ),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-actor")),
-            patch("controllers.console.workspace.rbac.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.console.workspace.rbac.svc.RBACService.DatasetAccess.replace_whitelist",
                 return_value=rbac_mod.svc.ResourceWhitelist(),
@@ -454,7 +454,6 @@ class TestPaginationForwarding:
             app.test_request_context(
                 "/workspaces/current/rbac/access-policies?resource_type=app&page=3&limit=25&reverse=false"
             ),
-            _enabled(True),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.AccessPolicies.list") as mock_list,
             patch("controllers.console.workspace.rbac._dump", return_value={}),
@@ -471,7 +470,6 @@ class TestPaginationForwarding:
     def test_workspace_app_matrix_forwards_outer_pagination_params(self, app):
         with (
             app.test_request_context("/workspaces/current/rbac/workspace/apps/access-policy?page=4&limit=10"),
-            _enabled(True),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.WorkspaceAccess.app_matrix") as mock_list,
             patch("controllers.console.workspace.rbac._dump", return_value={}),
@@ -489,7 +487,6 @@ class TestPaginationForwarding:
             app.test_request_context(
                 "/workspaces/current/rbac/workspace/datasets/access-policy?page=5&limit=15&reverse=true"
             ),
-            _enabled(True),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.WorkspaceAccess.dataset_matrix") as mock_list,
             patch("controllers.console.workspace.rbac._dump", return_value={}),
@@ -507,7 +504,6 @@ class TestAccessPolicyBindingLockUnlock:
     def test_lock_forwards_binding_id(self, app):
         with (
             app.test_request_context("/workspaces/current/rbac/access-policy-bindings/binding-1/lock", method="PUT"),
-            _enabled(True),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.AccessPolicyBindings.lock") as mock_lock,
             patch("controllers.console.workspace.rbac._dump", return_value={}),
@@ -521,7 +517,6 @@ class TestAccessPolicyBindingLockUnlock:
     def test_unlock_forwards_binding_id(self, app):
         with (
             app.test_request_context("/workspaces/current/rbac/access-policy-bindings/binding-1/unlock", method="PUT"),
-            _enabled(True),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.AccessPolicyBindings.unlock") as mock_unlock,
             patch("controllers.console.workspace.rbac._dump", return_value={}),
@@ -537,7 +532,6 @@ class TestRoleCopy:
     def test_role_copy_forwards_path_id(self, app):
         with (
             app.test_request_context("/workspaces/current/rbac/roles/role-1/copy", method="POST", json={}),
-            _enabled(True),
             patch("controllers.console.workspace.rbac._current_ids", return_value=("tenant-1", "acct-1")),
             patch("controllers.console.workspace.rbac.svc.RBACService.Roles.copy") as mock_copy,
             patch("controllers.console.workspace.rbac._dump", return_value={}),
@@ -555,8 +549,6 @@ class TestWorkspaceRbacGuards:
                 method="POST",
                 json={"name": "test_role", "permission_keys": []},
             ),
-            patch("libs.login.dify_config.LOGIN_DISABLED", True),
-            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.common.wraps.current_account_with_tenant",
                 return_value=(_account(), "tenant-1"),
@@ -576,8 +568,6 @@ class TestWorkspaceRbacGuards:
                 method="POST",
                 json={"name": "full_access", "resource_type": "app", "permission_keys": []},
             ),
-            patch("libs.login.dify_config.LOGIN_DISABLED", True),
-            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", True),
             patch(
                 "controllers.common.wraps.current_account_with_tenant",
                 return_value=(_account(), "tenant-1"),

--- a/api/tests/unit_tests/core/datasource/entities/test_datasource_entities.py
+++ b/api/tests/unit_tests/core/datasource/entities/test_datasource_entities.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from core.datasource.entities.datasource_entities import (
@@ -110,7 +108,7 @@ def test_datasource_entity():
     assert entity_with_params.parameters == [param]
 
 
-def test_datasource_provider_identity():
+def test_datasource_provider_identity(config_overrides):
     label = I18nObject(en_US="label", zh_Hans="标签")
     description = I18nObject(en_US="desc", zh_Hans="描述")
     identity = DatasourceProviderIdentity(
@@ -125,12 +123,11 @@ def test_datasource_provider_identity():
     assert identity.tags == [ToolLabelEnum.SEARCH]
 
     # Test generate_datasource_icon_url
-    with patch("core.datasource.entities.datasource_entities.dify_config") as mock_config:
-        mock_config.CONSOLE_API_URL = "http://api.example.com"
-        url = identity.generate_datasource_icon_url("tenant123")
-        assert "http://api.example.com/console/api/workspaces/current/plugin/icon" in url
-        assert "tenant_id=tenant123" in url
-        assert "filename=icon.png" in url
+    config_overrides(CONSOLE_API_URL="http://api.example.com")
+    url = identity.generate_datasource_icon_url("tenant123")
+    assert "http://api.example.com/console/api/workspaces/current/plugin/icon" in url
+    assert "tenant_id=tenant123" in url
+    assert "filename=icon.png" in url
 
     # Test hardcoded icon
     identity.icon = "https://assets.dify.ai/images/File%20Upload.svg"
@@ -138,10 +135,9 @@ def test_datasource_provider_identity():
 
     # Test with empty CONSOLE_API_URL
     identity.icon = "test.png"
-    with patch("core.datasource.entities.datasource_entities.dify_config") as mock_config:
-        mock_config.CONSOLE_API_URL = None
-        url = identity.generate_datasource_icon_url("tenant123")
-        assert url.startswith("/console/api/workspaces/current/plugin/icon")
+    config_overrides(CONSOLE_API_URL=None)
+    url = identity.generate_datasource_icon_url("tenant123")
+    assert url.startswith("/console/api/workspaces/current/plugin/icon")
 
 
 def test_datasource_provider_entity():

--- a/api/tests/unit_tests/core/datasource/test_datasource_file_manager.py
+++ b/api/tests/unit_tests/core/datasource/test_datasource_file_manager.py
@@ -58,13 +58,18 @@ def _message_file(id: str, *, url: str | None) -> MessageFile:
 
 
 class TestDatasourceFileManager:
+    @pytest.fixture(autouse=True)
+    def _file_config(self, config_overrides) -> None:
+        config_overrides(
+            FILES_URL="http://localhost:5001",
+            SECRET_KEY="test_secret",
+            STORAGE_TYPE="local",
+        )
+
     @patch("core.datasource.datasource_file_manager.time.time")
     @patch("core.datasource.datasource_file_manager.os.urandom")
-    @patch("core.datasource.datasource_file_manager.dify_config")
-    def test_sign_file(self, mock_config, mock_urandom, mock_time):
+    def test_sign_file(self, mock_urandom, mock_time):
         # Setup
-        mock_config.FILES_URL = "http://localhost:5001"
-        mock_config.SECRET_KEY = "test_secret"
         mock_time.return_value = 1700000000
         mock_urandom.return_value = b"1234567890abcdef"  # 16 bytes
 
@@ -82,11 +87,9 @@ class TestDatasourceFileManager:
 
     @patch("core.datasource.datasource_file_manager.storage")
     @patch("core.datasource.datasource_file_manager.uuid4")
-    @patch("core.datasource.datasource_file_manager.dify_config")
-    def test_create_file_by_raw(self, mock_config, mock_uuid, mock_storage, sqlite_session: Session):
+    def test_create_file_by_raw(self, mock_uuid, mock_storage, sqlite_session: Session):
         # Setup
         mock_uuid.return_value = MagicMock(hex="unique_hex")
-        mock_config.STORAGE_TYPE = "local"
 
         user_id = "user_123"
         tenant_id = "tenant_456"
@@ -117,11 +120,9 @@ class TestDatasourceFileManager:
 
     @patch("core.datasource.datasource_file_manager.storage")
     @patch("core.datasource.datasource_file_manager.uuid4")
-    @patch("core.datasource.datasource_file_manager.dify_config")
-    def test_create_file_by_raw_filename_no_extension(self, mock_config, mock_uuid, mock_storage):
+    def test_create_file_by_raw_filename_no_extension(self, mock_uuid, mock_storage):
         # Setup
         mock_uuid.return_value = MagicMock(hex="unique_hex")
-        mock_config.STORAGE_TYPE = "local"
 
         user_id = "user_123"
         tenant_id = "tenant_456"
@@ -143,13 +144,11 @@ class TestDatasourceFileManager:
 
     @patch("core.datasource.datasource_file_manager.storage")
     @patch("core.datasource.datasource_file_manager.uuid4")
-    @patch("core.datasource.datasource_file_manager.dify_config")
     @patch("core.datasource.datasource_file_manager.guess_extension")
-    def test_create_file_by_raw_unknown_extension(self, mock_guess_ext, mock_config, mock_uuid, mock_storage):
+    def test_create_file_by_raw_unknown_extension(self, mock_guess_ext, mock_uuid, mock_storage):
         # Setup
         mock_guess_ext.return_value = None  # Cannot guess
         mock_uuid.return_value = MagicMock(hex="unique_hex")
-        mock_config.STORAGE_TYPE = "local"
 
         # Execute
         upload_file = DatasourceFileManager.create_file_by_raw(
@@ -166,11 +165,9 @@ class TestDatasourceFileManager:
 
     @patch("core.datasource.datasource_file_manager.storage")
     @patch("core.datasource.datasource_file_manager.uuid4")
-    @patch("core.datasource.datasource_file_manager.dify_config")
-    def test_create_file_by_raw_no_filename(self, mock_config, mock_uuid, mock_storage):
+    def test_create_file_by_raw_no_filename(self, mock_uuid, mock_storage):
         # Setup
         mock_uuid.return_value = MagicMock(hex="unique_hex")
-        mock_config.STORAGE_TYPE = "local"
 
         # Execute
         upload_file = DatasourceFileManager.create_file_by_raw(

--- a/api/tests/unit_tests/core/datasource/test_notion_provider.py
+++ b/api/tests/unit_tests/core/datasource/test_notion_provider.py
@@ -137,13 +137,12 @@ class TestNotionExtractorAuthentication:
             plugin_id="langgenius/notion_datasource",
         )
 
-    @patch("core.rag.extractor.notion_extractor.dify_config")
     @patch("core.rag.extractor.notion_extractor.NotionExtractor._get_access_token")
-    def test_init_with_integration_token_fallback(self, mock_get_token, mock_config, mock_document_model):
+    def test_init_with_integration_token_fallback(self, mock_get_token, mock_document_model, config_overrides):
         """Test NotionExtractor falls back to integration token when credential not found."""
         # Arrange
         mock_get_token.side_effect = Exception("No credential id found")
-        mock_config.NOTION_INTEGRATION_TOKEN = "integration-token-fallback"
+        config_overrides(NOTION_INTEGRATION_TOKEN="integration-token-fallback")
 
         # Act
         extractor = NotionExtractor(
@@ -158,13 +157,12 @@ class TestNotionExtractorAuthentication:
         # Assert
         assert extractor._notion_access_token == "integration-token-fallback"
 
-    @patch("core.rag.extractor.notion_extractor.dify_config")
     @patch("core.rag.extractor.notion_extractor.NotionExtractor._get_access_token")
-    def test_init_missing_credentials_raises_error(self, mock_get_token, mock_config, mock_document_model):
+    def test_init_missing_credentials_raises_error(self, mock_get_token, mock_document_model, config_overrides):
         """Test NotionExtractor raises error when no credentials available."""
         # Arrange
         mock_get_token.side_effect = Exception("No credential id found")
-        mock_config.NOTION_INTEGRATION_TOKEN = None
+        config_overrides(NOTION_INTEGRATION_TOKEN=None)
 
         # Act & Assert
         with pytest.raises(ValueError) as exc_info:

--- a/api/tests/unit_tests/core/helper/test_creators.py
+++ b/api/tests/unit_tests/core/helper/test_creators.py
@@ -75,10 +75,11 @@ class TestUploadDSL:
 
 
 class TestGetRedirectUrl:
-    @patch("core.helper.creators.dify_config")
-    def test_without_oauth_client_id(self, mock_config):
-        mock_config.CREATORS_PLATFORM_API_URL = "https://creators.example.com"
-        mock_config.CREATORS_PLATFORM_OAUTH_CLIENT_ID = ""
+    def test_without_oauth_client_id(self, config_overrides):
+        config_overrides(
+            CREATORS_PLATFORM_API_URL="https://creators.example.com",
+            CREATORS_PLATFORM_OAUTH_CLIENT_ID="",
+        )
 
         from core.helper.creators import get_redirect_url
 
@@ -88,10 +89,11 @@ class TestGetRedirectUrl:
         assert "oauth_code" not in url
         assert url.startswith("https://creators.example.com")
 
-    @patch("core.helper.creators.dify_config")
-    def test_with_oauth_client_id(self, mock_config):
-        mock_config.CREATORS_PLATFORM_API_URL = "https://creators.example.com"
-        mock_config.CREATORS_PLATFORM_OAUTH_CLIENT_ID = "client-xyz"
+    def test_with_oauth_client_id(self, config_overrides):
+        config_overrides(
+            CREATORS_PLATFORM_API_URL="https://creators.example.com",
+            CREATORS_PLATFORM_OAUTH_CLIENT_ID="client-xyz",
+        )
 
         with patch(
             "services.oauth_server.OAuthServerService.sign_oauth_authorization_code",
@@ -105,10 +107,11 @@ class TestGetRedirectUrl:
             assert "dsl_claim_code=claim-abc" in url
             assert "oauth_code=oauth-code-123" in url
 
-    @patch("core.helper.creators.dify_config")
-    def test_strips_trailing_slash(self, mock_config):
-        mock_config.CREATORS_PLATFORM_API_URL = "https://creators.example.com/"
-        mock_config.CREATORS_PLATFORM_OAUTH_CLIENT_ID = ""
+    def test_strips_trailing_slash(self, config_overrides):
+        config_overrides(
+            CREATORS_PLATFORM_API_URL="https://creators.example.com/",
+            CREATORS_PLATFORM_OAUTH_CLIENT_ID="",
+        )
 
         from core.helper.creators import get_redirect_url
 

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -260,9 +260,7 @@ class TestIndividualHandlers:
 
     def test_handle_initialize_echoes_supported_version(self):
         """A supported requested version is echoed back unchanged."""
-        with patch("core.mcp.server.streamable_http.dify_config") as mock_config:
-            mock_config.project.version = "1.0.0"
-            result = handle_initialize("Test server", "2024-11-05")
+        result = handle_initialize("Test server", "2024-11-05")
 
         assert isinstance(result, types.InitializeResult)
         assert result.protocolVersion == "2024-11-05"
@@ -270,34 +268,26 @@ class TestIndividualHandlers:
 
     def test_handle_initialize_echoes_intermediate_version(self):
         """The intermediate supported version (2025-03-26) is echoed back."""
-        with patch("core.mcp.server.streamable_http.dify_config") as mock_config:
-            mock_config.project.version = "1.0.0"
-            result = handle_initialize("Test server", "2025-03-26")
+        result = handle_initialize("Test server", "2025-03-26")
 
         assert result.protocolVersion == "2025-03-26"
 
     def test_handle_initialize_negotiates_latest_for_modern_client(self):
         """A 2025-06-18 client gets 2025-06-18 back."""
-        with patch("core.mcp.server.streamable_http.dify_config") as mock_config:
-            mock_config.project.version = "1.0.0"
-            result = handle_initialize("Test server", "2025-06-18")
+        result = handle_initialize("Test server", "2025-06-18")
 
         assert result.protocolVersion == "2025-06-18"
 
     def test_handle_initialize_falls_back_for_unknown_version(self):
         """An unsupported requested version falls back to the server latest."""
-        with patch("core.mcp.server.streamable_http.dify_config") as mock_config:
-            mock_config.project.version = "1.0.0"
-            result = handle_initialize("Test server", "1999-01-01")
+        result = handle_initialize("Test server", "1999-01-01")
 
         assert result.protocolVersion == types.SERVER_LATEST_PROTOCOL_VERSION
         assert result.protocolVersion == "2025-06-18"
 
     def test_handle_initialize_non_string_version_falls_back(self):
         """A malformed (non-string) requested version falls back to the server latest."""
-        with patch("core.mcp.server.streamable_http.dify_config") as mock_config:
-            mock_config.project.version = "1.0.0"
-            result = handle_initialize("Test server", 20250618)
+        result = handle_initialize("Test server", 20250618)
 
         assert result.protocolVersion == types.SERVER_LATEST_PROTOCOL_VERSION
 

--- a/api/tests/unit_tests/core/mcp/test_utils.py
+++ b/api/tests/unit_tests/core/mcp/test_utils.py
@@ -16,6 +16,20 @@ from core.mcp.utils import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _mcp_config(config_overrides) -> None:
+    config_overrides(
+        SSRF_PROXY_ALL_URL=None,
+        SSRF_PROXY_HTTP_URL=None,
+        SSRF_PROXY_HTTPS_URL=None,
+        HTTP_REQUEST_NODE_SSL_VERIFY=True,
+        SSRF_DEFAULT_TIME_OUT=30.0,
+        SSRF_DEFAULT_CONNECT_TIME_OUT=10.0,
+        SSRF_DEFAULT_READ_TIME_OUT=60.0,
+        SSRF_DEFAULT_WRITE_TIME_OUT=30.0,
+    )
+
+
 class TestConstants:
     """Test module constants."""
 
@@ -32,11 +46,9 @@ class TestConstants:
 class TestCreateSSRFProxyMCPHTTPClient:
     """Test create_ssrf_proxy_mcp_http_client function."""
 
-    @patch("core.mcp.utils.dify_config")
-    def test_create_client_with_all_url_proxy(self, mock_config):
+    def test_create_client_with_all_url_proxy(self, config_overrides):
         """Test client creation with SSRF_PROXY_ALL_URL configured."""
-        mock_config.SSRF_PROXY_ALL_URL = "http://proxy.example.com:8080"
-        mock_config.HTTP_REQUEST_NODE_SSL_VERIFY = True
+        config_overrides(SSRF_PROXY_ALL_URL="http://proxy.example.com:8080")
 
         client = create_ssrf_proxy_mcp_http_client(
             headers={"Authorization": "Bearer token"}, timeout=httpx.Timeout(30.0)
@@ -50,13 +62,13 @@ class TestCreateSSRFProxyMCPHTTPClient:
         # Clean up
         client.close()
 
-    @patch("core.mcp.utils.dify_config")
-    def test_create_client_with_http_https_proxies(self, mock_config):
+    def test_create_client_with_http_https_proxies(self, config_overrides):
         """Test client creation with separate HTTP/HTTPS proxies."""
-        mock_config.SSRF_PROXY_ALL_URL = None
-        mock_config.SSRF_PROXY_HTTP_URL = "http://http-proxy.example.com:8080"
-        mock_config.SSRF_PROXY_HTTPS_URL = "http://https-proxy.example.com:8443"
-        mock_config.HTTP_REQUEST_NODE_SSL_VERIFY = False
+        config_overrides(
+            SSRF_PROXY_HTTP_URL="http://http-proxy.example.com:8080",
+            SSRF_PROXY_HTTPS_URL="http://https-proxy.example.com:8443",
+            HTTP_REQUEST_NODE_SSL_VERIFY=False,
+        )
 
         client = create_ssrf_proxy_mcp_http_client()
 
@@ -66,13 +78,8 @@ class TestCreateSSRFProxyMCPHTTPClient:
         # Clean up
         client.close()
 
-    @patch("core.mcp.utils.dify_config")
-    def test_create_client_without_proxy(self, mock_config):
+    def test_create_client_without_proxy(self):
         """Test client creation without proxy configuration."""
-        mock_config.SSRF_PROXY_ALL_URL = None
-        mock_config.SSRF_PROXY_HTTP_URL = None
-        mock_config.SSRF_PROXY_HTTPS_URL = None
-        mock_config.HTTP_REQUEST_NODE_SSL_VERIFY = True
 
         headers = {"X-Custom-Header": "value"}
         timeout = httpx.Timeout(timeout=30.0, connect=5.0, read=10.0, write=30.0)
@@ -88,13 +95,8 @@ class TestCreateSSRFProxyMCPHTTPClient:
         # Clean up
         client.close()
 
-    @patch("core.mcp.utils.dify_config")
-    def test_create_client_default_params(self, mock_config):
+    def test_create_client_default_params(self):
         """Test client creation with default parameters."""
-        mock_config.SSRF_PROXY_ALL_URL = None
-        mock_config.SSRF_PROXY_HTTP_URL = None
-        mock_config.SSRF_PROXY_HTTPS_URL = None
-        mock_config.HTTP_REQUEST_NODE_SSL_VERIFY = True
 
         client = create_ssrf_proxy_mcp_http_client()
 
@@ -140,15 +142,8 @@ class TestSSRFProxySSEConnect:
 
     @patch("core.mcp.utils.connect_sse", autospec=True)
     @patch("core.mcp.utils.create_ssrf_proxy_mcp_http_client", autospec=True)
-    @patch("core.mcp.utils.dify_config")
-    def test_sse_connect_without_client(self, mock_config, mock_create_client, mock_connect_sse):
+    def test_sse_connect_without_client(self, mock_create_client, mock_connect_sse):
         """Test SSE connection without pre-configured client."""
-        # Setup config
-        mock_config.SSRF_DEFAULT_TIME_OUT = 30.0
-        mock_config.SSRF_DEFAULT_CONNECT_TIME_OUT = 10.0
-        mock_config.SSRF_DEFAULT_READ_TIME_OUT = 60.0
-        mock_config.SSRF_DEFAULT_WRITE_TIME_OUT = 30.0
-
         # Setup mocks
         mock_client = Mock(spec=httpx.Client)
         mock_create_client.return_value = mock_client

--- a/api/tests/unit_tests/core/rag/embedding/test_cached_embedding.py
+++ b/api/tests/unit_tests/core/rag/embedding/test_cached_embedding.py
@@ -452,8 +452,9 @@ class TestCacheEmbeddingMultimodalQuery:
 
             assert "Normalized embedding is nan" in str(exc_info.value)
 
-    def test_embed_multimodal_query_api_error(self, mock_model_instance):
+    def test_embed_multimodal_query_api_error(self, mock_model_instance, config_overrides):
         """Test handling of API errors during multimodal query embedding."""
+        config_overrides(DEBUG=False)
         cache_embedding = CacheEmbedding(mock_model_instance)
         document = {"file_id": "file123"}
 
@@ -461,16 +462,14 @@ class TestCacheEmbeddingMultimodalQuery:
             mock_redis.get.return_value = None
             mock_model_instance.invoke_multimodal_embedding.side_effect = Exception("API Error")
 
-            with patch("core.rag.embedding.cached_embedding.dify_config") as mock_config:
-                mock_config.DEBUG = False
+            with pytest.raises(Exception) as exc_info:
+                cache_embedding.embed_multimodal_query(document)
 
-                with pytest.raises(Exception) as exc_info:
-                    cache_embedding.embed_multimodal_query(document)
+            assert "API Error" in str(exc_info.value)
 
-                assert "API Error" in str(exc_info.value)
-
-    def test_embed_multimodal_query_redis_set_error(self, mock_model_instance):
+    def test_embed_multimodal_query_redis_set_error(self, mock_model_instance, config_overrides):
         """Test handling of Redis set errors during multimodal query embedding."""
+        config_overrides(DEBUG=True)
         cache_embedding = CacheEmbedding(mock_model_instance)
         document = {"file_id": "file123"}
 
@@ -498,11 +497,8 @@ class TestCacheEmbeddingMultimodalQuery:
             mock_model_instance.invoke_multimodal_embedding.return_value = embedding_result
             mock_redis.setex.side_effect = RuntimeError("Redis Error")
 
-            with patch("core.rag.embedding.cached_embedding.dify_config") as mock_config:
-                mock_config.DEBUG = True
-
-                with pytest.raises(RuntimeError):
-                    cache_embedding.embed_multimodal_query(document)
+            with pytest.raises(RuntimeError):
+                cache_embedding.embed_multimodal_query(document)
 
 
 class TestCacheEmbeddingQueryErrors:
@@ -518,8 +514,11 @@ class TestCacheEmbeddingQueryErrors:
         model_instance.credentials = {"api_key": "test-key"}
         return model_instance
 
-    def test_embed_query_api_error_debug_mode(self, mock_model_instance, caplog: pytest.LogCaptureFixture):
+    def test_embed_query_api_error_debug_mode(
+        self, mock_model_instance, caplog: pytest.LogCaptureFixture, config_overrides
+    ):
         """Test handling of API errors in debug mode."""
+        config_overrides(DEBUG=True)
         cache_embedding = CacheEmbedding(mock_model_instance)
         query = "test query"
 
@@ -527,18 +526,18 @@ class TestCacheEmbeddingQueryErrors:
             mock_redis.get.return_value = None
             mock_model_instance.invoke_text_embedding.side_effect = RuntimeError("API Error")
 
-            with patch("core.rag.embedding.cached_embedding.dify_config") as mock_config:
-                mock_config.DEBUG = True
+            with caplog.at_level(logging.ERROR, logger="core.rag.embedding.cached_embedding"):
+                with pytest.raises(RuntimeError) as exc_info:
+                    cache_embedding.embed_query(query)
 
-                with caplog.at_level(logging.ERROR, logger="core.rag.embedding.cached_embedding"):
-                    with pytest.raises(RuntimeError) as exc_info:
-                        cache_embedding.embed_query(query)
+                assert "API Error" in str(exc_info.value)
+                assert any(record.levelno == logging.ERROR for record in caplog.records)
 
-                    assert "API Error" in str(exc_info.value)
-                    assert any(record.levelno == logging.ERROR for record in caplog.records)
-
-    def test_embed_query_redis_set_error_debug_mode(self, mock_model_instance, caplog: pytest.LogCaptureFixture):
+    def test_embed_query_redis_set_error_debug_mode(
+        self, mock_model_instance, caplog: pytest.LogCaptureFixture, config_overrides
+    ):
         """Test handling of Redis set errors in debug mode."""
+        config_overrides(DEBUG=True)
         cache_embedding = CacheEmbedding(mock_model_instance)
         query = "test query"
 
@@ -566,14 +565,11 @@ class TestCacheEmbeddingQueryErrors:
             mock_model_instance.invoke_text_embedding.return_value = embedding_result
             mock_redis.setex.side_effect = RuntimeError("Redis Error")
 
-            with patch("core.rag.embedding.cached_embedding.dify_config") as mock_config:
-                mock_config.DEBUG = True
+            with caplog.at_level(logging.ERROR, logger="core.rag.embedding.cached_embedding"):
+                with pytest.raises(RuntimeError):
+                    cache_embedding.embed_query(query)
 
-                with caplog.at_level(logging.ERROR, logger="core.rag.embedding.cached_embedding"):
-                    with pytest.raises(RuntimeError):
-                        cache_embedding.embed_query(query)
-
-                    assert any(record.levelno == logging.ERROR for record in caplog.records)
+                assert any(record.levelno == logging.ERROR for record in caplog.records)
 
 
 class TestCacheEmbeddingInitialization:

--- a/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
+++ b/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
@@ -1580,21 +1580,17 @@ class TestIndexingRunnerSplitter:
                 embedding_model_instance=mock_embedding_instance,
             )
 
-    def test_get_splitter_validates_max_tokens_too_large(self, mock_embedding_instance):
+    def test_get_splitter_validates_max_tokens_too_large(self, mock_embedding_instance, config_overrides):
         """Test splitter validation rejects max_tokens above maximum."""
-        # Arrange
-        with patch("core.indexing_runner.dify_config") as mock_config:
-            mock_config.INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH = 5000
-
-            # Act & Assert
-            with pytest.raises(ValueError, match="Custom segment length should be between"):
-                IndexingRunner._get_splitter(
-                    processing_rule_mode="custom",
-                    max_tokens=10000,  # Above maximum
-                    chunk_overlap=100,
-                    separator="\\n",
-                    embedding_model_instance=mock_embedding_instance,
-                )
+        config_overrides(INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH=5000)
+        with pytest.raises(ValueError, match="Custom segment length should be between"):
+            IndexingRunner._get_splitter(
+                processing_rule_mode="custom",
+                max_tokens=10000,  # Above maximum
+                chunk_overlap=100,
+                separator="\\n",
+                embedding_model_instance=mock_embedding_instance,
+            )
 
 
 class TestIndexingRunnerLoadSegments:
@@ -1782,30 +1778,29 @@ class TestIndexingRunnerEstimate:
                 "factory": mock_factory,
             }
 
-    def test_indexing_estimate_respects_batch_limit(self, mock_dependencies):
+    def test_indexing_estimate_respects_batch_limit(self, mock_dependencies, config_overrides):
         """Test indexing estimate enforces batch upload limit."""
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD, BATCH_UPLOAD_LIMIT=10)
         # Arrange
         runner = IndexingRunner()
         tenant_id = str(uuid.uuid4())
 
-        # Create too many extract settings
-        with patch("core.indexing_runner.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            mock_config.BATCH_UPLOAD_LIMIT = 10
-            extract_settings = [MagicMock() for _ in range(15)]
+        extract_settings = [MagicMock() for _ in range(15)]
 
-            # Act & Assert
-            with pytest.raises(ValueError, match="batch upload limit"):
-                runner.indexing_estimate(
-                    tenant_id=tenant_id,
-                    extract_settings=extract_settings,
-                    tmp_processing_rule={"mode": "automatic", "rules": {}},
-                    doc_form=IndexStructureType.PARAGRAPH_INDEX,
-                    session=mock_dependencies["session"],
-                )
+        with pytest.raises(ValueError, match="batch upload limit"):
+            runner.indexing_estimate(
+                tenant_id=tenant_id,
+                extract_settings=extract_settings,
+                tmp_processing_rule={"mode": "automatic", "rules": {}},
+                doc_form=IndexStructureType.PARAGRAPH_INDEX,
+                session=mock_dependencies["session"],
+            )
 
-    def test_indexing_estimate_commits_preview_cleanup_before_summary_workers(self, mock_dependencies):
+    def test_indexing_estimate_commits_preview_cleanup_before_summary_workers(
+        self, mock_dependencies, config_overrides
+    ):
         """Test preview cleanup is visible before summary workers use independent sessions."""
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
         runner = IndexingRunner()
         tenant_id = str(uuid.uuid4())
         mock_processor = MagicMock()
@@ -1845,10 +1840,7 @@ class TestIndexingRunnerEstimate:
         with (
             patch("core.indexing_runner.get_image_upload_file_ids", return_value=["image-1"]),
             patch("core.indexing_runner.storage") as mock_storage,
-            patch("core.indexing_runner.dify_config") as mock_config,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-
             result = runner.indexing_estimate(
                 tenant_id=tenant_id,
                 extract_settings=[MagicMock()],

--- a/api/tests/unit_tests/core/repositories/test_factory.py
+++ b/api/tests/unit_tests/core/repositories/test_factory.py
@@ -37,6 +37,13 @@ def sqlite_session_factory(sqlite_engine: Engine) -> sessionmaker[Session]:
 class TestRepositoryFactory:
     """Test cases for RepositoryFactory."""
 
+    @pytest.fixture(autouse=True)
+    def _repository_config(self, config_overrides) -> None:
+        config_overrides(
+            CORE_WORKFLOW_EXECUTION_REPOSITORY="unittest.mock.MagicMock",
+            CORE_WORKFLOW_NODE_EXECUTION_REPOSITORY="unittest.mock.MagicMock",
+        )
+
     def test_import_string_success(self):
         """Test successful class import."""
         # Test importing a real class
@@ -62,12 +69,8 @@ class TestRepositoryFactory:
             import_string("invalidpath")
         assert "doesn't look like a module path" in str(exc_info.value)
 
-    @patch("core.repositories.factory.dify_config")
-    def test_create_workflow_execution_repository_success(self, mock_config, sqlite_session_factory):
+    def test_create_workflow_execution_repository_success(self, sqlite_session_factory):
         """Test successful WorkflowExecutionRepository creation."""
-        # Setup mock configuration
-        mock_config.CORE_WORKFLOW_EXECUTION_REPOSITORY = "unittest.mock.MagicMock"
-
         # Create non-database dependencies
         mock_user = Account(name="Test Account", email="test@example.com")
         app_id = "test-app-id"
@@ -98,11 +101,9 @@ class TestRepositoryFactory:
             )
             assert result is mock_repository_instance
 
-    @patch("core.repositories.factory.dify_config")
-    def test_create_workflow_execution_repository_import_error(self, mock_config, sqlite_session_factory):
+    def test_create_workflow_execution_repository_import_error(self, sqlite_session_factory, config_overrides):
         """Test WorkflowExecutionRepository creation with import error."""
-        # Setup mock configuration with invalid class path
-        mock_config.CORE_WORKFLOW_EXECUTION_REPOSITORY = "invalid.module.InvalidClass"
+        config_overrides(CORE_WORKFLOW_EXECUTION_REPOSITORY="invalid.module.InvalidClass")
 
         mock_user = Account(name="Test Account", email="test@example.com")
 
@@ -116,12 +117,8 @@ class TestRepositoryFactory:
             )
         assert "Failed to create WorkflowExecutionRepository" in str(exc_info.value)
 
-    @patch("core.repositories.factory.dify_config")
-    def test_create_workflow_execution_repository_instantiation_error(self, mock_config, sqlite_session_factory):
+    def test_create_workflow_execution_repository_instantiation_error(self, sqlite_session_factory):
         """Test WorkflowExecutionRepository creation with instantiation error."""
-        # Setup mock configuration
-        mock_config.CORE_WORKFLOW_EXECUTION_REPOSITORY = "unittest.mock.MagicMock"
-
         mock_user = Account(name="Test Account", email="test@example.com")
 
         # Create a mock repository class that raises exception on instantiation
@@ -140,12 +137,8 @@ class TestRepositoryFactory:
                 )
             assert "Failed to create WorkflowExecutionRepository" in str(exc_info.value)
 
-    @patch("core.repositories.factory.dify_config")
-    def test_create_workflow_node_execution_repository_success(self, mock_config, sqlite_session_factory):
+    def test_create_workflow_node_execution_repository_success(self, sqlite_session_factory):
         """Test successful WorkflowNodeExecutionRepository creation."""
-        # Setup mock configuration
-        mock_config.CORE_WORKFLOW_NODE_EXECUTION_REPOSITORY = "unittest.mock.MagicMock"
-
         # Create non-database dependencies
         mock_user = EndUser()
         app_id = "test-app-id"
@@ -176,11 +169,9 @@ class TestRepositoryFactory:
             )
             assert result is mock_repository_instance
 
-    @patch("core.repositories.factory.dify_config")
-    def test_create_workflow_node_execution_repository_import_error(self, mock_config, sqlite_session_factory):
+    def test_create_workflow_node_execution_repository_import_error(self, sqlite_session_factory, config_overrides):
         """Test WorkflowNodeExecutionRepository creation with import error."""
-        # Setup mock configuration with invalid class path
-        mock_config.CORE_WORKFLOW_NODE_EXECUTION_REPOSITORY = "invalid.module.InvalidClass"
+        config_overrides(CORE_WORKFLOW_NODE_EXECUTION_REPOSITORY="invalid.module.InvalidClass")
 
         mock_user = EndUser()
 
@@ -194,12 +185,8 @@ class TestRepositoryFactory:
             )
         assert "Failed to create WorkflowNodeExecutionRepository" in str(exc_info.value)
 
-    @patch("core.repositories.factory.dify_config")
-    def test_create_workflow_node_execution_repository_instantiation_error(self, mock_config, sqlite_session_factory):
+    def test_create_workflow_node_execution_repository_instantiation_error(self, sqlite_session_factory):
         """Test WorkflowNodeExecutionRepository creation with instantiation error."""
-        # Setup mock configuration
-        mock_config.CORE_WORKFLOW_NODE_EXECUTION_REPOSITORY = "unittest.mock.MagicMock"
-
         mock_user = EndUser()
 
         # Create a mock repository class that raises exception on instantiation
@@ -224,12 +211,8 @@ class TestRepositoryFactory:
         error = RepositoryImportError(error_message)
         assert str(error) == error_message
 
-    @patch("core.repositories.factory.dify_config")
-    def test_create_with_engine_instead_of_sessionmaker(self, mock_config, sqlite_engine: Engine):
+    def test_create_with_engine_instead_of_sessionmaker(self, sqlite_engine: Engine):
         """Test repository creation with Engine instead of sessionmaker."""
-        # Setup mock configuration
-        mock_config.CORE_WORKFLOW_EXECUTION_REPOSITORY = "unittest.mock.MagicMock"
-
         # Pass the real Engine directly instead of wrapping it in sessionmaker
         mock_user = Account(name="Test Account", email="test@example.com")
         app_id = "test-app-id"

--- a/api/tests/unit_tests/core/tools/test_mcp_tool.py
+++ b/api/tests/unit_tests/core/tools/test_mcp_tool.py
@@ -257,41 +257,39 @@ def test_inject_forwarded_identity_sends_account_type_for_debugger():
     assert issue.call_args.kwargs["user_type"] == "account"
 
 
-def test_invoke_remote_mcp_tool_fails_closed_when_user_id_missing():
+def test_invoke_remote_mcp_tool_fails_closed_when_user_id_missing(config_overrides):
     """When forwarding is enabled AND the deployment is enterprise, missing
     user_id must raise — never silently invoke as the static identity."""
     tool = _build_forwarding_tool()
 
-    with patch("core.tools.mcp_tool.tool.dify_config") as cfg:
-        cfg.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
-        with pytest.raises(ToolInvokeError, match="no end-user context"):
-            tool.invoke_remote_mcp_tool({}, user_id=None, app_id=None)
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
+    with pytest.raises(ToolInvokeError, match="no end-user context"):
+        tool.invoke_remote_mcp_tool({}, user_id=None, app_id=None)
 
 
-def test_invoke_skips_forwarding_outside_enterprise_edition():
+def test_invoke_skips_forwarding_outside_enterprise_edition(config_overrides):
     """Non-enterprise deployments treat the DB selector as a no-op: a stale
     `identity_mode="idp_token"` row must NOT raise (fail-closed) AND must
     NOT call the enterprise inner API. The runtime falls through to the
     legacy provider-identity path."""
     tool = _build_forwarding_tool()
 
-    with patch("core.tools.mcp_tool.tool.dify_config") as cfg:
-        cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        # The fail-closed branch must NOT fire (no enterprise → no forwarding).
-        # The function will still try the legacy DB-load path; we patch that
-        # to keep the test unit-scoped.
-        with patch("core.tools.mcp_tool.tool.MCPClientWithAuthRetry") as client_cls:
-            client_cls.return_value.__enter__.return_value.invoke_tool.return_value = CallToolResult(
-                content=[],
-                _meta=None,
-            )
-            with patch.object(tool, "_inject_forwarded_identity") as inject:
-                with patch("services.tools.mcp_tools_manage_service.MCPToolManageService"):
-                    with patch("core.entities.mcp_provider.MCPProviderEntity.decrypt_server_url", return_value="u"):
-                        with patch("core.entities.mcp_provider.MCPProviderEntity.decrypt_headers", return_value={}):
-                            # Should not raise; should not call enterprise.
-                            try:
-                                tool.invoke_remote_mcp_tool({}, user_id=None, app_id=None)
-                            except Exception:
-                                pass
-            inject.assert_not_called()
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+    # The fail-closed branch must NOT fire (no enterprise → no forwarding).
+    # The function will still try the legacy DB-load path; we patch that
+    # to keep the test unit-scoped.
+    with patch("core.tools.mcp_tool.tool.MCPClientWithAuthRetry") as client_cls:
+        client_cls.return_value.__enter__.return_value.invoke_tool.return_value = CallToolResult(
+            content=[],
+            _meta=None,
+        )
+        with patch.object(tool, "_inject_forwarded_identity") as inject:
+            with patch("services.tools.mcp_tools_manage_service.MCPToolManageService"):
+                with patch("core.entities.mcp_provider.MCPProviderEntity.decrypt_server_url", return_value="u"):
+                    with patch("core.entities.mcp_provider.MCPProviderEntity.decrypt_headers", return_value={}):
+                        # Should not raise; should not call enterprise.
+                        try:
+                            tool.invoke_remote_mcp_tool({}, user_id=None, app_id=None)
+                        except Exception:
+                            pass
+        inject.assert_not_called()

--- a/api/tests/unit_tests/enums/test_quota_type.py
+++ b/api/tests/unit_tests/enums/test_quota_type.py
@@ -21,28 +21,23 @@ class TestQuotaType:
 
 
 class TestQuotaService:
-    def test_reserve_outside_cloud_edition(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService"),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    @pytest.fixture(autouse=True)
+    def _cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+
+    def test_reserve_outside_cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        with patch("services.billing_service.BillingService"):
             charge = QuotaService.reserve(QuotaType.TRIGGER, "t1")
             assert charge.success is True
             assert charge.charge_id is None
 
     def test_reserve_zero_amount_raises(self):
-        with patch("services.quota_service.dify_config") as mock_cfg:
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            with pytest.raises(ValueError, match="greater than 0"):
-                QuotaService.reserve(QuotaType.TRIGGER, "t1", amount=0)
+        with pytest.raises(ValueError, match="greater than 0"):
+            QuotaService.reserve(QuotaType.TRIGGER, "t1", amount=0)
 
     def test_reserve_success(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.return_value = {"reservation_id": "rid-1", "available": 99}
 
             charge = QuotaService.reserve(QuotaType.TRIGGER, "t1", amount=1)
@@ -57,11 +52,7 @@ class TestQuotaService:
     def test_reserve_no_reservation_id_raises(self):
         from services.errors.app import QuotaExceededError
 
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.return_value = {}
 
             with pytest.raises(QuotaExceededError):
@@ -70,22 +61,14 @@ class TestQuotaService:
     def test_reserve_quota_exceeded_propagates(self):
         from services.errors.app import QuotaExceededError
 
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.side_effect = QuotaExceededError(feature="trigger", tenant_id="t1", required=1)
 
             with pytest.raises(QuotaExceededError):
                 QuotaService.reserve(QuotaType.TRIGGER, "t1")
 
     def test_reserve_api_exception_returns_unlimited(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.side_effect = RuntimeError("network")
 
             charge = QuotaService.reserve(QuotaType.TRIGGER, "t1")
@@ -93,11 +76,7 @@ class TestQuotaService:
             assert charge.charge_id is None
 
     def test_consume_calls_reserve_and_commit(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_reserve.return_value = {"reservation_id": "rid-c"}
             mock_bs.quota_commit.return_value = {}
 
@@ -105,73 +84,43 @@ class TestQuotaService:
             assert charge.success is True
             mock_bs.quota_commit.assert_called_once()
 
-    def test_check_outside_cloud_edition(self):
-        with patch("services.quota_service.dify_config") as mock_cfg:
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            assert QuotaService.check(QuotaType.TRIGGER, "t1") is True
+    def test_check_outside_cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        assert QuotaService.check(QuotaType.TRIGGER, "t1") is True
 
     def test_check_zero_amount_raises(self):
-        with patch("services.quota_service.dify_config") as mock_cfg:
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            with pytest.raises(ValueError, match="greater than 0"):
-                QuotaService.check(QuotaType.TRIGGER, "t1", amount=0)
+        with pytest.raises(ValueError, match="greater than 0"):
+            QuotaService.check(QuotaType.TRIGGER, "t1", amount=0)
 
     def test_check_sufficient_quota(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", return_value=100),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", return_value=100):
             assert QuotaService.check(QuotaType.TRIGGER, "t1", amount=50) is True
 
     def test_check_insufficient_quota(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", return_value=5),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", return_value=5):
             assert QuotaService.check(QuotaType.TRIGGER, "t1", amount=10) is False
 
     def test_check_unlimited_quota(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", return_value=-1),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", return_value=-1):
             assert QuotaService.check(QuotaType.TRIGGER, "t1", amount=999) is True
 
     def test_check_exception_returns_true(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch.object(QuotaService, "get_remaining", side_effect=RuntimeError),
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch.object(QuotaService, "get_remaining", side_effect=RuntimeError):
             assert QuotaService.check(QuotaType.TRIGGER, "t1") is True
 
-    def test_release_outside_cloud_edition(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    def test_release_outside_cloud_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        with patch("services.billing_service.BillingService") as mock_bs:
             QuotaService.release(QuotaType.TRIGGER, "rid-1", "t1", "trigger_event")
             mock_bs.quota_release.assert_not_called()
 
     def test_release_empty_reservation(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             QuotaService.release(QuotaType.TRIGGER, "", "t1", "trigger_event")
             mock_bs.quota_release.assert_not_called()
 
     def test_release_success(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_release.return_value = {}
             QuotaService.release(QuotaType.TRIGGER, "rid-1", "t1", "trigger_event")
             mock_bs.quota_release.assert_called_once_with(
@@ -179,11 +128,7 @@ class TestQuotaService:
             )
 
     def test_release_exception_swallowed(self):
-        with (
-            patch("services.quota_service.dify_config") as mock_cfg,
-            patch("services.billing_service.BillingService") as mock_bs,
-        ):
-            mock_cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+        with patch("services.billing_service.BillingService") as mock_bs:
             mock_bs.quota_release.side_effect = RuntimeError("fail")
             QuotaService.release(QuotaType.TRIGGER, "rid-1", "t1", "trigger_event")
 

--- a/api/tests/unit_tests/extensions/storage/test_supabase_storage.py
+++ b/api/tests/unit_tests/extensions/storage/test_supabase_storage.py
@@ -10,105 +10,81 @@ from extensions.storage.supabase_storage import SupabaseStorage
 class TestSupabaseStorage:
     """Test suite for SupabaseStorage class."""
 
+    @pytest.fixture(autouse=True)
+    def _supabase_config(self, config_overrides) -> None:
+        config_overrides(
+            SUPABASE_URL="https://test.supabase.co",
+            SUPABASE_API_KEY="test-api-key",
+            SUPABASE_BUCKET_NAME="test-bucket",
+        )
+
     def test_init_success_with_all_config(self):
         """Test successful initialization when all required config is provided."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            # Mock bucket_exists to return True so create_bucket is not called
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
+                storage = SupabaseStorage()
 
-                # Mock bucket_exists to return True so create_bucket is not called
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
-                    storage = SupabaseStorage()
+                assert storage.bucket_name == "test-bucket"
+                mock_client_class.assert_called_once_with(
+                    supabase_url="https://test.supabase.co", supabase_key="test-api-key"
+                )
 
-                    assert storage.bucket_name == "test-bucket"
-                    mock_client_class.assert_called_once_with(
-                        supabase_url="https://test.supabase.co", supabase_key="test-api-key"
-                    )
-
-    def test_init_raises_error_when_url_missing(self):
+    def test_init_raises_error_when_url_missing(self, config_overrides):
         """Test initialization raises ValueError when SUPABASE_URL is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = None
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        config_overrides(SUPABASE_URL=None)
+        with pytest.raises(ValueError, match="SUPABASE_URL is not set"):
+            SupabaseStorage()
 
-            with pytest.raises(ValueError, match="SUPABASE_URL is not set"):
-                SupabaseStorage()
-
-    def test_init_raises_error_when_api_key_missing(self):
+    def test_init_raises_error_when_api_key_missing(self, config_overrides):
         """Test initialization raises ValueError when SUPABASE_API_KEY is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = None
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        config_overrides(SUPABASE_API_KEY=None)
+        with pytest.raises(ValueError, match="SUPABASE_API_KEY is not set"):
+            SupabaseStorage()
 
-            with pytest.raises(ValueError, match="SUPABASE_API_KEY is not set"):
-                SupabaseStorage()
-
-    def test_init_raises_error_when_bucket_name_missing(self):
+    def test_init_raises_error_when_bucket_name_missing(self, config_overrides):
         """Test initialization raises ValueError when SUPABASE_BUCKET_NAME is None."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = None
-
-            with pytest.raises(ValueError, match="SUPABASE_BUCKET_NAME is not set"):
-                SupabaseStorage()
+        config_overrides(SUPABASE_BUCKET_NAME=None)
+        with pytest.raises(ValueError, match="SUPABASE_BUCKET_NAME is not set"):
+            SupabaseStorage()
 
     def test_create_bucket_when_not_exists(self):
         """Test create_bucket creates bucket when it doesn't exist."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=False):
+                SupabaseStorage()
 
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=False):
-                    storage = SupabaseStorage()
-
-                    mock_client.storage.create_bucket.assert_called_once_with(id="test-bucket", name="test-bucket")
+                mock_client.storage.create_bucket.assert_called_once_with(id="test-bucket", name="test-bucket")
 
     def test_create_bucket_when_exists(self):
         """Test create_bucket does not create bucket when it already exists."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
+                SupabaseStorage()
 
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
-                    storage = SupabaseStorage()
-
-                    mock_client.storage.create_bucket.assert_not_called()
+                mock_client.storage.create_bucket.assert_not_called()
 
     @pytest.fixture
     def storage_with_mock_client(self):
         """Fixture providing SupabaseStorage with mocked client."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
-
-                with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
-                    storage = SupabaseStorage()
-                    # Create fresh mock for each test
-                    mock_client.reset_mock()
-                    yield storage, mock_client
+            with patch.object(SupabaseStorage, "bucket_exists", return_value=True):
+                storage = SupabaseStorage()
+                # Create fresh mock for each test
+                mock_client.reset_mock()
+                yield storage, mock_client
 
     def test_save(self, storage_with_mock_client):
         """Test save calls client.storage.from_(bucket).upload(path, data)."""
@@ -210,63 +186,48 @@ class TestSupabaseStorage:
 
     def test_bucket_exists_returns_true_when_bucket_found(self):
         """Test bucket_exists returns True when bucket is found in list."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            mock_bucket = Mock()
+            mock_bucket.name = "test-bucket"
+            mock_client.storage.list_buckets.return_value = [mock_bucket]
+            storage = SupabaseStorage()
+            result = storage.bucket_exists()
 
-                mock_bucket = Mock()
-                mock_bucket.name = "test-bucket"
-                mock_client.storage.list_buckets.return_value = [mock_bucket]
-                storage = SupabaseStorage()
-                result = storage.bucket_exists()
-
-                assert result is True
-                assert mock_client.storage.list_buckets.call_count >= 1
+            assert result is True
+            assert mock_client.storage.list_buckets.call_count >= 1
 
     def test_bucket_exists_returns_false_when_bucket_not_found(self):
         """Test bucket_exists returns False when bucket is not found in list."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            # Mock different bucket
+            mock_bucket = Mock()
+            mock_bucket.name = "different-bucket"
+            mock_client.storage.list_buckets.return_value = [mock_bucket]
+            mock_client.storage.create_bucket = Mock()
 
-                # Mock different bucket
-                mock_bucket = Mock()
-                mock_bucket.name = "different-bucket"
-                mock_client.storage.list_buckets.return_value = [mock_bucket]
-                mock_client.storage.create_bucket = Mock()
+            storage = SupabaseStorage()
+            result = storage.bucket_exists()
 
-                storage = SupabaseStorage()
-                result = storage.bucket_exists()
-
-                assert result is False
-                assert mock_client.storage.list_buckets.call_count >= 1
+            assert result is False
+            assert mock_client.storage.list_buckets.call_count >= 1
 
     def test_bucket_exists_returns_false_when_no_buckets(self):
         """Test bucket_exists returns False when no buckets exist."""
-        with patch("extensions.storage.supabase_storage.dify_config") as mock_config:
-            mock_config.SUPABASE_URL = "https://test.supabase.co"
-            mock_config.SUPABASE_API_KEY = "test-api-key"
-            mock_config.SUPABASE_BUCKET_NAME = "test-bucket"
+        with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
 
-            with patch("extensions.storage.supabase_storage.Client", autospec=True) as mock_client_class:
-                mock_client = Mock()
-                mock_client_class.return_value = mock_client
+            mock_client.storage.list_buckets.return_value = []
+            mock_client.storage.create_bucket = Mock()
 
-                mock_client.storage.list_buckets.return_value = []
-                mock_client.storage.create_bucket = Mock()
+            storage = SupabaseStorage()
+            result = storage.bucket_exists()
 
-                storage = SupabaseStorage()
-                result = storage.bucket_exists()
-
-                assert result is False
-                assert mock_client.storage.list_buckets.call_count >= 1
+            assert result is False
+            assert mock_client.storage.list_buckets.call_count >= 1

--- a/api/tests/unit_tests/extensions/test_redis.py
+++ b/api/tests/unit_tests/extensions/test_redis.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
 from redis import RedisError
 from redis.retry import Retry
 
@@ -14,16 +15,30 @@ from extensions.ext_redis import (
 )
 
 
-class TestGetConnectionHealthParams:
-    @patch("extensions.ext_redis.dify_config")
-    def test_includes_all_health_params(self, mock_config):
-        mock_config.REDIS_RETRY_RETRIES = 3
-        mock_config.REDIS_RETRY_BACKOFF_BASE = 1.0
-        mock_config.REDIS_RETRY_BACKOFF_CAP = 10.0
-        mock_config.REDIS_SOCKET_TIMEOUT = 5.0
-        mock_config.REDIS_SOCKET_CONNECT_TIMEOUT = 5.0
-        mock_config.REDIS_HEALTH_CHECK_INTERVAL = 30
+@pytest.fixture(autouse=True)
+def _redis_config(config_overrides) -> None:
+    config_overrides(
+        REDIS_USERNAME=None,
+        REDIS_PASSWORD=None,
+        REDIS_DB=0,
+        REDIS_SERIALIZATION_PROTOCOL=3,
+        REDIS_ENABLE_CLIENT_SIDE_CACHE=False,
+        REDIS_RETRY_RETRIES=3,
+        REDIS_RETRY_BACKOFF_BASE=1.0,
+        REDIS_RETRY_BACKOFF_CAP=10.0,
+        REDIS_SOCKET_TIMEOUT=5.0,
+        REDIS_SOCKET_CONNECT_TIMEOUT=5.0,
+        REDIS_HEALTH_CHECK_INTERVAL=30,
+        REDIS_KEEPALIVE=True,
+        REDIS_KEEPALIVE_IDLE=60,
+        REDIS_KEEPALIVE_INTERVAL=10,
+        REDIS_KEEPALIVE_COUNT=3,
+        REDIS_KEY_PREFIX="",
+    )
 
+
+class TestGetConnectionHealthParams:
+    def test_includes_all_health_params(self):
         params = _get_connection_health_params()
 
         assert "retry" in params
@@ -38,15 +53,7 @@ class TestGetConnectionHealthParams:
 
 
 class TestGetClusterConnectionHealthParams:
-    @patch("extensions.ext_redis.dify_config")
-    def test_excludes_health_check_interval(self, mock_config):
-        mock_config.REDIS_RETRY_RETRIES = 3
-        mock_config.REDIS_RETRY_BACKOFF_BASE = 1.0
-        mock_config.REDIS_RETRY_BACKOFF_CAP = 10.0
-        mock_config.REDIS_SOCKET_TIMEOUT = 5.0
-        mock_config.REDIS_SOCKET_CONNECT_TIMEOUT = 5.0
-        mock_config.REDIS_HEALTH_CHECK_INTERVAL = 30
-
+    def test_excludes_health_check_interval(self):
         params = _get_cluster_connection_health_params()
 
         assert "retry" in params
@@ -56,24 +63,7 @@ class TestGetClusterConnectionHealthParams:
 
 
 class TestGetBaseRedisParams:
-    @patch("extensions.ext_redis.dify_config")
-    def test_includes_retry_and_health_params(self, mock_config):
-        mock_config.REDIS_USERNAME = None
-        mock_config.REDIS_PASSWORD = None
-        mock_config.REDIS_DB = 0
-        mock_config.REDIS_SERIALIZATION_PROTOCOL = 3
-        mock_config.REDIS_ENABLE_CLIENT_SIDE_CACHE = False
-        mock_config.REDIS_RETRY_RETRIES = 3
-        mock_config.REDIS_RETRY_BACKOFF_BASE = 1.0
-        mock_config.REDIS_RETRY_BACKOFF_CAP = 10.0
-        mock_config.REDIS_SOCKET_TIMEOUT = 5.0
-        mock_config.REDIS_SOCKET_CONNECT_TIMEOUT = 5.0
-        mock_config.REDIS_HEALTH_CHECK_INTERVAL = 30
-        mock_config.REDIS_KEEPALIVE = True
-        mock_config.REDIS_KEEPALIVE_IDLE = 60
-        mock_config.REDIS_KEEPALIVE_INTERVAL = 10
-        mock_config.REDIS_KEEPALIVE_COUNT = 3
-
+    def test_includes_retry_and_health_params(self):
         params = _get_base_redis_params()
 
         assert "retry" in params
@@ -149,86 +139,74 @@ class TestRedisKeyPrefixHelpers:
 
 
 class TestRedisClientWrapperKeyPrefix:
-    def test_wrapper_get_prefixes_string_keys(self):
+    def test_wrapper_get_prefixes_string_keys(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.get("oauth_state:abc")
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.get("oauth_state:abc")
 
         mock_client.get.assert_called_once_with("enterprise-a:oauth_state:abc")
 
-    def test_wrapper_delete_prefixes_multiple_keys(self):
+    def test_wrapper_delete_prefixes_multiple_keys(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.delete("key:a", "key:b")
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.delete("key:a", "key:b")
 
         mock_client.delete.assert_called_once_with("enterprise-a:key:a", "enterprise-a:key:b")
 
-    def test_wrapper_lock_prefixes_lock_name(self):
+    def test_wrapper_lock_prefixes_lock_name(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.lock("resource-lock", timeout=10)
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.lock("resource-lock", timeout=10)
 
         mock_client.lock.assert_called_once()
         args, kwargs = mock_client.lock.call_args
         assert args == ("enterprise-a:resource-lock",)
         assert kwargs["timeout"] == 10
 
-    def test_wrapper_hash_operations_prefix_key_name(self):
+    def test_wrapper_hash_operations_prefix_key_name(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.hset("hash:key", "field", "value")
-            wrapper.hgetall("hash:key")
-            wrapper.hkeys("hash:key")
-            wrapper.hexists("hash:key", "field")
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.hset("hash:key", "field", "value")
+        wrapper.hgetall("hash:key")
+        wrapper.hkeys("hash:key")
+        wrapper.hexists("hash:key", "field")
 
         mock_client.hset.assert_called_once_with("enterprise-a:hash:key", "field", "value")
         mock_client.hgetall.assert_called_once_with("enterprise-a:hash:key")
         mock_client.hkeys.assert_called_once_with("enterprise-a:hash:key")
         mock_client.hexists.assert_called_once_with("enterprise-a:hash:key", "field")
 
-    def test_wrapper_zadd_prefixes_sorted_set_name(self):
+    def test_wrapper_zadd_prefixes_sorted_set_name(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            wrapper.zadd("zset:key", {"member": 1})
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        wrapper.zadd("zset:key", {"member": 1})
 
         mock_client.zadd.assert_called_once()
         args, kwargs = mock_client.zadd.call_args
         assert args == ("enterprise-a:zset:key", {"member": 1})
         assert kwargs["nx"] is False
 
-    def test_wrapper_preserves_keys_when_prefix_is_empty(self):
+    def test_wrapper_preserves_keys_when_prefix_is_empty(self, config_overrides):
         mock_client = MagicMock()
         wrapper = RedisClientWrapper()
         wrapper.initialize(mock_client)
 
-        with patch("extensions.ext_redis.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "   "
-
-            wrapper.get("plain:key")
+        config_overrides(REDIS_KEY_PREFIX="   ")
+        wrapper.get("plain:key")
 
         mock_client.get.assert_called_once_with("plain:key")

--- a/api/tests/unit_tests/libs/broadcast_channel/redis/test_channel_unit_tests.py
+++ b/api/tests/unit_tests/libs/broadcast_channel/redis/test_channel_unit_tests.py
@@ -137,25 +137,21 @@ class TestTopic:
 
         mock_redis_client.publish.assert_called_once_with("test-topic", payload)
 
-    def test_publish_prefixes_regular_topic(self, mock_redis_client: MagicMock):
-        with patch("extensions.redis_names.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-            topic = Topic(mock_redis_client, "test-topic")
-
-            topic.publish(b"test message")
+    def test_publish_prefixes_regular_topic(self, mock_redis_client: MagicMock, config_overrides):
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        topic = Topic(mock_redis_client, "test-topic")
+        topic.publish(b"test message")
 
         mock_redis_client.publish.assert_called_once_with("enterprise-a:test-topic", b"test message")
 
-    def test_subscribe_prefixes_regular_topic(self, mock_redis_client: MagicMock):
-        with patch("extensions.redis_names.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-            topic = Topic(mock_redis_client, "test-topic")
-
-            subscription = topic.subscribe()
-            try:
-                subscription._start_if_needed()
-            finally:
-                subscription.close()
+    def test_subscribe_prefixes_regular_topic(self, mock_redis_client: MagicMock, config_overrides):
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        topic = Topic(mock_redis_client, "test-topic")
+        subscription = topic.subscribe()
+        try:
+            subscription._start_if_needed()
+        finally:
+            subscription.close()
 
         mock_redis_client.pubsub.return_value.subscribe.assert_called_once_with("enterprise-a:test-topic")
 
@@ -196,12 +192,10 @@ class TestShardedTopic:
 
         mock_redis_client.spublish.assert_called_once_with("test-sharded-topic", payload)
 
-    def test_publish_prefixes_sharded_topic(self, mock_redis_client: MagicMock):
-        with patch("extensions.redis_names.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-            sharded_topic = ShardedTopic(mock_redis_client, "test-sharded-topic")
-
-            sharded_topic.publish(b"test sharded message")
+    def test_publish_prefixes_sharded_topic(self, mock_redis_client: MagicMock, config_overrides):
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        sharded_topic = ShardedTopic(mock_redis_client, "test-sharded-topic")
+        sharded_topic.publish(b"test sharded message")
 
         mock_redis_client.spublish.assert_called_once_with("enterprise-a:test-sharded-topic", b"test sharded message")
 
@@ -214,16 +208,14 @@ class TestShardedTopic:
         assert subscription._pubsub is mock_redis_client.pubsub.return_value
         assert subscription._topic == "test-sharded-topic"
 
-    def test_subscribe_prefixes_sharded_topic(self, mock_redis_client: MagicMock):
-        with patch("extensions.redis_names.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-            sharded_topic = ShardedTopic(mock_redis_client, "test-sharded-topic")
-
-            subscription = sharded_topic.subscribe()
-            try:
-                subscription._start_if_needed()
-            finally:
-                subscription.close()
+    def test_subscribe_prefixes_sharded_topic(self, mock_redis_client: MagicMock, config_overrides):
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        sharded_topic = ShardedTopic(mock_redis_client, "test-sharded-topic")
+        subscription = sharded_topic.subscribe()
+        try:
+            subscription._start_if_needed()
+        finally:
+            subscription.close()
 
         mock_redis_client.pubsub.return_value.ssubscribe.assert_called_once_with("enterprise-a:test-sharded-topic")
 

--- a/api/tests/unit_tests/libs/broadcast_channel/redis/test_streams_channel_unit_tests.py
+++ b/api/tests/unit_tests/libs/broadcast_channel/redis/test_streams_channel_unit_tests.py
@@ -2,7 +2,6 @@ import threading
 import time
 from dataclasses import dataclass
 from typing import Any, cast
-from unittest.mock import patch
 
 import pytest
 
@@ -169,21 +168,17 @@ class TestStreamsBroadcastChannel:
         # Expire called after publish
         assert fake_redis._expire_calls.get("stream:beta", 0) >= 1
 
-    def test_topic_uses_prefixed_stream_key(self, fake_redis: FakeStreamsRedis):
-        with patch("extensions.redis_names.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-
-            topic = StreamsBroadcastChannel(fake_redis, retention_seconds=60).topic("alpha")
+    def test_topic_uses_prefixed_stream_key(self, fake_redis: FakeStreamsRedis, config_overrides):
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        topic = StreamsBroadcastChannel(fake_redis, retention_seconds=60).topic("alpha")
 
         assert topic._topic == "alpha"
         assert topic._key == "enterprise-a:stream:alpha"
 
-    def test_publish_uses_prefixed_stream_key(self, fake_redis: FakeStreamsRedis):
-        with patch("extensions.redis_names.dify_config") as mock_config:
-            mock_config.REDIS_KEY_PREFIX = "enterprise-a"
-            topic = StreamsBroadcastChannel(fake_redis, retention_seconds=60).topic("beta")
-
-            topic.publish(b"hello")
+    def test_publish_uses_prefixed_stream_key(self, fake_redis: FakeStreamsRedis, config_overrides):
+        config_overrides(REDIS_KEY_PREFIX="enterprise-a")
+        topic = StreamsBroadcastChannel(fake_redis, retention_seconds=60).topic("beta")
+        topic.publish(b"hello")
 
         assert fake_redis._store["enterprise-a:stream:beta"][0][1] == {b"data": b"hello"}
         assert fake_redis._expire_calls.get("enterprise-a:stream:beta", 0) >= 1

--- a/api/tests/unit_tests/libs/test_passport.py
+++ b/api/tests/unit_tests/libs/test_passport.py
@@ -12,18 +12,16 @@ class TestPassportService:
     """Test PassportService JWT operations"""
 
     @pytest.fixture
-    def passport_service(self):
+    def passport_service(self, config_overrides):
         """Create PassportService instance with test secret key"""
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "test-secret-key-for-testing"
-            return PassportService()
+        config_overrides(SECRET_KEY="test-secret-key-for-testing")
+        return PassportService()
 
     @pytest.fixture
-    def another_passport_service(self):
+    def another_passport_service(self, config_overrides):
         """Create another PassportService instance with different secret key"""
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "another-secret-key-for-testing"
-            return PassportService()
+        config_overrides(SECRET_KEY="another-secret-key-for-testing")
+        return PassportService()
 
     # Core functionality tests
     def test_should_issue_and_verify_token(self, passport_service):
@@ -98,10 +96,8 @@ class TestPassportService:
         payload = {"user_id": "123"}
 
         # Create token with different algorithm
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "test-secret-key-for-testing"
-            # Create token with HS512 instead of HS256
-            wrong_alg_token = jwt.encode(payload, mock_config.SECRET_KEY, algorithm="HS512")
+        # Create token with HS512 instead of HS256
+        wrong_alg_token = jwt.encode(payload, "test-secret-key-for-testing", algorithm="HS512")
 
         # Should fail because service expects HS256
         # InvalidAlgorithmError is now caught by PyJWTError handler
@@ -134,20 +130,17 @@ class TestPassportService:
         past_time = datetime.now(UTC) - timedelta(hours=1)
         payload = {"user_id": "123", "exp": past_time.timestamp()}
 
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "test-secret-key-for-testing"
-            token = jwt.encode(payload, mock_config.SECRET_KEY, algorithm="HS256")
+        token = jwt.encode(payload, "test-secret-key-for-testing", algorithm="HS256")
 
         with pytest.raises(Unauthorized) as exc_info:
             passport_service.verify(token)
         assert str(exc_info.value) == "401 Unauthorized: Token has expired."
 
     # Configuration tests
-    def test_should_use_configured_secret_key_without_policy_validation(self):
+    def test_should_use_configured_secret_key_without_policy_validation(self, config_overrides):
         """Test that policy decisions are owned by config, not PassportService."""
-        with patch("libs.passport.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "configured"
-            service = PassportService()
+        config_overrides(SECRET_KEY="configured")
+        service = PassportService()
 
         assert service.sk == "configured"
 

--- a/api/tests/unit_tests/services/enterprise/test_account_deletion_sync.py
+++ b/api/tests/unit_tests/services/enterprise/test_account_deletion_sync.py
@@ -22,6 +22,11 @@ from services.enterprise.account_deletion_sync import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _enterprise_edition(config_overrides) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
+
+
 class TestQueueTask:
     def test_queue_task_redis_error(self, caplog: pytest.LogCaptureFixture):
         with patch("services.enterprise.account_deletion_sync.redis_client") as mock_redis:
@@ -53,36 +58,24 @@ class TestSyncWorkspaceMemberRemoval:
         workspace_id = str(uuid4())
         member_id = str(uuid4())
 
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        result = sync_workspace_member_removal(workspace_id=workspace_id, member_id=member_id, source="removed")
 
-            result = sync_workspace_member_removal(workspace_id=workspace_id, member_id=member_id, source="removed")
+        assert result is True
+        mock_queue_task.assert_called_once_with(workspace_id=workspace_id, member_id=member_id, source="removed")
 
-            assert result is True
-            mock_queue_task.assert_called_once_with(workspace_id=workspace_id, member_id=member_id, source="removed")
+    def test_sync_workspace_member_removal_non_enterprise_edition(self, mock_queue_task, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        result = sync_workspace_member_removal(workspace_id=str(uuid4()), member_id=str(uuid4()), source="test_source")
 
-    def test_sync_workspace_member_removal_non_enterprise_edition(self, mock_queue_task):
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-
-            result = sync_workspace_member_removal(
-                workspace_id=str(uuid4()), member_id=str(uuid4()), source="test_source"
-            )
-
-            assert result is True
-            mock_queue_task.assert_not_called()
+        assert result is True
+        mock_queue_task.assert_not_called()
 
     def test_sync_workspace_member_removal_queue_failure(self, mock_queue_task):
         mock_queue_task.return_value = False
 
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        result = sync_workspace_member_removal(workspace_id=str(uuid4()), member_id=str(uuid4()), source="test_source")
 
-            result = sync_workspace_member_removal(
-                workspace_id=str(uuid4()), member_id=str(uuid4()), source="test_source"
-            )
-
-            assert result is False
+        assert result is False
 
 
 @pytest.mark.parametrize("sqlite_session", [(TenantAccountJoin,)], indirect=True)
@@ -93,14 +86,15 @@ class TestSyncAccountDeletion:
             mock_queue.return_value = True
             yield mock_queue
 
-    def test_sync_account_deletion_non_enterprise_edition(self, mock_queue_task, sqlite_session: Session) -> None:
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    def test_sync_account_deletion_non_enterprise_edition(
+        self, mock_queue_task, sqlite_session: Session, config_overrides
+    ) -> None:
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
 
-            result = sync_account_deletion(account_id=str(uuid4()), source="account_deleted", session=sqlite_session)
+        result = sync_account_deletion(account_id=str(uuid4()), source="account_deleted", session=sqlite_session)
 
-            assert result is True
-            mock_queue_task.assert_not_called()
+        assert result is True
+        mock_queue_task.assert_not_called()
 
     def test_sync_account_deletion_multiple_workspaces(self, sqlite_session: Session, mock_queue_task) -> None:
         account_id = str(uuid4())
@@ -111,25 +105,19 @@ class TestSyncAccountDeletion:
             sqlite_session.add(join)
         sqlite_session.commit()
 
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        result = sync_account_deletion(account_id=account_id, source="account_deleted", session=sqlite_session)
 
-            result = sync_account_deletion(account_id=account_id, source="account_deleted", session=sqlite_session)
+        assert result is True
+        assert mock_queue_task.call_count == 3
 
-            assert result is True
-            assert mock_queue_task.call_count == 3
-
-            queued_workspace_ids = {call.kwargs["workspace_id"] for call in mock_queue_task.call_args_list}
-            assert queued_workspace_ids == set(tenant_ids)
+        queued_workspace_ids = {call.kwargs["workspace_id"] for call in mock_queue_task.call_args_list}
+        assert queued_workspace_ids == set(tenant_ids)
 
     def test_sync_account_deletion_no_workspaces(self, sqlite_session: Session, mock_queue_task) -> None:
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        result = sync_account_deletion(account_id=str(uuid4()), source="account_deleted", session=sqlite_session)
 
-            result = sync_account_deletion(account_id=str(uuid4()), source="account_deleted", session=sqlite_session)
-
-            assert result is True
-            mock_queue_task.assert_not_called()
+        assert result is True
+        mock_queue_task.assert_not_called()
 
     def test_sync_account_deletion_partial_failure(self, sqlite_session: Session, mock_queue_task) -> None:
         account_id = str(uuid4())
@@ -146,13 +134,10 @@ class TestSyncAccountDeletion:
 
         mock_queue_task.side_effect = queue_side_effect
 
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        result = sync_account_deletion(account_id=account_id, source="account_deleted", session=sqlite_session)
 
-            result = sync_account_deletion(account_id=account_id, source="account_deleted", session=sqlite_session)
-
-            assert result is False
-            assert mock_queue_task.call_count == 3
+        assert result is False
+        assert mock_queue_task.call_count == 3
 
     def test_sync_account_deletion_all_failures(self, sqlite_session: Session, mock_queue_task) -> None:
         account_id = str(uuid4())
@@ -164,10 +149,7 @@ class TestSyncAccountDeletion:
 
         mock_queue_task.return_value = False
 
-        with patch("services.enterprise.account_deletion_sync.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        result = sync_account_deletion(account_id=account_id, source="account_deleted", session=sqlite_session)
 
-            result = sync_account_deletion(account_id=account_id, source="account_deleted", session=sqlite_session)
-
-            assert result is False
-            mock_queue_task.assert_called_once()
+        assert result is False
+        mock_queue_task.assert_called_once()

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -269,13 +269,13 @@ class TestJoinDefaultWorkspace:
 
 
 class TestTryJoinDefaultWorkspace:
-    def test_try_join_default_workspace_non_enterprise_edition_noop(self):
-        with (
-            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
-            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
-        ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    @pytest.fixture(autouse=True)
+    def _enterprise_edition(self, config_overrides) -> None:
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
 
+    def test_try_join_default_workspace_non_enterprise_edition_noop(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        with patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join:
             try_join_default_workspace("11111111-1111-1111-1111-111111111111")
 
             mock_join.assert_not_called()
@@ -283,11 +283,7 @@ class TestTryJoinDefaultWorkspace:
     def test_try_join_default_workspace_successful_join_does_not_raise(self):
         account_id = "11111111-1111-1111-1111-111111111111"
 
-        with (
-            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
-            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
-        ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        with patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join:
             mock_join.return_value = DefaultWorkspaceJoinResult(
                 workspace_id="22222222-2222-2222-2222-222222222222",
                 joined=True,
@@ -302,11 +298,7 @@ class TestTryJoinDefaultWorkspace:
     def test_try_join_default_workspace_skipped_join_does_not_raise(self):
         account_id = "11111111-1111-1111-1111-111111111111"
 
-        with (
-            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
-            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
-        ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        with patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join:
             mock_join.return_value = DefaultWorkspaceJoinResult(
                 workspace_id="",
                 joined=False,
@@ -321,11 +313,7 @@ class TestTryJoinDefaultWorkspace:
     def test_try_join_default_workspace_api_failure_soft_fails(self):
         account_id = "11111111-1111-1111-1111-111111111111"
 
-        with (
-            patch("services.enterprise.enterprise_service.dify_config") as mock_config,
-            patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join,
-        ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
+        with patch("services.enterprise.enterprise_service.EnterpriseService.join_default_workspace") as mock_join:
             mock_join.side_effect = Exception("network failure")
 
             # Should not raise
@@ -334,11 +322,8 @@ class TestTryJoinDefaultWorkspace:
             mock_join.assert_called_once_with(account_id=account_id)
 
     def test_try_join_default_workspace_invalid_account_id_soft_fails(self):
-        with patch("services.enterprise.enterprise_service.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
-
-            # Should not raise even though UUID parsing fails inside join_default_workspace
-            try_join_default_workspace("not-a-uuid")
+        # Should not raise even though UUID parsing fails inside join_default_workspace
+        try_join_default_workspace("not-a-uuid")
 
 
 # ---------------------------------------------------------------------------
@@ -351,19 +336,19 @@ _EE_SVC = "services.enterprise.enterprise_service"
 class TestGetCachedLicenseStatus:
     """Tests for EnterpriseService.get_cached_license_status."""
 
-    def test_returns_none_outside_enterprise_edition(self):
-        with patch(f"{_EE_SVC}.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    @pytest.fixture(autouse=True)
+    def _enterprise_edition(self, config_overrides) -> None:
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
 
-            assert EnterpriseService.get_cached_license_status() is None
+    def test_returns_none_outside_enterprise_edition(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        assert EnterpriseService.get_cached_license_status() is None
 
     def test_cache_hit_returns_license_status_enum(self):
         with (
-            patch(f"{_EE_SVC}.dify_config") as mock_config,
             patch(f"{_EE_SVC}.redis_client") as mock_redis,
             patch.object(EnterpriseService, "get_info") as mock_get_info,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
             mock_redis.get.return_value = b"active"
 
             result = EnterpriseService.get_cached_license_status()
@@ -374,11 +359,9 @@ class TestGetCachedLicenseStatus:
 
     def test_cache_miss_fetches_api_and_caches_valid_status(self):
         with (
-            patch(f"{_EE_SVC}.dify_config") as mock_config,
             patch(f"{_EE_SVC}.redis_client") as mock_redis,
             patch.object(EnterpriseService, "get_info") as mock_get_info,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
             mock_redis.get.return_value = None
             mock_get_info.return_value = {"License": {"status": "active"}}
 
@@ -391,11 +374,9 @@ class TestGetCachedLicenseStatus:
 
     def test_cache_miss_fetches_api_and_caches_invalid_status_with_short_ttl(self):
         with (
-            patch(f"{_EE_SVC}.dify_config") as mock_config,
             patch(f"{_EE_SVC}.redis_client") as mock_redis,
             patch.object(EnterpriseService, "get_info") as mock_get_info,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
             mock_redis.get.return_value = None
             mock_get_info.return_value = {"License": {"status": "expired"}}
 
@@ -408,11 +389,9 @@ class TestGetCachedLicenseStatus:
 
     def test_redis_read_failure_falls_through_to_api(self):
         with (
-            patch(f"{_EE_SVC}.dify_config") as mock_config,
             patch(f"{_EE_SVC}.redis_client") as mock_redis,
             patch.object(EnterpriseService, "get_info") as mock_get_info,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
             mock_redis.get.side_effect = ConnectionError("redis down")
             mock_get_info.return_value = {"License": {"status": "active"}}
 
@@ -423,11 +402,9 @@ class TestGetCachedLicenseStatus:
 
     def test_redis_write_failure_still_returns_status(self):
         with (
-            patch(f"{_EE_SVC}.dify_config") as mock_config,
             patch(f"{_EE_SVC}.redis_client") as mock_redis,
             patch.object(EnterpriseService, "get_info") as mock_get_info,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
             mock_redis.get.return_value = None
             mock_redis.setex.side_effect = ConnectionError("redis down")
             mock_get_info.return_value = {"License": {"status": "expiring"}}
@@ -438,11 +415,9 @@ class TestGetCachedLicenseStatus:
 
     def test_api_failure_returns_none(self):
         with (
-            patch(f"{_EE_SVC}.dify_config") as mock_config,
             patch(f"{_EE_SVC}.redis_client") as mock_redis,
             patch.object(EnterpriseService, "get_info") as mock_get_info,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
             mock_redis.get.return_value = None
             mock_get_info.side_effect = Exception("network failure")
 
@@ -450,11 +425,9 @@ class TestGetCachedLicenseStatus:
 
     def test_api_returns_no_license_info(self):
         with (
-            patch(f"{_EE_SVC}.dify_config") as mock_config,
             patch(f"{_EE_SVC}.redis_client") as mock_redis,
             patch.object(EnterpriseService, "get_info") as mock_get_info,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.ENTERPRISE
             mock_redis.get.return_value = None
             mock_get_info.return_value = {}  # no "License" key
 

--- a/api/tests/unit_tests/services/enterprise/test_rbac_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_rbac_service.py
@@ -536,6 +536,10 @@ class TestWorkspaceAccess:
 
 @pytest.mark.parametrize("sqlite_session", [(TenantAccountJoin,)], indirect=True)
 class TestMyPermissions:
+    @pytest.fixture(autouse=True)
+    def _rbac_enabled(self, config_overrides) -> None:
+        config_overrides(RBAC_ENABLED=True)
+
     def test_resource_snapshot_maps_defaults_and_overrides(self, sqlite_session: Session):
         snapshot = svc.ResourcePermissionSnapshot(
             default_permission_keys=["app.acl.view_layout"],
@@ -559,8 +563,7 @@ class TestMyPermissions:
             "dataset": {"default_permission_keys": [], "overrides": []},
         }
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", True):
-            out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
+        out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
 
         call = _call_args(mock_send)
         assert call.method == "GET"
@@ -612,13 +615,14 @@ class TestMyPermissions:
         app_keys: list[str],
         dataset_keys: list[str],
         sqlite_session: Session,
+        config_overrides,
     ):
+        config_overrides(RBAC_ENABLED=False)
         sqlite_session.add(
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole(role))
         )
         sqlite_session.commit()
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
+        out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
 
         mock_send.assert_not_called()
         assert out.workspace.permission_keys == workspace_keys
@@ -654,13 +658,14 @@ class TestMyPermissions:
         role: str,
         expected_snippet_keys: set[str],
         sqlite_session: Session,
+        config_overrides,
     ):
+        config_overrides(RBAC_ENABLED=False)
         sqlite_session.add(
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole(role))
         )
         sqlite_session.commit()
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
+        out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
 
         actual_snippet_keys = {
             permission_key for permission_key in out.workspace.permission_keys if permission_key.startswith("snippets.")
@@ -669,9 +674,11 @@ class TestMyPermissions:
         mock_send.assert_not_called()
         assert actual_snippet_keys == expected_snippet_keys
 
-    def test_get_returns_empty_when_role_missing_and_rbac_disabled(self, mock_send: MagicMock, sqlite_session: Session):
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
+    def test_get_returns_empty_when_role_missing_and_rbac_disabled(
+        self, mock_send: MagicMock, sqlite_session: Session, config_overrides
+    ):
+        config_overrides(RBAC_ENABLED=False)
+        out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", session=sqlite_session)
 
         mock_send.assert_not_called()
         assert out.workspace.permission_keys == []
@@ -688,8 +695,7 @@ class TestMyPermissions:
             "dataset": {"default_permission_keys": [], "overrides": []},
         }
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", True):
-            out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", app_id="app-1", session=sqlite_session)
+        out = svc.RBACService.MyPermissions.get("tenant-1", "acct-1", app_id="app-1", session=sqlite_session)
 
         call = _call_args(mock_send)
         assert call.method == "GET"
@@ -700,6 +706,10 @@ class TestMyPermissions:
 
 @pytest.mark.parametrize("sqlite_session", [(TenantAccountJoin,)], indirect=True)
 class TestMemberRoles:
+    @pytest.fixture(autouse=True)
+    def _rbac_enabled(self, config_overrides) -> None:
+        config_overrides(RBAC_ENABLED=True)
+
     def test_get(self, mock_send: MagicMock, sqlite_session: Session):
         mock_send.return_value = {
             "account_id": "acct-2",
@@ -711,8 +721,7 @@ class TestMemberRoles:
                 }
             ],
         }
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", True):
-            out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
+        out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
         call = _call_args(mock_send)
         assert call.method == "GET"
         assert call.endpoint == "/rbac/members/rbac-roles"
@@ -720,14 +729,16 @@ class TestMemberRoles:
         assert out.account_id == "acct-2"
         assert out.roles[0].name == "Member"
 
-    def test_get_legacy_role_includes_permission_keys(self, mock_send: MagicMock, sqlite_session: Session):
+    def test_get_legacy_role_includes_permission_keys(
+        self, mock_send: MagicMock, sqlite_session: Session, config_overrides
+    ):
+        config_overrides(RBAC_ENABLED=False)
         sqlite_session.add(
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-2", role=svc.TenantAccountRole.EDITOR)
         )
         sqlite_session.commit()
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
+        out = svc.RBACService.MemberRoles.get("tenant-1", "acct-1", "acct-2", session=sqlite_session)
 
         mock_send.assert_not_called()
         assert out.account_id == "acct-2"
@@ -748,31 +759,32 @@ class TestMemberRoles:
 
     def test_replace(self, mock_send: MagicMock, sqlite_session: Session):
         mock_send.return_value = {"account_id": "acct-2", "roles": []}
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", True):
-            svc.RBACService.MemberRoles.replace(
-                "tenant-1",
-                "acct-1",
-                "acct-2",
-                role_ids=["workspace.owner", "workspace.editor"],
-                session=sqlite_session,
-            )
+        svc.RBACService.MemberRoles.replace(
+            "tenant-1",
+            "acct-1",
+            "acct-2",
+            role_ids=["workspace.owner", "workspace.editor"],
+            session=sqlite_session,
+        )
         call = _call_args(mock_send)
         assert call.method == "PUT"
         assert call.endpoint == "/rbac/members/rbac-roles"
         assert call.params == {"account_id": "acct-2"}
         assert call.json == {"role_ids": ["workspace.owner", "workspace.editor"]}
 
-    def test_replace_commits_legacy_join_role_when_rbac_disabled(self, mock_send: MagicMock, sqlite_session: Session):
+    def test_replace_commits_legacy_join_role_when_rbac_disabled(
+        self, mock_send: MagicMock, sqlite_session: Session, config_overrides
+    ):
+        config_overrides(RBAC_ENABLED=False)
         target_join = TenantAccountJoin(tenant_id="tenant-1", account_id="acct-2", role=svc.TenantAccountRole.NORMAL)
         sqlite_session.add(target_join)
         sqlite_session.commit()
         target_join_id = target_join.id
         engine = sqlite_session.get_bind()
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.MemberRoles.replace(
-                "tenant-1", "acct-1", "acct-2", role_ids=["editor"], session=sqlite_session
-            )
+        out = svc.RBACService.MemberRoles.replace(
+            "tenant-1", "acct-1", "acct-2", role_ids=["editor"], session=sqlite_session
+        )
 
         mock_send.assert_not_called()
         # Closing the writer rolls back any uncommitted update and prevents its identity map
@@ -789,17 +801,17 @@ class TestMemberRoles:
         assert "app.acl.preview" in out.roles[0].permission_keys
 
     def test_replace_legacy_owner_demotes_current_owner_when_rbac_disabled(
-        self, mock_send: MagicMock, sqlite_session: Session
+        self, mock_send: MagicMock, sqlite_session: Session, config_overrides
     ):
+        config_overrides(RBAC_ENABLED=False)
         target_join = TenantAccountJoin(tenant_id="tenant-1", account_id="acct-2", role=svc.TenantAccountRole.NORMAL)
         owner_join = TenantAccountJoin(tenant_id="tenant-1", account_id="acct-owner", role=svc.TenantAccountRole.OWNER)
         sqlite_session.add_all([target_join, owner_join])
         sqlite_session.commit()
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.MemberRoles.replace(
-                "tenant-1", "acct-1", "acct-2", role_ids=["owner"], session=sqlite_session
-            )
+        out = svc.RBACService.MemberRoles.replace(
+            "tenant-1", "acct-1", "acct-2", role_ids=["owner"], session=sqlite_session
+        )
 
         mock_send.assert_not_called()
         persisted_joins = {
@@ -837,6 +849,10 @@ class TestMemberRoles:
 
 @pytest.mark.parametrize("sqlite_session", [(TenantAccountJoin,)], indirect=True)
 class TestResourcePermissions:
+    @pytest.fixture(autouse=True)
+    def _rbac_enabled(self, config_overrides) -> None:
+        config_overrides(RBAC_ENABLED=True)
+
     def test_app_permissions_batch_get(self, mock_send: MagicMock, sqlite_session: Session):
         mock_send.return_value = {
             "data": [
@@ -848,10 +864,7 @@ class TestResourcePermissions:
             ]
         }
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", True):
-            out = svc.RBACService.AppPermissions.batch_get(
-                "tenant-1", "acct-1", ["app-1", "app-2"], session=sqlite_session
-            )
+        out = svc.RBACService.AppPermissions.batch_get("tenant-1", "acct-1", ["app-1", "app-2"], session=sqlite_session)
 
         call = _call_args(mock_send)
         assert call.method == "POST"
@@ -863,16 +876,14 @@ class TestResourcePermissions:
         }
 
     def test_app_permissions_batch_get_uses_legacy_role_permissions_when_rbac_disabled(
-        self, mock_send: MagicMock, sqlite_session: Session
+        self, mock_send: MagicMock, sqlite_session: Session, config_overrides
     ):
+        config_overrides(RBAC_ENABLED=False)
         sqlite_session.add(
             TenantAccountJoin(tenant_id="tenant-1", account_id="acct-1", role=svc.TenantAccountRole.EDITOR)
         )
         sqlite_session.commit()
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.AppPermissions.batch_get(
-                "tenant-1", "acct-1", ["app-1", "app-2"], session=sqlite_session
-            )
+        out = svc.RBACService.AppPermissions.batch_get("tenant-1", "acct-1", ["app-1", "app-2"], session=sqlite_session)
 
         mock_send.assert_not_called()
         assert out == {
@@ -889,10 +900,9 @@ class TestResourcePermissions:
             ]
         }
 
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", True):
-            out = svc.RBACService.DatasetPermissions.batch_get(
-                "tenant-1", "acct-1", ["ds-1", "ds-2"], session=sqlite_session
-            )
+        out = svc.RBACService.DatasetPermissions.batch_get(
+            "tenant-1", "acct-1", ["ds-1", "ds-2"], session=sqlite_session
+        )
 
         call = _call_args(mock_send)
         assert call.method == "POST"
@@ -904,8 +914,9 @@ class TestResourcePermissions:
         }
 
     def test_dataset_permissions_batch_get_uses_legacy_role_permissions_when_rbac_disabled(
-        self, mock_send: MagicMock, sqlite_session: Session
+        self, mock_send: MagicMock, sqlite_session: Session, config_overrides
     ):
+        config_overrides(RBAC_ENABLED=False)
         sqlite_session.add(
             TenantAccountJoin(
                 tenant_id="tenant-1",
@@ -914,10 +925,9 @@ class TestResourcePermissions:
             )
         )
         sqlite_session.commit()
-        with patch(f"{MODULE}.dify_config.RBAC_ENABLED", False):
-            out = svc.RBACService.DatasetPermissions.batch_get(
-                "tenant-1", "acct-1", ["ds-1", "ds-2"], session=sqlite_session
-            )
+        out = svc.RBACService.DatasetPermissions.batch_get(
+            "tenant-1", "acct-1", ["ds-1", "ds-2"], session=sqlite_session
+        )
 
         mock_send.assert_not_called()
         assert out == {

--- a/api/tests/unit_tests/services/plugin/test_dependencies_analysis.py
+++ b/api/tests/unit_tests/services/plugin/test_dependencies_analysis.py
@@ -150,18 +150,16 @@ class TestGenerateDependencies:
 
 
 class TestGenerateLatestDependencies:
-    @patch("services.plugin.dependencies_analysis.dify_config")
-    def test_returns_empty_when_marketplace_disabled(self, mock_config):
-        mock_config.MARKETPLACE_ENABLED = False
+    def test_returns_empty_when_marketplace_disabled(self, config_overrides):
+        config_overrides(MARKETPLACE_ENABLED=False)
 
         result = DependenciesAnalysisService.generate_latest_dependencies(["p1"])
 
         assert result == []
 
     @patch("services.plugin.dependencies_analysis.marketplace")
-    @patch("services.plugin.dependencies_analysis.dify_config")
-    def test_returns_marketplace_deps_when_enabled(self, mock_config, mock_marketplace):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_returns_marketplace_deps_when_enabled(self, mock_marketplace, config_overrides):
+        config_overrides(MARKETPLACE_ENABLED=True)
         manifest = MagicMock()
         manifest.latest_package_identifier = "org/plugin:2.0.0@newhash"
         mock_marketplace.batch_fetch_plugin_manifests.return_value = [manifest]

--- a/api/tests/unit_tests/services/plugin/test_plugin_migration.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_migration.py
@@ -12,8 +12,13 @@ from services.plugin.plugin_migration import PluginMigration
 MIGRATION_MODULE = "services.plugin.plugin_migration"
 
 
-def test_fetch_latest_package_identifier_returns_none_when_disabled(mocker: MockerFixture) -> None:
-    mocker.patch("services.plugin.plugin_migration.dify_config.MARKETPLACE_ENABLED", False)
+@pytest.fixture(autouse=True)
+def _marketplace_enabled(config_overrides) -> None:
+    config_overrides(MARKETPLACE_ENABLED=True)
+
+
+def test_fetch_latest_package_identifier_returns_none_when_disabled(mocker: MockerFixture, config_overrides) -> None:
+    config_overrides(MARKETPLACE_ENABLED=False)
     batch_fetch = mocker.patch("services.plugin.plugin_migration.marketplace.batch_fetch_plugin_manifests")
 
     result = PluginMigration._fetch_latest_package_identifier("langgenius/openai")
@@ -23,7 +28,6 @@ def test_fetch_latest_package_identifier_returns_none_when_disabled(mocker: Mock
 
 
 def test_fetch_latest_package_identifier_calls_marketplace_when_enabled(mocker: MockerFixture) -> None:
-    mocker.patch("services.plugin.plugin_migration.dify_config.MARKETPLACE_ENABLED", True)
     manifest = mocker.MagicMock()
     manifest.latest_package_identifier = "langgenius/openai:1.0.0@abc"
     mocker.patch(
@@ -61,21 +65,16 @@ def test_extract_app_tables_checks_agent_mode_with_its_session(mocker: MockerFix
 
 
 class TestHandlePluginInstanceInstall:
-    def test_raises_when_disabled_and_map_nonempty(self) -> None:
-        with patch(f"{MIGRATION_MODULE}.dify_config") as mock_cfg:
-            mock_cfg.MARKETPLACE_ENABLED = False
+    def test_raises_when_disabled_and_map_nonempty(self, config_overrides) -> None:
+        config_overrides(MARKETPLACE_ENABLED=False)
+        with pytest.raises(ValueError, match="Marketplace disabled"):
+            PluginMigration.handle_plugin_instance_install(
+                "tenant1", {"langgenius/openai": "langgenius/openai:1.0.0@abc"}
+            )
 
-            with pytest.raises(ValueError, match="Marketplace disabled"):
-                PluginMigration.handle_plugin_instance_install(
-                    "tenant1", {"langgenius/openai": "langgenius/openai:1.0.0@abc"}
-                )
-
-    def test_no_raise_when_disabled_and_map_empty(self) -> None:
-        with (
-            patch(f"{MIGRATION_MODULE}.dify_config") as mock_cfg,
-            patch(f"{MIGRATION_MODULE}.PluginInstaller") as mock_installer_cls,
-        ):
-            mock_cfg.MARKETPLACE_ENABLED = False
+    def test_no_raise_when_disabled_and_map_empty(self, config_overrides) -> None:
+        config_overrides(MARKETPLACE_ENABLED=False)
+        with patch(f"{MIGRATION_MODULE}.PluginInstaller") as mock_installer_cls:
             mock_installer = MagicMock()
             mock_installer_cls.return_value = mock_installer
             mock_installer.install_from_identifiers.return_value = MagicMock(all_installed=True)
@@ -86,12 +85,10 @@ class TestHandlePluginInstanceInstall:
 
     def test_proceeds_when_enabled(self) -> None:
         with (
-            patch(f"{MIGRATION_MODULE}.dify_config") as mock_cfg,
             patch(f"{MIGRATION_MODULE}.marketplace") as mock_marketplace,
             patch(f"{MIGRATION_MODULE}.PluginInstaller") as mock_installer_cls,
             patch(f"{MIGRATION_MODULE}.PluginService.invalidate_plugin_model_providers_cache") as invalidate_cache,
         ):
-            mock_cfg.MARKETPLACE_ENABLED = True
             mock_marketplace.download_plugin_pkg.return_value = b"pkg_data"
             mock_installer = MagicMock()
             mock_installer_cls.return_value = mock_installer
@@ -108,11 +105,9 @@ class TestHandlePluginInstanceInstall:
 
     def test_reports_failed_plugin_ids_when_install_batch_raises(self) -> None:
         with (
-            patch(f"{MIGRATION_MODULE}.dify_config") as mock_cfg,
             patch(f"{MIGRATION_MODULE}.marketplace") as mock_marketplace,
             patch(f"{MIGRATION_MODULE}.PluginInstaller") as mock_installer_cls,
         ):
-            mock_cfg.MARKETPLACE_ENABLED = True
             mock_marketplace.download_plugin_pkg.return_value = b"pkg_data"
             mock_installer = MagicMock()
             mock_installer_cls.return_value = mock_installer

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -30,6 +30,16 @@ OTHER_TENANT_ID = "22222222-2222-2222-2222-222222222222"
 USER_ID = "33333333-3333-3333-3333-333333333333"
 
 
+@pytest.fixture(autouse=True)
+def _plugin_config(config_overrides) -> None:
+    config_overrides(
+        MARKETPLACE_ENABLED=True,
+        PLUGIN_MODEL_PROVIDERS_CACHE_TTL=86400,
+        PLUGIN_MODEL_PROVIDERS_CACHE_ENABLED=True,
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+    )
+
+
 def _build_provider_entity(
     provider: str = "openai",
     installation_source: PluginInstallationSource | None = PluginInstallationSource.Marketplace,
@@ -103,14 +113,13 @@ def _provider_generation_key(tenant_id: str) -> str:
 
 
 class TestFetchLatestPluginVersion:
-    def test_skips_marketplace_fetch_when_disabled(self) -> None:
+    def test_skips_marketplace_fetch_when_disabled(self, config_overrides) -> None:
         """Cache misses stay None; marketplace is never called when disabled."""
+        config_overrides(MARKETPLACE_ENABLED=False)
         with (
-            patch(f"{MODULE}.dify_config") as mock_cfg,
             patch(f"{MODULE}.redis_client") as mock_redis,
             patch(f"{MODULE}.marketplace") as mock_marketplace,
         ):
-            mock_cfg.MARKETPLACE_ENABLED = False
             mock_redis.get.return_value = None  # all cache misses
 
             from core.plugin.plugin_service import PluginService
@@ -131,11 +140,9 @@ class TestFetchLatestPluginVersion:
         manifest.alternative_plugin_id = ""
 
         with (
-            patch(f"{MODULE}.dify_config") as mock_cfg,
             patch(f"{MODULE}.redis_client") as mock_redis,
             patch(f"{MODULE}.marketplace") as mock_marketplace,
         ):
-            mock_cfg.MARKETPLACE_ENABLED = True
             mock_redis.get.return_value = None
             mock_marketplace.batch_fetch_plugin_manifests.return_value = [manifest]
 
@@ -157,12 +164,7 @@ class TestPluginModelProviderCache:
         raw_payload = TypeAdapter(list[PluginModelProviderDeclaration]).dump_json([large_provider])
         cache_key = _provider_cache_key("tenant-1", 0)
 
-        with (
-            patch(f"{MODULE}.redis_client") as redis_client,
-            patch(f"{MODULE}.dify_config") as mock_config,
-        ):
-            mock_config.PLUGIN_MODEL_PROVIDERS_CACHE_TTL = 86400
-
+        with patch(f"{MODULE}.redis_client") as redis_client:
             from core.plugin.plugin_service import PluginService
 
             PluginService._store_cached_plugin_model_providers("tenant-1", 0, [large_provider])
@@ -254,11 +256,9 @@ class TestPluginModelProviderCache:
         cache_key = _provider_cache_key("tenant-1", 0)
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
-            patch(f"{MODULE}.dify_config") as mock_config,
         ):
             redis_client.get.side_effect = [None, None, None]
             redis_client.mget.side_effect = [[legacy_payload], [None]]
-            mock_config.PLUGIN_MODEL_PROVIDERS_CACHE_TTL = 86400
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
 
@@ -277,10 +277,10 @@ class TestPluginModelProviderCache:
             call([cache_key]),
         ]
 
-    def test_fetch_plugin_model_providers_bypasses_redis_when_cache_disabled(self) -> None:
+    def test_fetch_plugin_model_providers_bypasses_redis_when_cache_disabled(self, config_overrides) -> None:
         """With the cache disabled the daemon is the only source, and Redis is never touched."""
-        with patch(f"{MODULE}.redis_client") as redis_client, patch(f"{MODULE}.dify_config") as config:
-            config.PLUGIN_MODEL_PROVIDERS_CACHE_ENABLED = False
+        config_overrides(PLUGIN_MODEL_PROVIDERS_CACHE_ENABLED=False)
+        with patch(f"{MODULE}.redis_client") as redis_client:
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
 
@@ -298,7 +298,8 @@ class TestPluginModelProviderCache:
         redis_client.setex.assert_not_called()
         redis_client.lock.assert_not_called()
 
-    def test_fetch_plugin_model_providers_resolves_missing_installation_source(self) -> None:
+    def test_fetch_plugin_model_providers_resolves_missing_installation_source(self, config_overrides) -> None:
+        config_overrides(PLUGIN_MODEL_PROVIDERS_CACHE_ENABLED=False)
         provider = _build_plugin_model_provider(installation_source=None)
         installation = SimpleNamespace(
             plugin_unique_identifier=provider.plugin_unique_identifier,
@@ -308,12 +309,10 @@ class TestPluginModelProviderCache:
         from core.plugin.plugin_service import PluginService
 
         with (
-            patch(f"{MODULE}.dify_config") as config,
             patch.object(
                 PluginService, "list_installations_from_ids", return_value=[installation]
             ) as list_installations,
         ):
-            config.PLUGIN_MODEL_PROVIDERS_CACHE_ENABLED = False
             client = Mock()
             client.fetch_model_providers.return_value = [provider]
 
@@ -1207,13 +1206,11 @@ class TestPluginModelProviderCacheInvalidation:
     def test_upgrade_plugin_with_marketplace_invalidates_model_provider_cache_for_tenant(self) -> None:
         """Marketplace upgrades invalidate only the mutated tenant provider cache."""
         with (
-            patch(f"{MODULE}.dify_config") as mock_config,
             patch(f"{MODULE}.FeatureService") as feature_service,
             patch(f"{MODULE}.PluginInstaller") as installer_cls,
             patch(f"{MODULE}.marketplace") as marketplace,
             patch(f"{MODULE}.PluginService.invalidate_plugin_model_providers_cache") as invalidate_cache,
         ):
-            mock_config.MARKETPLACE_ENABLED = True
             feature_service.get_plugin_installation_permission.return_value = PluginInstallationPermissionModel(
                 restrict_to_marketplace_only=False,
                 plugin_installation_scope=PluginInstallationScope.ALL,
@@ -1317,13 +1314,11 @@ class TestPluginModelProviderCacheInvalidation:
     def test_install_from_marketplace_pkg_invalidates_model_provider_cache_for_tenant(self) -> None:
         """Marketplace package installs invalidate only the mutated tenant provider cache."""
         with (
-            patch(f"{MODULE}.dify_config") as mock_config,
             patch(f"{MODULE}.FeatureService") as feature_service,
             patch(f"{MODULE}.PluginService._check_plugin_installation_scope"),
             patch(f"{MODULE}.PluginInstaller") as installer_cls,
             patch(f"{MODULE}.PluginService.invalidate_plugin_model_providers_cache") as invalidate_cache,
         ):
-            mock_config.MARKETPLACE_ENABLED = True
             feature_service.get_system_features.return_value = SimpleNamespace(
                 plugin_installation_permission=SimpleNamespace(restrict_to_marketplace_only=False)
             )
@@ -1421,13 +1416,11 @@ class TestPluginModelProviderCacheInvalidation:
 
         with (
             patch(f"{MODULE}.db", SimpleNamespace(engine=sqlite_session.get_bind())),
-            patch(f"{MODULE}.dify_config") as mock_config,
             patch(f"{MODULE}.PluginInstaller") as installer_cls,
             patch(f"{MODULE}.ProviderCredentialsCache") as credentials_cache,
             patch(f"{MODULE}.PluginService.invalidate_plugin_model_providers_cache") as invalidate_cache,
             patch("core.provider_manager.ProviderManager.invalidate_configurations_cache") as invalidate_configurations,
         ):
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
             installer = installer_cls.return_value
             installer.list_plugins.return_value = [plugin]
             installer.uninstall.return_value = True

--- a/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
@@ -55,6 +55,15 @@ def plugin_db() -> Iterator[Session]:
             yield session
 
 
+@pytest.fixture(autouse=True)
+def _plugin_config(config_overrides) -> None:
+    config_overrides(
+        CONSOLE_API_URL="https://console.example.com",
+        MARKETPLACE_ENABLED=True,
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+    )
+
+
 class TestFetchLatestPluginVersion:
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.redis_client")
@@ -200,10 +209,7 @@ class TestCheckPluginInstallationScope:
 
 
 class TestGetPluginIconUrl:
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_constructs_url_with_params(self, mock_config):
-        mock_config.CONSOLE_API_URL = "https://console.example.com"
-
+    def test_constructs_url_with_params(self):
         url = PluginService.get_plugin_icon_url("tenant-1", "icon.svg")
 
         assert "tenant_id=tenant-1" in url
@@ -245,26 +251,20 @@ class TestIsPluginVerified:
 
 
 class TestUpgradePluginWithMarketplace:
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_raises_when_marketplace_disabled(self, mock_config):
-        mock_config.MARKETPLACE_ENABLED = False
+    def test_raises_when_marketplace_disabled(self, config_overrides):
+        config_overrides(MARKETPLACE_ENABLED=False)
 
         with pytest.raises(ValueError, match="marketplace is not enabled"):
             PluginService.upgrade_plugin_with_marketplace("t1", "old-uid", "new-uid")
 
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_raises_when_same_identifier(self, mock_config):
-        mock_config.MARKETPLACE_ENABLED = True
-
+    def test_raises_when_same_identifier(self):
         with pytest.raises(ValueError, match="same plugin"):
             PluginService.upgrade_plugin_with_marketplace("t1", "same-uid", "same-uid")
 
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_skips_download_when_already_installed(self, mock_config, mock_installer_cls, mock_fs, mock_marketplace):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_skips_download_when_already_installed(self, mock_installer_cls, mock_fs, mock_marketplace):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.return_value = MagicMock()
@@ -278,9 +278,7 @@ class TestUpgradePluginWithMarketplace:
     @patch("core.plugin.plugin_service.download_plugin_pkg")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_downloads_when_not_installed(self, mock_config, mock_installer_cls, mock_fs, mock_download):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_downloads_when_not_installed(self, mock_installer_cls, mock_fs, mock_download):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.side_effect = RuntimeError("not found")
@@ -303,11 +301,9 @@ class TestUpgradePluginWithMarketplace:
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
     def test_rejects_cached_pkg_outside_scope(
-        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace, mock_download, scope
+        self, mock_installer_cls, mock_fs, mock_marketplace, mock_download, scope
     ):
-        mock_config.MARKETPLACE_ENABLED = True
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(scope=scope)
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.return_value = MagicMock()
@@ -326,9 +322,7 @@ class TestUpgradePluginWithMarketplace:
 
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_rejects_before_touching_daemon_when_scope_is_none(self, mock_config, mock_installer_cls, mock_fs):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_rejects_before_touching_daemon_when_scope_is_none(self, mock_installer_cls, mock_fs):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(scope=PluginInstallationScope.NONE)
         installer = mock_installer_cls.return_value
 
@@ -341,11 +335,7 @@ class TestUpgradePluginWithMarketplace:
     @patch("core.plugin.plugin_service.marketplace")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_allows_cached_official_pkg_under_official_only(
-        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace
-    ):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_allows_cached_official_pkg_under_official_only(self, mock_installer_cls, mock_fs, mock_marketplace):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(
             scope=PluginInstallationScope.OFFICIAL_ONLY
         )
@@ -391,9 +381,8 @@ class TestUploadPkg:
 
 
 class TestInstallFromMarketplacePkg:
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_raises_when_marketplace_disabled(self, mock_config):
-        mock_config.MARKETPLACE_ENABLED = False
+    def test_raises_when_marketplace_disabled(self, config_overrides):
+        config_overrides(MARKETPLACE_ENABLED=False)
 
         with pytest.raises(ValueError, match="marketplace is not enabled"):
             PluginService.install_from_marketplace_pkg("t1", ["uid-1"])
@@ -401,9 +390,7 @@ class TestInstallFromMarketplacePkg:
     @patch("core.plugin.plugin_service.download_plugin_pkg")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_downloads_when_not_cached(self, mock_config, mock_installer_cls, mock_fs, mock_download):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_downloads_when_not_cached(self, mock_installer_cls, mock_fs, mock_download):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.side_effect = RuntimeError("not found")
@@ -423,9 +410,7 @@ class TestInstallFromMarketplacePkg:
 
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_uses_cached_when_already_downloaded(self, mock_config, mock_installer_cls: MagicMock, mock_fs: MagicMock):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_uses_cached_when_already_downloaded(self, mock_installer_cls: MagicMock, mock_fs: MagicMock):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission()
         installer = mock_installer_cls.return_value
         installer.fetch_plugin_manifest.return_value = MagicMock()
@@ -443,9 +428,7 @@ class TestInstallFromMarketplacePkg:
     @patch("core.plugin.plugin_service.download_plugin_pkg")
     @patch("core.plugin.plugin_service.FeatureService")
     @patch("core.plugin.plugin_service.PluginInstaller")
-    @patch("core.plugin.plugin_service.dify_config")
-    def test_rejects_cached_pkg_outside_scope(self, mock_config, mock_installer_cls, mock_fs, mock_download):
-        mock_config.MARKETPLACE_ENABLED = True
+    def test_rejects_cached_pkg_outside_scope(self, mock_installer_cls, mock_fs, mock_download):
         mock_fs.get_plugin_installation_permission.return_value = _make_permission(
             scope=PluginInstallationScope.OFFICIAL_ONLY
         )
@@ -516,9 +499,7 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = True
 
-        with patch("core.plugin.plugin_service.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = PluginService.uninstall(tenant_id, "install-1")
+        result = PluginService.uninstall(tenant_id, "install-1")
 
         assert result is True
         installer.uninstall.assert_called_once()
@@ -579,9 +560,7 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = True
 
-        with patch("core.plugin.plugin_service.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = PluginService.uninstall(tenant_id, "install-1", preserve_credentials=True)
+        result = PluginService.uninstall(tenant_id, "install-1", preserve_credentials=True)
 
         assert result is True
         plugin_db.expire_all()
@@ -609,9 +588,7 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = False
 
-        with patch("core.plugin.plugin_service.dify_config") as mock_config:
-            mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = PluginService.uninstall(tenant_id, "install-1")
+        result = PluginService.uninstall(tenant_id, "install-1")
 
         assert result is False
         plugin_db.expire_all()

--- a/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
+++ b/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
@@ -117,10 +117,16 @@ class TestRemoteRecommendAppRetrieval:
 
 
 class TestFetchFromDifyOfficial:
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
+    @pytest.fixture(autouse=True)
+    def _remote_config(self, config_overrides):
+        config_overrides(
+            HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN="https://example.com",
+            HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=300,
+            CONSOLE_WEB_URL="",
+        )
+
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_detail_returns_json_on_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_detail_returns_json_on_200(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"id": "app-1", "name": "Test"}
         mock_get.return_value = mock_response
@@ -130,20 +136,16 @@ class TestFetchFromDifyOfficial:
         assert result == {"id": "app-1", "name": "Test"}
         mock_get.assert_called_once()
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_detail_returns_none_on_non_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_detail_returns_none_on_non_200(self, mock_get):
         mock_get.return_value = MagicMock(status_code=404)
 
         result = RemoteRecommendAppRetrieval.fetch_recommended_app_detail_from_dify_official("app-1")
 
         assert result is None
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_preserves_remote_categories_order_on_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_apps_preserves_remote_categories_order_on_200(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {
             "recommended_apps": [],
@@ -155,19 +157,15 @@ class TestFetchFromDifyOfficial:
 
         assert result["categories"] == ["writing", "agent", "chat"]
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_raises_on_non_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_apps_raises_on_non_200(self, mock_get):
         mock_get.return_value = MagicMock(status_code=500)
 
         with pytest.raises(ValueError, match="fetch recommended apps failed"):
             RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_without_categories_key(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_apps_without_categories_key(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -177,11 +175,9 @@ class TestFetchFromDifyOfficial:
         assert "categories" not in result
         assert mock_get.call_args.kwargs["headers"] == {}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_forwards_request_origin_header(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "https://saas.dify.dev"
+    def test_apps_forwards_request_origin_header(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="https://saas.dify.dev")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -192,11 +188,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "https://cloud.example.com"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_falls_back_to_console_web_url_origin(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "https://saas.dify.dev/console"
+    def test_apps_falls_back_to_console_web_url_origin(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="https://saas.dify.dev/console")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -207,11 +201,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "https://saas.dify.dev/console"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_falls_back_to_console_web_url_without_request_context(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "http://localhost:3000/console"
+    def test_apps_falls_back_to_console_web_url_without_request_context(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="http://localhost:3000/console")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -220,11 +212,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "http://localhost:3000/console"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_uses_console_web_url_without_scheme(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.CONSOLE_WEB_URL = "saas.dify.dev"
+    def test_apps_uses_console_web_url_without_scheme(self, mock_get, config_overrides):
+        config_overrides(CONSOLE_WEB_URL="saas.dify.dev")
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -235,10 +225,8 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_args.kwargs["headers"] == {"Origin": "saas.dify.dev"}
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_learn_dify_apps_returns_json_on_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_learn_dify_apps_returns_json_on_200(self, mock_get):
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": [{"id": "learn-dify-app"}]}
         mock_get.return_value = mock_response
@@ -248,20 +236,16 @@ class TestFetchFromDifyOfficial:
         assert result == {"recommended_apps": [{"id": "learn-dify-app"}]}
         assert mock_get.call_args.args[0] == "https://example.com/apps/learn-dify?language=en-US"
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_learn_dify_apps_raises_on_non_200(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+    def test_learn_dify_apps_raises_on_non_200(self, mock_get):
         mock_get.return_value = MagicMock(status_code=500)
 
         with pytest.raises(ValueError, match="fetch learn dify apps failed"):
             RemoteRecommendAppRetrieval.fetch_learn_dify_apps_from_dify_official("en-US")
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_uses_cache_for_repeated_requests(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+    def test_apps_uses_cache_for_repeated_requests(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=600)
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": [{"id": "app-1"}]}
         mock_get.return_value = mock_response
@@ -272,11 +256,9 @@ class TestFetchFromDifyOfficial:
         assert first == second == {"recommended_apps": [{"id": "app-1"}]}
         mock_get.assert_called_once()
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_does_not_cache_failed_responses(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+    def test_apps_does_not_cache_failed_responses(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=600)
         mock_get.return_value = MagicMock(status_code=500)
 
         with pytest.raises(ValueError, match="fetch recommended apps failed"):
@@ -286,11 +268,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_count == 2
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_skips_cache_when_ttl_disabled(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 0
+    def test_apps_skips_cache_when_ttl_disabled(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=0)
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response
@@ -300,11 +280,9 @@ class TestFetchFromDifyOfficial:
 
         assert mock_get.call_count == 2
 
-    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_cache_isolated_by_origin_header(self, mock_get, mock_config):
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+    def test_apps_cache_isolated_by_origin_header(self, mock_get, config_overrides):
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL=600)
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {"recommended_apps": []}
         mock_get.return_value = mock_response

--- a/api/tests/unit_tests/services/retention/test_messages_clean_policy.py
+++ b/api/tests/unit_tests/services/retention/test_messages_clean_policy.py
@@ -116,19 +116,15 @@ class TestBillingSandboxPolicy:
 
 
 class TestCreateMessageCleanPolicy:
-    def test_non_cloud_edition_returns_disabled_policy(self):
-        with patch(f"{MODULE}.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            policy = create_message_clean_policy()
+    def test_non_cloud_edition_returns_disabled_policy(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        policy = create_message_clean_policy()
 
         assert isinstance(policy, BillingDisabledPolicy)
 
-    def test_cloud_edition_returns_sandbox_policy(self):
-        with (
-            patch(f"{MODULE}.dify_config") as cfg,
-            patch(f"{MODULE}.BillingService") as bs,
-        ):
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+    def test_cloud_edition_returns_sandbox_policy(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        with patch(f"{MODULE}.BillingService") as bs:
             bs.get_expired_subscription_cleanup_whitelist.return_value = ["wl1"]
             bs.get_plan_bulk_with_cache = MagicMock()
             policy = create_message_clean_policy(graceful_period_days=30)

--- a/api/tests/unit_tests/services/retention/workflow_run/test_clear_free_plan_expired_workflow_run_logs.py
+++ b/api/tests/unit_tests/services/retention/workflow_run/test_clear_free_plan_expired_workflow_run_logs.py
@@ -26,12 +26,17 @@ def mock_repo():
     return MagicMock()
 
 
+@pytest.fixture(autouse=True)
+def _cleanup_config(config_overrides):
+    config_overrides(
+        SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD=0,
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+    )
+
+
 @pytest.fixture
 def cleanup(mock_repo):
-    with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-        cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-        cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        yield WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+    return WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
 
 
 # ---------------------------------------------------------------------------
@@ -41,91 +46,68 @@ def cleanup(mock_repo):
 
 class TestWorkflowRunCleanupInit:
     def test_only_start_from_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="both set or both omitted"):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    start_from=datetime.datetime(2024, 1, 1),
-                    workflow_run_repo=mock_repo,
-                )
+        with pytest.raises(ValueError, match="both set or both omitted"):
+            WorkflowRunCleanup(
+                days=30,
+                batch_size=10,
+                start_from=datetime.datetime(2024, 1, 1),
+                workflow_run_repo=mock_repo,
+            )
 
     def test_only_end_before_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="both set or both omitted"):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    end_before=datetime.datetime(2024, 1, 1),
-                    workflow_run_repo=mock_repo,
-                )
+        with pytest.raises(ValueError, match="both set or both omitted"):
+            WorkflowRunCleanup(
+                days=30,
+                batch_size=10,
+                end_before=datetime.datetime(2024, 1, 1),
+                workflow_run_repo=mock_repo,
+            )
 
     def test_end_before_not_greater_than_start_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="end_before must be greater than start_from"):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    start_from=datetime.datetime(2024, 6, 1),
-                    end_before=datetime.datetime(2024, 1, 1),
-                    workflow_run_repo=mock_repo,
-                )
+        with pytest.raises(ValueError, match="end_before must be greater than start_from"):
+            WorkflowRunCleanup(
+                days=30,
+                batch_size=10,
+                start_from=datetime.datetime(2024, 6, 1),
+                end_before=datetime.datetime(2024, 1, 1),
+                workflow_run_repo=mock_repo,
+            )
 
     def test_equal_start_end_raises(self, mock_repo):
         dt = datetime.datetime(2024, 1, 1)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError):
-                WorkflowRunCleanup(
-                    days=30,
-                    batch_size=10,
-                    start_from=dt,
-                    end_before=dt,
-                    workflow_run_repo=mock_repo,
-                )
-
-    def test_zero_batch_size_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError, match="batch_size must be greater than 0"):
-                WorkflowRunCleanup(days=30, batch_size=0, workflow_run_repo=mock_repo)
-
-    def test_negative_batch_size_raises(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(ValueError):
-                WorkflowRunCleanup(days=30, batch_size=-1, workflow_run_repo=mock_repo)
-
-    def test_valid_window_init(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 7
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            start = datetime.datetime(2024, 1, 1)
-            end = datetime.datetime(2024, 6, 1)
-            c = WorkflowRunCleanup(
+        with pytest.raises(ValueError):
+            WorkflowRunCleanup(
                 days=30,
-                batch_size=5,
-                start_from=start,
-                end_before=end,
+                batch_size=10,
+                start_from=dt,
+                end_before=dt,
                 workflow_run_repo=mock_repo,
             )
-            assert c.window_start == start
-            assert c.window_end == end
+
+    def test_zero_batch_size_raises(self, mock_repo):
+        with pytest.raises(ValueError, match="batch_size must be greater than 0"):
+            WorkflowRunCleanup(days=30, batch_size=0, workflow_run_repo=mock_repo)
+
+    def test_negative_batch_size_raises(self, mock_repo):
+        with pytest.raises(ValueError):
+            WorkflowRunCleanup(days=30, batch_size=-1, workflow_run_repo=mock_repo)
+
+    def test_valid_window_init(self, mock_repo, config_overrides):
+        config_overrides(SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD=7)
+        start = datetime.datetime(2024, 1, 1)
+        end = datetime.datetime(2024, 6, 1)
+        c = WorkflowRunCleanup(
+            days=30,
+            batch_size=5,
+            start_from=start,
+            end_before=end,
+            workflow_run_repo=mock_repo,
+        )
+        assert c.window_start == start
+        assert c.window_end == end
 
     def test_default_task_label_is_custom(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
 
         assert c._metrics._base_attributes["task_label"] == "custom"
 
@@ -219,21 +201,15 @@ class TestIsWithinGracePeriod:
 class TestGetCleanupWhitelist:
     def test_non_cloud_edition_returns_empty(self, cleanup):
         cleanup._cleanup_whitelist = None
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            result = cleanup._get_cleanup_whitelist()
+        result = cleanup._get_cleanup_whitelist()
         assert result == set()
 
-    def test_cloud_edition_fetches_whitelist(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_expired_subscription_cleanup_whitelist.return_value = ["t1", "t2"]
-                result = c._get_cleanup_whitelist()
+    def test_cloud_edition_fetches_whitelist(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_expired_subscription_cleanup_whitelist.return_value = ["t1", "t2"]
+            result = c._get_cleanup_whitelist()
         assert result == {"t1", "t2"}
 
     def test_cached_whitelist_returned(self, cleanup):
@@ -241,16 +217,12 @@ class TestGetCleanupWhitelist:
         result = cleanup._get_cleanup_whitelist()
         assert result == {"cached"}
 
-    def test_billing_service_error_returns_empty(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_expired_subscription_cleanup_whitelist.side_effect = Exception("error")
-                result = c._get_cleanup_whitelist()
+    def test_billing_service_error_returns_empty(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_expired_subscription_cleanup_whitelist.side_effect = Exception("error")
+            result = c._get_cleanup_whitelist()
         assert result == set()
 
 
@@ -264,68 +236,51 @@ class TestFilterFreeTenants:
         result = cleanup._filter_free_tenants(["t1", "t2"])
         assert result == {"t1", "t2"}
 
-    def test_empty_tenants_returns_empty(self, cleanup):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            result = cleanup._filter_free_tenants([])
+    def test_empty_tenants_returns_empty(self, cleanup, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        result = cleanup._filter_free_tenants([])
         assert result == set()
 
-    def test_whitelisted_tenant_excluded(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = {"t1"}
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.return_value = {
-                    "t1": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
-                    "t2": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
-                }
-                result = c._filter_free_tenants(["t1", "t2"])
+    def test_whitelisted_tenant_excluded(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = {"t1"}
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.return_value = {
+                "t1": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
+                "t2": {"plan": CloudPlan.SANDBOX, "expiration_date": -1},
+            }
+            result = c._filter_free_tenants(["t1", "t2"])
         assert "t1" not in result
         assert "t2" in result
 
-    def test_paid_tenant_excluded(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = set()
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.return_value = {
-                    "t1": {"plan": "professional", "expiration_date": -1},
-                }
-                result = c._filter_free_tenants(["t1"])
+    def test_paid_tenant_excluded(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = set()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.return_value = {
+                "t1": {"plan": "professional", "expiration_date": -1},
+            }
+            result = c._filter_free_tenants(["t1"])
         assert result == set()
 
-    def test_missing_billing_info_treats_as_non_free(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = set()
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.return_value = {}
-                result = c._filter_free_tenants(["t1"])
+    def test_missing_billing_info_treats_as_non_free(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = set()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.return_value = {}
+            result = c._filter_free_tenants(["t1"])
         assert result == set()
 
-    def test_billing_bulk_error_treats_as_non_free(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
-            c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
-            c._cleanup_whitelist = set()
-            with patch(
-                "services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService"
-            ) as bs:
-                bs.get_plan_bulk_with_cache.side_effect = Exception("fail")
-                result = c._filter_free_tenants(["t1"])
+    def test_billing_bulk_error_treats_as_non_free(self, mock_repo, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        c = WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        c._cleanup_whitelist = set()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.BillingService") as bs:
+            bs.get_plan_bulk_with_cache.side_effect = Exception("fail")
+            result = c._filter_free_tenants(["t1"])
         assert result == set()
 
 
@@ -336,17 +291,12 @@ class TestFilterFreeTenants:
 
 class TestRunDeleteMode:
     def _make_cleanup(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            return WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
+        return WorkflowRunCleanup(days=30, batch_size=10, workflow_run_repo=mock_repo)
 
     def test_no_rows_stops_immediately(self, mock_repo):
         mock_repo.get_cleanup_refs_batch_by_time_range.return_value = []
         c = self._make_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_not_called()
 
     def test_all_paid_skips_delete(self, mock_repo):
@@ -355,9 +305,7 @@ class TestRunDeleteMode:
         c = self._make_cleanup(mock_repo)
         # Override the non-Cloud default to exercise the no-deletion path.
         c._filter_free_tenants = MagicMock(return_value=set())
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_not_called()
 
     def test_runs_deleted_successfully(self, mock_repo):
@@ -373,10 +321,8 @@ class TestRunDeleteMode:
             "pause_reasons": 0,
         }
         c = self._make_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.time.sleep"):
-                c.run()
+        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.time.sleep"):
+            c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_called_once()
 
     def test_delete_exception_reraises(self, mock_repo):
@@ -384,24 +330,19 @@ class TestRunDeleteMode:
         mock_repo.get_cleanup_refs_batch_by_time_range.side_effect = [[ref], [ref]]
         mock_repo.delete_runs_with_related_by_ids.side_effect = RuntimeError("db error")
         c = self._make_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            with pytest.raises(RuntimeError):
-                c.run()
+        with pytest.raises(RuntimeError):
+            c.run()
 
     def test_summary_with_window_start(self, mock_repo):
         mock_repo.get_cleanup_refs_batch_by_time_range.return_value = []
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c = WorkflowRunCleanup(
-                days=30,
-                batch_size=10,
-                start_from=datetime.datetime(2024, 1, 1),
-                end_before=datetime.datetime(2024, 6, 1),
-                workflow_run_repo=mock_repo,
-            )
-            c.run()
+        c = WorkflowRunCleanup(
+            days=30,
+            batch_size=10,
+            start_from=datetime.datetime(2024, 1, 1),
+            end_before=datetime.datetime(2024, 6, 1),
+            workflow_run_repo=mock_repo,
+        )
+        c.run()
 
 
 # ---------------------------------------------------------------------------
@@ -411,15 +352,12 @@ class TestRunDeleteMode:
 
 class TestRunDryRunMode:
     def _make_dry_cleanup(self, mock_repo):
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            return WorkflowRunCleanup(
-                days=30,
-                batch_size=10,
-                workflow_run_repo=mock_repo,
-                dry_run=True,
-            )
+        return WorkflowRunCleanup(
+            days=30,
+            batch_size=10,
+            workflow_run_repo=mock_repo,
+            dry_run=True,
+        )
 
     def test_dry_run_no_delete_called(self, mock_repo):
         ref = make_ref("t1")
@@ -434,35 +372,28 @@ class TestRunDryRunMode:
             "pause_reasons": 0,
         }
         c = self._make_dry_cleanup(mock_repo)
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.delete_runs_with_related_by_ids.assert_not_called()
         mock_repo.count_runs_with_related_by_ids.assert_called_once()
 
     def test_dry_run_summary_with_window_start(self, mock_repo):
         mock_repo.get_cleanup_refs_batch_by_time_range.return_value = []
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD = 0
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c = WorkflowRunCleanup(
-                days=30,
-                batch_size=10,
-                start_from=datetime.datetime(2024, 1, 1),
-                end_before=datetime.datetime(2024, 6, 1),
-                workflow_run_repo=mock_repo,
-                dry_run=True,
-            )
-            c.run()
+        c = WorkflowRunCleanup(
+            days=30,
+            batch_size=10,
+            start_from=datetime.datetime(2024, 1, 1),
+            end_before=datetime.datetime(2024, 6, 1),
+            workflow_run_repo=mock_repo,
+            dry_run=True,
+        )
+        c.run()
 
     def test_dry_run_all_paid_skips_count(self, mock_repo):
         ref = make_ref("t1")
         mock_repo.get_cleanup_refs_batch_by_time_range.side_effect = [[ref], []]
         c = self._make_dry_cleanup(mock_repo)
         c._filter_free_tenants = MagicMock(return_value=set())
-        with patch("services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs.dify_config") as cfg:
-            cfg.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-            c.run()
+        c.run()
         mock_repo.count_runs_with_related_by_ids.assert_not_called()
 
 

--- a/api/tests/unit_tests/services/test_datasource_provider_service.py
+++ b/api/tests/unit_tests/services/test_datasource_provider_service.py
@@ -83,18 +83,17 @@ class TestDatasourceProviderService:
             yield session
 
     @pytest.fixture(autouse=True)
-    def patch_externals(self):
+    def patch_externals(self, config_overrides):
+        config_overrides(CONSOLE_API_URL="http://localhost")
         with (
             patch("core.plugin.impl.base._httpx_client.request", side_effect=lambda **kw: httpx.request(**kw)),
             patch("core.plugin.impl.base._httpx_client.stream", side_effect=lambda **kw: httpx.stream(**kw)),
             patch("httpx.request") as mock_httpx,
-            patch("services.datasource_provider_service.dify_config") as mock_cfg,
             patch("services.datasource_provider_service.encrypter") as mock_enc,
             patch("services.datasource_provider_service.redis_client") as mock_redis,
             patch("services.datasource_provider_service.generate_incremental_name") as mock_genname,
             patch("services.datasource_provider_service.OAuthHandler") as mock_oauth,
         ):
-            mock_cfg.CONSOLE_API_URL = "http://localhost"
             mock_enc.encrypt_token.return_value = "enc_tok"
             mock_enc.decrypt_token.return_value = "dec_tok"
             mock_enc.decrypt.return_value = {"k": "dec"}

--- a/api/tests/unit_tests/services/test_recommended_app_service.py
+++ b/api/tests/unit_tests/services/test_recommended_app_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from typing import TypedDict, Unpack, cast
 from unittest.mock import MagicMock, patch
 
@@ -20,6 +21,15 @@ pytestmark = pytest.mark.parametrize(
     [(TrialApp, AccountTrialAppRecord, App)],
     indirect=True,
 )
+
+
+@pytest.fixture(autouse=True)
+def _recommended_app_config(config_overrides: Callable[..., None]) -> None:
+    config_overrides(
+        HOSTED_FETCH_APP_TEMPLATES_MODE="remote",
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+        ENABLE_TRIAL_APP=True,
+    )
 
 
 class RecommendedAppPayload(TypedDict, total=False):
@@ -58,14 +68,13 @@ class AppDetailKwargs(TypedDict, total=False):
     ],
 )
 def test_trial_app_policy_is_cloud_only(
-    monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     sqlite_session: Session,
     edition: DeploymentEdition,
     feature_enabled: bool,
     expected: bool,
 ) -> None:
-    monkeypatch.setattr(service_module.dify_config, "DEPLOYMENT_EDITION", edition)
-    monkeypatch.setattr(service_module.dify_config, "ENABLE_TRIAL_APP", feature_enabled)
+    config_overrides(DEPLOYMENT_EDITION=edition, ENABLE_TRIAL_APP=feature_enabled)
 
     assert RecommendedAppService.is_trial_app_enabled() is expected
 
@@ -168,11 +177,7 @@ def _persist_app(session: Session, *, name: str) -> App:
 
 class TestRecommendedAppServiceGetApps:
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
-    def test_success_with_apps(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
-    ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
+    def test_success_with_apps(self, mock_factory_class: MagicMock, sqlite_session: Session) -> None:
         expected = _apps_response()
 
         mock_instance = MagicMock()
@@ -189,11 +194,7 @@ class TestRecommendedAppServiceGetApps:
         mock_instance.get_recommended_apps_and_categories.assert_called_once_with("en-US", session=sqlite_session)
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
-    def test_fallback_to_builtin_when_empty(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
-    ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
+    def test_fallback_to_builtin_when_empty(self, mock_factory_class: MagicMock, sqlite_session: Session) -> None:
         empty_response = AppsResponse(recommended_apps=[], categories=[])
         builtin_response = _apps_response(
             recommended_apps=[{"app_id": "builtin-1", "name": "Builtin App", "category": "default"}]
@@ -214,11 +215,13 @@ class TestRecommendedAppServiceGetApps:
         mock_builtin_instance.fetch_recommended_apps_from_builtin.assert_called_once_with("en-US")
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_fallback_when_none_recommended_apps(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
+        self,
+        mock_factory_class: MagicMock,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "db"
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="db")
         none_response = AppsResponse(recommended_apps=None, categories=["test"])
         builtin_response = _apps_response()
 
@@ -236,11 +239,13 @@ class TestRecommendedAppServiceGetApps:
         mock_builtin_instance.fetch_recommended_apps_from_builtin.assert_called_once()
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_different_languages(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
+        self,
+        mock_factory_class: MagicMock,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "builtin"
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="builtin")
 
         for language in ["en-US", "zh-CN", "ja-JP", "fr-FR"]:
             lang_response = _apps_response(
@@ -256,12 +261,14 @@ class TestRecommendedAppServiceGetApps:
             mock_instance.get_recommended_apps_and_categories.assert_called_with(language, session=sqlite_session)
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_uses_correct_factory_mode(
-        self, mock_config: MagicMock, mock_factory_class: MagicMock, sqlite_session: Session
+        self,
+        mock_factory_class: MagicMock,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
         for mode in ["remote", "builtin", "db"]:
-            mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = mode
+            config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE=mode)
             response = _apps_response()
             mock_instance = MagicMock()
             mock_instance.get_recommended_apps_and_categories.return_value = response
@@ -310,16 +317,11 @@ class TestRecommendedAppServiceGetApp:
 
 class TestRecommendedAppServiceGetDetail:
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_returns_retrieval_detail_when_trial_disabled(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        mock_config.ENABLE_TRIAL_APP = True
         cases: list[tuple[str, RecommendedAppPayload]] = [
             (
                 "complex-app",
@@ -350,17 +352,14 @@ class TestRecommendedAppServiceGetDetail:
             mock_instance.get_recommend_app_detail.assert_called_once_with(app_id, session=sqlite_session)
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_different_modes(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        mock_config.ENABLE_TRIAL_APP = True
         for mode in ["remote", "builtin", "db"]:
-            mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = mode
+            config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE=mode)
             detail = _app_detail(app_id="test-app", name=f"App from {mode}")
             mock_instance = MagicMock()
             mock_instance.get_recommend_app_detail.return_value = detail
@@ -378,16 +377,11 @@ class TestRecommendedAppServiceGetDetail:
 
 class TestRecommendedAppServiceGetLearnDifyApps:
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_uses_configured_retrieval_source(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
-        mock_config.ENABLE_TRIAL_APP = True
         expected_app = RecommendedAppPayload(app_id="app-1", category="Workflow")
         mock_instance = MagicMock()
         mock_instance.get_learn_dify_apps.return_value = {
@@ -402,11 +396,13 @@ class TestRecommendedAppServiceGetLearnDifyApps:
         mock_factory_class.get_recommend_app_factory.assert_called_once_with("remote")
         mock_instance.get_learn_dify_apps.assert_called_once_with("en-US", session=sqlite_session)
 
-    @patch("services.recommended_app_service.dify_config")
     def test_sets_can_trial_when_trial_feature_enabled(
-        self, mock_config: MagicMock, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_session: Session,
+        config_overrides: Callable[..., None],
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "db"
+        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="db")
         app = RecommendedAppPayload(app_id="app-1", category="Workflow")
         mock_retrieval_instance = MagicMock()
         mock_retrieval_instance.get_learn_dify_apps.return_value = {
@@ -514,14 +510,11 @@ class TestRecommendedAppServiceTrialFeatures:
         assert detail_result["can_trial"] is has_trial_app
 
     @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    @patch("services.recommended_app_service.dify_config")
     def test_get_detail_returns_none_before_reading_trial_flag(
         self,
-        mock_config: MagicMock,
         mock_factory_class: MagicMock,
         sqlite_session: Session,
     ) -> None:
-        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
         mock_instance = MagicMock()
         mock_instance.get_recommend_app_detail.return_value = None
         mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)

--- a/api/tests/unit_tests/services/workflow/test_queue_dispatcher.py
+++ b/api/tests/unit_tests/services/workflow/test_queue_dispatcher.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from enums import DeploymentEdition
 from services.workflow.queue_dispatcher import (
     ProfessionalQueueDispatcher,
@@ -35,10 +37,12 @@ class TestDispatchers:
 
 
 class TestQueueDispatcherManager:
+    @pytest.fixture(autouse=True)
+    def _cloud_edition(self, config_overrides) -> None:
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+
     @patch("services.workflow.queue_dispatcher.BillingService")
-    @patch("services.workflow.queue_dispatcher.dify_config")
-    def test_cloud_edition_professional_plan(self, mock_config, mock_billing):
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+    def test_cloud_edition_professional_plan(self, mock_billing):
         mock_billing.get_info.return_value = {"subscription": {"plan": "professional"}}
 
         dispatcher = QueueDispatcherManager.get_dispatcher("tenant-1")
@@ -46,9 +50,7 @@ class TestQueueDispatcherManager:
         assert isinstance(dispatcher, ProfessionalQueueDispatcher)
 
     @patch("services.workflow.queue_dispatcher.BillingService")
-    @patch("services.workflow.queue_dispatcher.dify_config")
-    def test_cloud_edition_team_plan(self, mock_config, mock_billing):
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+    def test_cloud_edition_team_plan(self, mock_billing):
         mock_billing.get_info.return_value = {"subscription": {"plan": "team"}}
 
         dispatcher = QueueDispatcherManager.get_dispatcher("tenant-1")
@@ -56,9 +58,7 @@ class TestQueueDispatcherManager:
         assert isinstance(dispatcher, TeamQueueDispatcher)
 
     @patch("services.workflow.queue_dispatcher.BillingService")
-    @patch("services.workflow.queue_dispatcher.dify_config")
-    def test_cloud_edition_sandbox_plan(self, mock_config, mock_billing):
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+    def test_cloud_edition_sandbox_plan(self, mock_billing):
         mock_billing.get_info.return_value = {"subscription": {"plan": "sandbox"}}
 
         dispatcher = QueueDispatcherManager.get_dispatcher("tenant-1")
@@ -66,9 +66,7 @@ class TestQueueDispatcherManager:
         assert isinstance(dispatcher, SandboxQueueDispatcher)
 
     @patch("services.workflow.queue_dispatcher.BillingService")
-    @patch("services.workflow.queue_dispatcher.dify_config")
-    def test_cloud_edition_unknown_plan_defaults_to_sandbox(self, mock_config, mock_billing):
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+    def test_cloud_edition_unknown_plan_defaults_to_sandbox(self, mock_billing):
         mock_billing.get_info.return_value = {"subscription": {"plan": "enterprise"}}
 
         dispatcher = QueueDispatcherManager.get_dispatcher("tenant-1")
@@ -76,27 +74,22 @@ class TestQueueDispatcherManager:
         assert isinstance(dispatcher, SandboxQueueDispatcher)
 
     @patch("services.workflow.queue_dispatcher.BillingService")
-    @patch("services.workflow.queue_dispatcher.dify_config")
-    def test_cloud_edition_billing_failure_defaults_to_sandbox(self, mock_config, mock_billing):
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+    def test_cloud_edition_billing_failure_defaults_to_sandbox(self, mock_billing):
         mock_billing.get_info.side_effect = Exception("billing unavailable")
 
         dispatcher = QueueDispatcherManager.get_dispatcher("tenant-1")
 
         assert isinstance(dispatcher, SandboxQueueDispatcher)
 
-    @patch("services.workflow.queue_dispatcher.dify_config")
-    def test_non_cloud_edition_defaults_to_team(self, mock_config):
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.COMMUNITY
+    def test_non_cloud_edition_defaults_to_team(self, config_overrides):
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
 
         dispatcher = QueueDispatcherManager.get_dispatcher("tenant-1")
 
         assert isinstance(dispatcher, TeamQueueDispatcher)
 
     @patch("services.workflow.queue_dispatcher.BillingService")
-    @patch("services.workflow.queue_dispatcher.dify_config")
-    def test_missing_subscription_key_defaults_to_sandbox(self, mock_config, mock_billing):
-        mock_config.DEPLOYMENT_EDITION = DeploymentEdition.CLOUD
+    def test_missing_subscription_key_defaults_to_sandbox(self, mock_billing):
         mock_billing.get_info.return_value = {}
 
         dispatcher = QueueDispatcherManager.get_dispatcher("tenant-1")

--- a/api/tests/unit_tests/utils/encryption/test_system_encryption.py
+++ b/api/tests/unit_tests/utils/encryption/test_system_encryption.py
@@ -27,13 +27,12 @@ class TestSystemEncrypter:
         expected_key = hashlib.sha256(secret_key.encode()).digest()
         assert encrypter.key == expected_key
 
-    def test_init_with_none_secret_key(self):
+    def test_init_with_none_secret_key(self, config_overrides):
         """Test initialization with None secret key falls back to config"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "config_secret"
-            encrypter = SystemEncrypter(secret_key=None)
-            expected_key = hashlib.sha256(b"config_secret").digest()
-            assert encrypter.key == expected_key
+        config_overrides(SECRET_KEY="config_secret")
+        encrypter = SystemEncrypter(secret_key=None)
+        expected_key = hashlib.sha256(b"config_secret").digest()
+        assert encrypter.key == expected_key
 
     def test_init_with_empty_secret_key(self):
         """Test initialization with empty secret key"""
@@ -41,13 +40,12 @@ class TestSystemEncrypter:
         expected_key = hashlib.sha256(b"").digest()
         assert encrypter.key == expected_key
 
-    def test_init_without_secret_key_uses_config(self):
+    def test_init_without_secret_key_uses_config(self, config_overrides):
         """Test initialization without secret key uses config"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "default_secret"
-            encrypter = SystemEncrypter()
-            expected_key = hashlib.sha256(b"default_secret").digest()
-            assert encrypter.key == expected_key
+        config_overrides(SECRET_KEY="default_secret")
+        encrypter = SystemEncrypter()
+        expected_key = hashlib.sha256(b"default_secret").digest()
+        assert encrypter.key == expected_key
 
     def test_encrypt_params_basic(self):
         """Test basic parameters encryption"""
@@ -368,25 +366,23 @@ class TestFactoryFunctions:
         expected_key = hashlib.sha256(secret_key.encode()).digest()
         assert encrypter.key == expected_key
 
-    def test_create_system_encrypter_without_secret(self):
+    def test_create_system_encrypter_without_secret(self, config_overrides):
         """Test factory function without secret key"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "config_secret"
-            encrypter = create_system_encrypter()
+        config_overrides(SECRET_KEY="config_secret")
+        encrypter = create_system_encrypter()
 
-            assert isinstance(encrypter, SystemEncrypter)
-            expected_key = hashlib.sha256(b"config_secret").digest()
-            assert encrypter.key == expected_key
+        assert isinstance(encrypter, SystemEncrypter)
+        expected_key = hashlib.sha256(b"config_secret").digest()
+        assert encrypter.key == expected_key
 
-    def test_create_system_encrypter_with_none_secret(self):
+    def test_create_system_encrypter_with_none_secret(self, config_overrides):
         """Test factory function with None secret key"""
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "config_secret"
-            encrypter = create_system_encrypter(None)
+        config_overrides(SECRET_KEY="config_secret")
+        encrypter = create_system_encrypter(None)
 
-            assert isinstance(encrypter, SystemEncrypter)
-            expected_key = hashlib.sha256(b"config_secret").digest()
-            assert encrypter.key == expected_key
+        assert isinstance(encrypter, SystemEncrypter)
+        expected_key = hashlib.sha256(b"config_secret").digest()
+        assert encrypter.key == expected_key
 
 
 class TestGlobalEncrypterInstance:
@@ -405,19 +401,18 @@ class TestGlobalEncrypterInstance:
         assert encrypter1 is encrypter2
         assert isinstance(encrypter1, SystemEncrypter)
 
-    def test_get_system_encrypter_uses_config(self):
+    def test_get_system_encrypter_uses_config(self, config_overrides):
         """Test that global encrypter uses config"""
         # Clear the global instance first
         import core.tools.utils.system_encryption
 
         core.tools.utils.system_encryption._encrypter = None
 
-        with patch("core.tools.utils.system_encryption.dify_config") as mock_config:
-            mock_config.SECRET_KEY = "global_secret"
-            encrypter = get_system_encrypter()
+        config_overrides(SECRET_KEY="global_secret")
+        encrypter = get_system_encrypter()
 
-            expected_key = hashlib.sha256(b"global_secret").digest()
-            assert encrypter.key == expected_key
+        expected_key = hashlib.sha256(b"global_secret").digest()
+        assert encrypter.key == expected_key
 
 
 class TestConvenienceFunctions:


### PR DESCRIPTION
## Summary

- replace whole config mocks across plugin, datasource, MCP, embedding, indexing, and broadcast-channel tests
- centralize deterministic plugin cache, SSRF proxy, storage, deployment, and Redis-prefix values with typed overrides
- stop mocking project metadata where protocol tests do not assert it
- keep daemon, HTTP, Redis, storage, and repository mocks focused on external boundaries

## Stack

- depends on #40853

## Tests

- make lint
- make test with all 16 changed unit-test modules (528 passed)

From Codex