### PR TITLE
feat(ci): sync E2B template on release tag push

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -229,3 +229,32 @@ jobs:
           IMAGE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           docker buildx imagetools inspect "$IMAGE_NAME:$IMAGE_VERSION"
+
+  sync-e2b-template:
+    needs: create-manifest
+    runs-on: ubuntu-24.04
+    if: github.repository == 'langgenius/dify' && startsWith(github.ref, 'refs/tags/')
+    strategy:
+      matrix:
+        include:
+          - project: dev
+            api_key_secret: E2B_API_KEY_DEV
+          - project: prod
+            api_key_secret: E2B_API_KEY_PROD
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Sync E2B Template (${{ matrix.project }})
+        env:
+          E2B_API_KEY: ${{ secrets[matrix.api_key_secret] }}
+        run: ./dify-agent-runtime/docker/sync-e2b-template.sh

--- a/dify-agent-runtime/Makefile
+++ b/dify-agent-runtime/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test lint gen-cli-help integration integration-up integration-test integration-down
+.PHONY: build clean test lint gen-cli-help integration integration-up integration-test integration-down sync-e2b-template-dev sync-e2b-template-prod sync-e2b-template-dry-run
 BIN_DIR := bin
 AGENT_CLI_HELP_JSON := ../dify-agent/src/dify_agent/layers/_agent_cli_help.json
 
@@ -128,3 +128,18 @@ integration:
 	@$(MAKE) integration-up
 	@trap '$(MAKE) integration-down' EXIT; \
 	$(MAKE) integration-test
+
+# --- E2B Template sync ---
+#
+# Both E2B projects publish the same template name (dify-agent-local-sandbox);
+# the project itself is the isolation boundary. Export E2B_API_KEY_DEV /
+# E2B_API_KEY_PROD in your shell before running the non-dry-run targets.
+
+sync-e2b-template-dry-run:
+	./docker/sync-e2b-template.sh --dry-run
+
+sync-e2b-template-dev:
+	E2B_API_KEY=$(E2B_API_KEY_DEV) ./docker/sync-e2b-template.sh
+
+sync-e2b-template-prod:
+	E2B_API_KEY=$(E2B_API_KEY_PROD) ./docker/sync-e2b-template.sh


### PR DESCRIPTION
## Summary
- Wires `dify-agent-runtime/docker/sync-e2b-template.sh` (#39705) into the tag-triggered release pipeline (`build-push.yml`), which previously had no automated entry point and required someone to remember to run it by hand.
- Syncs both the `dev` and `prod` E2B projects on every release tag, via `E2B_API_KEY_DEV` / `E2B_API_KEY_PROD` repo secrets.
- Adds local Makefile targets (`sync-e2b-template-dry-run` / `-dev` / `-prod`) for testing the sync without needing a real release.

## Test plan
- [x] Local dry-run verified (`make sync-e2b-template-dry-run`) against an already-published main commit.
- [x] Local real sync verified end-to-end against the dev E2B project (template built, healthz passed, `dify-agent-local-sandbox` updated).
- [x] `E2B_API_KEY_DEV` / `E2B_API_KEY_PROD` need to be added as repo secrets before this job can run for real (not yet confirmed added).
- [ ] Prod-project sync path not yet exercised (only dev was tested locally).
