### PR TITLE
test(e2e): align agent model selector locators

### DIFF
--- a/e2e/features/step-definitions/agent-v2/configure.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/configure.steps.ts
@@ -42,10 +42,10 @@ async function fillAgentPromptEditor(page: Page, prompt: string) {
 }
 
 async function selectAgentModel(page: Page, modelName: string) {
-  await page.getByRole('combobox').first().click()
+  await page.getByRole('button', { name: 'Configure model' }).click()
   await page.getByPlaceholder('Search model').fill(modelName)
   const escapedModelName = modelName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  await page.getByRole('option', { name: new RegExp(`${escapedModelName}(?:\\s|$)`) }).click()
+  await page.getByRole('button', { name: new RegExp(`${escapedModelName}(?:\\s|$)`) }).click()
 }
 
 async function expectAgentComposerPrompt(world: DifyWorld, agentId: string, prompt: string) {


### PR DESCRIPTION
## Summary

- align the Agent v2 model-selection E2E helper with the Popover/button interaction model introduced in #40826
- locate the named `Configure model` trigger instead of the removed combobox role
- select the filtered model through its button role instead of the removed option role

## Failure

Post-merge run 31990035612 timed out waiting for `getByRole('combobox').first()` in `Selecting a compatible model in Configure persists after refresh`.

## Test plan

- Not run locally, per request
- Let CI validate the scoped E2E locator update