### PR TITLE
fix(web): update agent model request limit copy

### DIFF
--- a/web/i18n/en-US/agent-v-2.json
+++ b/web/i18n/en-US/agent-v-2.json
@@ -156,7 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Run the agent as a finished chat, exactly how people will experience it once published.",
   "agentDetail.configure.preview.empty.title": "Preview {{name}}",
   "agentDetail.configure.preview.endUserAuth": "End-user authentication",
-  "agentDetail.configure.preview.errors.agentModelRequestLimitExceeded": "This agent run stopped after reaching the maximum number of model requests. Try again, or break the task into smaller steps.",
+  "agentDetail.configure.preview.errors.agentModelRequestLimitExceeded": "This agent run was stopped at the model request limit. Try again, or break the task into smaller steps.",
   "agentDetail.configure.preview.errors.agentRunLimitExceeded": "This agent run was stopped at the time limit. Try again, or break the task into smaller steps.",
   "agentDetail.configure.preview.inputPlaceholder": "Message {{name}}",
   "agentDetail.configure.preview.restart": "Start fresh",

--- a/web/i18n/ja-JP/agent-v-2.json
+++ b/web/i18n/ja-JP/agent-v-2.json
@@ -198,7 +198,7 @@
   "agentDetail.configure.rightPanel.build": "ビルド",
   "agentDetail.configure.rightPanel.buildTipBody": "Build はチャットを通じてエージェントを設定します。やりたいことを説明すると、左側の設定が入力されます。",
   "agentDetail.configure.rightPanel.buildTipTitle": "チャットでエージェントを構築",
-  "agentDetail.configure.rightPanel.learnMore": "詳しく見る",
+  "agentDetail.configure.rightPanel.learnMore": "詳細を見る",
   "agentDetail.configure.rightPanel.modeLabel": "エージェント設定モード",
   "agentDetail.configure.rightPanel.preview": "プレビュー",
   "agentDetail.configure.rightPanel.previewDisabledTip": "Preview は Dify Cloud と Enterprise でのみ利用できます。",


### PR DESCRIPTION
## Summary

- Update the English model request-limit error copy to the approved wording.
- Align the shared Japanese “Learn more” label with the approved `詳細を見る` translation.
- Preserve the existing localized documentation link and all other locale translations.

## Why

PR #40784 introduced a dedicated model request-limit message across all supported locales, but the final approved English wording and Japanese link label differed from the merged copy.

## Impact

Users see the approved copy when an Agent V2 preview run reaches the model request limit. The Japanese help label is also aligned anywhere the shared Agent V2 key is used.

## Validation

- `tsx ./scripts/check-i18n.js`
- `vp test run features/agent-v2/agent-detail/configure/components/preview/__tests__/chat.spec.tsx` (45 passed)
- `git diff --check`