### PR TITLE
test: centralize account and feature config overrides

### DIFF
--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -10,7 +10,6 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.engine.interfaces import DBAPICursor, ExecutionContext
 from sqlalchemy.orm import Session, sessionmaker
 
-from configs import dify_config
 from enums import DeploymentEdition
 from models.account import (
     Account,
@@ -83,6 +82,10 @@ def _tenant(session: Session | None = None) -> Tenant:
 
 
 class TestAccountService:
+    @pytest.fixture(autouse=True)
+    def _account_config(self, config_overrides: Callable[..., None]) -> None:
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+
     """
     Comprehensive unit tests for AccountService methods.
 
@@ -361,20 +364,23 @@ class TestAccountService:
             )
 
     def test_create_account_email_frozen(
-        self, unbound_session: Session, mock_external_service_dependencies: _MockDependencies
+        self,
+        unbound_session: Session,
+        mock_external_service_dependencies: _MockDependencies,
+        config_overrides: Callable[..., None],
     ) -> None:
         """Test account creation with frozen email address."""
         # Setup mocks
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = True
-        with patch("services.account_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD):
-            with pytest.raises(AccountRegisterError):
-                AccountService.create_account(
-                    email="frozen@example.com",
-                    name="Test User",
-                    interface_language="en-US",
-                    session=unbound_session,
-                )
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+        with pytest.raises(AccountRegisterError):
+            AccountService.create_account(
+                email="frozen@example.com",
+                name="Test User",
+                interface_language="en-US",
+                session=unbound_session,
+            )
 
     def test_create_account_suspended_email_domain(
         self, unbound_session: Session, mock_external_service_dependencies: _MockDependencies
@@ -739,6 +745,10 @@ class TestAccountService:
 
 
 class TestTenantService:
+    @pytest.fixture(autouse=True)
+    def _tenant_config(self, config_overrides: Callable[..., None]) -> None:
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY, RBAC_ENABLED=False)
+
     """
     Comprehensive unit tests for TenantService methods.
 
@@ -1121,7 +1131,6 @@ class TestTenantService:
             service_session.commit()
 
             with (
-                patch("services.account_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
                 patch("services.enterprise.account_deletion_sync.sync_workspace_member_removal") as mock_sync,
             ):
                 mock_sync.return_value = True
@@ -1175,7 +1184,6 @@ class TestTenantService:
             service_session.commit()
 
             with (
-                patch("services.account_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
                 patch("services.enterprise.account_deletion_sync.sync_workspace_member_removal") as mock_sync,
             ):
                 mock_sync.return_value = True
@@ -1220,7 +1228,6 @@ class TestTenantService:
             service_session.commit()
 
             with (
-                patch("services.account_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
                 patch("services.enterprise.account_deletion_sync.sync_workspace_member_removal") as mock_sync,
             ):
                 mock_sync.return_value = True
@@ -1325,8 +1332,12 @@ class TestTenantService:
             assert persisted_target_join.role == TenantAccountRole.ADMIN
 
     def test_create_owner_tenant_rbac_enabled_assigns_owner_role(
-        self, sqlite_session: Session, mock_external_service_dependencies: _MockDependencies
+        self,
+        sqlite_session: Session,
+        mock_external_service_dependencies: _MockDependencies,
+        config_overrides: Callable[..., None],
     ) -> None:
+        config_overrides(RBAC_ENABLED=True)
         mock_account = TestAccountAssociatedDataFactory.create_account_mock(account_id="user-rbac", name="RBAC User")
         mock_external_service_dependencies["feature_service"].is_workspace_creation_allowed.return_value = True
         mock_external_service_dependencies[
@@ -1339,7 +1350,6 @@ class TestTenantService:
         sqlite_session.flush()
 
         with (
-            patch("services.account_service.dify_config.RBAC_ENABLED", True),
             patch("services.account_service.TenantService.create_tenant", return_value=mock_tenant),
             patch(
                 "services.account_service.AccountService._resolve_legacy_role_id",
@@ -1475,8 +1485,11 @@ class TestTenantService:
         with pytest.raises(NoPermissionError):
             TenantService.check_member_permission(tenant, mock_operator, mock_member, "remove", session=sqlite_session)
 
-    def test_rbac_member_can_remove_non_owner_member(self, sqlite_session: Session) -> None:
+    def test_rbac_member_can_remove_non_owner_member(
+        self, sqlite_session: Session, config_overrides: Callable[..., None]
+    ) -> None:
         """Test RBAC workspace.member.manage allows removing a non-owner member."""
+        config_overrides(RBAC_ENABLED=True)
         mock_tenant = _tenant(sqlite_session)
         mock_tenant.id = "tenant-456"
         mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123")
@@ -1486,7 +1499,6 @@ class TestTenantService:
         mock_permissions.workspace = MagicMock(permission_keys=["workspace.member.manage"])
 
         with (
-            patch("services.account_service.dify_config.RBAC_ENABLED", True),
             patch("services.account_service.RBACService.MyPermissions.get", return_value=mock_permissions),
             patch("services.account_service.AccountService.is_rbac_workspace_owner", return_value=False),
         ):
@@ -1494,8 +1506,11 @@ class TestTenantService:
                 mock_tenant, mock_operator, mock_member, "remove", session=sqlite_session
             )
 
-    def test_rbac_member_cannot_remove_without_permission(self, sqlite_session: Session) -> None:
+    def test_rbac_member_cannot_remove_without_permission(
+        self, sqlite_session: Session, config_overrides: Callable[..., None]
+    ) -> None:
         """Test RBAC permission check rejects removal without workspace.member.manage."""
+        config_overrides(RBAC_ENABLED=True)
         mock_tenant = _tenant(sqlite_session)
         mock_tenant.id = "tenant-456"
         mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123")
@@ -1505,7 +1520,6 @@ class TestTenantService:
         mock_permissions.workspace = MagicMock(permission_keys=["workspace.role.manage"])
 
         with (
-            patch("services.account_service.dify_config.RBAC_ENABLED", True),
             patch("services.account_service.RBACService.MyPermissions.get", return_value=mock_permissions),
         ):
             with pytest.raises(NoPermissionError):
@@ -1513,8 +1527,11 @@ class TestTenantService:
                     mock_tenant, mock_operator, mock_member, "remove", session=sqlite_session
                 )
 
-    def test_rbac_member_cannot_remove_owner_member(self, sqlite_session: Session) -> None:
+    def test_rbac_member_cannot_remove_owner_member(
+        self, sqlite_session: Session, config_overrides: Callable[..., None]
+    ) -> None:
         """Test RBAC permission check rejects removing an owner member."""
+        config_overrides(RBAC_ENABLED=True)
         mock_tenant = _tenant(sqlite_session)
         mock_tenant.id = "tenant-456"
         mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123")
@@ -1524,7 +1541,6 @@ class TestTenantService:
         mock_permissions.workspace = MagicMock(permission_keys=["workspace.member.manage"])
 
         with (
-            patch("services.account_service.dify_config.RBAC_ENABLED", True),
             patch("services.account_service.RBACService.MyPermissions.get", return_value=mock_permissions),
             patch("services.account_service.AccountService.is_rbac_workspace_owner", return_value=True),
         ):
@@ -1560,6 +1576,10 @@ class TestTenantService:
 
 
 class TestRegisterService:
+    @pytest.fixture(autouse=True)
+    def _register_config(self, config_overrides: Callable[..., None]) -> None:
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+
     """
     Comprehensive unit tests for RegisterService methods.
 
@@ -1719,10 +1739,10 @@ class TestRegisterService:
         self,
         sqlite_session: Session,
         mock_external_service_dependencies: _MockDependencies,
-        monkeypatch: pytest.MonkeyPatch,
+        config_overrides: Callable[..., None],
     ) -> None:
         """Enterprise-only side effect should be invoked for the ENTERPRISE edition."""
-        monkeypatch.setattr(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE, raising=False)
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
 
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1765,10 +1785,8 @@ class TestRegisterService:
         self,
         sqlite_session: Session,
         mock_external_service_dependencies: _MockDependencies,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Enterprise-only side effect should not be invoked for the COMMUNITY edition."""
-        monkeypatch.setattr(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY, raising=False)
 
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1799,12 +1817,12 @@ class TestRegisterService:
         self,
         sqlite_session: Session,
         mock_external_service_dependencies: _MockDependencies,
-        monkeypatch: pytest.MonkeyPatch,
+        config_overrides: Callable[..., None],
     ) -> None:
         """Default workspace join should still be attempted when personal workspace creation fails."""
         from services.errors.workspace import WorkSpaceNotAllowedCreateError
 
-        monkeypatch.setattr(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE, raising=False)
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
 
@@ -1906,10 +1924,10 @@ class TestRegisterService:
         self,
         sqlite_session: Session,
         mock_external_service_dependencies: _MockDependencies,
-        monkeypatch: pytest.MonkeyPatch,
+        config_overrides: Callable[..., None],
     ) -> None:
         """Enterprise-only side effect should be invoked after successful register commit."""
-        monkeypatch.setattr(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE, raising=False)
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
 
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1940,10 +1958,8 @@ class TestRegisterService:
         self,
         sqlite_session: Session,
         mock_external_service_dependencies: _MockDependencies,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Enterprise-only side effect should not be invoked for the COMMUNITY edition."""
-        monkeypatch.setattr(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY, raising=False)
 
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["billing_service"].is_email_in_freeze.return_value = False
@@ -1973,12 +1989,12 @@ class TestRegisterService:
         self,
         sqlite_session: Session,
         mock_external_service_dependencies: _MockDependencies,
-        monkeypatch: pytest.MonkeyPatch,
+        config_overrides: Callable[..., None],
     ) -> None:
         """Default workspace join should run even when personal workspace creation raises."""
         from services.errors.workspace import WorkSpaceNotAllowedCreateError
 
-        monkeypatch.setattr(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE, raising=False)
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["feature_service"].is_workspace_creation_allowed.return_value = True
         mock_external_service_dependencies[
@@ -2013,12 +2029,12 @@ class TestRegisterService:
         self,
         sqlite_session: Session,
         mock_external_service_dependencies: _MockDependencies,
-        monkeypatch: pytest.MonkeyPatch,
+        config_overrides: Callable[..., None],
     ) -> None:
         """Default workspace join should run before propagating workspace-limit registration failure."""
         from services.errors.workspace import WorkspacesLimitExceededError
 
-        monkeypatch.setattr(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE, raising=False)
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
         mock_external_service_dependencies["feature_service"].get_system_features.return_value.is_allow_register = True
         mock_external_service_dependencies["feature_service"].is_workspace_creation_allowed.return_value = True
         mock_external_service_dependencies[
@@ -3144,6 +3160,10 @@ def test_get_account_by_email_with_case_fallback_uses_lowercase(sqlite_session: 
 class TestIsEmailSendIpLimit:
     """The 10-minute first-strike window must actually take effect (#39477)."""
 
+    @pytest.fixture(autouse=True)
+    def _email_limit_config(self, config_overrides: Callable[..., None]) -> None:
+        config_overrides(EMAIL_SEND_IP_LIMIT_PER_MINUTE=60)
+
     def _mock_redis(self, *, minute_count: int, hour_count: int | None, frozen: bool = False) -> MagicMock:
         values = {
             "email_send_ip_limit_freeze:1.2.3.4": "1" if frozen else None,
@@ -3159,12 +3179,12 @@ class TestIsEmailSendIpLimit:
         with patch("services.account_service.redis_client", redis_client):
             assert AccountService.is_email_send_ip_limit("1.2.3.4") is True
 
-    def test_first_strike_sets_ten_minute_window(self) -> None:
+    def test_first_strike_sets_ten_minute_window(self, config_overrides: Callable[..., None]) -> None:
+        config_overrides(EMAIL_SEND_IP_LIMIT_PER_MINUTE=1)
         redis_client = self._mock_redis(minute_count=999, hour_count=None)
         redis_client.set.return_value = True
         with (
             patch("services.account_service.redis_client", redis_client),
-            patch.object(dify_config, "EMAIL_SEND_IP_LIMIT_PER_MINUTE", 1),
         ):
             assert AccountService.is_email_send_ip_limit("1.2.3.4") is True
 
@@ -3174,22 +3194,22 @@ class TestIsEmailSendIpLimit:
         redis_client.incr.assert_not_called()
         redis_client.expire.assert_not_called()
 
-    def test_first_strike_lost_claim_freezes_immediately(self) -> None:
+    def test_first_strike_lost_claim_freezes_immediately(self, config_overrides: Callable[..., None]) -> None:
+        config_overrides(EMAIL_SEND_IP_LIMIT_PER_MINUTE=1)
         redis_client = self._mock_redis(minute_count=999, hour_count=None)
         redis_client.set.return_value = None  # another worker claimed the strike first
         with (
             patch("services.account_service.redis_client", redis_client),
-            patch.object(dify_config, "EMAIL_SEND_IP_LIMIT_PER_MINUTE", 1),
         ):
             assert AccountService.is_email_send_ip_limit("1.2.3.4") is True
 
         redis_client.setex.assert_called_once_with("email_send_ip_limit_freeze:1.2.3.4", 60 * 60, 1)
 
-    def test_second_strike_inside_window_freezes_for_an_hour(self) -> None:
+    def test_second_strike_inside_window_freezes_for_an_hour(self, config_overrides: Callable[..., None]) -> None:
+        config_overrides(EMAIL_SEND_IP_LIMIT_PER_MINUTE=1)
         redis_client = self._mock_redis(minute_count=999, hour_count=1)
         with (
             patch("services.account_service.redis_client", redis_client),
-            patch.object(dify_config, "EMAIL_SEND_IP_LIMIT_PER_MINUTE", 1),
         ):
             assert AccountService.is_email_send_ip_limit("1.2.3.4") is True
 
@@ -3199,6 +3219,5 @@ class TestIsEmailSendIpLimit:
         redis_client = self._mock_redis(minute_count=0, hour_count=None)
         with (
             patch("services.account_service.redis_client", redis_client),
-            patch.object(dify_config, "EMAIL_SEND_IP_LIMIT_PER_MINUTE", 60),
         ):
             assert AccountService.is_email_send_ip_limit("1.2.3.4") is False

--- a/api/tests/unit_tests/services/test_clear_free_plan_expired_workflow_run_logs.py
+++ b/api/tests/unit_tests/services/test_clear_free_plan_expired_workflow_run_logs.py
@@ -1,4 +1,5 @@
 import datetime
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -8,6 +9,14 @@ from repositories.api_workflow_run_repository import WorkflowRunCleanupRef
 from services.billing_service import SubscriptionPlan
 from services.retention.workflow_run import clear_free_plan_expired_workflow_run_logs as cleanup_module
 from services.retention.workflow_run.clear_free_plan_expired_workflow_run_logs import WorkflowRunCleanup
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_config(config_overrides: Callable[..., None]) -> None:
+    config_overrides(
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+        SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD=0,
+    )
 
 
 def make_ref(run_id: str, tenant_id: str, created_at: datetime.datetime) -> WorkflowRunCleanupRef:
@@ -110,15 +119,9 @@ def create_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     repo: FakeRepo,
     *,
-    grace_period_days: int = 0,
     whitelist: set[str] | None = None,
     **kwargs: Any,
 ) -> WorkflowRunCleanup:
-    monkeypatch.setattr(
-        cleanup_module.dify_config,
-        "SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD",
-        grace_period_days,
-    )
     monkeypatch.setattr(
         cleanup_module.WorkflowRunCleanup,
         "_get_cleanup_whitelist",
@@ -129,8 +132,6 @@ def create_cleanup(
 
 def test_filter_free_tenants_outside_cloud_edition(monkeypatch: pytest.MonkeyPatch) -> None:
     cleanup = create_cleanup(monkeypatch, repo=FakeRepo([]), days=30, batch_size=10)
-
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
 
     def fail_bulk(_: list[str]) -> dict[str, SubscriptionPlan]:
         raise RuntimeError("should not call")
@@ -143,10 +144,10 @@ def test_filter_free_tenants_outside_cloud_edition(monkeypatch: pytest.MonkeyPat
     assert free == tenants
 
 
-def test_filter_free_tenants_bulk_mixed(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_filter_free_tenants_bulk_mixed(monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     cleanup = create_cleanup(monkeypatch, repo=FakeRepo([]), days=30, batch_size=10)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         cleanup_module.BillingService,
         "get_plan_bulk_with_cache",
@@ -163,10 +164,15 @@ def test_filter_free_tenants_bulk_mixed(monkeypatch: pytest.MonkeyPatch) -> None
     assert free == {"t_free", "t_missing"}
 
 
-def test_filter_free_tenants_respects_grace_period(monkeypatch: pytest.MonkeyPatch) -> None:
-    cleanup = create_cleanup(monkeypatch, repo=FakeRepo([]), days=30, batch_size=10, grace_period_days=45)
+def test_filter_free_tenants_respects_grace_period(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(
+        DEPLOYMENT_EDITION=DeploymentEdition.CLOUD,
+        SANDBOX_EXPIRED_RECORDS_CLEAN_GRACEFUL_PERIOD=45,
+    )
+    cleanup = create_cleanup(monkeypatch, repo=FakeRepo([]), days=30, batch_size=10)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     now = datetime.datetime.now(datetime.UTC)
     within_grace_ts = int((now - datetime.timedelta(days=10)).timestamp())
     outside_grace_ts = int((now - datetime.timedelta(days=90)).timestamp())
@@ -184,7 +190,10 @@ def test_filter_free_tenants_respects_grace_period(monkeypatch: pytest.MonkeyPat
     assert free == {"long_sandbox"}
 
 
-def test_filter_free_tenants_skips_cleanup_whitelist(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_filter_free_tenants_skips_cleanup_whitelist(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     cleanup = create_cleanup(
         monkeypatch,
         repo=FakeRepo([]),
@@ -193,7 +202,6 @@ def test_filter_free_tenants_skips_cleanup_whitelist(monkeypatch: pytest.MonkeyP
         whitelist={"tenant_whitelist"},
     )
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         cleanup_module.BillingService,
         "get_plan_bulk_with_cache",
@@ -211,10 +219,12 @@ def test_filter_free_tenants_skips_cleanup_whitelist(monkeypatch: pytest.MonkeyP
     assert free == {"tenant_regular"}
 
 
-def test_filter_free_tenants_bulk_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_filter_free_tenants_bulk_failure(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     cleanup = create_cleanup(monkeypatch, repo=FakeRepo([]), days=30, batch_size=10)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         cleanup_module.BillingService,
         "get_plan_bulk_with_cache",
@@ -226,7 +236,8 @@ def test_filter_free_tenants_bulk_failure(monkeypatch: pytest.MonkeyPatch) -> No
     assert free == set()
 
 
-def test_run_deletes_only_free_tenants(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_deletes_only_free_tenants(monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     cutoff = datetime.datetime.now()
     repo = FakeRepo(
         batches=[
@@ -238,7 +249,6 @@ def test_run_deletes_only_free_tenants(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=10)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         cleanup_module.BillingService,
         "get_plan_bulk_with_cache",
@@ -256,7 +266,10 @@ def test_run_deletes_only_free_tenants(monkeypatch: pytest.MonkeyPatch) -> None:
     assert repo.cleanup_ref_calls[1]["tenant_ids"] == ["t_free"]
 
 
-def test_run_filters_candidate_tenants_before_target_query(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_filters_candidate_tenants_before_target_query(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     cutoff = datetime.datetime.now()
     repo = FakeRepo(
         batches=[
@@ -268,7 +281,6 @@ def test_run_filters_candidate_tenants_before_target_query(monkeypatch: pytest.M
     )
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=10)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     billing_calls: list[list[str]] = []
 
     def fake_bulk(tenant_ids: list[str]) -> dict[str, SubscriptionPlan]:
@@ -287,12 +299,12 @@ def test_run_filters_candidate_tenants_before_target_query(monkeypatch: pytest.M
     assert repo.deleted == [["run-free"]]
 
 
-def test_run_skips_when_no_free_tenants(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_skips_when_no_free_tenants(monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     cutoff = datetime.datetime.now()
     repo = FakeRepo(batches=[[make_ref("run-paid", "t_paid", cutoff)]])
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=10)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         cleanup_module.BillingService,
         "get_plan_bulk_with_cache",
@@ -305,12 +317,14 @@ def test_run_skips_when_no_free_tenants(monkeypatch: pytest.MonkeyPatch) -> None
     assert len(repo.cleanup_ref_calls) == 2
 
 
-def test_run_paid_only_records_skipped_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_paid_only_records_skipped_metrics(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     cutoff = datetime.datetime.now()
     repo = FakeRepo(batches=[[make_ref("run-paid", "t_paid", cutoff)]])
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=10)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         cleanup_module.BillingService,
         "get_plan_bulk_with_cache",
@@ -342,8 +356,6 @@ def test_run_target_query_is_bounded_by_candidate_high_water(monkeypatch: pytest
     )
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=2)
 
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
-
     cleanup.run()
 
     assert repo.cleanup_ref_calls[1]["last_seen"] is None
@@ -372,7 +384,6 @@ def test_run_records_metrics_on_success(monkeypatch: pytest.MonkeyPatch) -> None
         },
     )
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=10)
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
 
     batch_calls: list[dict[str, object]] = []
     completion_calls: list[dict[str, object]] = []
@@ -400,7 +411,6 @@ def test_run_records_failed_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     cutoff = datetime.datetime.now()
     repo = FailingRepo(batches=[[make_ref("run-free", "t_free", cutoff)]])
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=10)
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
 
     completion_calls: list[dict[str, object]] = []
     monkeypatch.setattr(cleanup._metrics, "record_completion", lambda **kwargs: completion_calls.append(kwargs))
@@ -427,8 +437,6 @@ def test_run_dry_run_skips_deletions(monkeypatch: pytest.MonkeyPatch, capsys: py
         },
     )
     cleanup = create_cleanup(monkeypatch, repo=repo, days=30, batch_size=10, dry_run=True)
-
-    monkeypatch.setattr(cleanup_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
 
     cleanup.run()
 

--- a/api/tests/unit_tests/services/test_clear_free_plan_tenant_expired_logs.py
+++ b/api/tests/unit_tests/services/test_clear_free_plan_tenant_expired_logs.py
@@ -47,6 +47,12 @@ from models.workflow import (
 from services import clear_free_plan_tenant_expired_logs as service_module
 from services.clear_free_plan_tenant_expired_logs import ClearFreePlanTenantExpiredLogs
 
+
+@pytest.fixture(autouse=True)
+def _community_edition(config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+
+
 REAL_DATETIME = datetime.datetime
 SQLITE_MODELS = (
     Tenant,
@@ -527,14 +533,15 @@ def test_process_with_tenant_ids_filters_by_plan_and_logs_errors(
     caplog: pytest.LogCaptureFixture,
     sqlite_session: Session,
     sqlite_engine: Engine,
+    config_overrides: Callable[..., None],
 ) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     sqlite_session.add_all(
         [_create_tenant("tenant-sandbox"), _create_tenant("tenant-paid"), _create_tenant("tenant-fail")]
     )
     sqlite_session.commit()
     _configure_process_boundaries(monkeypatch, sqlite_engine)
     monkeypatch.setattr(service_module.click, "echo", MagicMock())
-    monkeypatch.setattr(service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
 
     def fake_get_info(tenant_id: str) -> dict[str, dict[str, str]]:
         if tenant_id == "tenant-sandbox":
@@ -587,7 +594,6 @@ def test_process_without_tenant_ids_batches_and_scales_interval(
     monkeypatch.setattr(service_module.datetime, "datetime", FixedDateTime)
     _configure_process_boundaries(monkeypatch, sqlite_engine)
     monkeypatch.setattr(service_module.click, "echo", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
     process_tenant = MagicMock()
     monkeypatch.setattr(ClearFreePlanTenantExpiredLogs, "process_tenant", process_tenant)
     statements: list[str] = []
@@ -627,7 +633,6 @@ def test_process_with_tenant_ids_emits_progress_every_100(
     sqlite_session.add_all([_create_tenant(tenant_id) for tenant_id in tenant_ids])
     sqlite_session.commit()
     _configure_process_boundaries(monkeypatch, sqlite_engine)
-    monkeypatch.setattr(service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
     echo = MagicMock()
     monkeypatch.setattr(service_module.click, "echo", echo)
     monkeypatch.setattr(ClearFreePlanTenantExpiredLogs, "process_tenant", MagicMock())
@@ -661,7 +666,6 @@ def test_process_without_tenant_ids_all_intervals_too_many_uses_min_interval(
     monkeypatch.setattr(service_module.datetime, "datetime", FixedDateTime)
     _configure_process_boundaries(monkeypatch, sqlite_engine)
     monkeypatch.setattr(service_module.click, "echo", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
     process_tenant = MagicMock()
     monkeypatch.setattr(ClearFreePlanTenantExpiredLogs, "process_tenant", process_tenant)
     statements: list[str] = []

--- a/api/tests/unit_tests/services/test_credit_pool_service.py
+++ b/api/tests/unit_tests/services/test_credit_pool_service.py
@@ -1,6 +1,6 @@
 """Credit-pool accounting tests backed by real SQLite sessions."""
 
-from collections.abc import Generator
+from collections.abc import Callable
 from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 from uuid import uuid4
@@ -48,9 +48,8 @@ def _make_redis_lock() -> MagicMock:
 
 
 @pytest.fixture(autouse=True)
-def _disable_billing_quota_by_default() -> Generator[None, None, None]:
-    with patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY):
-        yield
+def _disable_billing_quota_by_default(config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
 
 
 def test_get_pool_uses_provided_session(sqlite_session: Session) -> None:
@@ -248,10 +247,10 @@ def test_deduct_credits_capped_uses_tenant_redis_lock_before_db_deduction(sqlite
     get_locked_pool.assert_called_once_with(session=sqlite_session, tenant_id=tenant_id, pool_type="paid")
 
 
-def test_get_pool_uses_billing_quota_balance_when_enabled() -> None:
+def test_get_pool_uses_billing_quota_balance_when_enabled(config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     tenant_id = "tenant-1"
     with (
-        patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.billing_service.BillingService.quota_get_balance") as quota_get_balance,
     ):
         quota_get_balance.return_value = {
@@ -369,10 +368,12 @@ def test_reserve_credits_database_fallback_restores_released_amount(sqlite_sessi
     assert _get_quota_used(session=sqlite_session, pool_id=pool.id) == 2
 
 
-def test_check_and_deduct_credits_uses_billing_reserve_and_commit_when_enabled() -> None:
+def test_check_and_deduct_credits_uses_billing_reserve_and_commit_when_enabled(
+    config_overrides: Callable[..., None],
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     tenant_id = "tenant-1"
     with (
-        patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.billing_service.BillingService.quota_reserve") as quota_reserve,
         patch("services.billing_service.BillingService.quota_commit") as quota_commit,
         patch("services.billing_service.BillingService.quota_release") as quota_release,
@@ -413,9 +414,11 @@ def test_check_and_deduct_credits_uses_billing_reserve_and_commit_when_enabled()
     quota_release.assert_not_called()
 
 
-def test_check_and_deduct_credits_forwards_deterministic_billing_identity() -> None:
+def test_check_and_deduct_credits_forwards_deterministic_billing_identity(
+    config_overrides: Callable[..., None],
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     with (
-        patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.billing_service.BillingService.quota_reserve") as quota_reserve,
         patch("services.billing_service.BillingService.quota_commit") as quota_commit,
     ):
@@ -454,9 +457,11 @@ def test_check_and_deduct_credits_forwards_deterministic_billing_identity() -> N
     )
 
 
-def test_check_and_deduct_credits_raises_when_billing_reserve_is_insufficient() -> None:
+def test_check_and_deduct_credits_raises_when_billing_reserve_is_insufficient(
+    config_overrides: Callable[..., None],
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     with (
-        patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.billing_service.BillingService.quota_reserve") as quota_reserve,
     ):
         quota_reserve.return_value = {"reservation_id": "", "available": 1, "reserved": 0}
@@ -465,9 +470,11 @@ def test_check_and_deduct_credits_raises_when_billing_reserve_is_insufficient() 
             CreditPoolService.check_and_deduct_credits(tenant_id="tenant-1", credits_required=3)
 
 
-def test_check_and_deduct_credits_releases_billing_reservation_when_commit_fails() -> None:
+def test_check_and_deduct_credits_releases_billing_reservation_when_commit_fails(
+    config_overrides: Callable[..., None],
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     with (
-        patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.billing_service.BillingService.quota_reserve") as quota_reserve,
         patch("services.billing_service.BillingService.quota_commit", side_effect=RuntimeError("commit failed")),
         patch("services.billing_service.BillingService.quota_release") as quota_release,
@@ -487,9 +494,10 @@ def test_check_and_deduct_credits_releases_billing_reservation_when_commit_fails
 
 def test_check_and_deduct_credits_logs_when_billing_release_fails(
     caplog: pytest.LogCaptureFixture,
+    config_overrides: Callable[..., None],
 ) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     with (
-        patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.billing_service.BillingService.quota_reserve") as quota_reserve,
         patch("services.billing_service.BillingService.quota_commit", side_effect=RuntimeError("commit failed")),
         patch(
@@ -512,10 +520,12 @@ def test_check_and_deduct_credits_logs_when_billing_release_fails(
     assert caplog.records[0].exc_info is not None
 
 
-def test_deduct_credits_capped_uses_billing_consume_capped_when_enabled() -> None:
+def test_deduct_credits_capped_uses_billing_consume_capped_when_enabled(
+    config_overrides: Callable[..., None],
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     tenant_id = "tenant-1"
     with (
-        patch("services.credit_pool_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.billing_service.BillingService.quota_consume_capped") as quota_consume_capped,
     ):
         quota_consume_capped.return_value = {

--- a/api/tests/unit_tests/services/test_feature_service_change_email.py
+++ b/api/tests/unit_tests/services/test_feature_service_change_email.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 
 from services.feature_service import FeatureService
@@ -5,10 +7,10 @@ from services.feature_service import FeatureService
 
 @pytest.mark.parametrize("enabled", [False, True])
 def test_get_system_features_reads_enable_change_email(
-    monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     enabled: bool,
 ) -> None:
-    monkeypatch.setattr("services.feature_service.dify_config.ENABLE_CHANGE_EMAIL", enabled)
+    config_overrides(ENABLE_CHANGE_EMAIL=enabled)
 
     result = FeatureService.get_system_features()
 

--- a/api/tests/unit_tests/services/test_feature_service_deployment_edition.py
+++ b/api/tests/unit_tests/services/test_feature_service_deployment_edition.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,10 +24,11 @@ def test_system_feature_model_requires_deployment_edition() -> None:
 )
 def test_get_system_features_uses_configured_deployment_edition(
     monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     edition: DeploymentEdition,
 ) -> None:
     fulfill_from_enterprise = MagicMock()
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", edition)
+    config_overrides(DEPLOYMENT_EDITION=edition)
     monkeypatch.setattr(
         "services.feature_service.FeatureService._fulfill_params_from_enterprise",
         fulfill_from_enterprise,

--- a/api/tests/unit_tests/services/test_feature_service_explore_banner.py
+++ b/api/tests/unit_tests/services/test_feature_service_explore_banner.py
@@ -1,7 +1,8 @@
+from collections.abc import Callable
+
 import pytest
 
 from enums import DeploymentEdition
-from services import feature_service as feature_service_module
 from services.feature_service import FeatureService
 
 
@@ -16,12 +17,12 @@ from services.feature_service import FeatureService
 )
 def test_get_system_features_enables_explore_banner_only_for_cloud(
     monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     edition: DeploymentEdition,
     configured: bool,
     expected: bool,
 ) -> None:
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", edition)
-    monkeypatch.setattr(feature_service_module.dify_config, "ENABLE_EXPLORE_BANNER", configured)
+    config_overrides(DEPLOYMENT_EDITION=edition, ENABLE_EXPLORE_BANNER=configured)
     monkeypatch.setattr(FeatureService, "_fulfill_params_from_enterprise", lambda *_: None)
 
     result = FeatureService.get_system_features()

--- a/api/tests/unit_tests/services/test_feature_service_human_input_email_delivery.py
+++ b/api/tests/unit_tests/services/test_feature_service_human_input_email_delivery.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import pytest
@@ -80,10 +81,10 @@ CASES = [
 
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.name)
 def test_resolve_human_input_email_delivery_enabled_matrix(
-    monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     case: HumanInputEmailDeliveryCase,
 ):
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", case.deployment_edition)
+    config_overrides(DEPLOYMENT_EDITION=case.deployment_edition)
     features = FeatureModel()
     features.billing.enabled = case.billing_feature_enabled
     features.billing.subscription.plan = case.plan
@@ -96,8 +97,10 @@ def test_resolve_human_input_email_delivery_enabled_matrix(
     assert result is case.expected
 
 
-def test_get_vector_space_converts_billing_float_size(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
+def test_get_vector_space_converts_billing_float_size(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+):
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         feature_service_module.BillingService,
         "get_vector_space",
@@ -111,8 +114,10 @@ def test_get_vector_space_converts_billing_float_size(monkeypatch: pytest.Monkey
     assert result.usage_unknown is False
 
 
-def test_get_vector_space_preserves_unknown_usage(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
+def test_get_vector_space_preserves_unknown_usage(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+):
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
     monkeypatch.setattr(
         feature_service_module.BillingService,
         "get_vector_space",

--- a/api/tests/unit_tests/services/test_feature_service_internal_policies.py
+++ b/api/tests/unit_tests/services/test_feature_service_internal_policies.py
@@ -1,12 +1,15 @@
+from collections.abc import Callable
+
 import pytest
 
 from enums import DeploymentEdition
 from services.feature_service import FeatureService
 
 
-def test_workspace_creation_uses_environment_policy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
-    monkeypatch.setattr("services.feature_service.dify_config.ALLOW_CREATE_WORKSPACE", True)
+def test_workspace_creation_uses_environment_policy(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY, ALLOW_CREATE_WORKSPACE=True)
     monkeypatch.setattr(
         "services.feature_service.EnterpriseService.get_info",
         lambda: (_ for _ in ()).throw(AssertionError("enterprise API should not be called")),
@@ -15,8 +18,10 @@ def test_workspace_creation_uses_environment_policy(monkeypatch: pytest.MonkeyPa
     assert FeatureService.is_workspace_creation_allowed() is True
 
 
-def test_workspace_creation_uses_enterprise_policy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE)
+def test_workspace_creation_uses_enterprise_policy(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
     monkeypatch.setattr(
         "services.feature_service.EnterpriseService.get_info",
         lambda: {"IsAllowCreateWorkspace": False},
@@ -27,17 +32,17 @@ def test_workspace_creation_uses_enterprise_policy(monkeypatch: pytest.MonkeyPat
 
 def test_workspace_creation_keeps_environment_policy_when_enterprise_value_is_missing(
     monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
 ) -> None:
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE)
-    monkeypatch.setattr("services.feature_service.dify_config.ALLOW_CREATE_WORKSPACE", True)
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE, ALLOW_CREATE_WORKSPACE=True)
     monkeypatch.setattr("services.feature_service.EnterpriseService.get_info", lambda: {})
 
     assert FeatureService.is_workspace_creation_allowed() is True
 
 
-def test_plugin_manager_is_enabled_only_for_enterprise(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE)
+def test_plugin_manager_is_enabled_only_for_enterprise(config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
     assert FeatureService.is_plugin_manager_enabled() is True
 
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
     assert FeatureService.is_plugin_manager_enabled() is False

--- a/api/tests/unit_tests/services/test_feature_service_knowledge_file_size_limit.py
+++ b/api/tests/unit_tests/services/test_feature_service_knowledge_file_size_limit.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from unittest.mock import Mock
 
 import pytest
@@ -21,18 +22,17 @@ from services.feature_service import FeatureService
 )
 def test_get_knowledge_file_size_limit(
     monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     deployment_edition: DeploymentEdition,
     tenant_id: str | None,
     billing_feature_enabled: bool,
     plan: CloudPlan,
     expected: int,
 ) -> None:
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", deployment_edition)
-    monkeypatch.setattr(feature_service_module.dify_config, "UPLOAD_FILE_SIZE_LIMIT", 15)
-    monkeypatch.setattr(
-        feature_service_module.dify_config,
-        "KNOWLEDGE_UPLOAD_FILE_SIZE_LIMIT_FOR_PAID_PLAN",
-        50,
+    config_overrides(
+        DEPLOYMENT_EDITION=deployment_edition,
+        UPLOAD_FILE_SIZE_LIMIT=15,
+        KNOWLEDGE_UPLOAD_FILE_SIZE_LIMIT_FOR_PAID_PLAN=50,
     )
     get_info = Mock(
         return_value={
@@ -50,13 +50,13 @@ def test_get_knowledge_file_size_limit(
         get_info.assert_not_called()
 
 
-def test_paid_knowledge_file_size_limit_never_reduces_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
-    monkeypatch.setattr(feature_service_module.dify_config, "UPLOAD_FILE_SIZE_LIMIT", 100)
-    monkeypatch.setattr(
-        feature_service_module.dify_config,
-        "KNOWLEDGE_UPLOAD_FILE_SIZE_LIMIT_FOR_PAID_PLAN",
-        50,
+def test_paid_knowledge_file_size_limit_never_reduces_default(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(
+        DEPLOYMENT_EDITION=DeploymentEdition.CLOUD,
+        UPLOAD_FILE_SIZE_LIMIT=100,
+        KNOWLEDGE_UPLOAD_FILE_SIZE_LIMIT_FOR_PAID_PLAN=50,
     )
     monkeypatch.setattr(
         feature_service_module.BillingService,

--- a/api/tests/unit_tests/services/test_feature_service_knowledge_fs.py
+++ b/api/tests/unit_tests/services/test_feature_service_knowledge_fs.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 
 from enums import DeploymentEdition
@@ -11,10 +13,10 @@ def test_system_feature_model_disables_knowledge_fs_by_default() -> None:
 
 @pytest.mark.parametrize("enabled", [False, True])
 def test_get_system_features_reads_knowledge_fs_flag(
-    monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     enabled: bool,
 ) -> None:
-    monkeypatch.setattr("services.feature_service.dify_config.KNOWLEDGE_FS_ENABLED", enabled)
+    config_overrides(KNOWLEDGE_FS_ENABLED=enabled)
 
     result = FeatureService.get_system_features()
 

--- a/api/tests/unit_tests/services/test_feature_service_learn_app.py
+++ b/api/tests/unit_tests/services/test_feature_service_learn_app.py
@@ -1,7 +1,8 @@
+from collections.abc import Callable
+
 import pytest
 
 from enums import DeploymentEdition
-from services import feature_service as feature_service_module
 from services.entities.feature_entities import SystemFeatureModel
 from services.feature_service import FeatureService
 
@@ -14,8 +15,8 @@ def test_system_feature_model_defaults_enable_learn_app():
 
 
 @pytest.mark.parametrize("enabled", [True, False])
-def test_get_system_features_reads_enable_learn_app(monkeypatch: pytest.MonkeyPatch, enabled: bool):
-    monkeypatch.setattr(feature_service_module.dify_config, "ENABLE_LEARN_APP", enabled)
+def test_get_system_features_reads_enable_learn_app(config_overrides: Callable[..., None], enabled: bool):
+    config_overrides(ENABLE_LEARN_APP=enabled)
 
     result = FeatureService.get_system_features()
 
@@ -23,8 +24,10 @@ def test_get_system_features_reads_enable_learn_app(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.parametrize("enabled", [True, False])
-def test_get_system_features_reads_enable_step_by_step_tour(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
-    monkeypatch.setattr(feature_service_module.dify_config, "ENABLE_STEP_BY_STEP_TOUR", enabled)
+def test_get_system_features_reads_enable_step_by_step_tour(
+    config_overrides: Callable[..., None], enabled: bool
+) -> None:
+    config_overrides(ENABLE_STEP_BY_STEP_TOUR=enabled)
 
     result = FeatureService.get_system_features()
 

--- a/api/tests/unit_tests/services/test_feature_service_license_expiry_notice.py
+++ b/api/tests/unit_tests/services/test_feature_service_license_expiry_notice.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 
 from enums import DeploymentEdition
@@ -15,14 +17,12 @@ def test_license_model_defaults_license_expiry_notice_disabled() -> None:
 
 @pytest.mark.parametrize("enabled", [True, False])
 def test_get_license_non_enterprise_ignores_expiry_notice_config(
-    monkeypatch: pytest.MonkeyPatch, enabled: bool
+    config_overrides: Callable[..., None], enabled: bool
 ) -> None:
     """Non-enterprise deployments have no license, so the env toggle never turns the notice on."""
-    monkeypatch.setattr(feature_service_module.dify_config, "ENABLE_LICENSE_EXPIRY_NOTICE", enabled)
-    monkeypatch.setattr(
-        feature_service_module.dify_config,
-        "DEPLOYMENT_EDITION",
-        DeploymentEdition.COMMUNITY,
+    config_overrides(
+        ENABLE_LICENSE_EXPIRY_NOTICE=enabled,
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
     )
 
     result = FeatureService.get_license()
@@ -32,14 +32,12 @@ def test_get_license_non_enterprise_ignores_expiry_notice_config(
 
 @pytest.mark.parametrize("enabled", [True, False])
 def test_get_license_enterprise_reads_license_expiry_notice_enabled(
-    monkeypatch: pytest.MonkeyPatch, enabled: bool
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None], enabled: bool
 ) -> None:
     """The enterprise-sourced license carries the env-resolved notice flag alongside its real status."""
-    monkeypatch.setattr(feature_service_module.dify_config, "ENABLE_LICENSE_EXPIRY_NOTICE", enabled)
-    monkeypatch.setattr(
-        feature_service_module.dify_config,
-        "DEPLOYMENT_EDITION",
-        DeploymentEdition.ENTERPRISE,
+    config_overrides(
+        ENABLE_LICENSE_EXPIRY_NOTICE=enabled,
+        DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE,
     )
     monkeypatch.setattr(
         feature_service_module.EnterpriseService,

--- a/api/tests/unit_tests/services/test_feature_service_licensed_seats.py
+++ b/api/tests/unit_tests/services/test_feature_service_licensed_seats.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 
 from enums import DeploymentEdition
@@ -8,9 +10,9 @@ from services.feature_service import FeatureService
 _ENTERPRISE_INFO = {"License": {"licensedSeats": {"enabled": True, "limit": 3, "used": 1}}}
 
 
-def test_get_license_parses_licensed_seats(monkeypatch: pytest.MonkeyPatch):
+def test_get_license_parses_licensed_seats(monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]):
     """The authenticated license accessor copies the licensed-seat quota out of the enterprise payload."""
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE)
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
     monkeypatch.setattr(
         feature_service_module.EnterpriseService,
         "get_info",
@@ -25,9 +27,9 @@ def test_get_license_parses_licensed_seats(monkeypatch: pytest.MonkeyPatch):
     assert license_model.seats.size == 1
 
 
-def test_get_license_non_enterprise_is_unconstrained(monkeypatch: pytest.MonkeyPatch):
+def test_get_license_non_enterprise_is_unconstrained(config_overrides: Callable[..., None]):
     """Non-enterprise deployments have no license; seat allocation is unconstrained."""
-    monkeypatch.setattr("services.feature_service.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
 
     license_model = FeatureService.get_license()
 

--- a/api/tests/unit_tests/services/test_feature_service_plugin_installation_permission.py
+++ b/api/tests/unit_tests/services/test_feature_service_plugin_installation_permission.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 
 import pytest
 
@@ -9,9 +10,9 @@ from services.feature_service import FeatureService
 
 
 def test_get_plugin_installation_permission_defaults_to_all_for_non_enterprise(
-    monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
 ) -> None:
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
 
     permission = FeatureService.get_plugin_installation_permission()
 
@@ -21,8 +22,9 @@ def test_get_plugin_installation_permission_defaults_to_all_for_non_enterprise(
 
 def test_get_plugin_installation_permission_parses_enterprise_policy(
     monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
 ) -> None:
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE)
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
     monkeypatch.setattr(
         feature_service_module.EnterpriseService,
         "get_info",

--- a/api/tests/unit_tests/services/test_feature_service_trial_models.py
+++ b/api/tests/unit_tests/services/test_feature_service_trial_models.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from unittest.mock import Mock
 
 import pytest
@@ -13,25 +14,21 @@ def test_get_system_features_excludes_trial_models():
     assert "trial_models" not in result
 
 
-def test_get_trial_models_returns_providers_with_paid_or_trial_enabled(monkeypatch: pytest.MonkeyPatch):
+def test_get_trial_models_returns_providers_with_paid_or_trial_enabled(
+    config_overrides: Callable[..., None],
+):
+    values: dict[str, bool] = {}
     for provider in HostedTrialProvider:
-        monkeypatch.setattr(
-            feature_service_module.dify_config,
-            f"HOSTED_{provider.config_key}_PAID_ENABLED",
-            False,
-            raising=False,
-        )
-        monkeypatch.setattr(
-            feature_service_module.dify_config,
-            f"HOSTED_{provider.config_key}_TRIAL_ENABLED",
-            False,
-            raising=False,
-        )
+        values[f"HOSTED_{provider.config_key}_PAID_ENABLED"] = False
+        values[f"HOSTED_{provider.config_key}_TRIAL_ENABLED"] = False
 
-    monkeypatch.setattr(feature_service_module.dify_config, "HOSTED_OPENAI_PAID_ENABLED", True, raising=False)
-    monkeypatch.setattr(feature_service_module.dify_config, "HOSTED_OPENAI_TRIAL_ENABLED", True, raising=False)
-    monkeypatch.setattr(feature_service_module.dify_config, "HOSTED_XAI_PAID_ENABLED", True, raising=False)
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
+    values.update(
+        HOSTED_OPENAI_PAID_ENABLED=True,
+        HOSTED_OPENAI_TRIAL_ENABLED=True,
+        HOSTED_XAI_PAID_ENABLED=True,
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+    )
+    config_overrides(**values)
 
     result = FeatureService.get_trial_models("tenant_1")
 
@@ -50,26 +47,20 @@ def test_get_trial_models_returns_providers_with_paid_or_trial_enabled(monkeypat
 )
 def test_get_trial_models_filters_providers_by_workspace_plan(
     monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     plan: CloudPlan,
     expected: list[str],
 ) -> None:
+    values: dict[str, object] = {}
     for provider in HostedTrialProvider:
-        monkeypatch.setattr(
-            feature_service_module.dify_config,
-            f"HOSTED_{provider.config_key}_PAID_ENABLED",
-            False,
-            raising=False,
-        )
-        monkeypatch.setattr(
-            feature_service_module.dify_config,
-            f"HOSTED_{provider.config_key}_TRIAL_ENABLED",
-            False,
-            raising=False,
-        )
-
-    monkeypatch.setattr(feature_service_module.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
-    monkeypatch.setattr(feature_service_module.dify_config, "HOSTED_OPENAI_TRIAL_ENABLED", True, raising=False)
-    monkeypatch.setattr(feature_service_module.dify_config, "HOSTED_XAI_PAID_ENABLED", True, raising=False)
+        values[f"HOSTED_{provider.config_key}_PAID_ENABLED"] = False
+        values[f"HOSTED_{provider.config_key}_TRIAL_ENABLED"] = False
+    values.update(
+        DEPLOYMENT_EDITION=DeploymentEdition.CLOUD,
+        HOSTED_OPENAI_TRIAL_ENABLED=True,
+        HOSTED_XAI_PAID_ENABLED=True,
+    )
+    config_overrides(**values)
     get_workspace_plan = Mock(return_value=plan)
     monkeypatch.setattr(feature_service_module.FeatureService, "get_workspace_plan", get_workspace_plan)
 

--- a/api/tests/unit_tests/services/test_feature_service_webapp_public_access.py
+++ b/api/tests/unit_tests/services/test_feature_service_webapp_public_access.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 
 from enums import DeploymentEdition
@@ -14,11 +16,11 @@ from services.feature_service import FeatureService
     ids=["disabled_by_env", "enabled_by_env"],
 )
 def test_fulfill_system_params_from_env_sets_allow_public_access(
-    monkeypatch: pytest.MonkeyPatch,
+    config_overrides: Callable[..., None],
     env_value: bool,
     expected: bool,
 ):
-    monkeypatch.setattr("services.feature_service.dify_config.WEBAPP_PUBLIC_ACCESS_ENABLED", env_value)
+    config_overrides(WEBAPP_PUBLIC_ACCESS_ENABLED=env_value)
 
     system_features = SystemFeatureModel(deployment_edition=DeploymentEdition.COMMUNITY)
     FeatureService._fulfill_system_params_from_env(system_features)

--- a/api/tests/unit_tests/services/test_telemetry_service.py
+++ b/api/tests/unit_tests/services/test_telemetry_service.py
@@ -1,4 +1,5 @@
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from unittest.mock import Mock
 
@@ -14,22 +15,20 @@ from services.telemetry_service import CommunityTelemetryService
 
 
 @pytest.fixture
-def telemetry_enabled(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(telemetry_service.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY)
-    monkeypatch.setattr(telemetry_service.dify_config, "DISABLE_TELEMETRY", False)
-    monkeypatch.setattr(telemetry_service.dify_config, "DO_NOT_TRACK", False)
-    monkeypatch.setattr(telemetry_service.dify_config, "CI", False)
-    monkeypatch.setattr(telemetry_service.dify_config, "TELEMETRY_ENDPOINT", "https://telemetry.example.test/v1/events")
-    monkeypatch.setattr(
-        telemetry_service.dify_config,
-        "TELEMETRY_FALLBACK_ENDPOINT",
-        "https://telemetry-cn.example.test/v1/events",
+def telemetry_enabled(config_overrides: Callable[..., None]) -> None:
+    config_overrides(
+        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+        DISABLE_TELEMETRY=False,
+        DO_NOT_TRACK=False,
+        CI=False,
+        TELEMETRY_ENDPOINT="https://telemetry.example.test/v1/events",
+        TELEMETRY_FALLBACK_ENDPOINT="https://telemetry-cn.example.test/v1/events",
+        TELEMETRY_TIMEOUT_SECONDS=2,
     )
-    monkeypatch.setattr(telemetry_service.dify_config, "TELEMETRY_TIMEOUT_SECONDS", 2)
 
 
-def test_telemetry_is_disabled_for_enterprise(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(telemetry_service.dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE)
+def test_telemetry_is_disabled_for_enterprise(config_overrides: Callable[..., None]):
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.ENTERPRISE)
 
     assert CommunityTelemetryService._is_enabled() is False
 
@@ -45,9 +44,9 @@ def test_telemetry_is_disabled_for_enterprise(monkeypatch: pytest.MonkeyPatch):
     ],
 )
 def test_telemetry_is_disabled_when_a_required_condition_is_not_met(
-    telemetry_enabled, monkeypatch: pytest.MonkeyPatch, setting: str, value: str | bool
+    telemetry_enabled, config_overrides: Callable[..., None], setting: str, value: str | bool
 ):
-    monkeypatch.setattr(telemetry_service.dify_config, setting, value)
+    config_overrides(**{setting: value})
 
     assert CommunityTelemetryService._is_enabled() is False
 
@@ -263,8 +262,10 @@ def test_report_heartbeat_failure_does_not_mark_the_day_reported(
     assert setup.last_heartbeat_at is None
 
 
-def test_send_event_skips_when_telemetry_is_disabled(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(telemetry_service.dify_config, "DISABLE_TELEMETRY", True)
+def test_send_event_skips_when_telemetry_is_disabled(
+    monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+):
+    config_overrides(DISABLE_TELEMETRY=True)
     post_mock = Mock()
     monkeypatch.setattr(telemetry_service.httpx, "post", post_mock)
 
@@ -272,8 +273,10 @@ def test_send_event_skips_when_telemetry_is_disabled(monkeypatch: pytest.MonkeyP
     post_mock.assert_not_called()
 
 
-def test_send_event_skips_an_empty_fallback_endpoint(telemetry_enabled, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(telemetry_service.dify_config, "TELEMETRY_FALLBACK_ENDPOINT", "")
+def test_send_event_skips_an_empty_fallback_endpoint(
+    telemetry_enabled, monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+):
+    config_overrides(TELEMETRY_FALLBACK_ENDPOINT="")
 
     def fake_post(url: str, json: dict[str, str], timeout: int):
         raise httpx.ConnectError("offline", request=httpx.Request("POST", url))
@@ -283,12 +286,10 @@ def test_send_event_skips_an_empty_fallback_endpoint(telemetry_enabled, monkeypa
     assert CommunityTelemetryService._send_event({"event": "heartbeat"}) is False
 
 
-def test_send_event_does_not_retry_the_same_endpoint(telemetry_enabled, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(
-        telemetry_service.dify_config,
-        "TELEMETRY_FALLBACK_ENDPOINT",
-        telemetry_service.dify_config.TELEMETRY_ENDPOINT,
-    )
+def test_send_event_does_not_retry_the_same_endpoint(
+    telemetry_enabled, monkeypatch: pytest.MonkeyPatch, config_overrides: Callable[..., None]
+):
+    config_overrides(TELEMETRY_FALLBACK_ENDPOINT=telemetry_service.dify_config.TELEMETRY_ENDPOINT)
     post_mock = Mock(
         return_value=httpx.Response(
             204,

--- a/api/tests/unit_tests/services/test_vector_space_admission_service.py
+++ b/api/tests/unit_tests/services/test_vector_space_admission_service.py
@@ -1,5 +1,6 @@
 import json
 import threading
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from unittest.mock import call, patch
@@ -8,7 +9,6 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from configs import dify_config
 from core.rag.datasource.vdb.vector_type import VectorType
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
 from core.rag.models.document import AttachmentDocument, ChildDocument, Document
@@ -29,6 +29,14 @@ from services.vector_space_admission_service import (
 
 _MEBIBYTE = 1024 * 1024
 _ESTIMATE_LIMITS = "sandbox:60,professional:6400,team:25600"
+
+
+@pytest.fixture(autouse=True)
+def _vector_admission_config(config_overrides: Callable[..., None]) -> None:
+    config_overrides(
+        DEPLOYMENT_EDITION=DeploymentEdition.CLOUD,
+        TIDB_ON_QDRANT_ESTIMATED_STORAGE_LIMITS_MB=_ESTIMATE_LIMITS,
+    )
 
 
 class _FakeRedisLock:
@@ -101,11 +109,6 @@ def _check_estimate(
     with (
         patch.object(service, "_get_plan", return_value=plan),
         patch.object(service, "_get_embedding_dimension", return_value=3072),
-        patch.object(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
-        patch(
-            "services.vector_space_admission_service.dify_config.TIDB_ON_QDRANT_ESTIMATED_STORAGE_LIMITS_MB",
-            _ESTIMATE_LIMITS,
-        ),
         patch(
             "services.vector_space_admission_service.Vector.resolve_vector_type",
             return_value=VectorType.TIDB_ON_QDRANT,
@@ -237,10 +240,10 @@ def test_pipeline_qa_workload_counts_question_vectors_without_summaries() -> Non
     assert workload.summary_points == 0
 
 
-def test_admission_is_cloud_only(sqlite_session: Session) -> None:
+def test_admission_is_cloud_only(sqlite_session: Session, config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
     service = VectorSpaceAdmissionService()
     with (
-        patch.object(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.COMMUNITY),
         patch("services.vector_space_admission_service.Vector.resolve_vector_type") as resolve_vector_type,
         patch("services.vector_space_admission_service.BillingService.get_info") as get_info,
     ):
@@ -258,7 +261,6 @@ def test_admission_is_cloud_only(sqlite_session: Session) -> None:
 def test_admission_skips_non_tidb_vector_backends(sqlite_session: Session) -> None:
     service = VectorSpaceAdmissionService()
     with (
-        patch.object(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch("services.vector_space_admission_service.Vector.resolve_vector_type", return_value=VectorType.QDRANT),
         patch("services.vector_space_admission_service.BillingService.get_info") as get_info,
     ):
@@ -363,11 +365,6 @@ def test_usage_lookup_is_refreshed_for_each_document(sqlite_session: Session) ->
     with (
         patch.object(service, "_get_plan", return_value=CloudPlan.SANDBOX),
         patch.object(service, "_get_embedding_dimension", return_value=3072),
-        patch.object(dify_config, "DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
-        patch(
-            "services.vector_space_admission_service.dify_config.TIDB_ON_QDRANT_ESTIMATED_STORAGE_LIMITS_MB",
-            _ESTIMATE_LIMITS,
-        ),
         patch(
             "services.vector_space_admission_service.Vector.resolve_vector_type",
             return_value=VectorType.TIDB_ON_QDRANT,

--- a/api/tests/unit_tests/tasks/test_refresh_billing_vector_space_task.py
+++ b/api/tests/unit_tests/tasks/test_refresh_billing_vector_space_task.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
@@ -9,9 +10,13 @@ from tasks.refresh_billing_vector_space_task import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _cloud_edition(config_overrides: Callable[..., None]) -> None:
+    config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.CLOUD)
+
+
 def test_refresh_invalidates_vector_space_cache():
     with (
-        patch("tasks.refresh_billing_vector_space_task.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch(
             "tasks.refresh_billing_vector_space_task.BillingService.invalidate_vector_space_cache"
         ) as invalidate_cache,
@@ -25,7 +30,6 @@ def test_refresh_failure_schedules_retry():
     error = RuntimeError("billing unavailable")
 
     with (
-        patch("tasks.refresh_billing_vector_space_task.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch(
             "tasks.refresh_billing_vector_space_task.BillingService.invalidate_vector_space_cache",
             side_effect=error,
@@ -40,7 +44,6 @@ def test_refresh_failure_schedules_retry():
 
 def test_dispatch_failure_does_not_propagate():
     with (
-        patch("tasks.refresh_billing_vector_space_task.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD),
         patch.object(refresh_billing_vector_space_task, "delay", side_effect=RuntimeError("broker unavailable")),
     ):
         schedule_billing_vector_space_refresh("tenant-1")


### PR DESCRIPTION
## Summary

- centralize typed config overrides across account registration, retention cleanup, credit pools, telemetry, FeatureService policy matrices, and vector-space admission
- replace repeated deployment-edition, quota, hosted-trial, telemetry, workspace, and file-size config patches
- use scoped class/module defaults for Community and Cloud branches while preserving per-test overrides
- remove direct config patching from all FeatureService-focused test modules

## Stack

- depends on #40860

## Tests

- make lint
- make type-check-core
- make test with all 20 changed modules (290 passed)

From Codex