### PR TITLE
fix(workflow): preserve historical Agent node compatibility (cherry-pick #40859)

### DIFF
--- a/api/core/workflow/node_factory.py
+++ b/api/core/workflow/node_factory.py
@@ -41,6 +41,7 @@ from core.workflow.nodes.agent.plugin_strategy_adapter import (
 from core.workflow.nodes.agent.runtime_support import AgentRuntimeSupport
 from core.workflow.nodes.agent_v2 import DifyAgentNode
 from core.workflow.nodes.agent_v2.binding_resolver import WorkflowAgentBindingResolver
+from core.workflow.nodes.agent_v2.discriminator import is_dify_agent_node_data
 from core.workflow.nodes.agent_v2.output_adapter import WorkflowAgentOutputAdapter
 from core.workflow.nodes.agent_v2.runtime_request_builder import WorkflowAgentRuntimeRequestBuilder
 from core.workflow.nodes.human_input.callback import DifyHITLCallback
@@ -128,11 +129,26 @@ def get_node_type_classes_mapping() -> Mapping[NodeType, Mapping[str, type[Node]
     return Node.get_node_type_classes_mapping()
 
 
-def resolve_workflow_node_class(*, node_type: NodeType, node_version: str) -> type[Node]:
+def resolve_workflow_node_class(
+    *,
+    node_type: NodeType,
+    node_version: str,
+    node_data: Mapping[str, Any] | BaseNodeData | None = None,
+) -> type[Node]:
     """Resolve the production node class for the requested type/version."""
     node_mapping = get_node_type_classes_mapping().get(node_type)
     if not node_mapping:
         raise ValueError(f"No class mapping found for node type: {node_type}")
+
+    # Historical Agent nodes used version=2 for their tool-parameter format.
+    # Only the explicit kind marker identifies the newer Dify Agent node.
+    if (
+        node_data is not None
+        and node_type == BuiltinNodeTypes.AGENT
+        and node_version == "2"
+        and not is_dify_agent_node_data(node_data)
+    ):
+        node_version = "1"
 
     latest_node_class = node_mapping.get(LATEST_VERSION)
     matched_node_class = node_mapping.get(node_version)
@@ -388,7 +404,11 @@ class DifyNodeFactory(NodeFactory):
         typed_node_config = NodeConfigDictAdapter.validate_python(adapted_node_config)
         node_id = typed_node_config["id"]
         node_data = typed_node_config["data"]
-        node_class = self._resolve_node_class(node_type=node_data.type, node_version=str(node_data.version))
+        node_class = self._resolve_node_class(
+            node_type=node_data.type,
+            node_version=str(node_data.version),
+            node_data=node_data,
+        )
         # Graph configs are initially validated against permissive shared node data.
         # Re-validate using the resolved node class so workflow-local node schemas
         # stay explicit and constructors receive the concrete typed payload.
@@ -476,8 +496,17 @@ class DifyNodeFactory(NodeFactory):
         return node_data
 
     @staticmethod
-    def _resolve_node_class(*, node_type: NodeType, node_version: str) -> type[Node]:
-        return resolve_workflow_node_class(node_type=node_type, node_version=node_version)
+    def _resolve_node_class(
+        *,
+        node_type: NodeType,
+        node_version: str,
+        node_data: Mapping[str, Any] | BaseNodeData | None = None,
+    ) -> type[Node]:
+        return resolve_workflow_node_class(
+            node_type=node_type,
+            node_version=node_version,
+            node_data=node_data,
+        )
 
     def _build_agent_node_init_kwargs(self, *, node_class: type[Node]) -> dict[str, object]:
         if issubclass(node_class, DifyAgentNode):

--- a/api/core/workflow/nodes/agent_v2/discriminator.py
+++ b/api/core/workflow/nodes/agent_v2/discriminator.py
@@ -1,0 +1,28 @@
+from collections.abc import Mapping
+from typing import Any
+
+from graphon.entities.base_node_data import BaseNodeData
+from graphon.enums import BuiltinNodeTypes
+
+AGENT_NODE_KIND = "dify_agent"
+AGENT_NODE_VERSION = "2"
+
+
+def is_dify_agent_node_data(node_data: Mapping[str, Any] | BaseNodeData) -> bool:
+    """Return whether node data explicitly identifies the new Dify Agent node."""
+
+    if isinstance(node_data, Mapping):
+        node_type = node_data.get("type")
+        node_version = node_data.get("version")
+        agent_node_kind = node_data.get("agent_node_kind")
+    else:
+        serialized_node_data = node_data.model_dump(mode="python")
+        node_type = serialized_node_data.get("type")
+        node_version = serialized_node_data.get("version")
+        agent_node_kind = serialized_node_data.get("agent_node_kind")
+
+    return (
+        node_type == BuiltinNodeTypes.AGENT
+        and str(node_version) == AGENT_NODE_VERSION
+        and agent_node_kind == AGENT_NODE_KIND
+    )

--- a/api/core/workflow/nodes/agent_v2/entities.py
+++ b/api/core/workflow/nodes/agent_v2/entities.py
@@ -8,7 +8,7 @@ from graphon.enums import BuiltinNodeTypes, NodeType
 
 class DifyAgentNodeData(BaseNodeData):
     type: NodeType = BuiltinNodeTypes.AGENT
-    agent_node_kind: Literal["dify_agent"] = "dify_agent"
+    agent_node_kind: Literal["dify_agent"]
 
     @model_validator(mode="after")
     def validate_version(self) -> "DifyAgentNodeData":

--- a/api/core/workflow/nodes/agent_v2/validators.py
+++ b/api/core/workflow/nodes/agent_v2/validators.py
@@ -28,6 +28,7 @@ from models.model import UploadFile
 from models.workflow import Workflow
 from services.agent.knowledge_datasets import list_missing_tenant_knowledge_dataset_ids
 
+from .discriminator import is_dify_agent_node_data
 from .entities import DifyAgentNodeData
 
 
@@ -258,7 +259,7 @@ class WorkflowAgentNodeValidator:
             node_data = node.get("data")
             if not isinstance(node_id, str) or not isinstance(node_data, Mapping):
                 continue
-            if node_data.get("type") == BuiltinNodeTypes.AGENT and str(node_data.get("version")) == "2":
+            if is_dify_agent_node_data(node_data):
                 yield node_id, node_data
 
     @staticmethod

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -286,7 +286,11 @@ class WorkflowEntry:
         # Get node type
         node_type = node_config_data.type
         node_version = str(node_config_data.version)
-        node_cls = resolve_workflow_node_class(node_type=node_type, node_version=node_version)
+        node_cls = resolve_workflow_node_class(
+            node_type=node_type,
+            node_version=node_version,
+            node_data=node_config_data,
+        )
 
         # init graph context and runtime state
         run_context = build_dify_run_context(

--- a/api/services/agent/composer_candidates.py
+++ b/api/services/agent/composer_candidates.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any
 
+from core.workflow.nodes.agent_v2.discriminator import is_dify_agent_node_data
 from models.agent_config_entities import (
     AgentSoulConfig,
     DeclaredOutputConfig,
@@ -97,7 +98,7 @@ def previous_node_output_candidates(
             continue
 
         declared: list[DeclaredOutputConfig] | None = None
-        if kind == "agent" and str(data.get("version", "")) == "2":
+        if is_dify_agent_node_data(data):
             declared = declared_outputs_loader(nid)
         if declared is not None:
             for output in declared:

--- a/api/services/agent/dsl_service.py
+++ b/api/services/agent/dsl_service.py
@@ -18,8 +18,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from core.workflow.nodes.agent_v2.discriminator import is_dify_agent_node_data
 from core.workflow.nodes.agent_v2.validators import WorkflowAgentNodeValidator
-from graphon.enums import BuiltinNodeTypes
 from models import Account
 from models.agent import (
     APP_BACKED_AGENT_SOURCES,
@@ -629,7 +629,7 @@ class AgentDslService:
 
 def is_agent_v2_graph(graph: Mapping[str, Any]) -> bool:
     return any(
-        node.get("data", {}).get("type") == BuiltinNodeTypes.AGENT and node.get("data", {}).get("version") == "2"
+        isinstance(node.get("data"), Mapping) and is_dify_agent_node_data(node["data"])
         for node in graph.get("nodes", [])
         if isinstance(node, Mapping)
     )

--- a/api/services/workflow/node_output_inspector_service.py
+++ b/api/services/workflow/node_output_inspector_service.py
@@ -59,15 +59,12 @@ from core.workflow.nodes.agent_v2.binding_resolver import (
     WorkflowAgentBindingError,
     WorkflowAgentBindingResolver,
 )
+from core.workflow.nodes.agent_v2.discriminator import is_dify_agent_node_data
 from core.workflow.nodes.agent_v2.runtime_request_builder import (
     WorkflowAgentRuntimeRequestBuilder,
 )
 from factories.file_factory.builders import build_from_mapping
-from graphon.enums import (
-    BuiltinNodeTypes,
-    WorkflowExecutionStatus,
-    WorkflowNodeExecutionStatus,
-)
+from graphon.enums import WorkflowExecutionStatus, WorkflowNodeExecutionStatus
 from graphon.file import helpers as file_helpers
 from models import App
 from models.agent_config_entities import DeclaredOutputConfig, DeclaredOutputType
@@ -182,18 +179,12 @@ class _ResolvedDeclaration:
 
 
 def _is_agent_v2_node(node: Mapping[str, Any]) -> bool:
-    """A graph node is Agent v2 iff its ``data.type`` is the AGENT builtin
-    AND its ``data.version`` is ``"2"``.
+    """Return whether a graph node explicitly identifies the new Dify Agent node."""
 
-    ``BuiltinNodeTypes.AGENT`` is a ``ClassVar[NodeType]`` (plain string), not
-    a StrEnum, so we compare against it directly without ``.value``.
-    """
     data = node.get("data") or {}
     if not isinstance(data, Mapping):
         return False
-    if data.get("type") != BuiltinNodeTypes.AGENT:
-        return False
-    return str(data.get("version", "")) == "2"
+    return is_dify_agent_node_data(data)
 
 
 def _graph_nodes(workflow_run: WorkflowRun) -> list[Mapping[str, Any]]:

--- a/api/tests/integration_tests/services/test_node_output_inspector_service.py
+++ b/api/tests/integration_tests/services/test_node_output_inspector_service.py
@@ -133,7 +133,12 @@ def seeded_run(
         "nodes": [
             {
                 "id": "agent-node-1",
-                "data": {"type": "agent", "version": "2", "title": "My Agent"},
+                "data": {
+                    "type": "agent",
+                    "version": "2",
+                    "agent_node_kind": "dify_agent",
+                    "title": "My Agent",
+                },
             },
             {
                 "id": "tool-node-1",
@@ -328,7 +333,14 @@ def test_snapshot_404s_for_published_run_per_decision_d1(flask_req_ctx, fake_app
 def test_snapshot_surfaces_type_check_failure_from_metadata(flask_req_ctx, fake_app_model):
     """Per-output ``TYPE_CHECK_FAILED`` derived from the metadata blob the
     Stage 4 §5 stack records on the execution row."""
-    graph = {"nodes": [{"id": "agent-1", "data": {"type": "agent", "version": "2"}}]}
+    graph = {
+        "nodes": [
+            {
+                "id": "agent-1",
+                "data": {"type": "agent", "version": "2", "agent_node_kind": "dify_agent"},
+            }
+        ]
+    }
     workflow_run = _make_workflow_run(app_id=fake_app_model.id, tenant_id=fake_app_model.tenant_id, graph=graph)
     execution = _make_execution(
         app_id=fake_app_model.id,
@@ -375,7 +387,14 @@ def test_snapshot_surfaces_type_check_failure_from_metadata(flask_req_ctx, fake_
 def test_snapshot_surfaces_output_check_failure_from_metadata(flask_req_ctx, fake_app_model):
     """When ``output_type_check.passed`` but ``output_check.passed=False``, the
     output is flagged ``OUTPUT_CHECK_FAILED``."""
-    graph = {"nodes": [{"id": "agent-1", "data": {"type": "agent", "version": "2"}}]}
+    graph = {
+        "nodes": [
+            {
+                "id": "agent-1",
+                "data": {"type": "agent", "version": "2", "agent_node_kind": "dify_agent"},
+            }
+        ]
+    }
     workflow_run = _make_workflow_run(app_id=fake_app_model.id, tenant_id=fake_app_model.tenant_id, graph=graph)
     execution = _make_execution(
         app_id=fake_app_model.id,
@@ -470,7 +489,14 @@ def test_keeps_latest_execution_per_node_by_index(flask_req_ctx, fake_app_model)
     """Multiple executions for the same node_id → service keeps the highest
     ``index`` (matches the agent_v2 retry pattern that re-emits node
     executions)."""
-    graph = {"nodes": [{"id": "agent-1", "data": {"type": "agent", "version": "2"}}]}
+    graph = {
+        "nodes": [
+            {
+                "id": "agent-1",
+                "data": {"type": "agent", "version": "2", "agent_node_kind": "dify_agent"},
+            }
+        ]
+    }
     workflow_run = _make_workflow_run(app_id=fake_app_model.id, tenant_id=fake_app_model.tenant_id, graph=graph)
     older = _make_execution(
         app_id=fake_app_model.id,

--- a/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
@@ -1004,6 +1004,7 @@ class TestAppDslService:
                     "data": {
                         "type": BuiltinNodeTypes.AGENT,
                         "version": "2",
+                        "agent_node_kind": "dify_agent",
                         "agent_binding": {
                             "binding_type": WorkflowAgentBindingType.ROSTER_AGENT.value,
                             AGENT_PACKAGE_REF_KEY: "agent_1",
@@ -1015,6 +1016,7 @@ class TestAppDslService:
                     "data": {
                         "type": BuiltinNodeTypes.AGENT,
                         "version": "2",
+                        "agent_node_kind": "dify_agent",
                         "agent_binding": {
                             "binding_type": WorkflowAgentBindingType.INLINE_AGENT.value,
                             AGENT_PACKAGE_REF_KEY: "agent_1",

--- a/api/tests/unit_tests/controllers/console/app/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow.py
@@ -549,6 +549,7 @@ def test_draft_workflow_get_projects_agent_node_job_to_graph(monkeypatch: pytest
                     "data": {
                         "type": "agent",
                         "version": "2",
+                        "agent_node_kind": "dify_agent",
                     },
                 }
             ],
@@ -562,6 +563,7 @@ def test_draft_workflow_get_projects_agent_node_job_to_graph(monkeypatch: pytest
                 "data": {
                     "type": "agent",
                     "version": "2",
+                    "agent_node_kind": "dify_agent",
                     "agent_task": "Summarize it.",
                     "agent_declared_outputs": [{"name": "summary", "type": "string"}],
                 },

--- a/api/tests/unit_tests/core/app/apps/test_pause_resume.py
+++ b/api/tests/unit_tests/core/app/apps/test_pause_resume.py
@@ -1,5 +1,6 @@
 import sys
 import time
+from collections.abc import Mapping
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -106,10 +107,19 @@ class _StubToolNode(Node[_StubToolNodeData]):
 def _patch_tool_node(mocker: MockerFixture):
     original_resolve_node_class = node_factory_module.resolve_workflow_node_class
 
-    def _patched_resolve_node_class(*, node_type: NodeType, node_version: str) -> type[Node]:
+    def _patched_resolve_node_class(
+        *,
+        node_type: NodeType,
+        node_version: str,
+        node_data: Mapping[str, Any] | BaseNodeData | None = None,
+    ) -> type[Node]:
         if node_type == BuiltinNodeTypes.TOOL:
             return _StubToolNode
-        return original_resolve_node_class(node_type=node_type, node_version=node_version)
+        return original_resolve_node_class(
+            node_type=node_type,
+            node_version=node_version,
+            node_data=node_data,
+        )
 
     mocker.patch.object(node_factory_module, "resolve_workflow_node_class", side_effect=_patched_resolve_node_class)
 

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_agent_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_agent_node.py
@@ -321,7 +321,9 @@ def _node(
 
     return DifyAgentNode(
         node_id="agent-node",
-        data=DifyAgentNodeData.model_validate({"type": BuiltinNodeTypes.AGENT, "version": "2"}),
+        data=DifyAgentNodeData.model_validate(
+            {"type": BuiltinNodeTypes.AGENT, "version": "2", "agent_node_kind": "dify_agent"}
+        ),
         graph_init_params=graph_init_params,
         graph_runtime_state=cast(GraphRuntimeState, SimpleNamespace(variable_pool=FakeVariablePool())),
         binding_resolver=binding_resolver,

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_discriminator.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_discriminator.py
@@ -1,0 +1,31 @@
+import pytest
+from pydantic import ValidationError
+
+from core.workflow.nodes.agent_v2.discriminator import is_dify_agent_node_data
+from core.workflow.nodes.agent_v2.entities import DifyAgentNodeData
+from graphon.entities.base_node_data import BaseNodeData
+
+
+@pytest.mark.parametrize(
+    ("node_data", "expected"),
+    [
+        ({"type": "agent", "version": "2", "agent_node_kind": "dify_agent"}, True),
+        ({"type": "agent", "version": 2, "agent_node_kind": "dify_agent"}, True),
+        ({"type": "agent", "version": "2"}, False),
+        ({"type": "agent", "version": "1", "agent_node_kind": "dify_agent"}, False),
+        ({"type": "llm", "version": "2", "agent_node_kind": "dify_agent"}, False),
+    ],
+)
+def test_is_dify_agent_node_data_mapping(node_data: dict[str, object], expected: bool) -> None:
+    assert is_dify_agent_node_data(node_data) is expected
+
+
+def test_is_dify_agent_node_data_supports_base_node_data() -> None:
+    node_data = BaseNodeData.model_validate({"type": "agent", "version": "2", "agent_node_kind": "dify_agent"})
+
+    assert is_dify_agent_node_data(node_data) is True
+
+
+def test_dify_agent_node_data_requires_explicit_kind_marker() -> None:
+    with pytest.raises(ValidationError, match="agent_node_kind"):
+        DifyAgentNodeData.model_validate({"type": "agent", "version": "2"})

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
@@ -87,7 +87,10 @@ def _graph(edges: list[dict]) -> dict:
         "nodes": [
             {"id": "start", "data": {"type": "start"}},
             {"id": "previous-node", "data": {"type": "llm"}},
-            {"id": "agent-node", "data": {"type": "agent", "version": "2"}},
+            {
+                "id": "agent-node",
+                "data": {"type": "agent", "version": "2", "agent_node_kind": "dify_agent"},
+            },
             {"id": "later-node", "data": {"type": "llm"}},
         ],
         "edges": edges,
@@ -116,6 +119,18 @@ def _tool_graph(tool_data: dict) -> dict:
         ],
         "edges": [{"source": "start", "target": "tool-node"}],
     }
+
+
+def test_historical_agent_version_two_is_not_validated_as_dify_agent() -> None:
+    graph = {
+        "nodes": [{"id": "legacy-agent", "data": {"type": "agent", "version": "2"}}],
+        "edges": [],
+    }
+    session = Mock()
+
+    WorkflowAgentNodeValidator.validate_published_workflow(session=session, workflow=_workflow(graph))
+
+    session.scalar.assert_not_called()
 
 
 def test_publish_validation_accepts_upstream_previous_output_ref():

--- a/api/tests/unit_tests/core/workflow/test_node_mapping_bootstrap.py
+++ b/api/tests/unit_tests/core/workflow/test_node_mapping_bootstrap.py
@@ -23,7 +23,12 @@ def test_moved_core_nodes_resolve_after_importing_production_entrypoints():
         from core.app.apps import workflow_app_runner
         from core.workflow import workflow_entry
         from core.workflow.nodes.knowledge_index import KNOWLEDGE_INDEX_NODE_TYPE
-        from core.workflow.node_factory import DifyNodeFactory, NODE_TYPE_CLASSES_MAPPING
+        from core.workflow.node_factory import (
+            DifyNodeFactory,
+            NODE_TYPE_CLASSES_MAPPING,
+            resolve_workflow_node_class,
+        )
+        from core.workflow.nodes.agent import AgentNode
         from core.workflow.nodes.agent_v2 import DifyAgentNode
         from graphon.enums import BuiltinNodeTypes
         from services import workflow_service
@@ -45,6 +50,16 @@ def test_moved_core_nodes_resolve_after_importing_production_entrypoints():
         assert DifyNodeFactory._resolve_node_class(
             node_type=BuiltinNodeTypes.AGENT,
             node_version="2",
+        ) is DifyAgentNode
+        assert resolve_workflow_node_class(
+            node_type=BuiltinNodeTypes.AGENT,
+            node_version="2",
+            node_data={"type": "agent", "version": "2"},
+        ) is AgentNode
+        assert resolve_workflow_node_class(
+            node_type=BuiltinNodeTypes.AGENT,
+            node_version="2",
+            node_data={"type": "agent", "version": "2", "agent_node_kind": "dify_agent"},
         ) is DifyAgentNode
         """
     )

--- a/api/tests/unit_tests/services/agent/test_agent_dsl_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_dsl_service.py
@@ -59,7 +59,7 @@ def _snapshot(*, snapshot_id: str = "snapshot-1", soul: AgentSoulConfig | None =
 
 
 def _agent_node(node_id: str, binding: object | None = None) -> dict:
-    data = {"type": BuiltinNodeTypes.AGENT, "version": "2"}
+    data = {"type": BuiltinNodeTypes.AGENT, "version": "2", "agent_node_kind": "dify_agent"}
     if binding is not None:
         data["agent_binding"] = binding
     return {"id": node_id, "data": data}
@@ -727,4 +727,17 @@ def test_require_helpers_and_graph_detection() -> None:
     assert AgentDslService._agent_icon_type(AgentIconType.EMOJI.value) == AgentIconType.EMOJI
     assert AgentDslService._agent_icon_type(None) is None
     assert is_agent_v2_graph({"nodes": [_agent_node("agent")]}) is True
+    assert is_agent_v2_graph({"nodes": [{"id": "legacy-agent", "data": {"type": "agent", "version": "2"}}]}) is False
     assert is_agent_v2_graph({"nodes": ["invalid", {"data": {"type": "start"}}]}) is False
+
+
+def test_export_workflow_packages_ignores_historical_agent_version_two() -> None:
+    session = Mock()
+    service = AgentDslService(session)
+    graph = {"nodes": [{"id": "legacy-agent", "data": {"type": "agent", "version": "2"}}]}
+
+    portable_graph, packages = service.export_workflow_packages(workflow=Mock(), graph=graph)
+
+    assert portable_graph == graph
+    assert packages == {}
+    session.scalars.assert_not_called()

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -4161,7 +4161,12 @@ class TestWorkflowAgentDraftBindingSync:
             version=Workflow.VERSION_DRAFT,
             graph=json.dumps(
                 {
-                    "nodes": [{"id": "agent-node", "data": {"type": "agent", "version": "2"}}],
+                    "nodes": [
+                        {
+                            "id": "agent-node",
+                            "data": {"type": "agent", "version": "2", "agent_node_kind": "dify_agent"},
+                        }
+                    ],
                     "edges": [],
                 }
             ),
@@ -4218,6 +4223,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_task": agent_task,
                                 "agent_binding": {
                                     "binding_type": "roster_agent",
@@ -4352,6 +4358,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "roster_agent",
                                     "agent_id": "agent-1",
@@ -4431,6 +4438,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "inline_agent",
                                 },
@@ -4482,6 +4490,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "inline_agent",
                                 },
@@ -4528,6 +4537,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_task": "Summarize the upstream result.",
                                 "agent_declared_outputs": [
                                     {
@@ -4619,6 +4629,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_task": "Use the current node context.",
                                 "agent_binding": {
                                     "binding_type": "inline_agent",
@@ -4681,6 +4692,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "inline_agent",
                                 },
@@ -4727,6 +4739,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "inline_agent",
                                     "agent_id": "inline-agent-1",
@@ -4779,6 +4792,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "unknown",
                                     "agent_id": "agent-1",
@@ -4811,6 +4825,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "inline_agent",
                                     "agent_id": "inline-agent-1",
@@ -4848,6 +4863,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_binding": {
                                     "binding_type": "inline_agent",
                                     "agent_id": "inline-agent-1",
@@ -4894,6 +4910,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_task": "Use the latest tender context.",
                                 "agent_binding": {
                                     "binding_type": "roster_agent",
@@ -4959,6 +4976,7 @@ class TestWorkflowAgentDraftBindingSync:
                             "data": {
                                 "type": "agent",
                                 "version": "2",
+                                "agent_node_kind": "dify_agent",
                                 "agent_task": "Keep the prompt.",
                                 "agent_declared_outputs": [],
                                 "agent_binding": {

--- a/api/tests/unit_tests/services/agent/test_composer_candidates.py
+++ b/api/tests/unit_tests/services/agent/test_composer_candidates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 from fields.agent_fields import AgentComposerCandidatesResponse
 from models.agent_config_entities import AgentSoulConfig, DeclaredOutputConfig, DeclaredOutputType
@@ -23,8 +24,24 @@ _GRAPH = {
             },
         },
         {"id": "llm-1", "data": {"type": "llm", "title": "LLM"}},
-        {"id": "agent-up", "data": {"type": "agent", "version": "2", "title": "Upstream Agent"}},
-        {"id": "agent-target", "data": {"type": "agent", "version": "2", "title": "Target Agent"}},
+        {
+            "id": "agent-up",
+            "data": {
+                "type": "agent",
+                "version": "2",
+                "agent_node_kind": "dify_agent",
+                "title": "Upstream Agent",
+            },
+        },
+        {
+            "id": "agent-target",
+            "data": {
+                "type": "agent",
+                "version": "2",
+                "agent_node_kind": "dify_agent",
+                "title": "Target Agent",
+            },
+        },
         {"id": "end", "data": {"type": "end", "title": "END"}},
     ],
     "edges": [
@@ -96,6 +113,31 @@ def test_results_differ_per_node_id():
 
     assert {e["node_id"] for e in entries_target} == {"start-1", "llm-1", "agent-up"}
     assert {e["node_id"] for e in entries_llm} == {"start-1"}
+
+
+def test_historical_agent_version_two_uses_inferred_outputs() -> None:
+    graph = {
+        "nodes": [
+            {"id": "legacy", "data": {"type": "agent", "version": "2", "title": "Legacy"}},
+            {
+                "id": "target",
+                "data": {"type": "agent", "version": "2", "agent_node_kind": "dify_agent"},
+            },
+        ],
+        "edges": [{"source": "legacy", "target": "target"}],
+    }
+    declared_loader = Mock(return_value=[DeclaredOutputConfig(name="declared", type=DeclaredOutputType.STRING)])
+
+    entries, _ = previous_node_output_candidates(
+        graph=graph,
+        node_id="target",
+        declared_outputs_loader=declared_loader,
+        draft_variables_loader=lambda node_id: [("legacy_output", "string")] if node_id == "legacy" else [],
+        system_variables_loader=lambda: [],
+    )
+
+    assert [entry["output"] for entry in entries] == ["legacy_output"]
+    declared_loader.assert_not_called()
 
 
 def test_previous_outputs_capped_and_flagged():

--- a/api/tests/unit_tests/services/workflow/test_node_output_inspector_service.py
+++ b/api/tests/unit_tests/services/workflow/test_node_output_inspector_service.py
@@ -89,7 +89,7 @@ def _execution(
 def _agent_v2_node(*, node_id: str = "agent-node-1", title: str = "My Agent") -> dict[str, Any]:
     return {
         "id": node_id,
-        "data": {"type": "agent", "version": "2", "title": title},
+        "data": {"type": "agent", "version": "2", "agent_node_kind": "dify_agent", "title": title},
     }
 
 
@@ -157,6 +157,19 @@ def test_snapshot_accepts_published_run_d1_lifted():
     snapshot = service.snapshot_workflow_run(app_model=_app_model(), workflow_run_id="run-1", session=session)
     assert snapshot.workflow_run_id == "run-1"
     assert [n.node_id for n in snapshot.node_outputs] == ["agent-1"]
+
+
+def test_historical_agent_version_two_uses_inferred_outputs() -> None:
+    resolver = MagicMock()
+    service = NodeOutputInspectorService(binding_resolver=resolver)
+    run = _workflow_run(nodes=[{"id": "legacy-agent", "data": {"type": "agent", "version": "2", "title": "Legacy"}}])
+    execution = _execution(node_id="legacy-agent", outputs={"text": "legacy output"})
+    session = _mock_session(workflow_run=run, executions=[execution])
+
+    snapshot = service.snapshot_workflow_run(app_model=_app_model(), workflow_run_id="run-1", session=session)
+
+    assert [(output.name, output.type) for output in snapshot.node_outputs[0].outputs] == [("text", None)]
+    resolver.resolve.assert_not_called()
 
 
 def test_snapshot_accepts_webhook_triggered_run():


### PR DESCRIPTION
## Summary

Cherry-pick of #40859 onto `release/e-1.16.1`.

- require the explicit `agent_node_kind=dify_agent` marker when dispatching and validating new Agent workflow nodes
- route historical `type=agent, version=2` nodes back to the legacy Agent implementation while preserving their v2 tool-parameter semantics
- use the same discriminator for publish, DSL packaging, Composer candidates, and Node Output Inspector

No data migration is included. The new Agent feature has not been released, so compatibility for malformed dev-only new Agent records is intentionally out of scope.

## Conflict notes

`release/e-1.16.1` predates several unrelated `main` refactors that PR #40859's diff context touched incidentally. Resolved by applying only the discriminator-marker fix and discarding the unrelated drift:

- `api/core/workflow/node_factory.py` — this branch doesn't yet have the later `DifyLLMNode` routing / `_resolve_llm_model_reference` addition in `_resolve_node_class`. Kept the branch's existing routing and only threaded the `node_data` parameter needed for the discriminator check.
- `api/tests/unit_tests/services/agent/test_agent_services.py` — two hunks added the `agent_node_kind` marker, adapted to this branch's explicit `Workflow(...)` construction (it doesn't have main's newer `_workflow()` test helper). A third hunk was a patch-context misalignment against a test that was refactored on `main` after this branch was cut (`test_deletes_draft_binding_when_agent_node_removed` vs. main's since-renamed/expanded version) — discarded, left the branch's original test untouched.
- `api/tests/unit_tests/services/agent/test_workflow_publish_service.py` — same kind of misalignment pulled in a whole unrelated test plus unrelated signature-typing drift; discarded, kept the branch's original.
- `api/tests/unit_tests/services/workflow/test_node_output_inspector_service.py` — the new test used a `session_for` fixture that doesn't exist on this branch; rewrote it against the branch's existing `_mock_session`/`_make_service` helpers with the same assertions.
- `api/tests/unit_tests/services/agent/test_composer_candidates.py` — clean import merge (`SimpleNamespace` + `Mock`, both still needed).

Diff shape otherwise matches the original PR (20 files changed).

## Verification

- `uv run --project api python -m pytest` on every touched test file: 303 passed
- `uv run --project api python -m mypy api/core/workflow/node_factory.py`: no errors specific to this file (pre-existing unrelated `flask_restx`/`dify_agent.client` stub warnings only)
- pre-commit ruff lint: all checks passed