### PR TITLE
feat(dify-agent): enforce signed upload size limits

### DIFF
--- a/api/controllers/files/upload.py
+++ b/api/controllers/files/upload.py
@@ -32,6 +32,7 @@ class PluginUploadQuery(BaseModel):
     user_id: str | None = Field(default=None, description="User identifier")
     user_from: Literal["account", "end-user"] | None = Field(default=None, description="User identity type")
     conversation_id: str | None = Field(default=None, description="Conversation identifier")
+    max_size: int | None = Field(default=None, ge=0, description="Signed maximum file size in bytes")
 
 
 register_schema_models(files_ns, PluginUploadQuery)
@@ -113,14 +114,22 @@ class PluginUploadFileApi(Resource):
             timestamp=timestamp,
             nonce=nonce,
             sign=sign,
+            max_size=args.max_size,
         ):
             raise Forbidden("Invalid request.")
 
         try:
+            if args.max_size is None:
+                file_binary = file.stream.read()
+            else:
+                file_binary = file.stream.read(args.max_size + 1)
+                if len(file_binary) > args.max_size:
+                    raise FileTooLargeError("File size exceeds the signed upload limit.")
+
             tool_file = ToolFileManager().create_file_by_raw(
                 user_id=owner_id,
                 tenant_id=tenant_id,
-                file_binary=file.stream.read(),
+                file_binary=file_binary,
                 mimetype=mimetype,
                 filename=filename,
                 conversation_id=args.conversation_id,

--- a/api/controllers/inner_api/agent/files.py
+++ b/api/controllers/inner_api/agent/files.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Literal
 
 from flask_restx import Resource
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy.orm import Session
 
 from configs import dify_config
@@ -39,6 +39,7 @@ class AgentFileUploadRequestPayload(RequestRequestUploadFile):
     tenant_id: str
     user_id: str
     user_from: Literal["account", "end-user"] | None = None
+    max_size: int = Field(ge=0, description="Maximum upload size in bytes")
 
     model_config = ConfigDict(extra="forbid")
 
@@ -127,6 +128,7 @@ class AgentFileUploadRequestApi(Resource):
                 user_id=owner_id,
                 conversation_id=payload.conversation_id,
                 user_from=payload.user_from,
+                max_size=payload.max_size,
             )
         except ValueError as exc:
             raise AgentFileRequestHttpError(

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import json
 import os
 import time
 import urllib.parse
@@ -95,6 +96,7 @@ def get_signed_file_uri_for_plugin(
     user_id: str,
     conversation_id: str | None = None,
     user_from: Literal["account", "end-user"] | None = None,
+    max_size: int | None = None,
 ) -> str:
     """Build a signed plugin-upload URI without selecting a network origin."""
 
@@ -109,6 +111,7 @@ def get_signed_file_uri_for_plugin(
         timestamp=timestamp,
         nonce=nonce,
         user_from=user_from,
+        max_size=max_size,
     )
     sign = hmac.new(_secret_key(), data_to_sign.encode(), hashlib.sha256).digest()
     encoded_sign = base64.urlsafe_b64encode(sign).decode()
@@ -123,6 +126,8 @@ def get_signed_file_uri_for_plugin(
         query_params["conversation_id"] = conversation_id
     if user_from is not None:
         query_params["user_from"] = user_from
+    if max_size is not None:
+        query_params["max_size"] = str(max_size)
     query = urllib.parse.urlencode(query_params)
     return f"/files/upload/for-plugin?{query}"
 
@@ -138,6 +143,7 @@ def verify_plugin_file_signature(
     timestamp: str,
     nonce: str,
     sign: str,
+    max_size: int | None = None,
 ) -> bool:
     """Verify the signature used by the plugin-facing file upload endpoint."""
 
@@ -150,6 +156,7 @@ def verify_plugin_file_signature(
         timestamp=timestamp,
         nonce=nonce,
         user_from=user_from,
+        max_size=max_size,
     )
     recalculated_sign = hmac.new(_secret_key(), data_to_sign.encode(), hashlib.sha256).digest()
     recalculated_encoded_sign = base64.urlsafe_b64encode(recalculated_sign).decode()
@@ -171,13 +178,33 @@ def _plugin_upload_signature_payload(
     timestamp: str,
     nonce: str,
     user_from: Literal["account", "end-user"] | None,
+    max_size: int | None,
 ) -> str:
-    """Build the compatible upload signature payload with optional identity ownership.
+    """Build the compatible upload signature payload with optional protected claims.
 
-    Omitting ``user_from`` preserves the legacy payload. When present, the
-    identity kind is appended and HMAC-protected so account/end-user ownership
-    cannot be altered.
+    Omitting ``max_size`` preserves the legacy payload. Size-limited tickets use
+    a versioned JSON payload so unconstrained string fields cannot absorb or
+    impersonate optional trailing claims.
     """
+
+    if max_size is not None:
+        return json.dumps(
+            {
+                "conversation_id": conversation_id or "",
+                "filename": filename,
+                "max_size": max_size,
+                "mimetype": mimetype,
+                "nonce": nonce,
+                "tenant_id": tenant_id,
+                "timestamp": timestamp,
+                "user_from": user_from,
+                "user_id": user_id,
+                "version": 2,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
 
     payload = f"upload|{filename}|{mimetype}|{tenant_id}|{user_id}|{conversation_id or ''}|{timestamp}|{nonce}"
     if user_from is not None:

--- a/api/tests/unit_tests/controllers/files/test_upload.py
+++ b/api/tests/unit_tests/controllers/files/test_upload.py
@@ -2,7 +2,7 @@ import io
 import types
 from contextlib import contextmanager
 from inspect import unwrap
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -206,6 +206,7 @@ class TestPluginUploadFileApi:
             timestamp="123",
             nonce="abc",
             sign="sig",
+            max_size=None,
         )
         tool_file_manager.create_file_by_raw.assert_called_once_with(
             user_id="account-1",
@@ -335,6 +336,65 @@ class TestPluginUploadFileApi:
 
         with pytest.raises(module.FileTooLargeError):
             post_fn(api)
+
+    @patch.object(module, "get_user", return_value=_end_user())
+    @patch.object(module, "verify_plugin_file_signature", return_value=True)
+    @patch.object(module, "ToolFileManager")
+    def test_signed_max_size_bounds_file_read(
+        self,
+        mock_tool_file_manager,
+        mock_verify,
+        mock_get_user,
+    ):
+        dummy_file = DummyFile(content=b"data")
+        dummy_file.stream = MagicMock()
+        dummy_file.stream.read.return_value = b"data"
+        module.request = fake_request(
+            {
+                "timestamp": "123",
+                "nonce": "abc",
+                "sign": "sig",
+                "tenant_id": "tenant-1",
+                "user_id": "user-1",
+                "max_size": "4",
+            },
+            file=dummy_file,
+        )
+        mock_tool_file_manager.return_value.create_file_by_raw.return_value = _tool_file()
+        mock_tool_file_manager.sign_file.return_value = "signed-url"
+
+        unwrap(module.PluginUploadFileApi().post)(module.PluginUploadFileApi())
+
+        dummy_file.stream.read.assert_called_once_with(5)
+        assert mock_verify.call_args.kwargs["max_size"] == 4
+        assert mock_tool_file_manager.return_value.create_file_by_raw.call_args.kwargs["file_binary"] == b"data"
+
+    @patch.object(module, "get_user", return_value=_end_user())
+    @patch.object(module, "verify_plugin_file_signature", return_value=True)
+    @patch.object(module, "ToolFileManager")
+    def test_signed_max_size_rejects_oversized_file_before_creation(
+        self,
+        mock_tool_file_manager,
+        mock_verify,
+        mock_get_user,
+    ):
+        dummy_file = DummyFile(content=b"oversized")
+        module.request = fake_request(
+            {
+                "timestamp": "123",
+                "nonce": "abc",
+                "sign": "sig",
+                "tenant_id": "tenant-1",
+                "user_id": "user-1",
+                "max_size": "4",
+            },
+            file=dummy_file,
+        )
+
+        with pytest.raises(module.FileTooLargeError):
+            unwrap(module.PluginUploadFileApi().post)(module.PluginUploadFileApi())
+
+        mock_tool_file_manager.assert_not_called()
 
     @patch.object(module, "get_user", return_value=_end_user())
     @patch.object(module, "verify_plugin_file_signature", return_value=True)

--- a/api/tests/unit_tests/controllers/inner_api/test_agent_files.py
+++ b/api/tests/unit_tests/controllers/inner_api/test_agent_files.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from controllers.inner_api.agent.files import (
     AgentFileDownloadRequestApi,
     AgentFileUploadRequestApi,
+    AgentFileUploadRequestPayload,
 )
 from core.workflow.file_reference import build_file_reference
 from services.file_request_service import DownloadFileRequestResult
@@ -29,6 +30,7 @@ def test_upload_request_returns_origin_free_uri(app: Flask, unbound_session: Ses
         "filename": "report.pdf",
         "mimetype": "application/pdf",
         "conversation_id": "conversation-1",
+        "max_size": 64 * 1024 * 1024,
     }
     tenant = SimpleNamespace(id="tenant-1")
     user = SimpleNamespace(id="canonical-end-user-1")
@@ -51,7 +53,24 @@ def test_upload_request_returns_origin_free_uri(app: Flask, unbound_session: Ses
         user_id="canonical-end-user-1",
         conversation_id="conversation-1",
         user_from=None,
+        max_size=64 * 1024 * 1024,
     )
+
+
+def test_upload_request_payload_requires_non_negative_max_size() -> None:
+    payload = {
+        "tenant_id": "tenant-1",
+        "user_id": "user-1",
+        "filename": "report.pdf",
+        "mimetype": "application/pdf",
+    }
+
+    with pytest.raises(ValueError):
+        AgentFileUploadRequestPayload.model_validate(payload)
+    with pytest.raises(ValueError):
+        AgentFileUploadRequestPayload.model_validate({**payload, "max_size": -1})
+
+    assert AgentFileUploadRequestPayload.model_validate({**payload, "max_size": 0}).max_size == 0
 
 
 def test_download_request_returns_origin_free_uri_for_sandbox(app: Flask, unbound_session: Session) -> None:

--- a/api/tests/unit_tests/core/tools/test_signature.py
+++ b/api/tests/unit_tests/core/tools/test_signature.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Literal
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -172,6 +173,7 @@ def test_get_signed_file_uri_for_plugin_and_verify_roundtrip(monkeypatch: pytest
     assert query["tenant_id"] == ["tenant-id"]
     assert query["user_id"] == ["user-id"]
     assert query["conversation_id"] == ["conversation-id"]
+    assert "max_size" not in query
     assert (
         verify_plugin_file_signature(
             filename="report.pdf",
@@ -185,6 +187,50 @@ def test_get_signed_file_uri_for_plugin_and_verify_roundtrip(monkeypatch: pytest
         )
         is True
     )
+
+
+@pytest.mark.parametrize(
+    ("user_from", "forged_nonce_suffix"),
+    [
+        (None, "|1024"),
+        ("account", "|account|1024"),
+    ],
+)
+def test_plugin_upload_signature_binds_max_size_without_legacy_payload_ambiguity(
+    monkeypatch: pytest.MonkeyPatch,
+    user_from: Literal["account", "end-user"] | None,
+    forged_nonce_suffix: str,
+) -> None:
+    monkeypatch.setattr("core.tools.signature.time.time", lambda: 1700000000)
+    monkeypatch.setattr("core.tools.signature.os.urandom", lambda _: b"\x0a" * 16)
+    monkeypatch.setattr("core.tools.signature.dify_config.SECRET_KEY", "unit-secret")
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_ACCESS_TIMEOUT", 60)
+
+    uri = get_signed_file_uri_for_plugin(
+        filename="report.pdf",
+        mimetype="application/pdf",
+        tenant_id="tenant-id",
+        user_id="user-id",
+        user_from=user_from,
+        max_size=1024,
+    )
+    query = parse_qs(urlparse(uri).query)
+    signed = {
+        "filename": "report.pdf",
+        "mimetype": "application/pdf",
+        "tenant_id": "tenant-id",
+        "user_id": "user-id",
+        "timestamp": query["timestamp"][0],
+        "nonce": query["nonce"][0],
+        "sign": query["sign"][0],
+    }
+
+    assert query["max_size"] == ["1024"]
+    assert verify_plugin_file_signature(**signed, user_from=user_from, max_size=1024) is True
+    assert verify_plugin_file_signature(**signed, user_from=user_from, max_size=2048) is False
+    assert verify_plugin_file_signature(**signed, user_from=user_from) is False
+    forged = {**signed, "nonce": f"{signed['nonce']}{forged_nonce_suffix}"}
+    assert verify_plugin_file_signature(**forged) is False
 
 
 def test_plugin_upload_signature_binds_account_user_from(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/dify-agent/.example.env
+++ b/dify-agent/.example.env
@@ -58,6 +58,8 @@ DIFY_AGENT_STUB_API_BASE_URL=http://localhost:5050/agent-stub
 # Dify API base URL reachable from the Sandbox for the signed /files/* data plane,
 # including Config file and skill pulls.
 DIFY_AGENT_SANDBOX_FILES_BASE_URL=http://localhost:5001
+# Maximum Agent Stub upload size in MiB; forwarded to Dify API as a signed byte limit.
+DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT=50
 # Server-wide root secret used to derive Agent Stub JWE keys.
 # This is security-sensitive: it derives the JWE encryption key for Agent Stub bearer tokens.
 # Replace this development default in production.

--- a/dify-agent/docs/dify-agent/guide/index.md
+++ b/dify-agent/docs/dify-agent/guide/index.md
@@ -58,6 +58,7 @@ also reads `.env` and `dify-agent/.env` when present.
 | `DIFY_AGENT_SHELL_REDACT_PATTERNS` | empty | JSON array of additional regex patterns redacted from Shell output. |
 | `DIFY_AGENT_STUB_API_BASE_URL` | empty | HTTP(S) Agent Stub API base URL reachable from the Sandbox. It may be the service root or `/agent-stub`. Enables `DIFY_AGENT_STUB_*` env injection for user `shell.run` jobs. |
 | `DIFY_AGENT_SANDBOX_FILES_BASE_URL` | empty | Dify API base URL reachable from the Sandbox for signed `/files/*` upload/download bytes, including Config file and skill pulls. Required when Agent Stub file operations are enabled. May include an ingress path prefix, but not a query or fragment. |
+| `DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT` | `50` | Agent service-owned maximum Agent Stub upload size in MiB. The file-request handler factory converts it to bytes and sends it to Dify API as the required `max_size` used to sign a size-limited upload URL. |
 | `DIFY_AGENT_SERVER_SECRET_KEY` | empty | Security-sensitive server-wide root secret used to derive the JWE encryption key for Agent Stub bearer tokens; required when `DIFY_AGENT_STUB_API_BASE_URL` is set. The supplied default config uses a development value; set a unique unpadded base64url 32-byte secret in production. |
 | `DIFY_AGENT_OUTBOUND_HTTP_CONNECT_TIMEOUT` | `10` | Shared outbound HTTP connect timeout in seconds. |
 | `DIFY_AGENT_OUTBOUND_HTTP_READ_TIMEOUT` | `600` | Shared outbound HTTP read timeout in seconds. |
@@ -89,6 +90,7 @@ DIFY_AGENT_LOCAL_SANDBOX_WORKSPACE_ROOT=/tmp/dify-agent/workspaces
 DIFY_AGENT_LOCAL_SANDBOX_HOME_SNAPSHOT_ROOT=/tmp/dify-agent/home-snapshots
 DIFY_AGENT_STUB_API_BASE_URL=https://agent.example.com/agent-stub
 DIFY_AGENT_SANDBOX_FILES_BASE_URL=https://dify.example.com
+DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT=50
 # This is security-sensitive: it derives the JWE encryption key for Agent Stub bearer tokens.
 # Replace this development default in production.
 # Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(32))'
@@ -110,10 +112,11 @@ Removing Agent Stub gRPC is a breaking transport migration: replace every
 
 For a remote Sandbox, expose only `/agent-stub/*` from Agent Backend and the
 existing `/files/*` Dify API data plane. The `/files/*` ingress must preserve
-the complete signed query string, allow the configured upload body size, and
-use response streaming and timeouts suitable for large downloads. Do not expose
-Agent Backend `/runs`, Workspace, or Binding management routes through the
-Sandbox ingress.
+the complete signed query string and set its request-body limit above the
+configured file-size limit to leave room for multipart framing and headers; the
+two limits need not be numerically equal. Use response streaming and timeouts
+suitable for large downloads. Do not expose Agent Backend `/runs`, Workspace,
+or Binding management routes through the Sandbox ingress.
 
 Browser presentation URLs are independent. Configure Dify API `FILES_URL` to a
 browser-reachable public origin, or leave it empty so responses use same-origin

--- a/dify-agent/docs/dify-agent/user-manual/shell-layer/index.md
+++ b/dify-agent/docs/dify-agent/user-manual/shell-layer/index.md
@@ -93,6 +93,7 @@ topology.
 ```env
 DIFY_AGENT_STUB_API_BASE_URL=https://agent.example.com/agent-stub
 DIFY_AGENT_SANDBOX_FILES_BASE_URL=https://dify.example.com
+DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT=50
 DIFY_AGENT_SERVER_SECRET_KEY=replace-with-unpadded-base64url-for-32-random-bytes
 ```
 
@@ -100,6 +101,11 @@ HTTP URLs may be either the service root or the explicit `/agent-stub` root.
 The server normalizes a service root and rejects unrelated paths. The separate
 Sandbox file base must point to the Dify API ingress serving `/files/*`; it is
 used for CLI upload/download bytes, including Config file and skill pulls.
+`DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT` belongs to the Agent service, is in
+MiB, and defaults to `50`. The Agent service converts it to the signed upload
+URL's byte limit. Any ingress or proxy in front of `/files/*` must allow that
+file limit plus multipart framing and header overhead; its request-body limit
+does not need to be numerically identical.
 
 After `dify-agent file upload <path>` succeeds, the CLI prints JSON such as:
 

--- a/dify-agent/src/dify_agent/agent_stub/server/agent_stub_files.py
+++ b/dify-agent/src/dify_agent/agent_stub/server/agent_stub_files.py
@@ -103,7 +103,8 @@ class DifyApiAgentStubFileRequestHandler:
 
     The upload path calls ``/inner/api/agent/files/upload-request`` and injects the
     authenticated execution context's ``tenant_id``, ``user_id``, ``user_from``, and optional
-    ``conversation_id`` along with the requested filename and mimetype. The download path calls
+    ``conversation_id`` along with the requested filename, mimetype, and configured upload-size
+    limit. The download path calls
     ``/inner/api/agent/files/download-request`` and injects ``tenant_id``,
     ``user_id``, ``user_from``, and ``invoke_from`` plus the validated public
     file mapping.
@@ -119,6 +120,7 @@ class DifyApiAgentStubFileRequestHandler:
     inner_api_url: str
     inner_api_key: str
     sandbox_files_base_url: str
+    max_upload_size_bytes: int
     timeout: httpx.Timeout | float = 30.0
 
     async def create_upload_request(
@@ -147,6 +149,7 @@ class DifyApiAgentStubFileRequestHandler:
             "filename": request.filename,
             "mimetype": request.mimetype,
             "conversation_id": execution_context.conversation_id,
+            "max_size": self.max_upload_size_bytes,
         }
         data = await self._post_inner_api("/inner/api/agent/files/upload-request", payload)
         upload_uri = data.get("upload_uri")

--- a/dify-agent/src/dify_agent/server/settings.py
+++ b/dify-agent/src/dify_agent/server/settings.py
@@ -77,6 +77,12 @@ class ServerSettings(BaseSettings):
         default=None,
         validation_alias="DIFY_AGENT_SANDBOX_FILES_BASE_URL",
     )
+    stub_upload_file_size_limit: int = Field(
+        default=50,
+        ge=0,
+        description="Maximum Agent Stub upload size in MiB",
+        validation_alias="DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT",
+    )
     server_secret_key: str | None = None
     api_token: str | None = None
     shell_redact_patterns: str = ""
@@ -222,6 +228,7 @@ class ServerSettings(BaseSettings):
             inner_api_url=self.inner_api_url,
             inner_api_key=self.inner_api_key,
             sandbox_files_base_url=self.sandbox_files_base_url,
+            max_upload_size_bytes=self.stub_upload_file_size_limit * 1024 * 1024,
             timeout=self.create_outbound_http_timeout(),
         )
 

--- a/dify-agent/tests/local/dify_agent/agent_stub/protocol/test_agent_stub_protocol.py
+++ b/dify-agent/tests/local/dify_agent/agent_stub/protocol/test_agent_stub_protocol.py
@@ -15,6 +15,7 @@ from dify_agent.agent_stub.protocol.agent_stub import (
     AgentStubConfigDownloadSource,
     AgentStubFileDownloadRequest,
     AgentStubFileMapping,
+    AgentStubFileUploadRequest,
     agent_stub_connections_url,
     agent_stub_drive_base_for_ref,
     agent_stub_drive_commit_url,
@@ -52,6 +53,13 @@ def test_agent_stub_file_request_urls_handle_trailing_slash() -> None:
     assert agent_stub_file_download_request_url("https://agent.example.com/agent-stub") == (
         "https://agent.example.com/agent-stub/files/download-request"
     )
+
+
+def test_agent_stub_file_upload_request_rejects_client_max_size() -> None:
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        AgentStubFileUploadRequest.model_validate(
+            {"filename": "report.pdf", "mimetype": "application/pdf", "max_size": 1024}
+        )
 
 
 def test_agent_stub_drive_request_urls_handle_trailing_slash() -> None:

--- a/dify-agent/tests/local/dify_agent/agent_stub/server/test_agent_stub_files.py
+++ b/dify-agent/tests/local/dify_agent/agent_stub/server/test_agent_stub_files.py
@@ -47,6 +47,7 @@ def _file_handler(*, sandbox_files_base_url: str = "https://sandbox-files.exampl
         inner_api_url="https://api.internal.example.com",
         inner_api_key="inner-secret",
         sandbox_files_base_url=sandbox_files_base_url,
+        max_upload_size_bytes=50 * 1024 * 1024,
     )
 
 
@@ -66,6 +67,7 @@ def test_upload_request_uses_agent_inner_endpoint_and_binds_sandbox_base(monkeyp
             "filename": "report.pdf",
             "mimetype": "application/pdf",
             "conversation_id": "conversation-1",
+            "max_size": 50 * 1024 * 1024,
         }
         return httpx.Response(200, json={"upload_uri": "/files/upload/for-plugin?signed=yes"})
 

--- a/dify-agent/tests/local/dify_agent/server/test_settings.py
+++ b/dify-agent/tests/local/dify_agent/server/test_settings.py
@@ -97,12 +97,31 @@ def test_server_settings_defaults_shellctl_auth_token_to_none(
 def test_server_settings_reads_agent_stub_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DIFY_AGENT_STUB_API_BASE_URL", "https://agent.example.com/agent-stub/")
     monkeypatch.setenv("DIFY_AGENT_SANDBOX_FILES_BASE_URL", "https://dify.example.com/prefix/")
+    monkeypatch.setenv("DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT", "72")
     monkeypatch.setenv("DIFY_AGENT_SERVER_SECRET_KEY", _base64url_secret(secrets.token_bytes(32)))
 
     settings = ServerSettings()
 
     assert settings.agent_stub_api_base_url == "https://agent.example.com/agent-stub"
     assert settings.sandbox_files_base_url == "https://dify.example.com/prefix"
+    assert settings.stub_upload_file_size_limit == 72
+
+
+def test_server_settings_defaults_stub_upload_file_size_limit_to_50_mib(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert ServerSettings().stub_upload_file_size_limit == 50
+
+
+def test_server_settings_accepts_zero_and_rejects_negative_stub_upload_file_size_limit() -> None:
+    assert ServerSettings(stub_upload_file_size_limit=0).stub_upload_file_size_limit == 0
+
+    with pytest.raises(ValidationError):
+        _ = ServerSettings(stub_upload_file_size_limit=-1)
 
 
 def test_server_settings_normalizes_agent_stub_service_root_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -240,6 +259,7 @@ def test_server_settings_create_agent_stub_file_request_handler_returns_handler_
         inner_api_url="https://api.example.com",
         inner_api_key="inner-secret",
         sandbox_files_base_url="https://sandbox-files.example.com/dify",
+        stub_upload_file_size_limit=72,
     )
 
     handler = settings.create_agent_stub_file_request_handler()
@@ -248,6 +268,7 @@ def test_server_settings_create_agent_stub_file_request_handler_returns_handler_
     assert handler.inner_api_url == "https://api.example.com"
     assert handler.inner_api_key == "inner-secret"
     assert handler.sandbox_files_base_url == "https://sandbox-files.example.com/dify"
+    assert handler.max_upload_size_bytes == 72 * 1024 * 1024
 
 
 def test_server_settings_create_agent_stub_drive_request_handler_returns_none_without_full_settings() -> None:

--- a/docker/envs/core-services/dify-agent.env.example
+++ b/docker/envs/core-services/dify-agent.env.example
@@ -35,6 +35,8 @@ DIFY_AGENT_E2B_ACTIVE_TIMEOUT_SECONDS=3600
 DIFY_AGENT_E2B_SHELLCTL_PORT=5004
 # Sandbox-reachable Dify API base for signed /files/* transfers.
 DIFY_AGENT_SANDBOX_FILES_BASE_URL=http://api:5001
+# Maximum Agent Stub upload size in MiB; forwarded to Dify API as a signed byte limit.
+DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT=50
 DIFY_AGENT_STUB_API_BASE_URL=http://agent_backend:5050/agent-stub
 # This is security-sensitive: it derives the JWE encryption key for Agent Stub bearer tokens.
 # Replace this development default in production.


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Add the Agent service-owned `DIFY_AGENT_STUB_UPLOAD_FILE_SIZE_LIMIT` setting, defaulting to 50 MiB, and convert it to bytes when constructing the Agent Stub file-request handler.
- Send the byte limit as a required `max_size` field from Agent Backend to the Dify API inner upload-request endpoint without exposing it in the public Agent Stub upload DTO.
- Bind size-limited upload URLs with a versioned canonical JSON signature payload while preserving the existing legacy payload when `max_size` is absent.
- Read at most `max_size + 1` bytes for limited uploads and reject oversized files before creating a ToolFile.
- Keep ordinary plugin upload URLs unlimited by default, and document the Agent-owned setting and multipart ingress headroom.

Issue: N/A — scoped Agent Stub upload resource-boundary work.

## Root cause

Agent Stub and ordinary plugin uploads share `/files/upload/for-plugin`. The endpoint read the complete file without a size boundary before handing the bytes to ToolFile storage.

The upload limit also belongs to Agent Backend policy, but the first implementation placed it in Dify API configuration. That made the API own an Agent-specific limit instead of receiving the required policy value at the Agent-to-API boundary.

## Impact

Agent Backend now owns the Agent Stub upload limit and sends it as a required byte value to the Dify API inner endpoint. Dify API signs the value into the upload URL, so removing or increasing `max_size` invalidates the signature.

Uploads exceeding the signed limit return `413 file_too_large` before object storage or ToolFile creation. Existing plugin issuers omit `max_size`, retain their legacy signature payload, and continue using the current unlimited path.

This change does not add ticket single-use enforcement, Redis state, Agent CLI protocol fields, ToolFile schema changes, or storage-backend streaming. Werkzeug or the surrounding WSGI stack may still spool multipart content before controller execution.

## Validation

- Focused API unit tests: 27 passed.
- Focused Dify Agent tests: 77 passed.
- API and Dify Agent Ruff lint and format checks passed.
- Focused API Pyrefly and Mypy checks passed.
- Focused Dify Agent basedpyright check completed with 0 errors.
- Dify Agent MkDocs build passed.
- `git diff --check` passed after rebasing onto the latest `origin/main`.
- All five staged implementation reviews passed after scoped rework.

## Screenshots

N/A — backend upload policy, signed URL handling, configuration, tests, and documentation only.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

****This PR is made with gpt-5.6-sol (codex), while I'm responsible for all the changes.****