### PR TITLE
fix(dify-agent): use E2B traffic access header

### DIFF
--- a/dify-agent/src/dify_agent/runtime_backend/e2b.py
+++ b/dify-agent/src/dify_agent/runtime_backend/e2b.py
@@ -312,13 +312,13 @@ class E2BExecutionBindingBackend:
             raise BindingAcquireError("E2B sandbox did not provide a traffic access token")
         http_client = httpx.AsyncClient(
             base_url=entrypoint,
-            headers={"X-Access-Token": traffic_token},
+            headers={"e2b-traffic-access-token": traffic_token},
             follow_redirects=True,
             timeout=httpx.Timeout(60.0),
         )
 
         # Explicit token="" prevents process-level SHELLCTL_AUTH_TOKEN fallback;
-        # E2B port access is authenticated only by X-Access-Token above.
+        # E2B port access is authenticated only by e2b-traffic-access-token above.
         def client_factory() -> ShellctlClientProtocol:
             from shellctl.client import ShellctlClient
 

--- a/dify-agent/tests/local/dify_agent/runtime_backend/test_e2b.py
+++ b/dify-agent/tests/local/dify_agent/runtime_backend/test_e2b.py
@@ -336,7 +336,8 @@ async def test_e2b_acquire_retries_transient_shellctl_failures_until_ready(
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal attempts
         attempts += 1
-        assert request.headers["X-Access-Token"] == "traffic-token"
+        assert request.headers["e2b-traffic-access-token"] == "traffic-token"
+        assert "X-Access-Token" not in request.headers
         assert "Authorization" not in request.headers
         if attempts == 1:
             raise httpx.ReadTimeout("shellctl starting", request=request)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Send the non-empty E2B `traffic_access_token` with the `e2b-traffic-access-token` header required by restricted public sandbox URLs.
- Update the nearby transport-ownership comment so it no longer identifies `X-Access-Token` as the E2B traffic-token header.
- Strengthen the focused E2B acquisition test to assert the exact outgoing header and reject `X-Access-Token`.
- Keep the existing fail-closed behavior when E2B returns no traffic access token.

Issue: N/A — regression follow-up to #40871.

## Root cause

PR #40871 correctly disabled anonymous public traffic for newly created E2B sandboxes and required a non-empty `sandbox.traffic_access_token`. However, it sent that traffic token using `X-Access-Token`, which is the envd secure-access header rather than the public-port traffic-token header.

E2B's restricted-public-access proxy requires `e2b-traffic-access-token`. Production therefore rejected shellctl requests with HTTP 403 and reported that the required traffic-token header was missing even though Dify had received a valid token.

## Impact

E2B shellctl requests now cross the restricted public-port authentication boundary with the header E2B expects. RuntimeLease acquisition still fails before creating an HTTP client when the traffic token is absent or empty.

Process-level `SHELLCTL_AUTH_TOKEN` fallback remains disabled for this path. Local shellctl authentication, sandbox creation policy, port selection, retry behavior, and resource cleanup are unchanged.

## Validation

- Rebased onto current `origin/main` (`02f0e8cffa`) without conflicts.
- Focused E2B backend suite: 12 passed.
- Ruff lint and format checks passed for both changed Python files.
- Focused basedpyright check completed with 0 errors, 0 warnings, and 0 notes.
- `git diff --check` passed.

A live E2B deployment was not exercised locally; the regression test covers the exact outgoing HTTP header and the existing missing-token fail-closed cases.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A — backend E2B request authentication only. | N/A — backend E2B request authentication only. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

****This PR is made with gpt-5.6-sol (codex), while I'm responsible for all the changes.****