### PR TITLE
fix(api): enforce edit and RBAC permissions on model provider credential GET endpoints (#40899)

### DIFF
--- a/api/controllers/console/workspace/model_providers.py
+++ b/api/controllers/console/workspace/model_providers.py
@@ -209,6 +209,8 @@ class ModelProviderCredentialApi(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str, provider: str):

--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -349,6 +349,8 @@ class ModelProviderModelCredentialApi(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -5,6 +5,8 @@ import pytest
 
 from controllers.common.wraps import RBACPermission, RBACResourceScope
 from controllers.console.datasets.data_source import DataSourceApi
+from controllers.console.workspace.model_providers import ModelProviderCredentialApi
+from controllers.console.workspace.models import ModelProviderModelCredentialApi
 from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddApi
 
 
@@ -26,3 +28,26 @@ def test_workspace_credential_mutations_require_management_permission(
     assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
     assert rbac_config["scene"] == permission
     assert rbac_config["resource_required"] is False
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        ModelProviderCredentialApi.get,
+        ModelProviderModelCredentialApi.get,
+    ],
+)
+def test_model_provider_credential_get_requires_admin_and_rbac(
+    method: FunctionType,
+) -> None:
+    """GET endpoints that return provider credential details must enforce
+    the same admin + RBAC gates as their sibling POST/PUT/DELETE methods."""
+    legacy_wrapper = unwrap(method, stop=lambda wrapper: "is_admin_or_owner_required" in wrapper.__code__.co_qualname)
+    assert "is_admin_or_owner_required" in legacy_wrapper.__code__.co_qualname
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
+    assert rbac_config["scene"] == RBACPermission.CREDENTIAL_MANAGE
+    assert rbac_config["resource_required"] is False
+

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -50,4 +50,3 @@ def test_model_provider_credential_get_requires_admin_and_rbac(
     assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
     assert rbac_config["scene"] == RBACPermission.CREDENTIAL_MANAGE
     assert rbac_config["resource_required"] is False
-


### PR DESCRIPTION
## Summary

Fixes #40899

The `GET /console/api/workspaces/current/model-providers/<provider>/credentials` and `GET /console/api/workspaces/current/model-providers/<provider>/models/credentials` endpoints were missing authorization decorators:
- `@is_admin_or_owner_required`
- `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)`

This allowed workspace members without admin/owner roles or credential management RBAC permissions to fetch provider credential configuration details.

Added missing permission decorators to match sibling `post`, `put`, and `delete` endpoints and added corresponding unit test assertions.

## Screenshots

N/A (Backend API permission enforcement)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
