### PR TITLE
fix(api): repair two malformed logger format strings

### DIFF
--- a/api/controllers/trigger/trigger.py
+++ b/api/controllers/trigger/trigger.py
@@ -39,5 +39,5 @@ def trigger_endpoint(endpoint_id: str):
     except ValueError as e:
         return jsonify({"error": "Endpoint processing failed", "message": str(e)}), 400
     except Exception:
-        logger.exception("Webhook processing failed for {endpoint_id}")
+        logger.exception("Webhook processing failed for %s", endpoint_id)
         return jsonify({"error": "Internal server error"}), 500

--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -262,7 +262,7 @@ class HumanInputFormApi(Resource):
             raise NotFoundError("Form not found")
 
         if (recipient_type := form.recipient_type) is None:
-            logger.warning("Recipient type is None for form, form_id=%", form.id)
+            logger.warning("Recipient type is None for form, form_id=%s", form.id)
             raise AssertionError("Recipient type is None")
 
         try:

--- a/api/tests/unit_tests/controllers/trigger/test_trigger.py
+++ b/api/tests/unit_tests/controllers/trigger/test_trigger.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -71,3 +72,11 @@ class TestTriggerEndpoint:
 
         assert status == 500
         assert response["error"] == "Internal server error"
+
+    @patch.object(module.TriggerService, "process_endpoint", side_effect=Exception("boom"))
+    def test_unexpected_exception_logs_endpoint_id(self, mock_trigger, caplog):
+        with caplog.at_level(logging.ERROR, logger=module.logger.name):
+            module.trigger_endpoint(VALID_UUID)
+
+        assert VALID_UUID in caplog.text
+        assert "{endpoint_id}" not in caplog.text


### PR DESCRIPTION
## Summary

Fixes #40898.

Two logger calls in `api/controllers` use malformed format strings and produce no usable output.

**`api/controllers/web/human_input_form.py`** ended its format string in a bare `%` with no conversion character:

```python
logger.warning("Recipient type is None for form, form_id=%", form.id)
```

`logging` defers `msg % args` until a handler formats the record, so this raises `ValueError: incomplete format` inside the handler. The record is dropped and a `--- Logging error ---` traceback goes to stderr instead. The call sits immediately before `raise AssertionError("Recipient type is None")`, so the one line identifying the affected form is exactly the one that gets lost.

**`api/controllers/trigger/trigger.py`** used brace syntax in a `%`-style call, with no argument passed:

```python
logger.exception("Webhook processing failed for {endpoint_id}")
```

The literal text `{endpoint_id}` was emitted, so every webhook trigger failure logged an identical line with no way to tell which endpoint failed. Line 36 of the same function already used the correct lazy form, `logger.info("Endpoint not found for %s", endpoint_id)`.

Both are corrected to lazy `%s` interpolation, which is the style `.ruff.toml` already enforces via `G001`/`G003`/`G004`. Neither defect was caught by those rules: one is a malformed `%` conversion, the other a plain string literal that merely looks like a template.

### Notes for reviewers

- These are the only two malformed logger format strings in the repository. An AST sweep over every `logger.{debug,info,warning,error,exception,critical}` call in `api/` taking a constant format string — checking `%`-placeholder arity and stray `{...}` placeholders — finds no others.
- The regression test covers the `trigger.py` path, where an existing unit-test harness already exercises the exception branch. The `human_input_form.py` line is a one-character fix with no unit-test harness for the `web/` variant (only `console/`, `openapi/` and `service_api/` have one; `web/` is covered solely by a containers integration test), so no unit test accompanies it.
- `api/controllers/openapi/human_input_form.py:110` already contains the correct version of the same log line, which is what the `web/` variant appears to have been copied from.

### Verification

```
pytest tests/unit_tests/controllers/trigger/test_trigger.py   ->  7 passed
ruff format --check <changed files>                           ->  3 files already formatted
ruff check <changed files>                                    ->  All checks passed
mypy <changed source files>                                   ->  0 errors in changed files
pyrefly check <changed source files>                           ->  0 diagnostics
```

The new test was confirmed to fail against the unpatched `trigger.py` and pass with the fix.

Lint and type checks were run scoped to the changed files rather than via the repo-wide `make lint` / `make type-check` targets, because a full local sync cannot complete on Windows: `chroma-hnswlib==0.7.6` (pulled in transitively by the `vdb-all` group) has no wheel and requires MSVC C++ build tools. That is unrelated to this change.

## Screenshots

N/A — no user-facing change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
