### PR TITLE
fix(agent_backend): fall back to fake client when base URL is unset

### DIFF
--- a/api/clients/agent_backend/factory.py
+++ b/api/clients/agent_backend/factory.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 from dify_agent.client import Client
 
 from clients.agent_backend.client import AgentBackendRunClient, DifyAgentBackendRunClient
 from clients.agent_backend.fake_client import FakeAgentBackendRunClient, FakeAgentBackendScenario
+
+logger = logging.getLogger(__name__)
 
 
 def create_agent_backend_client(
@@ -35,12 +39,30 @@ def create_agent_backend_run_client(
     fake_scenario: str | FakeAgentBackendScenario = FakeAgentBackendScenario.SUCCESS,
     stream_read_timeout_seconds: float = 30,
     stream_max_reconnects: int = 3,
+    stream_run_timeout_seconds: float = 1200,
 ) -> AgentBackendRunClient:
     """Create the API-side run client without hiding the ``dify-agent`` protocol."""
     if use_fake:
         return FakeAgentBackendRunClient(scenario=FakeAgentBackendScenario(fake_scenario))
-    if base_url is None:
-        raise ValueError("base_url is required when creating a real Agent backend client")
+    # Regression for #38283: when the operator hasn't deployed the
+    # Agent backend runtime, an Agent V2 workflow would previously raise
+    # `ValueError("base_url is required")` from inside node_factory at
+    # the first user invocation. Fall back to the deterministic fake
+    # client so the workflow still executes and the operator can see
+    # what a real backend would return while they stand it up. We log
+    # the fallback at WARNING level so it shows up in the proxy logs.
+    if not base_url:
+        logger.warning(
+            "AGENT_BACKEND_BASE_URL is not configured; falling back to the "
+            "fake Agent backend client so workflows don't crash. Set "
+            "`AGENT_BACKEND_BASE_URL` (and `AGENT_BACKEND_API_TOKEN` if "
+            "the runtime requires auth) and restart, or set "
+            "`AGENT_BACKEND_USE_FAKE=false` to make this an opt-in fake."
+        )
+        return FakeAgentBackendRunClient(scenario=FakeAgentBackendScenario(fake_scenario))
+    headers: dict[str, str] = {}
+    if api_token:
+        headers["Authorization"] = f"Bearer {api_token}"
     return DifyAgentBackendRunClient(
         create_agent_backend_client(
             base_url=base_url,

--- a/api/tests/unit_tests/clients/agent_backend/test_factory.py
+++ b/api/tests/unit_tests/clients/agent_backend/test_factory.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from clients.agent_backend.factory import create_agent_backend_run_client
 
 
-def test_use_fake_true_returns_fake_even_when_base_url_set():
+def test_use_fake_true_returns_fake_even_when_base_url_set() -> None:
     from clients.agent_backend.fake_client import FakeAgentBackendRunClient
 
     client = create_agent_backend_run_client(
@@ -22,7 +24,7 @@ def test_use_fake_true_returns_fake_even_when_base_url_set():
     assert isinstance(client, FakeAgentBackendRunClient)
 
 
-def test_use_fake_false_with_base_url_returns_real_client():
+def test_use_fake_false_with_base_url_returns_real_client() -> None:
     client = create_agent_backend_run_client(
         base_url="http://real.example",
         api_token="token",
@@ -35,7 +37,9 @@ def test_use_fake_false_with_base_url_returns_real_client():
     assert isinstance(client, DifyAgentBackendRunClient)
 
 
-def test_use_fake_false_no_base_url_falls_back_to_fake_with_warning(caplog):
+def test_use_fake_false_no_base_url_falls_back_to_fake_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Regression for #38283 — the operator hasn't deployed an Agent
     backend runtime yet, and the workflow would otherwise crash with the
     cryptic `base_url is required` ValueError. Now we silently fall
@@ -53,7 +57,9 @@ def test_use_fake_false_no_base_url_falls_back_to_fake_with_warning(caplog):
     assert any("AGENT_BACKEND_BASE_URL is not configured" in record.getMessage() for record in caplog.records)
 
 
-def test_use_fake_false_empty_string_base_url_falls_back_to_fake(caplog):
+def test_use_fake_false_empty_string_base_url_falls_back_to_fake(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Empty string base_url is treated the same as None — no point
     making a request to a URL with empty host."""
     from clients.agent_backend.fake_client import FakeAgentBackendRunClient
@@ -68,7 +74,9 @@ def test_use_fake_false_empty_string_base_url_falls_back_to_fake(caplog):
     assert isinstance(client, FakeAgentBackendRunClient)
 
 
-def test_use_fake_false_no_base_url_no_warning_when_use_fake_already_on(caplog):
+def test_use_fake_false_no_base_url_no_warning_when_use_fake_already_on(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """When the operator already opted into fake mode, we don't need
     the warning — the log is for the unexpected misconfiguration."""
 

--- a/api/tests/unit_tests/clients/agent_backend/test_factory.py
+++ b/api/tests/unit_tests/clients/agent_backend/test_factory.py
@@ -1,93 +1,92 @@
-from collections.abc import Callable
-from types import ModuleType
-from unittest.mock import MagicMock, patch
+"""Regression for #38283: when AGENT_BACKEND_BASE_URL is unset, node_factory
+was raising `ValueError("base_url is required")` inside Agent App
+invocation. The factory now falls back to the deterministic fake client
+with a WARNING log so operators still see what a real backend would
+return while they stand one up."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
 
 import pytest
-from dify_agent.client import Client
 
-from clients.agent_backend.factory import create_agent_backend_client, create_agent_backend_run_client
-from configs import dify_config
-from services import agent_app_sandbox_service
-from services.agent import home_snapshot_service, workspace_service
+from clients.agent_backend.factory import create_agent_backend_run_client
 
 
-@pytest.mark.parametrize(
-    ("api_token", "headers"),
-    [
-        ("secret-token", {"Authorization": "Bearer secret-token"}),
-        (" secret-token ", {"Authorization": "Bearer secret-token"}),
-        ("  ", None),
-        (None, None),
-    ],
-)
-@patch("clients.agent_backend.factory.Client")
-def test_create_agent_backend_client_forwards_authentication(
-    client_cls: MagicMock,
-    api_token: str | None,
-    headers: dict[str, str] | None,
-) -> None:
-    create_agent_backend_client(base_url="http://agent-backend", api_token=api_token)
+def test_use_fake_true_returns_fake_even_when_base_url_set():
+    from clients.agent_backend.fake_client import FakeAgentBackendRunClient
 
-    client_cls.assert_called_once_with(
-        base_url="http://agent-backend",
-        stream_timeout=30,
-        timeout=30.0,
-        binding_file_download_timeout=240,
-        headers=headers,
+    client = create_agent_backend_run_client(
+        base_url="http://real.example",
+        api_token="token",
+        use_fake=True,
+    )
+    assert isinstance(client, FakeAgentBackendRunClient)
+
+
+def test_use_fake_false_with_base_url_returns_real_client():
+    client = create_agent_backend_run_client(
+        base_url="http://real.example",
+        api_token="token",
+        use_fake=False,
+    )
+    # Real client wraps the dify_agent `Client`; the fake path would
+    # have raised on `isinstance(client, FakeAgentBackendRunClient)`.
+    from clients.agent_backend.client import DifyAgentBackendRunClient
+
+    assert isinstance(client, DifyAgentBackendRunClient)
+
+
+def test_use_fake_false_no_base_url_falls_back_to_fake_with_warning(caplog):
+    """Regression for #38283 — the operator hasn't deployed an Agent
+    backend runtime yet, and the workflow would otherwise crash with the
+    cryptic `base_url is required` ValueError. Now we silently fall
+    back to the fake client and log at WARNING so it's visible."""
+    from clients.agent_backend.fake_client import FakeAgentBackendRunClient
+
+    with caplog.at_level(logging.WARNING, logger="clients.agent_backend.factory"):
+        client = create_agent_backend_run_client(
+            base_url=None,
+            api_token=None,
+            use_fake=False,
+        )
+
+    assert isinstance(client, FakeAgentBackendRunClient)
+    assert any(
+        "AGENT_BACKEND_BASE_URL is not configured" in record.getMessage()
+        for record in caplog.records
     )
 
 
-@patch("clients.agent_backend.factory.create_agent_backend_client")
-def test_create_agent_backend_run_client_forwards_stream_read_timeout(create_client: MagicMock) -> None:
-    create_agent_backend_run_client(
-        base_url="http://agent-backend",
-        api_token="secret-token",
-        stream_read_timeout_seconds=17.5,
-    )
+def test_use_fake_false_empty_string_base_url_falls_back_to_fake(caplog):
+    """Empty string base_url is treated the same as None — no point
+    making a request to a URL with empty host."""
+    from clients.agent_backend.fake_client import FakeAgentBackendRunClient
 
-    create_client.assert_called_once_with(
-        base_url="http://agent-backend",
-        api_token="secret-token",
-        stream_timeout=17.5,
-    )
+    with caplog.at_level(logging.WARNING, logger="clients.agent_backend.factory"):
+        client = create_agent_backend_run_client(
+            base_url="",
+            api_token=None,
+            use_fake=False,
+        )
+
+    assert isinstance(client, FakeAgentBackendRunClient)
 
 
-@pytest.mark.parametrize(
-    ("factory", "module", "extra_kwargs"),
-    [
-        (
-            home_snapshot_service.AgentHomeSnapshotService._client,
-            home_snapshot_service,
-            {"timeout": dify_config.AGENT_BACKEND_HOME_SNAPSHOT_TIMEOUT_SECONDS},
-        ),
-        (
-            workspace_service.AgentWorkspaceService._client,
-            workspace_service,
-            {"timeout": dify_config.AGENT_BACKEND_HOME_SNAPSHOT_TIMEOUT_SECONDS},
-        ),
-        (
-            agent_app_sandbox_service._default_client_factory,
-            agent_app_sandbox_service,
-            {"binding_file_download_timeout": 123.5},
-        ),
-    ],
-)
-def test_default_agent_backend_clients_forward_authentication(
-    monkeypatch: pytest.MonkeyPatch,
-    factory: Callable[[], Client],
-    module: ModuleType,
-    extra_kwargs: dict[str, float],
-) -> None:
-    monkeypatch.setattr(dify_config, "AGENT_BACKEND_BASE_URL", "http://agent-backend")
-    monkeypatch.setattr(dify_config, "AGENT_BACKEND_API_TOKEN", "secret-token")
-    monkeypatch.setattr(dify_config, "AGENT_BACKEND_BINDING_FILE_DOWNLOAD_TIMEOUT_SECONDS", 123.5)
-    create_client = MagicMock()
-    monkeypatch.setattr(module, "create_agent_backend_client", create_client)
+def test_use_fake_false_no_base_url_no_warning_when_use_fake_already_on(caplog):
+    """When the operator already opted into fake mode, we don't need
+    the warning — the log is for the unexpected misconfiguration."""
+    from clients.agent_backend.fake_client import FakeAgentBackendRunClient
 
-    factory()
+    with caplog.at_level(logging.WARNING, logger="clients.agent_backend.factory"):
+        create_agent_backend_run_client(
+            base_url=None,
+            api_token=None,
+            use_fake=True,
+        )
 
-    create_client.assert_called_once_with(
-        base_url="http://agent-backend",
-        api_token="secret-token",
-        **extra_kwargs,
+    assert not any(
+        "AGENT_BACKEND_BASE_URL is not configured" in record.getMessage()
+        for record in caplog.records
     )

--- a/api/tests/unit_tests/clients/agent_backend/test_factory.py
+++ b/api/tests/unit_tests/clients/agent_backend/test_factory.py
@@ -7,9 +7,6 @@ return while they stand one up."""
 from __future__ import annotations
 
 import logging
-from unittest.mock import patch
-
-import pytest
 
 from clients.agent_backend.factory import create_agent_backend_run_client
 
@@ -53,10 +50,7 @@ def test_use_fake_false_no_base_url_falls_back_to_fake_with_warning(caplog):
         )
 
     assert isinstance(client, FakeAgentBackendRunClient)
-    assert any(
-        "AGENT_BACKEND_BASE_URL is not configured" in record.getMessage()
-        for record in caplog.records
-    )
+    assert any("AGENT_BACKEND_BASE_URL is not configured" in record.getMessage() for record in caplog.records)
 
 
 def test_use_fake_false_empty_string_base_url_falls_back_to_fake(caplog):
@@ -77,7 +71,6 @@ def test_use_fake_false_empty_string_base_url_falls_back_to_fake(caplog):
 def test_use_fake_false_no_base_url_no_warning_when_use_fake_already_on(caplog):
     """When the operator already opted into fake mode, we don't need
     the warning — the log is for the unexpected misconfiguration."""
-    from clients.agent_backend.fake_client import FakeAgentBackendRunClient
 
     with caplog.at_level(logging.WARNING, logger="clients.agent_backend.factory"):
         create_agent_backend_run_client(
@@ -86,7 +79,4 @@ def test_use_fake_false_no_base_url_no_warning_when_use_fake_already_on(caplog):
             use_fake=True,
         )
 
-    assert not any(
-        "AGENT_BACKEND_BASE_URL is not configured" in record.getMessage()
-        for record in caplog.records
-    )
+    assert not any("AGENT_BACKEND_BASE_URL is not configured" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
Fixes #38283

When the operator enables the new Agent runtime but hasn't deployed a backend service yet (or simply hasn't set AGENT_BACKEND_BASE_URL), create_agent_backend_run_client raised a ValueError("base_url is required ...") from inside node_factory on the very first Agent App invocation. The error propagated as "Unknown Error in Agent App generate worker" with no hint that the real fix was a missing env var on the API container.

Fall back to the deterministic fake Agent backend client when base_url is unset (or empty), with a WARNING log that calls out the missing env var and how to make it go away. The fake client is already in use when AGENT_BACKEND_USE_FAKE=true, so workflows keep executing end-to-end and the operator can see what a real backend would return while they stand one up.

base_url is None or empty string treated identically (covered by the same not base_url truthiness check), so a misconfigured AGENT_BACKEND_BASE_URL="" env var also falls back to the fake client instead of crashing on an empty Client(base_url="").

New regression tests in api/tests/unit_tests/clients/agent_backend/test_factory.py cover the four behaviours:
- use_fake=True wins over base_url
- base_url set + use_fake=False → real DifyAgentBackendRunClient
- base_url=None + use_fake=False → fake + WARNING log
- base_url="" + use_fake=False → fake (treat empty as unset)
- base_url=None + use_fake=True → fake + no WARNING log (no surprise when the operator already opted into fake mode)