### PR TITLE
fix(api): clear stale cancellation signals when resuming a paused workflow

### DIFF
--- a/api/core/app/apps/execution_coordinator.py
+++ b/api/core/app/apps/execution_coordinator.py
@@ -8,6 +8,7 @@ from enum import Enum, auto
 
 from configs import dify_config
 from extensions.ext_redis import redis_client
+from graphon.graph_engine.command_channels import RedisChannel
 from graphon.graph_engine.manager import GraphEngineManager
 
 logger = logging.getLogger(__name__)
@@ -20,11 +21,50 @@ class AppExecutionState(Enum):
     TERMINAL = auto()
 
 
+def app_task_command_channel_key(task_id: str) -> str:
+    """Redis key of the GraphEngine command channel for one app task."""
+    return f"workflow:{task_id}:commands"
+
+
 def set_app_task_stop_flag(task_id: str) -> None:
     if not task_id:
         return
 
     redis_client.setex(f"generate_task_stopped:{task_id}", 600, 1)
+
+
+def clear_app_task_cancellation_signals(task_id: str) -> None:
+    """Discard cancellation signals left over from earlier attempts of one task.
+
+    Both cancellation channels are keyed by task ID and outlive the attempt that
+    armed them: the stop flag lives for 600 seconds and a queued ``AbortCommand``
+    for an hour, and neither is consumed while no engine is running. A resumed
+    workflow deliberately reuses the paused run's task ID, so without this reset
+    it inherits those signals and aborts itself as soon as it starts. Call this
+    only when starting a new attempt that is meant to run, never mid-execution.
+    """
+    if not task_id:
+        return
+
+    try:
+        redis_client.delete(f"generate_task_stopped:{task_id}")
+    except Exception:
+        logger.exception("Failed to clear stop flag for app task %s", task_id)
+
+    channel_key = app_task_command_channel_key(task_id)
+    try:
+        # fetch_commands() drains the queue and its pending marker together; the
+        # explicit delete covers a queue whose marker was already consumed.
+        discarded = RedisChannel(redis_client, channel_key).fetch_commands()
+        redis_client.delete(channel_key)
+        if discarded:
+            logger.info(
+                "Discarded %s stale GraphEngine command(s) for app task %s",
+                len(discarded),
+                task_id,
+            )
+    except Exception:
+        logger.exception("Failed to clear pending GraphEngine commands for app task %s", task_id)
 
 
 class AppExecutionCoordinator:

--- a/api/core/app/apps/workflow/app_runner.py
+++ b/api/core/app/apps/workflow/app_runner.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import cast
 
 from core.app.apps.base_app_queue_manager import AppQueueManager
+from core.app.apps.execution_coordinator import app_task_command_channel_key
 from core.app.apps.workflow.app_config_manager import WorkflowAppConfig
 from core.app.apps.workflow.command_channels import (
     CelerySignalCommandChannel,
@@ -153,7 +154,7 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
         # RUN WORKFLOW
         # Create Redis command channel for this workflow execution
         task_id = self.application_generate_entity.task_id
-        channel_key = f"workflow:{task_id}:commands"
+        channel_key = app_task_command_channel_key(task_id)
         celery_signal_channel = CelerySignalCommandChannel(
             shutdown_state_getter=celery_warm_shutdown_started,
             abort_reason=WORKFLOW_WARM_SHUTDOWN_ABORT_REASON,

--- a/api/tasks/app_generate/workflow_execute_task.py
+++ b/api/tasks/app_generate/workflow_execute_task.py
@@ -12,6 +12,7 @@ from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.app.apps.advanced_chat.app_generator import AdvancedChatAppGenerator
+from core.app.apps.execution_coordinator import clear_app_task_cancellation_signals
 from core.app.apps.message_based_app_generator import MessageBasedAppGenerator
 from core.app.apps.workflow.app_generator import WorkflowAppGenerator
 from core.app.entities.app_invoke_entities import (
@@ -557,6 +558,12 @@ def _resume_app_execution(payload: dict[str, Any]) -> None:
             type(generate_entity),
         )
         return
+
+    # The resumed attempt reuses the paused run's task ID, so cancellation
+    # signals armed against that ID before or during the pause would abort it
+    # immediately and report it as stopped by the user. This attempt is starting
+    # deliberately, so drop them before any engine can observe them.
+    clear_app_task_cancellation_signals(generate_entity.task_id)
 
     workflow_run_repo.resume_workflow_pause(workflow_run_id, pause_entity)
 

--- a/api/tests/unit_tests/core/app/apps/test_execution_coordinator.py
+++ b/api/tests/unit_tests/core/app/apps/test_execution_coordinator.py
@@ -2,7 +2,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from core.app.apps.execution_coordinator import AppExecutionCoordinator, AppExecutionState
+from core.app.apps.execution_coordinator import (
+    AppExecutionCoordinator,
+    AppExecutionState,
+    app_task_command_channel_key,
+    clear_app_task_cancellation_signals,
+)
 
 
 def test_listener_close_does_not_abort_running_attempt() -> None:
@@ -72,6 +77,54 @@ def test_pausing_started_attempt_cancels_watchdog() -> None:
     watchdog.start.assert_called_once()
     watchdog.cancel.assert_called_once()
     assert coordinator.state is AppExecutionState.PAUSED
+
+
+def test_clearing_cancellation_signals_drops_stop_flag_and_queued_commands() -> None:
+    channel = Mock()
+    channel.fetch_commands.return_value = [Mock()]
+    with (
+        patch("core.app.apps.execution_coordinator.redis_client") as redis_client,
+        patch("core.app.apps.execution_coordinator.RedisChannel", return_value=channel) as redis_channel,
+    ):
+        clear_app_task_cancellation_signals("task")
+
+    redis_channel.assert_called_once_with(redis_client, "workflow:task:commands")
+    channel.fetch_commands.assert_called_once_with()
+    assert redis_client.delete.call_args_list == [
+        (("generate_task_stopped:task",), {}),
+        (("workflow:task:commands",), {}),
+    ]
+
+
+def test_clearing_cancellation_signals_ignores_empty_task_id() -> None:
+    with (
+        patch("core.app.apps.execution_coordinator.redis_client") as redis_client,
+        patch("core.app.apps.execution_coordinator.RedisChannel") as redis_channel,
+    ):
+        clear_app_task_cancellation_signals("")
+
+    redis_client.delete.assert_not_called()
+    redis_channel.assert_not_called()
+
+
+def test_clearing_cancellation_signals_survives_command_channel_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        patch("core.app.apps.execution_coordinator.redis_client") as redis_client,
+        patch("core.app.apps.execution_coordinator.RedisChannel") as redis_channel,
+    ):
+        redis_channel.return_value.fetch_commands.side_effect = RuntimeError("redis read failed")
+
+        clear_app_task_cancellation_signals("task")
+
+    # The stop flag is cleared first, so a command-channel failure cannot leave it armed.
+    redis_client.delete.assert_called_once_with("generate_task_stopped:task")
+    assert "Failed to clear pending GraphEngine commands for app task task" in caplog.text
+
+
+def test_command_channel_key_matches_the_channel_the_stop_command_targets() -> None:
+    assert app_task_command_channel_key("task") == "workflow:task:commands"
 
 
 def test_stop_flag_failure_does_not_block_graph_stop(caplog: pytest.LogCaptureFixture) -> None:

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -852,6 +852,108 @@ def test_resume_app_execution_returns_early_when_advanced_chat_missing_conversat
     resume_advanced_chat.assert_not_called()
 
 
+def test_resume_app_execution_clears_stale_cancellation_signals_before_resuming(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_engine: Engine,
+    sqlite_session_factory: sessionmaker[Session],
+):
+    """A resumed run reuses the paused task ID, so it must not inherit its cancellation signals.
+
+    Regression test for #40878: a stop flag or queued AbortCommand left over from
+    an earlier attempt of the same task aborted the resumed run, which then
+    finished as "Stopped by user".
+    """
+    workflow_run_id = "run-id"
+    _persist_resumption_models(sqlite_session_factory, workflow_run_id=workflow_run_id)
+
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task.db", SimpleNamespace(engine=sqlite_engine))
+
+    pause_entity = MagicMock()
+    pause_entity.get_state.return_value = b"state"
+
+    workflow_run_repo = MagicMock()
+    workflow_run_repo.get_workflow_pause.return_value = pause_entity
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.DifyAPIRepositoryFactory.create_api_workflow_run_repository",
+        lambda *_args, **_kwargs: workflow_run_repo,
+    )
+
+    generate_entity = _build_workflow_generate_entity(stream=False)
+    resumption_context = MagicMock()
+    resumption_context.serialized_graph_runtime_state = "{}"
+    resumption_context.get_generate_entity.return_value = generate_entity
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.WorkflowResumptionContext.loads",
+        lambda *_args, **_kwargs: resumption_context,
+    )
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.GraphRuntimeState.from_snapshot",
+        lambda *_args, **_kwargs: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task._resolve_user_for_run", lambda *_args, **_kwargs: MagicMock()
+    )
+
+    calls: list[str] = []
+    clear_signals = MagicMock(side_effect=lambda task_id: calls.append(f"clear:{task_id}"))
+    resume_workflow = MagicMock(side_effect=lambda **_kwargs: calls.append("resume"))
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task.clear_app_task_cancellation_signals", clear_signals)
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task._resume_workflow", resume_workflow)
+
+    _resume_app_execution({"workflow_run_id": workflow_run_id})
+
+    clear_signals.assert_called_once_with(generate_entity.task_id)
+    # Clearing after the engine started would let it observe the stale abort first.
+    assert calls == [f"clear:{generate_entity.task_id}", "resume"]
+
+
+def test_resume_app_execution_keeps_cancellation_signals_when_resume_is_abandoned(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_engine: Engine,
+    sqlite_session_factory: sessionmaker[Session],
+):
+    """No attempt is starting, so nothing may clear the signals guarding this task."""
+    workflow_run_id = "run-id"
+    _persist_resumption_models(sqlite_session_factory, workflow_run_id=workflow_run_id)
+
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task.db", SimpleNamespace(engine=sqlite_engine))
+
+    pause_entity = MagicMock()
+    pause_entity.get_state.return_value = b"state"
+
+    workflow_run_repo = MagicMock()
+    workflow_run_repo.get_workflow_pause.return_value = pause_entity
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.DifyAPIRepositoryFactory.create_api_workflow_run_repository",
+        lambda *_args, **_kwargs: workflow_run_repo,
+    )
+
+    # Missing conversation id makes the advanced-chat resume bail out before running.
+    generate_entity = _build_advanced_chat_generate_entity(conversation_id=None)
+    resumption_context = MagicMock()
+    resumption_context.serialized_graph_runtime_state = "{}"
+    resumption_context.get_generate_entity.return_value = generate_entity
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.WorkflowResumptionContext.loads",
+        lambda *_args, **_kwargs: resumption_context,
+    )
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.GraphRuntimeState.from_snapshot",
+        lambda *_args, **_kwargs: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task._resolve_user_for_run", lambda *_args, **_kwargs: MagicMock()
+    )
+
+    clear_signals = MagicMock()
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task.clear_app_task_cancellation_signals", clear_signals)
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task._resume_advanced_chat", MagicMock())
+
+    _resume_app_execution({"workflow_run_id": workflow_run_id})
+
+    clear_signals.assert_not_called()
+
+
 def test_resume_advanced_chat_publishes_events_for_originally_blocking_runs(
     monkeypatch: pytest.MonkeyPatch,
     sqlite_session: Session,


### PR DESCRIPTION
## Summary

- Clear the task-scoped cancellation signals for a paused workflow run when it is resumed, so a resumed attempt cannot inherit a cancellation armed by an earlier attempt of the same task and abort itself as "Stopped by user".
- Reset both signals in `_resume_app_execution`: the `generate_task_stopped:{task_id}` Redis flag and any queued `AbortCommand` on `workflow:{task_id}:commands`, including its pending marker.
- Place the reset after the validation early-returns, so an abandoned resume leaves the task guarded, and before any engine starts, so no engine can observe a stale signal. Workflow and Chatflow share this path, so both are covered.
- Give the GraphEngine command-channel key one definition (`app_task_command_channel_key`) instead of a literal duplicated between the runner and the new reset.
- Add regression coverage for the reset itself and for the resume ordering that makes it effective.

Fixes #40878

## Root cause

A Human Input resume deliberately reuses the paused run's task ID: it is serialized into the pause state via `WorkflowResumptionContext` and restored in `_resume_app_execution`. Both cancellation channels, however, are keyed by task rather than by execution attempt, and nothing ever cleared them:

| Signal | TTL | Cleared by |
| --- | --- | --- |
| `generate_task_stopped:{task_id}` | 600s | nothing — only ever `setex`, never deleted |
| queued `AbortCommand` on `workflow:{task_id}:commands` | 3600s | only a running engine that polls the channel |

While a run is paused, no engine polls that channel, so both signals sit armed and are inherited by the resumed attempt. The resumed listener observes the flag in `AppQueueManager.listen()` and publishes `QueueStopEvent(stopped_by=USER_MANUAL)` with no reason — the only site in the backend that produces the literal `"Stopped by user."`, since every other stop path passes an explicit reason.

The condition also self-sustains. Once the flag is set, every later listener segment for that task re-triggers `request_abort()`, which resends the abort command and refreshes its one-hour TTL.

`AppExecutionCoordinator` already documents the intended invariant — "A resumed workflow creates a new coordinator even when it reuses the stable task ID" — but a fresh in-process coordinator cannot enforce it, because these two signals live in Redis, outside the process, keyed by task rather than by attempt.

#39485 and #39813 stopped one producer (listener detach) from arming the flag, but neither disarms it, so any remaining producer still reproduces the report on `main`.

## Impact

- A Human Input workflow now resumes and runs to completion even when a cancellation signal was armed against its task ID before or during the pause.
- Behaviour change worth calling out: a stop issued while a run is paused is now dropped on resume. Previously that stop had no visible effect at the time — the run stayed `paused` and the form stayed open — and only materialised minutes later if a form submission happened to land inside the 600-second window. Stopping a paused run deserves explicit handling at the endpoint; that is deliberately not in this PR.
- No change for non-resumable runs. Their task IDs are unique per run, so there is nothing to inherit.

## Tests

Added:

- `tests/unit_tests/core/app/apps/test_execution_coordinator.py` — both keys cleared, empty task ID is a no-op, the stop flag is still cleared when the command channel errors, and the key matches the channel `send_stop_command` targets.
- `tests/unit_tests/tasks/test_workflow_execute_task.py` — the reset runs on resume with the reused task ID and runs *before* the engine starts (asserted by call ordering, since clearing afterwards would be useless), and an abandoned resume does not clear.

Verified the new tests are not vacuous: stubbing out the single call in `_resume_app_execution` makes the ordering test fail, and restoring it makes it pass.

Results:

- `623 passed` — `tests/unit_tests/core/app/apps` + `tests/unit_tests/tasks/test_workflow_execute_task.py`
- `ruff format --check ./api` — 3282 files already formatted
- `ruff check ./api` — all checks passed
- `lint-imports` — 10 contracts kept, 0 broken
- `pyrefly` and `mypy` on the changed modules — no diagnostics

Also verified against a live stack built from this branch (API, worker, worker_beat, api_websocket):

- Armed both signals for a task ID in the real Redis, then called the deployed `clear_app_task_cancellation_signals()`: `flag=b'1' cmds=2 pending=b'1'` became `flag=None cmds=0 pending=None`.
- Ran a `Start -> Human Input -> LLM -> End` workflow in the console, confirmed the form, and the run finished `succeeded` with `error: None` in `workflow_runs`.

## Screenshots

| Before | After |
| ------ | ----- |
| Run ends `Stopped by user` after confirming the form <br/> <img width="400" alt="before" src="https://github.com/user-attachments/assets/9c64a065-4471-46ae-868a-44dbe59fa970" /> | Run resumes and finishes `Succeeded` <br/> <img width="400" alt="after" src="https://github.com/user-attachments/assets/84759ff6-9578-4905-94e8-ab49ac263c18" /> |
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods