### PR TITLE
fix(ci): use default Ubuntu mirror for Playwright

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Switch Ubuntu mirror
-        run: |
-          sudo sed -i 's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-          sudo apt-get update
-
       - name: Setup web dependencies
         uses: ./.github/actions/setup-web
 

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -126,11 +126,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Switch Ubuntu mirror
-        run: |
-          sudo sed -i 's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-          sudo apt-get update
-
       - name: Setup web environment
         uses: ./.github/actions/setup-web
 
@@ -164,11 +159,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Switch Ubuntu mirror
-        run: |
-          sudo sed -i 's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-          sudo apt-get update
 
       - name: Setup web environment
         uses: ./.github/actions/setup-web


### PR DESCRIPTION
## Summary

- remove the hard-coded Azure Ubuntu mirror override from Web Full-Stack E2E
- remove the same override from the dify-ui Browser Mode and Storybook jobs
- keep the existing Playwright `--with-deps` installation commands unchanged

## Root cause

The affected Depot runners could not connect to `azure.archive.ubuntu.com:80`. `apt-get update` emitted warnings but returned successfully, leaving the jobs without the Noble base, updates, and backports package indexes. The later Playwright dependency installation then failed with missing WebKit system packages before any E2E scenarios ran.

In the same workflow run, the Web Browser Tests job kept the Depot-provided `us-east-1.ec2.archive.ubuntu.com` source and completed its Playwright dependency installation successfully. Restoring the runner default avoids maintaining a repository-level cross-cloud mirror override.

Failure: https://github.com/langgenius/dify/actions/runs/32090148877/job/95570762056

## Impact

Playwright jobs now use the Ubuntu source configured by the Depot runner image. This also removes the redundant pre-install `apt-get update`; Playwright continues to install required system dependencies through `--with-deps`.

## Validation

- `vp fmt .github/workflows/web-e2e.yml .github/workflows/web-tests.yml --check`
- parsed both workflow files with Ruby YAML
- confirmed no Ubuntu mirror overrides remain under `.github`
- `git diff --check`