### PR TITLE
refactor(models): pass session to tools.py @property accessors

### DIFF
--- a/api/core/tools/custom_tool/provider.py
+++ b/api/core/tools/custom_tool/provider.py
@@ -104,7 +104,7 @@ class ApiToolProviderController(ToolProviderController[ToolProviderEntity, ApiTo
         elif auth_type == ApiProviderAuthType.NONE:
             pass
 
-        user = db_provider.user
+        user = db_provider.user(session=db.session())
         user_name = user.name if user else ""
 
         return ApiToolProviderController(

--- a/api/models/tools.py
+++ b/api/models/tools.py
@@ -21,7 +21,6 @@ from core.tools.entities.tool_entities import (
 )
 
 from .base import TypeBase
-from .engine import db
 from .enums import PermissionEnum
 from .model import Account, App, Tenant
 from .types import EnumText, LongText, StringUUID

--- a/api/models/tools.py
+++ b/api/models/tools.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import sqlalchemy as sa
 from deprecated import deprecated
 from sqlalchemy import ForeignKey, String, func, select
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.tools.entities.common_entities import I18nObject
@@ -197,15 +197,13 @@ class ApiToolProvider(TypeBase):
     def credentials(self) -> dict[str, Any]:
         return dict[str, Any](json.loads(self.credentials_str))
 
-    @property
-    def user(self) -> Account | None:
+    def user(self, session: Session) -> Account | None:
         if not self.user_id:
             return None
-        return db.session.scalar(select(Account).where(Account.id == self.user_id))
+        return session.scalar(select(Account).where(Account.id == self.user_id))
 
-    @property
-    def tenant(self) -> Tenant | None:
-        return db.session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))
+    def tenant(self, session: Session) -> Tenant | None:
+        return session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))
 
 
 class ToolLabelBinding(TypeBase):
@@ -277,13 +275,11 @@ class WorkflowToolProvider(TypeBase):
         init=False,
     )
 
-    @property
-    def user(self) -> Account | None:
-        return db.session.scalar(select(Account).where(Account.id == self.user_id))
+    def user(self, session: Session) -> Account | None:
+        return session.scalar(select(Account).where(Account.id == self.user_id))
 
-    @property
-    def tenant(self) -> Tenant | None:
-        return db.session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))
+    def tenant(self, session: Session) -> Tenant | None:
+        return session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))
 
     @property
     def parameter_configurations(self) -> list[WorkflowToolParameterConfiguration]:
@@ -292,9 +288,8 @@ class WorkflowToolProvider(TypeBase):
             for config in json.loads(self.parameter_configuration)
         ]
 
-    @property
-    def app(self) -> App | None:
-        return db.session.scalar(select(App).where(App.id == self.app_id))
+    def app(self, session: Session) -> App | None:
+        return session.scalar(select(App).where(App.id == self.app_id))
 
 
 class MCPToolProvider(TypeBase):
@@ -358,8 +353,8 @@ class MCPToolProvider(TypeBase):
         sa.String(32), nullable=False, server_default=sa.text("'off'"), default="off"
     )
 
-    def load_user(self) -> Account | None:
-        return db.session.scalar(select(Account).where(Account.id == self.user_id))
+    def load_user(self, session: Session) -> Account | None:
+        return session.scalar(select(Account).where(Account.id == self.user_id))
 
     @property
     def credentials(self) -> dict[str, Any]:

--- a/api/services/tools/mcp_tools_manage_service.py
+++ b/api/services/tools/mcp_tools_manage_service.py
@@ -692,7 +692,7 @@ class MCPToolManageService:
         self, db_provider: MCPToolProvider, provider_entity: MCPProviderEntity, tools: list[MCPTool]
     ) -> ToolProviderApiEntity:
         """Build API response for tool provider."""
-        user = db_provider.load_user()
+        user = db_provider.load_user(session=self._session)
         response = provider_entity.to_api_response(
             user_name=user.name if user else None,
         )

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -5,6 +5,8 @@ from typing import Any
 from pydantic import TypeAdapter, ValidationError
 from yarl import URL
 
+from extensions.ext_database import db
+
 from configs import dify_config
 from core.helper.provider_cache import ToolProviderCredentialsCache
 from core.mcp.types import Tool as MCPTool
@@ -251,7 +253,7 @@ class ToolTransformService:
 
         # Use provided user_name to avoid N+1 query, fallback to load_user() if not provided
         if user_name is None:
-            user = db_provider.load_user()
+            user = db_provider.load_user(session=db.session())
             user_name = user.name if user else None
 
         # Convert to entity and use its API response method
@@ -282,7 +284,7 @@ class ToolTransformService:
     ) -> list[ToolApiEntity]:
         # Use provided user_name to avoid N+1 query, fallback to load_user() if not provided
         if user_name is None:
-            user = mcp_provider.load_user()
+            user = mcp_provider.load_user(session=db.session())
             user_name = user.name if user else "Anonymous"
 
         return [
@@ -310,10 +312,10 @@ class ToolTransformService:
         convert provider controller to user provider
         """
         username = "Anonymous"
-        if db_provider.user is None:
+        if db_provider.user(session=db.session()) is None:
             raise ValueError(f"user is None for api provider {db_provider.id}")
         try:
-            user = db_provider.user
+            user = db_provider.user(session=db.session())
             if not user:
                 raise ValueError("user not found")
 

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -5,8 +5,6 @@ from typing import Any
 from pydantic import TypeAdapter, ValidationError
 from yarl import URL
 
-from extensions.ext_database import db
-
 from configs import dify_config
 from core.helper.provider_cache import ToolProviderCredentialsCache
 from core.mcp.types import Tool as MCPTool
@@ -29,6 +27,7 @@ from core.tools.plugin_tool.provider import PluginToolProviderController
 from core.tools.utils.encryption import create_provider_encrypter, create_tool_provider_encrypter
 from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
 from core.tools.workflow_as_tool.tool import WorkflowTool
+from extensions.ext_database import db
 from models.tools import ApiToolProvider, BuiltinToolProvider, MCPToolProvider, WorkflowToolProvider
 
 logger = logging.getLogger(__name__)

--- a/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
+++ b/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
@@ -43,7 +43,7 @@ def _db_provider() -> ApiToolProvider:
             name="provider-a",
             description="desc",
             icon="icon.svg",
-            user=SimpleNamespace(name="Alice"),
+            user=lambda session: SimpleNamespace(name="Alice"),
             tools=[bundle],
         ),
     )

--- a/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
+++ b/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
@@ -43,7 +43,7 @@ def _db_provider() -> ApiToolProvider:
             name="provider-a",
             description="desc",
             icon="icon.svg",
-            user=lambda: SimpleNamespace(name="Alice"),
+            user=lambda *a, **kw: SimpleNamespace(name="Alice"),
             tools=[bundle],
         ),
     )

--- a/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
+++ b/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
@@ -43,7 +43,7 @@ def _db_provider() -> ApiToolProvider:
             name="provider-a",
             description="desc",
             icon="icon.svg",
-            user=lambda session: SimpleNamespace(name="Alice"),
+            user=lambda: SimpleNamespace(name="Alice"),
             tools=[bundle],
         ),
     )


### PR DESCRIPTION
## Summary

Refactor `@property` accessors in `api/models/tools.py` that internally call `db.session` into plain methods accepting `session: Session` as an explicit parameter, following the pattern established in #40370.

### Changes
- `ApiToolProvider.user` and `ApiToolProvider.tenant` — removed `@property`, added `session: Session` parameter
- `WorkflowToolProvider.user`, `WorkflowToolProvider.tenant`, and `WorkflowToolProvider.app` — same treatment
- `MCPToolProvider.load_user` — added `session: Session` parameter
- Updated all call sites in `custom_tool/provider.py`, `tools_transform_service.py`, and `mcp_tools_manage_service.py` to pass session explicitly

## Checklist
- [x] Code follows the pattern from #40370
- [x] All call sites updated to pass session explicitly
- [x] No behavioral changes — session is passed explicitly instead of accessed implicitly
- [x] I have read the [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)

Fixes #40372 (tools.py portion)

---
*This PR was prepared with AI assistance. All changes have been manually reviewed and verified.*