### PR TITLE
fix(agent): seal event stream after terminal run

### DIFF
--- a/dify-agent/src/dify_agent/runtime/event_sink.py
+++ b/dify-agent/src/dify_agent/runtime/event_sink.py
@@ -1,10 +1,11 @@
 """Event sink contracts used by the runner and storage adapters.
 
-Non-terminal events remain append-only. Successful and failed terminal events
-use ``finalize_run`` so the event and matching run status are committed as one
-compare-and-set transition. Cancellation has a dedicated intent-aware finalizer.
-Tests can use ``InMemoryRunEventSink`` without Redis; production storage
-implements the same contract with Redis streams in
+Non-terminal events remain append-only while a run is running, then are rejected
+once a terminal event wins. Terminal events use ``finalize_run`` so the event
+and matching run status are committed as one compare-and-set transition.
+Cancellation has a dedicated intent-aware finalizer. Tests can use
+``InMemoryRunEventSink`` without Redis; production storage implements the same
+contract with Redis streams in
 ``dify_agent.storage.redis_run_store``.
 """
 
@@ -47,11 +48,19 @@ class RunFinalizationResult:
     event_id: str | None = None
 
 
+class RunSealedError(RuntimeError):
+    """Raised when a non-terminal event loses to a terminal transition."""
+
+    def __init__(self, status: RunStatus) -> None:
+        super().__init__(f"run is sealed with status {status!r}")
+        self.status: RunStatus = status
+
+
 class RunEventSink(Protocol):
     """Boundary used by runtime code to publish observable run progress."""
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
-        """Persist a non-terminal event and return its cursor id."""
+        """Persist a non-terminal event or raise ``RunSealedError``."""
         ...
 
     async def finalize_run(self, event: TerminalRunEvent) -> RunFinalizationResult:
@@ -74,7 +83,10 @@ class InMemoryRunEventSink:
         self.error_types = {}
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
-        """Store a non-terminal event and assign a monotonic per-run cursor."""
+        """Store a non-terminal event while the run remains running."""
+        status = self.statuses.get(event.run_id, "running")
+        if status != "running":
+            raise RunSealedError(status)
         event_id = str(len(self.events[event.run_id]) + 1)
         stored = event.model_copy(update={"id": event_id})
         self.events[event.run_id].append(stored)
@@ -207,6 +219,7 @@ __all__ = [
     "NonTerminalRunEvent",
     "RunEventSink",
     "RunFinalizationResult",
+    "RunSealedError",
     "TerminalRunEvent",
     "emit_pydantic_ai_event",
     "emit_run_event",

--- a/dify-agent/src/dify_agent/runtime/runner.py
+++ b/dify-agent/src/dify_agent/runtime/runner.py
@@ -66,6 +66,7 @@ from dify_agent.runtime.compaction import build_compaction_capability
 from dify_agent.runtime_backend import BindingLostError
 from dify_agent.runtime.event_sink import (
     RunEventSink,
+    RunSealedError,
     emit_pydantic_ai_event,
     emit_run_failed,
     emit_run_started,
@@ -218,10 +219,15 @@ class AgentRunRunner:
         self._terminal_session_snapshot = None
         if self.is_cancelled():
             return
-        _ = await emit_run_started(self.sink, run_id=self.run_id)
+        try:
+            _ = await emit_run_started(self.sink, run_id=self.run_id)
+        except RunSealedError:
+            return
 
         try:
             outcome = await self._run_agent()
+        except RunSealedError:
+            return
         except Exception as exc:
             if self.is_cancelled():
                 return

--- a/dify-agent/src/dify_agent/storage/redis_run_store.py
+++ b/dify-agent/src/dify_agent/storage/redis_run_store.py
@@ -30,6 +30,7 @@ from dify_agent.runtime.event_sink import (
     NonTerminalRunEvent,
     RunEventSink,
     RunFinalizationResult,
+    RunSealedError,
     TerminalRunEvent,
     terminal_event_status_fields,
 )
@@ -78,6 +79,24 @@ local event_id = redis.call("XADD", KEYS[2], "*", "payload", ARGV[7])
 redis.call("EXPIRE", KEYS[2], ttl)
 redis.call("SET", KEYS[1], updated_record_json, "EX", ttl)
 return {1, ARGV[1], event_id}
+"""
+
+_APPEND_EVENT_SCRIPT = """
+local record_json = redis.call("GET", KEYS[1])
+if not record_json then
+    return {-1, ""}
+end
+
+local record = cjson.decode(record_json)
+if record.status ~= "running" then
+    return {0, tostring(record.status)}
+end
+
+local event_id = redis.call("XADD", KEYS[2], "*", "payload", ARGV[1])
+local ttl = tonumber(ARGV[2])
+redis.call("EXPIRE", KEYS[2], ttl)
+redis.call("EXPIRE", KEYS[1], ttl)
+return {1, event_id}
 """
 
 
@@ -191,19 +210,26 @@ class RedisRunStore(RunEventSink):
         return RunRecord.model_validate_json(value)
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
-        """Append a non-terminal event JSON payload with refreshed TTLs."""
-        events_key = run_events_key(self.prefix, event.run_id)
+        """Append a non-terminal event only while its run record is running."""
         payload = RUN_EVENT_ADAPTER.dump_json(event, exclude={"id"}).decode()
-        async with self.redis.pipeline(transaction=True) as pipeline:
-            _ = pipeline.xadd(
-                events_key,
-                {"payload": payload},
-            )
-            _ = pipeline.expire(events_key, self.run_retention_seconds)
-            _ = pipeline.expire(run_record_key(self.prefix, event.run_id), self.run_retention_seconds)
-            results = cast(list[object], await pipeline.execute())
-        event_id = results[0]
-        return event_id.decode() if isinstance(event_id, bytes) else str(event_id)
+        raw_result = await cast(
+            Awaitable[object],
+            self.redis.eval(
+                _APPEND_EVENT_SCRIPT,
+                2,
+                run_record_key(self.prefix, event.run_id),
+                run_events_key(self.prefix, event.run_id),
+                payload,
+                str(self.run_retention_seconds),
+            ),
+        )
+        result = cast(list[object], raw_result)
+        applied = int(cast(int | bytes | str, result[0]))
+        if applied == -1:
+            raise RunNotFoundError(event.run_id)
+        if applied == 0:
+            raise RunSealedError(cast(RunStatus, _decode_redis_text(result[1])))
+        return _decode_redis_text(result[1])
 
     async def finalize_run(self, event: TerminalRunEvent) -> RunFinalizationResult:
         """Atomically append the first success/failure event and update its run record."""

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -63,6 +63,7 @@ from dify_agent.protocol.schemas import (
     PydanticAIStreamRunEvent,
     RunComposition,
     RunFailedEvent,
+    RunFailedEventData,
     RunFailureType,
     RunLayerSpec,
     RunSucceededEvent,
@@ -250,6 +251,27 @@ def test_cancelled_runner_does_not_emit_late_failure(
 
         assert "run-cancelled" not in sink.statuses
         assert [event.type for event in sink.events["run-cancelled"]] == ["run_started"]
+
+    asyncio.run(scenario())
+
+
+def test_runner_stops_when_terminal_transition_seals_events_before_starting() -> None:
+    async def scenario() -> None:
+        sink = InMemoryRunEventSink()
+        _ = await sink.finalize_run(
+            RunFailedEvent(run_id="run-sealed", data=RunFailedEventData(error="already finished"))
+        )
+        async with httpx.AsyncClient() as client:
+            runner = AgentRunRunner(
+                sink=sink,
+                request=_request(),
+                run_id="run-sealed",
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+            )
+            await runner.run()
+
+        assert [event.type for event in sink.events["run-sealed"]] == ["run_failed"]
 
     asyncio.run(scenario())
 

--- a/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
+++ b/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
@@ -22,7 +22,7 @@ from dify_agent.protocol.schemas import (
     utc_now,
 )
 from dify_agent.runtime.cancellation import RunCancellationIntent
-from dify_agent.runtime.event_sink import RunFinalizationResult
+from dify_agent.runtime.event_sink import RunFinalizationResult, RunSealedError
 from dify_agent.storage.redis_run_store import DEFAULT_RUN_RETENTION_SECONDS, RedisRunStore, RunNotFoundError
 
 
@@ -114,6 +114,19 @@ class FakeRedis:
 
     async def eval(self, script: str, numkeys: int, *keys_and_args: object) -> list[object]:
         self.commands.append(("eval", script, numkeys, *keys_and_args))
+        if numkeys == 2:
+            record_key = str(keys_and_args[0])
+            events_key = str(keys_and_args[1])
+            payload = str(keys_and_args[2])
+            record_json = self.values.get(record_key)
+            if record_json is None:
+                return [-1, ""]
+            if isinstance(record_json, bytes):
+                record_json = record_json.decode()
+            record = json.loads(cast(str, record_json))
+            if record["status"] != "running":
+                return [0, record["status"]]
+            return [1, self._append_stream_entry(events_key, {"payload": payload})]
         if self.eval_result is None:
             raise AssertionError("test must configure FakeRedis.eval_result")
         return list(self.eval_result)
@@ -418,28 +431,52 @@ def test_wait_for_cancellation_returns_none_when_success_wins() -> None:
     assert asyncio.run(scenario()) is None
 
 
+@pytest.mark.parametrize("terminal_type", ["run_succeeded", "run_failed", "run_cancelled"])
+def test_append_event_rejects_late_write_after_terminal_status_without_refreshing_ttls(terminal_type: str) -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+
+    async def scenario() -> str:
+        record = await store.create_run()
+        status = terminal_type.removeprefix("run_")
+        redis.values[f"test:runs:{record.run_id}:record"] = record.model_copy(update={"status": status}).model_dump_json()
+        _ = redis._append_stream_entry(
+            f"test:runs:{record.run_id}:events",
+            {"payload": RUN_EVENT_ADAPTER.dump_json(_terminal_event(terminal_type, record.run_id), exclude={"id"}).decode()},
+        )
+        redis.commands.clear()
+
+        with pytest.raises(RunSealedError) as raised:
+            _ = await store.append_event(RunStartedEvent(run_id=record.run_id))
+        assert raised.value.status == status
+        return record.run_id
+
+    run_id = asyncio.run(scenario())
+
+    assert len(redis.streams[f"test:runs:{run_id}:events"]) == 1
+    assert [command[0] for command in redis.commands] == ["eval"]
+
+
 def test_append_event_serializes_typed_event_without_id_and_expires_run_keys() -> None:
     redis = FakeRedis()
     store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
 
-    event_id = asyncio.run(store.append_event(RunStartedEvent(id="local", run_id="run-1")))
+    async def scenario() -> tuple[str, str]:
+        record = await store.create_run()
+        redis.commands.clear()
+        event_id = await store.append_event(RunStartedEvent(id="local", run_id=record.run_id))
+        return event_id, record.run_id
+
+    event_id, run_id = asyncio.run(scenario())
 
     assert event_id == "1-0"
-    pipeline_commands = [command for command in redis.commands if command[0] == "pipeline"]
-    assert len(pipeline_commands) == 1
-    assert pipeline_commands[0][1] is True
-    xadd_commands = [command for command in redis.commands if command[0] == "xadd"]
-    assert len(xadd_commands) == 1
-    fields = xadd_commands[0][2]
-    assert isinstance(fields, dict)
-    assert '"id"' not in str(fields["payload"])
-    assert '"type":"run_started"' in str(fields["payload"])
-    expire_commands = {command for command in redis.commands if command[0] == "expire"}
-    assert expire_commands == {
-        ("expire", "test:runs:run-1:events", 60),
-        ("expire", "test:runs:run-1:record", 60),
-    }
-    assert ("execute",) in redis.commands
+    assert [command[0] for command in redis.commands] == ["eval"]
+    eval_command = redis.commands[0]
+    assert eval_command[2] == 2
+    assert eval_command[3:5] == (f"test:runs:{run_id}:record", f"test:runs:{run_id}:events")
+    assert '"id"' not in str(eval_command[5])
+    assert '"type":"run_started"' in str(eval_command[5])
+    assert eval_command[6] == "60"
 
 
 def test_get_events_round_trips_run_succeeded_output_and_session_snapshot() -> None:

--- a/dify-agent/tests/local/dify_agent/storage/test_run_event_store_contract.py
+++ b/dify-agent/tests/local/dify_agent/storage/test_run_event_store_contract.py
@@ -1,0 +1,432 @@
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+import json
+from typing import TYPE_CHECKING, Literal, Protocol, cast, final
+
+import pytest
+
+from agenton.compositor import CompositorSessionSnapshot
+from dify_agent.protocol.schemas import (
+    RUN_EVENT_ADAPTER,
+    CancelRunRequest,
+    RunFailedEvent,
+    RunFailedEventData,
+    RunStartedEvent,
+    RunSucceededEvent,
+    RunSucceededEventData,
+    utc_now,
+)
+from dify_agent.runtime.cancellation import RunCancellationIntent
+from dify_agent.runtime.event_sink import InMemoryRunEventSink, RunFinalizationResult
+from dify_agent.storage.redis_run_store import RedisRunStore, RunNotFoundError
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+TerminalStatus = Literal["succeeded", "failed", "cancelled"]
+
+
+@dataclass(frozen=True)
+class StoreSnapshot:
+    cursors: tuple[str, ...]
+    event_types: tuple[str, ...]
+    ttl_writes: tuple[tuple[str, int], ...]
+
+
+class RunEventStoreHarness(Protocol):
+    run_id: str
+
+    async def append_started(self) -> str: ...
+
+    async def finalize(self, status: TerminalStatus) -> RunFinalizationResult: ...
+
+    def snapshot(self) -> StoreSnapshot: ...
+
+
+@final
+class TransactionalFakeRedis:
+    """CPU-only model of the Lua/pipeline effects used by the contract tests.
+
+    It intentionally understands both the old pipeline append and the new Lua
+    append. This lets the same regression test prove RED on the parent commit:
+    the old pipeline resumes after finalization and appends unconditionally.
+    """
+
+    def __init__(self) -> None:
+        self.values: dict[str, object] = {}
+        self.streams: dict[str, list[tuple[str, dict[str, object]]]] = {}
+        self.ttl_writes: list[tuple[str, int]] = []
+        self.pause_next_event_append = False
+        self.append_ready = asyncio.Event()
+        self.release_append = asyncio.Event()
+
+    async def set(self, key: str, value: object, *, ex: int | None = None) -> None:
+        self.values[key] = value
+        if ex is not None:
+            self.ttl_writes.append((key, ex))
+
+    async def get(self, key: str) -> object | None:
+        return self.values.get(key)
+
+    def pipeline(self, transaction: bool = True, shard_hint: str | None = None) -> "FakePipeline":
+        del transaction, shard_hint
+        return FakePipeline(self)
+
+    async def eval(self, script: str, numkeys: int, *keys_and_args: object) -> list[object]:
+        if numkeys == 2:
+            return await self._append_event(keys_and_args)
+        if 'record.status = ARGV[1]' in script:
+            return self._finalize_run(keys_and_args)
+        if 'record.status = "cancelled"' in script:
+            return self._finalize_cancellation(keys_and_args)
+        if 'redis.call("EXISTS", KEYS[2]) == 1' in script:
+            return self._request_cancellation(keys_and_args)
+        raise AssertionError("contract fake received an unknown Lua script")
+
+    async def before_event_append(self) -> None:
+        if not self.pause_next_event_append:
+            return
+        self.pause_next_event_append = False
+        _ = self.append_ready.set()
+        _ = await self.release_append.wait()
+
+    async def _append_event(self, args: tuple[object, ...]) -> list[object]:
+        record_key, events_key, payload, retention = map(str, args[:4])
+        await self.before_event_append()
+        record = self._record(record_key)
+        if record is None:
+            return [-1, ""]
+        if record["status"] != "running":
+            return [0, record["status"]]
+        event_id = self.append_stream(events_key, {"payload": payload})
+        self.refresh_ttl(events_key, int(retention))
+        self.refresh_ttl(record_key, int(retention))
+        return [1, event_id]
+
+    def _finalize_run(self, args: tuple[object, ...]) -> list[object]:
+        record_key, events_key, cancel_key = map(str, args[:3])
+        status = str(args[3])
+        record = self._record(record_key)
+        if record is None:
+            return [-1, "", ""]
+        if record["status"] != "running":
+            return [0, record["status"], ""]
+        if self.streams.get(cancel_key):
+            return [-2, "running", ""]
+
+        record["status"] = status
+        record["updated_at"] = str(args[4])
+        record["error"] = str(args[6]) if str(args[5]) == "1" else None
+        record["error_type"] = str(args[8]) if str(args[7]) == "1" else None
+        event_id = self.append_stream(events_key, {"payload": str(args[9])})
+        retention = int(str(args[10]))
+        self.refresh_ttl(events_key, retention)
+        self.values[record_key] = json.dumps(record)
+        self.refresh_ttl(record_key, retention)
+        return [1, status, event_id]
+
+    def _request_cancellation(self, args: tuple[object, ...]) -> list[object]:
+        record_key, cancel_key, events_key = map(str, args[:3])
+        record = self._record(record_key)
+        if record is None:
+            return [-1, ""]
+        status = str(record["status"])
+        if status in {"succeeded", "failed"}:
+            return [0, status]
+        if status == "cancelled" or self.streams.get(cancel_key):
+            return [1, status]
+
+        _ = self.append_stream(cancel_key, {"payload": str(args[3])})
+        retention = int(str(args[4]))
+        for key in (cancel_key, record_key, events_key):
+            self.refresh_ttl(key, retention)
+        return [1, "running"]
+
+    def _finalize_cancellation(self, args: tuple[object, ...]) -> list[object]:
+        record_key, cancel_key, events_key = map(str, args[:3])
+        record = self._record(record_key)
+        if record is None:
+            return [-1, "", ""]
+        status = str(record["status"])
+        if status != "running":
+            return [0, status, ""]
+        if not self.streams.get(cancel_key):
+            return [-2, "running", ""]
+
+        record["status"] = "cancelled"
+        record["updated_at"] = str(args[3])
+        record["error"] = str(args[5]) if str(args[4]) == "1" else None
+        record["error_type"] = None
+        event_id = self.append_stream(events_key, {"payload": str(args[6])})
+        _ = self.streams.pop(cancel_key, None)
+        retention = int(str(args[7]))
+        self.refresh_ttl(events_key, retention)
+        self.values[record_key] = json.dumps(record)
+        self.refresh_ttl(record_key, retention)
+        return [1, "cancelled", event_id]
+
+    def _record(self, key: str) -> dict[str, object] | None:
+        value = self.values.get(key)
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            value = value.decode()
+        return cast(dict[str, object], json.loads(cast(str, value)))
+
+    def append_stream(self, key: str, fields: Mapping[str, object]) -> str:
+        entries = self.streams.setdefault(key, [])
+        event_id = f"{len(entries) + 1}-0"
+        entries.append((event_id, dict(fields)))
+        return event_id
+
+    def refresh_ttl(self, key: str, retention: int) -> None:
+        self.ttl_writes.append((key, retention))
+
+
+@final
+class FakePipeline:
+    def __init__(self, redis: TransactionalFakeRedis) -> None:
+        self.redis = redis
+        self.operations: list[tuple[str, object, object]] = []
+
+    async def __aenter__(self) -> "FakePipeline":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        del exc_type, exc, traceback
+
+    def xadd(self, key: str, fields: Mapping[str, object]) -> "FakePipeline":
+        self.operations.append(("xadd", key, dict(fields)))
+        return self
+
+    def expire(self, key: str, seconds: int) -> "FakePipeline":
+        self.operations.append(("expire", key, seconds))
+        return self
+
+    async def execute(self) -> list[object]:
+        await self.redis.before_event_append()
+        results: list[object] = []
+        for operation, key, value in self.operations:
+            if operation == "xadd":
+                results.append(self.redis.append_stream(cast(str, key), cast(dict[str, object], value)))
+            else:
+                self.redis.refresh_ttl(cast(str, key), cast(int, value))
+                results.append(True)
+        return results
+
+
+@final
+class InMemoryHarness:
+    run_id: str = "contract-run"
+
+    def __init__(self) -> None:
+        self.sink = InMemoryRunEventSink()
+
+    async def append_started(self) -> str:
+        return await self.sink.append_event(RunStartedEvent(run_id=self.run_id))
+
+    async def finalize(self, status: TerminalStatus) -> RunFinalizationResult:
+        if status == "succeeded":
+            return await self.sink.finalize_run(
+                RunSucceededEvent(
+                    run_id=self.run_id,
+                    data=RunSucceededEventData(
+                        output="done",
+                        session_snapshot=CompositorSessionSnapshot(layers=[]),
+                    ),
+                )
+            )
+        if status == "failed":
+            return await self.sink.finalize_run(
+                RunFailedEvent(run_id=self.run_id, data=RunFailedEventData(error="failed"))
+            )
+        raise AssertionError("the in-memory RunEventSink contract has no cancellation finalizer")
+
+    def snapshot(self) -> StoreSnapshot:
+        events = self.sink.events[self.run_id]
+        return StoreSnapshot(
+            cursors=tuple(cast(str, event.id) for event in events),
+            event_types=tuple(event.type for event in events),
+            ttl_writes=(),
+        )
+
+
+@final
+class RedisHarness:
+    def __init__(self) -> None:
+        self.redis = TransactionalFakeRedis()
+        self.store = RedisRunStore(
+            cast("Redis", cast(object, self.redis)), prefix="contract", run_retention_seconds=60
+        )
+        self.run_id = ""
+        self._cancellation_intent: RunCancellationIntent | None = None
+
+    async def create(self) -> "RedisHarness":
+        self.run_id = (await self.store.create_run()).run_id
+        return self
+
+    async def append_started(self) -> str:
+        return await self.store.append_event(RunStartedEvent(run_id=self.run_id))
+
+    async def finalize(self, status: TerminalStatus) -> RunFinalizationResult:
+        if status == "succeeded":
+            return await self.store.finalize_run(
+                RunSucceededEvent(
+                    run_id=self.run_id,
+                    data=RunSucceededEventData(
+                        output="done",
+                        session_snapshot=CompositorSessionSnapshot(layers=[]),
+                    ),
+                )
+            )
+        if status == "failed":
+            return await self.store.finalize_run(
+                RunFailedEvent(run_id=self.run_id, data=RunFailedEventData(error="failed"))
+            )
+        if self._cancellation_intent is None:
+            self._cancellation_intent = RunCancellationIntent(reason="cancelled", requested_at=utc_now())
+            _ = await self.store.request_cancellation(
+                self.run_id,
+                CancelRunRequest(reason=self._cancellation_intent.reason),
+            )
+        return await self.store.finalize_cancellation(self.run_id, self._cancellation_intent)
+
+    def snapshot(self) -> StoreSnapshot:
+        entries = self.redis.streams.get(f"contract:runs:{self.run_id}:events", [])
+        payloads = [RUN_EVENT_ADAPTER.validate_json(cast(str, fields["payload"])) for _, fields in entries]
+        return StoreSnapshot(
+            cursors=tuple(cursor for cursor, _ in entries),
+            event_types=tuple(event.type for event in payloads),
+            ttl_writes=tuple(self.redis.ttl_writes),
+        )
+
+
+async def make_in_memory_harness() -> RunEventStoreHarness:
+    return InMemoryHarness()
+
+
+async def make_redis_harness() -> RunEventStoreHarness:
+    return await RedisHarness().create()
+
+
+HarnessFactory = Callable[[], Awaitable[RunEventStoreHarness]]
+_CONTRACT_CASES: tuple[tuple[HarnessFactory, TerminalStatus], ...] = (
+    (make_in_memory_harness, "succeeded"),
+    (make_in_memory_harness, "failed"),
+    (make_redis_harness, "succeeded"),
+    (make_redis_harness, "failed"),
+    (make_redis_harness, "cancelled"),
+)
+
+
+@pytest.mark.parametrize(
+    ("make_harness", "terminal_status"),
+    _CONTRACT_CASES,
+    ids=("memory-succeeded", "memory-failed", "redis-succeeded", "redis-failed", "redis-cancelled"),
+)
+def test_append_before_finalize_is_accepted_and_ordered(
+    make_harness: HarnessFactory, terminal_status: TerminalStatus
+) -> None:
+    async def scenario() -> tuple[str, RunFinalizationResult, StoreSnapshot]:
+        harness = await make_harness()
+        append_cursor = await harness.append_started()
+        result = await harness.finalize(terminal_status)
+        return append_cursor, result, harness.snapshot()
+
+    append_cursor, result, snapshot = asyncio.run(scenario())
+
+    assert result == RunFinalizationResult(applied=True, status=terminal_status, event_id=snapshot.cursors[1])
+    assert append_cursor == snapshot.cursors[0]
+    assert snapshot.event_types == ("run_started", f"run_{terminal_status}")
+
+
+@pytest.mark.parametrize(
+    ("make_harness", "terminal_status"),
+    _CONTRACT_CASES,
+    ids=("memory-succeeded", "memory-failed", "redis-succeeded", "redis-failed", "redis-cancelled"),
+)
+def test_finalize_seals_stream_without_mutating_rejected_write_state(
+    make_harness: HarnessFactory, terminal_status: TerminalStatus
+) -> None:
+    async def scenario() -> tuple[StoreSnapshot, StoreSnapshot, RuntimeError]:
+        harness = await make_harness()
+        result = await harness.finalize(terminal_status)
+        assert result.applied is True
+        before = harness.snapshot()
+        with pytest.raises(RuntimeError) as raised:
+            _ = await harness.append_started()
+        return before, harness.snapshot(), raised.value
+
+    before, after, error = asyncio.run(scenario())
+
+    # The public assumption is a runtime-owned coordination exception carrying
+    # the winning terminal status; callers do not depend on Redis exceptions.
+    assert getattr(error, "status", None) == terminal_status
+    assert before == after
+    assert after.event_types == (f"run_{terminal_status}",)
+
+
+@pytest.mark.parametrize(
+    ("make_harness", "terminal_status"),
+    _CONTRACT_CASES,
+    ids=("memory-succeeded", "memory-failed", "redis-succeeded", "redis-failed", "redis-cancelled"),
+)
+def test_duplicate_terminal_finalization_is_idempotent(
+    make_harness: HarnessFactory, terminal_status: TerminalStatus
+) -> None:
+    async def scenario() -> tuple[RunFinalizationResult, StoreSnapshot, StoreSnapshot]:
+        harness = await make_harness()
+        first = await harness.finalize(terminal_status)
+        before_duplicate = harness.snapshot()
+        duplicate = await harness.finalize(terminal_status)
+        assert first.applied is True
+        return duplicate, before_duplicate, harness.snapshot()
+
+    duplicate, before_duplicate, after_duplicate = asyncio.run(scenario())
+
+    assert duplicate == RunFinalizationResult(applied=False, status=terminal_status)
+    assert before_duplicate == after_duplicate
+
+
+def test_redis_in_flight_append_loses_when_finalize_linearizes_first() -> None:
+    async def scenario() -> tuple[StoreSnapshot, RuntimeError]:
+        harness = await RedisHarness().create()
+        harness.redis.pause_next_event_append = True
+        append_task = asyncio.create_task(harness.append_started())
+        _ = await asyncio.wait_for(harness.redis.append_ready.wait(), timeout=1)
+
+        result = await harness.finalize("succeeded")
+        assert result.applied is True
+        _ = harness.redis.release_append.set()
+        with pytest.raises(RuntimeError) as raised:
+            _ = await asyncio.wait_for(append_task, timeout=1)
+        return harness.snapshot(), raised.value
+
+    snapshot, error = asyncio.run(scenario())
+
+    assert getattr(error, "status", None) == "succeeded"
+    assert snapshot.event_types == ("run_succeeded",)
+    assert snapshot.cursors == ("1-0",)
+
+
+def test_redis_missing_run_append_keeps_not_found_contract_without_side_effects() -> None:
+    redis = TransactionalFakeRedis()
+    store = RedisRunStore(
+        cast("Redis", cast(object, redis)), prefix="contract", run_retention_seconds=60
+    )
+
+    with pytest.raises(RunNotFoundError):
+        _ = asyncio.run(store.append_event(RunStartedEvent(run_id="missing")))
+
+    assert redis.streams == {}
+    assert redis.ttl_writes == []
+
+
+def test_in_memory_missing_run_remains_implicitly_running() -> None:
+    sink = InMemoryRunEventSink()
+
+    cursor = asyncio.run(sink.append_event(RunStartedEvent(run_id="implicit")))
+
+    assert cursor == "1"
+    assert [event.type for event in sink.events["implicit"]] == ["run_started"]


### PR DESCRIPTION
## Summary
- atomically check the run status, append non-terminal events, and refresh TTLs in Redis
- reject cross-writer progress writes after a terminal state, without extending retention
- align the in-memory sink and stop runners when the event stream was already sealed

## Test plan
- `uv run pytest tests/local/dify_agent/storage/test_redis_run_store.py tests/local/dify_agent/runtime/test_runner.py -q`
- `make check`

Closes #40765