### PR TITLE
refactor(web): standardize dataset search inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2087,11 +2087,6 @@
       "count": 4
     }
   },
-  "web/app/components/datasets/documents/components/documents-header.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/documents/components/list.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1
@@ -2252,9 +2247,6 @@
     },
     "jsx-a11y/no-static-element-interactions": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "web/app/components/datasets/documents/detail/completed/common/chunk-content.tsx": {
@@ -2263,11 +2255,6 @@
     },
     "jsx-a11y/no-autofocus": {
       "count": 2
-    }
-  },
-  "web/app/components/datasets/documents/detail/completed/components/menu-bar.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "web/app/components/datasets/documents/detail/completed/components/segment-list-content.tsx": {

--- a/web/app/components/datasets/documents/components/__tests__/documents-header.spec.tsx
+++ b/web/app/components/datasets/documents/components/__tests__/documents-header.spec.tsx
@@ -83,7 +83,7 @@ describe('DocumentsHeader', () => {
 
     it('should render filter input', () => {
       render(<DocumentsHeader {...defaultProps} />)
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
     })
 
     it('should hide action controls by default when permissions are omitted', () => {
@@ -204,7 +204,7 @@ describe('DocumentsHeader', () => {
       const onInputChange = vi.fn()
       render(<DocumentsHeader {...defaultProps} onInputChange={onInputChange} />)
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('searchbox', { name: 'common.operation.search' })
       fireEvent.change(input, { target: { value: 'search query' } })
 
       expect(onInputChange).toHaveBeenCalledWith('search query')

--- a/web/app/components/datasets/documents/components/documents-header.tsx
+++ b/web/app/components/datasets/documents/components/documents-header.tsx
@@ -9,7 +9,7 @@ import { Button } from '@langgenius/dify-ui/button'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import Chip from '@/app/components/base/chip'
-import Input from '@/app/components/base/input'
+import { SearchInput } from '@/app/components/base/search-input'
 import Sort from '@/app/components/base/sort'
 import AutoDisabledDocument from '@/app/components/datasets/common/document-status-with-action/auto-disabled-document'
 import IndexFailed from '@/app/components/datasets/common/document-status-with-action/index-failed'
@@ -162,14 +162,7 @@ const DocumentsHeader: FC<DocumentsHeaderProps> = ({
             onSelect={(item) => onStatusFilterChange(item?.value ? String(item.value) : '')}
             onClear={onStatusFilterClear}
           />
-          <Input
-            showLeftIcon
-            showClearIcon
-            wrapperClassName="w-[200px]!"
-            value={inputValue}
-            onChange={(e) => onInputChange(e.target.value)}
-            onClear={() => onInputChange('')}
-          />
+          <SearchInput className="w-50!" value={inputValue} onValueChange={onInputChange} />
           <div className="h-3.5 w-px bg-divider-regular"></div>
           <Sort
             order={sortValue.startsWith('-') ? '-' : ''}

--- a/web/app/components/datasets/documents/detail/completed/__tests__/child-segment-list.spec.tsx
+++ b/web/app/components/datasets/documents/detail/completed/__tests__/child-segment-list.spec.tsx
@@ -173,7 +173,7 @@ describe('ChildSegmentList', () => {
     it('should render input field in full-doc mode', () => {
       render(<ChildSegmentList {...defaultProps} />)
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('searchbox', { name: 'common.operation.search' })
       expect(input).toBeInTheDocument()
     })
 
@@ -187,7 +187,7 @@ describe('ChildSegmentList', () => {
       const mockHandleInputChange = vi.fn()
       render(<ChildSegmentList {...defaultProps} handleInputChange={mockHandleInputChange} />)
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('searchbox', { name: 'common.operation.search' })
       fireEvent.change(input, { target: { value: 'search term' } })
 
       expect(mockHandleInputChange).toHaveBeenCalledWith('search term')

--- a/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
+++ b/web/app/components/datasets/documents/detail/completed/child-segment-list.tsx
@@ -5,7 +5,7 @@ import { RiArrowDownSLine, RiArrowRightSLine } from '@remixicon/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
-import Input from '@/app/components/base/input'
+import { SearchInput } from '@/app/components/base/search-input'
 import { formatNumber } from '@/utils/format'
 import { EditSlice } from '../../../formatted-text/flavours/edit-slice'
 import { FormattedText } from '../../../formatted-text/formatted'
@@ -211,13 +211,10 @@ const ChildSegmentList: FC<IChildSegmentCardProps> = ({
           </button>
         </div>
         {isFullDocMode && (
-          <Input
-            showLeftIcon
-            showClearIcon
-            wrapperClassName="w-52!"
-            value={inputValue}
-            onChange={(e) => handleInputChange?.(e.target.value)}
-            onClear={() => handleInputChange?.('')}
+          <SearchInput
+            className="w-52!"
+            value={inputValue ?? ''}
+            onValueChange={(value) => handleInputChange?.(value)}
           />
         )}
       </div>

--- a/web/app/components/datasets/documents/detail/completed/components/__tests__/menu-bar.spec.tsx
+++ b/web/app/components/datasets/documents/detail/completed/components/__tests__/menu-bar.spec.tsx
@@ -69,7 +69,7 @@ describe('MenuBar', () => {
 
   it('should call onInputChange when input changes', () => {
     renderMenuBar()
-    const input = screen.getByRole('textbox')
+    const input = screen.getByRole('searchbox', { name: 'common.operation.search' })
     fireEvent.change(input, { target: { value: 'test search' } })
     expect(defaultProps.onInputChange).toHaveBeenCalledWith('test search')
   })

--- a/web/app/components/datasets/documents/detail/completed/components/menu-bar.tsx
+++ b/web/app/components/datasets/documents/detail/completed/components/menu-bar.tsx
@@ -14,7 +14,7 @@ import {
 } from '@langgenius/dify-ui/select'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
-import Input from '@/app/components/base/input'
+import { SearchInput } from '@/app/components/base/search-input'
 import DisplayToggle from '../display-toggle'
 import s from '../style.module.css'
 
@@ -81,14 +81,7 @@ function MenuBar({
           ))}
         </SelectContent>
       </Select>
-      <Input
-        showLeftIcon
-        showClearIcon
-        wrapperClassName="w-52!"
-        value={inputValue}
-        onChange={(e) => onInputChange(e.target.value)}
-        onClear={() => onInputChange('')}
-      />
+      <SearchInput className="w-52!" value={inputValue} onValueChange={onInputChange} />
       <Divider type="vertical" className="mx-3 h-3.5" />
       <DisplayToggle isCollapsed={isCollapsed} toggleCollapsed={toggleCollapsed} />
     </div>


### PR DESCRIPTION
## Summary

- Replace deprecated search input compositions in the dataset documents header, full-document child segment list, and segment menu bar with `SearchInput`.
- Preserve the existing 200px and 208px widths and keep search state in each dataset owner.
- Update affected tests to query the controls through their native `searchbox` role.

Depends on #40912.

## Screenshots

Not included: this is a behavior-preserving component migration with equivalent dimensions and no intended design change.

## Validation

- `pnpm --dir web exec vp test run app/components/datasets/documents/components/__tests__/documents-header.spec.tsx app/components/datasets/documents/detail/completed/__tests__/child-segment-list.spec.tsx app/components/datasets/documents/detail/completed/components/__tests__/menu-bar.spec.tsx` (55 tests)
- `pnpm check` (run for the complete stack)

From Codex
