### PR TITLE
refactor(web): standardize label search inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3303,16 +3303,6 @@
       "count": 1
     }
   },
-  "web/app/components/tools/labels/filter.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "web/app/components/tools/labels/selector.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/tools/mcp/mcp-server-param-item.tsx": {
     "typescript/no-explicit-any": {
       "count": 1

--- a/web/app/components/tools/labels/__tests__/filter.spec.tsx
+++ b/web/app/components/tools/labels/__tests__/filter.spec.tsx
@@ -70,7 +70,7 @@ describe('LabelFilter', () => {
       await act(async () => fireEvent.click(trigger!))
 
       expect(screen.getByText('Agent')).toBeInTheDocument()
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
     })
   })
 
@@ -147,10 +147,10 @@ describe('LabelFilter', () => {
         fireEvent.click(screen.getByText('common.tag.tags'))
       })
 
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
 
       await act(async () => {
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         fireEvent.change(searchInput, { target: { value: 'rag' } })
       })
 
@@ -165,10 +165,10 @@ describe('LabelFilter', () => {
         fireEvent.click(screen.getByText('common.tag.tags'))
       })
 
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
 
       await act(async () => {
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         fireEvent.change(searchInput, { target: { value: 'nonexistent' } })
       })
 
@@ -182,10 +182,10 @@ describe('LabelFilter', () => {
         fireEvent.click(screen.getByText('common.tag.tags'))
       })
 
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
 
       await act(async () => {
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         fireEvent.change(searchInput, { target: { value: 'rag' } })
       })
 
@@ -193,7 +193,7 @@ describe('LabelFilter', () => {
       expect(screen.queryByRole('button', { name: 'Agent' })).not.toBeInTheDocument()
 
       await act(async () => {
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         fireEvent.change(searchInput, { target: { value: '' } })
       })
 

--- a/web/app/components/tools/labels/__tests__/selector.spec.tsx
+++ b/web/app/components/tools/labels/__tests__/selector.spec.tsx
@@ -112,7 +112,7 @@ describe('LabelSelector', () => {
         vi.advanceTimersByTime(10)
       })
 
-      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+      expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
     })
   })
 
@@ -192,10 +192,10 @@ describe('LabelSelector', () => {
         vi.advanceTimersByTime(10)
       })
 
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
 
       await act(async () => {
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         // Filter by 'rag' which only matches 'rag' name
         fireEvent.change(searchInput, { target: { value: 'rag' } })
         vi.advanceTimersByTime(10)
@@ -215,10 +215,10 @@ describe('LabelSelector', () => {
         vi.advanceTimersByTime(10)
       })
 
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
 
       await act(async () => {
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         fireEvent.change(searchInput, { target: { value: 'nonexistent' } })
         vi.advanceTimersByTime(10)
       })
@@ -234,10 +234,10 @@ describe('LabelSelector', () => {
         vi.advanceTimersByTime(10)
       })
 
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toBeInTheDocument()
 
       await act(async () => {
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         // First filter to show only RAG
         fireEvent.change(searchInput, { target: { value: 'rag' } })
         vi.advanceTimersByTime(10)
@@ -248,7 +248,7 @@ describe('LabelSelector', () => {
 
       await act(async () => {
         // Clear the input
-        const searchInput = screen.getByRole('textbox')
+        const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         fireEvent.change(searchInput, { target: { value: '' } })
         vi.advanceTimersByTime(10)
       })

--- a/web/app/components/tools/labels/filter.tsx
+++ b/web/app/components/tools/labels/filter.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { Tag03 } from '@/app/components/base/icons/src/vender/line/financeAndECommerce'
 import { Check } from '@/app/components/base/icons/src/vender/line/general'
 import { XCircle } from '@/app/components/base/icons/src/vender/solid/general'
-import Input from '@/app/components/base/input'
+import { SearchInput } from '@/app/components/base/search-input'
 import { useTags } from '@/app/components/plugins/hooks'
 
 type LabelFilterProps = {
@@ -76,13 +76,7 @@ const LabelFilter: FC<LabelFilterProps> = ({ value, onChange }) => {
         >
           <div className="relative">
             <div className="p-2">
-              <Input
-                showLeftIcon
-                showClearIcon
-                value={keywords}
-                onChange={(e) => setKeywords(e.target.value)}
-                onClear={() => setKeywords('')}
-              />
+              <SearchInput value={keywords} onValueChange={setKeywords} />
             </div>
             <div className="p-1">
               {filteredLabelList.map((label) => (

--- a/web/app/components/tools/labels/selector.tsx
+++ b/web/app/components/tools/labels/selector.tsx
@@ -6,7 +6,7 @@ import { useDebounceFn } from 'ahooks'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Tag03 } from '@/app/components/base/icons/src/vender/line/financeAndECommerce'
-import Input from '@/app/components/base/input'
+import { SearchInput } from '@/app/components/base/search-input'
 import { useTags } from '@/app/components/plugins/hooks'
 
 type LabelSelectorProps = {
@@ -66,13 +66,7 @@ function LabelSelector({ value, onChange }: LabelSelectorProps) {
         >
           <div className="relative w-147.75 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
             <div className="border-b-[0.5px] border-divider-regular p-2">
-              <Input
-                showLeftIcon
-                showClearIcon
-                value={keywords}
-                onChange={(e) => handleKeywordsChange(e.target.value)}
-                onClear={() => handleKeywordsChange('')}
-              />
+              <SearchInput value={keywords} onValueChange={handleKeywordsChange} />
             </div>
             <CheckboxGroup
               aria-label={t(($) => $['createTool.toolInput.labelPlaceholder'], { ns: 'tools' })}


### PR DESCRIPTION
## Summary

- Replace deprecated search input compositions in the label filter and label selector popovers with `SearchInput`.
- Keep label query and debounce ownership in the existing feature components while reusing the standard clear, focus, and IME behavior.
- Update affected tests to query the controls through their native `searchbox` role.

Depends on #40913.

## Screenshots

Not included: this is a behavior-preserving component migration with equivalent dimensions and no intended design change.

## Validation

- `pnpm --dir web exec vp test run app/components/tools/labels/__tests__/filter.spec.tsx app/components/tools/labels/__tests__/selector.spec.tsx` (33 tests)
- `pnpm check` (run for the complete stack)

From Codex
