### PR TITLE
test(dify-ui): stabilize dropdown menu story

### DIFF
--- a/packages/dify-ui/src/input-group/index.stories.tsx
+++ b/packages/dify-ui/src/input-group/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import * as React from 'react'
-import { expect, spyOn, within } from 'storybook/test'
+import { expect, spyOn, waitFor, waitForElementToBeRemoved, within } from 'storybook/test'
 import { Button } from '../button'
 import {
   DropdownMenu,
@@ -204,9 +204,15 @@ export const WithDropdownAction: Story = {
     await userEvent.click(trigger)
 
     const body = within(canvasElement.ownerDocument.body)
-    await userEvent.click(await body.findByRole('menuitem', { name: 'Settings' }))
+    const settings = await body.findByRole('menuitem', { name: 'Settings' })
+    const settingsRemoved = waitForElementToBeRemoved(() =>
+      body.queryByRole('menuitem', { name: 'Settings', hidden: true }),
+    )
+    await userEvent.click(settings)
 
-    await expect(trigger).toHaveFocus()
-    await expect(body.queryByRole('menuitem', { name: 'Settings' })).not.toBeInTheDocument()
+    await settingsRemoved
+    await waitFor(async () => {
+      await expect(trigger).toHaveFocus()
+    })
   },
 }


### PR DESCRIPTION
## Summary

- Wait for the portalled dropdown menu item to be physically removed before asserting focus restoration.
- Keep the real Storybook overlay animation lifecycle instead of disabling Base UI animations globally.

## Test plan

- `pnpm -C packages/dify-ui test:storybook`
- `vp test --project unit --run src/input-group/__tests__/index.spec.tsx`
- `pnpm -C packages/dify-ui type-check`
- `vp check packages/dify-ui`

From Codex