### PR TITLE
fix: preserve Agent tool-generated file outputs

### DIFF
--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -149,10 +149,10 @@ class AgentMessageTransformer:
                     json_list.append(message.message.json_object)
             elif message.type == ToolInvokeMessage.MessageType.LINK:
                 assert isinstance(message.message, ToolInvokeMessage.TextMessage)
-                file = self._file_from_link_message(message=message, tenant_id=tenant_id)
-                if file is not None:
-                    files.append(file)
-                stream_text = f"{'File' if file is not None else 'Link'}: {message.message.text}\n"
+                linked_file = self._file_from_link_message(message=message, tenant_id=tenant_id)
+                if linked_file is not None:
+                    files.append(linked_file)
+                stream_text = f"{'File' if linked_file is not None else 'Link'}: {message.message.text}\n"
                 text += stream_text
                 yield StreamChunkEvent(
                     selector=[node_id, "text"],

--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -149,7 +149,10 @@ class AgentMessageTransformer:
                     json_list.append(message.message.json_object)
             elif message.type == ToolInvokeMessage.MessageType.LINK:
                 assert isinstance(message.message, ToolInvokeMessage.TextMessage)
-                stream_text = f"Link: {message.message.text}\n"
+                file = self._file_from_link_message(message=message, tenant_id=tenant_id)
+                if file is not None:
+                    files.append(file)
+                stream_text = f"{'File' if file is not None else 'Link'}: {message.message.text}\n"
                 text += stream_text
                 yield StreamChunkEvent(
                     selector=[node_id, "text"],
@@ -300,3 +303,43 @@ class AgentMessageTransformer:
                 llm_usage=llm_usage,
             )
         )
+
+    @staticmethod
+    def _file_from_link_message(*, message: ToolInvokeMessage, tenant_id: str) -> File | None:
+        if not isinstance(message.message, ToolInvokeMessage.TextMessage):
+            return None
+        meta = message.meta
+        if not isinstance(meta, Mapping):
+            return None
+
+        file_value = meta.get("file")
+        if isinstance(file_value, File):
+            return file_value
+
+        tool_file_id = meta.get("tool_file_id")
+        if isinstance(tool_file_id, str) and tool_file_id:
+            with Session(db.engine) as session:
+                tool_file = session.scalar(
+                    select(ToolFile).where(ToolFile.id == tool_file_id, ToolFile.tenant_id == tenant_id)
+                )
+                if tool_file is None:
+                    raise ToolFileNotFoundError(tool_file_id)
+
+            return file_factory.build_from_mapping(
+                mapping={
+                    "tool_file_id": tool_file_id,
+                    "type": get_file_type_by_mime_type(tool_file.mimetype),
+                    "transfer_method": meta.get("transfer_method", FileTransferMethod.TOOL_FILE),
+                    "url": message.message.text,
+                },
+                tenant_id=tenant_id,
+                access_controller=_file_access_controller,
+            )
+
+        if isinstance(file_value, Mapping):
+            return file_factory.build_from_mapping(
+                mapping=dict(file_value),
+                tenant_id=tenant_id,
+                access_controller=_file_access_controller,
+            )
+        return None

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -162,6 +162,28 @@ def test_transform_rejects_unknown_tool_file_link() -> None:
         _run_transform([message])
 
 
+def test_file_from_link_message_ignores_non_text_message() -> None:
+    message = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.JSON,
+        message=ToolInvokeMessage.JsonMessage(json_object={}),
+    )
+
+    assert AgentMessageTransformer._file_from_link_message(message=message, tenant_id="tenant-id") is None
+
+
+def test_transform_keeps_fileless_link_metadata_as_text() -> None:
+    message = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LINK,
+        message=ToolInvokeMessage.TextMessage(text="https://dify.ai/docs"),
+        meta={"tool_file_id": "", "description": "documentation"},
+    )
+
+    text, files = _run_transform([message])
+
+    assert text == "Link: https://dify.ai/docs\n"
+    assert files.value == []
+
+
 def test_transform_keeps_plain_link_as_text() -> None:
     message = ToolInvokeMessage(
         type=ToolInvokeMessage.MessageType.LINK,

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -2,9 +2,12 @@ from collections.abc import Generator
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.utils.message_transformer import ToolFileMessageTransformer
 from core.workflow.file_reference import build_file_reference
+from core.workflow.nodes.agent.exceptions import ToolFileNotFoundError
 from core.workflow.nodes.agent.message_transformer import AgentMessageTransformer
 from graphon.enums import BuiltinNodeTypes
 from graphon.file import File, FileTransferMethod, FileType
@@ -118,6 +121,45 @@ def test_transform_promotes_serialized_tool_file_link_to_files_output() -> None:
     assert text == "File: /files/tools/tool-file-id.docx\n"
     assert files.value == [file]
     build_file.assert_called_once()
+
+
+def test_transform_promotes_serialized_file_mapping_without_tool_file_id() -> None:
+    file = _file()
+    file_mapping = file.model_dump(mode="json")
+    message = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LINK,
+        message=ToolInvokeMessage.TextMessage(text="https://example.com/report.docx"),
+        meta={"file": file_mapping},
+    )
+
+    with patch(
+        "core.workflow.nodes.agent.message_transformer.file_factory.build_from_mapping",
+        return_value=file,
+    ) as build_file:
+        text, files = _run_transform([message])
+
+    assert text == "File: https://example.com/report.docx\n"
+    assert files.value == [file]
+    build_file.assert_called_once()
+
+
+def test_transform_rejects_unknown_tool_file_link() -> None:
+    message = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LINK,
+        message=ToolInvokeMessage.TextMessage(text="/files/tools/missing.docx"),
+        meta={"tool_file_id": "missing"},
+    )
+
+    session = MagicMock()
+    session.scalar.return_value = None
+    session_context = MagicMock()
+    session_context.__enter__.return_value = session
+    with (
+        patch("core.workflow.nodes.agent.message_transformer.db", SimpleNamespace(engine=object())),
+        patch("core.workflow.nodes.agent.message_transformer.Session", return_value=session_context),
+        pytest.raises(ToolFileNotFoundError, match="missing"),
+    ):
+        _run_transform([message])
 
 
 def test_transform_keeps_plain_link_as_text() -> None:

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -24,10 +25,14 @@ def _file() -> File:
     )
 
 
+def _message_stream(messages: list[ToolInvokeMessage]) -> Generator[ToolInvokeMessage, None, None]:
+    yield from messages
+
+
 def _run_transform(messages: list[ToolInvokeMessage]) -> tuple[str, ArrayFileSegment]:
     events = list(
         AgentMessageTransformer().transform(
-            messages=iter(messages),
+            messages=_message_stream(messages),
             tool_info={},
             parameters_for_log={},
             user_id="user-id",
@@ -45,7 +50,7 @@ def _run_transform(messages: list[ToolInvokeMessage]) -> tuple[str, ArrayFileSeg
 
 
 def test_transform_passes_conversation_id_to_tool_file_message_transformer() -> None:
-    messages = iter(())
+    messages = _message_stream([])
     transformer = AgentMessageTransformer()
 
     with patch.object(ToolFileMessageTransformer, "transform_tool_invoke_messages", return_value=iter(())) as transform:

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -1,8 +1,47 @@
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.utils.message_transformer import ToolFileMessageTransformer
+from core.workflow.file_reference import build_file_reference
 from core.workflow.nodes.agent.message_transformer import AgentMessageTransformer
 from graphon.enums import BuiltinNodeTypes
+from graphon.file import File, FileTransferMethod, FileType
+from graphon.node_events import StreamCompletedEvent
+from graphon.variables.segments import ArrayFileSegment
+
+
+def _file() -> File:
+    return File(
+        type=FileType.DOCUMENT,
+        transfer_method=FileTransferMethod.TOOL_FILE,
+        reference=build_file_reference(record_id="tool-file-id"),
+        related_id="tool-file-id",
+        filename="report.docx",
+        extension=".docx",
+        mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        size=12,
+    )
+
+
+def _run_transform(messages: list[ToolInvokeMessage]) -> tuple[str, ArrayFileSegment]:
+    events = list(
+        AgentMessageTransformer().transform(
+            messages=iter(messages),
+            tool_info={},
+            parameters_for_log={},
+            user_id="user-id",
+            tenant_id="tenant-id",
+            conversation_id=None,
+            node_type=BuiltinNodeTypes.AGENT,
+            node_id="node-id",
+            node_execution_id="execution-id",
+        )
+    )
+    completed = next(event for event in events if isinstance(event, StreamCompletedEvent))
+    outputs = completed.node_run_result.outputs
+    assert isinstance(outputs["files"], ArrayFileSegment)
+    return outputs["text"], outputs["files"]
 
 
 def test_transform_passes_conversation_id_to_tool_file_message_transformer() -> None:
@@ -31,3 +70,58 @@ def test_transform_passes_conversation_id_to_tool_file_message_transformer() -> 
         tenant_id="tenant-id",
         conversation_id="conversation-id",
     )
+
+
+def test_transform_promotes_tool_file_message_to_files_output() -> None:
+    file = _file()
+    message = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.FILE,
+        message=ToolInvokeMessage.FileMessage(file_marker="file_marker"),
+        meta={"file": file},
+    )
+
+    text, files = _run_transform([message])
+
+    assert text == "File: /files/tools/tool-file-id.docx\n"
+    assert files.value == [file]
+
+
+def test_transform_promotes_serialized_tool_file_link_to_files_output() -> None:
+    file = _file()
+    message = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LINK,
+        message=ToolInvokeMessage.TextMessage(text="/files/tools/tool-file-id.docx"),
+        meta={"file": file.model_dump(mode="json"), "tool_file_id": "tool-file-id"},
+    )
+
+    session = MagicMock()
+    session.scalar.return_value = SimpleNamespace(
+        mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    session_context = MagicMock()
+    session_context.__enter__.return_value = session
+    with (
+        patch("core.workflow.nodes.agent.message_transformer.db", SimpleNamespace(engine=object())),
+        patch("core.workflow.nodes.agent.message_transformer.Session", return_value=session_context),
+        patch(
+            "core.workflow.nodes.agent.message_transformer.file_factory.build_from_mapping",
+            return_value=file,
+        ) as build_file,
+    ):
+        text, files = _run_transform([message])
+
+    assert text == "File: /files/tools/tool-file-id.docx\n"
+    assert files.value == [file]
+    build_file.assert_called_once()
+
+
+def test_transform_keeps_plain_link_as_text() -> None:
+    message = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LINK,
+        message=ToolInvokeMessage.TextMessage(text="https://dify.ai"),
+    )
+
+    text, files = _run_transform([message])
+
+    assert text == "Link: https://dify.ai\n"
+    assert files.value == []


### PR DESCRIPTION
## Summary

- promote file-bearing Agent `LINK` messages back into the workflow node `files` output
- rebuild serialized ToolFile links through the server-side file factory with tenant-scoped ownership checks
- keep ordinary links as text and preserve the existing stream output
- add focused coverage for direct and serialized tool-file messages

This is the Dify core half of the COM-13630 fix; the companion `cot_agent` change is langgenius/dify-official-plugins#3674.

## Screenshots

Not applicable (backend-only).

## Verification

- 55 related backend tests passed
- Ruff format/check passed
- Pyrefly: 0 diagnostics
- dev E2E passed for both Function Calling and ReAct using a Workflow Tool that downloads a PDF; each run produced one Agent `files` output

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Backend lint and targeted type checks passed.

Related: Linear COM-13630

From Codex