### PR TITLE
refactor(web): remove unnecessary setState in useEffect

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -138,9 +138,6 @@
     }
   },
   "web/app/account/(commonLayout)/delete-account/components/verify-email.tsx": {
-    "eslint-react/set-state-in-effect": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -371,11 +368,6 @@
       "count": 1
     }
   },
-  "web/app/components/app/configuration/config/automatic/prompt-res.tsx": {
-    "eslint-react/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "web/app/components/app/configuration/config/automatic/types.ts": {
     "erasable-syntax-only/enums": {
       "count": 1
@@ -408,9 +400,6 @@
     }
   },
   "web/app/components/app/configuration/dataset-config/settings-modal/index.tsx": {
-    "eslint-react/set-state-in-effect": {
-      "count": 2
-    },
     "jsx-a11y/click-events-have-key-events": {
       "count": 1
     },

--- a/web/app/account/(commonLayout)/delete-account/components/verify-email.tsx
+++ b/web/app/account/(commonLayout)/delete-account/components/verify-email.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Button } from '@langgenius/dify-ui/button'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
 import Countdown from '@/app/components/signin/countdown'
@@ -18,13 +18,10 @@ export default function VerifyEmail(props: DeleteAccountProps) {
   const { t } = useTranslation()
   const emailToken = useAccountDeleteStore((state) => state.sendEmailToken)
   const [verificationCode, setVerificationCode] = useState<string>()
-  const [shouldButtonDisabled, setShouldButtonDisabled] = useState(true)
   const { mutate: sendEmail } = useSendDeleteAccountEmail()
   const { isPending: isDeleting, mutateAsync: confirmDeleteAccount } = useConfirmDeleteAccount()
 
-  useEffect(() => {
-    setShouldButtonDisabled(!(verificationCode && CODE_EXP.test(verificationCode)) || isDeleting)
-  }, [verificationCode, isDeleting])
+  const shouldButtonDisabled = !(verificationCode && CODE_EXP.test(verificationCode)) || isDeleting
 
   const handleConfirm = useCallback(async () => {
     try {

--- a/web/app/components/app/configuration/config/automatic/prompt-res.tsx
+++ b/web/app/components/app/configuration/config/automatic/prompt-res.tsx
@@ -2,7 +2,6 @@
 import type { FC } from 'react'
 import type { WorkflowVariableBlockType } from '@/app/components/base/prompt-editor/types'
 import * as React from 'react'
-import { useEffect } from 'react'
 import PromptEditor from '@/app/components/base/prompt-editor'
 
 type Props = Readonly<{
@@ -10,15 +9,10 @@ type Props = Readonly<{
   workflowVariableBlock: WorkflowVariableBlockType
 }>
 
-const keyIdPrefix = 'prompt-res-editor'
 const PromptRes: FC<Props> = ({ value, workflowVariableBlock }) => {
-  const [editorKey, setEditorKey] = React.useState<string>('keyIdPrefix-0')
-  useEffect(() => {
-    setEditorKey(`${keyIdPrefix}-${Date.now()}`)
-  }, [value])
   return (
     <PromptEditor
-      key={editorKey}
+      key={value}
       value={value}
       editable={false}
       className="h-full bg-transparent pt-0"

--- a/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react'
 import type { RetrievalTranslate } from './retrieval-section'
-import type { Member } from '@/models/common'
 import type { DataSet } from '@/models/datasets'
 import type { RetrievalConfig } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
@@ -9,7 +8,7 @@ import { Textarea } from '@langgenius/dify-ui/textarea'
 import { RiCloseLine } from '@remixicon/react'
 import { isEqual } from 'es-toolkit/predicate'
 import { useQueryState } from 'nuqs'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from '@/app/components/app/configuration/toast'
 import Input from '@/app/components/base/input'
@@ -72,8 +71,8 @@ const SettingsModal: FC<SettingsModalProps> = ({
   const [selectedMemberIDs, setSelectedMemberIDs] = useState<string[]>(
     currentDataset.partial_member_list || [],
   )
-  const [memberList, setMemberList] = useState<Member[]>([])
   const { data: membersData } = useMembers()
+  const memberList = membersData?.accounts ?? []
 
   const [indexMethod, setIndexMethod] = useState(currentDataset.indexing_technique)
   const [retrievalConfig, setRetrievalConfig] = useState(
@@ -176,11 +175,6 @@ const SettingsModal: FC<SettingsModalProps> = ({
       setLoading(false)
     }
   }
-
-  useEffect(() => {
-    if (!membersData?.accounts) setMemberList([])
-    else setMemberList(membersData.accounts)
-  }, [membersData])
 
   const showMultiModalTip = useMemo(() => {
     return checkShowMultiModalTip({


### PR DESCRIPTION
## Summary

Part of #25194

Three cases where `useState` + `useEffect` can be replaced with simpler
derived values during render, per https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state

## Changes

- **`verify-email.tsx`** — `shouldButtonDisabled` is purely derived from
  `verificationCode` and `isDeleting`. Replaced with a `const`.
- **`prompt-res.tsx`** — The `editorKey` state + effect existed to force
  remount `PromptEditor` on value change. Passing `value` as the React `key`
  achieves the same thing without extra state.
- **`settings-modal/index.tsx`** — `memberList` was synced from React Query
  data via useEffect but never independently mutated. Derived inline.

## Type of Change

- [x] Refactoring (no behavior change)

## Testing

- [x] `tsc --noEmit` passes
- [x] oxlint passes (no new diagnostics)
- [x] lint-staged pre-commit hook passes
- [ ] No full UI verification (requires backend services)