### PR TITLE
fix(web): prevent signin page content from overflowing on mobile

### DIFF
--- a/web/app/(shareLayout)/webapp-signin/normalForm.tsx
+++ b/web/app/(shareLayout)/webapp-signin/normalForm.tsx
@@ -237,7 +237,7 @@ const NormalForm = () => {
                 </Link>
               </div>
               {isNonCloudEdition && (
-                <div className="w-hull mt-2 block system-xs-regular text-text-tertiary">
+                <div className="mt-2 block w-full system-xs-regular text-text-tertiary">
                   {t(($) => $.goToInit, { ns: 'login' })}
                   &nbsp;
                   <Link

--- a/web/app/signin/layout.tsx
+++ b/web/app/signin/layout.tsx
@@ -11,14 +11,14 @@ export default function SignInLayout({ children }: any) {
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>
         <div
           className={cn(
-            'flex w-full shrink-0 flex-col items-center rounded-2xl border border-effects-highlight bg-background-default-subtle',
+            'flex w-full min-w-0 flex-col items-center rounded-2xl border border-effects-highlight bg-background-default-subtle',
           )}
         >
           <Header />
           <div
             className={cn('flex w-full grow flex-col items-center justify-center px-6 md:px-27')}
           >
-            <div className="flex flex-col md:w-100">{children}</div>
+            <div className="flex w-full flex-col md:w-100">{children}</div>
           </div>
           {systemFeatures.branding.enabled === false && (
             <div className="px-8 py-6 system-xs-regular text-text-tertiary">

--- a/web/app/signin/normal-form.tsx
+++ b/web/app/signin/normal-form.tsx
@@ -328,7 +328,7 @@ function NormalForm() {
                 </Link>
               </div>
               {isNonCloudEdition && (
-                <div className="w-hull mt-2 block system-xs-regular text-text-tertiary">
+                <div className="mt-2 block w-full system-xs-regular text-text-tertiary">
                   {t(($) => $.goToInit, { ns: 'login' })}
                   &nbsp;
                   <Link


### PR DESCRIPTION
## Summary

Fixes #35606

The signin page buttons and text overflow their container on narrow
mobile viewports. Two root causes:

1. The card container uses `shrink-0` which prevents it from ever
   shrinking below its content width — replaced with `min-w-0`.
2. The form wrapper has `md:w-100` but no width on smaller screens.
   Since the parent uses `items-center` (prevents stretching), child
   elements with `w-full` have no proper constraint — added `w-full`
   so it fills the padded container on mobile.
3. Bonus: fixed `w-hull` typo (→ `w-full`) in both `normal-form.tsx`
   and `webapp-signin/normalForm.tsx`.

## Changes

- `web/app/signin/layout.tsx` — `shrink-0` → `min-w-0`, add `w-full`
  to inner wrapper
- `web/app/signin/normal-form.tsx` — `w-hull` → `w-full`
- `web/app/(shareLayout)/webapp-signin/normalForm.tsx` — same typo fix

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `tsc --noEmit` passes
- [x] lint-staged passes
- [ ] Visual verification requires running the app on a narrow viewport