### PR TITLE
refactor(web): compose search prefixes with input group

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2580,11 +2580,6 @@
       "count": 2
     }
   },
-  "web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/header/account-setting/model-provider-page/declarations.ts": {
     "erasable-syntax-only/enums": {
       "count": 11
@@ -2975,16 +2970,6 @@
   },
   "web/app/components/plugins/plugin-page/context.ts": {
     "typescript/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "web/app/components/plugins/plugin-page/filter-management/category-filter.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "web/app/components/plugins/plugin-page/filter-management/search-box.tsx": {
-    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -4128,17 +4113,6 @@
       "count": 1
     }
   },
-  "web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/member-list.tsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/human-input/components/delivery-method/test-email-sender.tsx": {
     "jsx-a11y/no-autofocus": {
       "count": 1
@@ -4243,17 +4217,6 @@
   },
   "web/app/components/workflow/nodes/knowledge-base/utils.ts": {
     "erasable-syntax-only/enums": {
-      "count": 1
-    }
-  },
-  "web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/add-condition.tsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     }
   },

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx
@@ -63,7 +63,7 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'Jane')
+    await user.type(screen.getByRole('searchbox', { name: 'common.operation.search' }), 'Jane')
 
     const items = getMemberButtons()
     expect(items).toHaveLength(1)
@@ -81,7 +81,7 @@ describe('MemberSelector', () => {
     expect(mockOnSelect).toHaveBeenCalledWith('2')
     await waitFor(() => {
       expect(
-        screen.queryByRole('textbox', { name: 'common.operation.search' }),
+        screen.queryByRole('searchbox', { name: 'common.operation.search' }),
       ).not.toBeInTheDocument()
     })
   })
@@ -91,7 +91,7 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'john@')
+    await user.type(screen.getByRole('searchbox', { name: 'common.operation.search' }), 'john@')
 
     const items = getMemberButtons()
     expect(items).toHaveLength(1)
@@ -126,7 +126,7 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'noname@')
+    await user.type(screen.getByRole('searchbox', { name: 'common.operation.search' }), 'noname@')
 
     const items = getMemberButtons()
     expect(items).toHaveLength(1)
@@ -149,7 +149,7 @@ describe('MemberSelector', () => {
 
     await user.click(getTrigger())
     await user.type(
-      screen.getByRole('textbox', { name: 'common.operation.search' }),
+      screen.getByRole('searchbox', { name: 'common.operation.search' }),
       'xyz-no-match-xyz',
     )
 
@@ -168,7 +168,7 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'john')
+    await user.type(screen.getByRole('searchbox', { name: 'common.operation.search' }), 'john')
 
     expect(screen.getByRole('button', { name: /John/ })).toBeInTheDocument()
   })
@@ -202,7 +202,7 @@ describe('MemberSelector', () => {
 
     expect(mockOnSelect).toHaveBeenCalledWith('2')
     expect(
-      screen.queryByRole('textbox', { name: 'common.operation.search' }),
+      screen.queryByRole('searchbox', { name: 'common.operation.search' }),
     ).not.toBeInTheDocument()
   })
 })

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
@@ -1,11 +1,11 @@
 'use client'
 import type { FC } from 'react'
 import { Avatar } from '@langgenius/dify-ui/avatar'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import * as React from 'react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { useMembers } from '@/service/use-common'
 
 type Props = Readonly<{
@@ -18,6 +18,7 @@ const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [searchValue, setSearchValue] = useState('')
+  const searchLabel = t(($) => $['operation.search'], { ns: 'common' })
 
   const { data } = useMembers()
 
@@ -80,12 +81,23 @@ const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
       >
         <div className="min-w-93 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-2 pb-1">
-            <Input
-              showLeftIcon
-              aria-label={t(($) => $['operation.search'], { ns: 'common' })}
-              value={searchValue}
-              onChange={(e) => setSearchValue(e.target.value)}
-            />
+            <InputGroup>
+              <InputGroupInput
+                type="search"
+                aria-label={searchLabel}
+                autoComplete="off"
+                className="[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+                placeholder={searchLabel}
+                value={searchValue}
+                onValueChange={setSearchValue}
+              />
+              <InputGroupAddon className="ps-2 pe-0.5">
+                <span
+                  aria-hidden="true"
+                  className="i-ri-search-line size-4 text-components-input-text-placeholder"
+                />
+              </InputGroupAddon>
+            </InputGroup>
           </div>
           <div className="p-1">
             {filteredList.map((account) => (

--- a/web/app/components/plugins/plugin-page/filter-management/__tests__/category-filter.spec.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/__tests__/category-filter.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
@@ -89,13 +90,12 @@ describe('CategoriesFilter', () => {
     expect(mockOnChange).toHaveBeenCalledWith([])
   })
 
-  it('should filter categories by search text', () => {
+  it('should filter categories by search text', async () => {
+    const user = userEvent.setup()
     render(<CategoriesFilter value={[]} onChange={vi.fn()} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'plugin.allCategories' }))
-    fireEvent.change(screen.getByPlaceholderText('plugin.searchCategories'), {
-      target: { value: 'mod' },
-    })
+    await user.click(screen.getByRole('button', { name: 'plugin.allCategories' }))
+    await user.type(screen.getByRole('searchbox', { name: 'plugin.searchCategories' }), 'mod')
 
     expect(screen.queryByText('Tool')).not.toBeInTheDocument()
     expect(screen.getByText('Model')).toBeInTheDocument()

--- a/web/app/components/plugins/plugin-page/filter-management/__tests__/search-box.spec.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/__tests__/search-box.spec.tsx
@@ -1,4 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 describe('SearchBox', () => {
@@ -10,23 +12,32 @@ describe('SearchBox', () => {
     SearchBox = mod.default
   })
 
-  it('should render input with placeholder', () => {
-    render(<SearchBox searchQuery="" onChange={vi.fn()} />)
-
-    expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', 'plugin.search')
-  })
-
-  it('should display current search query', () => {
-    render(<SearchBox searchQuery="test query" onChange={vi.fn()} />)
-
-    expect(screen.getByRole('textbox')).toHaveValue('test query')
-  })
-
-  it('should call onChange when input changes', () => {
+  it('should expose a labeled search box and forward the edited query', async () => {
+    const user = userEvent.setup()
     const mockOnChange = vi.fn()
-    render(<SearchBox searchQuery="" onChange={mockOnChange} />)
+    const TestSearchBox = () => {
+      const [query, setQuery] = useState('test query')
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'new query' } })
+      return (
+        <SearchBox
+          searchQuery={query}
+          onChange={(nextQuery) => {
+            setQuery(nextQuery)
+            mockOnChange(nextQuery)
+          }}
+        />
+      )
+    }
+
+    render(<TestSearchBox />)
+
+    const searchBox = screen.getByRole('searchbox', { name: 'plugin.search' })
+    expect(searchBox).toHaveAttribute('placeholder', 'plugin.search')
+    expect(searchBox).toHaveValue('test query')
+
+    await user.clear(searchBox)
+    await user.type(searchBox, 'new query')
+
     expect(mockOnChange).toHaveBeenCalledWith('new query')
   })
 })

--- a/web/app/components/plugins/plugin-page/filter-management/category-filter.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/category-filter.tsx
@@ -3,11 +3,11 @@
 import { Checkbox } from '@langgenius/dify-ui/checkbox'
 import { CheckboxGroup } from '@langgenius/dify-ui/checkbox-group'
 import { cn } from '@langgenius/dify-ui/cn'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { RiArrowDownSLine, RiCloseCircleFill } from '@remixicon/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { useCategories } from '../../hooks'
 
 type CategoriesFilterProps = {
@@ -18,6 +18,7 @@ const CategoriesFilter = ({ value, onChange }: CategoriesFilterProps) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [searchText, setSearchText] = useState('')
+  const searchLabel = t(($) => $.searchCategories, { ns: 'plugin' })
   const { categories: options, categoriesMap } = useCategories()
   const filteredOptions = options.filter((option) =>
     option.name.toLowerCase().includes(searchText.toLowerCase()),
@@ -69,12 +70,23 @@ const CategoriesFilter = ({ value, onChange }: CategoriesFilterProps) => {
       >
         <div className="w-60 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-2 pb-1">
-            <Input
-              showLeftIcon
-              value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
-              placeholder={t(($) => $.searchCategories, { ns: 'plugin' })}
-            />
+            <InputGroup>
+              <InputGroupInput
+                type="search"
+                aria-label={searchLabel}
+                autoComplete="off"
+                className="[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+                placeholder={searchLabel}
+                value={searchText}
+                onValueChange={setSearchText}
+              />
+              <InputGroupAddon className="ps-2 pe-0.5">
+                <span
+                  aria-hidden="true"
+                  className="i-ri-search-line size-4 text-components-input-text-placeholder"
+                />
+              </InputGroupAddon>
+            </InputGroup>
           </div>
           <CheckboxGroup
             aria-label={t(($) => $.allCategories, { ns: 'plugin' })}

--- a/web/app/components/plugins/plugin-page/filter-management/search-box.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/search-box.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 
 type SearchBoxProps = {
   searchQuery: string
@@ -10,18 +10,26 @@ type SearchBoxProps = {
 
 const SearchBox: React.FC<SearchBoxProps> = ({ searchQuery, onChange }) => {
   const { t } = useTranslation()
+  const searchLabel = t(($) => $.search, { ns: 'plugin' })
 
   return (
-    <Input
-      wrapperClassName="flex w-[200px] items-center rounded-lg"
-      className="bg-components-input-bg-normal"
-      showLeftIcon
-      value={searchQuery}
-      placeholder={t(($) => $.search, { ns: 'plugin' })}
-      onChange={(e) => {
-        onChange(e.target.value)
-      }}
-    />
+    <InputGroup className="w-50">
+      <InputGroupInput
+        type="search"
+        aria-label={searchLabel}
+        autoComplete="off"
+        className="[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+        placeholder={searchLabel}
+        value={searchQuery}
+        onValueChange={onChange}
+      />
+      <InputGroupAddon className="ps-2 pe-0.5">
+        <span
+          aria-hidden="true"
+          className="i-ri-search-line size-4 text-components-input-text-placeholder"
+        />
+      </InputGroupAddon>
+    </InputGroup>
   )
 }
 

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/__tests__/member-list.spec.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/__tests__/member-list.spec.tsx
@@ -1,5 +1,7 @@
 import type { Member } from '@/models/common'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import MemberList from '../member-list'
 
 const createMember = (overrides: Partial<Member>): Member => ({
@@ -29,33 +31,48 @@ const members: Member[] = [
 ]
 
 describe('human-input/delivery-method/recipient/member-list', () => {
-  it('should filter members, show selected state, and only add unselected members', () => {
+  it('should filter members, show selected state, and only add unselected members', async () => {
+    const user = userEvent.setup()
     const handleSearchChange = vi.fn()
     const handleSelect = vi.fn()
+    const TestMemberList = () => {
+      const [searchValue, setSearchValue] = useState('pending')
 
-    render(
-      <MemberList
-        value={[{ type: 'member', user_id: 'member-1' }]}
-        searchValue="pending"
-        onSearchChange={handleSearchChange}
-        list={members}
-        onSelect={handleSelect}
-        email="owner@example.com"
-      />,
-    )
+      return (
+        <MemberList
+          value={[{ type: 'member', user_id: 'member-1' }]}
+          searchValue={searchValue}
+          onSearchChange={(nextValue) => {
+            setSearchValue(nextValue)
+            handleSearchChange(nextValue)
+          }}
+          list={members}
+          onSelect={handleSelect}
+          email="owner@example.com"
+        />
+      )
+    }
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'owner' } })
+    render(<TestMemberList />)
+
+    const searchBox = screen.getByRole('searchbox', { name: 'common.operation.search' })
+    await user.clear(searchBox)
+    await user.type(searchBox, 'owner')
     expect(handleSearchChange).toHaveBeenCalledWith('owner')
+
+    expect(screen.getByText('Owner')).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'workflow.nodes.humanInput.deliveryMethod.emailConfigure.memberSelector.add',
+      ),
+    ).not.toBeInTheDocument()
+
+    await user.clear(searchBox)
+    await user.type(searchBox, 'pending')
 
     expect(screen.getByText('Pending User')).toBeInTheDocument()
     expect(screen.getByText('common.members.pending')).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'workflow.nodes.humanInput.deliveryMethod.emailConfigure.memberSelector.add',
-      ),
-    ).toBeInTheDocument()
-
-    fireEvent.click(screen.getByText('Pending User'))
+    await user.click(screen.getByText('Pending User'))
     expect(handleSelect).toHaveBeenCalledWith('member-2')
   })
 

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/member-list.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/member-list.tsx
@@ -4,9 +4,9 @@ import type { Recipient } from '@/app/components/workflow/nodes/human-input/type
 import type { Member } from '@/models/common'
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { cn } from '@langgenius/dify-ui/cn'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 
 const i18nPrefix = 'nodes.humanInput'
 
@@ -30,6 +30,7 @@ const MemberList: FC<Props> = ({
   hideSearch,
 }) => {
   const { t } = useTranslation()
+  const searchLabel = t(($) => $['operation.search'], { ns: 'common' })
 
   const filteredList = useMemo(() => {
     if (!list.length) return []
@@ -50,71 +51,81 @@ const MemberList: FC<Props> = ({
     <div className="min-w-[320px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
       {!hideSearch && (
         <div className="p-2 pb-1">
-          <Input
-            showLeftIcon
-            value={searchValue}
-            onChange={(e) => onSearchChange(e.target.value)}
-          />
+          <InputGroup>
+            <InputGroupInput
+              type="search"
+              aria-label={searchLabel}
+              autoComplete="off"
+              className="[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+              placeholder={searchLabel}
+              value={searchValue}
+              onValueChange={onSearchChange}
+            />
+            <InputGroupAddon className="ps-2 pe-0.5">
+              <span
+                aria-hidden="true"
+                className="i-ri-search-line size-4 text-components-input-text-placeholder"
+              />
+            </InputGroupAddon>
+          </InputGroup>
         </div>
       )}
       {filteredList.length > 0 && (
         <div className="max-h-62 overflow-y-auto p-1">
-          {filteredList.map((account) => (
-            <div
-              key={account.id}
-              className={cn(
-                'group flex cursor-pointer items-center gap-2 rounded-lg py-1 pr-3 pl-2 hover:bg-state-base-hover',
-                value.some((item) => item.user_id === account.id) &&
-                  'bg-transparent hover:bg-transparent',
-              )}
-              onClick={() => {
-                if (value.some((item) => item.user_id === account.id)) return
-                onSelect(account.id)
-              }}
-            >
-              <Avatar
-                className={cn(value.some((item) => item.user_id === account.id) && 'opacity-50')}
-                avatar={account.avatar_url}
-                size="sm"
-                name={account.name}
-              />
-              <div
+          {filteredList.map((account) => {
+            const isSelected = value.some((item) => item.user_id === account.id)
+
+            return (
+              <button
+                type="button"
+                key={account.id}
+                disabled={isSelected}
                 className={cn(
-                  'grow',
-                  value.some((item) => item.user_id === account.id) && 'opacity-50',
+                  'group flex w-full cursor-pointer appearance-none items-center gap-2 rounded-lg border-none bg-transparent py-1 pr-3 pl-2 text-start outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid',
+                  isSelected && 'cursor-default bg-transparent hover:bg-transparent',
                 )}
+                onClick={() => onSelect(account.id)}
               >
-                <div className="system-sm-medium text-text-secondary">
-                  {account.name}
-                  {account.status === 'pending' && (
-                    <span className="ml-1 system-xs-medium text-text-warning">
-                      {t(($) => $['members.pending'], { ns: 'common' })}
-                    </span>
-                  )}
-                  {email === account.email && (
-                    <span className="system-xs-regular text-text-tertiary">
-                      {t(($) => $['members.you'], { ns: 'common' })}
-                    </span>
-                  )}
+                <Avatar
+                  className={cn(isSelected && 'opacity-50')}
+                  avatar={account.avatar_url}
+                  size="sm"
+                  name={account.name}
+                />
+                <div className={cn('grow', isSelected && 'opacity-50')}>
+                  <div className="system-sm-medium text-text-secondary">
+                    {account.name}
+                    {account.status === 'pending' && (
+                      <span className="ml-1 system-xs-medium text-text-warning">
+                        {t(($) => $['members.pending'], { ns: 'common' })}
+                      </span>
+                    )}
+                    {email === account.email && (
+                      <span className="system-xs-regular text-text-tertiary">
+                        {t(($) => $['members.you'], { ns: 'common' })}
+                      </span>
+                    )}
+                  </div>
+                  <div className="system-xs-regular text-text-tertiary">{account.email}</div>
                 </div>
-                <div className="system-xs-regular text-text-tertiary">{account.email}</div>
-              </div>
-              {!value.some((item) => item.user_id === account.id) && (
-                <div className="hidden system-xs-medium text-text-accent group-hover:block">
-                  {t(($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.memberSelector.add`], {
-                    ns: 'workflow',
-                  })}
-                </div>
-              )}
-              {value.some((item) => item.user_id === account.id) && (
-                <div className="system-xs-regular text-text-tertiary">
-                  {t(($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.memberSelector.added`], {
-                    ns: 'workflow',
-                  })}
-                </div>
-              )}
-            </div>
-          ))}
+                {!isSelected && (
+                  <div className="hidden system-xs-medium text-text-accent group-hover:block">
+                    {t(($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.memberSelector.add`], {
+                      ns: 'workflow',
+                    })}
+                  </div>
+                )}
+                {isSelected && (
+                  <div className="system-xs-regular text-text-tertiary">
+                    {t(
+                      ($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.memberSelector.added`],
+                      { ns: 'workflow' },
+                    )}
+                  </div>
+                )}
+              </button>
+            )
+          })}
         </div>
       )}
     </div>

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/add-condition.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/add-condition.tsx
@@ -1,11 +1,11 @@
 import type { MetadataShape } from '@/app/components/workflow/nodes/knowledge-retrieval/types'
 import type { MetadataInDoc } from '@/models/datasets'
 import { Button } from '@langgenius/dify-ui/button'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { RiAddLine } from '@remixicon/react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import MetadataIcon from './metadata-icon'
 
 const AddCondition = ({
@@ -15,6 +15,9 @@ const AddCondition = ({
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [searchText, setSearchText] = useState('')
+  const searchLabel = t(($) => $['nodes.knowledgeRetrieval.metadata.panel.search'], {
+    ns: 'workflow',
+  })
 
   const filteredMetadataList = useMemo(() => {
     return metadataList?.filter((metadata) => metadata.name.includes(searchText))
@@ -45,20 +48,30 @@ const AddCondition = ({
       >
         <div className="w-[320px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <div className="p-2 pb-1">
-            <Input
-              showLeftIcon
-              placeholder={t(($) => $['nodes.knowledgeRetrieval.metadata.panel.search'], {
-                ns: 'workflow',
-              })}
-              value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
-            />
+            <InputGroup>
+              <InputGroupInput
+                type="search"
+                aria-label={searchLabel}
+                autoComplete="off"
+                className="[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+                placeholder={searchLabel}
+                value={searchText}
+                onValueChange={setSearchText}
+              />
+              <InputGroupAddon className="ps-2 pe-0.5">
+                <span
+                  aria-hidden="true"
+                  className="i-ri-search-line size-4 text-components-input-text-placeholder"
+                />
+              </InputGroupAddon>
+            </InputGroup>
           </div>
           <div className="p-1">
             {filteredMetadataList?.map((metadata) => (
-              <div
+              <button
+                type="button"
                 key={metadata.name}
-                className="flex h-6 cursor-pointer items-center rounded-md px-3 system-sm-medium text-text-secondary hover:bg-state-base-hover"
+                className="flex h-6 w-full cursor-pointer appearance-none items-center rounded-md border-none bg-transparent px-3 text-start system-sm-medium text-text-secondary outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
                 onClick={() => handleAddConditionWrapped(metadata)}
               >
                 <div className="mr-1 p-px">
@@ -68,7 +81,7 @@ const AddCondition = ({
                   {metadata.name}
                 </div>
                 <div className="shrink-0 system-xs-regular text-text-tertiary">{metadata.type}</div>
-              </div>
+              </button>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary

- replace five legacy left-icon search inputs with the Dify UI `InputGroup` anatomy
- expose native searchbox semantics and explicit accessible names without changing the existing 32px input surface or icon spacing
- use semantic buttons for the touched selectable rows so keyboard focus is visible and actionable

## Validation

- focused browser-mode tests included in the 157-test stack run
- `pnpm check`
- Web `pnpm type-check` with stale `.next` output isolated
- Web `pnpm lint:tss`
- `pnpm lint:tailwind`

## Screenshots

No visual change intended. Existing dimensions, typography, colors, and spacing are preserved.

From Codex