### PR TITLE
refactor(web): migrate retry units to number field

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3703,11 +3703,6 @@
       "count": 1
     }
   },
-  "web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/_base/components/selector.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 3

--- a/web/app/components/workflow/nodes/_base/components/retry/__tests__/retry-on-panel.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/retry/__tests__/retry-on-panel.spec.tsx
@@ -1,0 +1,85 @@
+import type { Node } from '@/app/components/workflow/types'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RetryOnPanel from '../retry-on-panel'
+
+const { mockHandleRetryConfigChange } = vi.hoisted(() => ({
+  mockHandleRetryConfigChange: vi.fn(),
+}))
+
+vi.mock('../hooks', () => ({
+  useRetryConfig: () => ({
+    handleRetryConfigChange: mockHandleRetryConfigChange,
+  }),
+}))
+
+const data = {
+  retry_config: {
+    retry_enabled: true,
+    max_retries: 3,
+    retry_interval: 1000,
+  },
+} as Node['data']
+
+describe('RetryOnPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should label the retry switch and grouped value controls', () => {
+    render(<RetryOnPanel id="node-1" data={data} />)
+
+    expect(
+      screen.getByRole('switch', { name: 'workflow.nodes.common.retry.retryOnFailure' }),
+    ).toBeChecked()
+
+    const maxRetriesLabel = 'workflow.nodes.common.retry.maxRetries'
+    const maxRetriesGroup = screen.getByRole('group', { name: maxRetriesLabel })
+    expect(within(maxRetriesGroup).getByRole('slider', { name: maxRetriesLabel })).toHaveAttribute(
+      'aria-valuenow',
+      '3',
+    )
+    const maxRetriesInput = within(maxRetriesGroup).getByRole('textbox', {
+      name: maxRetriesLabel,
+    })
+    expect(maxRetriesInput).toHaveAttribute('aria-roledescription', 'Number field')
+    expect(maxRetriesInput).toHaveValue('3')
+    expect(within(maxRetriesGroup).getByText('workflow.nodes.common.retry.times')).toBeVisible()
+
+    const retryIntervalLabel = 'workflow.nodes.common.retry.retryInterval'
+    const retryIntervalGroup = screen.getByRole('group', { name: retryIntervalLabel })
+    expect(
+      within(retryIntervalGroup).getByRole('slider', { name: retryIntervalLabel }),
+    ).toHaveAttribute('aria-valuenow', '1000')
+    expect(
+      within(retryIntervalGroup).getByRole('textbox', { name: retryIntervalLabel }),
+    ).toHaveValue('1000')
+    expect(within(retryIntervalGroup).getByText('workflow.nodes.common.retry.ms')).toBeVisible()
+  })
+
+  it('should update retry configuration through native control interactions', async () => {
+    const user = userEvent.setup()
+    render(<RetryOnPanel id="node-1" data={data} />)
+
+    await user.click(
+      screen.getByRole('switch', { name: 'workflow.nodes.common.retry.retryOnFailure' }),
+    )
+    expect(mockHandleRetryConfigChange).toHaveBeenLastCalledWith({
+      retry_enabled: false,
+      max_retries: 3,
+      retry_interval: 1000,
+    })
+
+    const maxRetriesInput = screen.getByRole('textbox', {
+      name: 'workflow.nodes.common.retry.maxRetries',
+    })
+    await user.click(maxRetriesInput)
+    await user.keyboard('{ArrowUp}')
+
+    expect(mockHandleRetryConfigChange).toHaveBeenLastCalledWith({
+      retry_enabled: true,
+      max_retries: 4,
+      retry_interval: 1000,
+    })
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
+++ b/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
@@ -1,18 +1,27 @@
 import type { Node } from '@/app/components/workflow/types'
 import { Fieldset, FieldsetLegend } from '@langgenius/dify-ui/fieldset'
+import {
+  NumberField,
+  NumberFieldGroup,
+  NumberFieldInput,
+  NumberFieldUnit,
+} from '@langgenius/dify-ui/number-field'
 import { Slider } from '@langgenius/dify-ui/slider'
 import { Switch } from '@langgenius/dify-ui/switch'
+import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import Split from '@/app/components/workflow/nodes/_base/components/split'
 import { useRetryConfig } from './hooks'
-import s from './style.module.css'
 
 type RetryOnPanelProps = Pick<Node, 'id' | 'data'>
 const RetryOnPanel = ({ id, data }: RetryOnPanelProps) => {
   const { t } = useTranslation()
   const { handleRetryConfigChange } = useRetryConfig(id)
   const { retry_config } = data
+  const retryEnabledId = useId()
+  const retryOnFailureLabel = t(($) => $['nodes.common.retry.retryOnFailure'], {
+    ns: 'workflow',
+  })
   const maxRetriesLabel = t(($) => $['nodes.common.retry.maxRetries'], { ns: 'workflow' })
   const retryIntervalLabel = t(($) => $['nodes.common.retry.retryInterval'], { ns: 'workflow' })
 
@@ -48,12 +57,14 @@ const RetryOnPanel = ({ id, data }: RetryOnPanelProps) => {
     <>
       <div className="pt-2">
         <div className="flex h-10 items-center justify-between px-4 py-2">
-          <div className="flex items-center">
-            <div className="mr-0.5 system-sm-semibold-uppercase text-text-secondary">
-              {t(($) => $['nodes.common.retry.retryOnFailure'], { ns: 'workflow' })}
-            </div>
-          </div>
+          <label
+            htmlFor={retryEnabledId}
+            className="mr-0.5 system-sm-semibold-uppercase text-text-secondary"
+          >
+            {retryOnFailureLabel}
+          </label>
           <Switch
+            id={retryEnabledId}
             checked={retry_config?.retry_enabled ?? false}
             onCheckedChange={(v) => handleRetryEnabledChange(v)}
           />
@@ -73,19 +84,21 @@ const RetryOnPanel = ({ id, data }: RetryOnPanelProps) => {
                 max={10}
                 aria-label={maxRetriesLabel}
               />
-              <Input
-                aria-label={maxRetriesLabel}
-                type="number"
-                wrapperClassName="w-[100px]"
+              <NumberField
+                className="w-25 shrink-0"
                 value={retry_config?.max_retries || 3}
-                onChange={(e) =>
-                  handleMaxRetriesChange(Number.parseInt(e.currentTarget.value, 10) || 3)
-                }
                 min={1}
                 max={10}
-                unit={t(($) => $['nodes.common.retry.times'], { ns: 'workflow' }) || ''}
-                className={s.input}
-              />
+                format={{ useGrouping: false }}
+                onValueChange={(value) => handleMaxRetriesChange(value ?? 3)}
+              >
+                <NumberFieldGroup>
+                  <NumberFieldInput aria-label={maxRetriesLabel} />
+                  <NumberFieldUnit>
+                    {t(($) => $['nodes.common.retry.times'], { ns: 'workflow' })}
+                  </NumberFieldUnit>
+                </NumberFieldGroup>
+              </NumberField>
             </Fieldset>
             <Fieldset className="flex items-center">
               <FieldsetLegend className="sr-only">{retryIntervalLabel}</FieldsetLegend>
@@ -100,19 +113,21 @@ const RetryOnPanel = ({ id, data }: RetryOnPanelProps) => {
                 max={5000}
                 aria-label={retryIntervalLabel}
               />
-              <Input
-                aria-label={retryIntervalLabel}
-                type="number"
-                wrapperClassName="w-[100px]"
+              <NumberField
+                className="w-25 shrink-0"
                 value={retry_config?.retry_interval || 1000}
-                onChange={(e) =>
-                  handleRetryIntervalChange(Number.parseInt(e.currentTarget.value, 10) || 1000)
-                }
                 min={100}
                 max={5000}
-                unit={t(($) => $['nodes.common.retry.ms'], { ns: 'workflow' }) || ''}
-                className={s.input}
-              />
+                format={{ useGrouping: false }}
+                onValueChange={(value) => handleRetryIntervalChange(value ?? 1000)}
+              >
+                <NumberFieldGroup>
+                  <NumberFieldInput aria-label={retryIntervalLabel} />
+                  <NumberFieldUnit>
+                    {t(($) => $['nodes.common.retry.ms'], { ns: 'workflow' })}
+                  </NumberFieldUnit>
+                </NumberFieldGroup>
+              </NumberField>
             </Fieldset>
           </div>
         )}

--- a/web/app/components/workflow/nodes/_base/components/retry/style.module.css
+++ b/web/app/components/workflow/nodes/_base/components/retry/style.module.css
@@ -1,5 +1,0 @@
-.input::-webkit-inner-spin-button,
-.input::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}


### PR DESCRIPTION
## Summary

- migrate the Retry panel max-retries and retry-interval controls from the legacy input to Dify UI `NumberField`
- keep the existing 100px surface, typography, unit placement, and ungrouped numeric formatting
- associate the retry switch with its visible label and group each slider/input pair under a shared fieldset name
- add behavior-focused tests for accessible naming and keyboard value changes

## Validation

- focused browser-mode tests included in the 157-test stack run
- `pnpm check`
- Web `pnpm type-check` with stale `.next` output isolated
- Web `pnpm lint:tss`
- `pnpm lint:tailwind`

## Screenshots

No visual change intended. Existing dimensions, typography, colors, and spacing are preserved.

From Codex