### PR TITLE
refactor(web): migrate clearable search inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2140,11 +2140,6 @@
       "count": 1
     }
   },
-  "web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/list/item.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 3
@@ -3772,19 +3767,13 @@
     }
   },
   "web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx": {
-    "import/no-duplicates": {
-      "count": 1
-    },
     "jsx-a11y/click-events-have-key-events": {
-      "count": 2
+      "count": 1
     },
     "jsx-a11y/no-autofocus": {
       "count": 1
     },
     "jsx-a11y/no-static-element-interactions": {
-      "count": 2
-    },
-    "no-restricted-imports": {
       "count": 1
     }
   },

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/__tests__/index.spec.tsx
@@ -1,5 +1,6 @@
 import type { OnlineDriveFile } from '@/models/pipeline'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { OnlineDriveFileType } from '@/models/pipeline'
 import FileList from '../index'
@@ -7,10 +8,11 @@ import FileList from '../index'
 // Mock ahooks useDebounceFn: required because tests verify the debounced
 // callback is invoked with specific arguments (mockDebounceFnRun assertions).
 const mockDebounceFnRun = vi.fn()
+const mockDebounceFnCancel = vi.fn()
 vi.mock('ahooks', () => ({
   useDebounceFn: (fn: (...args: unknown[]) => void) => {
     mockDebounceFnRun.mockImplementation(fn)
-    return { run: mockDebounceFnRun }
+    return { run: mockDebounceFnRun, cancel: mockDebounceFnCancel }
   },
 }))
 
@@ -80,6 +82,7 @@ describe('FileList', () => {
     vi.clearAllMocks()
     resetMockStoreState()
     mockDebounceFnRun.mockClear()
+    mockDebounceFnCancel.mockClear()
   })
 
   describe('Rendering', () => {
@@ -328,32 +331,21 @@ describe('FileList', () => {
     })
 
     describe('handleResetKeywords', () => {
-      it('should call resetKeywords prop when clear button is clicked', () => {
+      it('should cancel the pending search before clearing the query', async () => {
+        const user = userEvent.setup()
         const mockResetKeywords = vi.fn()
-        const props = createDefaultProps({ resetKeywords: mockResetKeywords, keywords: 'to-reset' })
+        const props = createDefaultProps({ resetKeywords: mockResetKeywords })
         render(<FileList {...props} />)
+        const input = screen.getByRole('searchbox', {
+          name: 'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
+        })
 
-        // Act - Click the clear icon div (it contains RiCloseCircleFill icon)
-        const clearButton = screen.getByRole('button', { name: 'common.operation.clear' })
-        expect(clearButton).toBeInTheDocument()
-        fireEvent.click(clearButton!)
+        await user.type(input, 'report')
+        await user.click(screen.getByRole('button', { name: 'common.operation.clear' }))
 
-        expect(mockResetKeywords).toHaveBeenCalledTimes(1)
-      })
-
-      it('should reset inputValue to empty string when clear is clicked', () => {
-        const props = createDefaultProps({ keywords: 'to-be-reset' })
-        render(<FileList {...props} />)
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-        fireEvent.change(input, { target: { value: 'some-search' } })
-
-        // Act - Find and click the clear icon
-        const clearButton = screen.getByRole('button', { name: 'common.operation.clear' })
-        expect(clearButton).toBeInTheDocument()
-        fireEvent.click(clearButton!)
-
+        expect(mockDebounceFnRun).toHaveBeenLastCalledWith('report')
+        expect(mockDebounceFnCancel).toHaveBeenCalledOnce()
+        expect(mockResetKeywords).toHaveBeenCalledOnce()
         expect(input).toHaveValue('')
       })
     })

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/__tests__/index.spec.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import Header from '../index'
 
-// Mock store - required by Breadcrumbs component
 const mockStoreState = {
   hasBucket: false,
   setOnlineDriveFileList: vi.fn(),
@@ -14,12 +14,11 @@ const mockStoreState = {
   prefix: [],
 }
 
-const mockGetState = vi.fn(() => mockStoreState)
-const mockDataSourceStore = { getState: mockGetState }
+const mockDataSourceStore = { getState: vi.fn(() => mockStoreState) }
 
 vi.mock('../../../../store', () => ({
   useDataSourceStore: () => mockDataSourceStore,
-  useDataSourceStoreWithSelector: (selector: (s: typeof mockStoreState) => unknown) =>
+  useDataSourceStoreWithSelector: (selector: (state: typeof mockStoreState) => unknown) =>
     selector(mockStoreState),
 }))
 
@@ -31,615 +30,65 @@ const createDefaultProps = (overrides?: Partial<HeaderProps>): HeaderProps => ({
   keywords: '',
   bucket: '',
   searchResultsLength: 0,
-  handleInputChange: vi.fn(),
-  handleResetKeywords: vi.fn(),
+  onSearchValueChange: vi.fn(),
   isInPipeline: false,
   ...overrides,
 })
 
-const resetMockStoreState = () => {
-  mockStoreState.hasBucket = false
-  mockStoreState.setOnlineDriveFileList = vi.fn()
-  mockStoreState.setSelectedFileIds = vi.fn()
-  mockStoreState.setBreadcrumbs = vi.fn()
-  mockStoreState.setPrefix = vi.fn()
-  mockStoreState.setBucket = vi.fn()
-  mockStoreState.breadcrumbs = []
-  mockStoreState.prefix = []
+const searchName = 'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'
+
+const ControlledHeader = ({
+  initialValue = '',
+  onSearchValueChange,
+}: {
+  initialValue?: string
+  onSearchValueChange: (value: string) => void
+}) => {
+  const [inputValue, setInputValue] = React.useState(initialValue)
+
+  return (
+    <Header
+      {...createDefaultProps()}
+      inputValue={inputValue}
+      onSearchValueChange={(value) => {
+        setInputValue(value)
+        onSearchValueChange(value)
+      }}
+    />
+  )
 }
 
 describe('Header', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetMockStoreState()
   })
 
-  describe('Rendering', () => {
-    it('should render Input component with correct props', () => {
-      const props = createDefaultProps({ inputValue: 'test-value' })
+  it('renders the current query as a labeled searchbox', () => {
+    render(<Header {...createDefaultProps({ inputValue: 'report' })} />)
 
-      render(<Header {...props} />)
-
-      const input = screen.getByPlaceholderText(
-        'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-      )
-      expect(input)!.toBeInTheDocument()
-      expect(input)!.toHaveValue('test-value')
-    })
-
-    it('should render Input with search icon', () => {
-      const props = createDefaultProps()
-
-      const { container } = render(<Header {...props} />)
-
-      // Assert - Input should have search icon class
-      const searchIcon = container.querySelector('.i-ri-search-line.size-4')
-      expect(searchIcon)!.toBeInTheDocument()
-    })
-
-    it('should render Input with correct wrapper width', () => {
-      const props = createDefaultProps()
-
-      const { container } = render(<Header {...props} />)
-
-      // Assert - Input wrapper should have w-[200px] class
-      const inputWrapper = container.querySelector('.w-\\[200px\\]')
-      expect(inputWrapper)!.toBeInTheDocument()
-    })
+    expect(screen.getByRole('searchbox', { name: searchName })).toHaveValue('report')
   })
 
-  describe('Props', () => {
-    describe('inputValue prop', () => {
-      it('should display empty input when inputValue is empty string', () => {
-        const props = createDefaultProps({ inputValue: '' })
+  it('reports the edited search value', async () => {
+    const user = userEvent.setup()
+    const onSearchValueChange = vi.fn()
+    render(<ControlledHeader onSearchValueChange={onSearchValueChange} />)
 
-        render(<Header {...props} />)
+    await user.type(screen.getByRole('searchbox', { name: searchName }), 'report')
 
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-        expect(input)!.toHaveValue('')
-      })
-
-      it('should display input value correctly', () => {
-        const props = createDefaultProps({ inputValue: 'search-query' })
-
-        render(<Header {...props} />)
-
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-        expect(input)!.toHaveValue('search-query')
-      })
-
-      it('should handle special characters in inputValue', () => {
-        const specialChars = 'test[file].txt (copy)'
-        const props = createDefaultProps({ inputValue: specialChars })
-
-        render(<Header {...props} />)
-
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-        expect(input)!.toHaveValue(specialChars)
-      })
-
-      it('should handle unicode characters in inputValue', () => {
-        const unicodeValue = '文件搜索 日本語'
-        const props = createDefaultProps({ inputValue: unicodeValue })
-
-        render(<Header {...props} />)
-
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-        expect(input)!.toHaveValue(unicodeValue)
-      })
-    })
-
-    describe('breadcrumbs prop', () => {
-      it('should render with empty breadcrumbs', () => {
-        const props = createDefaultProps({ breadcrumbs: [] })
-
-        render(<Header {...props} />)
-
-        // Assert - Component should render without errors
-        // Assert - Component should render without errors
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-
-      it('should render with single breadcrumb', () => {
-        const props = createDefaultProps({ breadcrumbs: ['folder1'] })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-
-      it('should render with multiple breadcrumbs', () => {
-        const props = createDefaultProps({ breadcrumbs: ['folder1', 'folder2', 'folder3'] })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-    })
-
-    describe('keywords prop', () => {
-      it('should pass keywords to Breadcrumbs', () => {
-        const props = createDefaultProps({ keywords: 'search-keyword' })
-
-        render(<Header {...props} />)
-
-        // Assert - keywords are passed through, component renders
-        // Assert - keywords are passed through, component renders
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-    })
-
-    describe('bucket prop', () => {
-      it('should render with empty bucket', () => {
-        const props = createDefaultProps({ bucket: '' })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-
-      it('should render with bucket value', () => {
-        const props = createDefaultProps({ bucket: 'my-bucket' })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-    })
-
-    describe('searchResultsLength prop', () => {
-      it('should handle zero search results', () => {
-        const props = createDefaultProps({ searchResultsLength: 0 })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-
-      it('should handle positive search results', () => {
-        const props = createDefaultProps({ searchResultsLength: 10, keywords: 'test' })
-
-        render(<Header {...props} />)
-
-        // Assert - Breadcrumbs will show search results text when keywords exist and results > 0
-        // Assert - Breadcrumbs will show search results text when keywords exist and results > 0
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-
-      it('should handle large search results count', () => {
-        const props = createDefaultProps({ searchResultsLength: 1000, keywords: 'test' })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-    })
-
-    describe('isInPipeline prop', () => {
-      it('should render correctly when isInPipeline is false', () => {
-        const props = createDefaultProps({ isInPipeline: false })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-
-      it('should render correctly when isInPipeline is true', () => {
-        const props = createDefaultProps({ isInPipeline: true })
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      })
-    })
+    expect(onSearchValueChange).toHaveBeenLastCalledWith('report')
   })
 
-  // Event Handlers Tests
-  describe('Event Handlers', () => {
-    describe('handleInputChange', () => {
-      it('should call handleInputChange when input value changes', () => {
-        const mockHandleInputChange = vi.fn()
-        const props = createDefaultProps({ handleInputChange: mockHandleInputChange })
-        render(<Header {...props} />)
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-
-        fireEvent.change(input, { target: { value: 'new-value' } })
-
-        expect(mockHandleInputChange).toHaveBeenCalledTimes(1)
-        // Verify that onChange event was triggered (React's synthetic event structure)
-        expect(mockHandleInputChange.mock.calls[0]![0]).toHaveProperty('type', 'change')
-      })
-
-      it('should call handleInputChange on each keystroke', () => {
-        const mockHandleInputChange = vi.fn()
-        const props = createDefaultProps({ handleInputChange: mockHandleInputChange })
-        render(<Header {...props} />)
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-
-        fireEvent.change(input, { target: { value: 'a' } })
-        fireEvent.change(input, { target: { value: 'ab' } })
-        fireEvent.change(input, { target: { value: 'abc' } })
-
-        expect(mockHandleInputChange).toHaveBeenCalledTimes(3)
-      })
-
-      it('should handle empty string input', () => {
-        const mockHandleInputChange = vi.fn()
-        const props = createDefaultProps({
-          inputValue: 'existing',
-          handleInputChange: mockHandleInputChange,
-        })
-        render(<Header {...props} />)
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-
-        fireEvent.change(input, { target: { value: '' } })
-
-        expect(mockHandleInputChange).toHaveBeenCalledTimes(1)
-        expect(mockHandleInputChange.mock.calls[0]![0]).toHaveProperty('type', 'change')
-      })
-
-      it('should handle whitespace-only input', () => {
-        const mockHandleInputChange = vi.fn()
-        const props = createDefaultProps({ handleInputChange: mockHandleInputChange })
-        render(<Header {...props} />)
-        const input = screen.getByPlaceholderText(
-          'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-        )
-
-        fireEvent.change(input, { target: { value: '   ' } })
-
-        expect(mockHandleInputChange).toHaveBeenCalledTimes(1)
-        expect(mockHandleInputChange.mock.calls[0]![0]).toHaveProperty('type', 'change')
-      })
-    })
-
-    describe('handleResetKeywords', () => {
-      it('should call handleResetKeywords when clear icon is clicked', () => {
-        const mockHandleResetKeywords = vi.fn()
-        const props = createDefaultProps({
-          inputValue: 'to-clear',
-          handleResetKeywords: mockHandleResetKeywords,
-        })
-        render(<Header {...props} />)
-
-        // Act - Find and click the clear icon container
-        const clearButton = screen.getByRole('button', { name: 'common.operation.clear' })
-        expect(clearButton)!.toBeInTheDocument()
-        fireEvent.click(clearButton!)
-
-        expect(mockHandleResetKeywords).toHaveBeenCalledTimes(1)
-      })
-
-      it('should not show clear icon when inputValue is empty', () => {
-        const props = createDefaultProps({ inputValue: '' })
-        render(<Header {...props} />)
-
-        // Act & Assert - Clear icon should not be visible
-        const clearIcon = screen.queryByRole('button', { name: 'common.operation.clear' })
-        expect(clearIcon).not.toBeInTheDocument()
-      })
-
-      it('should show clear icon when inputValue is not empty', () => {
-        const props = createDefaultProps({ inputValue: 'some-value' })
-        render(<Header {...props} />)
-
-        // Act & Assert - Clear icon should be visible
-        const clearIcon = screen.getByRole('button', { name: 'common.operation.clear' })
-        expect(clearIcon)!.toBeInTheDocument()
-      })
-    })
-  })
-
-  // Component Memoization Tests
-  describe('Memoization', () => {
-    it('should not re-render when props are the same', () => {
-      const mockHandleInputChange = vi.fn()
-      const mockHandleResetKeywords = vi.fn()
-      const props = createDefaultProps({
-        handleInputChange: mockHandleInputChange,
-        handleResetKeywords: mockHandleResetKeywords,
-      })
-
-      // Act - Initial render
-      const { rerender } = render(<Header {...props} />)
-
-      // Rerender with same props
-      rerender(<Header {...props} />)
-
-      // Assert - Component renders without errors
-      // Assert - Component renders without errors
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it('should re-render when inputValue changes', () => {
-      const props = createDefaultProps({ inputValue: 'initial' })
-      const { rerender } = render(<Header {...props} />)
-      const input = screen.getByPlaceholderText(
-        'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-      )
-      expect(input)!.toHaveValue('initial')
-
-      // Act - Rerender with different inputValue
-      const newProps = createDefaultProps({ inputValue: 'changed' })
-      rerender(<Header {...newProps} />)
-
-      // Assert - Input value should be updated
-      // Assert - Input value should be updated
-      expect(input)!.toHaveValue('changed')
-    })
-
-    it('should re-render when breadcrumbs change', () => {
-      const props = createDefaultProps({ breadcrumbs: [] })
-      const { rerender } = render(<Header {...props} />)
-
-      // Act - Rerender with different breadcrumbs
-      const newProps = createDefaultProps({ breadcrumbs: ['folder1', 'folder2'] })
-      rerender(<Header {...newProps} />)
-
-      // Assert - Component renders without errors
-      // Assert - Component renders without errors
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it('should re-render when keywords change', () => {
-      const props = createDefaultProps({ keywords: '' })
-      const { rerender } = render(<Header {...props} />)
-
-      // Act - Rerender with different keywords
-      const newProps = createDefaultProps({ keywords: 'search-term' })
-      rerender(<Header {...newProps} />)
-
-      // Assert - Component renders without errors
-      // Assert - Component renders without errors
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-  })
-
-  describe('Edge Cases and Error Handling', () => {
-    it('should handle very long inputValue', () => {
-      const longValue = 'a'.repeat(500)
-      const props = createDefaultProps({ inputValue: longValue })
-
-      render(<Header {...props} />)
-
-      const input = screen.getByPlaceholderText(
-        'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-      )
-      expect(input)!.toHaveValue(longValue)
-    })
-
-    it('should handle very long breadcrumb paths', () => {
-      const longBreadcrumbs = Array.from({ length: 20 }, (_, i) => `folder-${i}`)
-      const props = createDefaultProps({ breadcrumbs: longBreadcrumbs })
-
-      render(<Header {...props} />)
-
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it('should handle breadcrumbs with special characters', () => {
-      const specialBreadcrumbs = ['folder [1]', 'folder (2)', 'folder-3.backup']
-      const props = createDefaultProps({ breadcrumbs: specialBreadcrumbs })
-
-      render(<Header {...props} />)
-
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it('should handle breadcrumbs with unicode names', () => {
-      const unicodeBreadcrumbs = ['文件夹', 'フォルダ', 'Папка']
-      const props = createDefaultProps({ breadcrumbs: unicodeBreadcrumbs })
-
-      render(<Header {...props} />)
-
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it('should handle bucket with special characters', () => {
-      const props = createDefaultProps({ bucket: 'my-bucket_2024.backup' })
-
-      render(<Header {...props} />)
-
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it('should pass the event object to handleInputChange callback', () => {
-      const mockHandleInputChange = vi.fn()
-      const props = createDefaultProps({ handleInputChange: mockHandleInputChange })
-      render(<Header {...props} />)
-      const input = screen.getByPlaceholderText(
-        'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-      )
-
-      fireEvent.change(input, { target: { value: 'test-value' } })
-
-      // Assert - Verify the event object is passed correctly
-      expect(mockHandleInputChange).toHaveBeenCalledTimes(1)
-      const eventArg = mockHandleInputChange.mock.calls[0]![0]
-      expect(eventArg).toHaveProperty('type', 'change')
-      expect(eventArg).toHaveProperty('target')
-    })
-  })
-
-  describe('Prop Variations', () => {
-    it.each([
-      { isInPipeline: true, bucket: '' },
-      { isInPipeline: true, bucket: 'my-bucket' },
-      { isInPipeline: false, bucket: '' },
-      { isInPipeline: false, bucket: 'my-bucket' },
-    ])(
-      'should render correctly with isInPipeline=$isInPipeline and bucket=$bucket',
-      (propVariation) => {
-        const props = createDefaultProps(propVariation)
-
-        render(<Header {...props} />)
-
-        expect(
-          screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-        )!.toBeInTheDocument()
-      },
-    )
-
-    it.each([
-      { keywords: '', searchResultsLength: 0, description: 'no search' },
-      { keywords: 'test', searchResultsLength: 0, description: 'search with no results' },
-      { keywords: 'test', searchResultsLength: 5, description: 'search with results' },
-      { keywords: '', searchResultsLength: 5, description: 'no keywords but has results count' },
-    ])('should render correctly with $description', ({ keywords, searchResultsLength }) => {
-      const props = createDefaultProps({ keywords, searchResultsLength })
-
-      render(<Header {...props} />)
-
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it.each([
-      { breadcrumbs: [], inputValue: '', expected: 'empty state' },
-      { breadcrumbs: ['root'], inputValue: 'search', expected: 'single breadcrumb with search' },
-      { breadcrumbs: ['a', 'b', 'c'], inputValue: '', expected: 'multiple breadcrumbs no search' },
-      {
-        breadcrumbs: ['a', 'b', 'c', 'd', 'e'],
-        inputValue: 'query',
-        expected: 'many breadcrumbs with search',
-      },
-    ])('should handle $expected correctly', ({ breadcrumbs, inputValue }) => {
-      const props = createDefaultProps({ breadcrumbs, inputValue })
-
-      render(<Header {...props} />)
-
-      const input = screen.getByPlaceholderText(
-        'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-      )
-      expect(input)!.toHaveValue(inputValue)
-    })
-  })
-
-  // Integration with Child Components
-  describe('Integration with Child Components', () => {
-    it('should pass all required props to Breadcrumbs', () => {
-      const props = createDefaultProps({
-        breadcrumbs: ['folder1', 'folder2'],
-        keywords: 'test-keyword',
-        bucket: 'test-bucket',
-        searchResultsLength: 10,
-        isInPipeline: true,
-      })
-
-      render(<Header {...props} />)
-
-      // Assert - Component should render successfully, meaning props are passed correctly
-      // Assert - Component should render successfully, meaning props are passed correctly
-      expect(
-        screen.getByPlaceholderText('datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder'),
-      )!.toBeInTheDocument()
-    })
-
-    it('should pass correct props to Input component', () => {
-      const mockHandleInputChange = vi.fn()
-      const mockHandleResetKeywords = vi.fn()
-      const props = createDefaultProps({
-        inputValue: 'test-input',
-        handleInputChange: mockHandleInputChange,
-        handleResetKeywords: mockHandleResetKeywords,
-      })
-
-      render(<Header {...props} />)
-
-      const input = screen.getByPlaceholderText(
-        'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-      )
-      expect(input)!.toHaveValue('test-input')
-
-      // Test onChange handler
-      fireEvent.change(input, { target: { value: 'new-value' } })
-      expect(mockHandleInputChange).toHaveBeenCalled()
-    })
-  })
-
-  // Callback Stability Tests
-  describe('Callback Stability', () => {
-    it('should maintain stable handleInputChange callback after rerender', () => {
-      const mockHandleInputChange = vi.fn()
-      const props = createDefaultProps({ handleInputChange: mockHandleInputChange })
-      const { rerender } = render(<Header {...props} />)
-      const input = screen.getByPlaceholderText(
-        'datasetPipeline.onlineDrive.breadcrumbs.searchPlaceholder',
-      )
-
-      // Act - Fire change event, rerender, fire again
-      fireEvent.change(input, { target: { value: 'first' } })
-      rerender(<Header {...props} />)
-      fireEvent.change(input, { target: { value: 'second' } })
-
-      expect(mockHandleInputChange).toHaveBeenCalledTimes(2)
-    })
-
-    it('should maintain stable handleResetKeywords callback after rerender', () => {
-      const mockHandleResetKeywords = vi.fn()
-      const props = createDefaultProps({
-        inputValue: 'to-clear',
-        handleResetKeywords: mockHandleResetKeywords,
-      })
-      const { rerender } = render(<Header {...props} />)
-
-      // Act - Click clear, rerender, click again
-      fireEvent.click(screen.getByRole('button', { name: 'common.operation.clear' }))
-      rerender(<Header {...props} />)
-      fireEvent.click(screen.getByRole('button', { name: 'common.operation.clear' }))
-
-      expect(mockHandleResetKeywords).toHaveBeenCalledTimes(2)
-    })
+  it('clears the query and returns focus to the searchbox', async () => {
+    const user = userEvent.setup()
+    const onSearchValueChange = vi.fn()
+    render(<ControlledHeader initialValue="report" onSearchValueChange={onSearchValueChange} />)
+
+    await user.click(screen.getByRole('button', { name: 'common.operation.clear' }))
+
+    const searchbox = screen.getByRole('searchbox', { name: searchName })
+    expect(onSearchValueChange).toHaveBeenLastCalledWith('')
+    expect(searchbox).toHaveValue('')
+    expect(searchbox).toHaveFocus()
   })
 })

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
+import { SearchInput } from '@/app/components/base/search-input'
 import Breadcrumbs from './breadcrumbs'
 
 type HeaderProps = {
@@ -9,8 +9,7 @@ type HeaderProps = {
   keywords: string
   bucket: string
   searchResultsLength: number
-  handleInputChange: React.ChangeEventHandler<HTMLInputElement>
-  handleResetKeywords: () => void
+  onSearchValueChange: (value: string) => void
   isInPipeline: boolean
 }
 
@@ -21,10 +20,12 @@ const Header = ({
   bucket,
   isInPipeline,
   searchResultsLength,
-  handleInputChange,
-  handleResetKeywords,
+  onSearchValueChange,
 }: HeaderProps) => {
   const { t } = useTranslation()
+  const searchLabel = t(($) => $['onlineDrive.breadcrumbs.searchPlaceholder'], {
+    ns: 'datasetPipeline',
+  })
 
   return (
     <div className="flex items-center gap-x-2 bg-components-panel-bg p-1 pl-3">
@@ -35,16 +36,12 @@ const Header = ({
         searchResultsLength={searchResultsLength}
         isInPipeline={isInPipeline}
       />
-      <Input
+      <SearchInput
+        className="h-8 w-50 shrink-0"
         value={inputValue}
-        onChange={handleInputChange}
-        onClear={handleResetKeywords}
-        placeholder={t(($) => $['onlineDrive.breadcrumbs.searchPlaceholder'], {
-          ns: 'datasetPipeline',
-        })}
-        showLeftIcon
-        showClearIcon
-        wrapperClassName="w-[200px] h-8 shrink-0"
+        onValueChange={onSearchValueChange}
+        aria-label={searchLabel}
+        placeholder={searchLabel}
       />
     </div>
   )

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/index.tsx
@@ -37,22 +37,27 @@ const FileList = ({
 }: FileListProps) => {
   const [inputValue, setInputValue] = useState(keywords)
 
-  const { run: updateKeywordsWithDebounce } = useDebounceFn(
+  const { run: updateKeywordsWithDebounce, cancel: cancelKeywordsUpdate } = useDebounceFn(
     (keywords: string) => {
       updateKeywords(keywords)
     },
     { wait: 500 },
   )
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const keywords = e.target.value
-    setInputValue(keywords)
-    updateKeywordsWithDebounce(keywords)
-  }
-
   const handleResetKeywords = () => {
+    cancelKeywordsUpdate()
     setInputValue('')
     resetKeywords()
+  }
+
+  const handleSearchValueChange = (keywords: string) => {
+    if (!keywords) {
+      handleResetKeywords()
+      return
+    }
+
+    setInputValue(keywords)
+    updateKeywordsWithDebounce(keywords)
   }
 
   return (
@@ -63,9 +68,8 @@ const FileList = ({
         keywords={keywords}
         bucket={bucket}
         isInPipeline={isInPipeline}
-        handleInputChange={handleInputChange}
+        onSearchValueChange={handleSearchValueChange}
         searchResultsLength={searchResultsLength}
-        handleResetKeywords={handleResetKeywords}
       />
       <List
         fileList={fileList}

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-reference-vars.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-reference-vars.spec.tsx
@@ -1,5 +1,6 @@
 import type { NodeOutPutVar } from '@/app/components/workflow/types'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { VarType } from '@/app/components/workflow/types'
 import VarReferenceVars from '../var-reference-vars'
 
@@ -37,16 +38,24 @@ describe('VarReferenceVars', () => {
     },
   ])
 
-  it('should filter vars through the search box and call onClose on escape', () => {
+  it('should filter, clear without leaving the search group, and close on escape', async () => {
+    const user = userEvent.setup()
     const onClose = vi.fn()
-    render(<VarReferenceVars vars={baseVars} onChange={vi.fn()} onClose={onClose} />)
+    const onBlur = vi.fn()
+    render(
+      <VarReferenceVars vars={baseVars} onChange={vi.fn()} onClose={onClose} onBlur={onBlur} />,
+    )
 
-    fireEvent.change(screen.getByPlaceholderText('workflow.common.searchVar'), {
-      target: { value: 'valid' },
-    })
+    const searchBox = screen.getByRole('searchbox', { name: 'workflow.common.searchVar' })
+    await user.type(searchBox, 'valid')
     expect(screen.getByText('valid_name')).toBeInTheDocument()
 
-    fireEvent.keyDown(screen.getByPlaceholderText('workflow.common.searchVar'), { key: 'Escape' })
+    await user.click(screen.getByRole('button', { name: 'common.operation.clear' }))
+    expect(searchBox).toHaveValue('')
+    expect(searchBox).toHaveFocus()
+    expect(onBlur).not.toHaveBeenCalled()
+
+    await user.keyboard('{Escape}')
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
@@ -1,16 +1,16 @@
 'use client'
 import type { FC } from 'react'
-import type { StructuredOutput } from '../../../llm/types'
-import type { Field } from '@/app/components/workflow/nodes/llm/types'
+import type { Field, StructuredOutput } from '../../../llm/types'
 import type { NodeOutPutVar, ValueSelector, Var } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { useHover } from 'ahooks'
 import { noop } from 'es-toolkit/function'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import PickerStructurePanel from '@/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker'
 import { VariableIconWithColor } from '@/app/components/workflow/nodes/_base/components/variable/variable-label'
 import { VarType } from '@/app/components/workflow/types'
@@ -357,7 +357,9 @@ const VarReferenceVars: FC<Props> = ({
   const { t } = useTranslation()
   const [internalSearchValue, setInternalSearchValue] = useState('')
   const listRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const searchValue = searchText ?? internalSearchValue
+  const searchLabel = t(($) => $['common.searchVar'], { ns: 'workflow' })
   const filteredVars = useMemo(() => filterReferenceVars(vars, searchValue), [vars, searchValue])
   const selectableItems = useMemo(() => {
     return filteredVars.flatMap((node) =>
@@ -475,20 +477,50 @@ const VarReferenceVars: FC<Props> = ({
     <>
       {!hideSearch && (
         <>
-          <div className={cn('m-2', searchBoxClassName)} onClick={(e) => e.stopPropagation()}>
-            <Input
-              className={VAR_SEARCH_INPUT_CLASS_NAME}
-              showLeftIcon
-              showClearIcon
+          <InputGroup
+            className={cn('m-2 w-auto', searchBoxClassName)}
+            onClick={(event) => event.stopPropagation()}
+            onBlur={(event) => {
+              if (!event.currentTarget.contains(event.relatedTarget)) onBlur?.()
+            }}
+          >
+            <InputGroupInput
+              ref={searchInputRef}
+              type="search"
+              aria-label={searchLabel}
+              autoComplete="off"
+              className={cn(
+                VAR_SEARCH_INPUT_CLASS_NAME,
+                '[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none',
+              )}
               value={searchValue}
-              placeholder={t(($) => $['common.searchVar'], { ns: 'workflow' }) || ''}
-              onChange={(e) => setInternalSearchValue(e.target.value)}
+              placeholder={searchLabel}
+              onValueChange={setInternalSearchValue}
               onKeyDown={handleKeyDown}
-              onClear={() => setInternalSearchValue('')}
-              onBlur={onBlur}
               autoFocus={autoFocus}
             />
-          </div>
+            <InputGroupAddon className="ps-2 pe-0.5">
+              <span
+                aria-hidden="true"
+                className="i-ri-search-line size-4 text-components-input-text-placeholder"
+              />
+            </InputGroupAddon>
+            {!!searchValue && (
+              <InputGroupAddon align="inline-end" className="ps-0.5 pe-2">
+                <IconButton
+                  size="xs"
+                  aria-label={t(($) => $['operation.clear'], { ns: 'common' })}
+                  className="text-text-quaternary hover:bg-transparent hover:text-text-tertiary focus-visible:bg-components-input-bg-hover focus-visible:ring-inset"
+                  onClick={() => {
+                    setInternalSearchValue('')
+                    searchInputRef.current?.focus()
+                  }}
+                >
+                  <span aria-hidden="true" className="i-ri-close-circle-fill size-3.5" />
+                </IconButton>
+              </InputGroupAddon>
+            )}
+          </InputGroup>
           <div
             className="relative -left-1 h-[0.5px] bg-black/5"
             style={{


### PR DESCRIPTION
## Summary

- reuse the shared SearchInput recipe for the standard online-drive search field
- keep direct InputGroup composition in the variable picker, where keyboard and compound blur ownership remain feature-specific
- cancel pending debounced online-drive searches before clearing the query
- keep focus in the search input after clearing
- remove the redundant variable-search wrapper while preserving its margin and available width
- replace low-value Header implementation tests with observable searchbox value, clear, and focus contracts

## Validation

- 3 focused browser-mode suites, 60 tests
- pnpm check
- Web pnpm type-check with stale .next output isolated
- targeted Web accessibility lint
- targeted canonical Tailwind/Oxlint check

## Screenshots

The 32px online-drive search surface and variable-picker layout are preserved. Online-drive icon and clear-action spacing now follows the shared SearchInput recipe.

From Codex