### PR TITLE
fix(web): keep -webkit-mask-* prefixes in Lightning CSS output

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -12,6 +12,18 @@ const allowedDevOrigins = process.env.NEXT_ALLOWED_DEV_ORIGINS?.split(',')
 const nextConfig: NextConfig = {
   basePath: env.NEXT_PUBLIC_BASE_PATH,
   ...(allowedDevOrigins?.length ? { allowedDevOrigins } : {}),
+  experimental: {
+    // Turbopack uses Lightning CSS by default since Next 14.2. The browserslist
+    // floor in package.json was raised to `iOS >=16.4` (PR #38653) for the WASM
+    // SIMD MP3 encoder. With that floor Lightning CSS treats `-webkit-mask-*`
+    // vendor prefixes as unnecessary and strips them, breaking CSS mask icons on
+    // Chrome 112 and iOS 15. Forcing the `vendor-prefixes` feature keeps the
+    // prefixed code path always on regardless of browserslist targets, so the
+    // MP3 encoder floor and masked icons stay independent.
+    lightningCssFeatures: {
+      include: ['vendor-prefixes'],
+    },
+  },
   transpilePackages: ['@t3-oss/env-core', '@t3-oss/env-nextjs', 'echarts', 'zrender'],
   serverExternalPackages: ['loro-crdt'],
   turbopack: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -86,6 +86,20 @@ export default defineConfig(({ mode }) => {
             // SyntaxError: Named export not found. The requested module is a CommonJS module, which may not support all module.exports as named exports
             noExternal: ['emoji-mart'],
           },
+          css: {
+            // vinext uses Vite, which minifies CSS with Lightning CSS in
+            // production. The browserslist floor in package.json was raised to
+            // `iOS >=16.4` (PR #38653) for the WASM SIMD MP3 encoder. With that
+            // floor Lightning CSS considers `-webkit-mask-*` vendor prefixes
+            // unnecessary and strips them - breaking CSS mask icons on Chrome 112
+            // and iOS 15. `include: 262144` (= `Features.VendorPrefixes`, see
+            // lightningcss/node/targets.d.ts) forces the prefixed code path to
+            // always run regardless of the browserslist target, so both the MP3
+            // encoder and masked icons keep working independently.
+            lightningcss: {
+              include: 262144,
+            },
+          },
         }
       : {}),
 


### PR DESCRIPTION
## Problem
The browserslist floor was raised to `iOS >=16.4` in PR #38653 (for the WASM SIMD MP3 encoder). With that floor, Lightning CSS treats `-webkit-mask-*` vendor prefixes as unnecessary and strips them, breaking CSS mask icons on Chrome 112 and iOS 15.

## Fix
Force the `vendor-prefixes` feature so prefixed output is always emitted regardless of browserslist targets:
- `web/next.config.ts`: `experimental.lightningCssFeatures.include: ['vendor-prefixes']` (Turbopack path)
- `web/vite.config.ts`: `css.lightningcss.include: 262144` (= `Features.VendorPrefixes`, vinext path)

## Verification
- Tested: `-webkit-mask-size` now present in built CSS; icons render correctly on older browsers
- MP3 encoder floor (iOS 16.4) unchanged