### PR TITLE
fix(ci): align Oxlint suppression formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,3 +37,7 @@ indent_size = 2
 [package.json]
 indent_style = space
 indent_size = 2
+
+# Oxlint writes its generated suppression baseline without a final newline.
+[oxlint-suppressions.json]
+insert_final_newline = false


### PR DESCRIPTION
## Summary

- declare the generated Oxlint suppression baseline's canonical final-newline behavior in EditorConfig
- keep the file covered by EditorConfig validation without excluding it from SuperLinter

## Root cause

Oxlint serializes `oxlint-suppressions.json` without a final newline, while the repository-wide EditorConfig rule requires one. Autofix therefore restores Oxlint's canonical output after a manual newline fix, causing SuperLinter and autofix to disagree.

The file-specific EditorConfig rule makes the repository contract match the generator-owned format.

## Validation

- `editorconfig-checker v3.7.0 -config .github/linters/editorconfig-checker.json oxlint-suppressions.json .editorconfig`
- `git diff --check`