### PR TITLE
chore(web): align browser support targets

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -198,15 +198,10 @@
     "vitest-canvas-mock": "catalog:"
   },
   "browserslist": [
-    "last 1 Chrome version",
-    "last 1 Firefox version",
-    "last 1 Edge version",
-    "last 1 Safari version",
-    "iOS >=16.4",
-    "Android >= 10",
-    "and_chr >= 126",
-    "and_ff >= 137",
-    "and_uc >= 15.5",
-    "and_qq >= 14.9"
+    "chrome 111",
+    "edge 111",
+    "firefox 114",
+    "safari 16.4",
+    "ios_saf 16.4"
   ]
 }

--- a/web/package.json
+++ b/web/package.json
@@ -200,7 +200,7 @@
   "browserslist": [
     "chrome 111",
     "edge 111",
-    "firefox 114",
+    "firefox 128",
     "safari 16.4",
     "ios_saf 16.4"
   ]

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,4 @@
+import type { Plugin } from 'vite-plus'
 import { fileURLToPath } from 'node:url'
 import { configDefaults, defineConfig, lazyPlugins } from 'vite-plus'
 import {
@@ -11,6 +12,17 @@ import { nextStaticImageTestPlugin } from './plugins/vite/next-static-image-test
 const projectRoot = fileURLToPath(new URL('.', import.meta.url))
 const isCI = !!process.env.CI
 const rootClientInjectTarget = getRootClientInjectTarget(projectRoot)
+// Keep the Vinext browser output aligned with package.json#browserslist.
+const browserBuildTargets = ['chrome111', 'edge111', 'firefox128', 'safari16.4', 'ios16.4']
+const browserTargetsPlugin: Plugin = {
+  name: 'dify:browser-targets',
+  configEnvironment(name, options) {
+    if (name !== 'client') return
+    options.build ??= {}
+    options.build.target = browserBuildTargets
+    options.build.cssTarget = browserBuildTargets
+  },
+}
 
 export default defineConfig(({ mode }) => {
   const isTest = mode === 'test'
@@ -47,6 +59,7 @@ export default defineConfig(({ mode }) => {
         tailwindcss(),
         react(),
         vinext({ react: false }),
+        browserTargetsPlugin,
         customI18nHmrPlugin({ injectTarget: rootClientInjectTarget }),
         // reactGrabOpenFilePlugin({
         //   injectTarget: rootClientInjectTarget,
@@ -61,7 +74,6 @@ export default defineConfig(({ mode }) => {
         { find: /^loro-crdt$/, replacement: 'loro-crdt/base64' },
       ],
     },
-
     // vinext related config
     ...(!isTest && !isStorybook
       ? {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,3 @@
-import type { Plugin } from 'vite-plus'
 import { fileURLToPath } from 'node:url'
 import { configDefaults, defineConfig, lazyPlugins } from 'vite-plus'
 import {
@@ -12,17 +11,6 @@ import { nextStaticImageTestPlugin } from './plugins/vite/next-static-image-test
 const projectRoot = fileURLToPath(new URL('.', import.meta.url))
 const isCI = !!process.env.CI
 const rootClientInjectTarget = getRootClientInjectTarget(projectRoot)
-// Keep the Vinext browser output aligned with package.json#browserslist.
-const browserBuildTargets = ['chrome111', 'edge111', 'firefox128', 'safari16.4', 'ios16.4']
-const browserTargetsPlugin: Plugin = {
-  name: 'dify:browser-targets',
-  configEnvironment(name, options) {
-    if (name !== 'client') return
-    options.build ??= {}
-    options.build.target = browserBuildTargets
-    options.build.cssTarget = browserBuildTargets
-  },
-}
 
 export default defineConfig(({ mode }) => {
   const isTest = mode === 'test'
@@ -59,7 +47,6 @@ export default defineConfig(({ mode }) => {
         tailwindcss(),
         react(),
         vinext({ react: false }),
-        browserTargetsPlugin,
         customI18nHmrPlugin({ injectTarget: rootClientInjectTarget }),
         // reactGrabOpenFilePlugin({
         //   injectTarget: rootClientInjectTarget,
@@ -74,6 +61,7 @@ export default defineConfig(({ mode }) => {
         { find: /^loro-crdt$/, replacement: 'loro-crdt/base64' },
       ],
     },
+
     // vinext related config
     ...(!isTest && !isStorybook
       ? {


### PR DESCRIPTION
## Summary

- replace moving browser queries with a fixed support baseline for the default Next.js production build
- target Chrome 111, Edge 111, Firefox 128, Safari 16.4, and iOS Safari 16.4
- restore the CSS prefixes required by supported Chromium versions without lowering the iOS baseline

## Rationale

The previous `last 1 version` queries changed as Browserslist data evolved, so the generated Next.js output was not a stable support contract. In particular, Chrome 112 was no longer part of the compiler targets even though it is above the Next.js 16 browser floor.

The fixed targets use the strictest minimum required by the current frontend stack:

- Next.js 16: Chrome 111, Edge 111, Firefox 111, Safari 16.4
- Tailwind CSS v4: Chrome 111, Firefox 128, Safari 16.4
- Mediabunny MP3 encoder: Safari/iOS Safari 16.4 for WebAssembly SIMD

Tailwind CSS v4 depends on core CSS features such as `@property` that are not supported by Firefox before 128, so Firefox 128 is the effective application floor.

This change is intentionally scoped to `package.json#browserslist`, which is consumed by the default Next.js production toolchain. Vinext/Vite has an independent target configuration and is not changed here.

This is a compiler compatibility floor. Browsers below it may still work, but they are not implied by the configured targets.

## Validation

- Browserslist resolves exactly to `chrome 111`, `edge 111`, `firefox 128`, `ios_saf 16.4`, and `safari 16.4`
- `pnpm --dir web exec vp check vite.config.ts package.json`
- `pnpm -C web build`
- generated Next.js CSS: 431 standard `mask-image` declarations with no unpaired standard mask declarations
- `git diff --check`

Closes #40936.
Context: #40927.