### PR TITLE
fix(web): gate system features requests by connection

### DIFF
--- a/web/app/(commonLayout)/datasets/new/__tests__/layout.spec.tsx
+++ b/web/app/(commonLayout)/datasets/new/__tests__/layout.spec.tsx
@@ -2,18 +2,14 @@ import type { ReactElement, ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 
 const mocks = vi.hoisted(() => ({
-  ensureQueryData: vi.fn(),
+  ensureSystemFeatures: vi.fn(),
   redirect: vi.fn((_href: string) => {
     throw new Error('NEXT_REDIRECT')
   }),
-  systemFeaturesQueryOptions: { queryKey: ['console', 'system-features'] },
 }))
 
 vi.mock('@/features/system-features/server', () => ({
-  getSystemFeaturesQueryClient: () => ({
-    ensureQueryData: mocks.ensureQueryData,
-  }),
-  systemFeaturesServerQueryOptions: () => mocks.systemFeaturesQueryOptions,
+  ensureSystemFeatures: () => mocks.ensureSystemFeatures(),
 }))
 
 vi.mock('@/next/navigation', () => ({
@@ -29,19 +25,19 @@ async function renderLayout(children: ReactNode) {
 describe('NewKnowledgeLayout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.ensureQueryData.mockResolvedValue({ knowledge_fs_enabled: true })
+    mocks.ensureSystemFeatures.mockResolvedValue({ knowledge_fs_enabled: true })
   })
 
   it('renders new knowledge routes when KnowledgeFS is enabled', async () => {
     await renderLayout(<div>New knowledge content</div>)
 
-    expect(mocks.ensureQueryData).toHaveBeenCalledWith(mocks.systemFeaturesQueryOptions)
+    expect(mocks.ensureSystemFeatures).toHaveBeenCalledOnce()
     expect(screen.getByText('New knowledge content')).toBeInTheDocument()
     expect(mocks.redirect).not.toHaveBeenCalled()
   })
 
   it('redirects to datasets when KnowledgeFS is disabled', async () => {
-    mocks.ensureQueryData.mockResolvedValue({ knowledge_fs_enabled: false })
+    mocks.ensureSystemFeatures.mockResolvedValue({ knowledge_fs_enabled: false })
     const { default: Layout } = await import('../layout')
 
     await expect(Layout({ children: <div>New knowledge content</div> })).rejects.toThrow(
@@ -53,7 +49,7 @@ describe('NewKnowledgeLayout', () => {
 
   it('preserves System Features failures', async () => {
     const error = new Error('System Features unavailable')
-    mocks.ensureQueryData.mockRejectedValue(error)
+    mocks.ensureSystemFeatures.mockRejectedValue(error)
     const { default: Layout } = await import('../layout')
 
     await expect(Layout({ children: <div>New knowledge content</div> })).rejects.toBe(error)

--- a/web/app/(commonLayout)/datasets/new/layout.tsx
+++ b/web/app/(commonLayout)/datasets/new/layout.tsx
@@ -1,14 +1,9 @@
 import type { ReactNode } from 'react'
-import {
-  getSystemFeaturesQueryClient,
-  systemFeaturesServerQueryOptions,
-} from '@/features/system-features/server'
+import { ensureSystemFeatures } from '@/features/system-features/server'
 import { redirect } from '@/next/navigation'
 
 export default async function Layout({ children }: { children: ReactNode }) {
-  const systemFeatures = await getSystemFeaturesQueryClient().ensureQueryData(
-    systemFeaturesServerQueryOptions(),
-  )
+  const systemFeatures = await ensureSystemFeatures()
 
   if (!systemFeatures.knowledge_fs_enabled) redirect('/datasets')
 

--- a/web/app/__tests__/layout.spec.tsx
+++ b/web/app/__tests__/layout.spec.tsx
@@ -45,27 +45,6 @@ describe('Root layout System Features bootstrap', () => {
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   })
 
-  it('waits for request headers before RootLayout starts the System Features request', async () => {
-    let resolveHeaders!: (headers: Headers) => void
-    mocks.headers.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveHeaders = resolve
-        }),
-    )
-    mocks.getSystemFeatures.mockResolvedValue({ deployment_edition: 'CLOUD' })
-    const { default: RootLayout } = await import('../layout')
-
-    const layout = RootLayout({ children: <div>App</div> })
-    await Promise.resolve()
-
-    expect(mocks.getSystemFeatures).not.toHaveBeenCalled()
-
-    resolveHeaders(new Headers())
-    await expect(layout).resolves.toBeDefined()
-    expect(mocks.getSystemFeatures).toHaveBeenCalledOnce()
-  })
-
   it('caches the resolved System Features for dehydration', async () => {
     mocks.getSystemFeatures.mockResolvedValue({
       branding: {

--- a/web/app/__tests__/layout.spec.tsx
+++ b/web/app/__tests__/layout.spec.tsx
@@ -4,16 +4,21 @@ let queryClient: QueryClient
 
 const mocks = vi.hoisted(() => ({
   getSystemFeatures: vi.fn(),
-  requestHeaders: new Headers(),
+  headers: vi.fn(async () => new Headers()),
 }))
 
 vi.mock('@/features/system-features/server', () => ({
   getSystemFeaturesQueryClient: () => queryClient,
-  systemFeaturesServerQueryOptions: () => ({
-    queryKey: ['console', 'system-features'],
-    queryFn: mocks.getSystemFeatures,
-    retry: false,
-  }),
+  prefetchSystemFeatures: async () => {
+    const queryOptions = {
+      queryKey: ['console', 'system-features'],
+      queryFn: mocks.getSystemFeatures,
+      retry: false,
+    }
+    if (!queryClient.getQueryState(queryOptions.queryKey))
+      await queryClient.prefetchQuery(queryOptions)
+    return queryClient.getQueryData(queryOptions.queryKey)
+  },
 }))
 
 vi.mock('@/env', async (importOriginal) => {
@@ -30,13 +35,35 @@ vi.mock('@/i18n-config/server', () => ({
 }))
 
 vi.mock('@/next/headers', () => ({
-  headers: async () => mocks.requestHeaders,
+  headers: mocks.headers,
 }))
 
 describe('Root layout System Features bootstrap', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.headers.mockResolvedValue(new Headers())
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  })
+
+  it('waits for request headers before RootLayout starts the System Features request', async () => {
+    let resolveHeaders!: (headers: Headers) => void
+    mocks.headers.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveHeaders = resolve
+        }),
+    )
+    mocks.getSystemFeatures.mockResolvedValue({ deployment_edition: 'CLOUD' })
+    const { default: RootLayout } = await import('../layout')
+
+    const layout = RootLayout({ children: <div>App</div> })
+    await Promise.resolve()
+
+    expect(mocks.getSystemFeatures).not.toHaveBeenCalled()
+
+    resolveHeaders(new Headers())
+    await expect(layout).resolves.toBeDefined()
+    expect(mocks.getSystemFeatures).toHaveBeenCalledOnce()
   })
 
   it('caches the resolved System Features for dehydration', async () => {

--- a/web/app/components/base/analytics-consent/__tests__/cloud-analytics.spec.tsx
+++ b/web/app/components/base/analytics-consent/__tests__/cloud-analytics.spec.tsx
@@ -10,25 +10,18 @@ type ConfigState = {
   webPrefix: string | undefined
 }
 
-const { configState, getSystemFeatures, mockHeadersGet, systemFeaturesQueryKey } = vi.hoisted(
-  () => ({
-    configState: {
-      cookieYesSiteKey: 'site-key',
-      isProd: true,
-      webPrefix: 'https://cloud.dify.ai',
-    } as ConfigState,
-    getSystemFeatures: vi.fn(),
-    mockHeadersGet: vi.fn(),
-    systemFeaturesQueryKey: ['console', 'system-features'] as const,
-  }),
-)
+const { configState, mockHeadersGet, systemFeaturesQueryKey } = vi.hoisted(() => ({
+  configState: {
+    cookieYesSiteKey: 'site-key',
+    isProd: true,
+    webPrefix: 'https://cloud.dify.ai',
+  } as ConfigState,
+  mockHeadersGet: vi.fn(),
+  systemFeaturesQueryKey: ['console', 'system-features'] as const,
+}))
 
 vi.mock('@/features/system-features/server', () => ({
-  getSystemFeaturesQueryClient: () => queryClient,
-  systemFeaturesServerQueryOptions: () => ({
-    queryFn: getSystemFeatures,
-    queryKey: systemFeaturesQueryKey,
-  }),
+  getCachedSystemFeatures: () => queryClient.getQueryData(systemFeaturesQueryKey),
 }))
 
 vi.mock('@/config', () => ({
@@ -176,6 +169,5 @@ describe('CloudAnalytics', () => {
 
     expect(container.querySelector('script')).toBeNull()
     expect(queryByTestId('cloud-analytics-runtime')).toBeNull()
-    expect(getSystemFeatures).not.toHaveBeenCalled()
   })
 })

--- a/web/app/components/base/analytics-consent/cloud-analytics.tsx
+++ b/web/app/components/base/analytics-consent/cloud-analytics.tsx
@@ -1,8 +1,5 @@
 import { COOKIEYES_SITE_KEY, IS_PROD, WEB_PREFIX } from '@/config'
-import {
-  getSystemFeaturesQueryClient,
-  systemFeaturesServerQueryOptions,
-} from '@/features/system-features/server'
+import { getCachedSystemFeatures } from '@/features/system-features/server'
 import { headers } from '@/next/headers'
 import Script from '@/next/script'
 import { GoogleAnalyticsTagScripts, GoogleConsentDefaults } from '../ga'
@@ -12,9 +9,7 @@ import { isCloudAnalyticsRequest } from './request-boundary'
 const CURRENT_PATHNAME_HEADER = 'x-dify-pathname'
 
 export async function CloudAnalytics() {
-  const queryClient = getSystemFeaturesQueryClient()
-  const systemFeaturesQuery = systemFeaturesServerQueryOptions()
-  const systemFeatures = queryClient.getQueryData(systemFeaturesQuery.queryKey)
+  const systemFeatures = getCachedSystemFeatures()
 
   if (!systemFeatures) return null
 

--- a/web/app/components/base/zendesk/__tests__/index.spec.tsx
+++ b/web/app/components/base/zendesk/__tests__/index.spec.tsx
@@ -13,6 +13,9 @@ let mockNonce: string | null = 'test-nonce'
 let queryClient: QueryClient
 const systemFeaturesQueryKey = ['console', 'system-features']
 const getSystemFeatures = vi.fn()
+const mocks = vi.hoisted(() => ({
+  headers: vi.fn(),
+}))
 
 // Mock react's memo to just return the function
 vi.mock('react', async (importOriginal) => {
@@ -33,22 +36,20 @@ vi.mock('@/config', () => ({
 }))
 
 vi.mock('@/features/system-features/server', () => ({
-  getSystemFeaturesQueryClient: () => queryClient,
-  systemFeaturesServerQueryOptions: vi.fn(() => ({
-    queryKey: systemFeaturesQueryKey,
-    queryFn: getSystemFeatures,
-    retry: false,
-  })),
+  prefetchSystemFeatures: async () => {
+    const queryOptions = {
+      queryKey: systemFeaturesQueryKey,
+      queryFn: getSystemFeatures,
+      retry: false,
+    }
+    await queryClient.prefetchQuery(queryOptions)
+    return queryClient.getQueryData(queryOptions.queryKey)
+  },
 }))
 
 // Mock next/headers
 vi.mock('@/next/headers', () => ({
-  headers: vi.fn(() => ({
-    get: vi.fn((name: string) => {
-      if (name === 'x-nonce') return mockNonce
-      return null
-    }),
-  })),
+  headers: mocks.headers,
 }))
 
 // Mock next/script
@@ -79,6 +80,11 @@ describe('Zendesk', () => {
     getSystemFeatures.mockImplementation(async () => ({
       deployment_edition: mockDeploymentEdition,
     }))
+    mocks.headers.mockImplementation(async () => {
+      const requestHeaders = new Headers()
+      if (mockNonce !== null) requestHeaders.set('x-nonce', mockNonce)
+      return requestHeaders
+    })
   })
 
   // Helper to call the async component
@@ -100,6 +106,7 @@ describe('Zendesk', () => {
     mockZendeskWidgetKey = undefined
     const result = await renderZendesk()
     expect(result).toBeNull()
+    expect(mocks.headers).not.toHaveBeenCalled()
     expect(getSystemFeatures).not.toHaveBeenCalled()
   })
 

--- a/web/app/components/base/zendesk/index.tsx
+++ b/web/app/components/base/zendesk/index.tsx
@@ -1,19 +1,13 @@
 import { memo } from 'react'
 import { IS_PROD, ZENDESK_WIDGET_KEY } from '@/config'
-import {
-  getSystemFeaturesQueryClient,
-  systemFeaturesServerQueryOptions,
-} from '@/features/system-features/server'
+import { prefetchSystemFeatures } from '@/features/system-features/server'
 import { headers } from '@/next/headers'
 import Script from '@/next/script'
 
 const Zendesk = async () => {
   if (!ZENDESK_WIDGET_KEY) return null
 
-  const queryClient = getSystemFeaturesQueryClient()
-  const systemFeaturesQuery = systemFeaturesServerQueryOptions()
-  await queryClient.prefetchQuery(systemFeaturesQuery)
-  const systemFeatures = queryClient.getQueryData(systemFeaturesQuery.queryKey)
+  const systemFeatures = await prefetchSystemFeatures()
   if (!systemFeatures || systemFeatures.deployment_edition !== 'CLOUD') return null
 
   const nonce = IS_PROD ? ((await headers()).get('x-nonce') ?? '') : ''

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -11,7 +11,7 @@ import { getDatasetMap } from '@/env'
 import { SystemFeaturesBootstrapBoundary } from '@/features/system-features/bootstrap-boundary'
 import {
   getSystemFeaturesQueryClient,
-  systemFeaturesServerQueryOptions,
+  prefetchSystemFeatures,
 } from '@/features/system-features/server'
 import { getLocaleOnServer } from '@/i18n-config/server'
 import { headers } from '@/next/headers'
@@ -31,19 +31,8 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
 }
 
-const ensureSystemFeatures = async () => {
-  const queryClient = getSystemFeaturesQueryClient()
-  const queryOptions = systemFeaturesServerQueryOptions()
-  const queryState = queryClient.getQueryState(queryOptions.queryKey)
-
-  if (!queryState || queryState.status === 'pending') await queryClient.prefetchQuery(queryOptions)
-
-  return { queryClient, queryOptions }
-}
-
 export async function generateMetadata(): Promise<Metadata> {
-  const { queryClient, queryOptions } = await ensureSystemFeatures()
-  const systemFeatures = queryClient.getQueryData(queryOptions.queryKey)
+  const systemFeatures = await prefetchSystemFeatures()
   const applicationTitle = getApplicationTitle(systemFeatures?.branding)
 
   return {
@@ -56,12 +45,9 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const datasetMap = getDatasetMap()
-  const [locale, requestHeaders, { queryClient }] = await Promise.all([
-    getLocaleOnServer(),
-    headers(),
-    ensureSystemFeatures(),
-  ])
-  const dehydratedState = dehydrate(queryClient)
+  const requestHeaders = await headers()
+  const [locale] = await Promise.all([getLocaleOnServer(), prefetchSystemFeatures()])
+  const dehydratedState = dehydrate(getSystemFeaturesQueryClient())
   const nonce = IS_PROD ? (requestHeaders.get('x-nonce') ?? undefined) : undefined
   const themeProviderProps: Omit<ThemeProviderProps, 'children'> = {
     attribute: 'data-theme',

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -45,8 +45,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const datasetMap = getDatasetMap()
-  const requestHeaders = await headers()
-  const [locale] = await Promise.all([getLocaleOnServer(), prefetchSystemFeatures()])
+  const [locale, requestHeaders] = await Promise.all([
+    getLocaleOnServer(),
+    headers(),
+    prefetchSystemFeatures(),
+  ])
   const dehydratedState = dehydrate(getSystemFeaturesQueryClient())
   const nonce = IS_PROD ? (requestHeaders.get('x-nonce') ?? undefined) : undefined
   const themeProviderProps: Omit<ThemeProviderProps, 'children'> = {

--- a/web/features/home/page.tsx
+++ b/web/features/home/page.tsx
@@ -1,10 +1,7 @@
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { Suspense } from 'react'
 import { getQueryClient } from '@/app/get-query-client'
-import {
-  getSystemFeaturesQueryClient,
-  systemFeaturesServerQueryOptions,
-} from '@/features/system-features/server'
+import { ensureSystemFeatures } from '@/features/system-features/server'
 import { getLocaleOnServer } from '@/i18n-config/server'
 import { getServerConsoleClientContext, serverConsoleQuery } from '@/service/server'
 import { HomeContent } from './home-content/home-content'
@@ -31,9 +28,7 @@ export async function HomePage() {
     }),
   )
 
-  const enableExploreBanner = (
-    await getSystemFeaturesQueryClient().ensureQueryData(systemFeaturesServerQueryOptions())
-  ).enable_explore_banner
+  const enableExploreBanner = (await ensureSystemFeatures()).enable_explore_banner
   if (enableExploreBanner) {
     void homeQueryClient.prefetchQuery(
       serverConsoleQuery.explore.banners.get.queryOptions({

--- a/web/features/system-features/__tests__/server.spec.ts
+++ b/web/features/system-features/__tests__/server.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+
+import { QueryClient } from '@tanstack/react-query'
+
+let queryClient: QueryClient
+
+const mocks = vi.hoisted(() => ({
+  connection: vi.fn(async () => undefined),
+  getSystemFeatures: vi.fn(),
+}))
+
+vi.mock('server-only', () => ({}))
+
+vi.mock('@/app/get-query-client', () => ({
+  getQueryClient: () => queryClient,
+}))
+
+vi.mock('@/next/server', () => ({
+  connection: mocks.connection,
+}))
+
+vi.mock('@/service/server', () => ({
+  serverConsoleQuery: {
+    systemFeatures: {
+      get: {
+        queryOptions: () => ({
+          queryKey: ['console', 'system-features'],
+          queryFn: mocks.getSystemFeatures,
+          retry: false,
+        }),
+      },
+    },
+  },
+}))
+
+describe('System Features server requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mocks.connection.mockResolvedValue(undefined)
+    mocks.getSystemFeatures.mockResolvedValue({ deployment_edition: 'CLOUD' })
+  })
+
+  it.each(['prefetch', 'ensure'] as const)(
+    'waits for the request boundary before the %s query starts',
+    async (operation) => {
+      let establishConnection!: () => void
+      mocks.connection.mockImplementation(
+        () =>
+          new Promise<undefined>((resolve) => {
+            establishConnection = () => resolve(undefined)
+          }),
+      )
+      const { ensureSystemFeatures, prefetchSystemFeatures } = await import('../server')
+
+      const result = operation === 'prefetch' ? prefetchSystemFeatures() : ensureSystemFeatures()
+      await Promise.resolve()
+
+      expect(mocks.getSystemFeatures).not.toHaveBeenCalled()
+
+      establishConnection()
+      await expect(result).resolves.toEqual({ deployment_edition: 'CLOUD' })
+      expect(mocks.getSystemFeatures).toHaveBeenCalledOnce()
+      expect(queryClient.getQueryData(['console', 'system-features'])).toEqual({
+        deployment_edition: 'CLOUD',
+      })
+    },
+  )
+
+  it('keeps prefetch failures soft', async () => {
+    mocks.getSystemFeatures.mockRejectedValue(new Error('System Features unavailable'))
+    const { prefetchSystemFeatures } = await import('../server')
+
+    await expect(prefetchSystemFeatures()).resolves.toBeUndefined()
+    expect(queryClient.getQueryData(['console', 'system-features'])).toBeUndefined()
+  })
+
+  it('preserves ensure failures for hard route gates', async () => {
+    const error = new Error('System Features unavailable')
+    mocks.getSystemFeatures.mockRejectedValue(error)
+    const { ensureSystemFeatures } = await import('../server')
+
+    await expect(ensureSystemFeatures()).rejects.toBe(error)
+  })
+})

--- a/web/features/system-features/server.ts
+++ b/web/features/system-features/server.ts
@@ -1,9 +1,31 @@
 import { cache } from 'react'
 import { getQueryClient } from '@/app/get-query-client'
+import { connection } from '@/next/server'
 import { serverConsoleQuery } from '@/service/server'
 import 'server-only'
 
 export const getSystemFeaturesQueryClient = cache(getQueryClient)
 
-export const systemFeaturesServerQueryOptions = () =>
-  serverConsoleQuery.systemFeatures.get.queryOptions()
+const systemFeaturesServerQueryOptions = () => serverConsoleQuery.systemFeatures.get.queryOptions()
+
+export const getCachedSystemFeatures = () => {
+  const queryClient = getSystemFeaturesQueryClient()
+  const queryOptions = systemFeaturesServerQueryOptions()
+  return queryClient.getQueryData(queryOptions.queryKey)
+}
+
+export const prefetchSystemFeatures = async () => {
+  await connection()
+  const queryClient = getSystemFeaturesQueryClient()
+  const queryOptions = systemFeaturesServerQueryOptions()
+  const queryState = queryClient.getQueryState(queryOptions.queryKey)
+
+  if (!queryState || queryState.status === 'pending') await queryClient.prefetchQuery(queryOptions)
+
+  return queryClient.getQueryData(queryOptions.queryKey)
+}
+
+export const ensureSystemFeatures = async () => {
+  await connection()
+  return getSystemFeaturesQueryClient().ensureQueryData(systemFeaturesServerQueryOptions())
+}

--- a/web/next/server.ts
+++ b/web/next/server.ts
@@ -1,0 +1,1 @@
+export { connection } from 'next/server'


### PR DESCRIPTION
## Summary

- establish a request-time boundary before server-side System Features queries can start
- expose distinct cache-only, soft-prefetch, and hard-ensure operations from the System Features owner
- run locale resolution, nonce headers, and System Features prefetch concurrently while each owner enforces its own boundary
- keep hydration serialization with the root layout while updating metadata, Zendesk, Home, analytics, and dataset route consumers
- add behavior-focused coverage for the owner-level request boundary and soft/hard query failure semantics

## Root cause

During prerendering, `Promise.all` started the System Features backend request before `headers()` could suspend the static render. `generateMetadata` and independent segment/component entry points could also start the same request without their own request boundary. A failed prefetch was swallowed by TanStack Query while the ORPC interceptor still logged the error, leaving the build successful but non-hermetic and noisy.

`connection()` now makes the request-time requirement explicit at the System Features network owner. It does not silence errors or add authentication; it prevents these backend calls from starting during prerendering. Root-level `headers()` remains responsible only for the nonce and can run concurrently with the owner-gated prefetch.

## Impact

Normal request-time query results, caching, and backend request counts remain unchanged. Rendering that depends on System Features now waits for an incoming request instead of running during `next build`.

## Validation

- `pnpm exec vitest run features/system-features/__tests__/server.spec.ts app/__tests__/layout.spec.tsx 'app/(commonLayout)/datasets/new/__tests__/layout.spec.tsx' app/components/base/zendesk/__tests__/index.spec.tsx app/components/base/analytics-consent/__tests__/cloud-analytics.spec.tsx` — 5 files, 22 tests passed
- focused `vp check` — formatting, lint, and type checks passed
- `pnpm build` — Next.js 16.3 production build passed and generated 40/40 static pages without `ECONNREFUSED`, `fetch failed`, `DYNAMIC_SERVER_USAGE`, or System Features/ORPC error output