### PR TITLE
fix(api): bound ChildChunk content with max_length to cap embedding cost

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -182,13 +182,28 @@ class WorkflowUpdatePayload(BaseModel):
 
 DOCUMENT_BATCH_DOWNLOAD_ZIP_MAX_DOCS = 100
 
+# Per-request cap on a child chunk's `content` field. The default child chunk
+# size is ~1024 tokens (~4096 chars at ~4 chars/token); the cap sits well
+# above that and above the existing 10000-char "very long content" test
+# (tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py:222)
+# while still bounding embedding cost and DB row size.
+CHILD_CHUNK_CONTENT_MAX_LENGTH = 16384
+
 
 class ChildChunkCreatePayload(BaseModel):
-    content: str = Field(description="Child chunk text content.")
+    content: str = Field(
+        ...,
+        max_length=CHILD_CHUNK_CONTENT_MAX_LENGTH,
+        description="Child chunk text content.",
+    )
 
 
 class ChildChunkUpdatePayload(BaseModel):
-    content: str = Field(description="Child chunk text content.")
+    content: str = Field(
+        ...,
+        max_length=CHILD_CHUNK_CONTENT_MAX_LENGTH,
+        description="Child chunk text content.",
+    )
 
 
 class DocumentBatchDownloadZipPayload(BaseModel):

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -20,8 +20,10 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from flask import Flask
+from pydantic import ValidationError
 from werkzeug.exceptions import NotFound
 
+from controllers.common.controller_schemas import CHILD_CHUNK_CONTENT_MAX_LENGTH
 from controllers.service_api.dataset.segment import (
     ChildChunkApi,
     ChildChunkCreatePayload,
@@ -237,6 +239,16 @@ class TestChildChunkCreatePayload:
         payload = ChildChunkCreatePayload(content=special_content)
         assert payload.content == special_content
 
+    def test_payload_accepts_content_at_max_length(self):
+        """Content exactly at CHILD_CHUNK_CONTENT_MAX_LENGTH is accepted."""
+        payload = ChildChunkCreatePayload(content="A" * CHILD_CHUNK_CONTENT_MAX_LENGTH)
+        assert len(payload.content) == CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+    def test_payload_rejects_content_above_max_length(self):
+        """Content one character over the cap is rejected with ValidationError."""
+        with pytest.raises(ValidationError):
+            ChildChunkCreatePayload(content="A" * (CHILD_CHUNK_CONTENT_MAX_LENGTH + 1))
+
 
 class TestChildChunkListQuery:
     """Test suite for ChildChunkListQuery Pydantic model."""
@@ -287,6 +299,16 @@ class TestChildChunkUpdatePayload:
         """Test payload with empty content."""
         payload = ChildChunkUpdatePayload(content="")
         assert payload.content == ""
+
+    def test_payload_accepts_content_at_max_length(self):
+        """Content exactly at CHILD_CHUNK_CONTENT_MAX_LENGTH is accepted."""
+        payload = ChildChunkUpdatePayload(content="A" * CHILD_CHUNK_CONTENT_MAX_LENGTH)
+        assert len(payload.content) == CHILD_CHUNK_CONTENT_MAX_LENGTH
+
+    def test_payload_rejects_content_above_max_length(self):
+        """Content one character over the cap is rejected with ValidationError."""
+        with pytest.raises(ValidationError):
+            ChildChunkUpdatePayload(content="A" * (CHILD_CHUNK_CONTENT_MAX_LENGTH + 1))
 
 
 class TestSegmentServiceInterface:

--- a/packages/contracts/generated/api/console/datasets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/zod.gen.ts
@@ -217,14 +217,14 @@ export const zSegmentUpdatePayload = z.object({
  * ChildChunkCreatePayload
  */
 export const zChildChunkCreatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**
  * ChildChunkUpdatePayload
  */
 export const zChildChunkUpdatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -186,7 +186,7 @@ export const zChatRequestPayloadWithUser = z.object({
  * ChildChunkCreatePayload
  */
 export const zChildChunkCreatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**
@@ -234,7 +234,7 @@ export const zChildChunkListResponse = z.object({
  * ChildChunkUpdatePayload
  */
 export const zChildChunkUpdatePayload = z.object({
-  content: z.string(),
+  content: z.string().max(16384),
 })
 
 /**


### PR DESCRIPTION
## Summary

Bound `ChildChunkCreatePayload.content` and `ChildChunkUpdatePayload.content` with a `max_length=16384` cap to prevent unbounded content from being forwarded to the embedding model and persisted to `child_chunks.content` (LongText, unbounded).

Sibling of #39825 (TTS text had no `max_length`). Same pattern, different surface: a service-API caller can no longer submit a multi-MB child chunk and burn tenant-owned embedding budget.

## Problem

The two Pydantic models in `api/controllers/common/controller_schemas.py` accepted arbitrary-length strings. A `POST` to:

- `POST /v1/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks` (service API)
- `POST /console/api/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks` (console)

…could carry a `content` value of any size, and the value was then:

1. Forwarded to the embedding model via `ChildChunkAddToIndexTask` / `ChildChunkUpdateTask` (cost proportional to token count, billed to the tenant owner).
2. Persisted to `child_chunks.content` (typed as `LongText`, unbounded), skewing row size, slowing indexes, and bloating backups.

## Fix

Added `CHILD_CHUNK_CONTENT_MAX_LENGTH = 16384` as a module-level constant and applied it via `max_length=...` on both `ChildChunkCreatePayload.content` and `ChildChunkUpdatePayload.content`.

The cap sits well above the default child chunk size (~1024 tokens ≈ 4096 chars at ~4 chars/token) and above the existing 10000-char "very long content" test (`tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py:222-226`), while still bounding abuse.

```python
# api/controllers/common/controller_schemas.py
CHILD_CHUNK_CONTENT_MAX_LENGTH = 16384


class ChildChunkCreatePayload(BaseModel):
    content: str = Field(
        ...,
        max_length=CHILD_CHUNK_CONTENT_MAX_LENGTH,
        description="Child chunk text content.",
    )


class ChildChunkUpdatePayload(BaseModel):
    content: str = Field(
        ...,
        max_length=CHILD_CHUNK_CONTENT_MAX_LENGTH,
        description="Child chunk text content.",
    )
```

## Tests

Extended the existing `TestChildChunkCreatePayload` and `TestChildChunkUpdatePayload` classes in `tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py` with one boundary test each per direction:

- `test_payload_accepts_content_at_max_length` — content of length `CHILD_CHUNK_CONTENT_MAX_LENGTH` is accepted.
- `test_payload_rejects_content_above_max_length` — content of length `CHILD_CHUNK_CONTENT_MAX_LENGTH + 1` raises `ValidationError`.

The existing 10000-char "very long content" test continues to pass because 10000 < 16384.

## Files changed

- `api/controllers/common/controller_schemas.py` — 1 new constant, 2 fields updated with `max_length`.
- `api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py` — 4 new test methods (2 per payload class), 1 import.

## Verification

- `pytest tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py::TestChildChunkCreatePayload tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py::TestChildChunkUpdatePayload --noconftest -v` → 11/11 pass (5 + 2 existing, 2 + 2 new).
- `ruff check` on both files → all checks passed.
- `ruff format --check` on both files → already formatted.
- `pyrefly check` on `api/controllers/common/controller_schemas.py` → 0 diagnostics.

## Scope

- No API contract change for callers who send ≤ 16384 chars (the realistic case for any child chunk).
- No migration, no schema change, no behaviour change for in-range inputs.
- The 4× headroom over the default chunk size keeps the cap generous for any real chunk while still bounding abuse.

## Out of scope (potential follow-ups)

- `MessageFeedbackPayload.content` (`api/controllers/common/controller_schemas.py:94`) — same pattern (no `max_length`).
- `ConversationRenamePayload.name` (`api/controllers/common/controller_schemas.py:13`) — same pattern.
- `MetadataUpdatePayload.name` (`api/controllers/common/controller_schemas.py:212`) — same pattern.
- Parent chunk length limits (`ChildChunk` lives under a parent `Segment`).
- Embedding-side chunking policy in `core/rag/index_processor/`.

Fixes #40825
