### PR TITLE
fix(api): enforce admin and RBAC permissions on tool OAuth custom client GET endpoint (#40944)

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1296,6 +1296,8 @@ class ToolOAuthCustomClient(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
     def get(self, current_tenant_id: str, provider: str):

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -7,7 +7,7 @@ from controllers.common.wraps import RBACPermission, RBACResourceScope
 from controllers.console.datasets.data_source import DataSourceApi
 from controllers.console.workspace.model_providers import ModelProviderCredentialApi
 from controllers.console.workspace.models import ModelProviderModelCredentialApi
-from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddApi
+from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddApi, ToolOAuthCustomClient
 
 
 @pytest.mark.parametrize(
@@ -42,6 +42,21 @@ def test_model_provider_credential_get_requires_admin_and_rbac(
 ) -> None:
     """GET endpoints that return provider credential details must enforce
     the same admin + RBAC gates as their sibling POST/PUT/DELETE methods."""
+    legacy_wrapper = unwrap(method, stop=lambda wrapper: "is_admin_or_owner_required" in wrapper.__code__.co_qualname)
+    assert "is_admin_or_owner_required" in legacy_wrapper.__code__.co_qualname
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
+    assert rbac_config["scene"] == RBACPermission.CREDENTIAL_MANAGE
+    assert rbac_config["resource_required"] is False
+
+
+def test_tool_oauth_custom_client_get_requires_admin_and_rbac() -> None:
+    """GET endpoint that returns custom OAuth client params must enforce
+    the same admin + RBAC gates as its sibling POST and DELETE methods."""
+    method = ToolOAuthCustomClient.get
+
     legacy_wrapper = unwrap(method, stop=lambda wrapper: "is_admin_or_owner_required" in wrapper.__code__.co_qualname)
     assert "is_admin_or_owner_required" in legacy_wrapper.__code__.co_qualname
 


### PR DESCRIPTION
## Summary

Fixes #40944

The `GET /console/api/workspaces/current/tool-provider/builtin/<provider>/oauth/custom-client` endpoint in `ToolOAuthCustomClient` was missing authorization decorators:
- `@is_admin_or_owner_required`
- `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)`

This allowed workspace members without admin/owner roles or credential management RBAC permissions to fetch custom OAuth client configuration details.

Added missing permission decorators to match sibling `post` and `delete` methods and added corresponding unit test assertion.

## Screenshots

N/A (Backend API permission enforcement)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
