### PR TITLE
fix(logstore): normalize workflow timestamps to naive UTC

### DIFF
--- a/api/extensions/logstore/repositories/logstore_api_workflow_node_execution_repository.py
+++ b/api/extensions/logstore/repositories/logstore_api_workflow_node_execution_repository.py
@@ -8,7 +8,7 @@ WorkflowNodeExecutionModel operations using Aliyun SLS LogStore.
 import logging
 import time
 from collections.abc import Mapping, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, override
 
 from sqlalchemy.orm import sessionmaker
@@ -17,6 +17,7 @@ from extensions.logstore.aliyun_logstore import AliyunLogStore
 from extensions.logstore.repositories import safe_float, safe_int
 from extensions.logstore.sql_escape import escape_identifier, escape_logstore_query_value
 from graphon.enums import WorkflowNodeExecutionStatus
+from libs.datetime_utils import ensure_naive_utc, naive_utc_now
 from models.enums import CreatorUserRole
 from models.workflow import WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom
 from repositories.api_workflow_node_execution_repository import DifyAPIWorkflowNodeExecutionRepository
@@ -86,28 +87,29 @@ def _dict_to_workflow_node_execution_model(data: dict[str, Any]) -> WorkflowNode
     model.execution_metadata = data.get("execution_metadata")
 
     # Handle datetime fields
+    # Every branch must yield naive UTC, matching what the database path stores.
     created_at = data.get("created_at")
     match created_at:
         case None:
             # Provide default created_at if missing
-            model.created_at = datetime.now()
+            model.created_at = naive_utc_now()
         case str():
-            model.created_at = datetime.fromisoformat(created_at)
+            model.created_at = ensure_naive_utc(datetime.fromisoformat(created_at))
         case int() | float():
-            model.created_at = datetime.fromtimestamp(created_at)
+            model.created_at = datetime.fromtimestamp(created_at, tz=UTC).replace(tzinfo=None)
         case _:
-            model.created_at = created_at
+            model.created_at = ensure_naive_utc(created_at)
 
     finished_at = data.get("finished_at")
     match finished_at:
         case None:
             ...
         case str():
-            model.finished_at = datetime.fromisoformat(finished_at)
+            model.finished_at = ensure_naive_utc(datetime.fromisoformat(finished_at))
         case int() | float():
-            model.finished_at = datetime.fromtimestamp(finished_at)
+            model.finished_at = datetime.fromtimestamp(finished_at, tz=UTC).replace(tzinfo=None)
         case _:
-            model.finished_at = finished_at
+            model.finished_at = ensure_naive_utc(finished_at)
 
     return model
 

--- a/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
+++ b/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
@@ -17,7 +17,7 @@ import logging
 import os
 import time
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast, override
 
 from sqlalchemy.orm import sessionmaker
@@ -26,6 +26,7 @@ from extensions.logstore.aliyun_logstore import AliyunLogStore
 from extensions.logstore.repositories import safe_float, safe_int
 from extensions.logstore.sql_escape import escape_identifier, escape_logstore_query_value, escape_sql_string
 from graphon.enums import WorkflowExecutionStatus
+from libs.datetime_utils import ensure_naive_utc, naive_utc_now
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.workflow import WorkflowRun, WorkflowType
@@ -104,28 +105,30 @@ def _dict_to_workflow_run(data: dict[str, Any]) -> WorkflowRun:
     model.error = data.get("error_message") or data.get("error")
 
     # Handle datetime fields
+    # Every branch must yield naive UTC, matching what the database path stores.
+    # Mixing naive local time and aware values here breaks the elapsed_time subtraction below.
     started_at = data.get("started_at") or data.get("created_at")
     if started_at:
         match started_at:
             case str():
-                model.created_at = datetime.fromisoformat(started_at)
+                model.created_at = ensure_naive_utc(datetime.fromisoformat(started_at))
             case int() | float():
-                model.created_at = datetime.fromtimestamp(started_at)
+                model.created_at = datetime.fromtimestamp(started_at, tz=UTC).replace(tzinfo=None)
             case _:
-                model.created_at = started_at
+                model.created_at = ensure_naive_utc(started_at)
     else:
         # Provide default created_at if missing
-        model.created_at = datetime.now()
+        model.created_at = naive_utc_now()
 
     finished_at = data.get("finished_at")
     if finished_at:
         match finished_at:
             case str():
-                model.finished_at = datetime.fromisoformat(finished_at)
+                model.finished_at = ensure_naive_utc(datetime.fromisoformat(finished_at))
             case int() | float():
-                model.finished_at = datetime.fromtimestamp(finished_at)
+                model.finished_at = datetime.fromtimestamp(finished_at, tz=UTC).replace(tzinfo=None)
             case _:
-                model.finished_at = finished_at
+                model.finished_at = ensure_naive_utc(finished_at)
 
     # Compute elapsed_time from started_at and finished_at
     # LogStore doesn't store elapsed_time, it's computed in WorkflowExecution domain entity

--- a/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_node_execution_repository.py
+++ b/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_node_execution_repository.py
@@ -1,8 +1,14 @@
+import datetime
 import json
+import time
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from extensions.logstore.repositories.logstore_api_workflow_node_execution_repository import (
     LogstoreAPIWorkflowNodeExecutionRepository,
+    _dict_to_workflow_node_execution_model,
 )
 from models.workflow import WorkflowNodeExecutionModel
 
@@ -39,3 +45,45 @@ def test_get_execution_by_id_keeps_process_data_from_highest_failed_log_version(
     assert execution is not None
     assert execution.status.value == "failed"
     assert execution.process_data_dict == {"workflow_agent_binding_id": "binding-1"}
+
+
+_CREATED_AT = datetime.datetime(2026, 8, 18, 2, 0, 0, tzinfo=datetime.UTC)
+_FINISHED_AT = _CREATED_AT + datetime.timedelta(seconds=30)
+
+
+@pytest.fixture
+def non_utc_host_timezone(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Run the host clock in UTC+05:30 so local-time conversions become observable."""
+    monkeypatch.setenv("TZ", "Asia/Kolkata")
+    time.tzset()
+    yield
+    monkeypatch.undo()
+    time.tzset()
+
+
+@pytest.mark.parametrize(
+    ("case", "payload"),
+    [
+        ("both epoch", {"created_at": _CREATED_AT.timestamp(), "finished_at": _FINISHED_AT.timestamp()}),
+        ("aware iso and epoch", {"created_at": _CREATED_AT.isoformat(), "finished_at": _FINISHED_AT.timestamp()}),
+        (
+            "naive iso and epoch",
+            {"created_at": _CREATED_AT.replace(tzinfo=None).isoformat(), "finished_at": _FINISHED_AT.timestamp()},
+        ),
+        ("both datetime", {"created_at": _CREATED_AT, "finished_at": _FINISHED_AT}),
+    ],
+)
+@pytest.mark.usefixtures("non_utc_host_timezone")
+def test_dict_to_node_execution_normalizes_timestamps_to_naive_utc(case: str, payload: dict[str, object]) -> None:
+    model = _dict_to_workflow_node_execution_model({"id": "execution-1", **payload})
+
+    assert model.created_at == _CREATED_AT.replace(tzinfo=None), case
+    assert model.finished_at == _FINISHED_AT.replace(tzinfo=None), case
+
+
+@pytest.mark.usefixtures("non_utc_host_timezone")
+def test_dict_to_node_execution_defaults_missing_created_at_to_naive_utc_now() -> None:
+    model = _dict_to_workflow_node_execution_model({"id": "execution-1"})
+
+    assert model.created_at.tzinfo is None
+    assert abs((model.created_at - datetime.datetime.now(tz=datetime.UTC).replace(tzinfo=None)).total_seconds()) < 60

--- a/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_run_repository.py
+++ b/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_run_repository.py
@@ -1,0 +1,54 @@
+import datetime
+import time
+from collections.abc import Generator
+
+import pytest
+
+from extensions.logstore.repositories.logstore_api_workflow_run_repository import _dict_to_workflow_run
+
+_START = datetime.datetime(2026, 8, 18, 2, 0, 0, tzinfo=datetime.UTC)
+_FINISH = _START + datetime.timedelta(seconds=30)
+_EXPECTED_CREATED_AT = _START.replace(tzinfo=None)
+_EXPECTED_FINISHED_AT = _FINISH.replace(tzinfo=None)
+
+_BASE: dict[str, object] = {"id": "run-1", "tenant_id": "tenant-1", "app_id": "app-1", "workflow_id": "workflow-1"}
+
+
+@pytest.fixture
+def non_utc_host_timezone(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Run the host clock in UTC+05:30 so local-time conversions become observable."""
+    monkeypatch.setenv("TZ", "Asia/Kolkata")
+    time.tzset()
+    yield
+    monkeypatch.undo()
+    time.tzset()
+
+
+@pytest.mark.parametrize(
+    ("case", "payload"),
+    [
+        ("both epoch", {"started_at": _START.timestamp(), "finished_at": _FINISH.timestamp()}),
+        ("aware iso and epoch", {"started_at": _START.isoformat(), "finished_at": _FINISH.timestamp()}),
+        (
+            "naive iso and epoch",
+            {"started_at": _START.replace(tzinfo=None).isoformat(), "finished_at": _FINISH.timestamp()},
+        ),
+        ("both datetime", {"started_at": _START, "finished_at": _FINISH}),
+    ],
+)
+@pytest.mark.usefixtures("non_utc_host_timezone")
+def test_dict_to_workflow_run_normalizes_timestamps_to_naive_utc(case: str, payload: dict[str, object]) -> None:
+    model = _dict_to_workflow_run({**_BASE, **payload})
+
+    assert model.created_at == _EXPECTED_CREATED_AT, case
+    assert model.finished_at == _EXPECTED_FINISHED_AT, case
+    assert model.elapsed_time == 30.0, case
+
+
+@pytest.mark.usefixtures("non_utc_host_timezone")
+def test_dict_to_workflow_run_defaults_missing_started_at_to_naive_utc_now() -> None:
+    model = _dict_to_workflow_run({**_BASE, "finished_at": _FINISH.timestamp()})
+
+    assert model.created_at.tzinfo is None
+    # A naive local-time default would sit 5h30m ahead of UTC and drive elapsed_time negative.
+    assert abs((model.created_at - datetime.datetime.now(tz=datetime.UTC).replace(tzinfo=None)).total_seconds()) < 60


### PR DESCRIPTION
## Summary

Fixes #40943.

The two LogStore repositories deserialize workflow timestamps with calls that resolve against the **host's local clock**, while the rest of the codebase stores naive **UTC**:

- `datetime.fromtimestamp(ts)` without `tz` → naive local time
- `datetime.now()` → naive local time
- `datetime.fromisoformat(s)` → **aware** when the string carries an offset, naive otherwise

On its own that would just be a uniform offset. The real problem is that `created_at` and `finished_at` are matched **independently**, so one record's two timestamps can be produced by different branches and land in different frames — and `_dict_to_workflow_run` then subtracts them for `elapsed_time`.

Observed on a UTC+05:30 host (reproduction in the issue drives the real functions):

| Payload | Before | After |
| --- | --- | --- |
| both epoch | timestamps shifted +5:30 | correct naive UTC |
| aware ISO + epoch | `TypeError: can't subtract offset-naive and offset-aware datetimes` | `elapsed_time = 30.0` |
| naive ISO + epoch | 30-second run reported as **19830 s** | `elapsed_time = 30.0` |
| `started_at` missing | `elapsed_time` **negative** (`-49875.0`) | defaults to `naive_utc_now()` |

On a UTC host all four coincidentally agree, which is why this is easy to miss.

## Changes

Every branch of both `match` statements now terminates in naive UTC, using the helpers that already exist in `libs/datetime_utils`:

- `datetime.now()` → `naive_utc_now()` (the same call the Postgres write path uses)
- `datetime.fromtimestamp(ts)` → `datetime.fromtimestamp(ts, tz=UTC).replace(tzinfo=None)`
- `datetime.fromisoformat(s)` → wrapped in `ensure_naive_utc(...)`, which normalizes aware values and is a no-op for naive ones
- the already-a-`datetime` passthrough branch is wrapped in `ensure_naive_utc` too, so an aware value from upstream can't reintroduce the mixed-frame subtraction

Applied to all six call sites across `logstore_api_workflow_run_repository.py` and `logstore_api_workflow_node_execution_repository.py`. One change fixes the offset shift, the `TypeError`, and both bad `elapsed_time` results together.

Scope note: this path is only reachable when the Aliyun SLS LogStore backend is enabled, so deployments on the default Postgres path are unaffected. No behavior change on UTC hosts.

## Tests

Added regression coverage that pins `TZ=Asia/Kolkata` via `time.tzset()`, so the assertions are meaningful on the UTC CI host rather than passing by coincidence. It covers all four payload shapes plus the missing-timestamp default, for both repositories.

All 10 new tests fail on `main` and pass with this change:

```
uv run --project api --dev pytest api/tests/unit_tests/extensions/logstore/repositories/
13 passed
```

`ruff check`, `ruff format --check`, `mypy` and `pyrefly` are clean on the changed files (the two pre-existing `bad-instantiation` pyrefly diagnostics in the node-execution test file are on untouched lines).

## Screenshots

Not applicable — backend-only timezone correctness fix.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
