### PR TITLE
refactor(web): simplify debounced filter state

### DIFF
--- a/web/app/components/app/create-app-dialog/app-list/__tests__/index.spec.tsx
+++ b/web/app/components/app/create-app-dialog/app-list/__tests__/index.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderWithConsoleQuery as render } from '@/test/console/query-data'
 import { AppModeEnum } from '@/types/app'
 import Apps from '../index'
@@ -12,20 +13,8 @@ const mockPush = vi.fn()
 const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
 const mockTrackCreateApp = vi.fn()
-let latestDebounceFn = () => {}
 let mockWorkspacePermissionKeys: string[] = ['app.create_and_management']
 const mockUserProfile = { id: 'user-1' }
-
-vi.mock('ahooks', () => ({
-  useDebounceFn: (fn: () => void) => {
-    latestDebounceFn = fn
-    return {
-      run: () => setTimeout(() => latestDebounceFn(), 0),
-      cancel: vi.fn(),
-      flush: () => latestDebounceFn(),
-    }
-  },
-}))
 
 vi.mock('@/context/permission-state', async () => {
   const { createPermissionStateModuleMock } = await import('@/test/console/state-fixture')
@@ -517,5 +506,25 @@ describe('Apps', () => {
     fireEvent.click(screen.getByTestId('hide-create-modal'))
 
     expect(screen.queryByTestId('create-from-template-modal')).not.toBeInTheDocument()
+  })
+
+  it('clears an active search immediately and returns focus to the searchbox', async () => {
+    const user = userEvent.setup()
+    render(<Apps />)
+
+    const searchInput = screen.getByRole('searchbox', {
+      name: 'app.newAppFromTemplate.searchAllTemplate',
+    })
+
+    await user.type(searchInput, 'Alpha')
+    await waitFor(() => {
+      expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: 'common.operation.clear' }))
+
+    expect(searchInput).toHaveValue('')
+    expect(searchInput).toHaveFocus()
+    expect(screen.getByText('Cat A')).toBeInTheDocument()
+    expect(screen.getAllByTestId('app-card')).toHaveLength(6)
   })
 })

--- a/web/app/components/app/create-app-dialog/app-list/index.tsx
+++ b/web/app/components/app/create-app-dialog/app-list/index.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
-import { useDebounce } from 'ahooks'
+import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useAtomValue } from 'jotai'
 import * as React from 'react'
 import { useMemo, useState } from 'react'
@@ -59,7 +59,7 @@ const Apps = ({ onSuccess, onCreateFromBlank }: AppsProps) => {
   const allCategoriesEn = AppCategories.RECOMMENDED
 
   const [keywords, setKeywords] = useState('')
-  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const debouncedKeywords = useDebouncedValue(keywords, 500)
   const searchKeywords = keywords ? debouncedKeywords : ''
   const searchInputRef = React.useRef<HTMLInputElement>(null)
 

--- a/web/app/components/app/create-app-dialog/app-list/index.tsx
+++ b/web/app/components/app/create-app-dialog/app-list/index.tsx
@@ -3,10 +3,11 @@
 import type { CreateAppModalProps } from '@/app/components/explore/create-app-modal'
 import type { App } from '@/models/explore'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Input } from '@langgenius/dify-ui/input'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
-import { useDebounceFn } from 'ahooks'
+import { useDebounce } from 'ahooks'
 import { useAtomValue } from 'jotai'
 import * as React from 'react'
 import { useMemo, useState } from 'react'
@@ -58,19 +59,13 @@ const Apps = ({ onSuccess, onCreateFromBlank }: AppsProps) => {
   const allCategoriesEn = AppCategories.RECOMMENDED
 
   const [keywords, setKeywords] = useState('')
-  const [searchKeywords, setSearchKeywords] = useState('')
+  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const searchKeywords = keywords ? debouncedKeywords : ''
   const searchInputRef = React.useRef<HTMLInputElement>(null)
 
-  const { run: handleSearch } = useDebounceFn(
-    () => {
-      setSearchKeywords(keywords)
-    },
-    { wait: 500 },
-  )
-
-  const handleKeywordsChange = (value: string) => {
-    setKeywords(value)
-    handleSearch()
+  const handleClearSearch = () => {
+    setKeywords('')
+    searchInputRef.current?.focus()
   }
 
   const [currentType, setCurrentType] = useState<AppModeEnum[]>([])
@@ -194,36 +189,32 @@ const Apps = ({ onSuccess, onCreateFromBlank }: AppsProps) => {
           <div className="h-3.5">
             <Divider type="vertical" />
           </div>
-          <div className="relative w-full flex-1">
-            <Input
+          <InputGroup className="flex-1 bg-transparent hover:border-transparent hover:bg-transparent">
+            <InputGroupInput
               ref={searchInputRef}
               type="search"
               name="query"
               autoComplete="off"
               enterKeyHint="search"
               aria-label={t(($) => $['newAppFromTemplate.searchAllTemplate'], { ns: 'app' })}
-              className="w-full border-transparent bg-transparent pr-7 hover:border-transparent hover:bg-transparent focus:border-transparent focus:bg-transparent focus:shadow-none [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+              className="[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
               placeholder={t(($) => $['newAppFromTemplate.searchAllTemplate'], { ns: 'app' })}
               value={keywords}
-              onChange={(e) => handleKeywordsChange(e.target.value)}
+              onValueChange={setKeywords}
             />
             {keywords && (
-              <button
-                type="button"
-                aria-label={t(($) => $['operation.clear'], { ns: 'common' })}
-                className="group absolute top-1/2 right-2 -translate-y-1/2 rounded-sm border-none bg-transparent p-px outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
-                onClick={() => {
-                  handleKeywordsChange('')
-                  searchInputRef.current?.focus()
-                }}
-              >
-                <span
-                  aria-hidden
-                  className="i-ri-close-circle-fill size-3.5 text-text-quaternary group-hover:text-text-tertiary"
-                />
-              </button>
+              <InputGroupAddon align="inline-end" className="ps-0.75 pe-1.25">
+                <IconButton
+                  size="sm"
+                  aria-label={t(($) => $['operation.clear'], { ns: 'common' })}
+                  className="text-text-quaternary hover:bg-transparent hover:text-text-tertiary focus-visible:bg-components-input-bg-hover focus-visible:ring-inset"
+                  onClick={handleClearSearch}
+                >
+                  <span aria-hidden className="i-ri-close-circle-fill size-3.5" />
+                </IconButton>
+              </InputGroupAddon>
             )}
-          </div>
+          </InputGroup>
         </div>
         <div className="h-8 w-45"></div>
       </div>

--- a/web/app/components/datasets/list/index.tsx
+++ b/web/app/components/datasets/list/index.tsx
@@ -3,7 +3,8 @@
 import type { KnowledgeViewSwitcherProps } from '@/features/new-rag/components/knowledge-view-switcher'
 // Libraries
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { useBoolean, useDebounce } from 'ahooks'
+import { useBoolean } from 'ahooks'
+import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
@@ -55,10 +56,10 @@ function LegacyList({
   useDocumentTitle(t(($) => $.knowledge, { ns: 'dataset' }))
 
   const [keywords, setKeywords] = useState('')
-  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const debouncedKeywords = useDebouncedValue(keywords, 500)
   const searchKeywords = keywords ? debouncedKeywords : ''
   const [tagFilterValue, setTagFilterValue] = useState<string[]>([])
-  const debouncedTagIDs = useDebounce(tagFilterValue, { wait: 500 })
+  const debouncedTagIDs = useDebouncedValue(tagFilterValue, 500)
   const tagIDs = tagFilterValue.length > 0 ? debouncedTagIDs : []
 
   const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)

--- a/web/app/components/datasets/list/index.tsx
+++ b/web/app/components/datasets/list/index.tsx
@@ -3,7 +3,7 @@
 import type { KnowledgeViewSwitcherProps } from '@/features/new-rag/components/knowledge-view-switcher'
 // Libraries
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { useBoolean, useDebounceFn } from 'ahooks'
+import { useBoolean, useDebounce } from 'ahooks'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
@@ -55,29 +55,11 @@ function LegacyList({
   useDocumentTitle(t(($) => $.knowledge, { ns: 'dataset' }))
 
   const [keywords, setKeywords] = useState('')
-  const [searchKeywords, setSearchKeywords] = useState('')
-  const { run: handleSearch } = useDebounceFn(
-    () => {
-      setSearchKeywords(keywords)
-    },
-    { wait: 500 },
-  )
-  const handleKeywordsChange = (value: string) => {
-    setKeywords(value)
-    handleSearch()
-  }
+  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const searchKeywords = keywords ? debouncedKeywords : ''
   const [tagFilterValue, setTagFilterValue] = useState<string[]>([])
-  const [tagIDs, setTagIDs] = useState<string[]>([])
-  const { run: handleTagsUpdate } = useDebounceFn(
-    () => {
-      setTagIDs(tagFilterValue)
-    },
-    { wait: 500 },
-  )
-  const handleTagsChange = (value: string[]) => {
-    setTagFilterValue(value)
-    handleTagsUpdate()
-  }
+  const debouncedTagIDs = useDebounce(tagFilterValue, { wait: 500 })
+  const tagIDs = tagFilterValue.length > 0 ? debouncedTagIDs : []
 
   const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const canCreateDataset = hasPermission(workspacePermissionKeys, 'dataset.create_and_management')
@@ -154,9 +136,9 @@ function LegacyList({
         onConnectDataset={() => push('/datasets/connect')}
         onExternalApiClick={() => setShowExternalApiPanel(true)}
         onIncludeAllChange={toggleIncludeAll}
-        onKeywordsChange={handleKeywordsChange}
+        onKeywordsChange={setKeywords}
         onOpenTagManagement={() => setShowTagManagementModal(true)}
-        onTagsChange={handleTagsChange}
+        onTagsChange={setTagFilterValue}
         stepByStepTourCreateMenuOpen={
           activeKnowledgeGuide ? shouldOpenStepByStepTourCreateMenu : undefined
         }

--- a/web/app/components/datasets/settings/permission-selector/index.tsx
+++ b/web/app/components/datasets/settings/permission-selector/index.tsx
@@ -4,7 +4,7 @@ import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { RadioGroup } from '@langgenius/dify-ui/radio'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { useDebounceFn } from 'ahooks'
+import { useDebounce } from 'ahooks'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SearchInput } from '@/app/components/base/search-input'
@@ -41,17 +41,8 @@ const PermissionSelector = ({
     select: ({ rbac_enabled }) => rbac_enabled,
   })
   const [keywords, setKeywords] = useState('')
-  const [searchKeywords, setSearchKeywords] = useState('')
-  const { run: handleSearch } = useDebounceFn(
-    (nextKeywords: string) => {
-      setSearchKeywords(nextKeywords)
-    },
-    { wait: 500 },
-  )
-  const handleKeywordsChange = (nextKeywords: string) => {
-    setKeywords(nextKeywords)
-    handleSearch(nextKeywords)
-  }
+  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const searchKeywords = keywords ? debouncedKeywords : ''
   const selectMember = (member: Member) => {
     if (value.includes(member.id)) onMemberSelect(value.filter((id) => id !== member.id))
     else onMemberSelect([...value, member.id])
@@ -233,7 +224,7 @@ const PermissionSelector = ({
                   name="member-search"
                   value={keywords}
                   placeholder={t(($) => $['operation.search'], { ns: 'common' }) || ''}
-                  onValueChange={handleKeywordsChange}
+                  onValueChange={setKeywords}
                 />
               </div>
               <div className="flex flex-col p-1">

--- a/web/app/components/datasets/settings/permission-selector/index.tsx
+++ b/web/app/components/datasets/settings/permission-selector/index.tsx
@@ -4,7 +4,7 @@ import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { RadioGroup } from '@langgenius/dify-ui/radio'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { useDebounce } from 'ahooks'
+import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SearchInput } from '@/app/components/base/search-input'
@@ -41,7 +41,7 @@ const PermissionSelector = ({
     select: ({ rbac_enabled }) => rbac_enabled,
   })
   const [keywords, setKeywords] = useState('')
-  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const debouncedKeywords = useDebouncedValue(keywords, 500)
   const searchKeywords = keywords ? debouncedKeywords : ''
   const selectMember = (member: Member) => {
     if (value.includes(member.id)) onMemberSelect(value.filter((id) => id !== member.id))

--- a/web/app/components/tools/labels/__tests__/selector.spec.tsx
+++ b/web/app/components/tools/labels/__tests__/selector.spec.tsx
@@ -18,28 +18,12 @@ vi.mock('@/app/components/plugins/hooks', () => ({
   }),
 }))
 
-// Mock useDebounceFn to store the function and allow manual triggering
-let debouncedFn: (() => void) | null = null
-vi.mock('ahooks', () => ({
-  useDebounceFn: (fn: () => void) => {
-    debouncedFn = fn
-    return {
-      run: () => {
-        // Schedule to run after React state updates
-        setTimeout(() => debouncedFn?.(), 0)
-      },
-      cancel: vi.fn(),
-    }
-  },
-}))
-
 describe('LabelSelector', () => {
   const mockOnChange = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
-    debouncedFn = null
   })
 
   afterEach(() => {
@@ -198,7 +182,7 @@ describe('LabelSelector', () => {
         const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         // Filter by 'rag' which only matches 'rag' name
         fireEvent.change(searchInput, { target: { value: 'rag' } })
-        vi.advanceTimersByTime(10)
+        vi.advanceTimersByTime(500)
       })
 
       // Only RAG should be visible (rag contains 'rag')
@@ -220,7 +204,7 @@ describe('LabelSelector', () => {
       await act(async () => {
         const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         fireEvent.change(searchInput, { target: { value: 'nonexistent' } })
-        vi.advanceTimersByTime(10)
+        vi.advanceTimersByTime(500)
       })
 
       expect(screen.getByText('common.tag.noTag')).toBeInTheDocument()
@@ -240,7 +224,7 @@ describe('LabelSelector', () => {
         const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
         // First filter to show only RAG
         fireEvent.change(searchInput, { target: { value: 'rag' } })
-        vi.advanceTimersByTime(10)
+        vi.advanceTimersByTime(500)
       })
 
       expect(screen.getByText('RAG')).toBeInTheDocument()

--- a/web/app/components/tools/labels/selector.tsx
+++ b/web/app/components/tools/labels/selector.tsx
@@ -2,7 +2,7 @@ import { Checkbox } from '@langgenius/dify-ui/checkbox'
 import { CheckboxGroup } from '@langgenius/dify-ui/checkbox-group'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
-import { useDebounce } from 'ahooks'
+import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Tag03 } from '@/app/components/base/icons/src/vender/line/financeAndECommerce'
@@ -21,7 +21,7 @@ function LabelSelector({ value, onChange }: LabelSelectorProps) {
   const { tags: labelList } = useTags()
 
   const [keywords, setKeywords] = useState('')
-  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const debouncedKeywords = useDebouncedValue(keywords, 500)
   const searchKeywords = keywords ? debouncedKeywords : ''
 
   const filteredLabelList = labelList.filter((label) => label.name.includes(searchKeywords))

--- a/web/app/components/tools/labels/selector.tsx
+++ b/web/app/components/tools/labels/selector.tsx
@@ -2,7 +2,7 @@ import { Checkbox } from '@langgenius/dify-ui/checkbox'
 import { CheckboxGroup } from '@langgenius/dify-ui/checkbox-group'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
-import { useDebounceFn } from 'ahooks'
+import { useDebounce } from 'ahooks'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Tag03 } from '@/app/components/base/icons/src/vender/line/financeAndECommerce'
@@ -21,18 +21,8 @@ function LabelSelector({ value, onChange }: LabelSelectorProps) {
   const { tags: labelList } = useTags()
 
   const [keywords, setKeywords] = useState('')
-  const [searchKeywords, setSearchKeywords] = useState('')
-  const { run: handleSearch } = useDebounceFn(
-    () => {
-      setSearchKeywords(keywords)
-    },
-    { wait: 500 },
-  )
-
-  const handleKeywordsChange = (value: string) => {
-    setKeywords(value)
-    handleSearch()
-  }
+  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const searchKeywords = keywords ? debouncedKeywords : ''
 
   const filteredLabelList = labelList.filter((label) => label.name.includes(searchKeywords))
   const selectedLabels = value.map((v) => labelList.find((l) => l.name === v)?.label).join(', ')
@@ -66,7 +56,7 @@ function LabelSelector({ value, onChange }: LabelSelectorProps) {
         >
           <div className="relative w-147.75 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
             <div className="border-b-[0.5px] border-divider-regular p-2">
-              <SearchInput value={keywords} onValueChange={handleKeywordsChange} />
+              <SearchInput value={keywords} onValueChange={setKeywords} />
             </div>
             <CheckboxGroup
               aria-label={t(($) => $['createTool.toolInput.labelPlaceholder'], { ns: 'tools' })}

--- a/web/features/home/home-content/home-content.tsx
+++ b/web/features/home/home-content/home-content.tsx
@@ -6,7 +6,7 @@ import type { StepByStepTourTaskId } from '@/app/components/step-by-step-tour/ty
 import type { TrackCreateAppParams } from '@/utils/create-app-tracking'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQueryClient, useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query'
-import { useDebounce } from 'ahooks'
+import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -111,7 +111,7 @@ export function HomeContent() {
   )
 
   const [keywords, setKeywords] = useState('')
-  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const debouncedKeywords = useDebouncedValue(keywords, 500)
   const searchKeywords = keywords ? debouncedKeywords : ''
 
   const [currCategory, setCurrCategory] = useQueryState('category', {

--- a/web/features/home/home-content/home-content.tsx
+++ b/web/features/home/home-content/home-content.tsx
@@ -6,7 +6,7 @@ import type { StepByStepTourTaskId } from '@/app/components/step-by-step-tour/ty
 import type { TrackCreateAppParams } from '@/utils/create-app-tracking'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQueryClient, useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query'
-import { useDebounceFn } from 'ahooks'
+import { useDebounce } from 'ahooks'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -111,19 +111,8 @@ export function HomeContent() {
   )
 
   const [keywords, setKeywords] = useState('')
-  const [searchKeywords, setSearchKeywords] = useState('')
-
-  const { run: handleSearch } = useDebounceFn(
-    () => {
-      setSearchKeywords(keywords)
-    },
-    { wait: 500 },
-  )
-
-  const handleKeywordsChange = (value: string) => {
-    setKeywords(value)
-    handleSearch()
-  }
+  const debouncedKeywords = useDebounce(keywords, { wait: 500 })
+  const searchKeywords = keywords ? debouncedKeywords : ''
 
   const [currCategory, setCurrCategory] = useQueryState('category', {
     defaultValue: allCategoriesEn,
@@ -437,7 +426,7 @@ export function HomeContent() {
           currCategory={activeCategory}
           keywords={keywords}
           onCategoryChange={setCurrCategory}
-          onKeywordsChange={handleKeywordsChange}
+          onKeywordsChange={setKeywords}
         />
 
         <div className={cn('relative flex flex-1 shrink-0 grow flex-col pb-6')}>


### PR DESCRIPTION
## Summary

- Model debounced search and tag filters as derived values instead of independently writable state.
- Use foxact useDebouncedValue for value-derived delays and keep empty filters immediate.
- Compose the template search clear action with InputGroup and IconButton while preserving the transparent idle and hover surface of the shared filter bar.

## Visual and interaction contract

- Preserve the existing shared filter bar dimensions, layout, and lack of a leading search icon.
- Keep static and hover search surfaces transparent; retain the design-system active focus treatment.
- Preserve the existing SearchInput appearance in the other consumers.

## Testing

- Ran 5 focused suites covering template search, home templates, dataset filters and permissions, and tool label search: 104 tests passed.
- Ran targeted accessibility lint on all changed production components.
- Ran the repository check: formatting passed with 0 errors and existing repository warnings only.
- The final affected stack validation passed 8 suites and 114 tests.

From Codex