### PR TITLE
feat(workflow): expose bulk execution status as a system variable

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -170,6 +170,10 @@ class WorkflowRunPayload(BaseModel):
             "the returned `id` as `upload_file_id` with `transfer_method: local_file`."
         ),
     )
+    is_bulk_execution: bool = Field(
+        default=False,
+        description="Whether this workflow run is part of a bulk execution.",
+    )
 
 
 class WorkflowUpdatePayload(BaseModel):

--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -104,6 +104,10 @@ logger = logging.getLogger(__name__)
 class WorkflowRunRequest(BaseModel):
     inputs: dict
     files: list | None = Field(default=None)
+    is_bulk_execution: bool = Field(
+        default=False,
+        description="Whether this workflow run is part of a bulk execution.",
+    )
 
 
 class ChatRequest(BaseModel):

--- a/api/core/app/apps/workflow/app_generator.py
+++ b/api/core/app/apps/workflow/app_generator.py
@@ -223,6 +223,7 @@ class WorkflowAppGenerator(BaseAppGenerator):
                 call_depth=call_depth,
                 trace_manager=trace_manager,
                 workflow_execution_id=workflow_run_id,
+                is_bulk_execution=bool(args.get("is_bulk_execution", False)),
                 extras=extras,
             )
 

--- a/api/core/app/apps/workflow/app_runner.py
+++ b/api/core/app/apps/workflow/app_runner.py
@@ -118,6 +118,7 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
                 timestamp=int(naive_utc_now().timestamp()),
                 workflow_id=app_config.workflow_id,
                 workflow_execution_id=self.application_generate_entity.workflow_execution_id,
+                is_bulk_execution=self.application_generate_entity.is_bulk_execution,
             )
             variable_pool = VariablePool()
             add_variables_to_pool(

--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -281,6 +281,7 @@ class WorkflowAppGenerateEntity(AppGenerateEntity):
     # app config
     app_config: WorkflowUIBasedAppConfig = None  # type: ignore
     workflow_execution_id: str
+    is_bulk_execution: bool = False
 
     class SingleIterationRunEntity(BaseModel):
         """

--- a/api/core/workflow/system_variables.py
+++ b/api/core/workflow/system_variables.py
@@ -29,6 +29,7 @@ class SystemVariableKey(StrEnum):
     WORKFLOW_ID = "workflow_id"
     WORKFLOW_EXECUTION_ID = "workflow_run_id"
     TIMESTAMP = "timestamp"
+    IS_BULK_EXECUTION = "is_bulk_execution"
     DOCUMENT_ID = "document_id"
     ORIGINAL_DOCUMENT_ID = "original_document_id"
     BATCH = "batch"

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -24342,6 +24342,7 @@ Lifecycle state for an asynchronous archive download request.
 | ---- | ---- | ----------- | -------- |
 | files | [ object ] | File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`. | No |
 | inputs | object | Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app. | Yes |
+| is_bulk_execution | boolean | Whether this workflow run is part of a bulk execution. | No |
 
 #### WorkflowRunQuery
 
@@ -24358,6 +24359,7 @@ Query parameters for workflow runs.
 | ---- | ---- | ----------- | -------- |
 | files | [ object ] |  | No |
 | inputs | object |  | Yes |
+| is_bulk_execution | boolean | Whether this workflow run is part of a bulk execution. | No |
 
 #### WorkflowRunSnapshotView
 

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -4154,6 +4154,7 @@ in form definition, or a variable while the workflow is running.
 | ---- | ---- | ----------- | -------- |
 | files | [ object ] | File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`. | No |
 | inputs | object | Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app. | Yes |
+| is_bulk_execution | boolean | Whether this workflow run is part of a bulk execution. | No |
 | response_mode | string | Response mode. Use `blocking` for synchronous responses or `streaming` for Server-Sent Events. When omitted, the request runs in blocking mode. | No |
 
 #### WorkflowRunPayloadWithUser
@@ -4162,6 +4163,7 @@ in form definition, or a variable while the workflow is running.
 | ---- | ---- | ----------- | -------- |
 | files | [ object ] | File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`. | No |
 | inputs | object | Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app. | Yes |
+| is_bulk_execution | boolean | Whether this workflow run is part of a bulk execution. | No |
 | response_mode | string | Response mode. Use `blocking` for synchronous responses or `streaming` for Server-Sent Events. When omitted, the request runs in blocking mode. | No |
 | user | string | User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value. | Yes |
 

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -1736,3 +1736,4 @@ in form definition, or a variable while the workflow is running.
 | ---- | ---- | ----------- | -------- |
 | files | [ object ] | File list for workflow system file inputs. Available when file upload is enabled for the workflow. To attach a local file, first upload it via [Upload File](/api-reference/files/upload-file) and use the returned `id` as `upload_file_id` with `transfer_method: local_file`. | No |
 | inputs | object | Key-value pairs for workflow input variables. Values for file-type variables should be arrays of file objects with `type`, `transfer_method`, and either `url` or `upload_file_id`. Refer to the `user_input_form` field in the [Get App Parameters](/api-reference/applications/get-app-parameters) response to discover the variable names and types expected by your app. | Yes |
+| is_bulk_execution | boolean | Whether this workflow run is part of a bulk execution. | No |

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -51,6 +51,14 @@ from services.errors.llm import InvokeRateLimitError
 unwrap: Any = inspect_unwrap
 
 
+def test_workflow_run_request_bulk_execution_defaults_to_false() -> None:
+    assert WorkflowRunRequest(inputs={}).is_bulk_execution is False
+
+
+def test_workflow_run_request_accepts_bulk_execution() -> None:
+    assert WorkflowRunRequest(inputs={}, is_bulk_execution=True).is_bulk_execution is True
+
+
 class _UsesSQLiteSession:
     sqlite_session: Session
 

--- a/api/tests/unit_tests/controllers/web/test_pydantic_models.py
+++ b/api/tests/unit_tests/controllers/web/test_pydantic_models.py
@@ -319,6 +319,11 @@ class TestWorkflowRunPayload:
         p = WorkflowRunPayload(inputs={})
         assert p.inputs == {}
         assert p.files is None
+        assert p.is_bulk_execution is False
+
+    def test_accepts_bulk_execution(self) -> None:
+        p = WorkflowRunPayload(inputs={}, is_bulk_execution=True)
+        assert p.is_bulk_execution is True
 
     def test_with_files(self) -> None:
         p = WorkflowRunPayload(inputs={"k": "v"}, files=[{"id": "f1"}])

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_generator.py
@@ -265,6 +265,7 @@ def test_generate_includes_parent_trace_context_in_extras(
         args={
             "inputs": {"query": "hello"},
             "files": [],
+            "is_bulk_execution": True,
             "external_trace_id": "trace-1",
             "parent_trace_context": {
                 "parent_workflow_run_id": "outer-workflow-run-1",
@@ -280,6 +281,7 @@ def test_generate_includes_parent_trace_context_in_extras(
     assert result == {"data": {}}
     application_generate_entity = captured["application_generate_entity"]
     assert isinstance(application_generate_entity, WorkflowAppGenerateEntity)
+    assert application_generate_entity.is_bulk_execution is True
     extras = application_generate_entity.extras
     assert extras["external_trace_id"] == "trace-1"
     assert extras["parent_trace_context"].model_dump() == {

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
@@ -244,6 +244,7 @@ def test_run_adds_inputs_with_snippet_compatible_start_aliases() -> None:
     app_generate_entity.user_id = "user"
     app_generate_entity.invoke_from = InvokeFrom.SERVICE_API
     app_generate_entity.workflow_execution_id = "execution-id"
+    app_generate_entity.is_bulk_execution = False
     app_generate_entity.task_id = "task-id"
     app_generate_entity.call_depth = 0
     app_generate_entity.trace_manager = None

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
@@ -114,6 +114,64 @@ def test_run_uses_single_node_execution_branch(
     assert entry_kwargs["graph_runtime_state"] is graph_runtime_state
 
 
+@pytest.mark.parametrize("is_bulk_execution", [False, True])
+def test_run_adds_bulk_execution_system_variable(is_bulk_execution: bool) -> None:
+    app_config = MagicMock()
+    app_config.app_id = "app"
+    app_config.tenant_id = "tenant"
+    app_config.workflow_id = "workflow"
+
+    app_generate_entity = MagicMock(spec=WorkflowAppGenerateEntity)
+    app_generate_entity.app_config = app_config
+    app_generate_entity.inputs = {}
+    app_generate_entity.files = []
+    app_generate_entity.user_id = "user"
+    app_generate_entity.invoke_from = InvokeFrom.SERVICE_API
+    app_generate_entity.workflow_execution_id = "execution-id"
+    app_generate_entity.is_bulk_execution = is_bulk_execution
+    app_generate_entity.task_id = "task-id"
+    app_generate_entity.call_depth = 0
+    app_generate_entity.trace_manager = None
+    app_generate_entity.extras = {}
+    app_generate_entity.single_iteration_run = None
+    app_generate_entity.single_loop_run = None
+
+    workflow = Workflow(
+        tenant_id="tenant",
+        app_id="app",
+        id="workflow",
+        type="workflow",
+        version="v1",
+        graph=json.dumps({"nodes": [{"id": "start", "data": {"type": "start"}}], "edges": []}),
+    )
+    workflow.environment_variables = []
+
+    runner = WorkflowAppRunner(
+        application_generate_entity=app_generate_entity,
+        queue_manager=MagicMock(spec=AppQueueManager),
+        variable_loader=MagicMock(),
+        workflow=workflow,
+        system_user_id="system-user",
+        workflow_execution_repository=MagicMock(),
+        workflow_node_execution_repository=MagicMock(),
+    )
+
+    mock_workflow_entry = MagicMock()
+    mock_workflow_entry.graph_engine = MagicMock()
+    mock_workflow_entry.run.return_value = iter([])
+
+    with (
+        patch("core.app.apps.workflow.app_runner.RedisChannel"),
+        patch("core.app.apps.workflow.app_runner.redis_client"),
+        patch("core.app.apps.workflow.app_runner.WorkflowEntry", return_value=mock_workflow_entry) as entry_class,
+        patch.object(runner, "_init_graph", return_value=MagicMock()),
+    ):
+        runner.run()
+
+    variable_pool = entry_class.call_args.kwargs["variable_pool"]
+    assert variable_pool.get(["sys", "is_bulk_execution"]).value is is_bulk_execution
+
+
 def test_single_node_run_validates_target_node_config(monkeypatch: pytest.MonkeyPatch) -> None:
     runner = WorkflowBasedAppRunner(
         queue_manager=MagicMock(spec=AppQueueManager),

--- a/api/tests/unit_tests/core/app/entities/test_app_invoke_entities.py
+++ b/api/tests/unit_tests/core/app/entities/test_app_invoke_entities.py
@@ -36,7 +36,9 @@ def _build_workflow_app_config(app_mode: AppMode) -> WorkflowUIBasedAppConfig:
     )
 
 
-def _create_workflow_generate_entity(trace_manager: TraceQueueManager | None = None) -> WorkflowAppGenerateEntity:
+def _create_workflow_generate_entity(
+    trace_manager: TraceQueueManager | None = None, *, is_bulk_execution: bool = False
+) -> WorkflowAppGenerateEntity:
     return WorkflowAppGenerateEntity(
         task_id="workflow-task",
         app_config=_build_workflow_app_config(AppMode.WORKFLOW),
@@ -48,6 +50,7 @@ def _create_workflow_generate_entity(trace_manager: TraceQueueManager | None = N
         call_depth=1,
         trace_manager=trace_manager,
         workflow_execution_id="workflow-exec-id",
+        is_bulk_execution=is_bulk_execution,
         extras={"external_trace_id": "trace-id"},
     )
 
@@ -72,7 +75,7 @@ def _create_advanced_chat_generate_entity(
 
 
 def test_workflow_app_generate_entity_roundtrip_excludes_trace_manager():
-    entity = _create_workflow_generate_entity(trace_manager=TraceQueueManagerStub())
+    entity = _create_workflow_generate_entity(trace_manager=TraceQueueManagerStub(), is_bulk_execution=True)
 
     serialized = entity.model_dump_json()
     payload = json.loads(serialized)
@@ -82,6 +85,7 @@ def test_workflow_app_generate_entity_roundtrip_excludes_trace_manager():
     restored = WorkflowAppGenerateEntity.model_validate_json(serialized)
 
     assert restored.model_dump() == entity.model_dump()
+    assert restored.is_bulk_execution is True
     assert restored.trace_manager is None
 
 

--- a/api/tests/unit_tests/core/workflow/test_system_variable.py
+++ b/api/tests/unit_tests/core/workflow/test_system_variable.py
@@ -38,6 +38,14 @@ def test_build_system_variables_preserves_explicit_workflow_run_id():
     assert system_values["files"] == []
 
 
+def test_build_system_variables_keeps_bulk_execution_separate_from_rag_batch():
+    system_variables = build_system_variables(is_bulk_execution=True, batch="batch-123")
+    system_values = system_variables_to_mapping(system_variables)
+
+    assert system_values["is_bulk_execution"] is True
+    assert system_values["batch"] == "batch-123"
+
+
 def test_build_system_variables_preserves_file_values():
     file = File(
         file_type=FileType.DOCUMENT,

--- a/packages/contracts/generated/api/console/installed-apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/types.gen.ts
@@ -179,6 +179,7 @@ export type WorkflowRunPayload = {
   inputs: {
     [key: string]: unknown
   }
+  is_bulk_execution?: boolean
 }
 
 export type InstalledAppInfoResponse = {

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -163,6 +163,7 @@ export const zWorkflowRunPayload = z.object({
     )
     .nullish(),
   inputs: z.record(z.string(), z.unknown()),
+  is_bulk_execution: z.boolean().optional().default(false),
 })
 
 export const zJsonValue = z

--- a/packages/contracts/generated/api/console/trial-apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/trial-apps/types.gen.ts
@@ -166,6 +166,7 @@ export type WorkflowRunRequest = {
   inputs: {
     [key: string]: unknown
   }
+  is_bulk_execution?: boolean
 }
 
 export type SimpleResultResponse = {

--- a/packages/contracts/generated/api/console/trial-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/trial-apps/zod.gen.ts
@@ -125,6 +125,7 @@ export const zAudioBinaryResponse = z.custom<Blob | File>(
 export const zWorkflowRunRequest = z.object({
   files: z.array(z.unknown()).nullish(),
   inputs: z.record(z.string(), z.unknown()),
+  is_bulk_execution: z.boolean().optional().default(false),
 })
 
 /**

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -1652,6 +1652,7 @@ export type WorkflowRunPayload = {
   inputs: {
     [key: string]: unknown
   }
+  is_bulk_execution?: boolean
   response_mode?: 'blocking' | 'streaming' | null
 }
 
@@ -1665,6 +1666,7 @@ export type WorkflowRunPayloadWithUser = {
   inputs: {
     [key: string]: unknown
   }
+  is_bulk_execution?: boolean
   response_mode?: 'blocking' | 'streaming' | null
   user: string
 }

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -2268,6 +2268,7 @@ export const zWorkflowRunPayload = z.object({
     )
     .nullish(),
   inputs: z.record(z.string(), z.unknown()),
+  is_bulk_execution: z.boolean().optional().default(false),
   response_mode: z.enum(['blocking', 'streaming']).nullish(),
 })
 
@@ -2286,6 +2287,7 @@ export const zWorkflowRunPayloadWithUser = z.object({
     )
     .nullish(),
   inputs: z.record(z.string(), z.unknown()),
+  is_bulk_execution: z.boolean().optional().default(false),
   response_mode: z.enum(['blocking', 'streaming']).nullish(),
   user: z.string(),
 })

--- a/packages/contracts/generated/api/web/types.gen.ts
+++ b/packages/contracts/generated/api/web/types.gen.ts
@@ -664,6 +664,7 @@ export type WorkflowRunPayload = {
   inputs: {
     [key: string]: unknown
   }
+  is_bulk_execution?: boolean
 }
 
 export type GeneratedAppResponseWritable = JsonValue

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -929,6 +929,7 @@ export const zWorkflowRunPayload = z.object({
     )
     .nullish(),
   inputs: z.record(z.string(), z.unknown()),
+  is_bulk_execution: z.boolean().optional().default(false),
 })
 
 /**

--- a/web/app/components/share/text-generation/result/__tests__/result-request.spec.ts
+++ b/web/app/components/share/text-generation/result/__tests__/result-request.spec.ts
@@ -235,6 +235,7 @@ describe('result-request', () => {
         files: [file, secondFile],
         name: 'Alice',
       },
+      isBulkExecution: true,
       promptConfig,
       visionConfig,
     })
@@ -251,6 +252,7 @@ describe('result-request', () => {
           url: 'https://example.com/remote.png',
         }),
       ],
+      is_bulk_execution: true,
       inputs: {
         enabled: true,
         file: {

--- a/web/app/components/share/text-generation/result/hooks/__tests__/use-result-sender.spec.ts
+++ b/web/app/components/share/text-generation/result/hooks/__tests__/use-result-sender.spec.ts
@@ -181,6 +181,7 @@ type RenderSenderOptions = {
   controlSend?: number
   inputs?: Record<string, ResultInputValue>
   isPC?: boolean
+  isCallBatchAPI?: boolean
   isWorkflow?: boolean
   runState?: ResultRunStateController
   taskId?: number
@@ -192,6 +193,7 @@ const renderSender = ({
   controlSend = 0,
   inputs = { name: 'Alice' },
   isPC = true,
+  isCallBatchAPI = false,
   isWorkflow = false,
   runState,
   taskId,
@@ -210,7 +212,7 @@ const renderSender = ({
         controlRetry: props.controlRetry,
         controlSend: props.controlSend,
         inputs,
-        isCallBatchAPI: false,
+        isCallBatchAPI,
         isPC,
         isWorkflow,
         notify,
@@ -321,6 +323,9 @@ describe('useResultSender', () => {
       }),
     )
     expect(buildResultRequestDataMock).toHaveBeenCalled()
+    expect(buildResultRequestDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({ isBulkExecution: false }),
+    )
     expect(harness.runState.prepareForNewRun).toHaveBeenCalledTimes(1)
     expect(harness.runState.setRespondingTrue).toHaveBeenCalledTimes(1)
     expect(harness.runState.clearMoreLikeThis).toHaveBeenCalledTimes(1)
@@ -364,6 +369,18 @@ describe('useResultSender', () => {
     expect(harness.runState.resetRunState).toHaveBeenCalled()
     expect(harness.runState.setMessageId).toHaveBeenCalledWith('message-1')
     expect(onCompleted).toHaveBeenCalledWith('Replaced', 7, true)
+  })
+
+  it('should mark batch workflow requests as bulk executions', async () => {
+    const { result } = renderSender({ isCallBatchAPI: true, isWorkflow: true })
+
+    await act(async () => {
+      expect(await result.current.handleSend()).toBe(true)
+    })
+
+    expect(buildResultRequestDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({ isBulkExecution: true }),
+    )
   })
 
   it('should trigger workflow sends on retry and report workflow request failures', async () => {

--- a/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
+++ b/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
@@ -86,6 +86,7 @@ export const useResultSender = ({
     const data = buildResultRequestData({
       completionFiles,
       inputs,
+      isBulkExecution: isCallBatchAPI,
       promptConfig,
       visionConfig,
     })

--- a/web/app/components/share/text-generation/result/result-request.ts
+++ b/web/app/components/share/text-generation/result/result-request.ts
@@ -35,6 +35,7 @@ type ValidateResultRequestParams = {
 type BuildResultRequestDataParams = {
   completionFiles: VisionFile[]
   inputs: Record<string, ResultInputValue>
+  isBulkExecution: boolean
   promptConfig: PromptConfig | null
   visionConfig: VisionSettings
 }
@@ -129,6 +130,7 @@ export const validateResultRequest = ({
 export const buildResultRequestData = ({
   completionFiles,
   inputs,
+  isBulkExecution,
   promptConfig,
   visionConfig,
 }: BuildResultRequestDataParams) => {
@@ -152,6 +154,7 @@ export const buildResultRequestData = ({
 
   return {
     inputs: processedInputs,
+    is_bulk_execution: isBulkExecution,
     ...(visionConfig.enabled && completionFiles.length > 0
       ? {
           files: completionFiles.map((item) => {

--- a/web/app/components/workflow/__tests__/constants.spec.ts
+++ b/web/app/components/workflow/__tests__/constants.spec.ts
@@ -1,0 +1,22 @@
+import { getGlobalVars } from '../constants'
+import { VarType } from '../types'
+
+describe('getGlobalVars', () => {
+  beforeEach(() => {
+    globalThis.history.replaceState({}, '', '/app/app-id/workflow')
+  })
+
+  it('should expose bulk execution status for workflows', () => {
+    expect(getGlobalVars(false)).toContainEqual({
+      variable: 'sys.is_bulk_execution',
+      type: VarType.boolean,
+    })
+  })
+
+  it('should not expose bulk execution status for chatflows', () => {
+    expect(getGlobalVars(true)).not.toContainEqual({
+      variable: 'sys.is_bulk_execution',
+      type: VarType.boolean,
+    })
+  })
+})

--- a/web/app/components/workflow/constants.ts
+++ b/web/app/components/workflow/constants.ts
@@ -69,6 +69,10 @@ export const getGlobalVars = (isChatMode: boolean): Var[] => {
             variable: 'sys.timestamp',
             type: VarType.number,
           },
+          {
+            variable: 'sys.is_bulk_execution',
+            type: VarType.boolean,
+          },
         ]
       : []),
   ]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- expose a read-only Boolean `sys.is_bulk_execution` variable for top-level Workflow runs
- propagate the bulk execution flag from Batch requests through the workflow generate entity into the system variable pool
- default the flag to `false` for existing clients while allowing Service API callers to set it explicitly
- keep Chatflow and the existing RAG Pipeline `sys.batch` variable unchanged
- add frontend and backend regression coverage for request propagation, serialization, and variable visibility

Fixes #40021

## Screenshots

<img width="1191" height="1320" alt="Image" src="https://github.com/user-attachments/assets/ca5f5e13-2f5e-48aa-8619-0d76212f8dcb" />


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods