### PR TITLE
fix(web): remove only-me resource access option

### DIFF
--- a/web/app/components/access-rules-editor/__tests__/index.spec.tsx
+++ b/web/app/components/access-rules-editor/__tests__/index.spec.tsx
@@ -143,15 +143,12 @@ describe('AccessRulesEditor', () => {
     const allMembersButton = screen.getByRole('button', {
       name: /permission\.accessRule\.allPermittedMembers/,
     })
-    const onlyMeButton = screen.getByRole('button', { name: /permission\.accessRule\.onlyMe/ })
     const specificMembersButton = screen.getByRole('button', {
       name: /permission\.accessRule\.specificMembersOnly/,
     })
     expect(allMembersButton).toBeDisabled()
-    expect(onlyMeButton).toBeDisabled()
     expect(specificMembersButton).toBeDisabled()
     expect(allMembersButton).toHaveAttribute('aria-pressed', 'false')
-    expect(onlyMeButton).toHaveAttribute('aria-pressed', 'false')
     expect(specificMembersButton).toHaveAttribute('aria-pressed', 'false')
   })
 
@@ -201,7 +198,7 @@ describe('AccessRulesEditor', () => {
     expect(onRemoveAccessPolicyMemberBinding).toHaveBeenCalledWith('account-1', 'app-policy-id')
   })
 
-  it('should render and update the only-me resource access scope', () => {
+  it('should hide the only-me option and allow changing a legacy only-me scope', () => {
     const onOpenScopeChange = vi.fn()
 
     render(
@@ -217,10 +214,9 @@ describe('AccessRulesEditor', () => {
       />,
     )
 
-    expect(screen.getByRole('button', { name: /permission\.accessRule\.onlyMe/ })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    )
+    expect(
+      screen.queryByRole('button', { name: /permission\.accessRule\.onlyMe/ }),
+    ).not.toBeInTheDocument()
 
     fireEvent.click(
       screen.getByRole('button', { name: /permission\.accessRule\.specificMembersOnly/ }),

--- a/web/app/components/access-rules-editor/open-scope-section.tsx
+++ b/web/app/components/access-rules-editor/open-scope-section.tsx
@@ -48,7 +48,7 @@ function ResourceOpenScopeSection({ value, disabled, onChange }: ResourceOpenSco
         </h2>
         <TitleInfotip content={resourceOpenScopeDescription} />
       </div>
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <OpenScopeOption
           value="all"
           selected={value === 'all'}
@@ -57,14 +57,6 @@ function ResourceOpenScopeSection({ value, disabled, onChange }: ResourceOpenSco
           description={t(($) => $['accessRule.allPermittedMembersDescription'], {
             ns: 'permission',
           })}
-          onChange={onChange ? handleRequestChange : undefined}
-        />
-        <OpenScopeOption
-          value="only_me"
-          selected={value === 'only_me'}
-          disabled={disabled || !onChange}
-          title={t(($) => $['accessRule.onlyMe'], { ns: 'permission' })}
-          description={t(($) => $['accessRule.onlyMeDescription'], { ns: 'permission' })}
           onChange={onChange ? handleRequestChange : undefined}
         />
         <OpenScopeOption


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="1722" height="562" alt="image" src="https://github.com/user-attachments/assets/9c0f6cb9-3b47-44fc-a65d-b1cb319b3137" />|<img width="1768" height="498" alt="image" src="https://github.com/user-attachments/assets/fbfd8260-1f95-4d11-8c81-daff5facb777" />|

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
