### PR TITLE
fix(web): route enterprise documentation links

### DIFF
--- a/web/app/components/datasets/list/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/list/__tests__/index.spec.tsx
@@ -2,6 +2,7 @@ import type { ReactElement, ReactNode } from 'react'
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createStore, Provider } from 'jotai'
+import { queryClientAtom } from 'jotai-tanstack-query'
 import { hydrateRoot } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
@@ -382,14 +383,15 @@ describe('List', () => {
       await user.click(within(guide).getByRole('button', { name: 'dataset.newKnowledge.gotIt' }))
       firstRender.unmount()
 
-      const store = createStore()
-      seedRegisteredConsoleStateFixture(store)
       const { wrapper: NuqsWrapper } = createNuqsTestWrapper()
-      const { wrapper: QueryWrapper } = createConsoleQueryWrapper({
+      const { queryClient, wrapper: QueryWrapper } = createConsoleQueryWrapper({
         systemFeatures: {
           knowledge_fs_enabled: mockConsoleState.knowledgeFsEnabled,
         },
       })
+      const store = createStore()
+      store.set(queryClientAtom, queryClient)
+      seedRegisteredConsoleStateFixture(store)
       const app = (
         <QueryWrapper>
           <Provider store={store}>

--- a/web/app/components/goto-anything/actions/commands/__tests__/direct-commands.spec.ts
+++ b/web/app/components/goto-anything/actions/commands/__tests__/direct-commands.spec.ts
@@ -23,18 +23,13 @@ vi.mock('react-i18next', async () => {
   }
 })
 
-vi.mock('@/context/i18n', () => ({
-  defaultDocBaseUrl: 'https://docs.dify.ai',
-  getDocHomePath: () => '/home',
-}))
-
-vi.mock('@/i18n-config/language', () => ({
-  getDocLanguage: (locale: string) => (locale === 'en' ? 'en' : locale),
-}))
-
 describe('docsCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    docsCommand.unregister?.()
   })
 
   it('has correct metadata', () => {
@@ -45,11 +40,28 @@ describe('docsCommand', () => {
 
   it('execute opens documentation in new tab', () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    docsCommand.register?.({ getDocsHomeUrl: () => 'https://docs.dify.ai/en/home' })
 
     docsCommand.execute?.()
 
     expect(openSpy).toHaveBeenCalledWith(
       'https://docs.dify.ai/en/home',
+      '_blank',
+      'noopener,noreferrer',
+    )
+    openSpy.mockRestore()
+  })
+
+  it('execute uses the documentation URL registered by the provider', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    docsCommand.register?.({
+      getDocsHomeUrl: () => 'https://enterprise-docs.dify.ai/en/',
+    })
+
+    docsCommand.execute?.()
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://enterprise-docs.dify.ai/en/',
       '_blank',
       'noopener,noreferrer',
     )
@@ -77,18 +89,20 @@ describe('docsCommand', () => {
   })
 
   it('registers navigation.doc command', () => {
-    docsCommand.register?.({} as Record<string, never>)
+    docsCommand.register?.({ getDocsHomeUrl: () => 'https://docs.dify.ai/en/home' })
     expect(registerCommands).toHaveBeenCalledWith({ 'navigation.doc': expect.any(Function) })
   })
 
   it('registered handler opens doc URL with correct locale', async () => {
-    docsCommand.register?.({} as Record<string, never>)
+    docsCommand.register?.({
+      getDocsHomeUrl: () => 'https://enterprise-docs.dify.ai/en/',
+    })
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     const handlers = vi.mocked(registerCommands).mock.calls[0]![0]
     await handlers['navigation.doc']!()
 
     expect(openSpy).toHaveBeenCalledWith(
-      'https://docs.dify.ai/en/home',
+      'https://enterprise-docs.dify.ai/en/',
       '_blank',
       'noopener,noreferrer',
     )

--- a/web/app/components/goto-anything/actions/commands/__tests__/slash.spec.tsx
+++ b/web/app/components/goto-anything/actions/commands/__tests__/slash.spec.tsx
@@ -181,4 +181,15 @@ describe('SlashCommandProvider', () => {
       'refine',
     ])
   })
+
+  it('should register the enterprise documentation home URL', () => {
+    const { unmount } = render(<SlashCommandProvider />, {
+      systemFeatures: { deployment_edition: 'ENTERPRISE' },
+    })
+    const docsRegistration = mockRegister.mock.calls.find((call) => call[0].name === 'docs')
+
+    expect(docsRegistration?.[1].getDocsHomeUrl()).toBe('https://enterprise-docs.dify.ai/en/')
+
+    unmount()
+  })
 })

--- a/web/app/components/goto-anything/actions/commands/docs.tsx
+++ b/web/app/components/goto-anything/actions/commands/docs.tsx
@@ -1,17 +1,16 @@
 import type { SlashCommandHandler } from './types'
 import { getI18n } from 'react-i18next'
-import { defaultDocBaseUrl, getDocHomePath } from '@/context/i18n'
-import { getDocLanguage } from '@/i18n-config/language'
 import { registerCommands, unregisterCommands } from './command-bus'
 
-// Documentation command dependency types - no external dependencies needed
-type DocDeps = Record<string, never>
+type DocDeps = {
+  getDocsHomeUrl: () => string
+}
 
-const getDocsHomeUrl = () => {
-  const i18n = getI18n()
-  const currentLocale = i18n.language
-  const docLanguage = getDocLanguage(currentLocale)
-  return `${defaultDocBaseUrl}/${docLanguage}${getDocHomePath()}`
+let getDocsHomeUrl: (() => string) | undefined
+
+const openDocsHome = () => {
+  const url = getDocsHomeUrl?.()
+  if (url) window.open(url, '_blank', 'noopener,noreferrer')
 }
 
 /**
@@ -24,7 +23,7 @@ export const docsCommand: SlashCommandHandler<DocDeps> = {
 
   // Direct execution function
   execute: () => {
-    window.open(getDocsHomeUrl(), '_blank', 'noopener,noreferrer')
+    openDocsHome()
   },
 
   search(args: string, locale: string = 'en') {
@@ -47,15 +46,17 @@ export const docsCommand: SlashCommandHandler<DocDeps> = {
     ]
   },
 
-  register(_deps: DocDeps) {
+  register(deps: DocDeps) {
+    getDocsHomeUrl = deps.getDocsHomeUrl
     registerCommands({
       'navigation.doc': async (_args) => {
-        window.open(getDocsHomeUrl(), '_blank', 'noopener,noreferrer')
+        openDocsHome()
       },
     })
   },
 
   unregister() {
+    getDocsHomeUrl = undefined
     unregisterCommands(['navigation.doc'])
   },
 }

--- a/web/app/components/goto-anything/actions/commands/slash-provider.tsx
+++ b/web/app/components/goto-anything/actions/commands/slash-provider.tsx
@@ -2,6 +2,7 @@
 import { useTheme } from 'next-themes'
 import { useEffect } from 'react'
 import { ENABLE_FEATURE_PREVIEW } from '@/config'
+import { useDocLink } from '@/context/i18n'
 import { setLocaleOnClient } from '@/i18n-config'
 import { accountCommand } from './account'
 import { communityCommand } from './community'
@@ -15,6 +16,7 @@ import { slashCommandRegistry } from './registry'
 import { themeCommand } from './theme'
 
 type SlashCommandDeps = {
+  getDocsHomeUrl: () => string
   setTheme: (theme: string) => void
   setLocale: typeof setLocaleOnClient
 }
@@ -25,7 +27,7 @@ const registerSlashCommands = (deps: SlashCommandDeps) => {
     setLocale: deps.setLocale as (locale: string) => Promise<void>,
   })
   slashCommandRegistry.register(forumCommand, {})
-  slashCommandRegistry.register(docsCommand, {})
+  slashCommandRegistry.register(docsCommand, { getDocsHomeUrl: deps.getDocsHomeUrl })
   slashCommandRegistry.register(communityCommand, {})
   slashCommandRegistry.register(accountCommand, {})
   slashCommandRegistry.register(goCommand, {})
@@ -49,13 +51,15 @@ const unregisterSlashCommands = () => {
 
 export const SlashCommandProvider = () => {
   const theme = useTheme()
+  const getDocsHomeUrl = useDocLink()
   useEffect(() => {
     registerSlashCommands({
+      getDocsHomeUrl,
       setTheme: theme.setTheme,
       setLocale: setLocaleOnClient,
     })
     return () => unregisterSlashCommands()
-  }, [theme.setTheme])
+  }, [getDocsHomeUrl, theme.setTheme])
 
   return null
 }

--- a/web/app/components/header/account-setting/access-rules-page/permission-set-modal/index.tsx
+++ b/web/app/components/header/account-setting/access-rules-page/permission-set-modal/index.tsx
@@ -13,7 +13,7 @@ import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocale } from '@/context/i18n'
+import { getEnterpriseDocUrl, useLocale } from '@/context/i18n'
 import { getDocLanguage } from '@/i18n-config/language'
 import PermissionPicker from './permission-picker'
 
@@ -136,7 +136,7 @@ const PermissionSetModalBody = ({
 
       <div className="flex shrink-0 items-center justify-between gap-3 border-t border-divider-subtle px-6 py-4">
         <a
-          href={`https://enterprise-docs.dify.ai/${docLanguage}/3.11.x/use/workspace/permission-reference`}
+          href={getEnterpriseDocUrl('/use/workspace/permission-reference', docLanguage)}
           target="_blank"
           rel="noreferrer"
           className="inline-flex items-center gap-1 system-xs-medium text-text-accent hover:underline"

--- a/web/app/components/header/account-setting/permissions-page/role-modal/index.tsx
+++ b/web/app/components/header/account-setting/permissions-page/role-modal/index.tsx
@@ -13,7 +13,7 @@ import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocale } from '@/context/i18n'
+import { getEnterpriseDocUrl, useLocale } from '@/context/i18n'
 import { getDocLanguage } from '@/i18n-config/language'
 import PermissionField from './permission-field'
 
@@ -113,7 +113,7 @@ const RoleModal = ({ mode, open, role, onClose, onSubmit }: RoleModalProps) => {
         </div>
         <div className="flex shrink-0 items-center justify-between gap-3 border-t border-divider-subtle px-6 py-4">
           <a
-            href={`https://enterprise-docs.dify.ai/${docLanguage}/3.11.x/use/workspace/permission-reference`}
+            href={getEnterpriseDocUrl('/use/workspace/permission-reference', docLanguage)}
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-1 system-xs-medium text-text-accent hover:underline"

--- a/web/context/i18n.spec.ts
+++ b/web/context/i18n.spec.ts
@@ -261,7 +261,7 @@ describe('useDocLink', () => {
       expect(result.current()).toBe(`${enterpriseDocBaseUrl}/en/`)
     })
 
-    it('should use Chinese and fall back to English for unsupported documentation languages', () => {
+    it('should use Chinese and Japanese enterprise documentation languages', () => {
       vi.mocked(useTranslation).mockReturnValue({
         i18n: { language: 'zh-Hans' },
       } as ReturnType<typeof useTranslation>)
@@ -279,7 +279,7 @@ describe('useDocLink', () => {
       rerender()
 
       expect(result.current('/use-dify/nodes/start')).toBe(
-        `${enterpriseDocBaseUrl}/en/use/nodes/start`,
+        `${enterpriseDocBaseUrl}/ja/use/nodes/start`,
       )
     })
   })

--- a/web/context/i18n.spec.ts
+++ b/web/context/i18n.spec.ts
@@ -3,7 +3,7 @@ import type { DocPathWithoutLang } from '@/types/doc-paths'
 import { renderHook } from '@testing-library/react'
 import { useTranslation } from '#i18n'
 import { getDocLanguage } from '@/i18n-config/language'
-import { defaultDocBaseUrl, useDocLink } from './i18n'
+import { defaultDocBaseUrl, enterpriseDocBaseUrl, useDocLink } from './i18n'
 
 const mockDeploymentEdition = vi.hoisted(() => ({
   value: 'CLOUD' as 'COMMUNITY' | 'ENTERPRISE' | 'CLOUD',
@@ -212,6 +212,75 @@ describe('useDocLink', () => {
       const { result } = renderHook(() => useDocLink())
       const url = result.current('/self-host/deploy/overview' as DocPathWithoutLang)
       expect(url).toBe(`${defaultDocBaseUrl}/en/self-host/deploy/overview`)
+    })
+  })
+
+  describe('Enterprise documentation', () => {
+    beforeEach(() => {
+      mockDeploymentEdition.value = 'ENTERPRISE'
+    })
+
+    it('should route use documentation to the versioned enterprise documentation', () => {
+      const { result } = renderHook(() => useDocLink())
+
+      expect(result.current('/use-dify/build/workflow-chatflow')).toBe(
+        `${enterpriseDocBaseUrl}/en/use/build/workflow-chatflow`,
+      )
+    })
+
+    it('should route the shared documentation entry to the enterprise workflow guide', () => {
+      const { result } = renderHook(() => useDocLink())
+
+      expect(result.current('/use-dify/getting-started/introduction')).toBe(
+        `${enterpriseDocBaseUrl}/en/use/build/workflow-chatflow`,
+      )
+    })
+
+    it('should convert API and plugin documentation paths', () => {
+      const { result } = renderHook(() => useDocLink())
+
+      expect(result.current('/api-reference/guides/knowledge')).toBe(
+        `${enterpriseDocBaseUrl}/en/develop/api/guides/knowledge`,
+      )
+      expect(result.current('/develop-plugin/getting-started/getting-started-dify-plugin')).toBe(
+        `${enterpriseDocBaseUrl}/en/develop/plugins/getting-started/getting-started-dify-plugin`,
+      )
+    })
+
+    it('should remove public product prefixes and preserve anchors', () => {
+      const { result } = renderHook(() => useDocLink())
+
+      expect(result.current('/self-host/use-dify/workspace/tools#mcp' as DocPathWithoutLang)).toBe(
+        `${enterpriseDocBaseUrl}/en/use/workspace/tools#mcp`,
+      )
+    })
+
+    it('should open the enterprise documentation home when no path is provided', () => {
+      const { result } = renderHook(() => useDocLink())
+
+      expect(result.current()).toBe(`${enterpriseDocBaseUrl}/en/`)
+    })
+
+    it('should use Chinese and fall back to English for unsupported documentation languages', () => {
+      vi.mocked(useTranslation).mockReturnValue({
+        i18n: { language: 'zh-Hans' },
+      } as ReturnType<typeof useTranslation>)
+      vi.mocked(getDocLanguage).mockReturnValue('zh')
+
+      const { result, rerender } = renderHook(() => useDocLink())
+      expect(result.current('/use-dify/nodes/start')).toBe(
+        `${enterpriseDocBaseUrl}/zh/use/nodes/start`,
+      )
+
+      vi.mocked(useTranslation).mockReturnValue({
+        i18n: { language: 'ja-JP' },
+      } as ReturnType<typeof useTranslation>)
+      vi.mocked(getDocLanguage).mockReturnValue('ja')
+      rerender()
+
+      expect(result.current('/use-dify/nodes/start')).toBe(
+        `${enterpriseDocBaseUrl}/en/use/nodes/start`,
+      )
     })
   })
 

--- a/web/context/i18n.spec.ts
+++ b/web/context/i18n.spec.ts
@@ -228,15 +228,19 @@ describe('useDocLink', () => {
       )
     })
 
-    it('should route the shared documentation entry to the enterprise workflow guide', () => {
+    it.each([
+      ['/use-dify/getting-started/introduction', '/use/build/workflow-chatflow'],
+      ['/cli/overview', '/develop/cli/introduction'],
+      ['/cli/authenticate', '/develop/cli/account-users/authenticate'],
+      ['/cli/common-tasks', '/develop/cli/account-users/common-tasks'],
+      ['/cli/quick-start', '/develop/cli/account-users/quick-start'],
+    ] as const)('should map the renamed %s page to %s', (communityPath, enterprisePath) => {
       const { result } = renderHook(() => useDocLink())
 
-      expect(result.current('/use-dify/getting-started/introduction')).toBe(
-        `${enterpriseDocBaseUrl}/en/use/build/workflow-chatflow`,
-      )
+      expect(result.current(communityPath)).toBe(`${enterpriseDocBaseUrl}/en${enterprisePath}`)
     })
 
-    it('should convert API and plugin documentation paths', () => {
+    it('should convert API, plugin, and CLI documentation prefixes', () => {
       const { result } = renderHook(() => useDocLink())
 
       expect(result.current('/api-reference/guides/knowledge')).toBe(
@@ -245,6 +249,7 @@ describe('useDocLink', () => {
       expect(result.current('/develop-plugin/getting-started/getting-started-dify-plugin')).toBe(
         `${enterpriseDocBaseUrl}/en/develop/plugins/getting-started/getting-started-dify-plugin`,
       )
+      expect(result.current('/cli/install')).toBe(`${enterpriseDocBaseUrl}/en/develop/cli/install`)
     })
 
     it('should remove public product prefixes and preserve anchors', () => {
@@ -252,6 +257,32 @@ describe('useDocLink', () => {
 
       expect(result.current('/self-host/use-dify/workspace/tools#mcp' as DocPathWithoutLang)).toBe(
         `${enterpriseDocBaseUrl}/en/use/workspace/tools#mcp`,
+      )
+      expect(result.current('/cloud/use-dify/nodes/start' as DocPathWithoutLang)).toBe(
+        `${enterpriseDocBaseUrl}/en/use/nodes/start`,
+      )
+    })
+
+    it.each(['/cloud', '/self-host'] as const)(
+      'should map the bare %s product prefix to the enterprise documentation home',
+      (productPrefix) => {
+        const { result } = renderHook(() => useDocLink())
+
+        expect(result.current(productPrefix as DocPathWithoutLang)).toBe(
+          `${enterpriseDocBaseUrl}/en/`,
+        )
+      },
+    )
+
+    it.each([
+      '/use-dify/knowledge/knowledge-request-rate-limit',
+      '/cloud/use-dify/knowledge/knowledge-storage-limit',
+      '/cloud/use-dify/workspace/subscription-management#dify-for-education',
+    ] as const)('should fall back to the enterprise documentation home for %s', (communityPath) => {
+      const { result } = renderHook(() => useDocLink())
+
+      expect(result.current(communityPath as DocPathWithoutLang)).toBe(
+        `${enterpriseDocBaseUrl}/en/`,
       )
     })
 

--- a/web/context/i18n.ts
+++ b/web/context/i18n.ts
@@ -72,17 +72,36 @@ const replacePathPrefix = (path: string, sourcePrefix: string, targetPrefix: str
   return `${targetPrefix}${path.slice(sourcePrefix.length)}`
 }
 
+const enterpriseDocPathOverrides: Readonly<Record<string, string>> = {
+  '/use-dify/getting-started/introduction': '/use/build/workflow-chatflow',
+  '/cli/overview': '/develop/cli/introduction',
+  '/cli/authenticate': '/develop/cli/account-users/authenticate',
+  '/cli/common-tasks': '/develop/cli/account-users/common-tasks',
+  '/cli/quick-start': '/develop/cli/account-users/quick-start',
+}
+
+const unavailableEnterpriseDocPaths: ReadonlySet<string> = new Set([
+  '/use/knowledge/knowledge-request-rate-limit',
+  '/use/knowledge/knowledge-storage-limit',
+  '/use/workspace/subscription-management',
+])
+
 const getEnterpriseDocPath = (path: string): string => {
   const { pathname, hash } = splitPathHash(path)
-  let targetPath = pathname.replace(/^\/(?:cloud|self-host)(?=\/)/, '')
+  let targetPath = replacePathPrefix(pathname, '/cloud', '')
+  targetPath = replacePathPrefix(targetPath, '/self-host', '')
 
-  if (targetPath === '/use-dify/getting-started/introduction')
-    return `/use/build/workflow-chatflow${hash}`
+  if (!targetPath) return '/'
+
+  const overriddenPath = enterpriseDocPathOverrides[targetPath]
+  if (overriddenPath) return `${overriddenPath}${hash}`
 
   targetPath = replacePathPrefix(targetPath, '/use-dify', '/use')
   targetPath = replacePathPrefix(targetPath, '/api-reference', '/develop/api')
   targetPath = replacePathPrefix(targetPath, '/develop-plugin', '/develop/plugins')
   targetPath = replacePathPrefix(targetPath, '/cli', '/develop/cli')
+
+  if (unavailableEnterpriseDocPaths.has(targetPath)) return '/'
 
   return `${targetPath}${hash}`
 }

--- a/web/context/i18n.ts
+++ b/web/context/i18n.ts
@@ -72,8 +72,8 @@ const replacePathPrefix = (path: string, sourcePrefix: string, targetPrefix: str
   return `${targetPrefix}${path.slice(sourcePrefix.length)}`
 }
 
-const getEnterpriseDocLanguage = (docLanguage: DocLanguage): 'en' | 'zh' => {
-  return docLanguage === 'zh' ? 'zh' : 'en'
+const getEnterpriseDocLanguage = (docLanguage: DocLanguage): 'en' | 'zh' | 'ja' => {
+  return docLanguage
 }
 
 const getEnterpriseDocPath = (path: string): string => {

--- a/web/context/i18n.ts
+++ b/web/context/i18n.ts
@@ -72,10 +72,6 @@ const replacePathPrefix = (path: string, sourcePrefix: string, targetPrefix: str
   return `${targetPrefix}${path.slice(sourcePrefix.length)}`
 }
 
-const getEnterpriseDocLanguage = (docLanguage: DocLanguage): 'en' | 'zh' | 'ja' => {
-  return docLanguage
-}
-
 const getEnterpriseDocPath = (path: string): string => {
   const { pathname, hash } = splitPathHash(path)
   let targetPath = pathname.replace(/^\/(?:cloud|self-host)(?=\/)/, '')
@@ -92,10 +88,9 @@ const getEnterpriseDocPath = (path: string): string => {
 }
 
 export const getEnterpriseDocUrl = (path: string, docLanguage: DocLanguage): string => {
-  const language = getEnterpriseDocLanguage(docLanguage)
   const targetPath = path ? getEnterpriseDocPath(path) : '/'
 
-  return `${enterpriseDocBaseUrl}/${language}${targetPath}`
+  return `${enterpriseDocBaseUrl}/${docLanguage}${targetPath}`
 }
 
 export const useDocLink = (

--- a/web/context/i18n.ts
+++ b/web/context/i18n.ts
@@ -28,7 +28,7 @@ export const defaultDocBaseUrl = 'https://docs.dify.ai'
 export const enterpriseDocBaseUrl = 'https://enterprise-docs.dify.ai'
 export type DocPathMap = Partial<Record<Locale, DocPathWithoutLang>>
 
-export const getDocHomePath = () => '/home'
+const getDocHomePath = () => '/home'
 
 const getCurrentDocsProduct = (deploymentEdition: DeploymentEdition): DocsProduct => {
   if (deploymentEdition === 'CLOUD') return 'cloud'

--- a/web/context/i18n.ts
+++ b/web/context/i18n.ts
@@ -1,6 +1,6 @@
 import type { DeploymentEdition } from '@dify/contracts/api/console/system-features/types.gen'
 import type { Locale } from '@/i18n-config/language'
-import type { DocPathWithoutLang, DocsProduct } from '@/types/doc-paths'
+import type { DocLanguage, DocPathWithoutLang, DocsProduct } from '@/types/doc-paths'
 import { useAtomValue } from 'jotai'
 import { useCallback } from 'react'
 import { useTranslation } from '#i18n'
@@ -25,6 +25,7 @@ export const useGetPricingPageLanguage = () => {
 }
 
 export const defaultDocBaseUrl = 'https://docs.dify.ai'
+export const enterpriseDocBaseUrl = 'https://enterprise-docs.dify.ai'
 export type DocPathMap = Partial<Record<Locale, DocPathWithoutLang>>
 
 export const getDocHomePath = () => '/home'
@@ -64,18 +65,55 @@ const getProductAwarePath = (path: string, deploymentEdition: DeploymentEdition)
   return `/${targetProduct}${pathname}${hash}`
 }
 
+const replacePathPrefix = (path: string, sourcePrefix: string, targetPrefix: string): string => {
+  if (path === sourcePrefix) return targetPrefix
+  if (!path.startsWith(`${sourcePrefix}/`)) return path
+
+  return `${targetPrefix}${path.slice(sourcePrefix.length)}`
+}
+
+const getEnterpriseDocLanguage = (docLanguage: DocLanguage): 'en' | 'zh' => {
+  return docLanguage === 'zh' ? 'zh' : 'en'
+}
+
+const getEnterpriseDocPath = (path: string): string => {
+  const { pathname, hash } = splitPathHash(path)
+  let targetPath = pathname.replace(/^\/(?:cloud|self-host)(?=\/)/, '')
+
+  if (targetPath === '/use-dify/getting-started/introduction')
+    return `/use/build/workflow-chatflow${hash}`
+
+  targetPath = replacePathPrefix(targetPath, '/use-dify', '/use')
+  targetPath = replacePathPrefix(targetPath, '/api-reference', '/develop/api')
+  targetPath = replacePathPrefix(targetPath, '/develop-plugin', '/develop/plugins')
+  targetPath = replacePathPrefix(targetPath, '/cli', '/develop/cli')
+
+  return `${targetPath}${hash}`
+}
+
+export const getEnterpriseDocUrl = (path: string, docLanguage: DocLanguage): string => {
+  const language = getEnterpriseDocLanguage(docLanguage)
+  const targetPath = path ? getEnterpriseDocPath(path) : '/'
+
+  return `${enterpriseDocBaseUrl}/${language}${targetPath}`
+}
+
 export const useDocLink = (
   baseUrl?: string,
 ): ((path?: DocPathWithoutLang, pathMap?: DocPathMap) => string) => {
-  let baseDocUrl = baseUrl || defaultDocBaseUrl
-  baseDocUrl = baseDocUrl.endsWith('/') ? baseDocUrl.slice(0, -1) : baseDocUrl
   const locale = useLocale()
   const deploymentEdition = useAtomValue(deploymentEditionAtom)
+  const useEnterpriseDocs = deploymentEdition === 'ENTERPRISE' && !baseUrl
+  let baseDocUrl = baseUrl || (useEnterpriseDocs ? enterpriseDocBaseUrl : defaultDocBaseUrl)
+  baseDocUrl = baseDocUrl.endsWith('/') ? baseDocUrl.slice(0, -1) : baseDocUrl
   return useCallback(
     (path?: DocPathWithoutLang, pathMap?: DocPathMap): string => {
       const docLanguage = getDocLanguage(locale)
       const pathUrl = path || ''
       let targetPath = pathMap ? pathMap[locale] || pathUrl : pathUrl
+
+      if (useEnterpriseDocs) return getEnterpriseDocUrl(targetPath, docLanguage)
+
       const languagePrefix = `/${docLanguage}`
 
       if (!targetPath) {
@@ -86,6 +124,6 @@ export const useDocLink = (
 
       return `${baseDocUrl}${languagePrefix}${targetPath}`
     },
-    [baseDocUrl, deploymentEdition, locale],
+    [baseDocUrl, deploymentEdition, locale, useEnterpriseDocs],
   )
 }

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/cli-tool/__tests__/dialog.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/cli-tool/__tests__/dialog.spec.tsx
@@ -10,6 +10,10 @@ vi.mock('@langgenius/dify-ui/toast', () => ({
   },
 }))
 
+vi.mock('@/context/i18n', () => ({
+  useDocLink: () => () => 'https://docs.example.com',
+}))
+
 type CliToolDialogProps = Parameters<typeof CliToolDialog>[0]
 
 function renderCliToolDialog(props?: Partial<CliToolDialogProps>) {
@@ -129,6 +133,16 @@ describe('CliToolDialog', () => {
   })
 
   describe('Actions', () => {
+    it('should link to documentation through the shared documentation URL', () => {
+      renderCliToolDialog()
+
+      expect(
+        screen.getByRole('link', {
+          name: /agentV2\.agentDetail\.configure\.tools\.cliDialog\.learnMore/,
+        }),
+      ).toHaveAttribute('href', 'https://docs.example.com')
+    })
+
     it('should keep the form open when the backdrop is clicked', async () => {
       const user = userEvent.setup()
       const { onOpenChange } = renderCliToolDialog()

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/cli-tool/dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/cli-tool/dialog.tsx
@@ -19,6 +19,7 @@ import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDocLink } from '@/context/i18n'
 import { EnvVariablesTable } from '../../advanced/env'
 
 type CliToolFormValues = {
@@ -53,6 +54,7 @@ export function CliToolDialog({
 }) {
   const { t } = useTranslation('agentV2')
   const { t: tCommon } = useTranslation('common')
+  const docLink = useDocLink()
   const [installCommand, setInstallCommand] = useState(tool?.installCommand ?? '')
   const [toolName, setToolName] = useState(tool?.name ?? '')
   const [envVariables, setEnvVariables] = useState<EnvVariable[]>(() =>
@@ -236,7 +238,7 @@ export function CliToolDialog({
           </div>
           <div className="flex items-center gap-3 py-8">
             <a
-              href="https://docs.dify.ai/"
+              href={docLink()}
               target="_blank"
               rel="noreferrer"
               className="inline-flex min-w-0 flex-1 items-center gap-1 system-xs-regular text-text-accent hover:underline focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"

--- a/web/features/new-rag/__tests__/new-knowledge-list.spec.tsx
+++ b/web/features/new-rag/__tests__/new-knowledge-list.spec.tsx
@@ -85,6 +85,11 @@ vi.mock('@/context/permission-state', () => ({
   workspacePermissionKeysAtom: permissionStateMock.workspacePermissionKeysAtom,
 }))
 
+vi.mock('@/context/i18n', () => ({
+  useDocLink: () => (path?: string) => `https://docs.example.com${path ?? ''}`,
+  useLocale: () => 'en-US',
+}))
+
 vi.mock('@/service/client', () => ({
   consoleQuery: {
     knowledgeFs: {
@@ -139,6 +144,17 @@ describe('NewKnowledgeList', () => {
     })
     expect(options?.getNextPageParam({ items: [], nextCursor: 'next-page' })).toBe('next-page')
     expect(options?.getNextPageParam({ items: [] })).toBeUndefined()
+  })
+
+  it('links the guide through the shared documentation URL', () => {
+    setResolvedPage()
+
+    renderWithNuqs(<NewKnowledgeList view="new" onViewChange={vi.fn()} />)
+
+    expect(screen.getByRole('link', { name: 'dataset.newKnowledge.learnMore' })).toHaveAttribute(
+      'href',
+      'https://docs.example.com/use-dify/knowledge/readme',
+    )
   })
 
   it('links real knowledge spaces to the new detail shell', () => {

--- a/web/features/new-rag/components/knowledge-view-switcher.tsx
+++ b/web/features/new-rag/components/knowledge-view-switcher.tsx
@@ -9,6 +9,7 @@ import {
 import { SegmentedControl, SegmentedControlItem } from '@langgenius/dify-ui/segmented-control'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDocLink } from '@/context/i18n'
 import {
   useNewKnowledgeGuideDismissedValue,
   useSetNewKnowledgeGuideDismissed,
@@ -21,6 +22,7 @@ export type KnowledgeViewSwitcherProps = {
 
 export function KnowledgeViewSwitcher({ value, onChange }: KnowledgeViewSwitcherProps) {
   const { t } = useTranslation('dataset')
+  const docLink = useDocLink()
   const guideDismissed = useNewKnowledgeGuideDismissedValue()
   const setGuideDismissed = useSetNewKnowledgeGuideDismissed()
   const [guideOpenOverride, setGuideOpenOverride] = useState<boolean | null>(null)
@@ -84,7 +86,7 @@ export function KnowledgeViewSwitcher({ value, onChange }: KnowledgeViewSwitcher
             </PopoverDescription>
             <div className="mt-auto flex flex-wrap items-center justify-end gap-3 pt-3">
               <a
-                href="https://docs.dify.ai/en/guides/knowledge-base"
+                href={docLink('/use-dify/knowledge/readme')}
                 target="_blank"
                 rel="noreferrer"
                 className="rounded-sm system-xs-regular text-text-accent focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"


### PR DESCRIPTION
> [!IMPORTANT]
>
> This draft PR does not have an associated issue yet.

## Summary

- Route Web documentation links through an edition-aware shared helper.
- Send Enterprise deployments to `enterprise-docs.dify.ai` without a version segment and normalize public documentation paths.
- Migrate the Goto Anything docs command, permission references, the CLI tool dialog, and the New RAG knowledge switcher to the shared routing.
- Preserve explicitly supplied documentation base URLs and leave pipeline templates unchanged.

## Screenshots

Not applicable. This change affects destination URLs without changing the UI.

## Testing

- `vp staged`
- `pnpm --dir web exec vitest run context/i18n.spec.ts app/components/goto-anything/actions/commands/__tests__/direct-commands.spec.ts app/components/goto-anything/actions/commands/__tests__/slash.spec.tsx features/agent-v2/agent-detail/configure/components/orchestrate/tools/cli-tool/__tests__/dialog.spec.tsx features/new-rag/__tests__/new-knowledge-list.spec.tsx` (95 tests passed)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos.)
- [x] I have added tests for the behavior changes and kept the change atomic.
- [ ] I have updated the documentation accordingly.
- [x] I ran `vp staged` for the frontend changes.

From Codex