### PR TITLE
fix(ci): extend Playwright E2E install timeout

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Install Playwright browsers for core E2E
         if: ${{ !inputs.run-external-runtime }}
-        timeout-minutes: 15
+        # Chromium and WebKit system dependencies are fetched through apt, whose mirror speed varies.
+        timeout-minutes: 30
         working-directory: ./e2e
         run: vp run e2e:install:ci
 


### PR DESCRIPTION
## Summary

- extend the core Playwright browser installation timeout from 15 to 30 minutes
- keep the supported `playwright install --with-deps` path and the runner's default Ubuntu mirror
- document why the dual-browser install needs additional network variance headroom

## Root cause

The Web Full-Stack E2E job for #40956 timed out before any Cucumber scenarios ran. The core setup installs Chromium, WebKit, and their Linux system dependencies through apt. A normal successful run completes this step in about 7 minutes, but the Depot runner's default Ubuntu mirror slowed enough that the existing 15-minute step limit terminated the install.

Failure: https://github.com/langgenius/dify/actions/runs/32208286911/job/95935844621

This keeps the job-level 120-minute ceiling and avoids reintroducing the Azure mirror override removed in #40909.

## Impact

Transient Ubuntu mirror slowness has twice the installation window before it can fail the E2E gate. Test execution and browser coverage are unchanged.

## Validation

- `vp fmt .github/workflows/web-e2e.yml --check`
- parsed `.github/workflows/web-e2e.yml` with Ruby YAML
- `git diff --check`

From Codex