### PR TITLE
fix: remove unnecessary type conversions and promote lint rule to error

### DIFF
--- a/api/commands/account.py
+++ b/api/commands/account.py
@@ -20,7 +20,7 @@ def reset_password(email, new_password, password_confirm):
     Reset password of owner account
     Only available in SELF_HOSTED mode
     """
-    if str(new_password).strip() != str(password_confirm).strip():
+    if new_password.strip() != password_confirm.strip():
         click.echo(click.style("Passwords do not match.", fg="red"))
         return
     normalized_email = email.strip().lower()
@@ -62,7 +62,7 @@ def reset_email(email, new_email, email_confirm):
     Replace account email
     :return:
     """
-    if str(new_email).strip() != str(email_confirm).strip():
+    if new_email.strip() != email_confirm.strip():
         click.echo(click.style("New emails do not match.", fg="red"))
         return
     normalized_new_email = new_email.strip().lower()

--- a/api/core/workflow/nodes/agent_v2/runtime_feature_manifest.py
+++ b/api/core/workflow/nodes/agent_v2/runtime_feature_manifest.py
@@ -38,7 +38,7 @@ def build_runtime_feature_manifest(agent_soul: AgentSoulConfig) -> dict[str, Any
         value = _get_nested(soul_dump, section)
         has_value = bool(value)
         if isinstance(value, dict):
-            has_value = any(bool(item) for item in value.values())
+            has_value = any(value.values())
         if has_value:
             warnings.append(
                 {

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -315,4 +315,4 @@ python-platform = "linux"
 python-version = "3.12.0"
 infer-with-first-use = true
 min-severity = "warn"
-errors = { missing-override-decorator = "error", unnecessary-type-conversion = "error" }
+errors = { missing-override-decorator = "error", unnecessary-type-conversion = "info" }

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -315,4 +315,4 @@ python-platform = "linux"
 python-version = "3.12.0"
 infer-with-first-use = true
 min-severity = "warn"
-errors = { missing-override-decorator = "error", unnecessary-type-conversion = "info" }
+errors = { missing-override-decorator = "error", unnecessary-type-conversion = "error" }


### PR DESCRIPTION
## Summary

Closes #39947

Remove redundant type constructor calls that perform no-op conversions, and promote the `unnecessary-type-conversion` Pyrefly lint rule from `info` to `error` so CI catches future regressions.

## Changes

### `api/commands/account.py` (lines 23, 65)
- **Before:** `str(new_password).strip()`, `str(new_email).strip()`
- **After:** `new_password.strip()`, `new_email.strip()`
- **Why:** Click `@click.option` string parameters are already `str`. The outer `str()` is redundant.

### `api/core/workflow/nodes/agent_v2/runtime_feature_manifest.py` (line 41)
- **Before:** `any(bool(item) for item in value.values())`
- **After:** `any(value.values())`
- **Why:** `any()` already evaluates truthiness of each element; wrapping each in `bool()` is unnecessary.

### `api/pyproject.toml`
- **Before:** `unnecessary-type-conversion = "info"`
- **After:** `unnecessary-type-conversion = "error"`
- **Why:** With all existing violations fixed, promote to `error` to prevent regressions.

## Notes

Other `bool(value)` calls in the codebase (e.g., in `dsl.py`, `parameters.py`, `custom_tool/tool.py`) are **intentional type coercions** — they convert non-bool inputs to bool for explicit return types. These are not flagged by Pyrefly as unnecessary.