### PR TITLE
fix(api): add missing admin and RBAC permission decorators to model credentials GET endpoints

### DIFF
--- a/api/controllers/console/workspace/model_providers.py
+++ b/api/controllers/console/workspace/model_providers.py
@@ -209,6 +209,8 @@ class ModelProviderCredentialApi(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str, provider: str):

--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -349,6 +349,8 @@ class ModelProviderModelCredentialApi(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id


### PR DESCRIPTION
## Summary

Closes #40899

Add missing `@is_admin_or_owner_required` and `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)` decorators to the following GET endpoints:
- `ModelProviderCredentialApi.get` in `api/controllers/console/workspace/model_providers.py`
- `ModelProviderModelCredentialApi.get` in `api/controllers/console/workspace/models.py`

## Motivation & Impact

The corresponding `post`, `put`, and `delete` endpoints for model and provider credentials enforce that only workspace admins/owners or members with the `CREDENTIAL_MANAGE` RBAC permission can manage credentials. However, the `get` endpoints were missing these decorators, allowing non-admin members to retrieve configured credentials.

Adding these decorators aligns the read endpoints with their write counterparts and prevents unauthorized access to model credentials.