### PR TITLE
fix(agent): resolve suggested questions from runtime config

### DIFF
--- a/api/services/agent/runtime_config_service.py
+++ b/api/services/agent/runtime_config_service.py
@@ -1,0 +1,125 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from models.agent import (
+    AgentConfigDraft,
+    AgentConfigDraftType,
+    AgentConfigSnapshot,
+    AgentConfigVersionKind,
+    AgentDebugConversation,
+    AgentWorkspaceBinding,
+)
+from models.agent_config_entities import AgentSoulConfig
+from models.model import App, Conversation
+
+
+class AgentRuntimeConfigService:
+    """Resolve the Agent Soul generation that produced one conversation."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def resolve_conversation_soul(
+        self,
+        *,
+        app_model: App,
+        conversation: Conversation,
+        account_id: str | None,
+        use_debug_draft: bool,
+    ) -> AgentSoulConfig | None:
+        if use_debug_draft and account_id is not None:
+            draft_soul = self._resolve_debug_draft_soul(
+                app_model=app_model,
+                conversation=conversation,
+                account_id=account_id,
+            )
+            if draft_soul is not None:
+                return draft_soul
+
+        binding_soul = self._resolve_binding_soul(app_model=app_model, conversation=conversation)
+        if binding_soul is not None:
+            return binding_soul
+
+        from services.agent.roster_service import AgentRosterService
+
+        return AgentRosterService(self._session).get_published_agent_soul_for_app(
+            tenant_id=app_model.tenant_id,
+            app_id=app_model.id,
+        )
+
+    def _resolve_debug_draft_soul(
+        self,
+        *,
+        app_model: App,
+        conversation: Conversation,
+        account_id: str,
+    ) -> AgentSoulConfig | None:
+        debug_conversation = self._session.scalar(
+            select(AgentDebugConversation)
+            .where(
+                AgentDebugConversation.tenant_id == app_model.tenant_id,
+                AgentDebugConversation.app_id == app_model.id,
+                AgentDebugConversation.account_id == account_id,
+                AgentDebugConversation.conversation_id == conversation.id,
+            )
+            .limit(1)
+        )
+        if debug_conversation is None:
+            return None
+
+        draft_stmt = select(AgentConfigDraft).where(
+            AgentConfigDraft.tenant_id == app_model.tenant_id,
+            AgentConfigDraft.agent_id == debug_conversation.agent_id,
+            AgentConfigDraft.draft_type == debug_conversation.draft_type,
+        )
+        if debug_conversation.draft_type == AgentConfigDraftType.DEBUG_BUILD:
+            draft_stmt = draft_stmt.where(AgentConfigDraft.account_id == account_id)
+        draft = self._session.scalar(draft_stmt.order_by(AgentConfigDraft.updated_at.desc()).limit(1))
+        if draft is None:
+            return None
+        return AgentSoulConfig.model_validate(draft.config_snapshot_dict)
+
+    def _resolve_binding_soul(self, *, app_model: App, conversation: Conversation) -> AgentSoulConfig | None:
+        if not conversation.agent_workspace_binding_id:
+            return None
+        binding = self._session.scalar(
+            select(AgentWorkspaceBinding)
+            .where(
+                AgentWorkspaceBinding.id == conversation.agent_workspace_binding_id,
+                AgentWorkspaceBinding.tenant_id == app_model.tenant_id,
+                AgentWorkspaceBinding.app_id == app_model.id,
+            )
+            .limit(1)
+        )
+        if binding is None:
+            return None
+
+        if binding.agent_config_version_kind == AgentConfigVersionKind.SNAPSHOT:
+            snapshot = self._session.scalar(
+                select(AgentConfigSnapshot)
+                .where(
+                    AgentConfigSnapshot.id == binding.agent_config_version_id,
+                    AgentConfigSnapshot.tenant_id == app_model.tenant_id,
+                    AgentConfigSnapshot.agent_id == binding.agent_id,
+                )
+                .limit(1)
+            )
+            if snapshot is None:
+                return None
+            return AgentSoulConfig.model_validate(snapshot.config_snapshot_dict)
+
+        draft = self._session.scalar(
+            select(AgentConfigDraft)
+            .where(
+                AgentConfigDraft.id == binding.agent_config_version_id,
+                AgentConfigDraft.tenant_id == app_model.tenant_id,
+                AgentConfigDraft.agent_id == binding.agent_id,
+            )
+            .limit(1)
+        )
+        if draft is None:
+            return None
+        return AgentSoulConfig.model_validate(draft.config_snapshot_dict)
+
+
+__all__ = ["AgentRuntimeConfigService"]

--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.app.apps.advanced_chat.app_config_manager import AdvancedChatAppConfigManager
+from core.app.apps.agent_app.app_feature_projection import merge_agent_app_features
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.llm_generator.llm_generator import LLMGenerator
 from core.memory.token_buffer_memory import TokenBufferMemory
@@ -17,15 +18,18 @@ from extensions.ext_database import db
 from graphon.model_runtime.entities.model_entities import ModelType
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from models import Account
+from models.agent_config_entities import AgentSoulConfig
 from models.enums import FeedbackFromSource, FeedbackRating
 from models.model import (
     App,
     AppMode,
     AppModelConfig,
+    Conversation,
     EndUser,
     Message,
     MessageFeedback,
     SuggestedQuestionsAfterAnswerConfig,
+    load_annotation_reply_config,
 )
 from repositories.execution_extra_content_repository import ExecutionExtraContentRepository
 from repositories.sqlalchemy_execution_extra_content_repository import (
@@ -61,6 +65,38 @@ def attach_message_extra_contents(messages: Sequence[Message]) -> None:
 
 
 class MessageService:
+    @classmethod
+    def _get_agent_suggested_questions_config(
+        cls,
+        *,
+        app_model: App,
+        user: Account | EndUser,
+        conversation: Conversation,
+        invoke_from: InvokeFrom,
+        session: Session,
+    ) -> SuggestedQuestionsAfterAnswerConfig:
+        from services.agent.runtime_config_service import AgentRuntimeConfigService
+
+        agent_soul = AgentRuntimeConfigService(session).resolve_conversation_soul(
+            app_model=app_model,
+            conversation=conversation,
+            account_id=user.id if isinstance(user, Account) else None,
+            use_debug_draft=invoke_from == InvokeFrom.DEBUGGER,
+        )
+        app_model_config = (
+            session.get(AppModelConfig, app_model.app_model_config_id) if app_model.app_model_config_id else None
+        )
+        annotation_reply = load_annotation_reply_config(session, app_model.id) if app_model_config else None
+        features = merge_agent_app_features(
+            agent_soul=agent_soul or AgentSoulConfig(),
+            app_model_config=app_model_config,
+            annotation_reply=annotation_reply,
+        )
+        suggested_questions = features.get("suggested_questions_after_answer")
+        if not isinstance(suggested_questions, dict) or not suggested_questions.get("enabled", False):
+            raise SuggestedQuestionsAfterAnswerDisabledError()
+        return cast(SuggestedQuestionsAfterAnswerConfig, suggested_questions)
+
     @classmethod
     def pagination_by_first_id(
         cls,
@@ -301,6 +337,14 @@ class MessageService:
                 suggested_questions_after_answer_config = cast(
                     SuggestedQuestionsAfterAnswerConfig, suggested_questions_after_answer
                 )
+        elif app_model.mode == AppMode.AGENT:
+            suggested_questions_after_answer_config = cls._get_agent_suggested_questions_config(
+                app_model=app_model,
+                user=user,
+                conversation=conversation,
+                invoke_from=invoke_from,
+                session=session,
+            )
         else:
             if not conversation.override_model_configs:
                 app_model_config = session.scalar(

--- a/api/tests/unit_tests/services/agent/test_agent_runtime_config_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_runtime_config_service.py
@@ -1,0 +1,147 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from models.agent import (
+    AgentConfigDraft,
+    AgentConfigDraftType,
+    AgentConfigVersionKind,
+    AgentDebugConversation,
+    AgentWorkspaceBinding,
+)
+from models.agent_config_entities import AgentSoulConfig
+from models.model import App, Conversation
+from services.agent.runtime_config_service import AgentRuntimeConfigService
+
+
+def _app() -> MagicMock:
+    app = MagicMock(spec=App)
+    app.id = "app-1"
+    app.tenant_id = "tenant-1"
+    return app
+
+
+def _conversation(*, binding_id: str | None = None) -> MagicMock:
+    conversation = MagicMock(spec=Conversation)
+    conversation.id = "conversation-1"
+    conversation.agent_workspace_binding_id = binding_id
+    return conversation
+
+
+def _soul(prompt: str) -> AgentSoulConfig:
+    return AgentSoulConfig.model_validate(
+        {
+            "prompt": {"system_prompt": prompt},
+            "app_features": {"suggested_questions_after_answer": {"enabled": True}},
+        }
+    )
+
+
+def _patch_published_soul(monkeypatch: pytest.MonkeyPatch, soul: AgentSoulConfig) -> MagicMock:
+    roster_service = MagicMock()
+    roster_service.return_value.get_published_agent_soul_for_app.return_value = soul
+    monkeypatch.setattr("services.agent.roster_service.AgentRosterService", roster_service)
+    return roster_service
+
+
+def test_debug_without_mapping_falls_back_to_published_soul(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock(spec=Session)
+    session.scalar.return_value = None
+    published = _soul("published")
+    roster_service = _patch_published_soul(monkeypatch, published)
+
+    result = AgentRuntimeConfigService(session).resolve_conversation_soul(
+        app_model=_app(),
+        conversation=_conversation(),
+        account_id="account-1",
+        use_debug_draft=True,
+    )
+
+    assert result == published
+    roster_service.return_value.get_published_agent_soul_for_app.assert_called_once_with(
+        tenant_id="tenant-1",
+        app_id="app-1",
+    )
+
+
+def test_debug_without_draft_falls_back_to_published_soul(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock(spec=Session)
+    debug_conversation = MagicMock(spec=AgentDebugConversation)
+    debug_conversation.agent_id = "agent-1"
+    debug_conversation.draft_type = AgentConfigDraftType.DRAFT
+    session.scalar.side_effect = [debug_conversation, None]
+    published = _soul("published")
+    _patch_published_soul(monkeypatch, published)
+
+    result = AgentRuntimeConfigService(session).resolve_conversation_soul(
+        app_model=_app(),
+        conversation=_conversation(),
+        account_id="account-1",
+        use_debug_draft=True,
+    )
+
+    assert result == published
+
+
+def test_missing_binding_falls_back_to_published_soul(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock(spec=Session)
+    session.scalar.return_value = None
+    published = _soul("published")
+    _patch_published_soul(monkeypatch, published)
+
+    result = AgentRuntimeConfigService(session).resolve_conversation_soul(
+        app_model=_app(),
+        conversation=_conversation(binding_id="binding-1"),
+        account_id=None,
+        use_debug_draft=False,
+    )
+
+    assert result == published
+
+
+@pytest.mark.parametrize("version_kind", [AgentConfigVersionKind.SNAPSHOT, AgentConfigVersionKind.DRAFT])
+def test_missing_bound_version_falls_back_to_published_soul(
+    version_kind: AgentConfigVersionKind,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock(spec=Session)
+    binding = MagicMock(spec=AgentWorkspaceBinding)
+    binding.agent_id = "agent-1"
+    binding.agent_config_version_id = "version-1"
+    binding.agent_config_version_kind = version_kind
+    session.scalar.side_effect = [binding, None]
+    published = _soul("published")
+    _patch_published_soul(monkeypatch, published)
+
+    result = AgentRuntimeConfigService(session).resolve_conversation_soul(
+        app_model=_app(),
+        conversation=_conversation(binding_id="binding-1"),
+        account_id=None,
+        use_debug_draft=False,
+    )
+
+    assert result == published
+
+
+def test_bound_draft_returns_its_soul(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock(spec=Session)
+    binding = MagicMock(spec=AgentWorkspaceBinding)
+    binding.agent_id = "agent-1"
+    binding.agent_config_version_id = "draft-1"
+    binding.agent_config_version_kind = AgentConfigVersionKind.DRAFT
+    draft = MagicMock(spec=AgentConfigDraft)
+    bound = _soul("bound draft")
+    draft.config_snapshot_dict = bound.model_dump(mode="json")
+    session.scalar.side_effect = [binding, draft]
+    roster_service = _patch_published_soul(monkeypatch, _soul("published"))
+
+    result = AgentRuntimeConfigService(session).resolve_conversation_soul(
+        app_model=_app(),
+        conversation=_conversation(binding_id="binding-1"),
+        account_id=None,
+        use_debug_draft=False,
+    )
+
+    assert result == bound
+    roster_service.assert_not_called()

--- a/api/tests/unit_tests/services/test_message_service.py
+++ b/api/tests/unit_tests/services/test_message_service.py
@@ -878,7 +878,7 @@ class TestMessageServiceSuggestedQuestions:
             pending_form_id=None,
             pending_tool_call_id=None,
         )
-        binding.id = conversation.agent_workspace_binding_id
+        binding.id = "binding-123"
         _persist(sqlite_session, snapshot, binding)
         roster_service = MagicMock()
         roster_service.return_value.get_published_agent_soul_for_app.return_value = self._agent_soul(

--- a/api/tests/unit_tests/services/test_message_service.py
+++ b/api/tests/unit_tests/services/test_message_service.py
@@ -13,6 +13,15 @@ import services.message_service as service_module
 from core.app.entities.app_invoke_entities import InvokeFrom
 from graphon.model_runtime.entities.model_entities import ModelType
 from models.account import Account, AccountStatus
+from models.agent import (
+    AgentConfigDraft,
+    AgentConfigDraftType,
+    AgentConfigSnapshot,
+    AgentConfigVersionKind,
+    AgentDebugConversation,
+    AgentWorkspaceBinding,
+)
+from models.agent_config_entities import AgentSoulConfig
 from models.enums import (
     ConversationFromSource,
     EndUserType,
@@ -38,7 +47,17 @@ from services.errors.message import (
 )
 from services.message_service import MessageService, attach_message_extra_contents
 
-SQLITE_MODELS = (Conversation, Message, MessageFeedback, AppModelConfig, AppAnnotationSetting)
+SQLITE_MODELS = (
+    Conversation,
+    Message,
+    MessageFeedback,
+    AppModelConfig,
+    AppAnnotationSetting,
+    AgentConfigDraft,
+    AgentConfigSnapshot,
+    AgentDebugConversation,
+    AgentWorkspaceBinding,
+)
 pytestmark = [
     pytest.mark.usefixtures("sqlite_session"),
     pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True),
@@ -673,6 +692,22 @@ class TestMessageServiceFeedback:
 
 class TestMessageServiceSuggestedQuestions:
     @staticmethod
+    def _agent_soul(
+        *,
+        enabled: bool = True,
+        prompt: str | None = None,
+        model: dict[str, object] | None = None,
+    ) -> AgentSoulConfig:
+        suggested_questions: dict[str, object] = {"enabled": enabled}
+        if prompt is not None:
+            suggested_questions["prompt"] = prompt
+        if model is not None:
+            suggested_questions["model"] = model
+        return AgentSoulConfig.model_validate(
+            {"app_features": {"suggested_questions_after_answer": suggested_questions}}
+        )
+
+    @staticmethod
     def _chat_boundaries(
         monkeypatch: pytest.MonkeyPatch,
         conversation: Conversation,
@@ -731,6 +766,236 @@ class TestMessageServiceSuggestedQuestions:
 
         assert result == ["Q1?"]
         llm_generator.generate_suggested_questions_after_answer.assert_called_once()
+
+    @pytest.mark.parametrize("draft_type", [AgentConfigDraftType.DRAFT, AgentConfigDraftType.DEBUG_BUILD])
+    def test_agent_debug_uses_matching_draft(
+        self,
+        draft_type: AgentConfigDraftType,
+        monkeypatch: pytest.MonkeyPatch,
+        factory: MessageServiceTestDataFactory,
+        sqlite_session: Session,
+    ) -> None:
+        conversation = factory.create_conversation()
+        conversation.mode = AppMode.AGENT
+        _, _, llm_generator = self._chat_boundaries(monkeypatch, conversation)
+        account = factory.create_account()
+        draft = AgentConfigDraft(
+            tenant_id="tenant-123",
+            agent_id="agent-123",
+            draft_type=draft_type,
+            account_id=account.id if draft_type == AgentConfigDraftType.DEBUG_BUILD else None,
+            draft_owner_key=account.id if draft_type == AgentConfigDraftType.DEBUG_BUILD else "",
+            base_snapshot_id=None,
+            home_snapshot_id=None,
+            agent_workspace_binding_id=None,
+            config_snapshot=self._agent_soul(
+                prompt=f"{draft_type.value} prompt",
+                model={
+                    "provider": "openai",
+                    "name": "gpt-4o-mini",
+                    "mode": "chat",
+                    "completion_params": {"temperature": 0.1},
+                },
+            ),
+            created_by=account.id,
+            updated_by=account.id,
+        )
+        draft.id = "draft-123"
+        mapping = AgentDebugConversation(
+            tenant_id="tenant-123",
+            agent_id="agent-123",
+            app_id="app-123",
+            account_id=account.id,
+            draft_type=draft_type,
+            conversation_id=conversation.id,
+        )
+        mapping.id = "mapping-123"
+        app_model_config = AppModelConfig(
+            app_id="app-123",
+            suggested_questions_after_answer=json.dumps({"enabled": False}),
+        )
+        app_model_config.id = "config-123"
+        _persist(sqlite_session, draft, mapping, app_model_config)
+        roster_service = MagicMock()
+        monkeypatch.setattr("services.agent.roster_service.AgentRosterService", roster_service)
+        app = factory.create_app(mode=AppMode.AGENT)
+        app.app_model_config_id = app_model_config.id
+
+        result = MessageService.get_suggested_questions_after_answer(
+            app_model=app,
+            user=account,
+            message_id="msg-123",
+            invoke_from=InvokeFrom.DEBUGGER,
+            session=sqlite_session,
+        )
+
+        assert result == ["Q1?"]
+        roster_service.assert_not_called()
+        llm_generator.generate_suggested_questions_after_answer.assert_called_once_with(
+            tenant_id="tenant-123",
+            histories="histories",
+            instruction_prompt=f"{draft_type.value} prompt",
+            model_config={
+                "provider": "openai",
+                "name": "gpt-4o-mini",
+                "mode": "chat",
+                "completion_params": {"temperature": 0.1},
+            },
+        )
+
+    def test_agent_published_conversation_uses_bound_snapshot(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        factory: MessageServiceTestDataFactory,
+        sqlite_session: Session,
+    ) -> None:
+        conversation = factory.create_conversation()
+        conversation.mode = AppMode.AGENT
+        conversation.agent_workspace_binding_id = "binding-123"
+        _, _, llm_generator = self._chat_boundaries(monkeypatch, conversation)
+        snapshot = AgentConfigSnapshot(
+            tenant_id="tenant-123",
+            agent_id="agent-123",
+            version=1,
+            config_snapshot=self._agent_soul(prompt="bound snapshot prompt"),
+            home_snapshot_id=None,
+            summary=None,
+            version_note=None,
+            created_by="account-123",
+        )
+        snapshot.id = "snapshot-123"
+        binding = AgentWorkspaceBinding(
+            tenant_id="tenant-123",
+            app_id="app-123",
+            workspace_id="workspace-123",
+            agent_id="agent-123",
+            base_home_snapshot_id=None,
+            agent_config_version_id=snapshot.id,
+            agent_config_version_kind=AgentConfigVersionKind.SNAPSHOT,
+            backend_binding_ref="backend-binding-123",
+            session_snapshot=None,
+            retired_at=None,
+            pending_form_id=None,
+            pending_tool_call_id=None,
+        )
+        binding.id = conversation.agent_workspace_binding_id
+        _persist(sqlite_session, snapshot, binding)
+        roster_service = MagicMock()
+        roster_service.return_value.get_published_agent_soul_for_app.return_value = self._agent_soul(
+            prompt="current published prompt"
+        )
+        monkeypatch.setattr("services.agent.roster_service.AgentRosterService", roster_service)
+
+        result = MessageService.get_suggested_questions_after_answer(
+            app_model=factory.create_app(mode=AppMode.AGENT),
+            user=factory.create_end_user(),
+            message_id="msg-123",
+            invoke_from=InvokeFrom.SERVICE_API,
+            session=sqlite_session,
+        )
+
+        assert result == ["Q1?"]
+        roster_service.assert_not_called()
+        llm_generator.generate_suggested_questions_after_answer.assert_called_once_with(
+            tenant_id="tenant-123",
+            histories="histories",
+            instruction_prompt="bound snapshot prompt",
+            model_config=None,
+        )
+
+    def test_agent_without_binding_uses_published_soul(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        factory: MessageServiceTestDataFactory,
+        sqlite_session: Session,
+    ) -> None:
+        conversation = factory.create_conversation()
+        conversation.mode = AppMode.AGENT
+        _, _, llm_generator = self._chat_boundaries(monkeypatch, conversation)
+        roster_service = MagicMock()
+        roster_service.return_value.get_published_agent_soul_for_app.return_value = self._agent_soul(
+            prompt="published prompt"
+        )
+        monkeypatch.setattr("services.agent.roster_service.AgentRosterService", roster_service)
+
+        result = MessageService.get_suggested_questions_after_answer(
+            app_model=factory.create_app(mode=AppMode.AGENT),
+            user=factory.create_end_user(),
+            message_id="msg-123",
+            invoke_from=InvokeFrom.SERVICE_API,
+            session=sqlite_session,
+        )
+
+        assert result == ["Q1?"]
+        roster_service.return_value.get_published_agent_soul_for_app.assert_called_once_with(
+            tenant_id="tenant-123",
+            app_id="app-123",
+        )
+        llm_generator.generate_suggested_questions_after_answer.assert_called_once_with(
+            tenant_id="tenant-123",
+            histories="histories",
+            instruction_prompt="published prompt",
+            model_config=None,
+        )
+
+    def test_historical_agent_without_soul_uses_current_app_model_config(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        factory: MessageServiceTestDataFactory,
+        sqlite_session: Session,
+    ) -> None:
+        conversation = factory.create_conversation()
+        conversation.mode = AppMode.AGENT
+        _, _, llm_generator = self._chat_boundaries(monkeypatch, conversation)
+        app_model_config = AppModelConfig(
+            app_id="app-123",
+            suggested_questions_after_answer=json.dumps({"enabled": True, "prompt": "legacy prompt"}),
+        )
+        app_model_config.id = "config-123"
+        _persist(sqlite_session, app_model_config)
+        app = factory.create_app(mode=AppMode.AGENT)
+        app.app_model_config_id = app_model_config.id
+        roster_service = MagicMock()
+        roster_service.return_value.get_published_agent_soul_for_app.return_value = None
+        monkeypatch.setattr("services.agent.roster_service.AgentRosterService", roster_service)
+
+        result = MessageService.get_suggested_questions_after_answer(
+            app_model=app,
+            user=factory.create_end_user(),
+            message_id="msg-123",
+            invoke_from=InvokeFrom.SERVICE_API,
+            session=sqlite_session,
+        )
+
+        assert result == ["Q1?"]
+        llm_generator.generate_suggested_questions_after_answer.assert_called_once_with(
+            tenant_id="tenant-123",
+            histories="histories",
+            instruction_prompt="legacy prompt",
+            model_config=None,
+        )
+
+    def test_agent_disabled_raises_disabled_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        factory: MessageServiceTestDataFactory,
+        sqlite_session: Session,
+    ) -> None:
+        conversation = factory.create_conversation()
+        conversation.mode = AppMode.AGENT
+        self._chat_boundaries(monkeypatch, conversation)
+        roster_service = MagicMock()
+        roster_service.return_value.get_published_agent_soul_for_app.return_value = self._agent_soul(enabled=False)
+        monkeypatch.setattr("services.agent.roster_service.AgentRosterService", roster_service)
+
+        with pytest.raises(SuggestedQuestionsAfterAnswerDisabledError):
+            MessageService.get_suggested_questions_after_answer(
+                app_model=factory.create_app(mode=AppMode.AGENT),
+                user=factory.create_end_user(),
+                message_id="msg-123",
+                invoke_from=InvokeFrom.SERVICE_API,
+                session=sqlite_session,
+            )
 
     @pytest.mark.parametrize(
         ("config", "expected_prompt", "expected_model"),


### PR DESCRIPTION
Fixes #39681.

## Summary

- add an Agent-specific suggested-question config path instead of reading the debug Conversation's intentionally-null `app_model_config_id`
- resolve Build and Preview requests from the exact `AgentDebugConversation` draft
- resolve published conversations from their bound Agent snapshot, preserving historical behavior after republishing
- fall back to the current published Soul and then legacy AppModelConfig for historical Agent Apps
- project Soul and legacy app features through the same merge used by Agent runtime

## Root cause

Agent debug Conversations intentionally persist `app_model_config_id = NULL` because their model and feature configuration comes from the Agent Soul. `MessageService.get_suggested_questions_after_answer()` only special-cased Chatflow and sent new Agent Apps through the legacy AppModelConfig lookup. The null lookup raised `ValueError("did not find app model config")`, which the console controller converted to HTTP 500.

## Verification

- 183 related unit/controller/integration tests passed
- Ruff, Import Linter, Pyrefly, and no-new-getattr guard passed
- dev Build chat: suggested-questions endpoint returned 200
- dev Preview chat: endpoint returned 200 and rendered three follow-up questions
- published Service API: enabled snapshot returned three questions
- after publishing a disabled snapshot, the old message remained 200 through its bound snapshot while a new message returned the expected 400 `Suggested Questions Is Disabled.`
- temporary dev App, API token, and active Agent resources were removed after verification

From Codex