### PR TITLE
fix: re-index after an embedding model switch runs with the previous model

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -829,15 +829,21 @@ class DatasetService:
         # Reload dataset to get updated values
         session.refresh(dataset)
 
-        # update pipeline knowledge base node data
-        DatasetService._update_pipeline_knowledge_base_node_data(dataset, user.id, session)
-
         # Trigger vector index task if indexing technique changed. The worker
         # re-reads the datasets row in its own session, so publish only after
         # this transaction commits — firing now races the commit and the
         # re-index can run with the previous embedding model (#40961).
+        #
+        # Register BEFORE _update_pipeline_knowledge_base_node_data: for
+        # RAG_PIPELINE datasets that helper commits internally, and the
+        # re-index must dispatch on that commit. once=True keeps the later
+        # outer commit from dispatching twice, and normal datasets still
+        # dispatch on the outer commit as before.
         if action:
             DatasetService._register_index_tasks_after_commit(session, dataset.id, action)
+
+        # update pipeline knowledge base node data
+        DatasetService._update_pipeline_knowledge_base_node_data(dataset, user.id, session)
 
         # Note: summary_index_setting changes do not trigger automatic regeneration of existing summaries.
         # The new setting will only apply to:

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, Literal, TypedDict, cast
 import sqlalchemy as sa
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from redis.exceptions import LockNotOwnedError
-from sqlalchemy import ColumnElement, delete, exists, func, select, update
+from sqlalchemy import ColumnElement, delete, event, exists, func, select, update
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden, NotFound
 
@@ -832,16 +832,12 @@ class DatasetService:
         # update pipeline knowledge base node data
         DatasetService._update_pipeline_knowledge_base_node_data(dataset, user.id, session)
 
-        # Trigger vector index task if indexing technique changed
+        # Trigger vector index task if indexing technique changed. The worker
+        # re-reads the datasets row in its own session, so publish only after
+        # this transaction commits — firing now races the commit and the
+        # re-index can run with the previous embedding model (#40961).
         if action:
-            deal_dataset_vector_index_task.delay(dataset.id, action)
-            # If embedding_model changed, also regenerate summary vectors
-            if action == "update":
-                regenerate_summary_index_task.delay(
-                    dataset.id,
-                    regenerate_reason="embedding_model_changed",
-                    regenerate_vectors_only=True,
-                )
+            DatasetService._register_index_tasks_after_commit(session, dataset.id, action)
 
         # Note: summary_index_setting changes do not trigger automatic regeneration of existing summaries.
         # The new setting will only apply to:
@@ -849,6 +845,30 @@ class DatasetService:
         # 2. Manual summary generation requests
 
         return dataset
+
+    @staticmethod
+    def _register_index_tasks_after_commit(session: Session, dataset_id: str, action: str) -> None:
+        """Publish the re-index tasks once the surrounding transaction commits."""
+        cancelled = False
+
+        def cancel_on_rollback(_session: Session) -> None:
+            nonlocal cancelled
+            cancelled = True
+
+        def dispatch_after_commit(_session: Session) -> None:
+            if cancelled:
+                return
+            deal_dataset_vector_index_task.delay(dataset_id, action)
+            # If embedding_model changed, also regenerate summary vectors
+            if action == "update":
+                regenerate_summary_index_task.delay(
+                    dataset_id,
+                    regenerate_reason="embedding_model_changed",
+                    regenerate_vectors_only=True,
+                )
+
+        event.listen(session, "after_rollback", cancel_on_rollback, once=True)
+        event.listen(session, "after_commit", dispatch_after_commit, once=True)
 
     @staticmethod
     def _update_pipeline_knowledge_base_node_data(dataset: Dataset, updata_user_id: str, session: Session):

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
@@ -372,6 +372,9 @@ class TestDatasetServiceUpdateDataset:
 
         with patch("services.dataset_service.deal_dataset_vector_index_task") as mock_task:
             result = DatasetService.update_dataset(dataset.id, update_data, user, session=db_session_with_containers)
+            # The re-index task is dispatched on after_commit, not inline.
+            mock_task.delay.assert_not_called()
+            db_session_with_containers.commit()
             mock_task.delay.assert_called_once_with(dataset.id, "remove")
 
         db_session_with_containers.refresh(dataset)
@@ -427,6 +430,9 @@ class TestDatasetServiceUpdateDataset:
                 model="text-embedding-ada-002",
             )
             mock_get_binding.assert_called_once_with("openai", "text-embedding-ada-002", db_session_with_containers)
+            # The re-index task is dispatched on after_commit, not inline.
+            mock_task.delay.assert_not_called()
+            db_session_with_containers.commit()
             mock_task.delay.assert_called_once_with(dataset.id, "add")
 
         db_session_with_containers.refresh(dataset)
@@ -523,6 +529,10 @@ class TestDatasetServiceUpdateDataset:
                 model="text-embedding-3-small",
             )
             mock_get_binding.assert_called_once_with("openai", "text-embedding-3-small", db_session_with_containers)
+            # The re-index tasks are dispatched on after_commit, not inline.
+            mock_task.delay.assert_not_called()
+            mock_regenerate_task.delay.assert_not_called()
+            db_session_with_containers.commit()
             mock_task.delay.assert_called_once_with(dataset.id, "update")
             mock_regenerate_task.delay.assert_called_once_with(
                 dataset.id,

--- a/api/tests/unit_tests/services/test_dataset_service_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_dataset.py
@@ -643,11 +643,94 @@ class TestDatasetServiceCreationAndUpdate:
                 sqlite_session,
             )
 
-        assert updated.name == "After"
-        assert updated.description == "Changed"
-        assert transaction_events == []
+            assert updated.name == "After"
+            assert updated.description == "Changed"
+            assert transaction_events == []
+            vector_task.assert_not_called()
+            summary_task.assert_not_called()
+
+            sqlite_session.commit()
+
+        assert transaction_events == ["commit"]
         vector_task.assert_called_once_with(dataset.id, "update")
-        summary_task.assert_called_once()
+        summary_task.assert_called_once_with(
+            dataset.id,
+            regenerate_reason="embedding_model_changed",
+            regenerate_vectors_only=True,
+        )
+
+    @pytest.mark.parametrize(
+        ("action", "expect_summary"),
+        [("add", False), ("remove", False), ("update", True)],
+    )
+    def test_update_internal_dataset_dispatches_index_tasks_only_after_commit(
+        self, sqlite_session: Session, action: str, expect_summary: bool
+    ) -> None:
+        dataset = _dataset(name="Before")
+        sqlite_session.add(dataset)
+        sqlite_session.commit()
+
+        with (
+            patch.object(DatasetService, "_handle_indexing_technique_change", return_value=action),
+            patch.object(DatasetService, "_update_pipeline_knowledge_base_node_data"),
+            patch("services.dataset_service.deal_dataset_vector_index_task.delay") as vector_task,
+            patch("services.dataset_service.regenerate_summary_index_task.delay") as summary_task,
+        ):
+            DatasetService._update_internal_dataset(dataset, {"name": "After"}, _account(), sqlite_session)
+
+            vector_task.assert_not_called()
+            summary_task.assert_not_called()
+
+            sqlite_session.commit()
+
+        vector_task.assert_called_once_with(dataset.id, action)
+        if expect_summary:
+            summary_task.assert_called_once_with(
+                dataset.id,
+                regenerate_reason="embedding_model_changed",
+                regenerate_vectors_only=True,
+            )
+        else:
+            summary_task.assert_not_called()
+
+    def test_update_internal_dataset_skips_index_tasks_when_transaction_rolls_back(
+        self, sqlite_session: Session
+    ) -> None:
+        dataset = _dataset(name="Before")
+        sqlite_session.add(dataset)
+        sqlite_session.commit()
+
+        with (
+            patch.object(DatasetService, "_handle_indexing_technique_change", return_value="update"),
+            patch.object(DatasetService, "_update_pipeline_knowledge_base_node_data"),
+            patch("services.dataset_service.deal_dataset_vector_index_task.delay") as vector_task,
+            patch("services.dataset_service.regenerate_summary_index_task.delay") as summary_task,
+        ):
+            DatasetService._update_internal_dataset(dataset, {"name": "After"}, _account(), sqlite_session)
+
+            sqlite_session.rollback()
+            # A later commit on the same session must not fire the stale listener.
+            sqlite_session.commit()
+
+        vector_task.assert_not_called()
+        summary_task.assert_not_called()
+
+    def test_update_internal_dataset_without_action_dispatches_nothing(self, sqlite_session: Session) -> None:
+        dataset = _dataset(name="Before")
+        sqlite_session.add(dataset)
+        sqlite_session.commit()
+
+        with (
+            patch.object(DatasetService, "_handle_indexing_technique_change", return_value=None),
+            patch.object(DatasetService, "_update_pipeline_knowledge_base_node_data"),
+            patch("services.dataset_service.deal_dataset_vector_index_task.delay") as vector_task,
+            patch("services.dataset_service.regenerate_summary_index_task.delay") as summary_task,
+        ):
+            DatasetService._update_internal_dataset(dataset, {"name": "After"}, _account(), sqlite_session)
+            sqlite_session.commit()
+
+        vector_task.assert_not_called()
+        summary_task.assert_not_called()
 
     def test_update_pipeline_node_data_returns_for_non_pipeline_or_missing_pipeline(
         self, sqlite_session: Session

--- a/api/tests/unit_tests/services/test_dataset_service_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_dataset.py
@@ -732,6 +732,42 @@ class TestDatasetServiceCreationAndUpdate:
         vector_task.assert_not_called()
         summary_task.assert_not_called()
 
+    def test_update_internal_dataset_dispatches_on_rag_pipeline_internal_commit(
+        self, sqlite_session: Session
+    ) -> None:
+        """RAG_PIPELINE helpers commit internally; the re-index must dispatch
+        on that commit, and the later outer commit must not dispatch twice."""
+        dataset = _dataset(name="Before")
+        sqlite_session.add(dataset)
+        sqlite_session.commit()
+
+        def commit_inside_helper(_dataset, _user_id, session: Session) -> None:
+            session.commit()
+
+        with (
+            patch.object(DatasetService, "_handle_indexing_technique_change", return_value="update"),
+            patch.object(
+                DatasetService, "_update_pipeline_knowledge_base_node_data", side_effect=commit_inside_helper
+            ),
+            patch("services.dataset_service.deal_dataset_vector_index_task.delay") as vector_task,
+            patch("services.dataset_service.regenerate_summary_index_task.delay") as summary_task,
+        ):
+            DatasetService._update_internal_dataset(dataset, {"name": "After"}, _account(), sqlite_session)
+
+            # Dispatched by the helper's internal commit already.
+            vector_task.assert_called_once_with(dataset.id, "update")
+            summary_task.assert_called_once_with(
+                dataset.id,
+                regenerate_reason="embedding_model_changed",
+                regenerate_vectors_only=True,
+            )
+
+            # The outer commit must not dispatch a second time.
+            sqlite_session.commit()
+
+        vector_task.assert_called_once_with(dataset.id, "update")
+        summary_task.assert_called_once()
+
     def test_update_pipeline_node_data_returns_for_non_pipeline_or_missing_pipeline(
         self, sqlite_session: Session
     ) -> None:

--- a/api/tests/unit_tests/services/test_dataset_service_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_dataset.py
@@ -732,9 +732,7 @@ class TestDatasetServiceCreationAndUpdate:
         vector_task.assert_not_called()
         summary_task.assert_not_called()
 
-    def test_update_internal_dataset_dispatches_on_rag_pipeline_internal_commit(
-        self, sqlite_session: Session
-    ) -> None:
+    def test_update_internal_dataset_dispatches_on_rag_pipeline_internal_commit(self, sqlite_session: Session) -> None:
         """RAG_PIPELINE helpers commit internally; the re-index must dispatch
         on that commit, and the later outer commit must not dispatch twice."""
         dataset = _dataset(name="Before")
@@ -746,9 +744,7 @@ class TestDatasetServiceCreationAndUpdate:
 
         with (
             patch.object(DatasetService, "_handle_indexing_technique_change", return_value="update"),
-            patch.object(
-                DatasetService, "_update_pipeline_knowledge_base_node_data", side_effect=commit_inside_helper
-            ),
+            patch.object(DatasetService, "_update_pipeline_knowledge_base_node_data", side_effect=commit_inside_helper),
             patch("services.dataset_service.deal_dataset_vector_index_task.delay") as vector_task,
             patch("services.dataset_service.regenerate_summary_index_task.delay") as summary_task,
         ):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Switching a knowledge base between two embedding models looks fine in the console, but every chunk ends up re-embedded with the model that was declared *before* the PATCH. The declaration and the stored vectors silently land in different vector spaces, and retrieval quality drops with no error anywhere. Fixes #40961.

The ordering in `_update_internal_dataset` is the problem: it flushes the new `embedding_model` onto the `datasets` row and then calls `deal_dataset_vector_index_task.delay(...)` while the request transaction is still open (the commit only happens later in the `with_session` decorator; the `flush()` in between is deliberate, see #39191). The worker opens its own session, reads the pre-update row, and re-embeds with the old model. The task publish pretty much always wins that race against the request commit.

The issue itself suggests deferring the dispatch until after commit, so that's what I went with, it's also the smaller change. Both celery calls now run inside an `after_commit` hook on the session (same idiom as `register_new_agent_beta_publish_after_commit`), with an `after_rollback` guard so a rolled-back request can't leave a stale listener that fires on some later commit. `regenerate_summary_index_task` is dispatched from the same spot and reads the same row, so it goes through the hook too.

For RAG-pipeline knowledge bases nothing really changes: `_update_pipeline_knowledge_base_node_data` already commits mid-request, which is why they were mostly spared. The hook just fires at the decorator's commit instead.

One thing I didn't do: the issue also floats a way to force a re-index once declaration and vectors have already diverged. There's no dispatch path to reuse for that today, so it felt like a separate feature and I left it out.

Tests: extended the SQLite-backed update tests in `test_dataset_service_dataset.py`. They now assert the tasks are *not* published during `_update_internal_dataset` itself, that they fire on the following `commit()` with the right arguments for `add`/`remove`/`update`, that a rollback suppresses them even if the session commits again later, and that no action means no dispatch. Ran the update tests, ruff, pyrefly and mypy locally.

Not 100% sure the hook belongs as a static method on `DatasetService` vs a small helper in the tasks module, happy to move it if there's a house preference.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A (backend-only change) | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
