### PR TITLE
fix(logstore): normalize workflow datetimes to UTC

### DIFF
--- a/api/extensions/logstore/repositories/logstore_api_workflow_node_execution_repository.py
+++ b/api/extensions/logstore/repositories/logstore_api_workflow_node_execution_repository.py
@@ -8,7 +8,7 @@ WorkflowNodeExecutionModel operations using Aliyun SLS LogStore.
 import logging
 import time
 from collections.abc import Mapping, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, override
 
 from sqlalchemy.orm import sessionmaker
@@ -17,6 +17,7 @@ from extensions.logstore.aliyun_logstore import AliyunLogStore
 from extensions.logstore.repositories import safe_float, safe_int
 from extensions.logstore.sql_escape import escape_identifier, escape_logstore_query_value
 from graphon.enums import WorkflowNodeExecutionStatus
+from libs.datetime_utils import ensure_naive_utc, naive_utc_now
 from models.enums import CreatorUserRole
 from models.workflow import WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom
 from repositories.api_workflow_node_execution_repository import DifyAPIWorkflowNodeExecutionRepository
@@ -90,24 +91,24 @@ def _dict_to_workflow_node_execution_model(data: dict[str, Any]) -> WorkflowNode
     match created_at:
         case None:
             # Provide default created_at if missing
-            model.created_at = datetime.now()
+            model.created_at = naive_utc_now()
         case str():
-            model.created_at = datetime.fromisoformat(created_at)
+            model.created_at = ensure_naive_utc(datetime.fromisoformat(created_at))
         case int() | float():
-            model.created_at = datetime.fromtimestamp(created_at)
+            model.created_at = datetime.fromtimestamp(created_at, tz=UTC).replace(tzinfo=None)
         case _:
-            model.created_at = created_at
+            model.created_at = ensure_naive_utc(created_at)
 
     finished_at = data.get("finished_at")
     match finished_at:
         case None:
             ...
         case str():
-            model.finished_at = datetime.fromisoformat(finished_at)
+            model.finished_at = ensure_naive_utc(datetime.fromisoformat(finished_at))
         case int() | float():
-            model.finished_at = datetime.fromtimestamp(finished_at)
+            model.finished_at = datetime.fromtimestamp(finished_at, tz=UTC).replace(tzinfo=None)
         case _:
-            model.finished_at = finished_at
+            model.finished_at = ensure_naive_utc(finished_at)
 
     return model
 

--- a/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
+++ b/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
@@ -26,8 +26,8 @@ from extensions.logstore.aliyun_logstore import AliyunLogStore
 from extensions.logstore.repositories import safe_float, safe_int
 from extensions.logstore.sql_escape import escape_identifier, escape_logstore_query_value, escape_sql_string
 from graphon.enums import WorkflowExecutionStatus
-from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from libs.datetime_utils import ensure_naive_utc, naive_utc_now
+from libs.infinite_scroll_pagination import InfiniteScrollPagination
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.workflow import WorkflowRun, WorkflowType
 from repositories.api_workflow_run_repository import APIWorkflowRunRepository

--- a/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
+++ b/api/extensions/logstore/repositories/logstore_api_workflow_run_repository.py
@@ -17,7 +17,7 @@ import logging
 import os
 import time
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast, override
 
 from sqlalchemy.orm import sessionmaker
@@ -27,6 +27,7 @@ from extensions.logstore.repositories import safe_float, safe_int
 from extensions.logstore.sql_escape import escape_identifier, escape_logstore_query_value, escape_sql_string
 from graphon.enums import WorkflowExecutionStatus
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
+from libs.datetime_utils import ensure_naive_utc, naive_utc_now
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.workflow import WorkflowRun, WorkflowType
 from repositories.api_workflow_run_repository import APIWorkflowRunRepository
@@ -108,24 +109,24 @@ def _dict_to_workflow_run(data: dict[str, Any]) -> WorkflowRun:
     if started_at:
         match started_at:
             case str():
-                model.created_at = datetime.fromisoformat(started_at)
+                model.created_at = ensure_naive_utc(datetime.fromisoformat(started_at))
             case int() | float():
-                model.created_at = datetime.fromtimestamp(started_at)
+                model.created_at = datetime.fromtimestamp(started_at, tz=UTC).replace(tzinfo=None)
             case _:
-                model.created_at = started_at
+                model.created_at = ensure_naive_utc(started_at)
     else:
         # Provide default created_at if missing
-        model.created_at = datetime.now()
+        model.created_at = naive_utc_now()
 
     finished_at = data.get("finished_at")
     if finished_at:
         match finished_at:
             case str():
-                model.finished_at = datetime.fromisoformat(finished_at)
+                model.finished_at = ensure_naive_utc(datetime.fromisoformat(finished_at))
             case int() | float():
-                model.finished_at = datetime.fromtimestamp(finished_at)
+                model.finished_at = datetime.fromtimestamp(finished_at, tz=UTC).replace(tzinfo=None)
             case _:
-                model.finished_at = finished_at
+                model.finished_at = ensure_naive_utc(finished_at)
 
     # Compute elapsed_time from started_at and finished_at
     # LogStore doesn't store elapsed_time, it's computed in WorkflowExecution domain entity

--- a/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_run_repository.py
+++ b/api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_run_repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from extensions.logstore.repositories.logstore_api_workflow_run_repository import _dict_to_workflow_run
+
+
+def test_dict_to_workflow_run_normalizes_mixed_datetime_inputs_to_naive_utc() -> None:
+    started_at = datetime(2026, 8, 18, 2, 0, 0, tzinfo=UTC)
+    finished_at = started_at + timedelta(seconds=30)
+
+    model = _dict_to_workflow_run(
+        {
+            "id": "run-1",
+            "tenant_id": "tenant-1",
+            "app_id": "app-1",
+            "workflow_id": "workflow-1",
+            "started_at": started_at.isoformat(),
+            "finished_at": finished_at.timestamp(),
+        }
+    )
+
+    assert model.created_at == datetime(2026, 8, 18, 2, 0, 0)
+    assert model.finished_at == datetime(2026, 8, 18, 2, 0, 30)
+    assert model.elapsed_time == 30.0
+
+
+def test_dict_to_workflow_run_uses_naive_utc_now_when_started_at_missing() -> None:
+    finished_at = datetime(2026, 8, 18, 2, 0, 30, tzinfo=UTC)
+
+    model = _dict_to_workflow_run(
+        {
+            "id": "run-1",
+            "tenant_id": "tenant-1",
+            "app_id": "app-1",
+            "workflow_id": "workflow-1",
+            "finished_at": finished_at.timestamp(),
+        }
+    )
+
+    assert model.created_at.tzinfo is None
+    assert model.finished_at == datetime(2026, 8, 18, 2, 0, 30)


### PR DESCRIPTION
Refs #40943

### What
Normalize LogStore workflow timestamps to naive UTC in both workflow run and workflow node execution repositories.

### Why
The current code uses local-time datetime constructors for epoch and missing-value branches, which can shift timestamps by host timezone and produce incorrect or even negative elapsed times.

### How
- Use `naive_utc_now()` for missing timestamps
- Use `ensure_naive_utc(datetime.fromisoformat(...))` for ISO strings
- Use `datetime.fromtimestamp(..., tz=UTC).replace(tzinfo=None)` for epoch values
- Add a regression test for mixed timestamp inputs

### Verification
- `uv run --project api pytest -o addopts='--import-mode=importlib' api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_run_repository.py api/tests/unit_tests/extensions/logstore/repositories/test_logstore_api_workflow_node_execution_repository.py api/tests/unit_tests/extensions/logstore/repositories/test_logstore_workflow_node_execution_repository.py`
