### PR TITLE
fix(ui): stabilize toast stack interactions

### DIFF
--- a/packages/dify-ui/src/toast/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/toast/__tests__/index.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from 'vitest-browser-react'
+import { userEvent } from 'vitest/browser'
 import { createToast, createToastManager, toast, ToastHost } from '../index'
 
 const asHTMLElement = (element: HTMLElement | SVGElement) => element as HTMLElement
@@ -44,6 +45,103 @@ describe('@langgenius/dify-ui/toast', () => {
 
     await expect.element(screen.getByText('Third toast')).toBeInTheDocument()
     expect(document.body.querySelectorAll('[role="dialog"]')).toHaveLength(3)
+  })
+
+  it('should not intercept pointer events below a collapsed top-anchored stack', async () => {
+    const screen = await render(
+      <>
+        <style>{'[role="dialog"] { transition: none !important; }'}</style>
+        <button
+          type="button"
+          style={{
+            position: 'fixed',
+            top: 0,
+            right: 0,
+            width: 400,
+            height: 300,
+          }}
+        >
+          Underlying action
+        </button>
+        <ToastHost timeout={0} />
+      </>,
+    )
+
+    toast('Older notification')
+    toast('Newest notification')
+
+    const newestToast = screen.getByRole('dialog', { name: 'Newest notification' })
+    await expect.element(newestToast).toBeInTheDocument()
+
+    const toastDialogs = Array.from(document.body.querySelectorAll<HTMLElement>('[role="dialog"]'))
+    const newestBounds = newestToast.element().getBoundingClientRect()
+    const stackBottom = Math.max(
+      ...toastDialogs.map((dialog) => dialog.getBoundingClientRect().bottom),
+    )
+    const elementBelowStack = document.elementFromPoint(
+      newestBounds.left + newestBounds.width / 2,
+      stackBottom + 4,
+    )
+
+    expect(elementBelowStack).toBe(
+      screen.getByRole('button', { name: 'Underlying action' }).element(),
+    )
+  })
+
+  it('should dismiss an expanded background toast from its current row when swiped right', async () => {
+    const baseUIAnimationGlobal = globalThis as BaseUIAnimationGlobal
+    const animationState = baseUIAnimationGlobal.BASE_UI_ANIMATIONS_DISABLED
+    baseUIAnimationGlobal.BASE_UI_ANIMATIONS_DISABLED = false
+
+    try {
+      const screen = await render(
+        <>
+          <style>
+            {`
+            [role="dialog"][data-ending-style] {
+              transition: opacity 10000s !important;
+            }
+          `}
+          </style>
+          <button
+            type="button"
+            aria-label="Swipe destination"
+            style={{
+              position: 'fixed',
+              top: 100,
+              right: 0,
+              zIndex: 1000,
+              width: 20,
+              height: 20,
+            }}
+          />
+          <ToastHost timeout={0} />
+        </>,
+      )
+
+      toast('Background notification')
+      toast('Front notification')
+
+      const backgroundToast = screen.getByRole('dialog', { name: 'Background notification' })
+      await expect.element(backgroundToast).toBeInTheDocument()
+      await backgroundToast.hover()
+      await expect.element(backgroundToast).toHaveAttribute('data-expanded')
+
+      const toastElement = backgroundToast.element()
+      const bounds = toastElement.getBoundingClientRect()
+
+      await userEvent.dragAndDrop(toastElement, screen.getByLabelText('Swipe destination'), {
+        steps: 10,
+      })
+
+      await vi.waitFor(() => {
+        expect(toastElement).toHaveAttribute('data-ending-style')
+      })
+      expect(toastElement.getBoundingClientRect().top).toBeCloseTo(bounds.top, 0)
+    } finally {
+      await userEvent.unhover(document.body)
+      baseUIAnimationGlobal.BASE_UI_ANIMATIONS_DISABLED = animationState
+    }
   })
 
   it('should render a neutral toast when called directly', async () => {

--- a/packages/dify-ui/src/toast/index.stories.tsx
+++ b/packages/dify-ui/src/toast/index.stories.tsx
@@ -127,9 +127,9 @@ const StackExamples = () => {
   }
 
   const createVaryingHeightStack = () => {
-    toast.info('Long background toast', {
+    toast.error('Failed to publish the workflow', {
       description:
-        'This longer toast intentionally spans multiple lines so the collapsed stack can be checked against the shorter frontmost toast height without panel overflow.',
+        'The workflow could not be published because several dependent resources are unavailable. Check the model provider credentials, reconnect the knowledge base, and try publishing again after every dependency is ready.',
     })
     toast.success('Short front toast', {
       description: 'Short message.',

--- a/packages/dify-ui/src/toast/index.tsx
+++ b/packages/dify-ui/src/toast/index.tsx
@@ -183,16 +183,16 @@ function ToastCard({ toast: toastItem }: { toast: ToastObject<ToastData> }) {
       toast={toastItem}
       className={cn(
         'pointer-events-auto absolute top-0 right-0 w-full origin-top cursor-default rounded-xl select-none focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden',
-        '[--toast-current-height:var(--toast-frontmost-height,var(--toast-height))] [--toast-gap:8px] [--toast-peek:5px] [--toast-scale:calc(1-(var(--toast-index)*0.0225))] [--toast-shrink:calc(1-var(--toast-scale))]',
+        '[--toast-current-height:var(--toast-frontmost-height,var(--toast-height))] [--toast-expanded-offset-y:calc(var(--toast-offset-y)+var(--toast-swipe-movement-y)+(var(--toast-index)*var(--toast-gap)))] [--toast-gap:8px] [--toast-peek:5px] [--toast-scale:calc(1-(var(--toast-index)*0.0225))] [--toast-shrink:calc(1-var(--toast-scale))]',
         'z-[calc(100-var(--toast-index))] h-(--toast-current-height)',
         '[transition:transform_500ms_cubic-bezier(0.22,1,0.36,1),opacity_500ms,height_150ms] motion-reduce:transition-none',
         'transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)+(var(--toast-index)*var(--toast-peek))+(var(--toast-shrink)*var(--toast-current-height))))_scale(var(--toast-scale))]',
-        'data-expanded:h-(--toast-height) data-expanded:transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-offset-y)+var(--toast-swipe-movement-y)+(var(--toast-index)*8px)))_scale(1)]',
+        'data-expanded:h-(--toast-height) data-expanded:transform-[translateX(var(--toast-swipe-movement-x))_translateY(var(--toast-expanded-offset-y))_scale(1)]',
         'data-ending-style:pointer-events-none data-ending-style:transform-[translateY(-150%)] data-ending-style:opacity-0 data-ending-style:after:pointer-events-none',
         'data-ending-style:data-[swipe-direction=down]:transform-[translateY(calc(var(--toast-swipe-movement-y)+150%))]',
-        'data-ending-style:data-[swipe-direction=right]:transform-[translateX(calc(var(--toast-swipe-movement-x)+150%))]',
+        'data-ending-style:data-[swipe-direction=right]:transform-[translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--toast-expanded-offset-y))]',
         'data-limited:pointer-events-none data-limited:opacity-0 data-starting-style:transform-[translateY(-150%)] data-starting-style:opacity-0',
-        "after:pointer-events-auto after:absolute after:top-full after:left-0 after:h-[calc(var(--toast-gap)+1px)] after:w-full after:content-['']",
+        "after:pointer-events-auto after:absolute after:bottom-full after:left-0 after:h-[calc(var(--toast-gap)+1px)] after:w-full after:content-['']",
       )}
     >
       <div className="relative h-full overflow-hidden rounded-xl border border-components-panel-border bg-components-panel-bg-blur shadow-lg shadow-shadow-shadow-5 backdrop-blur-[5px]">
@@ -203,7 +203,7 @@ function ToastCard({ toast: toastItem }: { toast: ToastObject<ToastData> }) {
             getToneGradientClasses(toastType),
           )}
         />
-        <BaseToast.Content className="relative flex h-full items-start gap-1 overflow-hidden p-3 transition-opacity duration-200 data-behind:opacity-0 data-expanded:opacity-100 motion-reduce:transition-none">
+        <BaseToast.Content className="relative flex items-start gap-1 overflow-hidden p-3 transition-opacity duration-200 data-behind:opacity-0 data-expanded:opacity-100 motion-reduce:transition-none">
           <div className="flex shrink-0 items-center justify-center p-0.5">
             <ToastIcon type={toastType} />
           </div>


### PR DESCRIPTION
## Summary

- align the hover bridge direction with the top-anchored toast stack
- keep toast content at its natural height while the visual wrapper owns clipping
- preserve each expanded toast's vertical stack offset during right-swipe dismissal
- make the varying-height Storybook example include a substantially taller error toast

## Root cause

The hover bridge was copied from a bottom-anchored Base UI recipe even though Dify renders the viewport from the top. In addition, sizing `Toast.Content` to the animated root coupled Base UI's content measurement to the root height transition. Right-swipe ending styles also replaced the complete transform with an X-only transform, which reset background toasts to `translateY(0)` during dismissal.

## Impact

Collapsed stacks no longer expose an invisible hover area below the last card, expanded gaps remain hoverable, varying-height content keeps a stable measurement source, and background toasts exit horizontally from their current row instead of briefly flying toward the top-right corner.

## Validation

- `pnpm --filter @langgenius/dify-ui test --run src/toast/__tests__/index.spec.tsx` (15 tests)
- `pnpm --filter @langgenius/dify-ui test:storybook -- src/toast/index.stories.tsx` (211 tests)
- `vp check packages/dify-ui`
- manual browser verification in Storybook with three varying-height toasts