### PR TITLE
fix(web): prevent workflow requests after app deletion

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3301,11 +3301,6 @@
       "count": 1
     }
   },
-  "web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow-app/hooks/use-workflow-run-callbacks.ts": {
     "no-restricted-imports": {
       "count": 2
@@ -5568,7 +5563,7 @@
   },
   "web/types/workflow.ts": {
     "typescript/no-explicit-any": {
-      "count": 17
+      "count": 16
     }
   },
   "web/utils/completion-params.spec.ts": {

--- a/web/app/components/app-sidebar/app-info/__tests__/app-info-modals.spec.tsx
+++ b/web/app/components/app-sidebar/app-info/__tests__/app-info-modals.spec.tsx
@@ -133,7 +133,8 @@ const defaultProps = {
   isExporting: false,
   exportCheck: vi.fn(),
   handleConfirmExport: vi.fn(async () => {}),
-  onConfirmDelete: vi.fn(),
+  onConfirmDelete: vi.fn(async () => {}),
+  isDeleting: false,
 }
 
 describe('AppInfoModals', () => {
@@ -299,6 +300,19 @@ describe('AppInfoModals', () => {
     await user.click(screen.getByRole('button', { name: 'common.operation.confirm' }))
 
     expect(defaultProps.onConfirmDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('should disable delete controls while the deletion is pending', async () => {
+    await act(async () => {
+      render(<AppInfoModals {...defaultProps} activeModal="delete" isDeleting />)
+    })
+
+    expect(await screen.findByRole('textbox')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'common.operation.cancel' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'common.operation.confirm' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
   })
 
   it('should call handleConfirmExport when confirm on export warning', async () => {

--- a/web/app/components/app-sidebar/app-info/__tests__/use-app-info-actions.spec.ts
+++ b/web/app/components/app-sidebar/app-info/__tests__/use-app-info-actions.spec.ts
@@ -533,6 +533,7 @@ describe('useAppInfoActions', () => {
         type: 'error',
         message: expect.stringContaining('app.appDeleteFailed'),
       })
+      expect(mockOnPlanInfoChanged).not.toHaveBeenCalled()
     })
   })
 

--- a/web/app/components/app-sidebar/app-info/__tests__/use-app-info-actions.spec.ts
+++ b/web/app/components/app-sidebar/app-info/__tests__/use-app-info-actions.spec.ts
@@ -81,6 +81,10 @@ vi.mock('@langgenius/dify-ui/toast', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   queryOptions: <TOptions>(options: TOptions) => options,
+  useMutation: () => ({
+    mutateAsync: (...args: unknown[]) => mockDeleteApp(...args),
+    isPending: false,
+  }),
   useSuspenseQuery: () => ({
     data: { rbac_enabled: true },
   }),
@@ -93,7 +97,6 @@ vi.mock('@tanstack/react-query', () => ({
 vi.mock('@/service/apps', () => ({
   updateAppInfo: (...args: unknown[]) => mockUpdateAppInfo(...args),
   copyApp: (...args: unknown[]) => mockCopyApp(...args),
-  deleteApp: (...args: unknown[]) => mockDeleteApp(...args),
   fetchAppDetail: (...args: unknown[]) => mockFetchAppDetail(...args),
 }))
 
@@ -498,9 +501,9 @@ describe('useAppInfoActions', () => {
         await result.current.onConfirmDelete()
       })
 
-      expect(mockDeleteApp).toHaveBeenCalledWith('app-1')
+      expect(mockDeleteApp).toHaveBeenCalledWith({ params: { app_id: 'app-1' } })
       expect(toastMocks.call).toHaveBeenCalledWith({ type: 'success', message: 'app.appDeleted' })
-      expect(mockInvalidateQueries).toHaveBeenCalledTimes(3)
+      expect(mockOnPlanInfoChanged).not.toHaveBeenCalled()
       expect(mockReplace).toHaveBeenCalledWith('/apps')
       expect(mockSetAppDetail).toHaveBeenCalledWith()
     })

--- a/web/app/components/app-sidebar/app-info/app-info-modals.tsx
+++ b/web/app/components/app-sidebar/app-info/app-info-modals.tsx
@@ -46,7 +46,8 @@ type AppInfoModalsProps = {
   isExporting: boolean
   exportCheck: () => void
   handleConfirmExport: () => Promise<void>
-  onConfirmDelete: () => void
+  onConfirmDelete: () => Promise<void>
+  isDeleting: boolean
 }
 
 const AppInfoModals = ({
@@ -62,6 +63,7 @@ const AppInfoModals = ({
   exportCheck,
   handleConfirmExport,
   onConfirmDelete,
+  isDeleting,
 }: AppInfoModalsProps) => {
   const { t } = useTranslation()
   const [confirmDeleteInput, setConfirmDeleteInput] = useState('')
@@ -130,15 +132,15 @@ const AppInfoModals = ({
       )}
       <AlertDialog
         open={activeModal === 'delete'}
-        onOpenChange={(open) => !open && handleDeleteDialogClose()}
+        onOpenChange={(open) => !open && !isDeleting && handleDeleteDialogClose()}
       >
         <AlertDialogContent>
           <form
             className="flex flex-col"
             onSubmit={(e) => {
               e.preventDefault()
-              if (isDeleteConfirmDisabled) return
-              onConfirmDelete()
+              if (isDeleteConfirmDisabled || isDeleting) return
+              void onConfirmDelete()
             }}
           >
             <div className="flex flex-col gap-2 px-6 pt-6 pb-4">
@@ -169,12 +171,14 @@ const AppInfoModals = ({
                     placeholder={t(($) => $.deleteAppConfirmInputPlaceholder, { ns: 'app' })}
                     value={confirmDeleteInput}
                     onValueChange={setConfirmDeleteInput}
+                    disabled={isDeleting}
                   />
                   <InputGroupAddon align="inline-end" className="min-w-20 justify-end pe-1.75">
                     <Button
                       variant="tertiary"
                       size="small"
                       onClick={() => setConfirmDeleteInput(appDetail.name)}
+                      disabled={isDeleting}
                       className="rounded-full px-2.5"
                     >
                       {t(($) => $['operation.fill'], { ns: 'common' })}
@@ -184,10 +188,14 @@ const AppInfoModals = ({
               </Field>
             </div>
             <AlertDialogActions>
-              <AlertDialogCancelButton type="button">
+              <AlertDialogCancelButton type="button" disabled={isDeleting}>
                 {t(($) => $['operation.cancel'], { ns: 'common' })}
               </AlertDialogCancelButton>
-              <AlertDialogConfirmButton type="submit" disabled={isDeleteConfirmDisabled}>
+              <AlertDialogConfirmButton
+                type="submit"
+                disabled={isDeleteConfirmDisabled || isDeleting}
+                loading={isDeleting}
+              >
                 {t(($) => $['operation.confirm'], { ns: 'common' })}
               </AlertDialogConfirmButton>
             </AlertDialogActions>

--- a/web/app/components/app-sidebar/app-info/index.tsx
+++ b/web/app/components/app-sidebar/app-info/index.tsx
@@ -22,6 +22,7 @@ export const AppInfoView = ({ expand, actions }: AppInfoViewProps) => {
     exportCheck,
     handleConfirmExport,
     onConfirmDelete,
+    isDeleting,
   } = actions
 
   if (!appDetail) return null
@@ -48,6 +49,7 @@ export const AppInfoView = ({ expand, actions }: AppInfoViewProps) => {
         exportCheck={exportCheck}
         handleConfirmExport={handleConfirmExport}
         onConfirmDelete={onConfirmDelete}
+        isDeleting={isDeleting}
       />
     </>
   )

--- a/web/app/components/app-sidebar/app-info/use-app-info-actions.ts
+++ b/web/app/components/app-sidebar/app-info/use-app-info-actions.ts
@@ -7,7 +7,7 @@ import type { DuplicateAppModalProps } from '@/app/components/app/duplicate-moda
 import type { CreateAppModalProps } from '@/app/components/explore/create-app-modal'
 import type { App } from '@/types/app'
 import { toast } from '@langgenius/dify-ui/toast'
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore as useAppStore } from '@/app/components/app/store'
@@ -15,7 +15,7 @@ import { useExportAppDsl, useExportWorkflowAppDsl } from '@/app/components/app/u
 import { useProviderContext } from '@/context/provider-context'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useRouter } from '@/next/navigation'
-import { copyApp, deleteApp, fetchAppDetail, updateAppInfo } from '@/service/apps'
+import { copyApp, fetchAppDetail, updateAppInfo } from '@/service/apps'
 import { consoleQuery } from '@/service/client'
 import { AppModeEnum } from '@/types/app'
 import { getRedirection } from '@/utils/app-redirection'
@@ -95,6 +95,11 @@ export function useAppInfoActions({ resetKey }: UseAppInfoActionsParams) {
   const { exportAppDsl, isExporting: isAppDslExporting } = useExportAppDsl()
   const { exportWorkflowAppDsl, isExporting: isWorkflowAppDslExporting } = useExportWorkflowAppDsl()
   const isExporting = isAppDslExporting || isWorkflowAppDslExporting
+  const { mutateAsync: deleteCurrentApp, isPending: isDeleting } = useMutation(
+    consoleQuery.apps.byAppId.delete.mutationOptions({
+      context: { silent: true },
+    }),
+  )
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const isRbacEnabled = systemFeatures.rbac_enabled
 
@@ -307,15 +312,11 @@ export function useAppInfoActions({ resetKey }: UseAppInfoActionsParams) {
   const onConfirmDelete = useCallback(async () => {
     if (!appDetail) return
     try {
-      await deleteApp(appDetail.id)
+      await deleteCurrentApp({ params: { app_id: appDetail.id } })
       toast(
         t(($) => $.appDeleted, { ns: 'app' }),
         { type: 'success' },
       )
-      void queryClient.invalidateQueries({ queryKey: consoleQuery.apps.get.key() })
-      void queryClient.invalidateQueries({ queryKey: consoleQuery.apps.starred.get.key() })
-      void queryClient.invalidateQueries({ queryKey: consoleQuery.apps.recent.get.key() })
-      onPlanInfoChanged()
       setAppDetail()
       replace('/apps')
     } catch (e: unknown) {
@@ -325,7 +326,7 @@ export function useAppInfoActions({ resetKey }: UseAppInfoActionsParams) {
       )
     }
     closeModal()
-  }, [appDetail, closeModal, onPlanInfoChanged, queryClient, replace, setAppDetail, t])
+  }, [appDetail, closeModal, deleteCurrentApp, replace, setAppDetail, t])
 
   return {
     appDetail,
@@ -341,6 +342,7 @@ export function useAppInfoActions({ resetKey }: UseAppInfoActionsParams) {
     exportCheck,
     handleConfirmExport,
     onConfirmDelete,
+    isDeleting,
   }
 }
 

--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -1019,6 +1019,7 @@ describe('AppCard', () => {
       await waitFor(() => {
         expect(mockDeleteAppMutation).toHaveBeenCalled()
       })
+      expect(mockOnPlanInfoChanged).not.toHaveBeenCalled()
     })
 
     it('should handle delete failure', async () => {

--- a/web/app/components/apps/app-card/action-bar/index.tsx
+++ b/web/app/components/apps/app-card/action-bar/index.tsx
@@ -150,7 +150,6 @@ export const AppCardActionBar = memo(
           {
             onSuccess: () => {
               toast.success(t(($) => $.appDeleted, { ns: 'app' }))
-              onPlanInfoChanged()
               setShowConfirmDelete(false)
               setConfirmDeleteInput('')
             },
@@ -166,7 +165,7 @@ export const AppCardActionBar = memo(
         const message = error instanceof Error ? error.message : ''
         toast.error(`${t(($) => $.appDeleteFailed, { ns: 'app' })}${message ? `: ${message}` : ''}`)
       }
-    }, [app.id, deleteApp, onPlanInfoChanged, t])
+    }, [app.id, deleteApp, t])
 
     const onDeleteDialogOpenChange = useCallback(
       (open: boolean) => {

--- a/web/app/components/workflow-app/hooks/__tests__/use-nodes-sync-draft.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-nodes-sync-draft.spec.ts
@@ -2,11 +2,12 @@ import type { EnvironmentVariablePatch } from '@/service/workflow'
 import { act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { BlockEnum } from '@/app/components/workflow/types'
+import { consoleQuery } from '@/service/client'
 import { renderHookWithConsoleQuery } from '@/test/console/query-data'
 import { useNodesSyncDraft } from '../use-nodes-sync-draft'
 
 const mockGetNodes = vi.fn()
-const mockPostWithKeepalive = vi.fn()
+const mockPostWorkflowDraft = vi.fn().mockResolvedValue(undefined)
 const mockSetSyncWorkflowDraftHash = vi.fn()
 const mockSetDraftUpdatedAt = vi.fn()
 const mockGetNodesReadOnly = vi.fn()
@@ -83,16 +84,22 @@ vi.mock('@/service/workflow', () => ({
   syncWorkflowDraft: (p: unknown) => mockSyncWorkflowDraft(p),
 }))
 
-vi.mock('@/service/fetch', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/service/fetch')>()
+vi.mock('@/service/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/service/client')>()
   return {
     ...actual,
-    postWithKeepalive: (...args: unknown[]) => mockPostWithKeepalive(...args),
+    consoleClient: {
+      apps: {
+        byAppId: {
+          workflows: {
+            draft: {
+              post: (...args: unknown[]) => mockPostWorkflowDraft(...args),
+            },
+          },
+        },
+      },
+    },
   }
-})
-vi.mock('@/config', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/config')>()
-  return { ...actual, API_PREFIX: '/api' }
 })
 
 const mockHandleRefreshWorkflowDraft = vi.fn()
@@ -533,15 +540,72 @@ describe('useNodesSyncDraft — handleRefreshWorkflowDraft(true) on 409', () => 
       result.current.syncWorkflowDraftWhenPageClose()
     })
 
-    expect(mockPostWithKeepalive).toHaveBeenCalledWith(
-      '/api/apps/app-1/workflows/draft',
-      expect.objectContaining({
-        graph: expect.objectContaining({
-          viewport: { x: 1, y: 2, zoom: 3 },
+    expect(mockPostWorkflowDraft).toHaveBeenCalledWith(
+      {
+        params: { app_id: 'app-1' },
+        body: expect.objectContaining({
+          graph: expect.objectContaining({
+            viewport: { x: 1, y: 2, zoom: 3 },
+          }),
+          hash: 'hash-123',
         }),
-        hash: 'hash-123',
-      }),
+      },
+      {
+        context: {
+          keepalive: true,
+          silent: true,
+        },
+      },
     )
+  })
+
+  it('should stop draft persistence as soon as deleting the current app starts', async () => {
+    let resolveDelete: (() => void) | undefined
+    const callbacks = {
+      onError: vi.fn(),
+      onSettled: vi.fn(),
+    }
+    const { result, queryClient } = renderUseNodesSyncDraft()
+    const deleteMutation = queryClient.getMutationCache().build(queryClient, {
+      mutationKey: consoleQuery.apps.byAppId.delete.mutationKey(),
+      mutationFn: () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve
+        }),
+    })
+
+    let deletePromise: Promise<void> | undefined
+    await act(async () => {
+      deletePromise = deleteMutation.execute({ params: { app_id: 'app-1' } })
+      await Promise.resolve()
+    })
+
+    expect(deleteMutation.state.status).toBe('pending')
+
+    await act(async () => {
+      await result.current.doSyncWorkflowDraft(false, callbacks)
+      result.current.syncWorkflowDraftWhenPageClose()
+    })
+
+    expect(mockSyncWorkflowDraft).not.toHaveBeenCalled()
+    expect(mockPostWorkflowDraft).not.toHaveBeenCalled()
+    expect(callbacks.onError).not.toHaveBeenCalled()
+    expect(callbacks.onSettled).toHaveBeenCalledOnce()
+
+    resolveDelete?.()
+    await act(async () => {
+      await deletePromise
+    })
+
+    await act(async () => {
+      await result.current.doSyncWorkflowDraft(false, callbacks)
+      result.current.syncWorkflowDraftWhenPageClose()
+    })
+
+    expect(mockSyncWorkflowDraft).not.toHaveBeenCalled()
+    expect(mockPostWorkflowDraft).not.toHaveBeenCalled()
+    expect(callbacks.onError).not.toHaveBeenCalled()
+    expect(callbacks.onSettled).toHaveBeenCalledTimes(2)
   })
 
   it('should not post the local start placeholder when the page closes', () => {
@@ -564,14 +628,17 @@ describe('useNodesSyncDraft — handleRefreshWorkflowDraft(true) on 409', () => 
       result.current.syncWorkflowDraftWhenPageClose()
     })
 
-    expect(mockPostWithKeepalive).toHaveBeenCalledWith(
-      '/api/apps/app-1/workflows/draft',
+    expect(mockPostWorkflowDraft).toHaveBeenCalledWith(
       expect.objectContaining({
-        graph: expect.objectContaining({
-          nodes: [{ id: 'n1', position: { x: 1, y: 1 }, data: { type: BlockEnum.Start } }],
-          edges: [],
+        params: { app_id: 'app-1' },
+        body: expect.objectContaining({
+          graph: expect.objectContaining({
+            nodes: [{ id: 'n1', position: { x: 1, y: 1 }, data: { type: BlockEnum.Start } }],
+            edges: [],
+          }),
         }),
       }),
+      expect.anything(),
     )
   })
 
@@ -705,7 +772,7 @@ describe('useNodesSyncDraft — handleRefreshWorkflowDraft(true) on 409', () => 
       result.current.syncWorkflowDraftWhenPageClose()
     })
 
-    expect(mockPostWithKeepalive).not.toHaveBeenCalled()
+    expect(mockPostWorkflowDraft).not.toHaveBeenCalled()
   })
 
   it('should allow the trusted sole leader to flush with keepalive while hidden', () => {
@@ -720,7 +787,7 @@ describe('useNodesSyncDraft — handleRefreshWorkflowDraft(true) on 409', () => 
       result.current.syncWorkflowDraftWhenPageClose()
     })
 
-    expect(mockPostWithKeepalive).toHaveBeenCalledTimes(1)
+    expect(mockPostWorkflowDraft).toHaveBeenCalledTimes(1)
   })
 
   it('should still flush with keepalive on page close when collaboration is enabled but never connected', () => {
@@ -738,7 +805,7 @@ describe('useNodesSyncDraft — handleRefreshWorkflowDraft(true) on 409', () => 
       result.current.syncWorkflowDraftWhenPageClose()
     })
 
-    expect(mockPostWithKeepalive).toHaveBeenCalledTimes(1)
+    expect(mockPostWorkflowDraft).toHaveBeenCalledTimes(1)
   })
 
   it('should not flush an untrusted graph after an established collaboration disconnects', () => {
@@ -753,6 +820,6 @@ describe('useNodesSyncDraft — handleRefreshWorkflowDraft(true) on 409', () => 
       result.current.syncWorkflowDraftWhenPageClose()
     })
 
-    expect(mockPostWithKeepalive).not.toHaveBeenCalled()
+    expect(mockPostWorkflowDraft).not.toHaveBeenCalled()
   })
 })

--- a/web/app/components/workflow-app/hooks/__tests__/use-workflow-init.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-workflow-init.spec.ts
@@ -1,3 +1,4 @@
+import { CancelledError } from '@tanstack/react-query'
 import { waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { BlockEnum } from '@/app/components/workflow/types'
@@ -87,10 +88,13 @@ vi.mock('@/service/workflow-queries', () => ({
     queryKey: ['workflow', 'publish', appId],
     queryFn: () => mockFetchPublishedWorkflow(`/apps/${appId}/workflows/publish`),
   }),
+  appWorkflowDraftQueryOptions: (appId: string) => ({
+    queryKey: ['workflow', 'draft', appId],
+    queryFn: () => mockFetchWorkflowDraft(`/apps/${appId}/workflows/draft`),
+  }),
 }))
 
 vi.mock('@/service/workflow', () => ({
-  fetchWorkflowDraft: (...args: unknown[]) => mockFetchWorkflowDraft(...args),
   syncWorkflowDraft: (...args: unknown[]) => mockSyncWorkflowDraft(...args),
 }))
 
@@ -379,6 +383,29 @@ describe('useWorkflowInit', () => {
     })
 
     expect(consoleErrorSpy).toHaveBeenCalled()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should keep fulfilled preload data and ignore a sibling cancellation', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockFetchWorkflowDraft.mockReset().mockResolvedValue(draftResponse)
+    mockFetchDefaultBlockConfigs.mockRejectedValue(new CancelledError())
+    mockFetchPublishedWorkflow.mockResolvedValue({
+      created_at: 99,
+      graph: {
+        nodes: [{ id: 'start', data: { type: BlockEnum.Start } }],
+        edges: [{ source: 'start', target: 'end' }],
+      },
+    })
+
+    renderHook(() => useWorkflowInit())
+
+    await waitFor(() => {
+      expect(mockSetPublishedAt).toHaveBeenCalledWith(99)
+      expect(mockSetLastPublishedHasUserInput).toHaveBeenCalledWith(true)
+    })
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
     consoleErrorSpy.mockRestore()
   })
 

--- a/web/app/components/workflow-app/hooks/__tests__/use-workflow-init.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-workflow-init.spec.ts
@@ -14,8 +14,9 @@ const mockSetLastPublishedHasUserInput = vi.fn()
 const mockSetFileUploadConfig = vi.fn()
 const mockWorkflowStoreSetState = vi.fn()
 const mockWorkflowStoreGetState = vi.fn()
-const mockFetchNodesDefaultConfigs = vi.fn()
+const mockFetchDefaultBlockConfigs = vi.fn()
 const mockFetchPublishedWorkflow = vi.fn()
+const mockFetchWorkflowDraft = vi.fn()
 const mockSyncWorkflowDraft = vi.fn()
 
 const renderHook = <Result>(callback: () => Result) =>
@@ -78,18 +79,19 @@ vi.mock('@/service/use-workflow', () => ({
 }))
 
 vi.mock('@/service/workflow-queries', () => ({
+  appWorkflowDefaultBlockConfigsQueryOptions: (appId: string) => ({
+    queryKey: ['workflow', 'default-block-configs', appId],
+    queryFn: () => mockFetchDefaultBlockConfigs(appId),
+  }),
   appWorkflowQueryOptions: (appId: string) => ({
     queryKey: ['workflow', 'publish', appId],
     queryFn: () => mockFetchPublishedWorkflow(`/apps/${appId}/workflows/publish`),
   }),
 }))
 
-const mockFetchWorkflowDraft = vi.fn()
-
 vi.mock('@/service/workflow', () => ({
   fetchWorkflowDraft: (...args: unknown[]) => mockFetchWorkflowDraft(...args),
   syncWorkflowDraft: (...args: unknown[]) => mockSyncWorkflowDraft(...args),
-  fetchNodesDefaultConfigs: (...args: unknown[]) => mockFetchNodesDefaultConfigs(...args),
 }))
 
 const notExistError = () => ({
@@ -136,7 +138,7 @@ describe('useWorkflowInit', () => {
       setLastPublishedHasUserInput: mockSetLastPublishedHasUserInput,
       setFileUploadConfig: mockSetFileUploadConfig,
     })
-    mockFetchNodesDefaultConfigs.mockResolvedValue([])
+    mockFetchDefaultBlockConfigs.mockResolvedValue([])
     mockFetchPublishedWorkflow.mockResolvedValue({ created_at: 0, graph: { nodes: [], edges: [] } })
     mockFetchWorkflowDraft.mockRejectedValueOnce(notExistError())
     mockSyncWorkflowDraft.mockReset()
@@ -312,7 +314,7 @@ describe('useWorkflowInit', () => {
       ],
       conversation_variables: [{ id: 'conversation-1' }],
     })
-    mockFetchNodesDefaultConfigs.mockResolvedValue([
+    mockFetchDefaultBlockConfigs.mockResolvedValue([
       { type: 'start', config: { title: 'Start Config' } },
       { type: 'start', config: { title: 'Ignored Duplicate' } },
     ])
@@ -360,7 +362,7 @@ describe('useWorkflowInit', () => {
   it('should keep published metadata when loading node defaults fails', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     mockFetchWorkflowDraft.mockReset().mockResolvedValue(draftResponse)
-    mockFetchNodesDefaultConfigs.mockRejectedValue(new Error('preload failed'))
+    mockFetchDefaultBlockConfigs.mockRejectedValue(new Error('preload failed'))
     mockFetchPublishedWorkflow.mockResolvedValue({
       created_at: 99,
       graph: {
@@ -383,7 +385,7 @@ describe('useWorkflowInit', () => {
   it('should keep node defaults when loading published metadata fails', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     mockFetchWorkflowDraft.mockReset().mockResolvedValue(draftResponse)
-    mockFetchNodesDefaultConfigs.mockResolvedValue([
+    mockFetchDefaultBlockConfigs.mockResolvedValue([
       { type: 'start', config: { title: 'Start Config' } },
     ])
     mockFetchPublishedWorkflow.mockRejectedValue(new Error('published workflow failed'))

--- a/web/app/components/workflow-app/hooks/__tests__/use-workflow-init.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-workflow-init.spec.ts
@@ -1,8 +1,9 @@
-import { CancelledError } from '@tanstack/react-query'
-import { waitFor } from '@testing-library/react'
+import type { QueryClient } from '@tanstack/react-query'
+import { act, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { BlockEnum } from '@/app/components/workflow/types'
-import { createAccountProfileQueryWrapper } from '@/test/console/account-profile'
+import { createAccountProfileQueryClient } from '@/test/console/account-profile'
+import { createQueryClientWrapper } from '@/test/console/query-client'
 import { renderHook as renderHookWithConsoleState } from '@/test/console/render'
 import { AppACLPermission } from '@/utils/permission'
 import { useWorkflowInit } from '../use-workflow-init'
@@ -20,9 +21,12 @@ const mockFetchPublishedWorkflow = vi.fn()
 const mockFetchWorkflowDraft = vi.fn()
 const mockSyncWorkflowDraft = vi.fn()
 
-const renderHook = <Result>(callback: () => Result) =>
+const renderHook = <Result>(
+  callback: () => Result,
+  queryClient: QueryClient = createAccountProfileQueryClient({ id: 'user-1' }),
+) =>
   renderHookWithConsoleState(callback, {
-    wrapper: createAccountProfileQueryWrapper({ id: 'user-1' }),
+    wrapper: createQueryClientWrapper(queryClient),
   })
 
 let appStoreState: {
@@ -90,7 +94,8 @@ vi.mock('@/service/workflow-queries', () => ({
   }),
   appWorkflowDraftQueryOptions: (appId: string) => ({
     queryKey: ['workflow', 'draft', appId],
-    queryFn: () => mockFetchWorkflowDraft(`/apps/${appId}/workflows/draft`),
+    queryFn: ({ signal }: { signal: AbortSignal }) =>
+      mockFetchWorkflowDraft(`/apps/${appId}/workflows/draft`, signal),
   }),
 }))
 
@@ -303,6 +308,43 @@ describe('useWorkflowInit', () => {
     expect(mockSyncWorkflowDraft).not.toHaveBeenCalled()
   })
 
+  it('should resume draft initialization after a canceled query is invalidated', async () => {
+    const queryClient = createAccountProfileQueryClient({ id: 'user-1' })
+    mockFetchWorkflowDraft
+      .mockReset()
+      .mockImplementationOnce(
+        (_url: string, signal: AbortSignal) =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => reject(new DOMException('The operation was aborted', 'AbortError')),
+              { once: true },
+            )
+          }),
+      )
+      .mockResolvedValueOnce(draftResponse)
+
+    const { result } = renderHook(() => useWorkflowInit(), queryClient)
+
+    await waitFor(() => expect(mockFetchWorkflowDraft).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      await queryClient.cancelQueries({ queryKey: ['workflow'] })
+    })
+
+    expect(result.current.isLoading).toBe(true)
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ['workflow'] })
+    })
+
+    await waitFor(() => {
+      expect(result.current.data?.hash).toBe('server-hash')
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(mockFetchWorkflowDraft).toHaveBeenCalledTimes(2)
+  })
+
   it('should hydrate draft state, preload defaults, and derive published workflow metadata on success', async () => {
     workflowConfigState = {
       data: { enabled: true, sizeLimit: 20 },
@@ -383,29 +425,6 @@ describe('useWorkflowInit', () => {
     })
 
     expect(consoleErrorSpy).toHaveBeenCalled()
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('should keep fulfilled preload data and ignore a sibling cancellation', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    mockFetchWorkflowDraft.mockReset().mockResolvedValue(draftResponse)
-    mockFetchDefaultBlockConfigs.mockRejectedValue(new CancelledError())
-    mockFetchPublishedWorkflow.mockResolvedValue({
-      created_at: 99,
-      graph: {
-        nodes: [{ id: 'start', data: { type: BlockEnum.Start } }],
-        edges: [{ source: 'start', target: 'end' }],
-      },
-    })
-
-    renderHook(() => useWorkflowInit())
-
-    await waitFor(() => {
-      expect(mockSetPublishedAt).toHaveBeenCalledWith(99)
-      expect(mockSetLastPublishedHasUserInput).toHaveBeenCalledWith(true)
-    })
-
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
     consoleErrorSpy.mockRestore()
   })
 

--- a/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
@@ -1,10 +1,11 @@
+import type { QueryClient } from '@tanstack/react-query'
 import type {
   SyncDraftCallback,
   SyncDraftOptions,
   SyncDraftResult,
 } from '@/app/components/workflow/hooks-store'
 import type { WorkflowDraftFeaturesPayload } from '@/service/workflow'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { produce } from 'immer'
 import { useCallback } from 'react'
 import { useStoreApi } from 'reactflow'
@@ -21,13 +22,36 @@ import {
 } from '@/app/components/workflow/nodes/agent-v2/types'
 import { useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
-import { API_PREFIX } from '@/config'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
-import { postWithKeepalive } from '@/service/fetch'
+import { consoleClient, consoleQuery } from '@/service/client'
 import { syncWorkflowDraft } from '@/service/workflow'
 import { useWorkflowRefreshDraft } from './use-workflow-refresh-draft'
 
+const isAppDeletingOrDeleted = (queryClient: QueryClient, appId: string) => {
+  return Boolean(
+    queryClient.getMutationCache().find({
+      mutationKey: consoleQuery.apps.byAppId.delete.mutationKey(),
+      exact: true,
+      predicate: (mutation) => {
+        if (mutation.state.status !== 'pending' && mutation.state.status !== 'success') return false
+
+        const variables = mutation.state.variables
+        if (!variables || typeof variables !== 'object' || !('params' in variables)) return false
+
+        const { params } = variables
+        return (
+          typeof params === 'object' &&
+          params !== null &&
+          'app_id' in params &&
+          params.app_id === appId
+        )
+      },
+    }),
+  )
+}
+
 const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
+  const queryClient = useQueryClient()
   const store = useStoreApi()
   const workflowStore = useWorkflowStore()
   const featuresStore = useFeaturesStore()
@@ -36,6 +60,11 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
     ...systemFeaturesQueryOptions(),
     select: (s) => s.enable_collaboration_mode,
   })
+
+  const shouldSkipDraftSync = useCallback(() => {
+    const { appId, isWorkflowDataLoaded } = workflowStore.getState()
+    return !appId || !isWorkflowDataLoaded || isAppDeletingOrDeleted(queryClient, appId)
+  }, [queryClient, workflowStore])
 
   const getPostParams = useCallback(() => {
     const { getNodes, edges, transform } = store.getState()
@@ -122,6 +151,7 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
 
   const syncWorkflowDraftWhenPageClose = useCallback(() => {
     if (getNodesReadOnly()) return
+    if (shouldSkipDraftSync()) return
 
     const canPersistOnPageClose =
       !isCollaborationEnabled ||
@@ -129,10 +159,25 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
       collaborationManager.canUseLocalDraftFallback()
     if (!canPersistOnPageClose) return
 
+    const { appId } = workflowStore.getState()
     const postParams = getPostParams()
+    if (!appId || !postParams) return
 
-    if (postParams) postWithKeepalive(`${API_PREFIX}${postParams.url}`, postParams.params)
-  }, [getPostParams, getNodesReadOnly, isCollaborationEnabled])
+    void consoleClient.apps.byAppId.workflows.draft
+      .post(
+        {
+          params: { app_id: appId },
+          body: postParams.params,
+        },
+        {
+          context: {
+            keepalive: true,
+            silent: true,
+          },
+        },
+      )
+      .catch(() => {})
+  }, [getPostParams, getNodesReadOnly, isCollaborationEnabled, shouldSkipDraftSync, workflowStore])
 
   const performLocalSync = useCallback(
     async (
@@ -142,6 +187,10 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
       options?: SyncDraftOptions,
     ): Promise<SyncDraftResult | null> => {
       if (getNodesReadOnly()) return null
+      if (shouldSkipDraftSync()) {
+        callback?.onSettled?.()
+        return null
+      }
 
       if (isCollaborationEnabled && !collaborationManager.canPersistLocalGraph()) {
         callback?.onSettled?.()
@@ -195,7 +244,13 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
         callback?.onSettled?.()
       }
     },
-    [workflowStore, getNodesReadOnly, handleRefreshWorkflowDraft, isCollaborationEnabled],
+    [
+      workflowStore,
+      getNodesReadOnly,
+      handleRefreshWorkflowDraft,
+      isCollaborationEnabled,
+      shouldSkipDraftSync,
+    ],
   )
 
   const doSyncWorkflowDraftLocally = useSerialAsyncCallback(performLocalSync, getNodesReadOnly)
@@ -206,6 +261,10 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
       options?: SyncDraftOptions,
     ): Promise<SyncDraftResult | null> => {
       if (getNodesReadOnly()) return null
+      if (shouldSkipDraftSync()) {
+        callback?.onSettled?.()
+        return null
+      }
 
       const shouldRequestLeader =
         isCollaborationEnabled &&
@@ -243,6 +302,7 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
       getNodesReadOnly,
       getPostParams,
       isCollaborationEnabled,
+      shouldSkipDraftSync,
       workflowStore,
     ],
   )

--- a/web/app/components/workflow-app/hooks/use-workflow-init.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-init.ts
@@ -1,7 +1,7 @@
 import type { Edge, Node } from '@/app/components/workflow/types'
 import type { FileUploadConfigResponse } from '@/models/common'
 import type { FetchWorkflowDraftResponse } from '@/types/workflow'
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { CancelledError, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useStore as useAppStore } from '@/app/components/app/store'
@@ -10,9 +10,10 @@ import { BlockEnum } from '@/app/components/workflow/types'
 import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { useWorkflowConfig } from '@/service/use-workflow'
-import { fetchWorkflowDraft, syncWorkflowDraft } from '@/service/workflow'
+import { syncWorkflowDraft } from '@/service/workflow'
 import {
   appWorkflowDefaultBlockConfigsQueryOptions,
+  appWorkflowDraftQueryOptions,
   appWorkflowQueryOptions,
 } from '@/service/workflow-queries'
 import { AppModeEnum } from '@/types/app'
@@ -107,7 +108,7 @@ export const useWorkflowInit = () => {
 
   const handleGetInitialWorkflowData = useCallback(async () => {
     try {
-      const res = await fetchWorkflowDraft(`/apps/${appDetail.id}/workflows/draft`)
+      const res = await queryClient.fetchQuery(appWorkflowDraftQueryOptions(appDetail.id))
       const initialData = {
         ...res,
         graph: getWorkflowDraftGraphForCanvas(res.graph, {
@@ -198,6 +199,7 @@ export const useWorkflowInit = () => {
     getWorkflowDraftGraphForCanvas,
     nodesTemplate,
     edgesTemplate,
+    queryClient,
     workflowStore,
     setSyncWorkflowDraftHash,
   ])
@@ -223,7 +225,7 @@ export const useWorkflowInit = () => {
           {} as Record<string, unknown>,
         ),
       })
-    } else {
+    } else if (!(nodesDefaultConfigsResult.reason instanceof CancelledError)) {
       console.error(nodesDefaultConfigsResult.reason)
     }
 
@@ -234,7 +236,7 @@ export const useWorkflowInit = () => {
       const nodes = Array.isArray(graph?.nodes) ? (graph.nodes as Node[]) : undefined
       const edges = Array.isArray(graph?.edges) ? (graph.edges as Edge[]) : undefined
       workflowStore.getState().setLastPublishedHasUserInput(hasConnectedUserInput(nodes, edges))
-    } else {
+    } else if (!(publishedWorkflowResult.reason instanceof CancelledError)) {
       console.error(publishedWorkflowResult.reason)
       workflowStore.getState().setLastPublishedHasUserInput(false)
     }

--- a/web/app/components/workflow-app/hooks/use-workflow-init.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-init.ts
@@ -1,9 +1,9 @@
 import type { Edge, Node } from '@/app/components/workflow/types'
 import type { FileUploadConfigResponse } from '@/models/common'
 import type { FetchWorkflowDraftResponse } from '@/types/workflow'
-import { CancelledError, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
 import { BlockEnum } from '@/app/components/workflow/types'
@@ -69,10 +69,24 @@ const isNodeDefaultConfig = (
   )
 }
 
+type LocalWorkflowDraft = {
+  appId: string
+  draft: FetchWorkflowDraftResponse
+}
+
+const getWorkflowDraftErrorCode = async (error: object) => {
+  if (!('json' in error) || typeof error.json !== 'function') return undefined
+  if ('bodyUsed' in error && error.bodyUsed) return undefined
+
+  const body = (await error.json()) as { code?: string }
+  return body.code
+}
+
 export const useWorkflowInit = () => {
-  const queryClient = useQueryClient()
   const workflowStore = useWorkflowStore()
-  const { nodes: nodesTemplate, edges: edgesTemplate } = useWorkflowTemplate()
+  const workflowTemplate = useWorkflowTemplate()
+  const [initialWorkflowTemplate] = useState(workflowTemplate)
+  const { nodes: nodesTemplate, edges: edgesTemplate } = initialWorkflowTemplate
   const appDetail = useAppStore((state) => state.appDetail)!
   const { data: currentUserId } = useSuspenseQuery({
     ...userProfileQueryOptions(),
@@ -90,11 +104,35 @@ export const useWorkflowInit = () => {
   )
   const { getWorkflowDraftGraphForCanvas } = useWorkflowDraftGraphForCanvas(appDetail.mode)
   const setSyncWorkflowDraftHash = useStore((s) => s.setSyncWorkflowDraftHash)
-  const [data, setData] = useState<FetchWorkflowDraftResponse>()
-  const [isLoading, setIsLoading] = useState(true)
+  const {
+    data: serverDraft,
+    error: draftError,
+    refetch: refetchDraft,
+  } = useQuery(appWorkflowDraftQueryOptions(appDetail.id))
+  const { data: nodesDefaultConfigsData, error: nodesDefaultConfigsError } = useQuery(
+    appWorkflowDefaultBlockConfigsQueryOptions(appDetail.id),
+  )
+  const { data: publishedWorkflow, error: publishedWorkflowError } = useQuery(
+    appWorkflowQueryOptions(appDetail.id),
+  )
+  const [localDraftState, setLocalDraftState] = useState<LocalWorkflowDraft>()
+  const handledDraftErrorsRef = useRef(new WeakSet<object>())
+  const localDraft = localDraftState?.appId === appDetail.id ? localDraftState.draft : undefined
+  const sourceDraft = serverDraft ?? localDraft
+  const data = useMemo(() => {
+    if (!sourceDraft) return undefined
+
+    return {
+      ...sourceDraft,
+      graph: getWorkflowDraftGraphForCanvas(sourceDraft.graph, {
+        localStartPlaceholderNodes: nodesTemplate,
+      }),
+    }
+  }, [getWorkflowDraftGraphForCanvas, nodesTemplate, sourceDraft])
+
   useEffect(() => {
     workflowStore.setState({ appId: appDetail.id, appName: appDetail.name })
-  }, [appDetail.id, workflowStore])
+  }, [appDetail.id, appDetail.name, workflowStore])
 
   const handleUpdateWorkflowFileUploadConfig = useCallback(
     (config: FileUploadConfigResponse) => {
@@ -106,156 +144,129 @@ export const useWorkflowInit = () => {
   const { data: fileUploadConfigResponse, isLoading: isFileUploadConfigLoading } =
     useWorkflowConfig('/files/upload', handleUpdateWorkflowFileUploadConfig)
 
-  const handleGetInitialWorkflowData = useCallback(async () => {
-    try {
-      const res = await queryClient.fetchQuery(appWorkflowDraftQueryOptions(appDetail.id))
-      const initialData = {
-        ...res,
-        graph: getWorkflowDraftGraphForCanvas(res.graph, {
-          localStartPlaceholderNodes: nodesTemplate,
-        }),
-      }
+  const handleDraftError = useCallback(
+    async (error: object) => {
+      const errorCode = await getWorkflowDraftErrorCode(error)
+      if (errorCode !== 'draft_workflow_not_exist') return
 
-      setData(initialData)
+      const isAdvancedChat = appDetail.mode === AppModeEnum.ADVANCED_CHAT
+      const initialGraph = {
+        nodes: isAdvancedChat ? nodesTemplate : [],
+        edges: isAdvancedChat ? edgesTemplate : [],
+      }
       workflowStore.setState({
-        envSecrets: (initialData.environment_variables || [])
-          .filter((env) => env.value_type === 'secret')
-          .reduce(
-            (acc, env) => {
-              if (typeof env.value === 'string') acc[env.id] = env.value
-              return acc
-            },
-            {} as Record<string, string>,
-          ),
-        environmentVariables:
-          initialData.environment_variables?.map((env) =>
-            env.value_type === 'secret' ? { ...env, value: '[__HIDDEN__]' } : env,
-          ) || [],
-        conversationVariables: initialData.conversation_variables || [],
-        isWorkflowDataLoaded: true,
+        notInitialWorkflow: true,
+        showOnboarding: false,
+        shouldAutoOpenStartNodeSelector: false,
+        hasSelectedStartNode: false,
+        hasShownOnboarding: !isAdvancedChat,
       })
-      setSyncWorkflowDraftHash(initialData.hash)
-      setIsLoading(false)
-    } catch (error: unknown) {
-      const responseError = error as {
-        bodyUsed?: boolean
-        json?: () => Promise<{ code?: string }>
-      }
-      if (responseError.json && !responseError.bodyUsed && appDetail) {
-        responseError.json().then((err) => {
-          if (err.code === 'draft_workflow_not_exist') {
-            const isAdvancedChat = appDetail.mode === AppModeEnum.ADVANCED_CHAT
-            const initialGraph = {
-              nodes: isAdvancedChat ? nodesTemplate : [],
-              edges: isAdvancedChat ? edgesTemplate : [],
-            }
-            workflowStore.setState({
-              notInitialWorkflow: true,
-              showOnboarding: false,
-              shouldAutoOpenStartNodeSelector: false,
-              hasSelectedStartNode: false,
-              hasShownOnboarding: !isAdvancedChat,
-            })
 
-            if (!appACLCapabilities.canEdit) {
-              const initialData = createLocalWorkflowDraft({
-                ...getWorkflowDraftGraphForCanvas(initialGraph, {
-                  localStartPlaceholderNodes: nodesTemplate,
-                }),
-              })
-              setData(initialData)
-              workflowStore.setState({
-                envSecrets: {},
-                environmentVariables: [],
-                conversationVariables: [],
-                isWorkflowDataLoaded: true,
-              })
-              setSyncWorkflowDraftHash(initialData.hash)
-              setIsLoading(false)
-              return
-            }
-
-            syncWorkflowDraft({
-              url: `/apps/${appDetail.id}/workflows/draft`,
-              params: {
-                graph: initialGraph,
-                features: {
-                  retriever_resource: { enabled: true },
-                },
-                conversation_variables: [],
-              },
-            }).then((res) => {
-              workflowStore.getState().setDraftUpdatedAt(res.updated_at)
-              setSyncWorkflowDraftHash(res.hash)
-              handleGetInitialWorkflowData()
-            })
-          }
+      if (!appACLCapabilities.canEdit) {
+        setLocalDraftState({
+          appId: appDetail.id,
+          draft: createLocalWorkflowDraft(initialGraph),
         })
+        return
       }
-    }
-  }, [
-    appACLCapabilities.canEdit,
-    appDetail,
-    getWorkflowDraftGraphForCanvas,
-    nodesTemplate,
-    edgesTemplate,
-    queryClient,
-    workflowStore,
-    setSyncWorkflowDraftHash,
-  ])
+
+      const response = await syncWorkflowDraft({
+        url: `/apps/${appDetail.id}/workflows/draft`,
+        params: {
+          graph: initialGraph,
+          features: {
+            retriever_resource: { enabled: true },
+          },
+          conversation_variables: [],
+        },
+      })
+      workflowStore.getState().setDraftUpdatedAt(response.updated_at)
+      setSyncWorkflowDraftHash(response.hash)
+      await refetchDraft()
+    },
+    [
+      appACLCapabilities.canEdit,
+      appDetail.id,
+      appDetail.mode,
+      edgesTemplate,
+      nodesTemplate,
+      refetchDraft,
+      setSyncWorkflowDraftHash,
+      workflowStore,
+    ],
+  )
 
   useEffect(() => {
-    handleGetInitialWorkflowData()
-  }, [])
+    if (typeof draftError !== 'object' || draftError === null) return
+    if (handledDraftErrorsRef.current.has(draftError)) return
 
-  const handleFetchPreloadData = useCallback(async () => {
-    const [nodesDefaultConfigsResult, publishedWorkflowResult] = await Promise.allSettled([
-      queryClient.fetchQuery(appWorkflowDefaultBlockConfigsQueryOptions(appDetail.id)),
-      queryClient.fetchQuery(appWorkflowQueryOptions(appDetail.id)),
-    ])
+    handledDraftErrorsRef.current.add(draftError)
+    void handleDraftError(draftError).catch(console.error)
+  }, [draftError, handleDraftError])
 
-    if (nodesDefaultConfigsResult.status === 'fulfilled') {
-      const nodesDefaultConfigsData = nodesDefaultConfigsResult.value
-      workflowStore.setState({
-        nodesDefaultConfigs: nodesDefaultConfigsData.filter(isNodeDefaultConfig).reduce(
-          (acc, block) => {
-            if (!acc[block.type]) acc[block.type] = { ...block.config }
+  useEffect(() => {
+    if (!data) return
+
+    workflowStore.setState({
+      envSecrets: (data.environment_variables || [])
+        .filter((env) => env.value_type === 'secret')
+        .reduce(
+          (acc, env) => {
+            if (typeof env.value === 'string') acc[env.id] = env.value
             return acc
           },
-          {} as Record<string, unknown>,
+          {} as Record<string, string>,
         ),
-      })
-    } else if (!(nodesDefaultConfigsResult.reason instanceof CancelledError)) {
-      console.error(nodesDefaultConfigsResult.reason)
-    }
-
-    if (publishedWorkflowResult.status === 'fulfilled') {
-      const publishedWorkflow = publishedWorkflowResult.value
-      workflowStore.getState().setPublishedAt(publishedWorkflow?.created_at ?? 0)
-      const graph = publishedWorkflow?.graph
-      const nodes = Array.isArray(graph?.nodes) ? (graph.nodes as Node[]) : undefined
-      const edges = Array.isArray(graph?.edges) ? (graph.edges as Edge[]) : undefined
-      workflowStore.getState().setLastPublishedHasUserInput(hasConnectedUserInput(nodes, edges))
-    } else if (!(publishedWorkflowResult.reason instanceof CancelledError)) {
-      console.error(publishedWorkflowResult.reason)
-      workflowStore.getState().setLastPublishedHasUserInput(false)
-    }
-  }, [workflowStore, appDetail, queryClient])
+      environmentVariables:
+        data.environment_variables?.map((env) =>
+          env.value_type === 'secret' ? { ...env, value: '[__HIDDEN__]' } : env,
+        ) || [],
+      conversationVariables: data.conversation_variables || [],
+      isWorkflowDataLoaded: true,
+    })
+    setSyncWorkflowDraftHash(data.hash)
+    workflowStore.getState().setDraftUpdatedAt(data.updated_at)
+    workflowStore.getState().setToolPublished(data.tool_published)
+  }, [data, setSyncWorkflowDraftHash, workflowStore])
 
   useEffect(() => {
-    handleFetchPreloadData()
-  }, [handleFetchPreloadData])
+    if (!nodesDefaultConfigsData) return
+
+    workflowStore.setState({
+      nodesDefaultConfigs: nodesDefaultConfigsData.filter(isNodeDefaultConfig).reduce(
+        (acc, block) => {
+          if (!acc[block.type]) acc[block.type] = { ...block.config }
+          return acc
+        },
+        {} as Record<string, unknown>,
+      ),
+    })
+  }, [nodesDefaultConfigsData, workflowStore])
 
   useEffect(() => {
-    if (data) {
-      workflowStore.getState().setDraftUpdatedAt(data.updated_at)
-      workflowStore.getState().setToolPublished(data.tool_published)
-    }
-  }, [data, workflowStore])
+    if (nodesDefaultConfigsError) console.error(nodesDefaultConfigsError)
+  }, [nodesDefaultConfigsError])
+
+  useEffect(() => {
+    if (publishedWorkflow === undefined) return
+
+    workflowStore.getState().setPublishedAt(publishedWorkflow?.created_at ?? 0)
+    const graph = publishedWorkflow?.graph
+    const nodes = Array.isArray(graph?.nodes) ? (graph.nodes as Node[]) : undefined
+    const edges = Array.isArray(graph?.edges) ? (graph.edges as Edge[]) : undefined
+    workflowStore.getState().setLastPublishedHasUserInput(hasConnectedUserInput(nodes, edges))
+  }, [publishedWorkflow, workflowStore])
+
+  useEffect(() => {
+    if (!publishedWorkflowError) return
+
+    console.error(publishedWorkflowError)
+    workflowStore.getState().setLastPublishedHasUserInput(false)
+  }, [publishedWorkflowError, workflowStore])
 
   return {
     data,
-    isLoading: isLoading || isFileUploadConfigLoading,
+    isLoading: !data || isFileUploadConfigLoading,
     fileUploadConfigResponse,
   }
 }

--- a/web/app/components/workflow-app/hooks/use-workflow-init.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-init.ts
@@ -10,8 +10,11 @@ import { BlockEnum } from '@/app/components/workflow/types'
 import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { useWorkflowConfig } from '@/service/use-workflow'
-import { fetchNodesDefaultConfigs, fetchWorkflowDraft, syncWorkflowDraft } from '@/service/workflow'
-import { appWorkflowQueryOptions } from '@/service/workflow-queries'
+import { fetchWorkflowDraft, syncWorkflowDraft } from '@/service/workflow'
+import {
+  appWorkflowDefaultBlockConfigsQueryOptions,
+  appWorkflowQueryOptions,
+} from '@/service/workflow-queries'
 import { AppModeEnum } from '@/types/app'
 import { getAppACLCapabilities } from '@/utils/permission'
 import { useWorkflowDraftGraphForCanvas } from './use-workflow-draft-graph-for-canvas'
@@ -52,6 +55,17 @@ const hasConnectedUserInput = (nodes: Node[] = [], edges: Edge[] = []): boolean 
   if (!startNodeIds.length) return false
 
   return edges.some((edge) => startNodeIds.includes(edge.source))
+}
+
+const isNodeDefaultConfig = (
+  block: Record<string, unknown>,
+): block is { type: string; config: Record<string, unknown> } => {
+  return (
+    typeof block.type === 'string' &&
+    typeof block.config === 'object' &&
+    block.config !== null &&
+    !Array.isArray(block.config)
+  )
 }
 
 export const useWorkflowInit = () => {
@@ -194,14 +208,14 @@ export const useWorkflowInit = () => {
 
   const handleFetchPreloadData = useCallback(async () => {
     const [nodesDefaultConfigsResult, publishedWorkflowResult] = await Promise.allSettled([
-      fetchNodesDefaultConfigs(`/apps/${appDetail.id}/workflows/default-workflow-block-configs`),
+      queryClient.fetchQuery(appWorkflowDefaultBlockConfigsQueryOptions(appDetail.id)),
       queryClient.fetchQuery(appWorkflowQueryOptions(appDetail.id)),
     ])
 
     if (nodesDefaultConfigsResult.status === 'fulfilled') {
       const nodesDefaultConfigsData = nodesDefaultConfigsResult.value
       workflowStore.setState({
-        nodesDefaultConfigs: nodesDefaultConfigsData.reduce(
+        nodesDefaultConfigs: nodesDefaultConfigsData.filter(isNodeDefaultConfig).reduce(
           (acc, block) => {
             if (!acc[block.type]) acc[block.type] = { ...block.config }
             return acc

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -8,7 +8,6 @@ import type { WorkflowHistoryState } from './store/workflow/history-slice'
 import type { WorkflowSliceShape } from './store/workflow/workflow-slice'
 import type { ConversationVariable, Edge, EnvironmentVariable, Node } from './types'
 import type { EventEmitterValue } from '@/context/event-emitter'
-import type { VarInInspect } from '@/types/workflow'
 import {
   AlertDialog,
   AlertDialogActions,
@@ -20,6 +19,7 @@ import {
 } from '@langgenius/dify-ui/alert-dialog'
 import { cn } from '@langgenius/dify-ui/cn'
 import { toast } from '@langgenius/dify-ui/toast'
+import { useQuery } from '@tanstack/react-query'
 import { useEventListener } from 'ahooks'
 import { isEqual } from 'es-toolkit/predicate'
 import { setAutoFreeze } from 'immer'
@@ -55,7 +55,7 @@ import {
   useAllMCPTools,
   useAllWorkflowTools,
 } from '@/service/use-tools'
-import { fetchAllInspectVars } from '@/service/workflow'
+import { workflowInspectVariablesQueryOptions } from '@/service/workflow-queries'
 import CandidateNode from './candidate-node'
 import UserCursors from './collaboration/components/user-cursors'
 import { collaborationManager } from './collaboration/core/collaboration-manager'
@@ -604,16 +604,9 @@ export const Workflow: FC<WorkflowProps> = memo(
     const dataSourceList = useStore((s) => s.dataSourceList)
     // buildInTools, customTools, workflowTools, mcpTools, dataSourceList
     const configsMap = useHooksStore((s) => s.configsMap)
-    const [isLoadedVars, setIsLoadedVars] = useState(false)
-    const [vars, setVars] = useState<VarInInspect[]>([])
-    useEffect(() => {
-      ;(async () => {
-        if (!configsMap?.flowType || !configsMap?.flowId) return
-        const data = await fetchAllInspectVars(configsMap.flowType, configsMap.flowId)
-        setVars(data)
-        setIsLoadedVars(true)
-      })()
-    }, [configsMap?.flowType, configsMap?.flowId])
+    const { data: vars = [], isSuccess: isLoadedVars } = useQuery(
+      workflowInspectVariablesQueryOptions(configsMap?.flowType, configsMap?.flowId),
+    )
     useEffect(() => {
       if (schemaTypeDefinitions && isLoadedVars) {
         fetchInspectVars({

--- a/web/app/components/workflow/workflow-generator/__tests__/apply.spec.ts
+++ b/web/app/components/workflow/workflow-generator/__tests__/apply.spec.ts
@@ -16,7 +16,16 @@ const mockDeleteApp = vi.fn()
 
 vi.mock('@/service/apps', () => ({
   createApp: (params: unknown) => mockCreateApp(params),
-  deleteApp: (appId: string) => mockDeleteApp(appId),
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleClient: {
+    apps: {
+      byAppId: {
+        delete: (input: unknown, options: unknown) => mockDeleteApp(input, options),
+      },
+    },
+  },
 }))
 
 vi.mock('@/service/workflow', () => ({
@@ -149,7 +158,7 @@ describe('applyToNewApp', () => {
   })
 
   // Sync failure must roll back the createApp so the user isn't left with an
-  // empty app in their /apps list. deleteApp is called with the new app id,
+  // empty app in their /apps list. The delete endpoint receives the new app id,
   // and the original sync error is re-thrown so the caller can toast it.
   it('should delete the new app when syncWorkflowDraft fails', async () => {
     mockCreateApp.mockResolvedValueOnce({ id: 'doomed', mode: AppModeEnum.WORKFLOW })
@@ -165,7 +174,10 @@ describe('applyToNewApp', () => {
       }),
     ).rejects.toBe(syncErr)
 
-    expect(mockDeleteApp).toHaveBeenCalledWith('doomed')
+    expect(mockDeleteApp).toHaveBeenCalledWith(
+      { params: { app_id: 'doomed' } },
+      { context: { silent: true } },
+    )
   })
 
   // The truly stuck path: sync fails AND the rollback delete also fails. We

--- a/web/app/components/workflow/workflow-generator/apply.ts
+++ b/web/app/components/workflow/workflow-generator/apply.ts
@@ -1,5 +1,6 @@
 import type { GeneratedGraph, WorkflowGeneratorMode } from './types'
-import { createApp, deleteApp } from '@/service/apps'
+import { createApp } from '@/service/apps'
+import { consoleClient } from '@/service/client'
 import { fetchWorkflowDraft, syncWorkflowDraft } from '@/service/workflow'
 import { AppModeEnum } from '@/types/app'
 
@@ -111,7 +112,7 @@ export const applyToNewApp = async ({
   // already succeeded so the app exists; if the sync fails (network blip,
   // backend rejection of the graph) we MUST roll the createApp back so the
   // user isn't left with a discoverable-but-empty app sitting at the top
-  // of their /apps list. ``deleteApp`` is best-effort — if that also fails
+  // of their /apps list. The delete is best-effort — if that also fails
   // (it usually won't, it's a simple DELETE) we surface ``WorkflowApplyOrphanError``
   // so the caller can route to /apps where the orphan is still recoverable
   // by hand.
@@ -126,7 +127,10 @@ export const applyToNewApp = async ({
     })
   } catch (syncErr) {
     try {
-      await deleteApp(app.id)
+      await consoleClient.apps.byAppId.delete(
+        { params: { app_id: app.id } },
+        { context: { silent: true } },
+      )
     } catch (deleteErr) {
       throw new WorkflowApplyOrphanError(app.id, deleteErr)
     }

--- a/web/service/__tests__/use-workflow.spec.tsx
+++ b/web/service/__tests__/use-workflow.spec.tsx
@@ -2,8 +2,17 @@ import type { ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import { useUpdateWorkflow } from '../use-workflow'
-import { appWorkflowVersionsInfiniteQueryKey } from '../workflow-queries'
+import { FlowType } from '@/types/common'
+import {
+  useInvalidateConversationVarValues,
+  useInvalidateSysVarValues,
+  useUpdateWorkflow,
+} from '../use-workflow'
+import {
+  appWorkflowConversationVariableValuesQueryOptions,
+  appWorkflowSystemVariableValuesQueryOptions,
+  appWorkflowVersionsInfiniteQueryKey,
+} from '../workflow-queries'
 
 const mockPatch = vi.hoisted(() => vi.fn())
 
@@ -51,6 +60,41 @@ describe('useUpdateWorkflow', () => {
     })
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: appWorkflowVersionsInfiniteQueryKey(),
+    })
+  })
+})
+
+describe('workflow variable query invalidation', () => {
+  it('should invalidate the generated conversation variable query', async () => {
+    const queryClient = new QueryClient()
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(
+      () => useInvalidateConversationVarValues(FlowType.appFlow, 'app-1'),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: appWorkflowConversationVariableValuesQueryOptions('app-1').queryKey,
+    })
+  })
+
+  it('should invalidate the generated system variable query', async () => {
+    const queryClient = new QueryClient()
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useInvalidateSysVarValues(FlowType.appFlow, 'app-1'), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: appWorkflowSystemVariableValuesQueryOptions('app-1').queryKey,
     })
   })
 })

--- a/web/service/apps.ts
+++ b/web/service/apps.ts
@@ -168,10 +168,6 @@ export const importDSLConfirm = ({
   return post<DSLImportResponse>(`apps/imports/${import_id}/confirm`, { body: {} })
 }
 
-export const deleteApp = (appID: string): Promise<CommonResponse> => {
-  return del<CommonResponse>(`apps/${appID}`)
-}
-
 export const updateAppSiteStatus = ({
   url,
   body,

--- a/web/service/client.spec.ts
+++ b/web/service/client.spec.ts
@@ -795,16 +795,21 @@ describe('consoleQuery app mutation defaults', () => {
     expect(synchronized).toBe(true)
   })
 
-  it('should keep a delete mutation pending until every app list synchronizes', async () => {
+  it('should refresh plan usage and keep a delete mutation pending until every app list synchronizes', async () => {
     const consoleQuery = await loadConsoleQuery()
     const queryClient = new QueryClient()
-    const invalidationResolvers: Array<() => void> = []
-    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          invalidationResolvers.push(resolve)
-        }),
-    )
+    const appListInvalidationResolvers: Array<() => void> = []
+    const featuresQueryKey = consoleQuery.features.get.key()
+    const invalidateQueries = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockImplementation((filters) => {
+        if (JSON.stringify(filters?.queryKey) === JSON.stringify(featuresQueryKey))
+          return new Promise<void>(() => {})
+
+        return new Promise<void>((resolve) => {
+          appListInvalidationResolvers.push(resolve)
+        })
+      })
     const mutationOptions = consoleQuery.apps.byAppId.delete.mutationOptions()
 
     const synchronization = mutationOptions.onSuccess?.(
@@ -829,9 +834,12 @@ describe('consoleQuery app mutation defaults', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: consoleQuery.apps.recent.get.key(),
     })
-    expect(invalidateQueries).toHaveBeenCalledTimes(3)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: consoleQuery.features.get.key(),
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(4)
 
-    invalidationResolvers.forEach((resolve) => resolve())
+    appListInvalidationResolvers.forEach((resolve) => resolve())
     await synchronization
 
     expect(synchronized).toBe(true)

--- a/web/service/client.spec.ts
+++ b/web/service/client.spec.ts
@@ -795,10 +795,11 @@ describe('consoleQuery app mutation defaults', () => {
     expect(synchronized).toBe(true)
   })
 
-  it('should cancel every current app workflow query before deleting the app', async () => {
+  it('should cancel app workflow queries before deletion and restore them on failure', async () => {
     const consoleQuery = await loadConsoleQuery()
     const queryClient = new QueryClient()
     const cancelQueries = vi.spyOn(queryClient, 'cancelQueries')
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
     const mutationOptions = consoleQuery.apps.byAppId.delete.mutationOptions()
     const input = { params: { app_id: 'app-1' } }
     const otherInput = { params: { app_id: 'app-2' } }
@@ -828,6 +829,19 @@ describe('consoleQuery app mutation defaults', () => {
       queryKey: workflowQueryKey,
     })
     expect(cancelQueries).toHaveBeenCalledTimes(1)
+
+    const recovery = mutationOptions.onError?.(
+      new Error('delete failed') as never,
+      input,
+      undefined,
+      createMutationContext(queryClient),
+    )
+
+    expect(recovery).toBeUndefined()
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: workflowQueryKey,
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
   })
 
   it('should refresh plan usage and keep a delete mutation pending until every app list synchronizes', async () => {

--- a/web/service/client.spec.ts
+++ b/web/service/client.spec.ts
@@ -795,6 +795,41 @@ describe('consoleQuery app mutation defaults', () => {
     expect(synchronized).toBe(true)
   })
 
+  it('should cancel every current app workflow query before deleting the app', async () => {
+    const consoleQuery = await loadConsoleQuery()
+    const queryClient = new QueryClient()
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries')
+    const mutationOptions = consoleQuery.apps.byAppId.delete.mutationOptions()
+    const input = { params: { app_id: 'app-1' } }
+    const otherInput = { params: { app_id: 'app-2' } }
+    const workflowQueryKey = consoleQuery.apps.byAppId.workflows.key({ input })
+
+    queryClient.setQueryData(
+      consoleQuery.apps.byAppId.workflows.defaultWorkflowBlockConfigs.get.key({ input }),
+      'default-configs',
+    )
+    queryClient.setQueryData(
+      consoleQuery.apps.byAppId.workflows.draft.conversationVariables.get.key({ input }),
+      'conversation-variables',
+    )
+    queryClient.setQueryData(
+      consoleQuery.apps.byAppId.workflows.draft.systemVariables.get.key({ input: otherInput }),
+      'other-app-system-variables',
+    )
+
+    expect(
+      queryClient.getQueriesData({ queryKey: workflowQueryKey }).map(([, data]) => data),
+    ).toEqual(expect.arrayContaining(['default-configs', 'conversation-variables']))
+    expect(queryClient.getQueriesData({ queryKey: workflowQueryKey })).toHaveLength(2)
+
+    await mutationOptions.onMutate?.(input, createMutationContext(queryClient))
+
+    expect(cancelQueries).toHaveBeenCalledWith({
+      queryKey: workflowQueryKey,
+    })
+    expect(cancelQueries).toHaveBeenCalledTimes(1)
+  })
+
   it('should refresh plan usage and keep a delete mutation pending until every app list synchronizes', async () => {
     const consoleQuery = await loadConsoleQuery()
     const queryClient = new QueryClient()

--- a/web/service/client.ts
+++ b/web/service/client.ts
@@ -527,8 +527,12 @@ export const consoleQuery: RouterUtils<typeof consoleClient> = createTanstackQue
         byAppId: {
           delete: {
             mutationOptions: {
-              onSuccess: (_data, _variables, _onMutateResult, context) =>
-                Promise.all([
+              onSuccess: (_data, _variables, _onMutateResult, context) => {
+                void context.client.invalidateQueries({
+                  queryKey: consoleQuery.features.get.key(),
+                })
+
+                return Promise.all([
                   context.client.invalidateQueries({ queryKey: consoleQuery.apps.get.key() }),
                   context.client.invalidateQueries({
                     queryKey: consoleQuery.apps.starred.get.key(),
@@ -536,7 +540,8 @@ export const consoleQuery: RouterUtils<typeof consoleClient> = createTanstackQue
                   context.client.invalidateQueries({
                     queryKey: consoleQuery.apps.recent.get.key(),
                   }),
-                ]),
+                ])
+              },
             },
           },
           put: {

--- a/web/service/client.ts
+++ b/web/service/client.ts
@@ -527,6 +527,12 @@ export const consoleQuery: RouterUtils<typeof consoleClient> = createTanstackQue
         byAppId: {
           delete: {
             mutationOptions: {
+              onMutate: async (variables, context) => {
+                const input = { params: { app_id: variables.params.app_id } }
+                await context.client.cancelQueries({
+                  queryKey: consoleQuery.apps.byAppId.workflows.key({ input }),
+                })
+              },
               onSuccess: (_data, _variables, _onMutateResult, context) => {
                 void context.client.invalidateQueries({
                   queryKey: consoleQuery.features.get.key(),

--- a/web/service/client.ts
+++ b/web/service/client.ts
@@ -529,7 +529,14 @@ export const consoleQuery: RouterUtils<typeof consoleClient> = createTanstackQue
             mutationOptions: {
               onMutate: async (variables, context) => {
                 const input = { params: { app_id: variables.params.app_id } }
+                const workflowQueryKey = consoleQuery.apps.byAppId.workflows.key({ input })
                 await context.client.cancelQueries({
+                  queryKey: workflowQueryKey,
+                })
+              },
+              onError: (_error, variables, _onMutateResult, context) => {
+                const input = { params: { app_id: variables.params.app_id } }
+                void context.client.invalidateQueries({
                   queryKey: consoleQuery.apps.byAppId.workflows.key({ input }),
                 })
               },

--- a/web/service/use-workflow.ts
+++ b/web/service/use-workflow.ts
@@ -1,20 +1,24 @@
 import type { CommonResponse } from '@/models/common'
-import type { FlowType } from '@/types/common'
 import type {
   FetchWorkflowDraftPageParams,
   FetchWorkflowDraftPageResponse,
   NodeTracing,
   PublishWorkflowParams,
   UpdateWorkflowParams,
-  VarInInspect,
   WorkflowConfigResponse,
   WorkflowRunHistoryResponse,
 } from '@/types/workflow'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { FlowType } from '@/types/common'
 import { del, get, patch, post, put } from './base'
 import { useInvalid } from './use-base'
 import { getFlowPrefix } from './utils'
-import { appWorkflowQueryOptions, appWorkflowVersionsInfiniteQueryKey } from './workflow-queries'
+import {
+  appWorkflowConversationVariableValuesQueryOptions,
+  appWorkflowQueryOptions,
+  appWorkflowSystemVariableValuesQueryOptions,
+  appWorkflowVersionsInfiniteQueryKey,
+} from './workflow-queries'
 
 const NAME_SPACE = 'workflow'
 
@@ -178,20 +182,19 @@ export const useInvalidAllLastRun = (flowType?: FlowType, flowId?: string) => {
 }
 
 export const useConversationVarValues = (flowType?: FlowType, flowId?: string) => {
-  return useQuery({
-    enabled: !!flowId,
-    queryKey: [NAME_SPACE, flowType, 'conversation var values', flowId],
-    queryFn: async () => {
-      const { items } = (await get(
-        `${getFlowPrefix(flowType)}/${flowId}/workflows/draft/conversation-variables`,
-      )) as { items: VarInInspect[] }
-      return items
-    },
-  })
+  const appId =
+    flowType === FlowType.ragPipeline || flowType === FlowType.snippet ? undefined : flowId
+  return useQuery(appWorkflowConversationVariableValuesQueryOptions(appId))
 }
 
 export const useInvalidateConversationVarValues = (flowType: FlowType, flowId: string) => {
-  return useInvalid([NAME_SPACE, flowType, 'conversation var values', flowId])
+  const queryClient = useQueryClient()
+  return () => {
+    if (flowType !== FlowType.appFlow) return Promise.resolve()
+    return queryClient.invalidateQueries({
+      queryKey: appWorkflowConversationVariableValuesQueryOptions(flowId).queryKey,
+    })
+  }
 }
 
 export const useResetConversationVar = (flowType: FlowType, flowId: string) => {
@@ -213,20 +216,19 @@ export const useResetToLastRunValue = (flowType: FlowType, flowId: string) => {
 }
 
 export const useSysVarValues = (flowType?: FlowType, flowId?: string) => {
-  return useQuery({
-    enabled: !!flowId,
-    queryKey: [NAME_SPACE, flowType, 'sys var values', flowId],
-    queryFn: async () => {
-      const { items } = (await get(
-        `${getFlowPrefix(flowType)}/${flowId}/workflows/draft/system-variables`,
-      )) as { items: VarInInspect[] }
-      return items
-    },
-  })
+  const appId =
+    flowType === FlowType.ragPipeline || flowType === FlowType.snippet ? undefined : flowId
+  return useQuery(appWorkflowSystemVariableValuesQueryOptions(appId))
 }
 
 export const useInvalidateSysVarValues = (flowType: FlowType, flowId: string) => {
-  return useInvalid([NAME_SPACE, flowType, 'sys var values', flowId])
+  const queryClient = useQueryClient()
+  return () => {
+    if (flowType !== FlowType.appFlow) return Promise.resolve()
+    return queryClient.invalidateQueries({
+      queryKey: appWorkflowSystemVariableValuesQueryOptions(flowId).queryKey,
+    })
+  }
 }
 
 export const useDeleteAllInspectorVars = (flowType: FlowType, flowId: string) => {

--- a/web/service/workflow-queries.ts
+++ b/web/service/workflow-queries.ts
@@ -15,6 +15,17 @@ export function appWorkflowQueryOptions(appId: string | null | undefined) {
   })
 }
 
+export function appWorkflowDefaultBlockConfigsQueryOptions(appId: string) {
+  return consoleQuery.apps.byAppId.workflows.defaultWorkflowBlockConfigs.get.queryOptions({
+    input: {
+      params: {
+        app_id: appId,
+      },
+    },
+    context: { silent: true },
+  })
+}
+
 export function appWorkflowVersionsInfiniteQueryOptions(appId: string | null | undefined) {
   return consoleQuery.apps.byAppId.workflows.get.infiniteOptions({
     input: appId

--- a/web/service/workflow-queries.ts
+++ b/web/service/workflow-queries.ts
@@ -1,5 +1,8 @@
-import { skipToken } from '@tanstack/react-query'
+import type { FetchWorkflowDraftResponse, VarInInspect } from '@/types/workflow'
+import { queryOptions, skipToken } from '@tanstack/react-query'
+import { FlowType } from '@/types/common'
 import { consoleQuery } from './client'
+import { fetchAllInspectVars } from './workflow'
 
 const WORKFLOW_VERSIONS_PAGE_SIZE = 10
 
@@ -22,7 +25,101 @@ export function appWorkflowDefaultBlockConfigsQueryOptions(appId: string) {
         app_id: appId,
       },
     },
-    context: { silent: true },
+  })
+}
+
+export function appWorkflowDraftQueryOptions(appId: string) {
+  const input = {
+    params: {
+      app_id: appId,
+    },
+  }
+
+  return queryOptions({
+    queryKey: consoleQuery.apps.byAppId.workflows.draft.get.key({ input }),
+    queryFn: ({ signal }) =>
+      consoleQuery.apps.byAppId.workflows.draft.get.call(input, {
+        signal,
+        context: { silent: true },
+      }) as Promise<FetchWorkflowDraftResponse>,
+    retry: false,
+    staleTime: 0,
+  })
+}
+
+export function appWorkflowInspectVariablesQueryKey(appId: string) {
+  return consoleQuery.apps.byAppId.workflows.draft.variables.get.key({
+    input: {
+      params: {
+        app_id: appId,
+      },
+    },
+  })
+}
+
+export function appWorkflowConversationVariableValuesQueryOptions(appId?: string) {
+  return consoleQuery.apps.byAppId.workflows.draft.conversationVariables.get.queryOptions({
+    input: appId
+      ? {
+          params: {
+            app_id: appId,
+          },
+        }
+      : skipToken,
+    select: (data) => (data.items ?? []) as VarInInspect[],
+  })
+}
+
+export function appWorkflowSystemVariableValuesQueryOptions(appId?: string) {
+  return consoleQuery.apps.byAppId.workflows.draft.systemVariables.get.queryOptions({
+    input: appId
+      ? {
+          params: {
+            app_id: appId,
+          },
+        }
+      : skipToken,
+    select: (data) => (data.items ?? []) as VarInInspect[],
+  })
+}
+
+const workflowInspectVariablesQueryKey = (flowType: FlowType, flowId: string) => {
+  if (flowType === FlowType.ragPipeline) {
+    return consoleQuery.rag.pipelines.byPipelineId.workflows.draft.variables.get.key({
+      input: {
+        params: {
+          pipeline_id: flowId,
+        },
+      },
+    })
+  }
+
+  if (flowType === FlowType.snippet) {
+    return consoleQuery.snippets.bySnippetId.workflows.draft.variables.get.key({
+      input: {
+        params: {
+          snippet_id: flowId,
+        },
+      },
+    })
+  }
+
+  return appWorkflowInspectVariablesQueryKey(flowId)
+}
+
+export function workflowInspectVariablesQueryOptions(flowType?: FlowType, flowId?: string) {
+  return queryOptions({
+    queryKey:
+      flowType && flowId
+        ? workflowInspectVariablesQueryKey(flowType, flowId)
+        : consoleQuery.apps.byAppId.workflows.draft.variables.get.key(),
+    queryFn: ({ signal }) => {
+      if (!flowType || !flowId) return Promise.resolve([])
+      return fetchAllInspectVars(flowType, flowId, signal)
+    },
+    enabled: Boolean(flowType && flowId),
+    retry: false,
+    staleTime: 0,
   })
 }
 

--- a/web/service/workflow.spec.ts
+++ b/web/service/workflow.spec.ts
@@ -1,17 +1,37 @@
 import type { EnvironmentVariable } from '@/app/components/workflow/types'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import { updateEnvironmentVariables } from './workflow'
+import { FlowType } from '@/types/common'
+import { fetchAllInspectVars, updateEnvironmentVariables } from './workflow'
 
+const mockGet = vi.hoisted(() => vi.fn())
 const mockPost = vi.hoisted(() => vi.fn())
 
 vi.mock('./base', () => ({
-  get: vi.fn(),
+  get: mockGet,
   post: mockPost,
 }))
 
 vi.mock('./client', () => ({
   consoleClient: {},
 }))
+
+describe('fetchAllInspectVars', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps background variable preloading silent', async () => {
+    mockGet.mockResolvedValue({ items: [], total: 0 })
+
+    await fetchAllInspectVars(FlowType.appFlow, 'app-1')
+
+    expect(mockGet).toHaveBeenCalledWith(
+      'apps/app-1/workflows/draft/variables',
+      { params: { page: 1, limit: 100 } },
+      { silent: true },
+    )
+  })
+})
 
 describe('updateEnvironmentVariables', () => {
   beforeEach(() => {

--- a/web/service/workflow.spec.ts
+++ b/web/service/workflow.spec.ts
@@ -4,6 +4,7 @@ import { FlowType } from '@/types/common'
 import { fetchAllInspectVars, updateEnvironmentVariables } from './workflow'
 
 const mockGet = vi.hoisted(() => vi.fn())
+const mockGetAppInspectVariables = vi.hoisted(() => vi.fn())
 const mockPost = vi.hoisted(() => vi.fn())
 
 vi.mock('./base', () => ({
@@ -12,7 +13,19 @@ vi.mock('./base', () => ({
 }))
 
 vi.mock('./client', () => ({
-  consoleClient: {},
+  consoleClient: {
+    apps: {
+      byAppId: {
+        workflows: {
+          draft: {
+            variables: {
+              get: mockGetAppInspectVariables,
+            },
+          },
+        },
+      },
+    },
+  },
 }))
 
 describe('fetchAllInspectVars', () => {
@@ -20,15 +33,15 @@ describe('fetchAllInspectVars', () => {
     vi.clearAllMocks()
   })
 
-  it('keeps background variable preloading silent', async () => {
-    mockGet.mockResolvedValue({ items: [], total: 0 })
+  it('forwards the query cancellation signal without suppressing request errors', async () => {
+    mockGetAppInspectVariables.mockResolvedValue({ items: [], total: 0 })
+    const signal = new AbortController().signal
 
-    await fetchAllInspectVars(FlowType.appFlow, 'app-1')
+    await fetchAllInspectVars(FlowType.appFlow, 'app-1', signal)
 
-    expect(mockGet).toHaveBeenCalledWith(
-      'apps/app-1/workflows/draft/variables',
-      { params: { page: 1, limit: 100 } },
-      { silent: true },
+    expect(mockGetAppInspectVariables).toHaveBeenCalledWith(
+      { params: { app_id: 'app-1' }, query: { page: 1, limit: 100 } },
+      { signal },
     )
   })
 })

--- a/web/service/workflow.ts
+++ b/web/service/workflow.ts
@@ -10,7 +10,6 @@ import type {
   ConversationVariableResponse,
   FetchWorkflowDraftResponse,
   HumanInputFormData,
-  NodesDefaultConfigsResponse,
   VarInInspect,
 } from '@/types/workflow'
 import { get, post } from './base'
@@ -48,10 +47,6 @@ export const syncWorkflowDraft = ({
     { body: params },
     { silent: true },
   )
-}
-
-export const fetchNodesDefaultConfigs = (url: string) => {
-  return get<NodesDefaultConfigsResponse>(url)
 }
 
 export const singleNodeRun = (
@@ -114,10 +109,13 @@ const fetchAllInspectVarsOnePage = async (
   flowId: string,
   page: number,
 ): Promise<{ total: number; items: VarInInspect[] }> => {
-  return get(`${getFlowPrefix(flowType)}/${flowId}/workflows/draft/variables`, {
-    params: { page, limit: 100 },
-  })
+  return get(
+    `${getFlowPrefix(flowType)}/${flowId}/workflows/draft/variables`,
+    { params: { page, limit: 100 } },
+    { silent: true },
+  )
 }
+
 export const fetchAllInspectVars = async (
   flowType: FlowType,
   flowId: string,

--- a/web/service/workflow.ts
+++ b/web/service/workflow.ts
@@ -5,13 +5,13 @@ import type {
   EnvironmentVariable,
 } from '@/app/components/workflow/types'
 import type { CommonResponse } from '@/models/common'
-import type { FlowType } from '@/types/common'
 import type {
   ConversationVariableResponse,
   FetchWorkflowDraftResponse,
   HumanInputFormData,
   VarInInspect,
 } from '@/types/workflow'
+import { FlowType } from '@/types/common'
 import { get, post } from './base'
 import { consoleClient } from './client'
 import { getFlowPrefix } from './utils'
@@ -108,26 +108,47 @@ const fetchAllInspectVarsOnePage = async (
   flowType: FlowType,
   flowId: string,
   page: number,
+  signal?: AbortSignal,
 ): Promise<{ total: number; items: VarInInspect[] }> => {
-  return get(
-    `${getFlowPrefix(flowType)}/${flowId}/workflows/draft/variables`,
-    { params: { page, limit: 100 } },
-    { silent: true },
-  )
+  const query = { page, limit: 100 }
+  let response
+
+  if (flowType === FlowType.ragPipeline) {
+    response = await consoleClient.rag.pipelines.byPipelineId.workflows.draft.variables.get(
+      { params: { pipeline_id: flowId }, query },
+      { signal },
+    )
+  } else if (flowType === FlowType.snippet) {
+    response = await consoleClient.snippets.bySnippetId.workflows.draft.variables.get(
+      { params: { snippet_id: flowId }, query },
+      { signal },
+    )
+  } else {
+    response = await consoleClient.apps.byAppId.workflows.draft.variables.get(
+      { params: { app_id: flowId }, query },
+      { signal },
+    )
+  }
+
+  return {
+    items: (response.items ?? []) as VarInInspect[],
+    total: response.total ?? 0,
+  }
 }
 
 export const fetchAllInspectVars = async (
   flowType: FlowType,
   flowId: string,
+  signal?: AbortSignal,
 ): Promise<VarInInspect[]> => {
-  const res = await fetchAllInspectVarsOnePage(flowType, flowId, 1)
+  const res = await fetchAllInspectVarsOnePage(flowType, flowId, 1, signal)
   const { items, total } = res
   if (total <= 100) return items
 
   const pageCount = Math.ceil(total / 100)
   const promises = []
   for (let i = 2; i <= pageCount; i++)
-    promises.push(fetchAllInspectVarsOnePage(flowType, flowId, i))
+    promises.push(fetchAllInspectVarsOnePage(flowType, flowId, i, signal))
 
   const restData = await Promise.all(promises)
   restData.forEach(({ items: item }) => {

--- a/web/types/workflow.ts
+++ b/web/types/workflow.ts
@@ -427,11 +427,6 @@ export type WorkflowRunHistoryResponse = {
   data: WorkflowRunHistory[]
 }
 
-export type NodesDefaultConfigsResponse = {
-  type: string
-  config: any
-}[]
-
 export type ConversationVariableResponse = {
   data: (ConversationVariable & { updated_at: number; created_at: number })[]
   has_more: boolean


### PR DESCRIPTION
## Summary

- use the generated app deletion mutation and keep the delete dialog pending until cache synchronization completes
- stop regular, queued, and page-close draft persistence once deletion of the current app starts or succeeds
- cancel the current app workflow query subtree before DELETE so draft, default configuration, inspect, conversation, and system variable requests cannot race the deleted resource
- migrate workflow initialization and preload paths to observed generated queries with AbortSignal propagation while preserving their existing cache and retry contracts
- restore the current app workflow query subtree in the background when deletion fails, without delaying the mutation error state
- centralize app-list and plan-usage refresh in the app deletion mutation defaults

## Root cause

Deleting an app from its detail page left both workflow persistence and background preload lifecycles active until navigation unmounted the page. Queued saves and in-flight workflow queries could therefore reach the backend after the app had been deleted, producing `app_not_found` 404 responses and unrelated error toasts.

App deletion also changes the billing `buildApps` usage reported by the features query. That refresh was owned by local callbacks on only some delete surfaces instead of the shared deletion mutation contract.

The first cancellation fix used one-shot `fetchQuery` initialization. If DELETE failed while that query was pending, cancellation left the query idle and the initialization effect never ran again, so the studio could remain loading until a page refresh.

## User impact

Deletion now cancels all active workflow queries for the current app before the delete request starts, without affecting another app. No new draft persistence starts after deletion begins. If deletion fails, observed queries resume in the background and the existing page recovers without blocking the mutation error state.

The dialog retains a stable pending state, navigation waits only for required app-list synchronization, and plan usage refreshes in the background. Normal preload failures remain visible; only the existing expected draft-not-exist flow stays silent.

## Validation

- 10 focused Vitest files, 236 tests passed
- `pnpm check`
- `git diff --check`

Fixes SNP-693
