### PR TITLE
fix: hide soft-deleted conversations from console APIs

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -395,7 +395,13 @@ class ChatConversationDetailApi(Resource):
 
 def _get_conversation(session: Session, current_user: Account, app_model, conversation_id):
     conversation = session.scalar(
-        sa.select(Conversation).where(Conversation.id == conversation_id, Conversation.app_id == app_model.id).limit(1)
+        sa.select(Conversation)
+        .where(
+            Conversation.id == conversation_id,
+            Conversation.app_id == app_model.id,
+            Conversation.is_deleted.is_(False),
+        )
+        .limit(1)
     )
 
     if not conversation:

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -402,7 +402,11 @@ def _list_chat_messages(*, session: Session, app_model: App, current_user: Accou
     else:
         conversation = session.scalar(
             select(Conversation)
-            .where(Conversation.id == args.conversation_id, Conversation.app_id == app_model.id)
+            .where(
+                Conversation.id == args.conversation_id,
+                Conversation.app_id == app_model.id,
+                Conversation.is_deleted.is_(False),
+            )
             .limit(1)
         )
 

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -544,7 +544,14 @@ def _get_message_detail(*, session: Session, app_model: App, message_id: UUID):
     message_id_str = str(message_id)
 
     message = session.scalar(
-        select(Message).where(Message.id == message_id_str, Message.app_id == app_model.id).limit(1)
+        select(Message)
+        .join(Conversation, Conversation.id == Message.conversation_id)
+        .where(
+            Message.id == message_id_str,
+            Message.app_id == app_model.id,
+            Conversation.is_deleted.is_(False),
+        )
+        .limit(1)
     )
 
     if not message:

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from inspect import unwrap
 from unittest.mock import MagicMock
+from uuid import UUID
 
 import pytest
 from flask import Flask
@@ -160,6 +161,20 @@ def test_get_conversation_missing_raises_not_found(sqlite_session: Session) -> N
     session = sqlite_session
     with pytest.raises(NotFound):
         conversation_module._get_conversation(session, _make_account(), _app(), "missing")
+
+
+def test_chat_conversation_detail_rejects_soft_deleted_conversation(app: Flask, sqlite_session: Session) -> None:
+    conversation_id = "550e8400-e29b-41d4-a716-446655440000"
+    conversation = _conversation(conversation_id=conversation_id)
+    conversation.is_deleted = True
+    sqlite_session.add(conversation)
+    sqlite_session.flush()
+
+    api = conversation_module.ChatConversationDetailApi()
+    method = unwrap(api.get)
+    with app.test_request_context():
+        with pytest.raises(NotFound):
+            method(api, sqlite_session, _make_account(), _app(), UUID(conversation_id))
 
 
 def test_conversation_response_source_uses_caller_session(sqlite_session: Session) -> None:

--- a/api/tests/unit_tests/controllers/console/app/test_message_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_message_api.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from inspect import unwrap
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import UUID
 
 import pytest
 from flask import Flask
@@ -153,6 +154,25 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
 
     assert result is response_source
     response_source_factory.assert_called_once_with(message, session=session)
+
+
+def test_message_detail_rejects_message_from_soft_deleted_conversation(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
+    message_id = "550e8400-e29b-41d4-a716-446655440000"
+    message = _persist_message(sqlite_session, message_id=message_id)
+    conversation = sqlite_session.get(Conversation, message.conversation_id)
+    assert conversation is not None
+    conversation.is_deleted = True
+    sqlite_session.flush()
+    monkeypatch.setattr(message_module, "attach_message_extra_contents", lambda _messages: None)
+    monkeypatch.setattr(message_module, "dump_response", lambda _model, value: value)
+
+    api = message_module.MessageApi()
+    method = unwrap(api.get)
+    with app.test_request_context():
+        with pytest.raises(NotFound):
+            method(api, sqlite_session, SimpleNamespace(id="app-1"), UUID(message_id))
 
 
 def test_chat_message_list_rejects_soft_deleted_conversation(app: Flask, sqlite_session: Session) -> None:

--- a/api/tests/unit_tests/controllers/console/app/test_message_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_message_api.py
@@ -9,6 +9,7 @@ import pytest
 from flask import Flask
 from sqlalchemy import event
 from sqlalchemy.orm import Session
+from werkzeug.exceptions import NotFound
 
 from controllers.console.app import message as message_module
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -16,7 +17,9 @@ from models.enums import ConversationFromSource
 from models.model import AppMode, Conversation, Message
 
 
-def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1") -> Message:
+def _persist_conversation(
+    session: Session, *, app_id: str = "app-1", conversation_id: str = "conversation-1"
+) -> Conversation:
     conversation = Conversation(
         app_id=app_id,
         app_model_config_id=None,
@@ -35,7 +38,16 @@ def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1"
         from_end_user_id=None,
         from_account_id="account-1",
     )
-    conversation.id = "conversation-1"
+    conversation.id = conversation_id
+    session.add(conversation)
+    session.flush()
+    return conversation
+
+
+def _persist_message(
+    session: Session, *, message_id: str, app_id: str = "app-1", conversation_id: str = "conversation-1"
+) -> Message:
+    conversation = _persist_conversation(session, app_id=app_id, conversation_id=conversation_id)
     message = Message(
         app_id=app_id,
         conversation_id=conversation.id,
@@ -59,7 +71,7 @@ def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1"
         app_mode=AppMode.CHAT,
     )
     message.id = message_id
-    session.add_all([conversation, message])
+    session.add(message)
     session.flush()
     return message
 
@@ -141,6 +153,24 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
 
     assert result is response_source
     response_source_factory.assert_called_once_with(message, session=session)
+
+
+def test_chat_message_list_rejects_soft_deleted_conversation(app: Flask, sqlite_session: Session) -> None:
+    conversation_id = "550e8400-e29b-41d4-a716-446655440000"
+    conversation = _persist_conversation(sqlite_session, conversation_id=conversation_id)
+    conversation.is_deleted = True
+    sqlite_session.flush()
+
+    api = message_module.ChatMessageListApi()
+    method = unwrap(api.get)
+    with app.test_request_context(query_string={"conversation_id": conversation_id}):
+        with pytest.raises(NotFound):
+            method(
+                api,
+                sqlite_session,
+                SimpleNamespace(id="account-1"),
+                SimpleNamespace(id="app-1", mode=AppMode.CHAT),
+            )
 
 
 def test_message_response_source_uses_caller_session_for_nested_fields(unbound_session: Session) -> None:


### PR DESCRIPTION
## Summary

- exclude soft-deleted conversations from console conversation detail lookups
- prevent message history lookups from returning soft-deleted conversations
- add regression coverage for both console endpoints

Fixes #40976

## Screenshots

Not applicable. This is a backend-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

## Tests

- `uv run --project api pytest -q api/tests/unit_tests/controllers/console/app/test_conversation_api.py api/tests/unit_tests/controllers/console/app/test_message_api.py`
- `uv run --project api ruff check api/controllers/console/app/conversation.py api/controllers/console/app/message.py api/tests/unit_tests/controllers/console/app/test_conversation_api.py api/tests/unit_tests/controllers/console/app/test_message_api.py`
- `uv run --project api ruff format --check api/controllers/console/app/conversation.py api/controllers/console/app/message.py api/tests/unit_tests/controllers/console/app/test_conversation_api.py api/tests/unit_tests/controllers/console/app/test_message_api.py`
