### PR TITLE
fix(api): add missing admin and RBAC permission decorators to OAuth custom-client GET endpoint

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1296,6 +1296,8 @@ class ToolOAuthCustomClient(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
     def get(self, current_tenant_id: str, provider: str):


### PR DESCRIPTION
## Summary

Closes #40944

Add missing `@is_admin_or_owner_required` and `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)` decorators to the GET endpoint:
- `ToolOAuthCustomClient.get` in `api/controllers/console/workspace/tool_providers.py`

## Motivation & Impact

The `POST` and `DELETE` handlers of `ToolOAuthCustomClient` already enforce that only workspace admins/owners or members with the `CREDENTIAL_MANAGE` RBAC permission can manage OAuth custom clients. However, the `GET` endpoint was missing these decorators, allowing normal workspace members to retrieve sensitive OAuth client secrets.

Adding these decorators protects the endpoint and aligns the read handler with the write and delete operations.