### PR TITLE
fix: preserve early workflow events in streams transport

### DIFF
--- a/api/core/app/apps/message_based_app_generator.py
+++ b/api/core/app/apps/message_based_app_generator.py
@@ -321,10 +321,14 @@ class MessageBasedAppGenerator(BaseAppGenerator):
         workflow_run_id: str,
         idle_timeout=300,
         on_subscribe: Callable[[], None] | None = None,
+        *,
+        topic: Topic | None = None,
+        cursor: str | None = None,
     ) -> Generator[Mapping | str, None, None]:
-        topic = cls.get_response_topic(app_mode, workflow_run_id)
+        topic = topic if topic is not None else cls.get_response_topic(app_mode, workflow_run_id)
         return stream_topic_events(
             topic=topic,
             idle_timeout=idle_timeout,
             on_subscribe=on_subscribe,
+            cursor=cursor,
         )

--- a/api/core/app/apps/message_generator.py
+++ b/api/core/app/apps/message_generator.py
@@ -28,12 +28,16 @@ class MessageGenerator:
         ping_interval: float = 10.0,
         on_subscribe: Callable[[], None] | None = None,
         terminal_events: Iterable[str | StreamEvent] | None = None,
+        *,
+        topic: Topic | None = None,
+        cursor: str | None = None,
     ) -> Generator[Mapping | str, None, None]:
-        topic = cls.get_response_topic(app_mode, workflow_run_id)
+        topic = topic if topic is not None else cls.get_response_topic(app_mode, workflow_run_id)
         return stream_topic_events(
             topic=topic,
             idle_timeout=idle_timeout,
             ping_interval=ping_interval,
             on_subscribe=on_subscribe,
             terminal_events=terminal_events,
+            cursor=cursor,
         )

--- a/api/core/app/apps/streaming_utils.py
+++ b/api/core/app/apps/streaming_utils.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Generator, Iterable, Mapping
 from typing import Any
 
 from core.app.entities.task_entities import StreamEvent
-from libs.broadcast_channel.channel import Topic
+from libs.broadcast_channel.channel import CursorTopic, Topic
 from libs.broadcast_channel.exc import SubscriptionClosedError
 
 
@@ -17,6 +17,7 @@ def stream_topic_events(
     ping_interval: float | None = None,
     on_subscribe: Callable[[], None] | None = None,
     terminal_events: Iterable[str | StreamEvent] | None = None,
+    cursor: str | None = None,
 ) -> Generator[Mapping[str, Any] | str, None, None]:
     # send a PING event immediately to prevent the connection staying in pending state for a long time.
     #
@@ -27,7 +28,14 @@ def stream_topic_events(
     terminal_values = _normalize_terminal_events(terminal_events)
     last_msg_time = time.time()
     last_ping_time = last_msg_time
-    with topic.subscribe() as sub:
+    if cursor is None:
+        subscription = topic.subscribe()
+    else:
+        if not isinstance(topic, CursorTopic):
+            raise ValueError("The broadcast topic does not support cursor-based subscriptions")
+        subscription = topic.subscribe(cursor=cursor)
+
+    with subscription as sub:
         # on_subscribe fires only after the Redis subscription is active.
         # This is used to gate task start and reduce pub/sub race for the first event.
         if on_subscribe is not None:

--- a/api/libs/broadcast_channel/channel.py
+++ b/api/libs/broadcast_channel/channel.py
@@ -8,7 +8,7 @@ import types
 from abc import abstractmethod
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
-from typing import Protocol, Self, override
+from typing import Protocol, Self, override, runtime_checkable
 
 
 class Subscription(AbstractContextManager["Subscription"], Protocol):
@@ -115,6 +115,22 @@ class Topic(Producer, Subscriber, Protocol):
     @abstractmethod
     def as_subscriber(self) -> Subscriber:
         """as_subscriber create a read-only view for this topic."""
+        ...
+
+
+@runtime_checkable
+class CursorTopic(Topic, Protocol):
+    """A durable topic that can resume a subscription from a captured cursor."""
+
+    @abstractmethod
+    def latest_cursor(self) -> str:
+        """Return the latest published cursor, or the transport's beginning cursor when empty."""
+        ...
+
+    @override
+    @abstractmethod
+    def subscribe(self, *, cursor: str | None = None) -> Subscription:
+        """Subscribe after ``cursor``; omit it to retain the transport's live-subscription behavior."""
         ...
 
 

--- a/api/libs/broadcast_channel/redis/streams_channel.py
+++ b/api/libs/broadcast_channel/redis/streams_channel.py
@@ -70,16 +70,24 @@ class StreamsTopic:
     def as_subscriber(self) -> Subscriber:
         return self
 
-    def subscribe(self) -> Subscription:
-        return _StreamsSubscription(self._client, self._key)
+    def subscribe(self, *, cursor: str | None = None) -> Subscription:
+        return _StreamsSubscription(self._client, self._key, cursor="$" if cursor is None else cursor)
+
+    def latest_cursor(self) -> str:
+        entries = self._client.xrevrange(self._key, count=1)
+        if not entries:
+            return "0-0"
+        entry_id, _ = entries[0]
+        return entry_id.decode() if isinstance(entry_id, bytes) else str(entry_id)
 
 
 class _StreamsSubscription(Subscription):
     _SENTINEL = object()
 
-    def __init__(self, client: Redis | RedisCluster, key: str):
+    def __init__(self, client: Redis | RedisCluster, key: str, *, cursor: str = "$"):
         self._client = client
         self._key = key
+        self._cursor = cursor
 
         self._queue: queue.Queue[object] = queue.Queue()
 
@@ -104,10 +112,7 @@ class _StreamsSubscription(Subscription):
         # since this method runs in a dedicated thread, acquiring `_lock` inside this method won't cause
         # deadlock.
 
-        # Setting initial last id to `$` to signal redis that we only want new messages.
-        #
-        # ref: https://redis.io/docs/latest/commands/xread/#the-special--id
-        last_id = "$"
+        last_id = self._cursor
         try:
             while True:
                 with self._lock:

--- a/api/services/app_generate_service.py
+++ b/api/services/app_generate_service.py
@@ -23,6 +23,7 @@ from core.app.layers.pause_state_persist_layer import PauseStateLayerConfig
 from core.db import session_factory
 from enums import DeploymentEdition, QuotaType
 from extensions.otel import AppGenerateHandler, trace_span
+from libs.broadcast_channel.channel import CursorTopic, Topic
 from models.model import Account, App, AppMode, EndUser
 from models.workflow import Workflow, WorkflowRun
 from services.errors.app import QuotaExceededError, WorkflowIdFormatError, WorkflowNotFoundError
@@ -45,7 +46,7 @@ class AppGenerateService:
         """
         Build a subscription callback that coordinates when the background task starts.
 
-        - streams transport: start immediately (events are durable; late subscribers can replay).
+        - streams transport: start immediately after the caller captures the topic cursor.
         - pubsub/sharded transport: start on first subscribe, with a short fallback timer so the task
           still runs if the client never connects.
         """
@@ -67,7 +68,6 @@ class AppGenerateService:
 
         channel_type = dify_config.PUBSUB_REDIS_CHANNEL_TYPE
         if channel_type == "streams":
-            # With Redis Streams, we can safely start right away; consumers can read past events.
             _try_start()
 
             # Keep return type Callable[[], None] consistent while allowing an extra (no-op) call.
@@ -86,6 +86,16 @@ class AppGenerateService:
                 timer.cancel()
 
         return _on_subscribe
+
+    @classmethod
+    def _prepare_streaming_task(
+        cls,
+        topic: Topic,
+        start_task: Callable[[], None],
+    ) -> tuple[Callable[[], None], str | None]:
+        """Capture a durable topic's cursor before the task can publish its first event."""
+        cursor = topic.latest_cursor() if isinstance(topic, CursorTopic) else None
+        return cls._build_streaming_task_on_subscribe(start_task), cursor
 
     @classmethod
     @trace_span(AppGenerateHandler)
@@ -255,14 +265,17 @@ class AppGenerateService:
                     def on_subscribe():
                         workflow_based_app_execution_task.delay(payload_json)
 
-                    on_subscribe = cls._build_streaming_task_on_subscribe(on_subscribe)
                     generator = AdvancedChatAppGenerator()
+                    topic = generator.get_response_topic(AppMode.ADVANCED_CHAT, payload.workflow_run_id)
+                    on_subscribe, cursor = cls._prepare_streaming_task(topic, on_subscribe)
                     return rate_limit.generate(
                         generator.convert_to_event_stream(
                             generator.retrieve_events(
                                 AppMode.ADVANCED_CHAT,
                                 payload.workflow_run_id,
                                 on_subscribe=on_subscribe,
+                                topic=topic,
+                                cursor=cursor,
                             ),
                         ),
                         request_id=request_id,
@@ -312,13 +325,16 @@ class AppGenerateService:
                     def on_subscribe():
                         workflow_based_app_execution_task.delay(payload_json)
 
-                    on_subscribe = cls._build_streaming_task_on_subscribe(on_subscribe)
+                    topic = MessageBasedAppGenerator.get_response_topic(AppMode.WORKFLOW, payload.workflow_run_id)
+                    on_subscribe, cursor = cls._prepare_streaming_task(topic, on_subscribe)
                     return rate_limit.generate(
                         WorkflowAppGenerator.convert_to_event_stream(
                             MessageBasedAppGenerator.retrieve_events(
                                 AppMode.WORKFLOW,
                                 payload.workflow_run_id,
                                 on_subscribe=on_subscribe,
+                                topic=topic,
+                                cursor=cursor,
                             ),
                         ),
                         request_id,

--- a/api/services/app_generate_service.py
+++ b/api/services/app_generate_service.py
@@ -94,6 +94,7 @@ class AppGenerateService:
         start_task: Callable[[], None],
     ) -> tuple[Callable[[], None], str | None]:
         """Capture a durable topic's cursor before the task can publish its first event."""
+        # Streams dispatch immediately in `_build_streaming_task_on_subscribe`, so this lookup must happen first.
         cursor = topic.latest_cursor() if isinstance(topic, CursorTopic) else None
         return cls._build_streaming_task_on_subscribe(start_task), cursor
 

--- a/api/tests/unit_tests/libs/broadcast_channel/redis/test_streams_channel_unit_tests.py
+++ b/api/tests/unit_tests/libs/broadcast_channel/redis/test_streams_channel_unit_tests.py
@@ -27,7 +27,7 @@ class FakeStreamsRedis:
         self._store: dict[str, list[tuple[str, dict]]] = {}
         self._next_id: dict[str, int] = {}
         self._expire_calls: dict[str, int] = {}
-        self._dollar_snapshots: dict[str, int] = {}
+        self._condition = threading.Condition()
 
     # Publisher API
     def xadd(self, key: str, fields: dict[str, Any], *, maxlen: int | None = None) -> str:
@@ -35,11 +35,13 @@ class FakeStreamsRedis:
 
         The test double ignores maxlen trimming semantics; only records the entry.
         """
-        n = self._next_id.get(key, 0) + 1
-        self._next_id[key] = n
-        entry_id = f"{n}-0"
-        self._store.setdefault(key, []).append((entry_id, fields))
-        return entry_id
+        with self._condition:
+            n = self._next_id.get(key, 0) + 1
+            self._next_id[key] = n
+            entry_id = f"{n}-0"
+            self._store.setdefault(key, []).append((entry_id, fields))
+            self._condition.notify_all()
+            return entry_id
 
     def expire(self, key: str, seconds: int) -> None:
         self._expire_calls[key] = self._expire_calls.get(key, 0) + 1
@@ -53,26 +55,33 @@ class FakeStreamsRedis:
         # Expect a single key
         assert len(streams) == 1
         key, last_id = next(iter(streams.items()))
-        entries = self._store.get(key, [])
+        with self._condition:
+            entries = self._store.get(key, [])
 
-        # Find position strictly greater than last_id
-        start_idx = 0
-        if last_id == "$":
-            start_idx = self._dollar_snapshots.setdefault(key, len(entries))
-        elif last_id != "0-0":
-            for i, (eid, _f) in enumerate(entries):
-                if eid == last_id:
-                    start_idx = i + 1
-                    break
-        if start_idx >= len(entries):
-            # Simulate blocking wait (bounded) if requested
-            if block and block > 0:
-                time.sleep(min(0.01, block / 1000.0))
-            return []
+            # Find position strictly greater than last_id. Redis resolves `$` at the start of every XREAD.
+            start_idx = 0
+            if last_id == "$":
+                start_idx = len(entries)
+            elif last_id != "0-0":
+                for i, (eid, _f) in enumerate(entries):
+                    if eid == last_id:
+                        start_idx = i + 1
+                        break
 
-        end_idx = len(entries) if count is None else min(len(entries), start_idx + count)
-        batch = entries[start_idx:end_idx]
-        return [(key, batch)]
+            if start_idx >= len(entries) and block is not None:
+                timeout = None if block == 0 else block / 1000.0
+                self._condition.wait_for(
+                    lambda: len(self._store.get(key, [])) > start_idx,
+                    timeout=timeout,
+                )
+                entries = self._store.get(key, [])
+
+            if start_idx >= len(entries):
+                return []
+
+            end_idx = len(entries) if count is None else min(len(entries), start_idx + count)
+            batch = entries[start_idx:end_idx]
+            return [(key, batch)]
 
 
 class FailExpireRedis(FakeStreamsRedis):
@@ -149,6 +158,17 @@ def fake_redis() -> FakeStreamsRedis:
 @pytest.fixture
 def streams_channel(fake_redis: FakeStreamsRedis) -> StreamsBroadcastChannel:
     return StreamsBroadcastChannel(fake_redis, retention_seconds=60)
+
+
+def test_fake_xread_resolves_dollar_on_every_call(fake_redis: FakeStreamsRedis) -> None:
+    key = "stream:dollar"
+    fake_redis.xadd(key, {b"data": b"before-first-read"})
+
+    assert fake_redis.xread({key: "$"}, block=1) == []
+
+    fake_redis.xadd(key, {b"data": b"between-reads"})
+
+    assert fake_redis.xread({key: "$"}, block=1) == []
 
 
 class TestStreamsBroadcastChannel:

--- a/api/tests/unit_tests/libs/broadcast_channel/redis/test_streams_channel_unit_tests.py
+++ b/api/tests/unit_tests/libs/broadcast_channel/redis/test_streams_channel_unit_tests.py
@@ -44,6 +44,10 @@ class FakeStreamsRedis:
     def expire(self, key: str, seconds: int) -> None:
         self._expire_calls[key] = self._expire_calls.get(key, 0) + 1
 
+    def xrevrange(self, key: str, *, count: int | None = None) -> list[tuple[str, dict[str, Any]]]:
+        entries = list(reversed(self._store.get(key, [])))
+        return entries if count is None else entries[:count]
+
     # Consumer API
     def xread(self, streams: dict[str, Any], block: int | None = None, count: int | None = None):
         # Expect a single key
@@ -189,6 +193,18 @@ class TestStreamsBroadcastChannel:
         assert topic.as_producer() is topic
         assert topic.as_subscriber() is topic
 
+    def test_latest_cursor_returns_beginning_for_empty_stream(self, streams_channel: StreamsBroadcastChannel) -> None:
+        topic = streams_channel.topic("empty")
+
+        assert topic.latest_cursor() == "0-0"
+
+    def test_latest_cursor_returns_most_recent_entry(self, streams_channel: StreamsBroadcastChannel) -> None:
+        topic = streams_channel.topic("cursor")
+        topic.publish(b"first")
+        topic.publish(b"second")
+
+        assert topic.latest_cursor() == "2-0"
+
     def test_publish_logs_warning_when_expire_fails(self, caplog: pytest.LogCaptureFixture):
         channel = StreamsBroadcastChannel(FailExpireRedis(), retention_seconds=60)
         topic = channel.topic("expire-warning")
@@ -199,6 +215,19 @@ class TestStreamsBroadcastChannel:
 
 
 class TestStreamsSubscription:
+    def test_explicit_cursor_receives_only_messages_published_after_capture(
+        self,
+        streams_channel: StreamsBroadcastChannel,
+    ) -> None:
+        topic = streams_channel.topic("cursor-subscription")
+        topic.publish(b"previous-invocation")
+        cursor = topic.latest_cursor()
+        topic.publish(b"current-invocation")
+
+        sub = topic.subscribe(cursor=cursor)
+        with sub:
+            assert sub.receive(timeout=0.1) == b"current-invocation"
+
     def test_subscribe_only_receives_messages_published_after_subscription_starts(
         self,
         streams_channel: StreamsBroadcastChannel,

--- a/api/tests/unit_tests/services/test_app_generate_service.py
+++ b/api/tests/unit_tests/services/test_app_generate_service.py
@@ -25,6 +25,7 @@ from pytest_mock import MockerFixture
 import services.app_generate_service as ags_module
 from core.app.entities.app_invoke_entities import InvokeFrom
 from enums import DeploymentEdition, QuotaType
+from libs.broadcast_channel.channel import CursorTopic
 from models.model import AppMode
 from services.app_generate_service import AppGenerateService
 from services.errors.app import WorkflowIdFormatError, WorkflowNotFoundError
@@ -380,6 +381,9 @@ class TestGenerate:
         # so the inner closure (line 165) actually executes.
         monkeypatch.setattr(ags_module.dify_config, "PUBSUB_REDIS_CHANNEL_TYPE", "streams")
         gen_instance = MagicMock()
+        topic = mocker.Mock(spec=CursorTopic)
+        topic.latest_cursor.return_value = "12-0"
+        gen_instance.get_response_topic.return_value = topic
         gen_instance.retrieve_events.return_value = iter([])
         gen_instance.convert_to_event_stream.side_effect = lambda x: x
         mocker.patch(
@@ -397,6 +401,8 @@ class TestGenerate:
         )
         # In streaming mode it should go through retrieve_events, not generate
         gen_instance.retrieve_events.assert_called_once()
+        assert gen_instance.retrieve_events.call_args.kwargs["topic"] is topic
+        assert gen_instance.retrieve_events.call_args.kwargs["cursor"] == "12-0"
         # The inner on_subscribe closure was invoked by _build_streaming_task_on_subscribe
         delay_spy.assert_called_once()
 
@@ -439,6 +445,12 @@ class TestGenerate:
         # Let _build_streaming_task_on_subscribe invoke the real on_subscribe
         # so the inner closure (line 216) actually executes.
         monkeypatch.setattr(ags_module.dify_config, "PUBSUB_REDIS_CHANNEL_TYPE", "streams")
+        topic = mocker.Mock(spec=CursorTopic)
+        topic.latest_cursor.return_value = "34-0"
+        mocker.patch(
+            "services.app_generate_service.MessageBasedAppGenerator.get_response_topic",
+            return_value=topic,
+        )
         retrieve_spy = mocker.patch(
             "services.app_generate_service.MessageBasedAppGenerator.retrieve_events",
             return_value=iter([]),
@@ -457,6 +469,8 @@ class TestGenerate:
             session=MagicMock(),
         )
         retrieve_spy.assert_called_once()
+        assert retrieve_spy.call_args.kwargs["topic"] is topic
+        assert retrieve_spy.call_args.kwargs["cursor"] == "34-0"
         # The inner on_subscribe closure was invoked by _build_streaming_task_on_subscribe
         delay_spy.assert_called_once()
 

--- a/api/tests/unit_tests/services/test_app_generate_service_streaming_integration.py
+++ b/api/tests/unit_tests/services/test_app_generate_service_streaming_integration.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import uuid
 from collections import defaultdict, deque
 from typing import Any
@@ -60,39 +61,64 @@ class _FakeStreams:
         # key -> list[(id, {field: value})]
         self._data: dict[str, list[tuple[str, dict]]] = defaultdict(list)
         self._seq: dict[str, int] = defaultdict(int)
-        self._dollar_snapshots: dict[str, int] = {}
+        self._condition = threading.Condition()
 
     def xadd(self, key: str, fields: dict[str, Any], *, maxlen: int | None = None) -> str:
         # maxlen is accepted for API compatibility with redis-py; ignored in this test double
-        self._seq[key] += 1
-        eid = f"{self._seq[key]}-0"
-        self._data[key].append((eid, fields))
-        return eid
+        with self._condition:
+            self._seq[key] += 1
+            eid = f"{self._seq[key]}-0"
+            self._data[key].append((eid, fields))
+            self._condition.notify_all()
+            return eid
 
     def expire(self, key: str, seconds: int) -> None:
         # no-op for tests
         return None
 
     def xrevrange(self, key: str, *, count: int | None = None) -> list[tuple[str, dict[str, Any]]]:
-        entries = list(reversed(self._data.get(key, [])))
-        return entries if count is None else entries[:count]
+        with self._condition:
+            entries = list(reversed(self._data.get(key, [])))
+            return entries if count is None else entries[:count]
 
     def xread(self, streams: dict[str, Any], block: int | None = None, count: int | None = None):
         assert len(streams) == 1
         key, last_id = next(iter(streams.items()))
-        entries = self._data.get(key, [])
-        start = 0
-        if last_id == "$":
-            start = self._dollar_snapshots.setdefault(key, len(entries))
-        elif last_id != "0-0":
-            for i, (eid, _f) in enumerate(entries):
-                if eid == last_id:
-                    start = i + 1
-                    break
-        if start >= len(entries):
-            return []
-        end = len(entries) if count is None else min(len(entries), start + count)
-        return [(key, entries[start:end])]
+        with self._condition:
+            entries = self._data.get(key, [])
+            start = 0
+            if last_id == "$":
+                start = len(entries)
+            elif last_id != "0-0":
+                for i, (eid, _f) in enumerate(entries):
+                    if eid == last_id:
+                        start = i + 1
+                        break
+
+            if start >= len(entries) and block is not None:
+                timeout = None if block == 0 else block / 1000.0
+                self._condition.wait_for(
+                    lambda: len(self._data.get(key, [])) > start,
+                    timeout=timeout,
+                )
+                entries = self._data.get(key, [])
+
+            if start >= len(entries):
+                return []
+            end = len(entries) if count is None else min(len(entries), start + count)
+            return [(key, entries[start:end])]
+
+
+def test_fake_streams_xread_resolves_dollar_on_every_call() -> None:
+    fake = _FakeStreams()
+    key = "stream:dollar"
+    fake.xadd(key, {b"data": b"before-first-read"})
+
+    assert fake.xread({key: "$"}, block=1) == []
+
+    fake.xadd(key, {b"data": b"between-reads"})
+
+    assert fake.xread({key: "$"}, block=1) == []
 
 
 @pytest.fixture

--- a/api/tests/unit_tests/services/test_app_generate_service_streaming_integration.py
+++ b/api/tests/unit_tests/services/test_app_generate_service_streaming_integration.py
@@ -60,6 +60,7 @@ class _FakeStreams:
         # key -> list[(id, {field: value})]
         self._data: dict[str, list[tuple[str, dict]]] = defaultdict(list)
         self._seq: dict[str, int] = defaultdict(int)
+        self._dollar_snapshots: dict[str, int] = {}
 
     def xadd(self, key: str, fields: dict[str, Any], *, maxlen: int | None = None) -> str:
         # maxlen is accepted for API compatibility with redis-py; ignored in this test double
@@ -72,12 +73,18 @@ class _FakeStreams:
         # no-op for tests
         return None
 
+    def xrevrange(self, key: str, *, count: int | None = None) -> list[tuple[str, dict[str, Any]]]:
+        entries = list(reversed(self._data.get(key, [])))
+        return entries if count is None else entries[:count]
+
     def xread(self, streams: dict[str, Any], block: int | None = None, count: int | None = None):
         assert len(streams) == 1
         key, last_id = next(iter(streams.items()))
         entries = self._data.get(key, [])
         start = 0
-        if last_id != "0-0":
+        if last_id == "$":
+            start = self._dollar_snapshots.setdefault(key, len(entries))
+        elif last_id != "0-0":
             for i, (eid, _f) in enumerate(entries):
                 if eid == last_id:
                     start = i + 1
@@ -145,10 +152,18 @@ def test_streams_full_flow_prepublish_and_replay():
     def start_task():
         _publish_events(app_mode, run_id, events)
 
-    on_subscribe = AppGenerateService._build_streaming_task_on_subscribe(start_task)
+    topic = MessageGenerator.get_response_topic(app_mode, run_id)
+    on_subscribe, cursor = AppGenerateService._prepare_streaming_task(topic, start_task)
 
-    # Start retrieving BEFORE subscription is established; in streams mode, we also started immediately
-    gen = MessageGenerator.retrieve_events(app_mode, run_id, idle_timeout=2.0, on_subscribe=on_subscribe)
+    # The task starts before subscription, but the captured cursor replays only this invocation's events.
+    gen = MessageGenerator.retrieve_events(
+        app_mode,
+        run_id,
+        idle_timeout=2.0,
+        on_subscribe=on_subscribe,
+        topic=topic,
+        cursor=cursor,
+    )
 
     received = []
     for msg in gen:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #40948.

Redis Streams subscriptions currently start from `$`, while streaming workflow tasks are enqueued before the listener performs its first `XREAD`. A fast worker can therefore publish `workflow_started` and early node events before `$` is resolved, causing those events to be skipped even though they remain stored in Redis.

This PR captures the stream tip before dispatching a fresh workflow task and uses it as that subscription's starting cursor. Subscriptions without an explicit cursor continue to default to `$`, preserving the live-only behavior introduced to avoid replaying stale `workflow_paused` events in #34040.

Changes include:

- Add a cursor-capable topic protocol and per-subscription starting cursors for Redis Streams.
- Treat a missing or empty stream as cursor `0-0`, since workflow streams are created lazily by the first `XADD`.
- Capture the stream tip before Celery task dispatch for fresh Workflow and Advanced Chat runs.
- Pass the captured topic and cursor through the event generator to the final Streams subscription.
- Correct the Streams test double so `$` only observes entries appended after the initial read.
- Add regression coverage for explicit cursors while retaining coverage for the default `$` behavior.

Validation:

- `uv run --project api pytest -q api/tests/unit_tests/libs/broadcast_channel/redis/test_streams_channel_unit_tests.py api/tests/unit_tests/services/test_app_generate_service_streaming_integration.py api/tests/unit_tests/services/test_app_generate_service.py` — 71 passed.
- Focused Ruff checks passed for all changed files.
- Ruff format checks passed for all changed files.
- Focused Pyrefly checks passed for all changed production files.
- Docker-backed integration tests were not run locally because they are CI-only.

## Screenshots

N/A — backend event-delivery fix.

## Checklist

- [ ] This change requires a documentation update, included: [[Dify Document](https://github.com/langgenius/dify-docs)](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods