### PR TITLE
feat(cli): add intent-based command search

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -48,11 +48,13 @@ Background docs: `difyctl help account`, `difyctl help external`, `difyctl help 
 Run `difyctl --help` for the full list of commands.
 Run `difyctl <cmd> --help` for per-command reference.
 
-For agents (and scripting), start with `difyctl help agent` — the cross-command operating guide (output, discovery, auth, exit codes, errors, HITL, retry). Every help surface is also machine-readable: `difyctl help -o json` dumps the whole command tree plus the global contract (exit codes, output formats, error envelope, HITL protocol), and `difyctl <cmd> --help -o json` returns one command's descriptor.
+Use `difyctl search "<intent>" -o json` to find candidate commands, then inspect the selected command with `difyctl help <path> -o json` before running it.
+
+For agents (and scripting), start with `difyctl help agent` — the cross-command operating guide (output, discovery, auth, exit codes, errors, HITL, retry). Every help surface is also machine-readable: `difyctl help -o json` dumps the whole command tree plus the global contract (exit codes, output formats, error envelope, HITL protocol), and `difyctl help <path> -o json` returns one command's descriptor.
 
 ## Agent skill
 
-`difyctl skills install` installs a single, pure-delegation `SKILL.md` into your local agents so they auto-load it. The skill does not freeze the command set — it points the agent at `difyctl help -o json` for the live surface, so it never drifts from your binary. It is embedded in the binary (version-stamped) rather than checked in.
+`difyctl skills install` installs a single, pure-delegation `SKILL.md` into your local agents so they auto-load it. The skill does not freeze the command set — it directs the agent through live `search` results and per-command help, so it never drifts from your binary. It is embedded in the binary (version-stamped) rather than checked in.
 
 - `difyctl skills install` — dry-run: detect installed agents (Claude Code, Codex, opencode, Cursor, pi) and print where the skill would land. Writes nothing.
 - `difyctl skills install --yes` — write to every detected agent, printing each path. `--agent claude-code[,cursor]` restricts to a subset; `<dir>` forces one explicit directory (handy when your agent isn't detected).

--- a/cli/src/commands/search/index.ts
+++ b/cli/src/commands/search/index.ts
@@ -1,0 +1,82 @@
+import type { SearchDocument, SearchResult } from './search'
+import type { TableCell, TableColumn } from '@/framework/output'
+import { DifyCommand } from '@/commands/_shared/dify-command'
+import { Args, Flags } from '@/framework/flags'
+import { describeCommand } from '@/framework/help'
+import { OutputFormat, table } from '@/framework/output'
+import { collectCommands } from '@/framework/registry'
+import { searchCommands } from './search'
+
+const SEARCH_COLUMNS: readonly TableColumn[] = [
+  { name: 'PATH', priority: 0 },
+  { name: 'DESCRIPTION', priority: 0 },
+  { name: 'EFFECT', priority: 0 },
+  { name: 'SCORE', priority: 0 },
+]
+
+class SearchOutput {
+  readonly results: readonly SearchResult[]
+
+  constructor(results: readonly SearchResult[]) {
+    this.results = results
+  }
+
+  tableColumns(): readonly TableColumn[] {
+    return SEARCH_COLUMNS
+  }
+
+  tableRows(): readonly (readonly TableCell[])[] {
+    return this.results.map((result) => [
+      result.path,
+      result.description,
+      result.effect,
+      result.score,
+    ])
+  }
+
+  json(): { results: readonly SearchResult[] } {
+    return { results: this.results }
+  }
+}
+
+export default class Search extends DifyCommand {
+  static override description = 'Find commands by intent using the live help metadata'
+
+  static override examples = [
+    '<%= config.bin %> search "export an app"',
+    '<%= config.bin %> search "export an app" -o json',
+  ]
+
+  static override args = {
+    intent: Args.string({ description: 'intent to match against command help', required: true }),
+  }
+
+  static override flags = {
+    output: Flags.outputFormat({
+      options: [OutputFormat.JSON, OutputFormat.YAML],
+      default: '',
+    }),
+  }
+
+  async run(argv: string[]) {
+    const { args, flags } = this.parse(Search, argv)
+    const { commandTree } = await import('@/commands/tree.generated')
+    const documents: SearchDocument[] = collectCommands(commandTree)
+      .filter(({ path }) => path.join(' ') !== 'search')
+      .map(({ command, path }) => {
+        const descriptor = describeCommand(command, path.join(' '))
+        return {
+          path: descriptor.command,
+          description: descriptor.description,
+          effect: descriptor.effect,
+          flags: descriptor.flags,
+          agentGuide: descriptor.agentGuide,
+        }
+      })
+
+    return table({
+      format: flags.output,
+      data: new SearchOutput(searchCommands(args.intent, documents)),
+    })
+  }
+}

--- a/cli/src/commands/search/search.test.ts
+++ b/cli/src/commands/search/search.test.ts
@@ -1,0 +1,64 @@
+import type { SearchDocument } from './search'
+import { describe, expect, it } from 'vite-plus/test'
+import { searchCommands } from './search'
+
+const DOCUMENTS: readonly SearchDocument[] = [
+  {
+    path: 'export studio-app',
+    description: "Export a studio app's DSL configuration as YAML",
+    effect: 'read',
+    flags: [{ name: 'include-secret', description: 'include encrypted secret values' }],
+    agentGuide: 'Back up an app definition and recreate it elsewhere.',
+  },
+  {
+    path: 'get app',
+    description: "List apps or describe one app's basic info",
+    effect: 'read',
+    flags: [{ name: 'workspace', description: 'workspace ID' }],
+    agentGuide: 'List apps to find ids and modes before running one.',
+  },
+  {
+    path: 'run app',
+    description: 'Run an app and print the response',
+    effect: 'write',
+    flags: [{ name: 'inputs', description: 'structured app inputs' }],
+    agentGuide: 'Run an app with its input schema.',
+  },
+]
+
+describe('searchCommands', () => {
+  it('ranks path matches above descriptive matches and folds simple plurals', () => {
+    const results = searchCommands('export apps', DOCUMENTS)
+
+    expect(results[0]).toEqual({
+      path: 'export studio-app',
+      description: "Export a studio app's DSL configuration as YAML",
+      effect: 'read',
+      score: 8,
+    })
+    expect(results.findIndex(({ path }) => path === 'get app')).toBeGreaterThan(0)
+  })
+
+  it('uses flag and guide tokens without counting repeated words', () => {
+    const results = searchCommands('encrypted recreate', DOCUMENTS)
+
+    expect(results).toEqual([
+      {
+        path: 'export studio-app',
+        description: "Export a studio app's DSL configuration as YAML",
+        effect: 'read',
+        score: 2,
+      },
+    ])
+  })
+
+  it('breaks equal scores by path', () => {
+    const results = searchCommands('app', DOCUMENTS)
+
+    expect(results.map(({ path }) => path)).toEqual(['export studio-app', 'get app', 'run app'])
+  })
+
+  it('returns no candidates for an intent without searchable tokens', () => {
+    expect(searchCommands('---', DOCUMENTS)).toEqual([])
+  })
+})

--- a/cli/src/commands/search/search.ts
+++ b/cli/src/commands/search/search.ts
@@ -1,0 +1,77 @@
+type SearchEffect = 'read' | 'write' | 'destructive'
+
+export type SearchDocument = {
+  readonly path: string
+  readonly description: string | null
+  readonly effect: SearchEffect
+  readonly flags: readonly {
+    readonly name: string
+    readonly description: string
+  }[]
+  readonly agentGuide: string | null
+}
+
+export type SearchResult = {
+  readonly path: string
+  readonly description: string | null
+  readonly effect: SearchEffect
+  readonly score: number
+}
+
+const PATH_WEIGHT = 4
+const DESCRIPTION_WEIGHT = 2
+const DETAIL_WEIGHT = 1
+
+function normalizeToken(token: string): string {
+  if (token.length > 3 && token.endsWith('s') && !/(?:is|ss|us)$/.test(token))
+    return token.slice(0, -1)
+
+  return token
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set((value.toLowerCase().match(/[a-z0-9]+/g) ?? []).map(normalizeToken))
+}
+
+function documentScore(query: ReadonlySet<string>, document: SearchDocument): number {
+  const path = tokenize(document.path)
+  const description = tokenize(document.description ?? '')
+  const details = tokenize(
+    [
+      ...document.flags.flatMap((flag) => [flag.name, flag.description]),
+      document.agentGuide ?? '',
+    ].join(' '),
+  )
+
+  let score = 0
+  for (const token of query) {
+    if (path.has(token)) score += PATH_WEIGHT
+    else if (description.has(token)) score += DESCRIPTION_WEIGHT
+    else if (details.has(token)) score += DETAIL_WEIGHT
+  }
+
+  return score
+}
+
+export function searchCommands(
+  intent: string,
+  documents: readonly SearchDocument[],
+): SearchResult[] {
+  const query = tokenize(intent)
+  if (query.size === 0) return []
+
+  return documents
+    .map((document) => ({ document, score: documentScore(query, document) }))
+    .filter(({ score }) => score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        (a.document.path < b.document.path ? -1 : a.document.path > b.document.path ? 1 : 0),
+    )
+    .map(({ document, score }) => ({
+      path: document.path,
+      description: document.description,
+      effect: document.effect,
+      score,
+    }))
+}

--- a/cli/src/commands/tree.generated.ts
+++ b/cli/src/commands/tree.generated.ts
@@ -24,6 +24,7 @@ import GetWorkspace from '@/commands/get/workspace/index'
 import ImportStudioApp from '@/commands/import/studio-app/index'
 import ResumeApp from '@/commands/resume/app/index'
 import RunApp from '@/commands/run/app/index'
+import Search from '@/commands/search/index'
 import SetMember from '@/commands/set/member/index'
 import SkillsInstall from '@/commands/skills/install/index'
 import UseAccount from '@/commands/use/account/index'
@@ -102,6 +103,7 @@ export const commandTree: CommandTree = {
       app: { command: RunApp, subcommands: {} },
     },
   },
+  search: { command: Search, subcommands: {} },
   set: {
     subcommands: {
       member: { command: SetMember, subcommands: {} },

--- a/cli/src/help/skill-template.ts
+++ b/cli/src/help/skill-template.ts
@@ -1,15 +1,3 @@
-// The difyctl agent skill, in full — one hand-authored, pure-delegation file.
-//
-// It inlines NO command list, NO flag list, and ships no reference files. The
-// command surface is discovered at runtime via `difyctl help -o json`, so this
-// template has nothing to derive from the binary and nothing that can drift
-// from it. `{{VERSION}}` is the only substitution; it is filled at emit time by
-// renderSkill() in ./skill.
-//
-// RED LINE: keep this pure delegation. The moment a command or flag listing is
-// added here, the embedded static copy can fall out of sync with the command
-// surface — at which point it must instead be generated from the command model
-// with a snapshot test (see SKILL-SPEC.md §10, decision D2).
 export const SKILL_TEMPLATE = `---
 name: difyctl
 description: Drive the difyctl CLI to manage Dify apps, workspaces, members and runs. Use when the task involves difyctl or operating a Dify instance from the command line.
@@ -20,10 +8,21 @@ description: Drive the difyctl CLI to manage Dify apps, workspaces, members and 
 difyctl is self-describing — do not guess commands.
 
 ## Discover the command surface
-Run \`difyctl help -o json\` for the version-current map: every command
-(args, flags, examples, \`effect\`) plus the global \`contract\` (exit codes,
-output formats, error envelope, HITL protocol). Treat that JSON as the
-source of truth; this file only bootstraps you into it.
+1. Find candidates:
+   \`difyctl search "<intent>" -o json\`
+   Treat hits as candidates only — do not execute from this output.
+2. Inspect the chosen command:
+   \`difyctl help <path> -o json\`
+   Expand a multi-token path as separate shell arguments; never quote the
+   entire returned path.
+   That JSON is the source of truth for args, flags, examples, \`effect\`,
+   and \`agentGuide\`.
+
+When the task depends on global exit codes, error envelopes, HITL, or retry
+semantics, read \`difyctl help agent\`.
+
+Only when search returns no viable candidate, fall back to
+\`difyctl help -o json\`. Do not run the full sitemap after useful search results.
 
 ## The one non-obvious thing: HITL pauses are not failures
 A run can pause for human input. It exits with **code 0** and emits a
@@ -31,8 +30,8 @@ A run can pause for human input. It exits with **code 0** and emits a
 Resume as the payload instructs (see \`difyctl resume app --help\`).
 
 ## Before any write/destructive action
-Check the command's \`effect\` (\`read\` / \`write\` / \`destructive\`) in
-\`difyctl help -o json\` before running it.
+Never execute a write/destructive candidate from search output. Treat the
+inspected command's \`effect\` as the confirmation gate before running it.
 
 ---
 difyctl skill v{{VERSION}} — if \`difyctl version\` differs, re-run

--- a/cli/src/help/skill.test.ts
+++ b/cli/src/help/skill.test.ts
@@ -5,9 +5,7 @@ import { versionInfo } from '@/version/info'
 import { renderSkill } from './skill'
 import { SKILL_TEMPLATE } from './skill-template'
 
-// Self-references the skill is allowed to name — operational pointers, not a
-// command listing. Everything else must be discovered via `help -o json`.
-const SELF_REFERENCES = new Set(['resume app', 'skills install', 'version'])
+const SELF_REFERENCES = new Set(['resume app', 'search', 'skills install', 'version'])
 
 describe('renderSkill', () => {
   it('substitutes the version stamp and changes nothing else', () => {
@@ -25,8 +23,12 @@ describe('renderSkill', () => {
     expect(renderSkill({ version: versionInfo.version })).not.toContain('{{')
   })
 
-  it('points at the machine-readable surface instead of inlining it', () => {
-    expect(renderSkill({ version: versionInfo.version })).toContain('difyctl help -o json')
+  it('uses search then per-command help while retaining the troubleshooting sitemap', () => {
+    const skill = renderSkill({ version: versionInfo.version })
+    expect(skill).toContain('difyctl search "<intent>" -o json')
+    expect(skill).toContain('difyctl help <path> -o json')
+    expect(skill).toContain('difyctl help agent')
+    expect(skill).toContain('difyctl help -o json')
   })
 
   it('enumerates no command from the tree (zero drift surface)', () => {

--- a/cli/src/help/skill.ts
+++ b/cli/src/help/skill.ts
@@ -4,11 +4,6 @@ export type RenderSkillOptions = {
   readonly version: string
 }
 
-// Renders the difyctl SKILL.md by substituting only the version stamp into the
-// hand-authored, pure-delegation template. There is no command-tree walk: the
-// skill points agents at `difyctl help -o json` for the live command surface
-// rather than enumerating it, so there is nothing to derive and nothing to
-// drift. The single file is what `skills install` writes / prints.
 export function renderSkill(opts: RenderSkillOptions): string {
   return SKILL_TEMPLATE.replaceAll('{{VERSION}}', opts.version)
 }

--- a/cli/src/help/topics.test.ts
+++ b/cli/src/help/topics.test.ts
@@ -43,6 +43,8 @@ describe('agent topic', () => {
     expect(out).toContain('-o json')
     expect(out).toContain('EXIT CODES')
     expect(out).toContain('DIFY_TOKEN')
+    expect(out).toContain('difyctl search "<intent>" -o json')
+    expect(out).toContain('difyctl help <path> -o json')
     expect(out).toContain('difyctl help -o json')
     expect(out).toContain('HUMAN-IN-THE-LOOP')
   })

--- a/cli/src/help/topics.ts
+++ b/cli/src/help/topics.ts
@@ -87,9 +87,10 @@ APP vs STUDIO-APP
   noun supports.
 
 DISCOVERY
-  difyctl help -o json        full command tree + this contract, machine-readable
-  difyctl get app -o json     list apps (ids + modes)
-  difyctl describe app <id>   one app's mode and input schema
+  difyctl search "<intent>" -o json   find candidate commands by intent
+  difyctl help <path> -o json         inspect one candidate before running it
+  difyctl help -o json                full command tree + contract for troubleshooting
+  difyctl describe app <id>           one app's mode and input schema
 
 AUTH
   Interactive:     difyctl auth login         (browser device flow)

--- a/cli/test/e2e/suites/agent/agent-skill-workflow.e2e.ts
+++ b/cli/test/e2e/suites/agent/agent-skill-workflow.e2e.ts
@@ -3,7 +3,7 @@
  *
  * Scenario: an AI agent has loaded difyctl SKILL.md and drives difyctl to:
  *   1. Bootstrap  - read SKILL.md via `skills install --stdout`
- *   2. Discover   - `help -o json` for full command surface + contract
+ *   2. Discover   - `search` for candidates, then per-command help
  *   3. Auth check - no token → exit 4 + JSON error envelope
  *   4. Discover apps    - `get app -o json`
  *   5. Describe app     - `describe app <id> -o json`
@@ -14,7 +14,7 @@
  *  10. Pipeline safety  - no ANSI/spinner, stdout/stderr separation
  *
  * PRD: §3 Agent-Driven, §5 Agent onboarding, Req 1.3/2.1/2.3/3.1-3.3
- * Agent Skills PRD: §4/§5.2 SKILL.md → help -o json discovery pattern
+ * Agent Skills PRD: §4/§5.2 SKILL.md → live command discovery
  *
  * Groups 1-3, 9: no auth required (local mode compatible)
  * Groups 4-8, 10: require DIFY_E2E_TOKEN / staging — wrapped with optionalIt
@@ -45,13 +45,15 @@ const itWithWorkflow = optionalIt(Boolean(E.token) && Boolean(E.workflowAppId))
 const itWithHitl = optionalIt(Boolean(E.token) && Boolean(E.hitlAppId))
 
 // ---------------------------------------------------------------------------
-// 1 + 2. Skill bootstrap → help -o json discovery
+// 1 + 2. Skill bootstrap → search → per-command help
 // ---------------------------------------------------------------------------
 
 describe('E2E / agent skill — bootstrap + discovery (no auth)', () => {
-  it('[P0] SKILL.md contains `difyctl help -o json` as the discovery entry point', async () => {
+  it('[P0] SKILL.md directs agents through search and per-command help', async () => {
     const r = await run(['skills', 'install', '--stdout'])
     expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain('difyctl search "<intent>" -o json')
+    expect(r.stdout).toContain('difyctl help <path> -o json')
     expect(r.stdout).toContain('difyctl help -o json')
   })
 
@@ -61,7 +63,7 @@ describe('E2E / agent skill — bootstrap + discovery (no auth)', () => {
     const { commands } = JSON.parse(helpR.stdout) as { commands: Array<{ command: string }> }
     const skillR = await run(['skills', 'install', '--stdout'])
     expect(skillR.exitCode).toBe(0)
-    const ALLOWED = new Set(['resume app', 'skills install', 'version'])
+    const ALLOWED = new Set(['resume app', 'search', 'skills install', 'version'])
     for (const { command } of commands) {
       if (ALLOWED.has(command)) continue
       expect(skillR.stdout, `skill must not enumerate "${command}"`).not.toContain(command)
@@ -100,6 +102,19 @@ describe('E2E / agent skill — bootstrap + discovery (no auth)', () => {
     expect(map.topics.map((t: { name: string }) => t.name)).toEqual(
       expect.arrayContaining(['account', 'agent', 'environment', 'external']),
     )
+  })
+
+  it('[P0] search ranks the intended command and returns candidate metadata only', async () => {
+    const r = await run(['search', 'export app', '-o', 'json'])
+    expect(r.exitCode).toBe(0)
+    assertPipeFriendlyJson(r)
+    const parsed = JSON.parse(r.stdout) as {
+      results: Array<Record<string, unknown>>
+    }
+    expect(parsed.results[0]).toMatchObject({ path: 'export studio-app', effect: 'read' })
+    expect(parsed.results.some(({ path }) => path === 'search')).toBe(false)
+    expect(parsed.results.some(({ flags }) => flags !== undefined)).toBe(false)
+    expect(parsed.results.some(({ agentGuide }) => agentGuide !== undefined)).toBe(false)
   })
 
   it('[P0] every command in help -o json has args, flags, examples arrays', async () => {


### PR DESCRIPTION
## Summary

- add `difyctl search "<intent>"` over live command help metadata
- update the Agent Skill to discover candidates with search and verify them with per-command help
- cover ranking, generated registry wiring, Skill guidance, and agent workflow behavior

Issue: none; this draft is opened for maintainer discussion.

## Screenshots

Not applicable — CLI-only change.

## Checklist

- [x] Documentation is updated in `cli/README.md`.
- [x] I understand this PR may be closed without prior discussion or an assigned issue.
- [x] Tests cover each introduced behavior and the change is atomic.
- [x] `pnpm tree:check`, `pnpm test`, local agent-workflow E2E, `pnpm build`, and staged-path `vp check` passed.

Fixes #41035