### PR TITLE
fix(api): enforce dataset document ownership

### DIFF
--- a/api/controllers/console/datasets/datasets_segments.py
+++ b/api/controllers/console/datasets/datasets_segments.py
@@ -631,12 +631,16 @@ class DatasetDocumentSegmentBatchImportApi(Resource):
     ):
         # check dataset
         dataset_id_str = str(dataset_id)
-        dataset = DatasetService.get_dataset(dataset_id_str, session)
+        dataset = DatasetService.get_dataset_for_tenant(dataset_id_str, current_tenant_id, session=session)
         if not dataset:
             raise NotFound("Dataset not found.")
+
         # check document
         document_id_str = str(document_id)
-        document = DocumentService.get_document(dataset_id_str, document_id_str, session=session)
+        document_ref = DatasetRefService.create_document_ref_from_id(
+            DatasetRefService.create_dataset_ref(dataset), document_id_str
+        )
+        document = DatasetRefService.get_document_by_ref(document_ref, session=session)
         if not document:
             raise NotFound("Document not found.")
 

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
@@ -587,17 +587,20 @@ class TestDatasetDocumentSegmentBatchImportApi:
             used=False,
         )
         user = MagicMock(id="u1")
+        dataset = MagicMock(id="ds-1", tenant_id="tenant-1")
         session = MagicMock()
         session.scalar.return_value = upload_file
         with (
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
             patch(
-                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=MagicMock()
-            ),
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=dataset,
+            ) as get_dataset_for_tenant,
             patch(
-                "controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=MagicMock()
-            ),
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=MagicMock(),
+            ) as get_document_by_ref,
             patch("controllers.console.datasets.datasets_segments.redis_client.setnx", return_value=True),
             patch(
                 "controllers.console.datasets.datasets_segments.batch_create_segment_to_index_task.delay",
@@ -609,6 +612,11 @@ class TestDatasetDocumentSegmentBatchImportApi:
             )
         assert status == 200
         assert response["job_status"] == "waiting"
+        get_dataset_for_tenant.assert_called_once_with("ds-1", "tenant-1", session=session)
+        document_ref = get_document_by_ref.call_args.args[0]
+        assert document_ref.dataset.tenant_id == "tenant-1"
+        assert document_ref.dataset.dataset_id == "ds-1"
+        assert document_ref.document_id == "doc-1"
 
     def test_post_dataset_not_found(self, app: Flask):
         api = DatasetDocumentSegmentBatchImportApi()
@@ -620,7 +628,10 @@ class TestDatasetDocumentSegmentBatchImportApi:
         with (
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
-            patch("controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=None),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=None,
+            ),
         ):
             with pytest.raises(NotFound):
                 method(
@@ -644,9 +655,13 @@ class TestDatasetDocumentSegmentBatchImportApi:
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
             patch(
-                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=MagicMock()
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=MagicMock(),
             ),
-            patch("controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=None),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=None,
+            ),
         ):
             with pytest.raises(NotFound):
                 method(
@@ -670,10 +685,12 @@ class TestDatasetDocumentSegmentBatchImportApi:
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
             patch(
-                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=MagicMock()
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=MagicMock(),
             ),
             patch(
-                "controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=MagicMock()
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=MagicMock(),
             ),
         ):
             with pytest.raises(NotFound):
@@ -694,10 +711,12 @@ class TestDatasetDocumentSegmentBatchImportApi:
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
             patch(
-                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=MagicMock()
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=MagicMock(),
             ),
             patch(
-                "controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=MagicMock()
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=MagicMock(),
             ),
         ):
             with pytest.raises(ValueError):
@@ -718,10 +737,12 @@ class TestDatasetDocumentSegmentBatchImportApi:
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
             patch(
-                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=MagicMock()
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=MagicMock(),
             ),
             patch(
-                "controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=MagicMock()
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=MagicMock(),
             ),
             patch(
                 "controllers.console.datasets.datasets_segments.redis_client.setnx", side_effect=Exception("redis down")
@@ -1155,8 +1176,14 @@ class TestSegmentOperationCases:
         with (
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
-            patch("controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=dataset),
-            patch("controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=None),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=dataset,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=None,
+            ),
         ):
             with pytest.raises(NotFound):
                 method(
@@ -1183,8 +1210,14 @@ class TestSegmentOperationCases:
         with (
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
-            patch("controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=dataset),
-            patch("controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=document),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=dataset,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=document,
+            ),
         ):
             with pytest.raises(NotFound):
                 method(
@@ -1217,11 +1250,13 @@ class TestSegmentOperationCases:
         with (
             app.test_request_context("/", json=payload),
             patch.object(type(console_ns), "payload", payload),
-            patch("controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=dataset),
-            patch("controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=document),
             patch(
-                "controllers.console.datasets.datasets_segments.DatasetService.check_dataset_permission",
-                return_value=None,
+                "controllers.console.datasets.datasets_segments.DatasetService.get_dataset_for_tenant",
+                return_value=dataset,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetRefService.get_document_by_ref",
+                return_value=document,
             ),
             patch(
                 "controllers.console.datasets.datasets_segments.batch_create_segment_to_index_task.delay",


### PR DESCRIPTION
## Summary

- Scope Dataset lookup to the current tenant for dataset segment batch imports.
- Resolve the Document through the existing ownership-bound reference to enforce both tenant and Dataset ownership.
- Related issue: [FPRD-123](https://linear.app/dify/issue/FPRD-123/datasets-batch-import-%E6%8E%A5%E5%8F%A3%E8%B7%A8%E7%A7%9F%E6%88%B7%E5%86%99%E5%85%A5)

## Screenshots

Not applicable.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods