### PR TITLE
refactor(web): migrate signup email field

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -5189,11 +5189,6 @@
       "count": 1
     }
   },
-  "web/app/signup/components/input-mail.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/signup/layout.tsx": {
     "typescript/no-explicit-any": {
       "count": 1

--- a/web/app/signup/components/input-mail.spec.tsx
+++ b/web/app/signup/components/input-mail.spec.tsx
@@ -6,7 +6,7 @@ import { useLocale } from '@/context/i18n'
 import { useSearchParams } from '@/next/navigation'
 import { useSendMail } from '@/service/use-common'
 import { renderWithConsoleQuery } from '@/test/console/query-data'
-import Form from './input-mail'
+import SignupEmailForm from './input-mail'
 
 const mockSubmitMail = vi.fn()
 const mockOnSuccess = vi.fn()
@@ -61,7 +61,7 @@ const renderForm = ({
     mutateAsync: mockSubmitMail,
     isPending,
   } as unknown as UseSendMailResult)
-  return renderWithConsoleQuery(<Form onSuccess={mockOnSuccess} />, {
+  return renderWithConsoleQuery(<SignupEmailForm onSuccess={mockOnSuccess} />, {
     systemFeatures: { branding: { enabled: brandingEnabled } },
   })
 }

--- a/web/app/signup/components/input-mail.tsx
+++ b/web/app/signup/components/input-mail.tsx
@@ -1,11 +1,13 @@
 'use client'
 import type { MailSendResponse } from '@/service/use-common'
 import { Button } from '@langgenius/dify-ui/button'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Form } from '@langgenius/dify-ui/form'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import Split from '@/app/signin/split'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -17,7 +19,7 @@ import { useSendMail } from '@/service/use-common'
 type Props = {
   onSuccess: (email: string, payload: string) => void
 }
-export default function Form({ onSuccess }: Props) {
+export default function SignupEmailForm({ onSuccess }: Props) {
   const { t } = useTranslation()
   const [email, setEmail] = useState('')
   const locale = useLocale()
@@ -45,29 +47,25 @@ export default function Form({ onSuccess }: Props) {
   }, [email, locale, submitMail, t, isPending, onSuccess])
 
   return (
-    <form
+    <Form
       onSubmit={(e) => {
         e.preventDefault()
         handleSubmit()
       }}
     >
-      <div className="mb-3">
-        <label htmlFor="email" className="my-2 system-md-semibold text-text-secondary">
+      <Field name="email" className="mb-3">
+        <FieldLabel className="py-0 text-[14px] leading-5 font-semibold text-text-secondary">
           {t(($) => $.email, { ns: 'login' })}
-        </label>
-        <div className="mt-1">
-          <Input
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            id="email"
-            name="email"
-            type="email"
-            autoComplete="email"
-            spellCheck={false}
-            placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) || ''}
-          />
-        </div>
-      </div>
+        </FieldLabel>
+        <Input
+          value={email}
+          onValueChange={setEmail}
+          type="email"
+          autoComplete="email"
+          spellCheck={false}
+          placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) || ''}
+        />
+      </Field>
       <div className="mb-2">
         <Button variant="primary" type="submit" disabled={isPending || !email} className="w-full">
           {t(($) => $['signup.verifyMail'], { ns: 'login' })}
@@ -107,6 +105,6 @@ export default function Form({ onSuccess }: Props) {
           </div>
         </>
       )}
-    </form>
+    </Form>
   )
 }


### PR DESCRIPTION
## Summary

- replace the legacy signup email input with Dify UI `Form`, `Field`, `FieldLabel`, and `Input`
- preserve the visible label, email metadata, native Enter submission, and existing mutation flow
- keep the measured legacy auth typography while making `Field` the owner of the field name and anatomy spacing

## Validation

- `vp test run app/signup/components/input-mail.spec.tsx` — 7 tests passed
- targeted `vp check` and Web accessibility lint passed
- verified on `localhost:3000/signup`: the input remains 400 × 32 px and the label remains 14/20 semibold
