### PR TITLE
fix(web): redirect after deleting an agent

### DIFF
--- a/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
+++ b/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
@@ -1,13 +1,15 @@
 import type { AgentAppDetailWithSite } from '@dify/contracts/api/console/agent/types.gen'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AgentDetailSection, AgentDetailTop } from '../navigation'
 
 const mocks = vi.hoisted(() => ({
+  deleteAgent: vi.fn(),
   exportAppDsl: vi.fn(),
   pathname: '/agents/agent-1/configure',
   queryData: undefined as AgentAppDetailWithSite | undefined,
+  replace: vi.fn(),
 }))
 
 vi.mock('@/app/components/app/use-export-app-dsl', () => ({
@@ -33,6 +35,7 @@ vi.mock('@/next/navigation', () => ({
   usePathname: () => mocks.pathname,
   useRouter: () => ({
     back: vi.fn(),
+    replace: mocks.replace,
   }),
 }))
 
@@ -64,7 +67,7 @@ vi.mock('@/service/client', () => ({
         },
         delete: {
           mutationOptions: () => ({
-            mutationFn: vi.fn(),
+            mutationFn: mocks.deleteAgent,
           }),
         },
         put: {
@@ -106,6 +109,7 @@ function renderAgentDetailSection(expand = true) {
 describe('AgentDetailSection', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.deleteAgent.mockResolvedValue({})
     mocks.exportAppDsl.mockResolvedValue(undefined)
     mocks.pathname = '/agents/agent-1/configure'
     mocks.queryData = createAgent()
@@ -161,6 +165,48 @@ describe('AgentDetailSection', () => {
       appId: 'app-1',
       appName: 'Research Agent',
     })
+  })
+
+  it('returns to the roster after deleting the current agent', async () => {
+    const user = userEvent.setup()
+    renderAgentDetailSection()
+
+    await user.click(screen.getByRole('button', { name: /agentV2\.roster\.moreActions/ }))
+    await user.click(screen.getByRole('menuitem', { name: 'common.operation.delete' }))
+
+    const dialog = await screen.findByRole('alertdialog', {
+      name: /agentV2\.roster\.deleteDialog\.title/,
+    })
+    await user.click(within(dialog).getByRole('button', { name: 'common.operation.delete' }))
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/agents')
+    })
+    expect(mocks.deleteAgent.mock.calls[0]?.[0]).toEqual({
+      params: {
+        agent_id: 'agent-1',
+      },
+    })
+  })
+
+  it('keeps the current agent open when deletion fails', async () => {
+    const user = userEvent.setup()
+    mocks.deleteAgent.mockRejectedValue(new Error('Delete failed'))
+    renderAgentDetailSection()
+
+    await user.click(screen.getByRole('button', { name: /agentV2\.roster\.moreActions/ }))
+    await user.click(screen.getByRole('menuitem', { name: 'common.operation.delete' }))
+
+    const dialog = await screen.findByRole('alertdialog', {
+      name: /agentV2\.roster\.deleteDialog\.title/,
+    })
+    await user.click(within(dialog).getByRole('button', { name: 'common.operation.delete' }))
+
+    await waitFor(() => {
+      expect(mocks.deleteAgent).toHaveBeenCalled()
+    })
+    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(dialog).toBeInTheDocument()
   })
 
   it('does not render more actions in collapsed sidebar mode', () => {

--- a/web/features/agent-v2/agent-detail/sidebar-actions.tsx
+++ b/web/features/agent-v2/agent-detail/sidebar-actions.tsx
@@ -15,6 +15,7 @@ import { useExportAppDsl } from '@/app/components/app/use-export-app-dsl'
 import { DeleteAgentDialog } from '@/features/agent-v2/roster/components/delete-agent-dialog'
 import { DuplicateAgentDialog } from '@/features/agent-v2/roster/components/duplicate-agent-dialog'
 import { EditAgentDialog } from '@/features/agent-v2/roster/components/edit-agent-dialog'
+import { useRouter } from '@/next/navigation'
 
 type AgentDetailSidebarActionAgent = Pick<
   AgentAppPartial,
@@ -40,6 +41,7 @@ export function AgentDetailSidebarActions({ agent }: { agent: AgentDetailSidebar
   const [duplicateSessionKey, setDuplicateSessionKey] = useState(0)
   const [isDeleteOpen, setIsDeleteOpen] = useState(false)
   const { exportAppDsl, isExporting } = useExportAppDsl()
+  const router = useRouter()
   const dialogAgent: AgentAppPartial = {
     description: agent.description,
     icon: agent.icon,
@@ -127,6 +129,7 @@ export function AgentDetailSidebarActions({ agent }: { agent: AgentDetailSidebar
         agentName={agent.name}
         open={isDeleteOpen}
         onOpenChange={setIsDeleteOpen}
+        onDeleted={() => router.replace('/agents')}
       />
     </>
   )

--- a/web/features/agent-v2/roster/components/delete-agent-dialog.tsx
+++ b/web/features/agent-v2/roster/components/delete-agent-dialog.tsx
@@ -19,6 +19,7 @@ type DeleteAgentDialogProps = {
   agentName: string
   open: boolean
   onOpenChange: (open: boolean) => void
+  onDeleted?: () => void
 }
 
 export function DeleteAgentDialog({
@@ -26,6 +27,7 @@ export function DeleteAgentDialog({
   agentName,
   open,
   onOpenChange,
+  onDeleted,
 }: DeleteAgentDialogProps) {
   const { t } = useTranslation('agentV2')
   const { t: tCommon } = useTranslation('common')
@@ -44,6 +46,7 @@ export function DeleteAgentDialog({
         onSuccess: () => {
           toast.success(t(($) => $['roster.deleteSuccess']))
           onOpenChange(false)
+          onDeleted?.()
         },
         onError: () => {
           toast.error(t(($) => $['roster.deleteFailed']))

--- a/web/service/client.spec.ts
+++ b/web/service/client.spec.ts
@@ -1425,11 +1425,36 @@ describe('consoleQuery agent mutation defaults', () => {
     expect(queryClient.getQueryData(composerQueryKey)).toEqual(savedComposerState)
   })
 
-  it('should invalidate invite option lists after deleting an agent', async () => {
+  it('should clear deleted agent queries and invalidate invite option lists', async () => {
     const consoleQuery = await loadConsoleQuery()
     const queryClient = new QueryClient()
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
     const deletedAgent = createAgent()
+    const otherAgent = createAgent({ id: 'agent-2' })
+    const deletedAgentDetailQueryKey = consoleQuery.agent.byAgentId.get.queryKey({
+      input: {
+        params: {
+          agent_id: deletedAgent.id,
+        },
+      },
+    })
+    const deletedAgentComposerQueryKey = consoleQuery.agent.byAgentId.composer.get.queryKey({
+      input: {
+        params: {
+          agent_id: deletedAgent.id,
+        },
+      },
+    })
+    const otherAgentDetailQueryKey = consoleQuery.agent.byAgentId.get.queryKey({
+      input: {
+        params: {
+          agent_id: otherAgent.id,
+        },
+      },
+    })
+    queryClient.setQueryData(deletedAgentDetailQueryKey, deletedAgent)
+    queryClient.setQueryData(deletedAgentComposerQueryKey, createComposerState())
+    queryClient.setQueryData(otherAgentDetailQueryKey, otherAgent)
 
     const mutationOptions = consoleQuery.agent.byAgentId.delete.mutationOptions()
     await mutationOptions.onSuccess?.(
@@ -1446,6 +1471,9 @@ describe('consoleQuery agent mutation defaults', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: consoleQuery.agent.inviteOptions.get.key(),
     })
+    expect(queryClient.getQueryData(deletedAgentDetailQueryKey)).toBeUndefined()
+    expect(queryClient.getQueryData(deletedAgentComposerQueryKey)).toBeUndefined()
+    expect(queryClient.getQueryData(otherAgentDetailQueryKey)).toEqual(otherAgent)
   })
 })
 

--- a/web/service/client.ts
+++ b/web/service/client.ts
@@ -1062,6 +1062,15 @@ export const consoleQuery: RouterUtils<typeof consoleClient> = createTanstackQue
           delete: {
             mutationOptions: {
               onSuccess: (_data, variables, _onMutateResult, context) => {
+                context.client.removeQueries({
+                  queryKey: consoleQuery.agent.byAgentId.key({
+                    input: {
+                      params: {
+                        agent_id: variables.params.agent_id,
+                      },
+                    },
+                  }),
+                })
                 context.client.setQueriesData(
                   {
                     queryKey: consoleQuery.agent.get.key({ type: 'query' }),


### PR DESCRIPTION
## Summary

- redirect to the Agent roster after deleting the Agent currently open in the detail view
- remove the deleted Agent's detail and composer queries while preserving other Agent caches
- cover successful navigation, failed deletion, and cache cleanup behavior

## Why

Deleting an Agent from its detail view left the user on a route for a resource that no longer exists. The detail surface now owns the post-delete navigation, while the shared mutation defaults own cache cleanup for every deletion entry point.

## Screenshots

Not applicable. This change does not alter the visual design.

## Validation

- `vp staged`
- `vp test run features/agent-v2/agent-detail/__tests__/navigation.spec.tsx service/client.spec.ts` (52 tests)
- `vp test run features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx` (16 tests)
- `git diff --check`

## Checklist

- [x] I've added tests for the changed behavior.
- [x] I ran `vp staged`.
- [ ] Documentation update required.

Fixes DIFY-2910

From Codex
