### PR TITLE
ci(web): run browser tests on GitHub Ubuntu

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -46,7 +46,7 @@ jobs:
 
   browser-test:
     name: Web Browser Tests
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     defaults:
       run:


### PR DESCRIPTION
## Summary

- run Web Browser Tests on GitHub-hosted Ubuntu 24.04
- keep the sharded Vitest unit jobs on Depot
- preserve the existing Playwright Chromium and system dependency installation

## Why

Recent Depot Browser Mode jobs spent roughly 6-10 minutes in Ubuntu package metadata downloads while the browser tests themselves completed in seconds. The full-stack Playwright E2E job already uses GitHub-hosted Ubuntu, so this moves the Playwright-dependent Browser Mode lane to the same runner boundary without changing test behavior.

## Testing

- git diff --check
- workflow-only change; GitHub Actions will provide the runtime verification

## Evidence

- https://github.com/langgenius/dify/actions/runs/32330166761/job/96309325627?pr=40994