### PR TITLE
feat(workflow): add direct node search entry

### DIFF
--- a/web/app/components/goto-anything/dialog-handle.ts
+++ b/web/app/components/goto-anything/dialog-handle.ts
@@ -3,3 +3,16 @@
 import { createDialogHandle } from '@langgenius/dify-ui/dialog'
 
 export const gotoAnythingDialogHandle = createDialogHandle()
+
+let pendingInitialSearchQuery = ''
+
+export const openGotoAnythingDialog = (initialSearchQuery = '') => {
+  pendingInitialSearchQuery = initialSearchQuery
+  gotoAnythingDialogHandle.open(null)
+}
+
+export const consumeInitialSearchQuery = () => {
+  const initialSearchQuery = pendingInitialSearchQuery
+  pendingInitialSearchQuery = ''
+  return initialSearchQuery
+}

--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -50,7 +50,7 @@ import { pluginSearchQueryOptions } from './actions/plugin'
 import { addRecentItem, getRecentItems } from './actions/recent-store'
 import { EmptyState } from './components/empty-state'
 import { Footer } from './components/footer'
-import { gotoAnythingDialogHandle } from './dialog-handle'
+import { consumeInitialSearchQuery, gotoAnythingDialogHandle } from './dialog-handle'
 import { GOTO_ANYTHING_HOTKEY } from './hotkeys'
 
 const appWorkflowPathPattern = /^\/app\/[^/]+\/workflow$/
@@ -283,7 +283,7 @@ function GotoAnythingDialog() {
   const groupedResults = groupSearchResults(dedupedResults)
 
   function resetSearch() {
-    setSearchQuery('')
+    setSearchQuery(consumeInitialSearchQuery())
   }
 
   useHotkey(

--- a/web/app/components/workflow-app/components/workflow-header/index.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/index.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import Header from '@/app/components/workflow/header'
+import NodeSearchButton from '@/app/components/workflow/header/node-search-button'
 import { useResetWorkflowVersionHistory } from '@/service/use-workflow'
 import { useIsChatMode } from '../../hooks/use-is-chat-mode'
 import ChatVariableTrigger from './chat-variable-trigger'
@@ -37,7 +38,12 @@ const WorkflowHeader = () => {
     return {
       normal: {
         components: {
-          middle: <FeaturesTrigger />,
+          middle: (
+            <>
+              <NodeSearchButton />
+              <FeaturesTrigger />
+            </>
+          ),
           chatVariableTrigger: <ChatVariableTrigger />,
         },
         runAndHistoryProps: {

--- a/web/app/components/workflow/header/__tests__/node-search-button.spec.tsx
+++ b/web/app/components/workflow/header/__tests__/node-search-button.spec.tsx
@@ -1,0 +1,29 @@
+import type { ReactElement } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import NodeSearchButton from '../node-search-button'
+
+const { mockOpenGotoAnythingDialog } = vi.hoisted(() => ({
+  mockOpenGotoAnythingDialog: vi.fn(),
+}))
+
+vi.mock('@/app/components/goto-anything/dialog-handle', () => ({
+  openGotoAnythingDialog: mockOpenGotoAnythingDialog,
+}))
+
+vi.mock('../../operator/tip-popup', () => ({
+  default: ({ children }: { children: ReactElement }) => children,
+}))
+
+describe('NodeSearchButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the workflow node search scope from the header', () => {
+    render(<NodeSearchButton />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(mockOpenGotoAnythingDialog).toHaveBeenCalledWith('@node ')
+  })
+})

--- a/web/app/components/workflow/header/node-search-button.tsx
+++ b/web/app/components/workflow/header/node-search-button.tsx
@@ -1,0 +1,33 @@
+import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { memo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { openGotoAnythingDialog } from '@/app/components/goto-anything/dialog-handle'
+import TipPopup from '../operator/tip-popup'
+
+const NodeSearchButton = () => {
+  const { t } = useTranslation()
+  const label = t(($) => $['gotoAnything.actions.searchWorkflowNodesDesc'], { ns: 'app' })
+
+  const handleClick = () => {
+    openGotoAnythingDialog('@node ')
+  }
+
+  return (
+    <TipPopup title={label}>
+      <IconButton
+        aria-label={label}
+        size="lg"
+        variant="ghost"
+        className="rounded-md"
+        onClick={handleClick}
+      >
+        <span
+          aria-hidden
+          className="i-ri-search-line size-4 text-components-button-secondary-text"
+        />
+      </IconButton>
+    </TipPopup>
+  )
+}
+
+export default memo(NodeSearchButton)


### PR DESCRIPTION
## Summary

- add a visible search button to the workflow canvas header
- open the existing Go to Anything dialog directly in the `@node` scope
- preserve the existing keyboard shortcut and add a focused interaction test

Fixes #40988

## Validation

- `../node_modules/.bin/node ../node_modules/vite-plus/bin/vp test --config vite.config.ts app/components/workflow/header/__tests__/node-search-button.spec.tsx --run`
- `./node_modules/.bin/node ./node_modules/vite-plus/bin/vp check web/app/components/goto-anything/dialog-handle.ts web/app/components/goto-anything/index.tsx web/app/components/workflow/header/node-search-button.tsx web/app/components/workflow-app/components/workflow-header/index.tsx web/app/components/workflow/header/__tests__/node-search-button.spec.tsx`
