### PR TITLE
fix(web): clarify agent deletion consequences

### DIFF
--- a/web/features/agent-v2/roster/components/__tests__/delete-agent-dialog.spec.tsx
+++ b/web/features/agent-v2/roster/components/__tests__/delete-agent-dialog.spec.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { DeleteAgentDialog } from '../delete-agent-dialog'
+
+const mutationMock = vi.hoisted(() => ({
+  isPending: false,
+  mutate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => mutationMock,
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    agent: {
+      byAgentId: {
+        delete: {
+          mutationOptions: vi.fn(() => ({})),
+        },
+      },
+    },
+  },
+}))
+
+vi.mock('react-i18next', async () => {
+  const { createReactI18nextMock } = await import('@/test/i18n-mock')
+  const { default: agentV2 } = await import('@/i18n/en-US/agent-v-2.json')
+  return createReactI18nextMock({
+    'roster.deleteDialog.description': agentV2['roster.deleteDialog.description'],
+    'roster.deleteDialog.title': agentV2['roster.deleteDialog.title'],
+  })
+})
+
+describe('DeleteAgentDialog', () => {
+  it('identifies the deleted agent and explains the irreversible impact', () => {
+    render(
+      <DeleteAgentDialog
+        agentId="agent-1"
+        agentName="Research Agent"
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'This permanently deletes Research Agent. Its web app, API access, and workflows that use it stop working immediately.',
+      ),
+    ).toBeInTheDocument()
+  })
+})

--- a/web/features/agent-v2/roster/components/delete-agent-dialog.tsx
+++ b/web/features/agent-v2/roster/components/delete-agent-dialog.tsx
@@ -62,7 +62,7 @@ export function DeleteAgentDialog({
           {t(($) => $['roster.deleteDialog.title'], { name: agentName })}
         </AlertDialogTitle>
         <AlertDialogDescription className="mt-2 system-md-regular wrap-break-word whitespace-pre-wrap text-text-tertiary">
-          {t(($) => $['roster.deleteDialog.description'])}
+          {t(($) => $['roster.deleteDialog.description'], { name: agentName })}
         </AlertDialogDescription>
         <AlertDialogActions className="p-0 pt-6">
           <AlertDialogCancelButton disabled={deleteAgentMutation.isPending}>

--- a/web/i18n/ar-TN/agent-v-2.json
+++ b/web/i18n/ar-TN/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "مثلاً مساعد بحث",
   "roster.createSuccess": "تم إنشاء الوكيل.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "ستتم إزالة هذا Agent من قائمة Agent.",
+  "roster.deleteDialog.description": "سيؤدي هذا إلى حذف {{name}} نهائيًا. سيتوقف تطبيق الويب الخاص به، والوصول عبر API، وجميع عمليات سير العمل التي تستخدمه عن العمل فورًا.",
   "roster.deleteDialog.title": "حذف {{name}}؟",
   "roster.deleteFailed": "فشل حذف الوكيل.",
   "roster.deleteSuccess": "تم حذف الوكيل.",

--- a/web/i18n/de-DE/agent-v-2.json
+++ b/web/i18n/de-DE/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "z. B. Research Assistant",
   "roster.createSuccess": "Agent erstellt.",
   "roster.dateTimeFormat": "DD.MM.YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Dieser Agent wird aus der Agent-Liste entfernt.",
+  "roster.deleteDialog.description": "Dadurch wird {{name}} dauerhaft gelöscht. Die zugehörige Webapp, der API-Zugriff und alle Workflows, die diesen Agenten verwenden, funktionieren ab sofort nicht mehr.",
   "roster.deleteDialog.title": "{{name}} löschen?",
   "roster.deleteFailed": "Agent konnte nicht gelöscht werden.",
   "roster.deleteSuccess": "Agent gelöscht.",

--- a/web/i18n/en-US/agent-v-2.json
+++ b/web/i18n/en-US/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "e.g. Research Assistant",
   "roster.createSuccess": "Agent created.",
   "roster.dateTimeFormat": "MM/DD/YYYY hh:mm:ss A",
-  "roster.deleteDialog.description": "This Agent will be removed from the Agent list.",
+  "roster.deleteDialog.description": "This permanently deletes {{name}}. Its web app, API access, and workflows that use it stop working immediately.",
   "roster.deleteDialog.title": "Delete {{name}}?",
   "roster.deleteFailed": "Failed to delete agent.",
   "roster.deleteSuccess": "Agent deleted.",

--- a/web/i18n/es-ES/agent-v-2.json
+++ b/web/i18n/es-ES/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "p. ej. Asistente de investigación",
   "roster.createSuccess": "Agente creado.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Este Agent se eliminará de la lista de Agent.",
+  "roster.deleteDialog.description": "Esto elimina permanentemente {{name}}. Su aplicación web, el acceso a la API y los flujos de trabajo que lo usan dejarán de funcionar de inmediato.",
   "roster.deleteDialog.title": "¿Eliminar {{name}}?",
   "roster.deleteFailed": "Error al eliminar el agente.",
   "roster.deleteSuccess": "Agente eliminado.",

--- a/web/i18n/fa-IR/agent-v-2.json
+++ b/web/i18n/fa-IR/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "مثلاً دستیار پژوهش",
   "roster.createSuccess": "عامل ایجاد شد.",
   "roster.dateTimeFormat": "YYYY/MM/DD HH:mm:ss",
-  "roster.deleteDialog.description": "این Agent از فهرست Agent حذف خواهد شد.",
+  "roster.deleteDialog.description": "این کار {{name}} را برای همیشه حذف می‌کند. برنامه وب آن، دسترسی به API و گردش‌های کاری که از آن استفاده می‌کنند، بلافاصله از کار می‌افتند.",
   "roster.deleteDialog.title": "حذف {{name}}؟",
   "roster.deleteFailed": "حذف عامل ناموفق بود.",
   "roster.deleteSuccess": "عامل حذف شد.",

--- a/web/i18n/fr-FR/agent-v-2.json
+++ b/web/i18n/fr-FR/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "p. ex. Assistant de recherche",
   "roster.createSuccess": "Agent créé.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Cet Agent sera supprimé de la liste Agent.",
+  "roster.deleteDialog.description": "Cette action supprime définitivement {{name}}. Son application web, son accès à l’API et les workflows qui l’utilisent cesseront immédiatement de fonctionner.",
   "roster.deleteDialog.title": "Supprimer {{name}} ?",
   "roster.deleteFailed": "Échec de la suppression de l’agent.",
   "roster.deleteSuccess": "Agent supprimé.",

--- a/web/i18n/hi-IN/agent-v-2.json
+++ b/web/i18n/hi-IN/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "उदा. शोध सहायक",
   "roster.createSuccess": "एजेंट बन गया।",
   "roster.dateTimeFormat": "DD/MM/YYYY hh:mm:ss A",
-  "roster.deleteDialog.description": "यह Agent, Agent सूची से हटा दिया जाएगा।",
+  "roster.deleteDialog.description": "इससे {{name}} स्थायी रूप से हटा दिया जाएगा। इसका वेब ऐप, API एक्सेस और इसका उपयोग करने वाले वर्कफ़्लो तुरंत काम करना बंद कर देंगे।",
   "roster.deleteDialog.title": "{{name}} हटाएँ?",
   "roster.deleteFailed": "एजेंट हटाने में विफल।",
   "roster.deleteSuccess": "एजेंट हटा दिया गया।",

--- a/web/i18n/id-ID/agent-v-2.json
+++ b/web/i18n/id-ID/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "mis. Asisten Riset",
   "roster.createSuccess": "Agen dibuat.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Agent ini akan dihapus dari daftar Agent.",
+  "roster.deleteDialog.description": "Tindakan ini menghapus {{name}} secara permanen. Aplikasi web dan akses API miliknya, serta alur kerja yang menggunakannya, akan langsung berhenti berfungsi.",
   "roster.deleteDialog.title": "Hapus {{name}}?",
   "roster.deleteFailed": "Gagal menghapus agen.",
   "roster.deleteSuccess": "Agen dihapus.",

--- a/web/i18n/it-IT/agent-v-2.json
+++ b/web/i18n/it-IT/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "ad es. Assistente di ricerca",
   "roster.createSuccess": "Agente creato.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Questo Agent sarà rimosso dall’elenco Agent.",
+  "roster.deleteDialog.description": "Questa azione elimina definitivamente {{name}}. La sua app web, l’accesso API e i workflow che lo utilizzano smetteranno immediatamente di funzionare.",
   "roster.deleteDialog.title": "Eliminare {{name}}?",
   "roster.deleteFailed": "Impossibile eliminare l’agente.",
   "roster.deleteSuccess": "Agente eliminato.",

--- a/web/i18n/ja-JP/agent-v-2.json
+++ b/web/i18n/ja-JP/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "例: リサーチアシスタント",
   "roster.createSuccess": "エージェントを作成しました。",
   "roster.dateTimeFormat": "YYYY/MM/DD HH:mm:ss",
-  "roster.deleteDialog.description": "この Agent は Agent リストから削除されます。",
+  "roster.deleteDialog.description": "{{name}} を完全に削除します。その Web アプリと API アクセス、これを使用するワークフローは直ちに動作しなくなります。",
   "roster.deleteDialog.title": "{{name}} を削除しますか？",
   "roster.deleteFailed": "エージェントの削除に失敗しました。",
   "roster.deleteSuccess": "エージェントを削除しました。",

--- a/web/i18n/ko-KR/agent-v-2.json
+++ b/web/i18n/ko-KR/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "예: 리서치 어시스턴트",
   "roster.createSuccess": "에이전트가 생성되었습니다.",
   "roster.dateTimeFormat": "YYYY-MM-DD HH:mm:ss",
-  "roster.deleteDialog.description": "이 Agent 가 Agent 목록에서 제거됩니다.",
+  "roster.deleteDialog.description": "이 작업은 {{name}}을(를) 영구적으로 삭제합니다. 해당 에이전트의 웹 앱과 API 액세스, 그리고 이를 사용하는 워크플로는 즉시 작동을 멈춥니다.",
   "roster.deleteDialog.title": "{{name}}을(를) 삭제하시겠습니까?",
   "roster.deleteFailed": "에이전트 삭제에 실패했습니다.",
   "roster.deleteSuccess": "에이전트가 삭제되었습니다.",

--- a/web/i18n/lo-LA/agent-v-2.json
+++ b/web/i18n/lo-LA/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "ຕົວຢ່າງ: ຜູ້ຊ່ວຍການວິໄຈ",
   "roster.createSuccess": "ສ້າງຕົວແທນສຳເລັດ.",
   "roster.dateTimeFormat": "DD/MM/YYYY hh:mm:ss A",
-  "roster.deleteDialog.description": "ຕົວແທນນີ້ຈະຖືກລຶບອອກຈາກລາຍຊື່ຕົວແທນ.",
+  "roster.deleteDialog.description": "ການດຳເນີນການນີ້ຈະລຶບ {{name}} ຢ່າງຖາວອນ. ເວັບແອັບ ແລະ ການເຂົ້າເຖິງ API ຂອງຕົວແທນນີ້, ພ້ອມທັງເວີກໂຟລທີ່ໃຊ້ຕົວແທນນີ້, ຈະຢຸດໃຊ້ງານທັນທີ.",
   "roster.deleteDialog.title": "ລຶບ {{name}} ບໍ?",
   "roster.deleteFailed": "ລຶບຕົວແທນບໍ່ສຳເລັດ.",
   "roster.deleteSuccess": "ລຶບຕົວແທນສຳເລັດ.",

--- a/web/i18n/nl-NL/agent-v-2.json
+++ b/web/i18n/nl-NL/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "bv. Research Assistant",
   "roster.createSuccess": "Agent aangemaakt.",
   "roster.dateTimeFormat": "DD-MM-YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Deze Agent wordt verwijderd uit de Agent-lijst.",
+  "roster.deleteDialog.description": "Hiermee wordt {{name}} permanent verwijderd. De bijbehorende webapp en API-toegang, evenals workflows die deze Agent gebruiken, werken onmiddellijk niet meer.",
   "roster.deleteDialog.title": "{{name}} verwijderen?",
   "roster.deleteFailed": "Verwijderen van agent mislukt.",
   "roster.deleteSuccess": "Agent verwijderd.",

--- a/web/i18n/pl-PL/agent-v-2.json
+++ b/web/i18n/pl-PL/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "np. Asystent badawczy",
   "roster.createSuccess": "Agent utworzony.",
   "roster.dateTimeFormat": "DD.MM.YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Ten Agent zostanie usunięty z listy Agent.",
+  "roster.deleteDialog.description": "Spowoduje to trwałe usunięcie {{name}}. Jego aplikacja webowa, dostęp do API oraz workflow, które go używają, natychmiast przestaną działać.",
   "roster.deleteDialog.title": "Usunąć {{name}}?",
   "roster.deleteFailed": "Nie udało się usunąć agenta.",
   "roster.deleteSuccess": "Agent usunięty.",

--- a/web/i18n/pt-BR/agent-v-2.json
+++ b/web/i18n/pt-BR/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "ex.: Assistente de pesquisa",
   "roster.createSuccess": "Agente criado.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Este Agent será removido da lista de Agent.",
+  "roster.deleteDialog.description": "Isso excluirá permanentemente {{name}}. O aplicativo web e o acesso à API desse Agent, bem como os workflows que o utilizam, deixarão de funcionar imediatamente.",
   "roster.deleteDialog.title": "Excluir {{name}}?",
   "roster.deleteFailed": "Falha ao excluir o agente.",
   "roster.deleteSuccess": "Agente excluído.",

--- a/web/i18n/ro-RO/agent-v-2.json
+++ b/web/i18n/ro-RO/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "de ex. Asistent de cercetare",
   "roster.createSuccess": "Agent creat.",
   "roster.dateTimeFormat": "DD.MM.YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Acest Agent va fi eliminat din lista Agent.",
+  "roster.deleteDialog.description": "Această acțiune șterge definitiv {{name}}. Aplicația web și accesul la API ale Agentului, precum și workflow-urile care îl folosesc, vor înceta imediat să funcționeze.",
   "roster.deleteDialog.title": "Ștergeți {{name}}?",
   "roster.deleteFailed": "Ștergerea agentului a eșuat.",
   "roster.deleteSuccess": "Agent șters.",

--- a/web/i18n/ru-RU/agent-v-2.json
+++ b/web/i18n/ru-RU/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "напр. Помощник по исследованиям",
   "roster.createSuccess": "Агент создан.",
   "roster.dateTimeFormat": "DD.MM.YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Этот Agent будет удалён из списка Agent.",
+  "roster.deleteDialog.description": "Это навсегда удалит {{name}}. Веб-приложение и доступ к API этого Agent, а также использующие его рабочие процессы немедленно перестанут работать.",
   "roster.deleteDialog.title": "Удалить {{name}}?",
   "roster.deleteFailed": "Не удалось удалить агента.",
   "roster.deleteSuccess": "Агент удалён.",

--- a/web/i18n/sl-SI/agent-v-2.json
+++ b/web/i18n/sl-SI/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "npr. Raziskovalni asistent",
   "roster.createSuccess": "Agent ustvarjen.",
   "roster.dateTimeFormat": "DD. MM. YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Ta Agent bo odstranjen s seznama Agent.",
+  "roster.deleteDialog.description": "S tem trajno izbrišete {{name}}. Spletna aplikacija in dostop do API-ja tega Agenta ter poteki dela, ki ga uporabljajo, bodo takoj prenehali delovati.",
   "roster.deleteDialog.title": "Izbrišem {{name}}?",
   "roster.deleteFailed": "Agenta ni bilo mogoče izbrisati.",
   "roster.deleteSuccess": "Agent izbrisan.",

--- a/web/i18n/th-TH/agent-v-2.json
+++ b/web/i18n/th-TH/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "เช่น ผู้ช่วยวิจัย",
   "roster.createSuccess": "สร้างตัวแทนแล้ว",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Agent นี้จะถูกลบออกจากรายการ Agent",
+  "roster.deleteDialog.description": "การดำเนินการนี้จะลบ {{name}} อย่างถาวร เว็บแอปและการเข้าถึง API ของ Agent นี้ รวมถึงเวิร์กโฟลว์ที่ใช้ Agent นี้ จะหยุดทำงานทันที",
   "roster.deleteDialog.title": "ลบ {{name}} หรือไม่",
   "roster.deleteFailed": "ลบตัวแทนไม่สำเร็จ",
   "roster.deleteSuccess": "ลบตัวแทนแล้ว",

--- a/web/i18n/tr-TR/agent-v-2.json
+++ b/web/i18n/tr-TR/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "örn. Araştırma Asistanı",
   "roster.createSuccess": "Ajan oluşturuldu.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Bu Agent, Agent listesinden kaldırılacak.",
+  "roster.deleteDialog.description": "Bu işlem {{name}} adlı Agent'ı kalıcı olarak siler. Bu Agent'ın web uygulaması ve API erişimi ile onu kullanan iş akışları hemen çalışmayı durdurur.",
   "roster.deleteDialog.title": "{{name}} silinsin mi?",
   "roster.deleteFailed": "Ajan silinemedi.",
   "roster.deleteSuccess": "Ajan silindi.",

--- a/web/i18n/uk-UA/agent-v-2.json
+++ b/web/i18n/uk-UA/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "напр. Помічник з досліджень",
   "roster.createSuccess": "Агента створено.",
   "roster.dateTimeFormat": "DD.MM.YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Цей Agent буде видалений зі списку Agent.",
+  "roster.deleteDialog.description": "Це назавжди видалить {{name}}. Вебзастосунок і доступ до API цього Agent, а також робочі процеси, що його використовують, негайно припинять працювати.",
   "roster.deleteDialog.title": "Видалити {{name}}?",
   "roster.deleteFailed": "Не вдалося видалити агента.",
   "roster.deleteSuccess": "Агента видалено.",

--- a/web/i18n/vi-VN/agent-v-2.json
+++ b/web/i18n/vi-VN/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "ví dụ: Trợ lý nghiên cứu",
   "roster.createSuccess": "Đã tạo tác nhân.",
   "roster.dateTimeFormat": "DD/MM/YYYY HH:mm:ss",
-  "roster.deleteDialog.description": "Agent này sẽ bị xóa khỏi danh sách Agent.",
+  "roster.deleteDialog.description": "Thao tác này sẽ xóa vĩnh viễn {{name}}. Ứng dụng web, quyền truy cập API và các quy trình làm việc sử dụng Agent này sẽ ngừng hoạt động ngay lập tức.",
   "roster.deleteDialog.title": "Xóa {{name}}?",
   "roster.deleteFailed": "Xóa tác nhân thất bại.",
   "roster.deleteSuccess": "Đã xóa tác nhân.",

--- a/web/i18n/zh-Hans/agent-v-2.json
+++ b/web/i18n/zh-Hans/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "例如：研究助理",
   "roster.createSuccess": "Agent 已创建。",
   "roster.dateTimeFormat": "YYYY-MM-DD HH:mm:ss",
-  "roster.deleteDialog.description": "此 Agent 将从 Agent 列表中移除。",
+  "roster.deleteDialog.description": "此操作将永久删除 {{name}}。其 Web 应用、API 访问及使用它的工作流将立即失效。",
   "roster.deleteDialog.title": "删除 {{name}}？",
   "roster.deleteFailed": "Agent 删除失败。",
   "roster.deleteSuccess": "Agent 已删除。",

--- a/web/i18n/zh-Hant/agent-v-2.json
+++ b/web/i18n/zh-Hant/agent-v-2.json
@@ -383,7 +383,7 @@
   "roster.createForm.rolePlaceholder": "例如：研究助理",
   "roster.createSuccess": "Agent 已建立。",
   "roster.dateTimeFormat": "YYYY-MM-DD HH:mm:ss",
-  "roster.deleteDialog.description": "此 Agent 將從 Agent 清單中移除。",
+  "roster.deleteDialog.description": "此操作將永久刪除 {{name}}。其 Web 應用程式、API 存取及使用它的工作流程將立即停止運作。",
   "roster.deleteDialog.title": "刪除 {{name}}？",
   "roster.deleteFailed": "Agent 刪除失敗。",
   "roster.deleteSuccess": "Agent 已刪除。",


### PR DESCRIPTION
## Summary
- make the Agent deletion confirmation identify the agent and explain its permanent impact
- align the confirmation copy across all 24 supported locales
- add a regression test backed by the real en-US resource

## Validation
- `vp test run features/agent-v2/roster/components/__tests__` (35 tests passed)
- `pnpm i18n:check`
- `vp fmt --check` for all changed files
- `pnpm lint:eslint web/i18n/*/agent-v-2.json`
- `vp lint --quiet --type-aware --type-check` for the changed component and test
- `git diff --check`

Full `pnpm check` remains blocked by the pre-existing TypeScript diagnostic in `eslint.config.mjs:424` (`hyoban` is not assignable to `Plugin`).

Fixes DIFY-2909