### PR TITLE
fix(snippets): implement delete for published snippet workflow versions

### DIFF
--- a/api/controllers/console/snippets/snippet_workflow.py
+++ b/api/controllers/console/snippets/snippet_workflow.py
@@ -60,6 +60,7 @@ from models.snippet import CustomizedSnippet
 from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.agent.workflow_publish_service import WorkflowAgentPublishService
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import DraftWorkflowDeletionError, WorkflowInUseError
 from services.snippet_generate_service import SnippetGenerateService
 from services.snippet_service import SnippetService
 from tasks.collect_agent_resources_task import enqueue_agent_resource_collection
@@ -479,6 +480,39 @@ class SnippetWorkflowByIdApi(Resource):
         response = SnippetWorkflowResponse.model_validate(workflow, from_attributes=True).model_dump(mode="json")
         response["input_fields"] = snippet.input_fields_list
         return response
+
+    @console_ns.doc("delete_snippet_workflow_by_id")
+    @console_ns.doc(description="Delete a published snippet workflow version")
+    @console_ns.doc(params={"snippet_id": "Snippet ID", "workflow_id": "Workflow ID"})
+    @console_ns.response(204, "Workflow deleted successfully")
+    @console_ns.response(400, "Workflow is in use")
+    @console_ns.response(404, "Workflow not found")
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @get_snippet
+    @edit_permission_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.SNIPPETS_CREATE_AND_MODIFY, resource_required=False
+    )
+    def delete(self, snippet: CustomizedSnippet, workflow_id: str):
+        """Delete a published snippet workflow version."""
+        snippet_service = _snippet_service()
+        with _snippet_session_maker().begin() as session:
+            try:
+                snippet_service.delete_workflow(
+                    session=session,
+                    snippet=snippet,
+                    workflow_id=workflow_id,
+                )
+            except WorkflowInUseError as e:
+                raise BadRequest(str(e))
+            except DraftWorkflowDeletionError as e:
+                raise BadRequest(str(e))
+            except ValueError as e:
+                raise NotFound(str(e))
+
+        return None, 204
 
 
 @console_ns.route("/snippets/<uuid:snippet_id>/workflow-runs")

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -9130,6 +9130,24 @@ Reset a draft workflow variable to its default value (snippet scope)
 | 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
 | 400 | No draft workflow found |  |
 
+### [DELETE] /snippets/{snippet_id}/workflows/{workflow_id}
+**Delete a published snippet workflow version**
+
+#### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ------ |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
+| workflow_id | path | Workflow ID | Yes | string |
+
+#### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 204 | Workflow deleted successfully |
+| 400 | Workflow is in use |
+| 404 | Workflow not found |
+
 ### [PATCH] /snippets/{snippet_id}/workflows/{workflow_id}
 **Update a published snippet workflow version's display metadata**
 

--- a/api/services/snippet_service.py
+++ b/api/services/snippet_service.py
@@ -39,6 +39,7 @@ from models.workflow import (
 from repositories.factory import DifyAPIRepositoryFactory
 from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import DraftWorkflowDeletionError, WorkflowInUseError
 from services.tag_service import TagService
 from services.workflow_node_execution_trace_service import (
     WorkflowNodeExecutionTrace,
@@ -841,6 +842,53 @@ class SnippetService:
         workflow.updated_at = datetime.now(UTC).replace(tzinfo=None)
         session.add(workflow)
         return workflow
+
+    def delete_workflow(
+        self,
+        *,
+        session: Session,
+        snippet: CustomizedSnippet,
+        workflow_id: str,
+    ) -> bool:
+        """
+        Delete a published snippet workflow version.
+
+        :param session: Database session
+        :param snippet: CustomizedSnippet instance
+        :param workflow_id: Workflow ID
+        :return: True if successful
+        :raises: ValueError if workflow not found
+        :raises: WorkflowInUseError if workflow is the snippet's active version or published as a tool
+        :raises: DraftWorkflowDeletionError if workflow is a draft version
+        """
+        stmt = select(Workflow).where(
+            Workflow.id == workflow_id,
+            Workflow.tenant_id == snippet.tenant_id,
+            Workflow.app_id == snippet.id,
+            self._snippet_kind_filter(),
+        )
+        workflow = session.scalar(stmt)
+        if not workflow:
+            raise ValueError(f"Workflow with ID {workflow_id} not found")
+
+        if workflow.version == Workflow.VERSION_DRAFT:
+            raise DraftWorkflowDeletionError("Cannot delete draft workflow versions")
+
+        if snippet.workflow_id == workflow.id:
+            raise WorkflowInUseError(f"Cannot delete workflow that is currently in use by snippet '{snippet.id}'")
+
+        tool_provider = session.scalar(
+            select(WorkflowToolProvider).where(
+                WorkflowToolProvider.tenant_id == snippet.tenant_id,
+                WorkflowToolProvider.app_id == snippet.id,
+                WorkflowToolProvider.version == workflow.version,
+            )
+        )
+        if tool_provider:
+            raise WorkflowInUseError("Cannot delete workflow that is published as a tool")
+
+        session.delete(workflow)
+        return True
 
     # --- Default Block Configs ---
 

--- a/api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py
+++ b/api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py
@@ -505,6 +505,70 @@ def test_update_published_snippet_workflow_raises_not_found(
     assert snippet.name == "Snippet"
 
 
+def test_delete_published_snippet_workflow_succeeds(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    snippet = _snippet()
+    delete_workflow = Mock(return_value=True)
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=delete_workflow),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/workflow-1", method="DELETE"):
+        response, status_code = handler(api, snippet, workflow_id="workflow-1")
+
+    assert status_code == 204
+    assert response is None
+    delete_workflow.assert_called_once()
+    delete_call = delete_workflow.call_args.kwargs
+    assert isinstance(delete_call["session"], Session)
+    assert delete_call["snippet"] is snippet
+    assert delete_call["workflow_id"] == "workflow-1"
+
+
+def test_delete_published_snippet_workflow_raises_not_found(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    def delete_missing_workflow(**_kwargs):
+        raise ValueError("Workflow with ID missing-workflow not found")
+
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=Mock(side_effect=delete_missing_workflow)),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/missing-workflow", method="DELETE"):
+        with pytest.raises(NotFound):
+            handler(api, _snippet(), workflow_id="missing-workflow")
+
+
+def test_delete_published_snippet_workflow_raises_bad_request_when_in_use(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def delete_active_workflow(**_kwargs):
+        raise snippet_workflow_module.WorkflowInUseError("Cannot delete workflow that is currently in use")
+
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=Mock(side_effect=delete_active_workflow)),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/workflow-1", method="DELETE"):
+        with pytest.raises(HTTPException) as exc_info:
+            handler(api, _snippet(), workflow_id="workflow-1")
+
+    assert exc_info.value.code == 400
+
+
 def test_workflow_run_detail_raises_not_found_when_run_missing(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     snippet = _snippet()
     monkeypatch.setattr(

--- a/api/tests/unit_tests/services/test_snippet_service.py
+++ b/api/tests/unit_tests/services/test_snippet_service.py
@@ -28,6 +28,7 @@ from models.workflow import (
     WorkflowType,
 )
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import DraftWorkflowDeletionError, WorkflowInUseError
 from services.snippet_service import SnippetService
 
 
@@ -339,6 +340,64 @@ def test_update_workflow_returns_none_when_missing(sqlite_session: Session) -> N
     )
 
     assert result is None
+
+
+def test_delete_workflow_removes_published_version(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+    workflow = _create_workflow(
+        workflow_id="workflow-1",
+        version="2026-01-01 00:00:00",
+        graph={"nodes": []},
+        features={},
+    )
+    snippet = _snippet(workflow_id="workflow-2")
+    sqlite_session.add_all([snippet, workflow])
+    sqlite_session.flush()
+
+    result = service.delete_workflow(session=sqlite_session, snippet=snippet, workflow_id="workflow-1")
+
+    assert result is True
+    sqlite_session.flush()
+    assert sqlite_session.get(Workflow, "workflow-1") is None
+
+
+def test_delete_workflow_raises_when_missing(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+
+    with pytest.raises(ValueError, match="not found"):
+        service.delete_workflow(session=sqlite_session, snippet=_snippet(), workflow_id="missing-workflow")
+
+
+def test_delete_workflow_raises_for_draft_version(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+    workflow = _create_workflow(
+        workflow_id="workflow-1",
+        version=Workflow.VERSION_DRAFT,
+        graph={"nodes": []},
+        features={},
+    )
+    snippet = _snippet()
+    sqlite_session.add_all([snippet, workflow])
+    sqlite_session.flush()
+
+    with pytest.raises(DraftWorkflowDeletionError):
+        service.delete_workflow(session=sqlite_session, snippet=snippet, workflow_id="workflow-1")
+
+
+def test_delete_workflow_raises_when_currently_active(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+    workflow = _create_workflow(
+        workflow_id="workflow-1",
+        version="2026-01-01 00:00:00",
+        graph={"nodes": []},
+        features={},
+    )
+    snippet = _snippet(workflow_id="workflow-1")
+    sqlite_session.add_all([snippet, workflow])
+    sqlite_session.flush()
+
+    with pytest.raises(WorkflowInUseError):
+        service.delete_workflow(session=sqlite_session, snippet=snippet, workflow_id="workflow-1")
 
 
 def test_get_default_block_configs_skips_empty_defaults(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/contracts/generated/api/console/snippets/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/orpc.gen.ts
@@ -3,6 +3,8 @@
 import { oc } from '@orpc/contract'
 import * as z from 'zod'
 import {
+  zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath,
+  zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse,
   zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesPath,
   zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesResponse,
   zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdPath,
@@ -875,6 +877,25 @@ export const restore = {
 }
 
 /**
+ * Delete a published snippet workflow version
+ *
+ * Delete a published snippet workflow version
+ */
+export const delete4 = oc
+  .route({
+    description: 'Delete a published snippet workflow version',
+    inputStructure: 'detailed',
+    method: 'DELETE',
+    operationId: 'deleteSnippetsBySnippetIdWorkflowsByWorkflowId',
+    path: '/snippets/{snippet_id}/workflows/{workflow_id}',
+    successStatus: 204,
+    summary: 'Delete a published snippet workflow version',
+    tags: ['console'],
+  })
+  .input(z.object({ params: zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath }))
+  .output(zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse)
+
+/**
  * Update a published snippet workflow version's display metadata
  *
  * Update published snippet workflow attributes
@@ -898,6 +919,7 @@ export const patch2 = oc
   .output(zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdResponse)
 
 export const byWorkflowId = {
+  delete: delete4,
   patch: patch2,
   restore,
 }

--- a/packages/contracts/generated/api/console/snippets/types.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/types.gen.ts
@@ -1758,6 +1758,28 @@ export type PostSnippetsBySnippetIdWorkflowsPublishResponses = {
 export type PostSnippetsBySnippetIdWorkflowsPublishResponse =
   PostSnippetsBySnippetIdWorkflowsPublishResponses[keyof PostSnippetsBySnippetIdWorkflowsPublishResponses]
 
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdData = {
+  body?: never
+  path: {
+    snippet_id: string
+    workflow_id: string
+  }
+  query?: never
+  url: '/snippets/{snippet_id}/workflows/{workflow_id}'
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdErrors = {
+  400: unknown
+  404: unknown
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses = {
+  204: void
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse =
+  DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses[keyof DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses]
+
 export type PatchSnippetsBySnippetIdWorkflowsByWorkflowIdData = {
   body: WorkflowUpdatePayload
   path: {

--- a/packages/contracts/generated/api/console/snippets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/zod.gen.ts
@@ -1988,6 +1988,16 @@ export const zPostSnippetsBySnippetIdWorkflowsPublishPath = z.object({
  */
 export const zPostSnippetsBySnippetIdWorkflowsPublishResponse = zWorkflowPublishResponse
 
+export const zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath = z.object({
+  snippet_id: z.uuid(),
+  workflow_id: z.string(),
+})
+
+/**
+ * Workflow deleted successfully
+ */
+export const zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse = z.void()
+
 export const zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdBody = zWorkflowUpdatePayload
 
 export const zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdPath = z.object({


### PR DESCRIPTION
### Summary

Fixes #41000.

`SnippetWorkflowByIdApi` (`api/controllers/console/snippets/snippet_workflow.py`) only implemented `patch()` for the route `/console/api/snippets/<snippet_id>/workflows/<workflow_id>`. The Snippet version-history panel (`web/app/components/snippets/components/workflow-panel.tsx`) sends a `DELETE` to that same URL when a user deletes a historical version, so the backend replied `405 Method Not Allowed` and the delete silently failed in the UI.

This adds:
- `SnippetService.delete_workflow` (`api/services/snippet_service.py`), mirroring the existing `WorkflowService.delete_workflow` used for app workflow versions: it looks up the workflow scoped to the snippet's tenant/app id and kind, then raises
  - `ValueError` if the workflow doesn't exist,
  - `DraftWorkflowDeletionError` if it's the draft version,
  - `WorkflowInUseError` if it's the snippet's currently active version (`snippet.workflow_id`) or is published as a tool (`WorkflowToolProvider`),
  otherwise deletes it.
- `SnippetWorkflowByIdApi.delete()`, following the same auth/permission decorators as `patch()` on this resource, translating those exceptions to `400`/`404` and returning `204` on success (matching `WorkflowByIdApi.delete()` for app workflows).

### Test plan

Added unit tests that fail on `HEAD~1` (before this change) and pass with the fix:

- `api/tests/unit_tests/services/test_snippet_service.py`
  - `test_delete_workflow_removes_published_version`
  - `test_delete_workflow_raises_when_missing`
  - `test_delete_workflow_raises_for_draft_version`
  - `test_delete_workflow_raises_when_currently_active`
- `api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py`
  - `test_delete_published_snippet_workflow_succeeds`
  - `test_delete_published_snippet_workflow_raises_not_found`
  - `test_delete_published_snippet_workflow_raises_bad_request_when_in_use`

Verified the new tests fail against the pre-fix source (`git checkout HEAD~1 -- api/controllers/console/snippets/snippet_workflow.py api/services/snippet_service.py`) with:
```
AttributeError: 'SnippetWorkflowByIdApi' object has no attribute 'delete'
AttributeError: 'SnippetService' object has no attribute 'delete_workflow'
```
and pass after restoring the fix.

Ran, on the fixed source:
```
$ make test TARGET_TESTS="api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py api/tests/unit_tests/services/test_snippet_service.py"
...
59 passed, 2 warnings in 76.53s
```
```
$ uv run --project api --dev ruff format --check <changed files>
4 files already formatted
$ uv run --project api --dev ruff check api/
All checks passed!
$ ./dev/pyrefly-check-local api/controllers/console/snippets/snippet_workflow.py api/services/snippet_service.py
(no output — clean)
$ uv --directory api run --dev lint-imports
Contracts: 14 kept, 0 broken.
$ uv run --project api --dev python api/dev/lint_response_contracts.py
Response contract lint: 483 valid, 0 mismatch, 2 refactorable (both pre-existing, unrelated files), 364 unknown
```

### AI assistance disclosure

This change was authored with the assistance of an AI coding agent (Claude Code), with human-equivalent review of the diff, tests, and check output described above before submission.
