### PR TITLE
fix(api): implement DELETE endpoint for published snippet workflow versions (#41000)

### DIFF
--- a/api/controllers/console/snippets/snippet_workflow.py
+++ b/api/controllers/console/snippets/snippet_workflow.py
@@ -60,6 +60,7 @@ from models.snippet import CustomizedSnippet
 from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.agent.workflow_publish_service import WorkflowAgentPublishService
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import DraftWorkflowDeletionError, WorkflowInUseError
 from services.snippet_generate_service import SnippetGenerateService
 from services.snippet_service import SnippetService
 from tasks.collect_agent_resources_task import enqueue_agent_resource_collection
@@ -479,6 +480,43 @@ class SnippetWorkflowByIdApi(Resource):
         response = SnippetWorkflowResponse.model_validate(workflow, from_attributes=True).model_dump(mode="json")
         response["input_fields"] = snippet.input_fields_list
         return response
+
+    @console_ns.doc("delete_snippet_workflow_by_id")
+    @console_ns.doc(description="Delete a published snippet workflow version")
+    @console_ns.doc(params={"snippet_id": "Snippet ID", "workflow_id": "Workflow ID"})
+    @console_ns.response(204, "Workflow deleted successfully")
+    @console_ns.response(400, "Cannot delete workflow in use or draft workflow")
+    @console_ns.response(404, "Workflow not found")
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @get_snippet
+    @edit_permission_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.SNIPPETS_CREATE_AND_MODIFY, resource_required=False
+    )
+    def delete(
+        self,
+        snippet: CustomizedSnippet,
+        workflow_id: str,
+    ):
+        """Delete a published snippet workflow version that is not currently active."""
+        snippet_service = _snippet_service()
+        with _snippet_session_maker().begin() as session:
+            try:
+                snippet_service.delete_workflow(
+                    session=session,
+                    snippet=snippet,
+                    workflow_id=workflow_id,
+                )
+            except WorkflowInUseError as e:
+                raise BadRequest(str(e)) from e
+            except DraftWorkflowDeletionError as e:
+                raise BadRequest(str(e)) from e
+            except ValueError as e:
+                raise NotFound(str(e)) from e
+
+        return None, 204
 
 
 @console_ns.route("/snippets/<uuid:snippet_id>/workflow-runs")

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -9450,6 +9450,26 @@ Reset a draft workflow variable to its default value (snippet scope)
 | 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
 | 400 | No draft workflow found |  |
 
+### [DELETE] /snippets/{snippet_id}/workflows/{workflow_id}
+**Delete a published snippet workflow version that is not currently active**
+
+Delete a published snippet workflow version
+
+#### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ------ |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
+| workflow_id | path | Workflow ID | Yes | string |
+
+#### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 204 | Workflow deleted successfully |
+| 400 | Cannot delete workflow in use or draft workflow |
+| 404 | Workflow not found |
+
 ### [PATCH] /snippets/{snippet_id}/workflows/{workflow_id}
 **Update a published snippet workflow version's display metadata**
 

--- a/api/services/snippet_service.py
+++ b/api/services/snippet_service.py
@@ -39,12 +39,15 @@ from models.workflow import (
 from repositories.factory import DifyAPIRepositoryFactory
 from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import WorkflowInUseError
 from services.tag_service import TagService
 from services.workflow_node_execution_trace_service import (
     WorkflowNodeExecutionTrace,
     assemble_workflow_node_execution_traces,
 )
+from services.workflow_ref_service import WorkflowRefService
 from services.workflow_restore import apply_published_workflow_snapshot_to_draft
+from services.workflow_service import WorkflowService
 from tasks.collect_agent_resources_task import enqueue_agent_resource_collection
 
 logger = logging.getLogger(__name__)
@@ -841,6 +844,31 @@ class SnippetService:
         workflow.updated_at = datetime.now(UTC).replace(tzinfo=None)
         session.add(workflow)
         return workflow
+
+    def delete_workflow(
+        self,
+        *,
+        session: Session,
+        snippet: CustomizedSnippet,
+        workflow_id: str,
+    ) -> bool:
+        """
+        Delete a published snippet workflow version that is not currently active.
+
+        :param session: Database session
+        :param snippet: CustomizedSnippet instance
+        :param workflow_id: Workflow ID to delete
+        :return: True if deleted successfully
+        :raises WorkflowInUseError: If the workflow is currently in use by the snippet
+        :raises DraftWorkflowDeletionError: If the workflow is a draft version
+        :raises ValueError: If the workflow is not found
+        """
+        if snippet.workflow_id == workflow_id:
+            raise WorkflowInUseError(f"Cannot delete workflow that is currently in use by snippet '{snippet.id}'")
+
+        workflow_service = WorkflowService()
+        workflow_ref = WorkflowRefService.create_snippet_workflow_ref(snippet, workflow_id)
+        return workflow_service.delete_workflow(session=session, workflow_ref=workflow_ref)
 
     # --- Default Block Configs ---
 

--- a/api/services/workflow_ref_service.py
+++ b/api/services/workflow_ref_service.py
@@ -4,6 +4,7 @@ from typing import NamedTuple
 
 from models.dataset import Pipeline
 from models.model import App
+from models.snippet import CustomizedSnippet
 
 
 class WorkflowRef(NamedTuple):
@@ -15,7 +16,7 @@ class WorkflowRef(NamedTuple):
 
 
 class WorkflowRefService:
-    """Factory helpers for app and RAG pipeline workflow refs."""
+    """Factory helpers for app, RAG pipeline, and snippet workflow refs."""
 
     @staticmethod
     def create_app_workflow_ref(app: App, workflow_id: str) -> WorkflowRef:
@@ -24,3 +25,7 @@ class WorkflowRefService:
     @staticmethod
     def create_pipeline_workflow_ref(pipeline: Pipeline, workflow_id: str) -> WorkflowRef:
         return WorkflowRef(tenant_id=pipeline.tenant_id, owner_id=pipeline.id, workflow_id=workflow_id)
+
+    @staticmethod
+    def create_snippet_workflow_ref(snippet: CustomizedSnippet, workflow_id: str) -> WorkflowRef:
+        return WorkflowRef(tenant_id=snippet.tenant_id, owner_id=snippet.id, workflow_id=workflow_id)

--- a/api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py
+++ b/api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py
@@ -566,3 +566,124 @@ def test_workflow_task_stop_uses_queue_flag_and_graph_command(app: Flask, monkey
     assert result == {"result": "success"}
     set_stop_flag.assert_called_once_with("task-1")
     send_stop_command.assert_called_once_with("task-1")
+
+
+@pytest.mark.parametrize("sqlite_session", [(CustomizedSnippet,)], indirect=True)
+def test_delete_published_snippet_workflow_success(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
+) -> None:
+    snippet = _snippet()
+    sqlite_session.add(snippet)
+    sqlite_session.commit()
+
+    delete_workflow = Mock(return_value=True)
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=delete_workflow),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/workflow-1", method="DELETE"):
+        response, status_code = handler(api, snippet=snippet, workflow_id="workflow-1")
+
+    assert status_code == 204
+    assert response is None
+    delete_workflow.assert_called_once()
+    delete_call = delete_workflow.call_args.kwargs
+    assert isinstance(delete_call["session"], Session)
+    assert delete_call["snippet"] is snippet
+    assert delete_call["workflow_id"] == "workflow-1"
+
+
+@pytest.mark.parametrize("sqlite_session", [(CustomizedSnippet,)], indirect=True)
+def test_delete_published_snippet_workflow_in_use_raises_400(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
+) -> None:
+    snippet = _snippet(workflow_id="workflow-1")
+    sqlite_session.add(snippet)
+    sqlite_session.commit()
+
+    def fail_in_use(*, session: Session, snippet: CustomizedSnippet, workflow_id: str):
+        raise snippet_workflow_module.WorkflowInUseError(
+            "Cannot delete workflow that is currently in use by snippet 'snippet-1'"
+        )
+
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=Mock(side_effect=fail_in_use)),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/workflow-1", method="DELETE"):
+        with pytest.raises(HTTPException) as exc:
+            handler(api, snippet=snippet, workflow_id="workflow-1")
+
+    assert exc.value.code == 400
+    assert "currently in use by snippet" in exc.value.description
+
+
+@pytest.mark.parametrize("sqlite_session", [(CustomizedSnippet,)], indirect=True)
+def test_delete_published_snippet_workflow_draft_raises_400(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
+) -> None:
+    snippet = _snippet()
+    sqlite_session.add(snippet)
+    sqlite_session.commit()
+
+    def fail_draft(*, session: Session, snippet: CustomizedSnippet, workflow_id: str):
+        raise snippet_workflow_module.DraftWorkflowDeletionError("Cannot delete draft workflow versions")
+
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=Mock(side_effect=fail_draft)),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/draft-workflow", method="DELETE"):
+        with pytest.raises(HTTPException) as exc:
+            handler(api, snippet=snippet, workflow_id="draft-workflow")
+
+    assert exc.value.code == 400
+    assert "Cannot delete draft workflow versions" in exc.value.description
+
+
+@pytest.mark.parametrize("sqlite_session", [(CustomizedSnippet,)], indirect=True)
+def test_delete_published_snippet_workflow_not_found_raises_404(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
+) -> None:
+    snippet = _snippet()
+    sqlite_session.add(snippet)
+    sqlite_session.commit()
+
+    def fail_not_found(*, session: Session, snippet: CustomizedSnippet, workflow_id: str):
+        raise ValueError("Workflow with ID missing-workflow not found")
+
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=Mock(side_effect=fail_not_found)),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/missing-workflow", method="DELETE"):
+        with pytest.raises(NotFound, match="Workflow with ID missing-workflow not found"):
+            handler(api, snippet=snippet, workflow_id="missing-workflow")

--- a/packages/contracts/generated/api/console/snippets/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/orpc.gen.ts
@@ -3,6 +3,8 @@
 import { oc } from '@orpc/contract'
 import * as z from 'zod'
 import {
+  zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath,
+  zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse,
   zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesPath,
   zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesResponse,
   zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdPath,
@@ -875,6 +877,25 @@ export const restore = {
 }
 
 /**
+ * Delete a published snippet workflow version that is not currently active
+ *
+ * Delete a published snippet workflow version
+ */
+export const delete4 = oc
+  .route({
+    description: 'Delete a published snippet workflow version',
+    inputStructure: 'detailed',
+    method: 'DELETE',
+    operationId: 'deleteSnippetsBySnippetIdWorkflowsByWorkflowId',
+    path: '/snippets/{snippet_id}/workflows/{workflow_id}',
+    successStatus: 204,
+    summary: 'Delete a published snippet workflow version that is not currently active',
+    tags: ['console'],
+  })
+  .input(z.object({ params: zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath }))
+  .output(zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse)
+
+/**
  * Update a published snippet workflow version's display metadata
  *
  * Update published snippet workflow attributes
@@ -898,6 +919,7 @@ export const patch2 = oc
   .output(zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdResponse)
 
 export const byWorkflowId = {
+  delete: delete4,
   patch: patch2,
   restore,
 }

--- a/packages/contracts/generated/api/console/snippets/types.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/types.gen.ts
@@ -1779,6 +1779,28 @@ export type PostSnippetsBySnippetIdWorkflowsPublishResponses = {
 export type PostSnippetsBySnippetIdWorkflowsPublishResponse =
   PostSnippetsBySnippetIdWorkflowsPublishResponses[keyof PostSnippetsBySnippetIdWorkflowsPublishResponses]
 
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdData = {
+  body?: never
+  path: {
+    snippet_id: string
+    workflow_id: string
+  }
+  query?: never
+  url: '/snippets/{snippet_id}/workflows/{workflow_id}'
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdErrors = {
+  400: unknown
+  404: unknown
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses = {
+  204: void
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse =
+  DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses[keyof DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses]
+
 export type PatchSnippetsBySnippetIdWorkflowsByWorkflowIdData = {
   body: WorkflowUpdatePayload
   path: {

--- a/packages/contracts/generated/api/console/snippets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/zod.gen.ts
@@ -2014,6 +2014,16 @@ export const zPostSnippetsBySnippetIdWorkflowsPublishPath = z.object({
  */
 export const zPostSnippetsBySnippetIdWorkflowsPublishResponse = zWorkflowPublishResponse
 
+export const zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath = z.object({
+  snippet_id: z.uuid(),
+  workflow_id: z.string(),
+})
+
+/**
+ * Workflow deleted successfully
+ */
+export const zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse = z.void()
+
 export const zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdBody = zWorkflowUpdatePayload
 
 export const zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdPath = z.object({


### PR DESCRIPTION
## Summary
Fixes #41000

When deleting a published snippet workflow version from the Version History UI (\DELETE /console/api/snippets/{snippet_id}/workflows/{workflow_id}\), the request failed with HTTP 405 Method Not Allowed because \SnippetWorkflowByIdApi\ only implemented \patch()\ and was missing the \delete()\ method.

This PR adds the missing \delete()\ endpoint to \SnippetWorkflowByIdApi\, adds \create_snippet_workflow_ref\ to \WorkflowRefService\, implements \delete_workflow\ in \SnippetService\ (which ensures that currently active published versions cannot be deleted), and adds comprehensive unit tests.

cc @FFXN (issue author) @asukaminato0721 @JzoNgKVO

## Changes
- \pi/services/workflow_ref_service.py\: Added \create_snippet_workflow_ref\ helper for \CustomizedSnippet\.
- \pi/services/snippet_service.py\: Added \delete_workflow\ to \SnippetService\ with in-use validation against \snippet.workflow_id\.
- \pi/controllers/console/snippets/snippet_workflow.py\: Implemented \delete\ method on \SnippetWorkflowByIdApi\ with standard auth/RBAC decorators and error handling.
- \pi/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py\: Added unit tests covering successful deletion (204), active workflow deletion prevention (400), draft deletion error (400), and missing workflow error (404).

## Checklist
- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran \make lint && make type-check\ (backend) and \p staged\ (frontend) to appease the lint gods