### PR TITLE
refactor(web): use shared session factory for JWT decoding

### DIFF
--- a/api/controllers/web/wraps.py
+++ b/api/controllers/web/wraps.py
@@ -6,11 +6,11 @@ from typing import Concatenate
 from flask import request
 from flask_restx import Resource
 from sqlalchemy import select
-from sqlalchemy.orm import sessionmaker
 from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 
 from constants import HEADER_NAME_APP_CODE
 from controllers.web.error import WebAppAuthAccessDeniedError, WebAppAuthRequiredError
+from core.db.session_factory import session_factory
 from core.logging.context import set_identity_context
 from extensions.ext_database import db
 from libs.passport import PassportService
@@ -54,7 +54,7 @@ def decode_jwt_token(app_code: str | None = None, user_id: str | None = None) ->
         decoded = PassportService().verify(tk)
         app_code = decoded.get("app_code")
         app_id = decoded.get("app_id")
-        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
+        with session_factory.create_session() as session:
             app_model = session.scalar(select(App).where(App.id == app_id))
             site = session.scalar(select(Site).where(Site.code == app_code))
             if not app_model:

--- a/api/tests/unit_tests/controllers/web/test_wraps.py
+++ b/api/tests/unit_tests/controllers/web/test_wraps.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
 from unittest import mock
+from uuid import uuid4
 
 import pytest
 from flask import Flask
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import Unauthorized
 
 from core.logging.context import clear_request_context, get_identity_context
@@ -52,14 +54,37 @@ def test_validate_jwt_token_does_not_set_identity_when_authentication_fails() ->
     assert get_identity_context() == ("", "", "")
 
 
-def test_decode_jwt_token_uses_shared_session_factory() -> None:
+def test_decode_jwt_token_uses_shared_session_factory(sqlite_session: Session) -> None:
     from controllers.web import wraps
+    from models.enums import EndUserType
+    from models.model import AppMode, CustomizeTokenStrategy, Site
 
-    app_model = SimpleNamespace(enable_site=True)
-    site = SimpleNamespace()
-    end_user = SimpleNamespace(session_id="session-id")
-    session = mock.MagicMock()
-    session.scalar.side_effect = [app_model, site, end_user]
+    tenant_id = str(uuid4())
+    app_model = App(
+        tenant_id=tenant_id,
+        mode=AppMode.CHAT.value,
+        name="test-app",
+        enable_site=True,
+        enable_api=True,
+    )
+    sqlite_session.add(app_model)
+    sqlite_session.commit()
+
+    site = Site(
+        app_id=app_model.id,
+        title="test-site",
+        default_language="en-US",
+        customize_token_strategy=CustomizeTokenStrategy.NOT_ALLOW,
+        code="app-code",
+    )
+    end_user = EndUser(
+        tenant_id=tenant_id,
+        app_id=app_model.id,
+        type=EndUserType.BROWSER,
+        session_id="session-id",
+    )
+    sqlite_session.add_all((site, end_user))
+    sqlite_session.commit()
 
     with (
         mock.patch.object(wraps, "extract_webapp_passport", return_value="jwt-token"),
@@ -69,16 +94,12 @@ def test_decode_jwt_token_uses_shared_session_factory() -> None:
             "FeatureService",
             get_system_features=mock.Mock(return_value=SimpleNamespace(webapp_auth=SimpleNamespace(enabled=False))),
         ),
-        mock.patch.object(wraps.session_factory, "create_session") as mock_create_session,
     ):
         mock_passport_service.return_value.verify.return_value = {
             "app_code": "app-code",
-            "app_id": "app-id",
-            "end_user_id": "end-user-id",
+            "app_id": app_model.id,
+            "end_user_id": end_user.id,
         }
-        mock_create_session.return_value.__enter__.return_value = session
 
         with Flask(__name__).test_request_context("/", headers={"X-App-Code": "app-code"}):
             assert wraps.decode_jwt_token() == (app_model, end_user)
-
-    mock_create_session.assert_called_once_with()

--- a/api/tests/unit_tests/controllers/web/test_wraps.py
+++ b/api/tests/unit_tests/controllers/web/test_wraps.py
@@ -102,4 +102,7 @@ def test_decode_jwt_token_uses_shared_session_factory(sqlite_session: Session) -
         }
 
         with Flask(__name__).test_request_context("/", headers={"X-App-Code": "app-code"}):
-            assert wraps.decode_jwt_token() == (app_model, end_user)
+            result_app, result_end_user = wraps.decode_jwt_token()
+
+    assert result_app.id == app_model.id
+    assert result_end_user.id == end_user.id

--- a/api/tests/unit_tests/controllers/web/test_wraps.py
+++ b/api/tests/unit_tests/controllers/web/test_wraps.py
@@ -1,6 +1,8 @@
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+from flask import Flask
 from werkzeug.exceptions import Unauthorized
 
 from core.logging.context import clear_request_context, get_identity_context
@@ -48,3 +50,35 @@ def test_validate_jwt_token_does_not_set_identity_when_authentication_fails() ->
         protected_view()
 
     assert get_identity_context() == ("", "", "")
+
+
+def test_decode_jwt_token_uses_shared_session_factory() -> None:
+    from controllers.web import wraps
+
+    app_model = SimpleNamespace(enable_site=True)
+    site = SimpleNamespace()
+    end_user = SimpleNamespace(session_id="session-id")
+    session = mock.MagicMock()
+    session.scalar.side_effect = [app_model, site, end_user]
+
+    with (
+        mock.patch.object(wraps, "extract_webapp_passport", return_value="jwt-token"),
+        mock.patch.object(wraps, "PassportService") as mock_passport_service,
+        mock.patch.object(
+            wraps,
+            "FeatureService",
+            get_system_features=mock.Mock(return_value=SimpleNamespace(webapp_auth=SimpleNamespace(enabled=False))),
+        ),
+        mock.patch.object(wraps.session_factory, "create_session") as mock_create_session,
+    ):
+        mock_passport_service.return_value.verify.return_value = {
+            "app_code": "app-code",
+            "app_id": "app-id",
+            "end_user_id": "end-user-id",
+        }
+        mock_create_session.return_value.__enter__.return_value = session
+
+        with Flask(__name__).test_request_context("/", headers={"X-App-Code": "app-code"}):
+            assert wraps.decode_jwt_token() == (app_model, end_user)
+
+    mock_create_session.assert_called_once_with()


### PR DESCRIPTION
## Summary
- use the application-configured session factory in web JWT decoding
- remove controller-local `sessionmaker` construction
- preserve existing enterprise auth database access

## Why
This continues the dependency-injection cleanup tracked in #36544 and keeps session creation centralized in `core.db.session_factory`.

## Testing
- added unit coverage in `api/tests/unit_tests/controllers/web/test_wraps.py` using the shared `sqlite_session` fixture
- targeted pytest in Linux / Python 3.12: `3 passed`
- `uvx ruff check api/tests/unit_tests/controllers/web/test_wraps.py api/controllers/web/wraps.py`
- `python -m compileall -q api/controllers/web/wraps.py api/tests/unit_tests/controllers/web/test_wraps.py`

## Checklist
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

Refs #36544