### PR TITLE
chore: inline custom ESLint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,6 @@
 
 import markdown from '@eslint/markdown'
 import md from 'eslint-markdown'
-import hyoban from 'eslint-plugin-hyoban'
 import jsonc from 'eslint-plugin-jsonc'
 import markdownPreferences from 'eslint-plugin-markdown-preferences'
 import pnpm from 'eslint-plugin-pnpm'
@@ -421,12 +420,11 @@ export default defineConfig([
     files: ['web/i18n/**/*.json'],
     plugins: {
       dify,
-      hyoban,
     },
     rules: {
       'dify/consistent-placeholders': 'error',
+      'dify/i18n-flat-key': 'error',
       'dify/no-extra-keys': 'error',
-      'hyoban/i18n-flat-key': 'error',
       'jsonc/sort-keys': 'error',
     },
   },

--- a/lint.config.ts
+++ b/lint.config.ts
@@ -164,6 +164,10 @@ export const lintConfig = {
     'eslint-plugin-antfu',
     ...(enableTailwindCanonicalClasses ? ['eslint-plugin-better-tailwindcss'] : []),
     'eslint-plugin-command',
+    {
+      name: 'dify',
+      specifier: './web/plugins/eslint/index.js',
+    },
     'eslint-plugin-erasable-syntax-only',
     {
       name: 'eslint-comments',
@@ -173,7 +177,6 @@ export const lintConfig = {
       name: 'eslint-react',
       specifier: '@eslint-react/eslint-plugin',
     },
-    'eslint-plugin-hyoban',
     {
       name: 'jsdoc-js',
       specifier: 'eslint-plugin-jsdoc',
@@ -813,7 +816,7 @@ export const lintConfig = {
     {
       files: ['web/**/*.tsx'],
       rules: {
-        'hyoban/prefer-tailwind-icons': [
+        'dify/prefer-tailwind-icons': [
           'warn',
           {
             prefix: 'i-',

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-better-tailwindcss": "catalog:",
     "eslint-plugin-command": "catalog:",
     "eslint-plugin-erasable-syntax-only": "catalog:",
-    "eslint-plugin-hyoban": "catalog:",
     "eslint-plugin-jsdoc": "catalog:",
     "eslint-plugin-jsonc": "catalog:",
     "eslint-plugin-markdown-preferences": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,9 +327,6 @@ catalogs:
     eslint-plugin-erasable-syntax-only:
       specifier: 0.4.2
       version: 0.4.2
-    eslint-plugin-hyoban:
-      specifier: 0.14.1
-      version: 0.14.1
     eslint-plugin-jsdoc:
       specifier: 63.3.3
       version: 63.3.3
@@ -687,9 +684,6 @@ importers:
       eslint-plugin-erasable-syntax-only:
         specifier: 'catalog:'
         version: 0.4.2(@typescript-eslint/parser@8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@11.0.0))(supports-color@11.0.0))(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@11.0.0))(supports-color@10.2.2)
-      eslint-plugin-hyoban:
-        specifier: 'catalog:'
-        version: 0.14.1(eslint@10.8.1(jiti@2.7.0)(supports-color@11.0.0))
       eslint-plugin-jsdoc:
         specifier: 'catalog:'
         version: 63.3.3(eslint@10.8.1(jiti@2.7.0)(supports-color@11.0.0))(supports-color@11.0.0)
@@ -6005,11 +5999,6 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
-
-  eslint-plugin-hyoban@0.14.1:
-    resolution: {integrity: sha512-R7UX1AMUilGfFftGoHKTlG0BVN5PsiZLN78Yqi6GZBaheQkvwRj4Dw+k+wW+1nKcueyh4IKdvt+n+0ayLEnZYA==}
-    peerDependencies:
-      eslint: '*'
 
   eslint-plugin-jsdoc@63.3.3:
     resolution: {integrity: sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==}
@@ -13414,10 +13403,6 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@11.0.0)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@11.0.0))
 
-  eslint-plugin-hyoban@0.14.1(eslint@10.8.1(jiti@2.7.0)(supports-color@11.0.0)):
-    dependencies:
-      eslint: 10.8.1(jiti@2.7.0)(supports-color@11.0.0)
-
   eslint-plugin-jsdoc@63.3.3(eslint@10.8.1(jiti@2.7.0)(supports-color@11.0.0))(supports-color@11.0.0):
     dependencies:
       '@es-joy/jsdoccomment': 0.91.0
@@ -17170,7 +17155,6 @@ time:
   eslint-plugin-better-tailwindcss@4.7.0: '2026-07-19T13:26:01.366Z'
   eslint-plugin-command@3.5.3: '2026-07-14T04:59:31.991Z'
   eslint-plugin-erasable-syntax-only@0.4.2: '2026-06-18T00:56:01.038Z'
-  eslint-plugin-hyoban@0.14.1: '2026-03-08T02:51:00.805Z'
   eslint-plugin-jsdoc@63.3.3: '2026-08-02T18:02:10.488Z'
   eslint-plugin-jsonc@3.4.1: '2026-08-04T07:21:02.632Z'
   eslint-plugin-markdown-preferences@0.41.1: '2026-04-09T23:28:41.552Z'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -170,7 +170,6 @@ catalog:
   eslint-plugin-better-tailwindcss: 4.7.0
   eslint-plugin-command: 3.5.3
   eslint-plugin-erasable-syntax-only: 0.4.2
-  eslint-plugin-hyoban: 0.14.1
   eslint-plugin-jsdoc: 63.3.3
   eslint-plugin-jsonc: 3.4.1
   eslint-plugin-markdown-preferences: 0.41.1

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/credits-exhausted-alert.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/credits-exhausted-alert.tsx
@@ -71,7 +71,7 @@ export default function CreditsExhaustedAlert({
             {t(($) => $['modelProvider.card.usageLabel'], { ns: 'common' })}
           </MeterLabel>
           <div className="flex items-center gap-0.5 system-xs-regular text-text-tertiary">
-            {/* oxlint-disable-next-line hyoban/prefer-tailwind-icons -- This generated icon class is not available to Tailwind. */}
+            {/* oxlint-disable-next-line dify/prefer-tailwind-icons -- This generated icon class is not available to Tailwind. */}
             <CreditsCoin className="size-3" />
             <span>
               {formatNumber(usedCredits)}/{formatNumber(totalCredits)}

--- a/web/app/components/plugins/plugin-page/plugin-tasks/components/plugin-item.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/components/plugin-item.tsx
@@ -34,7 +34,7 @@ const PluginItem: FC<PluginItemProps> = ({
         {hasPluginIcon ? (
           <CardIcon size="small" src={getIconUrl(plugin.icon)} />
         ) : (
-          // oxlint-disable-next-line hyoban/prefer-tailwind-icons -- Reuse the same MagicBox component as the marketplace install button.
+          // oxlint-disable-next-line dify/prefer-tailwind-icons -- Reuse the same MagicBox component as the marketplace install button.
           <MagicBox className="size-8 text-text-tertiary" />
         )}
         <div className="absolute -right-0.5 -bottom-0.5 z-10">{statusIcon}</div>

--- a/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
@@ -325,7 +325,7 @@ const GenericTable: FC<GenericTableProps> = ({
                       className="p-1"
                       aria-label="Delete row"
                     >
-                      {/* oxlint-disable-next-line hyoban/prefer-tailwind-icons */}
+                      {/* oxlint-disable-next-line dify/prefer-tailwind-icons */}
                       <RiDeleteBinLine className="size-3.5 text-text-destructive" />
                     </button>
                   </div>

--- a/web/app/components/workflow/panel/env-panel/index.tsx
+++ b/web/app/components/workflow/panel/env-panel/index.tsx
@@ -802,7 +802,7 @@ const EnvPanel = () => {
             className="flex size-6 cursor-pointer items-center justify-center"
             onClick={() => setShowEnvPanel(false)}
           >
-            {/* oxlint-disable-next-line hyoban/prefer-tailwind-icons */}
+            {/* oxlint-disable-next-line dify/prefer-tailwind-icons */}
             <RiCloseLine className="size-4 text-text-tertiary" />
           </button>
         </div>

--- a/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
+++ b/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
@@ -135,7 +135,7 @@ const IterationLogTrigger = ({
       className="flex w-full cursor-pointer items-center self-stretch rounded-lg bg-components-button-tertiary-bg-hover px-3 py-2 inset-ring-0 hover:bg-components-button-tertiary-bg-hover"
       onClick={handleOnShowIterationDetail}
     >
-      {/* oxlint-disable-next-line hyoban/prefer-tailwind-icons */}
+      {/* oxlint-disable-next-line dify/prefer-tailwind-icons */}
       <Iteration className="size-4 shrink-0 text-components-button-tertiary-text" />
       <div className="flex-1 text-left system-sm-medium text-components-button-tertiary-text">
         {t(($) => $['nodes.iteration.iteration'], { ns: 'workflow', count: displayIterationCount })}
@@ -146,7 +146,7 @@ const IterationLogTrigger = ({
           </>
         )}
       </div>
-      {/* oxlint-disable-next-line hyoban/prefer-tailwind-icons */}
+      {/* oxlint-disable-next-line dify/prefer-tailwind-icons */}
       <RiArrowRightSLine className="size-4 shrink-0 text-components-button-tertiary-text" />
     </Button>
   )

--- a/web/plugins/eslint/index.js
+++ b/web/plugins/eslint/index.js
@@ -1,15 +1,19 @@
 import consistentPlaceholders from './rules/consistent-placeholders.js'
+import i18nFlatKey from './rules/i18n-flat-key.js'
 import noExtraKeys from './rules/no-extra-keys.js'
+import preferTailwindIcons from './rules/prefer-tailwind-icons.js'
 
 /** @type {import('eslint').ESLint.Plugin} */
 const plugin = {
   meta: {
-    name: 'dify-i18n',
+    name: 'dify',
     version: '1.0.0',
   },
   rules: {
     'consistent-placeholders': consistentPlaceholders,
+    'i18n-flat-key': i18nFlatKey,
     'no-extra-keys': noExtraKeys,
+    'prefer-tailwind-icons': preferTailwindIcons,
   },
 }
 

--- a/web/plugins/eslint/rules/i18n-flat-key.js
+++ b/web/plugins/eslint/rules/i18n-flat-key.js
@@ -1,0 +1,83 @@
+function getPropertyKey(property) {
+  if (property.key.type === 'JSONIdentifier') return property.key.name
+  if (property.key.type === 'JSONLiteral' && typeof property.key.value === 'string')
+    return property.key.value
+  return null
+}
+
+function getReportNode(sourceCode, targetNode) {
+  return sourceCode.getNodeByRangeIndex(targetNode.range[0]) ?? sourceCode.ast
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensure i18n JSON keys are flat and valid as object paths',
+    },
+    messages: {
+      nestedJsonNotAllowed:
+        'Invalid JSON structure: nested object is not allowed, use flat keys instead',
+      keyConflictsWithPrefix: "Invalid key structure: '{{key}}' conflicts with '{{prefix}}'",
+      keyIsPrefixOfAnother: "Invalid key structure: '{{key}}' is a prefix of another key",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      JSONObjectExpression(node) {
+        if (node.parent.type !== 'JSONExpressionStatement') {
+          const targetNode = node.parent.type === 'JSONProperty' ? node.parent.key : node
+          context.report({
+            node: getReportNode(context.sourceCode, targetNode),
+            messageId: 'nestedJsonNotAllowed',
+          })
+          return
+        }
+
+        const keyEntries = new Map()
+        for (const property of node.properties) {
+          const key = getPropertyKey(property)
+          if (key === null || keyEntries.has(key)) continue
+          keyEntries.set(key, {
+            key,
+            keyNode: property.key,
+          })
+        }
+
+        const keys = [...keyEntries.keys()]
+        const keyPrefixes = new Set()
+        for (const key of keys) {
+          if (!key.includes('.')) continue
+          const parts = key.split('.')
+          for (let i = 1; i < parts.length; i++) {
+            const prefix = parts.slice(0, i).join('.')
+            if (keyEntries.has(prefix)) {
+              const keyNode = keyEntries.get(key)?.keyNode ?? node
+              context.report({
+                node: getReportNode(context.sourceCode, keyNode),
+                messageId: 'keyConflictsWithPrefix',
+                data: {
+                  key,
+                  prefix,
+                },
+              })
+            }
+            keyPrefixes.add(prefix)
+          }
+        }
+
+        for (const key of keys) {
+          if (!keyPrefixes.has(key)) continue
+          const keyNode = keyEntries.get(key)?.keyNode ?? node
+          context.report({
+            node: getReportNode(context.sourceCode, keyNode),
+            messageId: 'keyIsPrefixOfAnother',
+            data: { key },
+          })
+        }
+      },
+    }
+  },
+}

--- a/web/plugins/eslint/rules/prefer-tailwind-icons.js
+++ b/web/plugins/eslint/rules/prefer-tailwind-icons.js
@@ -1,0 +1,386 @@
+const CAMEL_TO_KEBAB_UPPERCASE_REGEX = /([A-Z]+)([A-Z][a-z])/gu
+const CAMEL_TO_KEBAB_LETTER_DIGIT_REGEX = /([a-z])(\d)/giu
+const CAMEL_TO_KEBAB_DIGIT_LETTER_REGEX = /(\d)([a-z])/giu
+const CAMEL_TO_KEBAB_LOWER_UPPER_REGEX = /([a-z\d])([A-Z])/gu
+const CAMEL_TO_KEBAB_SEPARATOR_REGEX = /[_\s]+/gu
+const REPEATED_DASH_REGEX = /-+/gu
+const EDGE_DASH_REGEX = /^-|-$/gu
+const REGEX_FLAGS_PATTERN = /^[a-z]*$/iu
+const NORMALIZE_SEGMENT_SPACES_REGEX = /\s+/gu
+const warned = new Set()
+
+function warnOnce(message) {
+  if (warned.has(message)) return
+  warned.add(message)
+  console.warn(message)
+}
+
+function camelToKebab(value) {
+  return value
+    .replace(CAMEL_TO_KEBAB_UPPERCASE_REGEX, '$1-$2')
+    .replace(CAMEL_TO_KEBAB_LETTER_DIGIT_REGEX, '$1-$2')
+    .replace(CAMEL_TO_KEBAB_DIGIT_LETTER_REGEX, '$1-$2')
+    .replace(CAMEL_TO_KEBAB_LOWER_UPPER_REGEX, '$1-$2')
+    .replace(CAMEL_TO_KEBAB_SEPARATOR_REGEX, '-')
+    .replace(REPEATED_DASH_REGEX, '-')
+    .replace(EDGE_DASH_REGEX, '')
+    .toLowerCase()
+}
+
+function pixelToClass(pixels, classPrefix) {
+  if (pixels % 4 === 0) return `${classPrefix}-${pixels / 4}`
+  return `${classPrefix}-[${pixels}px]`
+}
+
+function parseRegexPattern(pattern) {
+  if (!pattern.startsWith('/')) return null
+  let closingSlashIndex = -1
+  for (let i = pattern.length - 1; i > 0; i--) {
+    if (pattern[i] !== '/') continue
+    let backslashCount = 0
+    for (let j = i - 1; j >= 0 && pattern[j] === '\\'; j--) backslashCount++
+    if (backslashCount % 2 === 0) {
+      closingSlashIndex = i
+      break
+    }
+  }
+  if (closingSlashIndex <= 1) return null
+  const source = pattern.slice(1, closingSlashIndex)
+  const flags = pattern.slice(closingSlashIndex + 1)
+  if (!REGEX_FLAGS_PATTERN.test(flags)) return null
+  try {
+    return new RegExp(source, flags)
+  } catch {
+    return null
+  }
+}
+
+function createRegex(pattern, optionName) {
+  if (pattern.startsWith('/') && pattern.lastIndexOf('/') > 0) {
+    const literalRegex = parseRegexPattern(pattern)
+    if (literalRegex) return literalRegex
+    warnOnce(`[prefer-tailwind-icons] Invalid regex literal in "${optionName}": ${pattern}`)
+    return null
+  }
+  try {
+    return new RegExp(pattern)
+  } catch {
+    warnOnce(`[prefer-tailwind-icons] Invalid regex in "${optionName}": ${pattern}`)
+    return null
+  }
+}
+
+function hasRegexMatch(value, regex) {
+  regex.lastIndex = 0
+  return regex.test(value)
+}
+
+function normalizeSegment(value) {
+  return value
+    .replaceAll('/', '-')
+    .replaceAll('_', '-')
+    .replace(NORMALIZE_SEGMENT_SPACES_REGEX, '')
+    .replace(REPEATED_DASH_REGEX, '-')
+    .replace(EDGE_DASH_REGEX, '')
+    .toLowerCase()
+}
+
+function getIconClass(importName, source, config, globalPrefix) {
+  const prefix = config.prefix ?? globalPrefix
+  config.sourceRegex.lastIndex = 0
+  config.nameRegex.lastIndex = 0
+  const sourceMatch = source.match(config.sourceRegex)
+  const nameMatch = importName.match(config.nameRegex)
+  const getGroup = (...keys) => {
+    for (const key of keys) {
+      const fromName = nameMatch?.groups?.[key]
+      if (fromName) return fromName
+      const fromSource = sourceMatch?.groups?.[key]
+      if (fromSource) return fromSource
+    }
+    return ''
+  }
+  const iconSetPart = normalizeSegment(getGroup('set', 'iconSet'))
+  const iconNamePart =
+    camelToKebab(getGroup('name', 'icon') || importName) || camelToKebab(importName)
+  const variantPart = normalizeSegment(getGroup('variant'))
+  return [prefix, iconSetPart, iconNamePart, variantPart]
+    .filter(Boolean)
+    .join('-')
+    .replace(REPEATED_DASH_REGEX, '-')
+}
+
+function normalizeLibraryConfig(config) {
+  const sourceRegex = createRegex(config.source, 'libraries[].source')
+  if (!sourceRegex) return null
+  const nameRegex = createRegex(config.name ?? '.*', 'libraries[].name')
+  if (!nameRegex) return null
+  return {
+    sourceRegex,
+    nameRegex,
+    prefix: config.prefix,
+  }
+}
+
+function normalizeLibraryConfigs(configs) {
+  const resolved = []
+  for (const config of configs) {
+    const normalized = normalizeLibraryConfig(config)
+    if (normalized) resolved.push(normalized)
+  }
+  return resolved
+}
+
+function isNamedImportSpecifier(specifier) {
+  return (
+    specifier.type === 'ImportSpecifier' &&
+    specifier.imported.type === 'Identifier' &&
+    specifier.local.type === 'Identifier'
+  )
+}
+
+function isJsxAttributeNamed(attribute, name) {
+  return (
+    attribute.type === 'JSXAttribute' &&
+    attribute.name.type === 'JSXIdentifier' &&
+    attribute.name.name === name
+  )
+}
+
+function getNumericJsxAttributeValue(attribute) {
+  if (!attribute.value) return null
+  if (attribute.value.type === 'Literal' && typeof attribute.value.value === 'number')
+    return attribute.value.value
+  if (
+    attribute.value.type === 'JSXExpressionContainer' &&
+    attribute.value.expression.type === 'Literal' &&
+    typeof attribute.value.expression.value === 'number'
+  ) {
+    return attribute.value.expression.value
+  }
+  return null
+}
+
+function getClassNameValueText(classNames, classNameAttribute, sourceCode) {
+  if (!classNameAttribute?.value) return `{${JSON.stringify(classNames)}}`
+  if (
+    classNameAttribute.value.type === 'Literal' &&
+    typeof classNameAttribute.value.value === 'string'
+  ) {
+    const merged = `${classNames} ${classNameAttribute.value.value}`.trim()
+    return `{${JSON.stringify(merged)}}`
+  }
+  if (classNameAttribute.value.type === 'JSXExpressionContainer') {
+    const expression = classNameAttribute.value.expression
+    if (expression.type === 'JSXEmptyExpression') return `{${JSON.stringify(classNames)}}`
+    if (
+      expression.type === 'CallExpression' &&
+      expression.callee.type === 'Identifier' &&
+      expression.callee.name === 'cn'
+    ) {
+      const existingArguments = expression.arguments.map((argument) => sourceCode.getText(argument))
+      const argumentsText = [JSON.stringify(classNames), ...existingArguments].join(', ')
+      return `{cn(${argumentsText})}`
+    }
+    const expressionText = sourceCode.getText(expression)
+    const escapedClassNames = classNames
+      .replaceAll('\\', '\\\\')
+      .replaceAll('`', '\\`')
+      .replaceAll('${', '\\${')
+    return `{\`${escapedClassNames} \${${expressionText}}\`}`
+  }
+  return null
+}
+
+function hasRuntimeReference(sourceCode, specifier) {
+  try {
+    const variable = sourceCode.getDeclaredVariables(specifier)[0]
+    if (!variable) return false
+    return variable.references.some((reference) => {
+      if (reference.identifier === specifier.local) return false
+      if (typeof reference.isTypeReference === 'boolean') return !reference.isTypeReference
+      if (typeof reference.isValueReference === 'boolean') return reference.isValueReference
+      return true
+    })
+  } catch {
+    return false
+  }
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    hasSuggestions: true,
+    docs: {
+      description: 'Prefer Tailwind CSS icon classes over icon library components',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          libraries: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                source: { type: 'string' },
+                name: { type: 'string' },
+                prefix: { type: 'string' },
+              },
+              required: ['source'],
+              additionalProperties: false,
+            },
+          },
+          prefix: {
+            type: 'string',
+            description: 'Global class prefix added before generated icon classes',
+          },
+          propMappings: {
+            type: 'object',
+            additionalProperties: { type: 'string' },
+            description: 'Maps component props to Tailwind class prefixes',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferTailwindIcon:
+        'Prefer using Tailwind CSS icon class "{{iconClass}}" over "{{componentName}}" from "{{source}}"',
+      preferTailwindIconImport:
+        'Icon "{{importedName}}" from "{{source}}" can be replaced with Tailwind CSS class "{{iconClass}}"',
+    },
+  },
+  create(context) {
+    const [options = {}] = context.options
+    const resolvedConfigs = normalizeLibraryConfigs(options.libraries ?? [])
+    if (resolvedConfigs.length === 0) return {}
+
+    const globalPrefix = options.prefix ?? ''
+    const propMappings = options.propMappings ?? {}
+    const iconImports = new Map()
+    const sourceCode = context.sourceCode
+
+    return {
+      ImportDeclaration(node) {
+        if (node.importKind === 'type' || typeof node.source.value !== 'string') return
+        const source = node.source.value
+        const matchedConfig = resolvedConfigs.find((config) =>
+          hasRegexMatch(source, config.sourceRegex),
+        )
+        if (!matchedConfig) return
+
+        for (const specifier of node.specifiers) {
+          if (!isNamedImportSpecifier(specifier) || specifier.importKind === 'type') continue
+          const importedName = specifier.imported.name
+          if (!hasRegexMatch(importedName, matchedConfig.nameRegex)) continue
+          const localName = specifier.local.name
+          iconImports.set(localName, {
+            node: specifier,
+            importedName,
+            localName,
+            config: matchedConfig,
+            source,
+            used: false,
+          })
+        }
+      },
+      JSXOpeningElement(node) {
+        if (node.name.type !== 'JSXIdentifier') return
+        const iconInfo = iconImports.get(node.name.name)
+        if (!iconInfo) return
+
+        iconInfo.used = true
+        const iconClass = getIconClass(
+          iconInfo.importedName,
+          iconInfo.source,
+          iconInfo.config,
+          globalPrefix,
+        )
+        const classNameAttribute = node.attributes.find((attribute) =>
+          isJsxAttributeNamed(attribute, 'className'),
+        )
+        const mappedClasses = []
+        const consumedMappedAttributes = new Set()
+        for (const [propName, classPrefix] of Object.entries(propMappings)) {
+          const mappedAttribute = node.attributes.find((attribute) =>
+            isJsxAttributeNamed(attribute, propName),
+          )
+          if (!mappedAttribute) continue
+          const pixelValue = getNumericJsxAttributeValue(mappedAttribute)
+          if (pixelValue === null) continue
+          mappedClasses.push(pixelToClass(pixelValue, classPrefix))
+          consumedMappedAttributes.add(mappedAttribute)
+        }
+
+        const classesToAdd = [iconClass, ...mappedClasses].filter(Boolean).join(' ')
+        const classValue = getClassNameValueText(classesToAdd, classNameAttribute, sourceCode)
+        if (node.parent.type !== 'JSXElement') return
+
+        context.report({
+          node,
+          messageId: 'preferTailwindIcon',
+          data: {
+            iconClass,
+            componentName: iconInfo.localName,
+            source: iconInfo.source,
+          },
+          ...(classValue
+            ? {
+                suggest: [
+                  {
+                    messageId: 'preferTailwindIcon',
+                    data: {
+                      iconClass,
+                      componentName: iconInfo.localName,
+                      source: iconInfo.source,
+                    },
+                    fix(fixer) {
+                      const otherAttributes = node.attributes
+                        .filter((attribute) => {
+                          if (attribute === classNameAttribute) return false
+                          if (attribute.type !== 'JSXAttribute') return true
+                          return !consumedMappedAttributes.has(attribute)
+                        })
+                        .map((attribute) => sourceCode.getText(attribute))
+                        .join(' ')
+                      const attrsText = otherAttributes
+                        ? `className=${classValue} ${otherAttributes}`
+                        : `className=${classValue}`
+                      if (node.selfClosing)
+                        return fixer.replaceText(node.parent, `<span ${attrsText} />`)
+                      const fixes = [fixer.replaceText(node, `<span ${attrsText}>`)]
+                      if (node.parent.closingElement)
+                        fixes.push(fixer.replaceText(node.parent.closingElement, '</span>'))
+                      return fixes
+                    },
+                  },
+                ],
+              }
+            : {}),
+        })
+      },
+      'Program:exit': () => {
+        for (const iconInfo of iconImports.values()) {
+          if (iconInfo.used || !hasRuntimeReference(sourceCode, iconInfo.node)) continue
+          const iconClass = getIconClass(
+            iconInfo.importedName,
+            iconInfo.source,
+            iconInfo.config,
+            globalPrefix,
+          )
+          context.report({
+            node: iconInfo.node,
+            messageId: 'preferTailwindIconImport',
+            data: {
+              importedName: iconInfo.importedName,
+              source: iconInfo.source,
+              iconClass,
+            },
+          })
+        }
+      },
+    }
+  },
+}


### PR DESCRIPTION
## Summary

- inline the i18n-flat-key and prefer-tailwind-icons rules in the local Dify ESLint plugin
- switch ESLint, Oxlint, and suppression comments to the dify rule namespace
- remove eslint-plugin-hyoban from the workspace catalog, root dependencies, and lockfile

Issue: N/A (lint maintenance)

## Screenshots

Not applicable.

## Verification

- vp staged
- vp check (0 errors)
- eslint --concurrency=auto
- targeted diagnostics for both inlined rules

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [ ] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [x] I ran vp staged for the frontend lint configuration changes.

From Codex