### PR TITLE
fix(billing): remove misleading tax assurance

### DIFF
--- a/web/__tests__/billing/pricing-modal-flow.test.tsx
+++ b/web/__tests__/billing/pricing-modal-flow.test.tsx
@@ -189,12 +189,10 @@ describe('Pricing Modal Flow', () => {
       expect(screen.getByText(/plansCommon\.annualBilling/i)).toBeInTheDocument()
     })
 
-    it('should show tax tip in footer for cloud category', () => {
+    it('should show the tax exclusion notice in the footer for cloud category', () => {
       render(<Pricing onCancel={onCancel} />)
 
-      // Use exact match to avoid matching taxTipSecond
       expect(screen.getByText('billing.plansCommon.taxTip')).toBeInTheDocument()
-      expect(screen.getByText('billing.plansCommon.taxTipSecond')).toBeInTheDocument()
     })
   })
 

--- a/web/app/components/billing/pricing/footer.tsx
+++ b/web/app/components/billing/pricing/footer.tsx
@@ -26,9 +26,6 @@ const Footer = ({ pricingPageURL, currentCategory }: FooterProps) => {
             <span className="system-xs-regular">
               {t(($) => $['plansCommon.taxTip'], { ns: 'billing' })}
             </span>
-            <span className="system-xs-regular">
-              {t(($) => $['plansCommon.taxTipSecond'], { ns: 'billing' })}
-            </span>
           </div>
         )}
         <span className="flex h-fit items-center gap-x-1 text-saas-dify-blue-accessible">

--- a/web/i18n/ar-TN/billing.json
+++ b/web/i18n/ar-TN/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "سير العمل",
   "plansCommon.talkToSales": "تحدث إلى المبيعات",
   "plansCommon.taxTip": "جميع أسعار الاشتراك (الشهرية / السنوية) لا تشمل الضرائب المطبقة (مثل ضريبة القيمة المضافة وضريبة المبيعات).",
-  "plansCommon.taxTipSecond": "إذا لم تكن في منطقتك متطلبات ضريبية، فلن تظهر أي ضريبة عند الدفع، ولن يتم تحصيل أي رسوم إضافية طوال فترة الاشتراك.",
   "plansCommon.teamMember_one": "{{count,number}} عضو في الفريق",
   "plansCommon.teamMember_other": "{{count,number}} أعضاء في الفريق",
   "plansCommon.teamWorkspace": "{{count,number}} مساحة عمل للفريق",

--- a/web/i18n/de-DE/billing.json
+++ b/web/i18n/de-DE/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Workflow",
   "plansCommon.talkToSales": "Mit dem Vertrieb sprechen",
   "plansCommon.taxTip": "Alle Abonnementspreise (monatlich/jährlich) verstehen sich zuzüglich der geltenden Steuern (z. B. MwSt., Umsatzsteuer).",
-  "plansCommon.taxTipSecond": "Wenn in Ihrer Region keine relevanten Steuervorschriften gelten, wird an der Kasse keine Steuer angezeigt und Ihnen werden während der gesamten Abonnementlaufzeit keine zusätzlichen Gebühren berechnet.",
   "plansCommon.teamMember_one": "{{count,number}} Teammitglied",
   "plansCommon.teamMember_other": "{{count,number}} Teammitglieder",
   "plansCommon.teamWorkspace": "{{count,number}} Team Arbeitsplatz",

--- a/web/i18n/en-US/billing.json
+++ b/web/i18n/en-US/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Workflow",
   "plansCommon.talkToSales": "Talk to Sales",
   "plansCommon.taxTip": "All subscription prices (monthly/annual) exclude applicable taxes (e.g., VAT, sales tax).",
-  "plansCommon.taxTipSecond": "If your region has no applicable tax requirements, no tax will appear in your checkout, and you won’t be charged any additional fees for the entire subscription term.",
   "plansCommon.teamMember_one": "{{count,number}} Team Member",
   "plansCommon.teamMember_other": "{{count,number}} Team Members",
   "plansCommon.teamWorkspace": "{{count,number}} Team Workspace",

--- a/web/i18n/es-ES/billing.json
+++ b/web/i18n/es-ES/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Flujo de Trabajo",
   "plansCommon.talkToSales": "Hablar con Ventas",
   "plansCommon.taxTip": "Todos los precios de suscripción (mensuales/anuales) excluyen los impuestos aplicables (por ejemplo, IVA, impuesto sobre ventas).",
-  "plansCommon.taxTipSecond": "Si su región no tiene requisitos fiscales aplicables, no se mostrará ningún impuesto en su pago y no se le cobrará ninguna tarifa adicional durante todo el período de suscripción.",
   "plansCommon.teamMember_one": "{{count,number}} miembro del equipo",
   "plansCommon.teamMember_other": "{{count,number}} Miembros del equipo",
   "plansCommon.teamWorkspace": "{{count,number}} Espacio de Trabajo en Equipo",

--- a/web/i18n/fa-IR/billing.json
+++ b/web/i18n/fa-IR/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "جریان کار",
   "plansCommon.talkToSales": "صحبت با فروش",
   "plansCommon.taxTip": "تمام قیمت‌های اشتراک (ماهانه/سالانه) شامل مالیات‌های مربوطه (مثلاً مالیات بر ارزش افزوده، مالیات فروش) نمی‌شوند.",
-  "plansCommon.taxTipSecond": "اگر منطقه شما هیچ الزامات مالیاتی قابل اجرا نداشته باشد، هیچ مالیاتی در هنگام پرداخت نشان داده نمی‌شود و برای کل مدت اشتراک هیچ هزینه اضافی از شما دریافت نخواهد شد.",
   "plansCommon.teamMember_one": "{{count,number}} عضو تیم",
   "plansCommon.teamMember_other": "{{count,number}} اعضای تیم",
   "plansCommon.teamWorkspace": "{{count,number}} فضاي کار تيمي",

--- a/web/i18n/fr-FR/billing.json
+++ b/web/i18n/fr-FR/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Flux de travail",
   "plansCommon.talkToSales": "Parlez aux Ventes",
   "plansCommon.taxTip": "Tous les prix des abonnements (mensuels/annuels) s'entendent hors taxes applicables (par exemple, TVA, taxe de vente).",
-  "plansCommon.taxTipSecond": "Si votre région n'a pas de exigences fiscales applicables, aucune taxe n'apparaîtra lors de votre paiement et vous ne serez pas facturé de frais supplémentaires pendant toute la durée de l'abonnement.",
   "plansCommon.teamMember_one": "{{count,number}} membre de l'équipe",
   "plansCommon.teamMember_other": "{{count,number}} Membres de l'équipe",
   "plansCommon.teamWorkspace": "{{count,number}} Espace de travail d'équipe",

--- a/web/i18n/hi-IN/billing.json
+++ b/web/i18n/hi-IN/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "कार्यप्रवाह",
   "plansCommon.talkToSales": "बिक्री से बात करें",
   "plansCommon.taxTip": "सभी सदस्यता मूल्य (मासिक/वार्षिक) लागू करों (जैसे, VAT, बिक्री कर) को शामिल नहीं करते हैं।",
-  "plansCommon.taxTipSecond": "यदि आपके क्षेत्र में कोई लागू कर आवश्यकताएँ नहीं हैं, तो आपकी चेकआउट में कोई कर नहीं दिखाई देगा, और पूरे सदस्यता अवधि के लिए आपसे कोई अतिरिक्त शुल्क नहीं लिया जाएगा।",
   "plansCommon.teamMember_one": "{{count,number}} टीम सदस्य",
   "plansCommon.teamMember_other": "{{count,number}} टीम सदस्य",
   "plansCommon.teamWorkspace": "{{count,number}} टीम कार्यक्षेत्र",

--- a/web/i18n/id-ID/billing.json
+++ b/web/i18n/id-ID/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Alur Kerja",
   "plansCommon.talkToSales": "Bicaralah dengan Sales",
   "plansCommon.taxTip": "Semua harga langganan (bulanan/tahunan) belum termasuk pajak yang berlaku (misalnya, PPN, pajak penjualan).",
-  "plansCommon.taxTipSecond": "Jika wilayah Anda tidak memiliki persyaratan pajak yang berlaku, tidak akan ada pajak yang muncul saat checkout, dan Anda tidak akan dikenakan biaya tambahan apa pun selama masa langganan.",
   "plansCommon.teamMember_one": "Anggota Tim {{count,number}}",
   "plansCommon.teamMember_other": "Anggota Tim {{count,number}}",
   "plansCommon.teamWorkspace": "Ruang Kerja Tim {{count,number}}",

--- a/web/i18n/it-IT/billing.json
+++ b/web/i18n/it-IT/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Flusso di Lavoro",
   "plansCommon.talkToSales": "Parla con le vendite",
   "plansCommon.taxTip": "Tutti i prezzi degli abbonamenti (mensili/annuali) non includono le tasse applicabili (ad esempio, IVA, imposta sulle vendite).",
-  "plansCommon.taxTipSecond": "Se nella tua regione non ci sono requisiti fiscali applicabili, nessuna tassa apparirà al momento del pagamento e non ti verranno addebitate spese aggiuntive per l'intera durata dell'abbonamento.",
   "plansCommon.teamMember_one": "{{count,number}} membro del team",
   "plansCommon.teamMember_other": "{{count,number}} membri del team",
   "plansCommon.teamWorkspace": "{{count,number}} Spazio di lavoro di squadra",

--- a/web/i18n/ja-JP/billing.json
+++ b/web/i18n/ja-JP/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "ワークフロー",
   "plansCommon.talkToSales": "営業と話す",
   "plansCommon.taxTip": "すべてのサブスクリプション料金（月額／年額）は、適用される税金（例：消費税、付加価値税）を含みません。",
-  "plansCommon.taxTipSecond": "お客様の地域に適用税がない場合、チェックアウト時に税金は表示されず、サブスクリプション期間中に追加料金が請求されることもありません。",
   "plansCommon.teamMember_one": "チームメンバー：{{count,number}}人",
   "plansCommon.teamMember_other": "チームメンバー：{{count,number}}人",
   "plansCommon.teamWorkspace": "{{count,number}}チームワークスペース",

--- a/web/i18n/ko-KR/billing.json
+++ b/web/i18n/ko-KR/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "워크플로우",
   "plansCommon.talkToSales": "영업팀과 상담하기",
   "plansCommon.taxTip": "모든 구독 요금(월간/연간)에는 해당 세금(예: 부가가치세, 판매세)이 포함되어 있지 않습니다.",
-  "plansCommon.taxTipSecond": "귀하의 지역에 적용 가능한 세금 요구 사항이 없는 경우, 결제 시 세금이 표시되지 않으며 전체 구독 기간 동안 추가 요금이 부과되지 않습니다.",
   "plansCommon.teamMember_one": "{{count,number}} 팀원",
   "plansCommon.teamMember_other": "{{count,number}} 팀원",
   "plansCommon.teamWorkspace": "{{count,number}} 팀 작업 공간",

--- a/web/i18n/lo-LA/billing.json
+++ b/web/i18n/lo-LA/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Workflow (ຂະບວນການເຮັດວຽກ)",
   "plansCommon.talkToSales": "ລົມກັບຝ່າຍຂາຍ",
   "plansCommon.taxTip": "ລາຄາສະໝັກສະມາຊິກທັງໝົດ (ລາຍເດືອນ/ລາຍປີ) ບໍ່ລວມພາສີ (ເຊັ່ນ: VAT, ພາສີການຂາຍ).",
-  "plansCommon.taxTipSecond": "ຫາກພາກພື້ນຂອງທ່ານບໍ່ມີຂໍ້ກຳນົດກ່ຽວກັບພາສີ, ຈະບໍ່ມີພາສີສະແດງໃນຂັ້ນຕອນການຊຳລະເງິນ.",
   "plansCommon.teamMember_one": "{{count,number}} ສະມາຊິກໃນທິມ",
   "plansCommon.teamMember_other": "{{count,number}} ສະມາຊິກໃນທິມ",
   "plansCommon.teamWorkspace": "{{count,number}} ພື້ນທີ່ເຮັດວຽກຂອງທິມ",

--- a/web/i18n/nl-NL/billing.json
+++ b/web/i18n/nl-NL/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Workflow",
   "plansCommon.talkToSales": "Talk to Sales",
   "plansCommon.taxTip": "All subscription prices (monthly/annual) exclude applicable taxes (e.g., VAT, sales tax).",
-  "plansCommon.taxTipSecond": "If your region has no applicable tax requirements, no tax will appear in your checkout, and you won’t be charged any additional fees for the entire subscription term.",
   "plansCommon.teamMember_one": "{{count,number}} Team Member",
   "plansCommon.teamMember_other": "{{count,number}} Team Members",
   "plansCommon.teamWorkspace": "{{count,number}} Team Workspace",

--- a/web/i18n/pl-PL/billing.json
+++ b/web/i18n/pl-PL/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Przepływ pracy",
   "plansCommon.talkToSales": "Porozmawiaj z działem sprzedaży",
   "plansCommon.taxTip": "Wszystkie ceny subskrypcji (miesięczne/roczne) nie obejmują obowiązujących podatków (np. VAT, podatek od sprzedaży).",
-  "plansCommon.taxTipSecond": "Jeśli w Twoim regionie nie ma obowiązujących przepisów podatkowych, podatek nie pojawi się podczas realizacji zamówienia i nie zostaną naliczone żadne dodatkowe opłaty przez cały okres subskrypcji.",
   "plansCommon.teamMember_one": "{{count,number}} Członek zespołu",
   "plansCommon.teamMember_other": "{{count,number}} członków zespołu",
   "plansCommon.teamWorkspace": "{{count,number}} Zespół Workspace",

--- a/web/i18n/pt-BR/billing.json
+++ b/web/i18n/pt-BR/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Fluxo de trabalho",
   "plansCommon.talkToSales": "Fale com a equipe de Vendas",
   "plansCommon.taxTip": "Todos os preços de assinatura (mensal/anual) não incluem os impostos aplicáveis (por exemplo, IVA, imposto sobre vendas).",
-  "plansCommon.taxTipSecond": "Se a sua região não tiver requisitos fiscais aplicáveis, nenhum imposto aparecerá no seu checkout e você não será cobrado por taxas adicionais durante todo o período da assinatura.",
   "plansCommon.teamMember_one": "{{count,number}} Membro da Equipe",
   "plansCommon.teamMember_other": "{{count,number}} Membros da Equipe",
   "plansCommon.teamWorkspace": "{{count,number}} Espaço de Trabalho da Equipe",

--- a/web/i18n/ro-RO/billing.json
+++ b/web/i18n/ro-RO/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Flux de lucru",
   "plansCommon.talkToSales": "Vorbiți cu vânzările",
   "plansCommon.taxTip": "Toate prețurile abonamentelor (lunare/anuale) nu includ taxele aplicabile (de exemplu, TVA, taxa pe vânzări).",
-  "plansCommon.taxTipSecond": "Dacă regiunea dumneavoastră nu are cerințe fiscale aplicabile, niciun impozit nu va apărea la finalizarea comenzii și nu vi se vor percepe taxe suplimentare pe întreaga durată a abonamentului.",
   "plansCommon.teamMember_one": "{{count,number}} Membru al echipei",
   "plansCommon.teamMember_other": "{{count,number}} membri ai echipei",
   "plansCommon.teamWorkspace": "{{count,number}} Spațiu de lucru în echipă",

--- a/web/i18n/ru-RU/billing.json
+++ b/web/i18n/ru-RU/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Рабочий процесс",
   "plansCommon.talkToSales": "Поговорить с отделом продаж",
   "plansCommon.taxTip": "Все цены на подписку (ежемесячную/годовую) не включают применимые налоги (например, НДС, налог с продаж).",
-  "plansCommon.taxTipSecond": "Если в вашем регионе нет применимых налоговых требований, налоги не будут отображаться при оформлении заказа, и с вас не будут взиматься дополнительные сборы за весь срок подписки.",
   "plansCommon.teamMember_one": "{{count,number}} Член команды",
   "plansCommon.teamMember_other": "{{count,number}} Члены команды",
   "plansCommon.teamWorkspace": "{{count,number}} Командное рабочее пространство",

--- a/web/i18n/sl-SI/billing.json
+++ b/web/i18n/sl-SI/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Potek dela",
   "plansCommon.talkToSales": "Pogovorite se s prodajo",
   "plansCommon.taxTip": "Vse cene naročnin (mesečne/letne) ne vključujejo veljavnih davkov (npr. DDV, davek na promet).",
-  "plansCommon.taxTipSecond": "Če vaša regija nima veljavnih davčnih zahtev, se v vaši košarici ne bo prikazal noben davek in za celotno obdobje naročnine vam ne bodo zaračunani nobeni dodatni stroški.",
   "plansCommon.teamMember_one": "{{count,number}} član ekipe",
   "plansCommon.teamMember_other": "{{count,number}} Članov ekipe",
   "plansCommon.teamWorkspace": "{{count,number}} Ekipa delovni prostor",

--- a/web/i18n/th-TH/billing.json
+++ b/web/i18n/th-TH/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "เวิร์กโฟลว์",
   "plansCommon.talkToSales": "พูดคุยกับฝ่ายขาย",
   "plansCommon.taxTip": "ราคาการสมัครสมาชิกทั้งหมด (รายเดือน/รายปี) ไม่รวมภาษีที่ใช้บังคับ (เช่น ภาษีมูลค่าเพิ่ม, ภาษีการขาย)",
-  "plansCommon.taxTipSecond": "หากภูมิภาคของคุณไม่มีข้อกำหนดเกี่ยวกับภาษีที่ใช้ได้ จะไม่มีการคิดภาษีในขั้นตอนการชำระเงินของคุณ และคุณจะไม่ถูกเรียกเก็บค่าธรรมเนียมเพิ่มเติมใด ๆ ตลอดระยะเวลาสมาชิกทั้งหมด",
   "plansCommon.teamMember_one": "{{count,number}} สมาชิกทีม",
   "plansCommon.teamMember_other": "{{count,number}} สมาชิกทีม",
   "plansCommon.teamWorkspace": "{{count,number}} ทีมทำงาน",

--- a/web/i18n/tr-TR/billing.json
+++ b/web/i18n/tr-TR/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "İş Akışı",
   "plansCommon.talkToSales": "Satışlarla Konuşun",
   "plansCommon.taxTip": "Tüm abonelik fiyatları (aylık/yıllık) geçerli vergiler (ör. KDV, satış vergisi) hariçtir.",
-  "plansCommon.taxTipSecond": "Bölgenizde geçerli vergi gereksinimleri yoksa, ödeme sayfanızda herhangi bir vergi görünmeyecek ve tüm abonelik süresi boyunca ek bir ücret tahsil edilmeyecektir.",
   "plansCommon.teamMember_one": "{{count,number}} Takım Üyesi",
   "plansCommon.teamMember_other": "{{count,number}} Takım Üyesi",
   "plansCommon.teamWorkspace": "{{count,number}} Takım Çalışma Alanı",

--- a/web/i18n/uk-UA/billing.json
+++ b/web/i18n/uk-UA/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Робочий процес",
   "plansCommon.talkToSales": "Поговоріть зі службою продажів",
   "plansCommon.taxTip": "Всі ціни на підписку (щомісячна/щорічна) не включають відповідні податки (наприклад, ПДВ, податок з продажу).",
-  "plansCommon.taxTipSecond": "Якщо для вашого регіону немає відповідних податкових вимог, податок не відображатиметься на вашому чек-ауті, і з вас не стягуватимуть додаткові збори протягом усього терміну підписки.",
   "plansCommon.teamMember_one": "{{count,number}} член команди",
   "plansCommon.teamMember_other": "{{count,number}} членів команди",
   "plansCommon.teamWorkspace": "{{count,number}} Командний Простір",

--- a/web/i18n/vi-VN/billing.json
+++ b/web/i18n/vi-VN/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "Quy trình làm việc",
   "plansCommon.talkToSales": "Nói chuyện với Bộ phận Bán hàng",
   "plansCommon.taxTip": "Tất cả giá đăng ký (hàng tháng/hàng năm) chưa bao gồm các loại thuế áp dụng (ví dụ: VAT, thuế bán hàng).",
-  "plansCommon.taxTipSecond": "Nếu khu vực của bạn không có yêu cầu thuế áp dụng, sẽ không có thuế xuất hiện trong quá trình thanh toán của bạn và bạn sẽ không bị tính bất kỳ khoản phí bổ sung nào trong suốt thời gian đăng ký.",
   "plansCommon.teamMember_one": "{{count,number}} thành viên trong nhóm",
   "plansCommon.teamMember_other": "{{count,number}} thành viên trong nhóm",
   "plansCommon.teamWorkspace": "{{count,number}} Không gian làm việc của Đội",

--- a/web/i18n/zh-Hans/billing.json
+++ b/web/i18n/zh-Hans/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "工作流",
   "plansCommon.talkToSales": "联系销售",
   "plansCommon.taxTip": "所有订阅价格（按月/按年）均不含适用税费（如增值税、销售税）。",
-  "plansCommon.taxTipSecond": "如果您所在地区无适用税费要求，结账时将不会显示税费，且在整个订阅周期内您都无需支付任何额外费用。",
   "plansCommon.teamMember_one": "{{count,number}} 名团队成员",
   "plansCommon.teamMember_other": "{{count,number}} 名团队成员",
   "plansCommon.teamWorkspace": "{{count,number}} 个团队空间",

--- a/web/i18n/zh-Hant/billing.json
+++ b/web/i18n/zh-Hant/billing.json
@@ -131,7 +131,6 @@
   "plansCommon.supportItems.workflow": "工作流",
   "plansCommon.talkToSales": "聯絡銷售",
   "plansCommon.taxTip": "所有訂閱價格（月費/年費）不包含適用的稅費（例如增值稅、銷售稅）。",
-  "plansCommon.taxTipSecond": "如果您的地區沒有適用的稅務要求，結帳時將不會顯示任何稅款，且在整個訂閱期間您也不會被收取任何額外費用。",
   "plansCommon.teamMember_one": "{{count,number}} 團隊成員",
   "plansCommon.teamMember_other": "{{count,number}} 團隊成員",
   "plansCommon.teamWorkspace": "{{count,number}} 團隊工作空間",


### PR DESCRIPTION
## Summary

- remove the second tax notice sentence from the in-product Cloud Pricing footer because it overpromises that no additional fees can apply for the full subscription term
- remove the obsolete `plansCommon.taxTipSecond` key from all 24 supported billing locales while preserving each locale’s existing tax-exclusion notice
- update the Pricing modal flow test to cover the remaining notice

## Screenshots

Not included. This change only removes the second line from the existing footer notice and does not change the Pricing layout.

## Testing

- `vp test run --project unit __tests__/billing/pricing-modal-flow.test.tsx` (19 passed)
- `vp lint web/app/components/billing/pricing/footer.tsx web/__tests__/billing/pricing-modal-flow.test.tsx`
- `pnpm run lint:eslint -- web/i18n/*/billing.json`
- `vp fmt --check web/app/components/billing/pricing/footer.tsx web/__tests__/billing/pricing-modal-flow.test.tsx web/i18n/*/billing.json`
- `git diff --check`
- `pnpm check` (formatting passed; repository-wide type checking remains blocked by the existing `eslint.config.mjs:424` TS2322 plugin type error)

## Checklist

- [x] No documentation update is required.
- [x] The existing Pricing modal flow test covers the retained tax-exclusion notice.
- [x] Frontend staged-file checks passed during commit.

From Codex