### PR TITLE
fix(api): tighten app detail response contract

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -50,7 +50,7 @@ from graphon.enums import WorkflowExecutionStatus
 from libs.helper import build_icon_url, dump_response, to_timestamp
 from libs.login import login_required
 from models import Account, App, DatasetPermissionEnum, Workflow
-from models.model import IconType
+from models.model import AppMode, IconType
 from services.app_dsl_service import AppDslService
 from services.app_service import (
     AppListParams,
@@ -446,8 +446,8 @@ class RecentAppListResponse(ResponseModel):
 class AppDetail(AppResponseModel):
     id: str
     name: str
-    description: str | None = None
-    mode: str = Field(validation_alias="mode_compatible_with_agent")
+    description: str
+    mode: AppMode = Field(validation_alias="mode_compatible_with_agent")
     icon: str | None = None
     icon_background: str | None = None
     enable_site: bool
@@ -459,11 +459,11 @@ class AppDetail(AppResponseModel):
     )
     workflow: WorkflowPartial | None = None
     tracing: Any | None = None
-    use_icon_as_answer_icon: bool | None = None
+    use_icon_as_answer_icon: bool
     created_by: str | None = None
-    created_at: int | None = None
+    created_at: int
     updated_by: str | None = None
-    updated_at: int | None = None
+    updated_at: int
     access_mode: str | None = None
     tags: list[Tag] = Field(default_factory=list)
     permission_keys: list[str] = Field(default_factory=list)
@@ -471,13 +471,13 @@ class AppDetail(AppResponseModel):
 
     @field_validator("created_at", "updated_at", mode="before")
     @classmethod
-    def _normalize_timestamp(cls, value: datetime | int | None) -> int | None:
+    def _normalize_timestamp(cls, value: datetime | int) -> int:
         return to_timestamp(value)
 
 
 class AppDetailWithSite(AppDetail):
     icon_type: str | None = None
-    api_base_url: str | None = None
+    api_base_url: str
     max_active_requests: int | None = None
     deleted_tools: list[DeletedTool] = Field(default_factory=list)
     site: AppDetailSiteResponse | None = None

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -13029,17 +13029,17 @@ Model class for AI model.
 | ---- | ---- | ----------- | -------- |
 | access_mode | string |  | No |
 | access_ready | boolean |  | No |
-| api_base_url | string |  | No |
+| api_base_url | string |  | Yes |
 | app_id | string |  | No |
 | backing_app_id | string |  | No |
 | bound_agent_id | string |  | No |
-| created_at | integer |  | No |
+| created_at | integer |  | Yes |
 | created_by | string |  | No |
 | debug_conversation_has_messages | boolean |  | No |
 | debug_conversation_id | string |  | No |
 | debug_conversation_message_count | integer |  | No |
 | deleted_tools | [ [DeletedTool](#deletedtool) ] |  | No |
-| description | string |  | No |
+| description | string |  | Yes |
 | enable_api | boolean |  | Yes |
 | enable_site | boolean |  | Yes |
 | hidden_app_backed | boolean |  | No |
@@ -13050,7 +13050,7 @@ Model class for AI model.
 | id | string |  | Yes |
 | maintainer | string |  | No |
 | max_active_requests | integer |  | No |
-| mode | string |  | Yes |
+| mode | [AppMode](#appmode) |  | Yes |
 | model_config | [AppModelConfigResponse](#appmodelconfigresponse) |  | No |
 | name | string |  | Yes |
 | permission_keys | [ string ] |  | No |
@@ -13058,9 +13058,9 @@ Model class for AI model.
 | site | [AppDetailSiteResponse](#appdetailsiteresponse) |  | No |
 | tags | [ [Tag](#tag) ] |  | No |
 | tracing |  |  | No |
-| updated_at | integer |  | No |
+| updated_at | integer |  | Yes |
 | updated_by | string |  | No |
-| use_icon_as_answer_icon | boolean |  | No |
+| use_icon_as_answer_icon | boolean |  | Yes |
 | workflow | [WorkflowPartial](#workflowpartial) |  | No |
 
 #### AgentAppFeaturesPayload
@@ -14985,24 +14985,24 @@ This class is used to store the schema information of an api based tool.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | access_mode | string |  | No |
-| created_at | integer |  | No |
+| created_at | integer |  | Yes |
 | created_by | string |  | No |
-| description | string |  | No |
+| description | string |  | Yes |
 | enable_api | boolean |  | Yes |
 | enable_site | boolean |  | Yes |
 | icon | string |  | No |
 | icon_background | string |  | No |
 | id | string |  | Yes |
 | maintainer | string |  | No |
-| mode | string |  | Yes |
+| mode | [AppMode](#appmode) |  | Yes |
 | model_config | [AppModelConfigResponse](#appmodelconfigresponse) |  | No |
 | name | string |  | Yes |
 | permission_keys | [ string ] |  | No |
 | tags | [ [Tag](#tag) ] |  | No |
 | tracing |  |  | No |
-| updated_at | integer |  | No |
+| updated_at | integer |  | Yes |
 | updated_by | string |  | No |
-| use_icon_as_answer_icon | boolean |  | No |
+| use_icon_as_answer_icon | boolean |  | Yes |
 | workflow | [WorkflowPartial](#workflowpartial) |  | No |
 
 #### AppDetailSiteResponse
@@ -15040,13 +15040,13 @@ This class is used to store the schema information of an api based tool.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | access_mode | string |  | No |
-| api_base_url | string |  | No |
+| api_base_url | string |  | Yes |
 | app_id | string |  | No |
 | bound_agent_id | string |  | No |
-| created_at | integer |  | No |
+| created_at | integer |  | Yes |
 | created_by | string |  | No |
 | deleted_tools | [ [DeletedTool](#deletedtool) ] |  | No |
-| description | string |  | No |
+| description | string |  | Yes |
 | enable_api | boolean |  | Yes |
 | enable_site | boolean |  | Yes |
 | icon | string |  | No |
@@ -15056,16 +15056,16 @@ This class is used to store the schema information of an api based tool.
 | id | string |  | Yes |
 | maintainer | string |  | No |
 | max_active_requests | integer |  | No |
-| mode | string |  | Yes |
+| mode | [AppMode](#appmode) |  | Yes |
 | model_config | [AppModelConfigResponse](#appmodelconfigresponse) |  | No |
 | name | string |  | Yes |
 | permission_keys | [ string ] |  | No |
 | site | [AppDetailSiteResponse](#appdetailsiteresponse) |  | No |
 | tags | [ [Tag](#tag) ] |  | No |
 | tracing |  |  | No |
-| updated_at | integer |  | No |
+| updated_at | integer |  | Yes |
 | updated_by | string |  | No |
-| use_icon_as_answer_icon | boolean |  | No |
+| use_icon_as_answer_icon | boolean |  | Yes |
 | workflow | [WorkflowPartial](#workflowpartial) |  | No |
 
 #### AppDslVersionResponse

--- a/api/tests/unit_tests/commands/test_generate_swagger_specs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_specs.py
@@ -253,8 +253,17 @@ def test_generate_specs_include_console_contract_shapes_for_schema_migration(tmp
     app_model_config = schemas["AppDetailWithSite"]["properties"]["model_config"]
     assert {"$ref": "#/components/schemas/AppModelConfigResponse"} in app_model_config["anyOf"]
     app_detail = schemas["AppDetail"]
-    assert "mode" in app_detail["properties"]
+    assert app_detail["properties"]["mode"]["$ref"] == "#/components/schemas/AppMode"
     assert "mode_compatible_with_agent" not in app_detail["properties"]
+    assert {
+        "created_at",
+        "description",
+        "mode",
+        "updated_at",
+        "use_icon_as_answer_icon",
+    }.issubset(app_detail["required"])
+    assert schemas["AppDetailWithSite"]["properties"]["api_base_url"]["type"] == "string"
+    assert "api_base_url" in schemas["AppDetailWithSite"]["required"]
     sync_draft_workflow = schemas["SyncDraftWorkflowResponse"]
     assert _response_schema(paths["/apps/{app_id}/workflows/draft"]["post"])["$ref"] == (
         "#/components/schemas/SyncDraftWorkflowResponse"

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -215,9 +215,9 @@ def _app_detail_obj(**overrides) -> App:
         "tracing": None,
         "use_icon_as_answer_icon": False,
         "created_by": "account-1",
-        "created_at": None,
+        "created_at": datetime(2024, 1, 1),
         "updated_by": "account-1",
-        "updated_at": None,
+        "updated_at": datetime(2024, 1, 1),
         "max_active_requests": 0,
     }
     overrides.pop("bound_agent_id", None)

--- a/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
@@ -423,6 +423,12 @@ def test_app_detail_with_site_includes_nested_serialization(app_models):
 
     serialized = AppDetailWithSite.model_validate(app_obj, from_attributes=True).model_dump(mode="json")
 
+    assert serialized["description"] == "Desc"
+    assert serialized["mode"] == "advanced-chat"
+    assert serialized["use_icon_as_answer_icon"] is True
+    assert serialized["created_at"] == int(timestamp.timestamp())
+    assert serialized["updated_at"] == int(timestamp.timestamp())
+    assert serialized["api_base_url"] == "https://api.example.com/v1"
     assert serialized["icon_url"] == "signed:detail-icon"
     assert serialized["model_config"]["retriever_resource"] == {"enabled": True}
     assert serialized["deleted_tools"][0]["tool_name"] == "search"
@@ -432,6 +438,10 @@ def test_app_detail_with_site_includes_nested_serialization(app_models):
     assert serialized["permission_keys"] == ["app.acl.view_layout", "app.acl.edit"]
     assert serialized["bound_agent_id"] == "agent-1"
     assert "role" not in serialized
+
+    invalid_app_obj = SimpleNamespace(**(vars(app_obj) | {"mode_compatible_with_agent": "unsupported"}))
+    with pytest.raises(ValidationError):
+        AppDetailWithSite.model_validate(invalid_app_obj, from_attributes=True)
 
 
 def test_app_response_view_uses_the_caller_session_for_query_backed_fields(
@@ -606,6 +616,10 @@ def test_app_create_api_attaches_permission_keys(app, app_module, unbound_sessio
         mode_compatible_with_agent="advanced-chat",
         enable_site=True,
         enable_api=True,
+        use_icon_as_answer_icon=False,
+        created_at=_ts(),
+        updated_at=_ts(),
+        api_base_url="https://api.example.com/v1",
         permission_keys=[],
     )
 
@@ -985,6 +999,10 @@ def test_app_detail_api_attaches_current_user_permission_keys(app, app_module, u
         mode_compatible_with_agent="chat",
         enable_site=True,
         enable_api=True,
+        use_icon_as_answer_icon=False,
+        created_at=_ts(),
+        updated_at=_ts(),
+        api_base_url="https://api.example.com/v1",
         permission_keys=[],
     )
 

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -24,17 +24,17 @@ export type AgentAppCreatePayload = {
 export type AgentAppDetailWithSite = {
   access_mode?: string | null
   access_ready?: boolean
-  api_base_url?: string | null
+  api_base_url: string
   app_id?: string | null
   backing_app_id?: string | null
   bound_agent_id?: string | null
-  created_at?: number | null
+  created_at: number
   created_by?: string | null
   debug_conversation_has_messages?: boolean
   debug_conversation_id?: string | null
   debug_conversation_message_count?: number
   deleted_tools?: Array<DeletedTool>
-  description?: string | null
+  description: string
   enable_api: boolean
   enable_site: boolean
   hidden_app_backed?: boolean
@@ -45,7 +45,7 @@ export type AgentAppDetailWithSite = {
   id: string
   maintainer?: string | null
   max_active_requests?: number | null
-  mode: string
+  mode: AppMode
   model_config?: AppModelConfigResponse | null
   name: string
   permission_keys?: Array<string>
@@ -53,9 +53,9 @@ export type AgentAppDetailWithSite = {
   site?: AppDetailSiteResponse | null
   tags?: Array<Tag>
   tracing?: unknown | null
-  updated_at?: number | null
+  updated_at: number
   updated_by?: string | null
-  use_icon_as_answer_icon?: boolean | null
+  use_icon_as_answer_icon: boolean
   workflow?: WorkflowPartial | null
 }
 
@@ -474,6 +474,16 @@ export type DeletedTool = {
   tool_name: string
   type: string
 }
+
+export type AppMode =
+  | 'advanced-chat'
+  | 'agent'
+  | 'agent-chat'
+  | 'channel'
+  | 'chat'
+  | 'completion'
+  | 'rag-pipeline'
+  | 'workflow'
 
 export type AppModelConfigResponse = {
   agent_mode?: unknown | null
@@ -1739,17 +1749,17 @@ export type AgentAppPaginationWritable = {
 export type AgentAppDetailWithSiteWritable = {
   access_mode?: string | null
   access_ready?: boolean
-  api_base_url?: string | null
+  api_base_url: string
   app_id?: string | null
   backing_app_id?: string | null
   bound_agent_id?: string | null
-  created_at?: number | null
+  created_at: number
   created_by?: string | null
   debug_conversation_has_messages?: boolean
   debug_conversation_id?: string | null
   debug_conversation_message_count?: number
   deleted_tools?: Array<DeletedTool>
-  description?: string | null
+  description: string
   enable_api: boolean
   enable_site: boolean
   hidden_app_backed?: boolean
@@ -1759,7 +1769,7 @@ export type AgentAppDetailWithSiteWritable = {
   id: string
   maintainer?: string | null
   max_active_requests?: number | null
-  mode: string
+  mode: AppMode
   model_config?: AppModelConfigResponse | null
   name: string
   permission_keys?: Array<string>
@@ -1767,9 +1777,9 @@ export type AgentAppDetailWithSiteWritable = {
   site?: AppDetailSiteResponseWritable | null
   tags?: Array<Tag>
   tracing?: unknown | null
-  updated_at?: number | null
+  updated_at: number
   updated_by?: string | null
-  use_icon_as_answer_icon?: boolean | null
+  use_icon_as_answer_icon: boolean
   workflow?: WorkflowPartial | null
 }
 

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -257,6 +257,20 @@ export const zDeletedTool = z.object({
 })
 
 /**
+ * AppMode
+ */
+export const zAppMode = z.enum([
+  'advanced-chat',
+  'agent',
+  'agent-chat',
+  'channel',
+  'chat',
+  'completion',
+  'rag-pipeline',
+  'workflow',
+])
+
+/**
  * AppModelConfigResponse
  */
 export const zAppModelConfigResponse = z.object({
@@ -343,17 +357,17 @@ export const zWorkflowPartial = z.object({
 export const zAgentAppDetailWithSite = z.object({
   access_mode: z.string().nullish(),
   access_ready: z.boolean().optional().default(false),
-  api_base_url: z.string().nullish(),
+  api_base_url: z.string(),
   app_id: z.string().nullish(),
   backing_app_id: z.string().nullish(),
   bound_agent_id: z.string().nullish(),
-  created_at: z.int().nullish(),
+  created_at: z.int(),
   created_by: z.string().nullish(),
   debug_conversation_has_messages: z.boolean().optional().default(false),
   debug_conversation_id: z.string().nullish(),
   debug_conversation_message_count: z.int().optional().default(0),
   deleted_tools: z.array(zDeletedTool).optional(),
-  description: z.string().nullish(),
+  description: z.string(),
   enable_api: z.boolean(),
   enable_site: z.boolean(),
   hidden_app_backed: z.boolean().optional().default(false),
@@ -364,7 +378,7 @@ export const zAgentAppDetailWithSite = z.object({
   id: z.string(),
   maintainer: z.string().nullish(),
   max_active_requests: z.int().nullish(),
-  mode: z.string(),
+  mode: zAppMode,
   model_config: zAppModelConfigResponse.nullish(),
   name: z.string(),
   permission_keys: z.array(z.string()).optional(),
@@ -372,9 +386,9 @@ export const zAgentAppDetailWithSite = z.object({
   site: zAppDetailSiteResponse.nullish(),
   tags: z.array(zTag).optional(),
   tracing: z.unknown().nullish(),
-  updated_at: z.int().nullish(),
+  updated_at: z.int(),
   updated_by: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
+  use_icon_as_answer_icon: z.boolean(),
   workflow: zWorkflowPartial.nullish(),
 })
 
@@ -2529,17 +2543,17 @@ export const zAppDetailSiteResponseWritable = z.object({
 export const zAgentAppDetailWithSiteWritable = z.object({
   access_mode: z.string().nullish(),
   access_ready: z.boolean().optional().default(false),
-  api_base_url: z.string().nullish(),
+  api_base_url: z.string(),
   app_id: z.string().nullish(),
   backing_app_id: z.string().nullish(),
   bound_agent_id: z.string().nullish(),
-  created_at: z.int().nullish(),
+  created_at: z.int(),
   created_by: z.string().nullish(),
   debug_conversation_has_messages: z.boolean().optional().default(false),
   debug_conversation_id: z.string().nullish(),
   debug_conversation_message_count: z.int().optional().default(0),
   deleted_tools: z.array(zDeletedTool).optional(),
-  description: z.string().nullish(),
+  description: z.string(),
   enable_api: z.boolean(),
   enable_site: z.boolean(),
   hidden_app_backed: z.boolean().optional().default(false),
@@ -2549,7 +2563,7 @@ export const zAgentAppDetailWithSiteWritable = z.object({
   id: z.string(),
   maintainer: z.string().nullish(),
   max_active_requests: z.int().nullish(),
-  mode: z.string(),
+  mode: zAppMode,
   model_config: zAppModelConfigResponse.nullish(),
   name: z.string(),
   permission_keys: z.array(z.string()).optional(),
@@ -2557,9 +2571,9 @@ export const zAgentAppDetailWithSiteWritable = z.object({
   site: zAppDetailSiteResponseWritable.nullish(),
   tags: z.array(zTag).optional(),
   tracing: z.unknown().nullish(),
-  updated_at: z.int().nullish(),
+  updated_at: z.int(),
   updated_by: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
+  use_icon_as_answer_icon: z.boolean(),
   workflow: zWorkflowPartial.nullish(),
 })
 

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -23,13 +23,13 @@ export type CreateAppPayload = {
 
 export type AppDetailWithSite = {
   access_mode?: string | null
-  api_base_url?: string | null
+  api_base_url: string
   app_id?: string | null
   bound_agent_id?: string | null
-  created_at?: number | null
+  created_at: number
   created_by?: string | null
   deleted_tools?: Array<DeletedTool>
-  description?: string | null
+  description: string
   enable_api: boolean
   enable_site: boolean
   icon?: string | null
@@ -39,16 +39,16 @@ export type AppDetailWithSite = {
   id: string
   maintainer?: string | null
   max_active_requests?: number | null
-  mode: string
+  mode: AppMode
   model_config?: AppModelConfigResponse | null
   name: string
   permission_keys?: Array<string>
   site?: AppDetailSiteResponse | null
   tags?: Array<Tag>
   tracing?: unknown | null
-  updated_at?: number | null
+  updated_at: number
   updated_by?: string | null
-  use_icon_as_answer_icon?: boolean | null
+  use_icon_as_answer_icon: boolean
   workflow?: WorkflowPartial | null
 }
 
@@ -356,24 +356,24 @@ export type AppApiStatusPayload = {
 
 export type AppDetail = {
   access_mode?: string | null
-  created_at?: number | null
+  created_at: number
   created_by?: string | null
-  description?: string | null
+  description: string
   enable_api: boolean
   enable_site: boolean
   icon?: string | null
   icon_background?: string | null
   id: string
   maintainer?: string | null
-  mode: string
+  mode: AppMode
   model_config?: AppModelConfigResponse | null
   name: string
   permission_keys?: Array<string>
   tags?: Array<Tag>
   tracing?: unknown | null
-  updated_at?: number | null
+  updated_at: number
   updated_by?: string | null
-  use_icon_as_answer_icon?: boolean | null
+  use_icon_as_answer_icon: boolean
   workflow?: WorkflowPartial | null
 }
 
@@ -1263,6 +1263,16 @@ export type DeletedTool = {
   tool_name: string
   type: string
 }
+
+export type AppMode =
+  | 'advanced-chat'
+  | 'agent'
+  | 'agent-chat'
+  | 'channel'
+  | 'chat'
+  | 'completion'
+  | 'rag-pipeline'
+  | 'workflow'
 
 export type AppModelConfigResponse = {
   agent_mode?: unknown | null
@@ -2952,13 +2962,13 @@ export type AppPaginationWritable = {
 
 export type AppDetailWithSiteWritable = {
   access_mode?: string | null
-  api_base_url?: string | null
+  api_base_url: string
   app_id?: string | null
   bound_agent_id?: string | null
-  created_at?: number | null
+  created_at: number
   created_by?: string | null
   deleted_tools?: Array<DeletedTool>
-  description?: string | null
+  description: string
   enable_api: boolean
   enable_site: boolean
   icon?: string | null
@@ -2967,16 +2977,16 @@ export type AppDetailWithSiteWritable = {
   id: string
   maintainer?: string | null
   max_active_requests?: number | null
-  mode: string
+  mode: AppMode
   model_config?: AppModelConfigResponse | null
   name: string
   permission_keys?: Array<string>
   site?: AppDetailSiteResponseWritable | null
   tags?: Array<Tag>
   tracing?: unknown | null
-  updated_at?: number | null
+  updated_at: number
   updated_by?: string | null
-  use_icon_as_answer_icon?: boolean | null
+  use_icon_as_answer_icon: boolean
   workflow?: WorkflowPartial | null
 }
 

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -845,6 +845,20 @@ export const zDeletedTool = z.object({
 })
 
 /**
+ * AppMode
+ */
+export const zAppMode = z.enum([
+  'advanced-chat',
+  'agent',
+  'agent-chat',
+  'channel',
+  'chat',
+  'completion',
+  'rag-pipeline',
+  'workflow',
+])
+
+/**
  * AppModelConfigResponse
  */
 export const zAppModelConfigResponse = z.object({
@@ -930,13 +944,13 @@ export const zWorkflowPartial = z.object({
  */
 export const zAppDetailWithSite = z.object({
   access_mode: z.string().nullish(),
-  api_base_url: z.string().nullish(),
+  api_base_url: z.string(),
   app_id: z.string().nullish(),
   bound_agent_id: z.string().nullish(),
-  created_at: z.int().nullish(),
+  created_at: z.int(),
   created_by: z.string().nullish(),
   deleted_tools: z.array(zDeletedTool).optional(),
-  description: z.string().nullish(),
+  description: z.string(),
   enable_api: z.boolean(),
   enable_site: z.boolean(),
   icon: z.string().nullish(),
@@ -946,16 +960,16 @@ export const zAppDetailWithSite = z.object({
   id: z.string(),
   maintainer: z.string().nullish(),
   max_active_requests: z.int().nullish(),
-  mode: z.string(),
+  mode: zAppMode,
   model_config: zAppModelConfigResponse.nullish(),
   name: z.string(),
   permission_keys: z.array(z.string()).optional(),
   site: zAppDetailSiteResponse.nullish(),
   tags: z.array(zTag).optional(),
   tracing: z.unknown().nullish(),
-  updated_at: z.int().nullish(),
+  updated_at: z.int(),
   updated_by: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
+  use_icon_as_answer_icon: z.boolean(),
   workflow: zWorkflowPartial.nullish(),
 })
 
@@ -964,24 +978,24 @@ export const zAppDetailWithSite = z.object({
  */
 export const zAppDetail = z.object({
   access_mode: z.string().nullish(),
-  created_at: z.int().nullish(),
+  created_at: z.int(),
   created_by: z.string().nullish(),
-  description: z.string().nullish(),
+  description: z.string(),
   enable_api: z.boolean(),
   enable_site: z.boolean(),
   icon: z.string().nullish(),
   icon_background: z.string().nullish(),
   id: z.string(),
   maintainer: z.string().nullish(),
-  mode: z.string(),
+  mode: zAppMode,
   model_config: zAppModelConfigResponse.nullish(),
   name: z.string(),
   permission_keys: z.array(z.string()).optional(),
   tags: z.array(zTag).optional(),
   tracing: z.unknown().nullish(),
-  updated_at: z.int().nullish(),
+  updated_at: z.int(),
   updated_by: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
+  use_icon_as_answer_icon: z.boolean(),
   workflow: zWorkflowPartial.nullish(),
 })
 
@@ -4078,13 +4092,13 @@ export const zAppDetailSiteResponseWritable = z.object({
  */
 export const zAppDetailWithSiteWritable = z.object({
   access_mode: z.string().nullish(),
-  api_base_url: z.string().nullish(),
+  api_base_url: z.string(),
   app_id: z.string().nullish(),
   bound_agent_id: z.string().nullish(),
-  created_at: z.int().nullish(),
+  created_at: z.int(),
   created_by: z.string().nullish(),
   deleted_tools: z.array(zDeletedTool).optional(),
-  description: z.string().nullish(),
+  description: z.string(),
   enable_api: z.boolean(),
   enable_site: z.boolean(),
   icon: z.string().nullish(),
@@ -4093,16 +4107,16 @@ export const zAppDetailWithSiteWritable = z.object({
   id: z.string(),
   maintainer: z.string().nullish(),
   max_active_requests: z.int().nullish(),
-  mode: z.string(),
+  mode: zAppMode,
   model_config: zAppModelConfigResponse.nullish(),
   name: z.string(),
   permission_keys: z.array(z.string()).optional(),
   site: zAppDetailSiteResponseWritable.nullish(),
   tags: z.array(zTag).optional(),
   tracing: z.unknown().nullish(),
-  updated_at: z.int().nullish(),
+  updated_at: z.int(),
   updated_by: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
+  use_icon_as_answer_icon: z.boolean(),
   workflow: zWorkflowPartial.nullish(),
 })
 

--- a/web/app/components/app/configuration/hooks/__tests__/use-configuration.spec.tsx
+++ b/web/app/components/app/configuration/hooks/__tests__/use-configuration.spec.tsx
@@ -280,12 +280,17 @@ describe('useConfiguration', () => {
       input: { params: { app_id: 'app-1' } },
     })
     queryClient.setQueryData(detailQueryKey, {
+      api_base_url: 'https://api.example.com/v1',
+      created_at: 1781660000,
+      description: 'Cached app description',
       enable_api: false,
       enable_site: false,
       icon_url: null,
       id: 'app-1',
       mode: 'chat',
       name: 'Cached app',
+      updated_at: 1781660000,
+      use_icon_as_answer_icon: false,
     })
 
     await waitFor(() => {

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/app-inputs-panel.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/app-inputs-panel.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { AppDetailWithSite } from '@dify/contracts/api/console/apps/types.gen'
+import type { AppPartial } from '@dify/contracts/api/console/apps/types.gen'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useRef } from 'react'
@@ -13,7 +13,7 @@ type Props = Readonly<{
     app_id: string
     inputs: Record<string, unknown>
   }
-  appDetail: Pick<AppDetailWithSite, 'id' | 'mode'>
+  appDetail: Pick<AppPartial, 'id' | 'mode'>
   onFormChange: (value: Record<string, unknown>) => void
 }>
 

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/hooks/use-app-inputs-form-schema.ts
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/hooks/use-app-inputs-form-schema.ts
@@ -1,6 +1,7 @@
 'use client'
 import type {
   AppDetailWithSite,
+  AppPartial,
   WorkflowResponse,
 } from '@dify/contracts/api/console/apps/types.gen'
 import type { FileUpload } from '@/app/components/base/features/types'
@@ -159,7 +160,7 @@ function buildWorkflowSchema(
 }
 
 type UseAppInputsFormSchemaParams = {
-  appDetail: Pick<AppDetailWithSite, 'id' | 'mode'>
+  appDetail: Pick<AppPartial, 'id' | 'mode'>
 }
 
 type UseAppInputsFormSchemaResult = {

--- a/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
+++ b/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
@@ -81,7 +81,9 @@ vi.mock('@/service/client', () => ({
 }))
 
 const createAgent = (overrides: Partial<AgentAppDetailWithSite> = {}): AgentAppDetailWithSite => ({
+  api_base_url: 'https://api.example.com/v1',
   app_id: 'app-1',
+  created_at: 1781660000,
   description: 'Find and summarize market materials.',
   enable_api: true,
   enable_site: true,
@@ -93,6 +95,8 @@ const createAgent = (overrides: Partial<AgentAppDetailWithSite> = {}): AgentAppD
   mode: 'agent',
   name: 'Research Agent',
   role: 'Research Assistant',
+  updated_at: 1781660000,
+  use_icon_as_answer_icon: false,
   ...overrides,
 })
 

--- a/web/features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx
@@ -179,6 +179,8 @@ vi.mock('@/service/client', () => ({
 function createAgent(overrides: Partial<AgentAppDetailWithSite> = {}): AgentAppDetailWithSite {
   return {
     access_ready: true,
+    created_at: 1781660000,
+    description: 'Support Agent description',
     enable_api: true,
     enable_site: true,
     icon_url: null,
@@ -189,6 +191,8 @@ function createAgent(overrides: Partial<AgentAppDetailWithSite> = {}): AgentAppD
     backing_app_id: 'app-1',
     api_base_url: 'https://api.example.test/v1',
     access_mode: 'sso_verified',
+    updated_at: 1781660000,
+    use_icon_as_answer_icon: false,
     site: {
       access_token: 'site-token',
       app_base_url: 'https://chat.example.test',
@@ -559,20 +563,6 @@ describe('Agent access surface cards', () => {
 
       expect(
         screen.getByRole('button', { name: 'agentV2.agentDetail.access.webApp.actions.settings' }),
-      ).toBeDisabled()
-    })
-
-    it('should keep customize disabled until the generated contract provides the required fields', () => {
-      renderWithQueryClient(
-        <WebAppAccessCard
-          agent={createAgent({ api_base_url: null })}
-          agentId="agent-1"
-          isLoading={false}
-        />,
-      )
-
-      expect(
-        screen.getByRole('button', { name: 'agentV2.agentDetail.access.webApp.actions.customize' }),
       ).toBeDisabled()
     })
 

--- a/web/service/client.spec.ts
+++ b/web/service/client.spec.ts
@@ -1,4 +1,5 @@
 import type { ApiBasedExtensionResponse } from '@dify/contracts/api/console/api-based-extension/types.gen'
+import type { AppDetailWithSite } from '@dify/contracts/api/console/apps/types.gen'
 import type { TagResponse as Tag } from '@dify/contracts/api/console/tags/types.gen'
 import type { DocumentProcessingTaskEvent } from '@dify/contracts/knowledge-fs/types.gen'
 import type { MutationFunctionContext, QueryFunctionContext } from '@tanstack/react-query'
@@ -109,6 +110,8 @@ const getRetryFn = (queryOptions: object): RetryFn => {
 const createAgent = (overrides: Partial<AgentMutationResponse> = {}): AgentMutationResponse => ({
   ...overrides,
   access_ready: overrides.access_ready ?? true,
+  api_base_url: overrides.api_base_url ?? 'https://api.example.com/v1',
+  created_at: overrides.created_at ?? 1781660000,
   debug_conversation_has_messages: overrides.debug_conversation_has_messages ?? false,
   debug_conversation_message_count: overrides.debug_conversation_message_count ?? 0,
   enable_api: overrides.enable_api ?? true,
@@ -120,6 +123,8 @@ const createAgent = (overrides: Partial<AgentMutationResponse> = {}): AgentMutat
   mode: overrides.mode ?? 'agent',
   name: overrides.name ?? 'Agent',
   role: overrides.role ?? 'Assistant',
+  updated_at: overrides.updated_at ?? 1781660000,
+  use_icon_as_answer_icon: overrides.use_icon_as_answer_icon ?? false,
 })
 
 const createComposerState = (
@@ -671,13 +676,18 @@ describe('consoleQuery app mutation defaults', () => {
       input: { params: { app_id: 'app-2' } },
     })
     const updatedApp = {
+      api_base_url: 'https://api.example.com/v1',
+      created_at: 1781660000,
+      description: 'Updated description',
       enable_api: false,
       enable_site: false,
       icon_url: null,
       id: 'app-1',
       mode: 'chat',
       name: 'Updated app',
-    }
+      updated_at: 1781660000,
+      use_icon_as_answer_icon: false,
+    } satisfies AppDetailWithSite
     queryClient.setQueryData(detailQueryKey, { ...updatedApp, name: 'Old app' })
     queryClient.setQueryData(otherDetailQueryKey, { ...updatedApp, id: 'app-2', name: 'Other app' })
 


### PR DESCRIPTION
## Summary

- model app detail mode with the backend AppMode enum instead of an unconstrained string
- mark description, timestamps, answer-icon usage, and API base URL as required where the App model guarantees values
- regenerate the console apps and inherited agent TypeScript/Zod contracts
- add response serialization and OpenAPI schema regressions

## Why

The generated AppDetailWithSite contract was wider than the runtime response, which pushed nullable and string handling into frontend consumers. This fixes the Pydantic response owner so generated contracts match the real serialization boundary.

The PR intentionally does not add author_name or enable_sso, does not introduce a frontend compatibility DTO, and does not change app store ownership.

## Test plan

- uv run --project api --group dev pytest api/tests/unit_tests/controllers/console/app/test_app_response_models.py api/tests/unit_tests/commands/test_generate_swagger_specs.py api/tests/unit_tests/controllers/test_swagger.py
- uv run --project api --group dev pytest api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py api/tests/unit_tests/controllers/console/agent/test_app_helpers.py
- uv run --project api --group dev ruff check api/controllers/console/app/app.py api/tests/unit_tests/commands/test_generate_swagger_specs.py api/tests/unit_tests/controllers/console/app/test_app_response_models.py api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
- uv run --project api --group dev mypy --config-file api/pyproject.toml --check-untyped-defs --disable-error-code=import-untyped api/controllers/console/app/app.py
- vp run @dify/contracts#type-check
- vp run @dify/contracts#gen-api-contract

Results: 126 focused backend tests passed; Ruff, mypy, contract type-check, and contract generation passed.