### PR TITLE
fix(ci): run Playwright browsers on Depot

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
     name: Web Full-Stack E2E
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 120
     defaults:
       run:
@@ -46,17 +46,29 @@ jobs:
         working-directory: ./e2e
         run: vp run test:unit
 
-      - name: Install Playwright browsers for core E2E
-        if: ${{ !inputs.run-external-runtime }}
-        timeout-minutes: 15
+      - name: Start Playwright browser server
         working-directory: ./e2e
-        run: vp run e2e:install:ci
+        run: |
+          playwright_version="$(node --print "require('@playwright/test/package.json').version")"
+          docker run --detach --init \
+            --ipc=host \
+            --name dify-playwright \
+            --network=host \
+            --volume "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE:ro" \
+            --workdir "$GITHUB_WORKSPACE/e2e" \
+            "mcr.microsoft.com/playwright:v${playwright_version}-noble" \
+            ./node_modules/.bin/playwright run-server \
+            --host 127.0.0.1 \
+            --port 3001 \
+            --unsafe
 
-      - name: Install Chromium for external runtime E2E
-        if: ${{ inputs.run-external-runtime }}
-        timeout-minutes: 15
-        working-directory: ./e2e
-        run: vp run e2e:install:ci:chromium
+          if ! curl --fail --silent --show-error --retry 30 --retry-connrefused --retry-delay 1 \
+            http://127.0.0.1:3001/json >/dev/null; then
+            docker logs dify-playwright
+            exit 1
+          fi
+
+          echo 'PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3001/' >> "$GITHUB_ENV"
 
       - name: Run isolated source-api and built-web Cucumber E2E tests
         if: ${{ !inputs.run-external-runtime }}
@@ -143,6 +155,11 @@ jobs:
           fi
 
           vp run e2e:post-merge
+
+      - name: Stop Playwright browser server
+        if: ${{ always() }}
+        continue-on-error: true
+        run: docker rm --force dify-playwright
 
       - name: Upload Cucumber report
         if: ${{ !cancelled() }}

--- a/e2e/features/support/hooks.ts
+++ b/e2e/features/support/hooks.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url'
 import { After, AfterAll, Before, setDefaultTimeout, Status } from '@cucumber/cucumber'
 import { chromium, webkit } from '@playwright/test'
 import { AUTH_BOOTSTRAP_TIMEOUT_MS, ensureAuthenticatedState } from '../../fixtures/auth'
+import { launchBrowser } from '../../support/browser'
 import { runCleanupTasks, shouldFailForCleanupErrors } from '../../support/cleanup'
 import { getVoiceInputTestMaterialPath } from '../../support/test-materials'
 import { baseURL, cucumberHeadless, cucumberSlowMo, e2eBrowser } from '../../test-env'
@@ -80,7 +81,7 @@ const captureDiagnosticPage = async (
 }
 
 const getMicrophoneBrowser = () => {
-  microphoneBrowserPromise ??= chromium.launch({
+  microphoneBrowserPromise ??= launchBrowser(chromium, {
     args: [
       '--use-fake-device-for-media-stream',
       '--use-fake-ui-for-media-stream',
@@ -98,7 +99,7 @@ Before({ timeout: AUTH_BOOTSTRAP_TIMEOUT_MS }, async function (this: DifyWorld, 
 
   if (!browser) {
     const browserType = e2eBrowser === 'webkit' ? webkit : chromium
-    browser = await browserType.launch({
+    browser = await launchBrowser(browserType, {
       headless: cucumberHeadless,
       slowMo: cucumberSlowMo,
     })

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,7 +13,6 @@
     "e2e:full:headed": "tsx ./scripts/run-cucumber.ts --full --headed",
     "e2e:headed": "tsx ./scripts/run-cucumber.ts --headed",
     "e2e:install": "playwright install --with-deps chromium webkit",
-    "e2e:install:ci": "playwright install --with-deps --only-shell chromium webkit",
     "e2e:install:ci:chromium": "playwright install --with-deps --only-shell chromium",
     "e2e:middleware:down": "tsx ./scripts/setup.ts middleware-down",
     "e2e:middleware:up": "tsx ./scripts/setup.ts middleware-up",

--- a/e2e/scripts/seed-runner.ts
+++ b/e2e/scripts/seed-runner.ts
@@ -2,6 +2,7 @@ import { chromium } from '@playwright/test'
 import { createAgentV2SeedTasks } from '../features/agent-v2/support/seed'
 import { ensureAuthenticatedState } from '../fixtures/auth'
 import { createStandaloneConsoleSession } from '../support/api/console-session'
+import { launchBrowser } from '../support/browser'
 import { runSeedTasks, writeSeedReport } from '../support/seed'
 import { baseURL } from '../test-env'
 
@@ -19,7 +20,7 @@ const getTasks = (pack: string, profile: string) => {
 }
 
 const ensureAuth = async () => {
-  const browser = await chromium.launch({ headless: true })
+  const browser = await launchBrowser(chromium, { headless: true })
   try {
     await ensureAuthenticatedState(browser, baseURL)
   } finally {

--- a/e2e/support/browser.ts
+++ b/e2e/support/browser.ts
@@ -1,0 +1,12 @@
+import type { BrowserType, LaunchOptions } from '@playwright/test'
+
+export const launchBrowser = (browserType: BrowserType, options: LaunchOptions) => {
+  const endpoint = process.env.PW_TEST_CONNECT_WS_ENDPOINT
+  if (!endpoint) return browserType.launch(options)
+
+  return browserType.connect(endpoint, {
+    headers: {
+      'x-playwright-launch-options': JSON.stringify(options),
+    },
+  })
+}

--- a/e2e/tests/browser.test.ts
+++ b/e2e/tests/browser.test.ts
@@ -1,0 +1,24 @@
+import type { BrowserType } from '@playwright/test'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import { launchBrowser } from '../support/browser'
+
+describe('launchBrowser', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('forwards launch options to the remote browser server', async () => {
+    const connect = vi.fn()
+    const launch = vi.fn()
+    const browserType = { connect, launch } as unknown as BrowserType
+    const options = { headless: true, slowMo: 10 }
+    vi.stubEnv('PW_TEST_CONNECT_WS_ENDPOINT', 'ws://127.0.0.1:3001/')
+
+    await launchBrowser(browserType, options)
+
+    expect(connect).toHaveBeenCalledWith('ws://127.0.0.1:3001/', {
+      headers: {
+        'x-playwright-launch-options': JSON.stringify(options),
+      },
+    })
+    expect(launch).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Keep the full-stack E2E job on `depot-ubuntu-24.04-4`.
- Run Chromium and WebKit in the version-matched official Playwright container while Compose, API, and Web remain on the Depot host.
- Route all E2E browser launches through one local-or-remote helper and remove the unused host browser install script.

## Why

Depot runner APT mirror throughput made Playwright system dependency installation time out before tests started.
The GitHub-hosted runner change in #40986 conflicts with the company requirement to use Depot.
The browser sidecar removes the runner-image dependency without changing the existing host network or Compose lifecycle.

## Verification

- `vp run test:unit` — 47 passed.
- `vp run type-check` — passed.
- `vp check` on all changed TypeScript files — passed.
- YAML, JSON, and `git diff --check` — passed.