### PR TITLE
fix(console): return rendered form content in console human input form API (#38604)

### DIFF
--- a/api/controllers/console/human_input_form.py
+++ b/api/controllers/console/human_input_form.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from controllers.common.errors import InvalidArgumentError, NotFoundError
 from controllers.common.fields import EventStreamResponse
-from controllers.common.human_input import HumanInputFormSubmitPayload
+from controllers.common.human_input import HumanInputFormSubmitPayload, stringify_form_default_values
 from controllers.common.schema import register_response_schema_models, register_schema_models
 from controllers.console import console_ns
 from controllers.console.wraps import (
@@ -32,6 +32,7 @@ from core.app.apps.message_generator import MessageGenerator
 from core.app.apps.workflow.app_generator import WorkflowAppGenerator
 from core.workflow.human_input_policy import HumanInputSurface, is_recipient_type_allowed_for_surface
 from extensions.ext_database import db
+from libs.helper import to_timestamp
 from libs.login import login_required
 from models import Account, App
 from models.enums import CreatorUserRole
@@ -62,8 +63,14 @@ register_response_schema_models(
 
 
 def _jsonify_form_definition(form: Form) -> Response:
-    payload = form.get_definition().model_dump()
-    payload["expiration_time"] = int(form.expiration_time.timestamp())
+    definition_payload = form.get_definition().model_dump()
+    payload = {
+        "form_content": definition_payload.get("rendered_content") or definition_payload.get("form_content", ""),
+        "inputs": definition_payload.get("inputs", []),
+        "resolved_default_values": stringify_form_default_values(definition_payload.get("default_values", {})),
+        "user_actions": definition_payload.get("user_actions", []),
+        "expiration_time": to_timestamp(form.expiration_time),
+    }
     return Response(json.dumps(payload, ensure_ascii=False), mimetype="application/json")
 
 

--- a/api/tests/unit_tests/controllers/console/test_human_input_form.py
+++ b/api/tests/unit_tests/controllers/console/test_human_input_form.py
@@ -27,14 +27,28 @@ from models.model import AppMode
 
 def test_jsonify_form_definition() -> None:
     expiration = datetime(2024, 1, 1, tzinfo=UTC)
-    definition = SimpleNamespace(model_dump=lambda: {"fields": []})
+    definition = SimpleNamespace(
+        model_dump=lambda: {
+            "form_content": "raw {{#123.text#}}",
+            "rendered_content": "rendered text",
+            "inputs": [{"id": "inp-1"}],
+            "default_values": {"key": "val", "num": 123},
+            "user_actions": [{"id": "act-1"}],
+        }
+    )
     form = SimpleNamespace(get_definition=lambda: definition, expiration_time=expiration)
 
     response = _jsonify_form_definition(form)
 
     assert isinstance(response, Response)
     payload = json.loads(response.get_data(as_text=True))
-    assert payload["expiration_time"] == int(expiration.timestamp())
+    assert payload == {
+        "form_content": "rendered text",
+        "inputs": [{"id": "inp-1"}],
+        "resolved_default_values": {"key": "val", "num": "123"},
+        "user_actions": [{"id": "act-1"}],
+        "expiration_time": int(expiration.timestamp()),
+    }
 
 
 def test_ensure_console_access_rejects(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -46,7 +60,15 @@ def test_ensure_console_access_rejects(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_get_form_definition_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     expiration = datetime(2024, 1, 1, tzinfo=UTC)
-    definition = SimpleNamespace(model_dump=lambda: {"fields": ["a"]})
+    definition = SimpleNamespace(
+        model_dump=lambda: {
+            "form_content": "raw {{#123.text#}}",
+            "rendered_content": "rendered text",
+            "inputs": ["a"],
+            "default_values": {},
+            "user_actions": [],
+        }
+    )
     form = SimpleNamespace(tenant_id="tenant-1", get_definition=lambda: definition, expiration_time=expiration)
 
     class _ServiceStub:
@@ -66,7 +88,8 @@ def test_get_form_definition_success(app: Flask, monkeypatch: pytest.MonkeyPatch
         response = handler(api, "tenant-1", form_token="token")
 
     payload = json.loads(response.get_data(as_text=True))
-    assert payload["fields"] == ["a"]
+    assert payload["form_content"] == "rendered text"
+    assert payload["inputs"] == ["a"]
 
 
 def test_get_form_definition_not_found(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

### Summary
Fixes #38604.

When a workflow pauses at a Human Input node and the page is refreshed or viewed in the console, the Human Input form endpoint (`/console/api/form/human_input/<form_token>`) previously returned raw unrendered form content (e.g. `{{#1778488854176.text#}}`) instead of the substituted `rendered_content`, and did not format `resolved_default_values` with `stringify_form_default_values`.

In contrast, `web`, `service_api`, and `openapi` endpoints already format `"form_content": definition_payload["rendered_content"]` and serialize `resolved_default_values`.

This PR aligns `api/controllers/console/human_input_form.py` with the other endpoints:
1. Sets `form_content` to `rendered_content` (falling back to `form_content` if empty).
2. Sets `resolved_default_values` serialized with `stringify_form_default_values`.
3. Updates unit tests in `api/tests/unit_tests/controllers/console/test_human_input_form.py` to verify the serialized payload.

### Tests
- `pytest tests/unit_tests/controllers/console/test_human_input_form.py` (13 passed)
- `pytest tests/unit_tests/controllers/web/test_human_input_form.py tests/unit_tests/controllers/service_api/app/test_human_input_form.py tests/unit_tests/services/test_human_input_service.py` (57 passed)
- `ruff check` and `ruff format --check` passed
