### PR TITLE
refactor: pass session explicitly in schedule tasks (#37403)

### DIFF
--- a/api/schedule/check_upgradable_plugin_task.py
+++ b/api/schedule/check_upgradable_plugin_task.py
@@ -3,9 +3,9 @@ import math
 import time
 
 import click
+from celery import shared_task
 from sqlalchemy import select
 
-import app
 from core.db.session_factory import session_factory
 from core.helper.marketplace import fetch_global_plugin_manifest
 from models.account import TenantPluginAutoUpgradeStrategy, TenantPluginAutoUpgradeStrategySetting
@@ -21,7 +21,7 @@ CACHE_REDIS_KEY_PREFIX = check_task.CACHE_REDIS_KEY_PREFIX
 CACHE_REDIS_TTL = check_task.CACHE_REDIS_TTL
 
 
-@app.celery.task(queue="plugin")
+@shared_task(queue="plugin")
 def check_upgradable_plugin_task():
     click.echo(click.style("Start check upgradable plugin.", fg="green"))
     start_at = time.perf_counter()

--- a/api/schedule/check_upgradable_plugin_task.py
+++ b/api/schedule/check_upgradable_plugin_task.py
@@ -6,8 +6,8 @@ import click
 from sqlalchemy import select
 
 import app
+from core.db.session_factory import session_factory
 from core.helper.marketplace import fetch_global_plugin_manifest
-from extensions.ext_database import db
 from models.account import TenantPluginAutoUpgradeStrategy, TenantPluginAutoUpgradeStrategySetting
 from tasks import process_tenant_plugin_autoupgrade_check_task as check_task
 
@@ -29,14 +29,15 @@ def check_upgradable_plugin_task():
     now_seconds_of_day = time.time() % 86400 - 30  # we assume the tz is UTC
     click.echo(click.style(f"Now seconds of day: {now_seconds_of_day}", fg="green"))
 
-    strategies = db.session.scalars(
-        select(TenantPluginAutoUpgradeStrategy).where(
-            TenantPluginAutoUpgradeStrategy.upgrade_time_of_day >= now_seconds_of_day,
-            TenantPluginAutoUpgradeStrategy.upgrade_time_of_day
-            < now_seconds_of_day + AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL,
-            TenantPluginAutoUpgradeStrategy.strategy_setting != TenantPluginAutoUpgradeStrategySetting.DISABLED,
-        )
-    ).all()
+    with session_factory.create_session() as session:
+        strategies = session.scalars(
+            select(TenantPluginAutoUpgradeStrategy).where(
+                TenantPluginAutoUpgradeStrategy.upgrade_time_of_day >= now_seconds_of_day,
+                TenantPluginAutoUpgradeStrategy.upgrade_time_of_day
+                < now_seconds_of_day + AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL,
+                TenantPluginAutoUpgradeStrategy.strategy_setting != TenantPluginAutoUpgradeStrategySetting.DISABLED,
+            )
+        ).all()
 
     total_strategies = len(strategies)
     click.echo(click.style(f"Total strategies: {total_strategies}", fg="green"))

--- a/api/schedule/clean_embedding_cache_task.py
+++ b/api/schedule/clean_embedding_cache_task.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 import app
 from configs import dify_config
-from extensions.ext_database import db
+from core.db.session_factory import session_factory
 from models.dataset import Embedding
 
 
@@ -17,24 +17,25 @@ def clean_embedding_cache_task():
     clean_days = int(dify_config.PLAN_SANDBOX_CLEAN_DAY_SETTING)
     start_at = time.perf_counter()
     thirty_days_ago = datetime.datetime.now() - datetime.timedelta(days=clean_days)
-    while True:
-        try:
-            embedding_ids = db.session.scalars(
-                select(Embedding.id)
-                .where(Embedding.created_at < thirty_days_ago)
-                .order_by(Embedding.created_at.desc())
-                .limit(100)
-            ).all()
-        except SQLAlchemyError:
-            raise
-        if embedding_ids:
-            for embedding_id in embedding_ids:
-                db.session.execute(
-                    text("DELETE FROM embeddings WHERE id = :embedding_id"), {"embedding_id": embedding_id}
-                )
+    with session_factory.create_session() as session:
+        while True:
+            try:
+                embedding_ids = session.scalars(
+                    select(Embedding.id)
+                    .where(Embedding.created_at < thirty_days_ago)
+                    .order_by(Embedding.created_at.desc())
+                    .limit(100)
+                ).all()
+            except SQLAlchemyError:
+                raise
+            if embedding_ids:
+                for embedding_id in embedding_ids:
+                    session.execute(
+                        text("DELETE FROM embeddings WHERE id = :embedding_id"), {"embedding_id": embedding_id}
+                    )
 
-            db.session.commit()
-        else:
-            break
+                session.commit()
+            else:
+                break
     end_at = time.perf_counter()
     click.echo(click.style(f"Cleaned embedding cache from db success latency: {end_at - start_at}", fg="green"))

--- a/api/schedule/clean_embedding_cache_task.py
+++ b/api/schedule/clean_embedding_cache_task.py
@@ -2,16 +2,16 @@ import datetime
 import time
 
 import click
+from celery import shared_task
 from sqlalchemy import select, text
 from sqlalchemy.exc import SQLAlchemyError
 
-import app
 from configs import dify_config
 from core.db.session_factory import session_factory
 from models.dataset import Embedding
 
 
-@app.celery.task(queue="dataset")
+@shared_task(queue="dataset")
 def clean_embedding_cache_task():
     click.echo(click.style("Start clean embedding cache.", fg="green"))
     clean_days = int(dify_config.PLAN_SANDBOX_CLEAN_DAY_SETTING)

--- a/api/schedule/clean_oauth_access_tokens_task.py
+++ b/api/schedule/clean_oauth_access_tokens_task.py
@@ -15,7 +15,7 @@ from sqlalchemy import delete, or_, select
 
 import app
 from configs import dify_config
-from extensions.ext_database import db
+from core.db.session_factory import session_factory
 from models.oauth import OAuthAccessToken
 
 logger = logging.getLogger(__name__)
@@ -37,13 +37,14 @@ def clean_oauth_access_tokens_task():
     )
 
     total = 0
-    while True:
-        ids = db.session.scalars(select(OAuthAccessToken.id).where(candidates).limit(DELETE_BATCH_SIZE)).all()
-        if not ids:
-            break
-        db.session.execute(delete(OAuthAccessToken).where(OAuthAccessToken.id.in_(ids)))
-        db.session.commit()
-        total += len(ids)
+    with session_factory.create_session() as session:
+        while True:
+            ids = session.scalars(select(OAuthAccessToken.id).where(candidates).limit(DELETE_BATCH_SIZE)).all()
+            if not ids:
+                break
+            session.execute(delete(OAuthAccessToken).where(OAuthAccessToken.id.in_(ids)))
+            session.commit()
+            total += len(ids)
 
     end_at = time.perf_counter()
     click.echo(

--- a/api/schedule/clean_oauth_access_tokens_task.py
+++ b/api/schedule/clean_oauth_access_tokens_task.py
@@ -11,9 +11,9 @@ import time
 from datetime import UTC, datetime, timedelta
 
 import click
+from celery import shared_task
 from sqlalchemy import delete, or_, select
 
-import app
 from configs import dify_config
 from core.db.session_factory import session_factory
 from models.oauth import OAuthAccessToken
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 DELETE_BATCH_SIZE = 500
 
 
-@app.celery.task(queue="retention")
+@shared_task(queue="retention")
 def clean_oauth_access_tokens_task():
     click.echo(click.style("Start clean oauth_access_tokens.", fg="green"))
     retention_days = int(dify_config.OAUTH_ACCESS_TOKEN_RETENTION_DAYS)

--- a/api/schedule/create_tidb_serverless_task.py
+++ b/api/schedule/create_tidb_serverless_task.py
@@ -3,10 +3,11 @@ import time
 import click
 from dify_vdb_tidb_on_qdrant.tidb_service import TidbService
 from sqlalchemy import func, select
+from sqlalchemy.orm import Session
 
 import app
 from configs import dify_config
-from extensions.ext_database import db
+from core.db.session_factory import session_factory
 from models.dataset import TidbAuthBinding
 from models.enums import TidbAuthBindingStatus
 
@@ -18,27 +19,28 @@ def create_tidb_serverless_task():
         return
     tidb_serverless_number = dify_config.TIDB_SERVERLESS_NUMBER
     start_at = time.perf_counter()
-    while True:
-        try:
-            # check the number of idle tidb serverless
-            idle_tidb_serverless_number = (
-                db.session.scalar(select(func.count(TidbAuthBinding.id)).where(TidbAuthBinding.active == False)) or 0
-            )
-            if idle_tidb_serverless_number >= tidb_serverless_number:
-                break
-            # create tidb serverless
-            iterations_per_thread = 20
-            create_clusters(iterations_per_thread)
+    with session_factory.create_session() as session:
+        while True:
+            try:
+                # check the number of idle tidb serverless
+                idle_tidb_serverless_number = (
+                    session.scalar(select(func.count(TidbAuthBinding.id)).where(TidbAuthBinding.active == False)) or 0
+                )
+                if idle_tidb_serverless_number >= tidb_serverless_number:
+                    break
+                # create tidb serverless
+                iterations_per_thread = 20
+                create_clusters(iterations_per_thread, session)
 
-        except Exception as e:
-            click.echo(click.style(f"Error: {e}", fg="red"))
-            break
+            except Exception as e:
+                click.echo(click.style(f"Error: {e}", fg="red"))
+                break
 
     end_at = time.perf_counter()
     click.echo(click.style(f"Create tidb serverless task success latency: {end_at - start_at}", fg="green"))
 
 
-def create_clusters(batch_size):
+def create_clusters(batch_size, session: Session):
     try:
         # TODO: maybe we can set the default value for the following parameters in the config file
         new_clusters = TidbService.batch_create_tidb_serverless_cluster(
@@ -61,7 +63,7 @@ def create_clusters(batch_size):
                 active=False,
                 status=TidbAuthBindingStatus.CREATING,
             )
-            db.session.add(tidb_auth_binding)
-        db.session.commit()
+            session.add(tidb_auth_binding)
+        session.commit()
     except Exception as e:
         click.echo(click.style(f"Error: {e}", fg="red"))

--- a/api/schedule/create_tidb_serverless_task.py
+++ b/api/schedule/create_tidb_serverless_task.py
@@ -1,18 +1,18 @@
 import time
 
 import click
+from celery import shared_task
 from dify_vdb_tidb_on_qdrant.tidb_service import TidbService
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-import app
 from configs import dify_config
 from core.db.session_factory import session_factory
 from models.dataset import TidbAuthBinding
 from models.enums import TidbAuthBindingStatus
 
 
-@app.celery.task(queue="dataset")
+@shared_task(queue="dataset")
 def create_tidb_serverless_task():
     click.echo(click.style("Start create tidb serverless task.", fg="green"))
     if not dify_config.CREATE_TIDB_SERVICE_JOB_ENABLED:

--- a/api/schedule/queue_monitor_task.py
+++ b/api/schedule/queue_monitor_task.py
@@ -7,7 +7,6 @@ from redis import Redis
 
 import app
 from configs import dify_config
-from extensions.ext_database import db
 from libs.email_i18n import EmailType, get_email_i18n_service
 
 redis_config = parse_url(dify_config.CELERY_BROKER_URL)
@@ -77,6 +76,3 @@ def queue_monitor_task():
 
     except Exception:
         logger.exception(click.style("Exception occurred during queue monitoring", fg="red"))
-    finally:
-        if db.session.is_active:
-            db.session.close()

--- a/api/schedule/queue_monitor_task.py
+++ b/api/schedule/queue_monitor_task.py
@@ -2,34 +2,40 @@ import logging
 from datetime import datetime
 
 import click
+from celery import shared_task
 from kombu.utils.url import parse_url  # type: ignore
 from redis import Redis
 
-import app
 from configs import dify_config
 from libs.email_i18n import EmailType, get_email_i18n_service
-
-redis_config = parse_url(dify_config.CELERY_BROKER_URL)
-celery_redis = Redis(
-    host=str(redis_config.get("hostname") or "localhost"),
-    port=int(redis_config.get("port") or 6379),
-    password=str(pwd) if (pwd := redis_config.get("password")) is not None else None,
-    db=int(redis_config.get("virtual_host")) if redis_config.get("virtual_host") else 1,
-    ssl=dify_config.BROKER_USE_SSL,
-    ssl_ca_certs=dify_config.REDIS_SSL_CA_CERTS if dify_config.BROKER_USE_SSL else None,
-    ssl_cert_reqs=getattr(dify_config, "REDIS_SSL_CERT_REQS", None) if dify_config.BROKER_USE_SSL else None,
-    ssl_certfile=getattr(dify_config, "REDIS_SSL_CERTFILE", None) if dify_config.BROKER_USE_SSL else None,
-    ssl_keyfile=getattr(dify_config, "REDIS_SSL_KEYFILE", None) if dify_config.BROKER_USE_SSL else None,
-    # Add conservative socket timeouts and health checks to avoid long-lived half-open sockets
-    socket_timeout=5,
-    socket_connect_timeout=5,
-    health_check_interval=30,
-)
 
 logger = logging.getLogger(__name__)
 
 
-@app.celery.task(queue="monitor")
+def _create_celery_redis() -> Redis:
+    broker_url = dify_config.CELERY_BROKER_URL
+    if not broker_url:
+        raise ValueError("CELERY_BROKER_URL is required for queue monitoring")
+
+    redis_config = parse_url(broker_url)
+    return Redis(
+        host=str(redis_config.get("hostname") or "localhost"),
+        port=int(redis_config.get("port") or 6379),
+        password=str(pwd) if (pwd := redis_config.get("password")) is not None else None,
+        db=int(redis_config.get("virtual_host")) if redis_config.get("virtual_host") else 1,
+        ssl=dify_config.BROKER_USE_SSL,
+        ssl_ca_certs=dify_config.REDIS_SSL_CA_CERTS if dify_config.BROKER_USE_SSL else None,
+        ssl_cert_reqs=getattr(dify_config, "REDIS_SSL_CERT_REQS", None) if dify_config.BROKER_USE_SSL else None,
+        ssl_certfile=getattr(dify_config, "REDIS_SSL_CERTFILE", None) if dify_config.BROKER_USE_SSL else None,
+        ssl_keyfile=getattr(dify_config, "REDIS_SSL_KEYFILE", None) if dify_config.BROKER_USE_SSL else None,
+        # Add conservative socket timeouts and health checks to avoid long-lived half-open sockets
+        socket_timeout=5,
+        socket_connect_timeout=5,
+        health_check_interval=30,
+    )
+
+
+@shared_task(queue="monitor")
 def queue_monitor_task():
     queue_name = "dataset"
     threshold = dify_config.QUEUE_MONITOR_THRESHOLD
@@ -39,6 +45,7 @@ def queue_monitor_task():
         return
 
     try:
+        celery_redis = _create_celery_redis()
         queue_length = celery_redis.llen(f"{queue_name}")
         logger.info(click.style(f"Start monitor {queue_name}", fg="green"))
 

--- a/api/schedule/queue_monitor_task.py
+++ b/api/schedule/queue_monitor_task.py
@@ -25,9 +25,9 @@ def _create_celery_redis() -> Redis:
         db=int(redis_config.get("virtual_host")) if redis_config.get("virtual_host") else 1,
         ssl=dify_config.BROKER_USE_SSL,
         ssl_ca_certs=dify_config.REDIS_SSL_CA_CERTS if dify_config.BROKER_USE_SSL else None,
-        ssl_cert_reqs=getattr(dify_config, "REDIS_SSL_CERT_REQS", None) if dify_config.BROKER_USE_SSL else None,
-        ssl_certfile=getattr(dify_config, "REDIS_SSL_CERTFILE", None) if dify_config.BROKER_USE_SSL else None,
-        ssl_keyfile=getattr(dify_config, "REDIS_SSL_KEYFILE", None) if dify_config.BROKER_USE_SSL else None,
+        ssl_cert_reqs=dify_config.REDIS_SSL_CERT_REQS if dify_config.BROKER_USE_SSL else None,
+        ssl_certfile=dify_config.REDIS_SSL_CERTFILE if dify_config.BROKER_USE_SSL else None,
+        ssl_keyfile=dify_config.REDIS_SSL_KEYFILE if dify_config.BROKER_USE_SSL else None,
         # Add conservative socket timeouts and health checks to avoid long-lived half-open sockets
         socket_timeout=5,
         socket_connect_timeout=5,

--- a/api/schedule/update_tidb_serverless_status_task.py
+++ b/api/schedule/update_tidb_serverless_status_task.py
@@ -2,17 +2,17 @@ import time
 from collections.abc import Sequence
 
 import click
+from celery import shared_task
 from dify_vdb_tidb_on_qdrant.tidb_service import TidbService
 from sqlalchemy import select
 
-import app
 from configs import dify_config
 from core.db.session_factory import session_factory
 from models.dataset import TidbAuthBinding
 from models.enums import TidbAuthBindingStatus
 
 
-@app.celery.task(queue="dataset")
+@shared_task(queue="dataset")
 def update_tidb_serverless_status_task():
     click.echo(click.style("Update tidb serverless status task.", fg="green"))
     start_at = time.perf_counter()

--- a/api/schedule/update_tidb_serverless_status_task.py
+++ b/api/schedule/update_tidb_serverless_status_task.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 
 import app
 from configs import dify_config
-from extensions.ext_database import db
+from core.db.session_factory import session_factory
 from models.dataset import TidbAuthBinding
 from models.enums import TidbAuthBindingStatus
 
@@ -17,17 +17,18 @@ def update_tidb_serverless_status_task():
     click.echo(click.style("Update tidb serverless status task.", fg="green"))
     start_at = time.perf_counter()
     try:
-        # check the number of idle tidb serverless
-        tidb_serverless_list = db.session.scalars(
-            select(TidbAuthBinding).where(
-                TidbAuthBinding.active == False,
-                TidbAuthBinding.status == TidbAuthBindingStatus.CREATING,
-            )
-        ).all()
-        if len(tidb_serverless_list) == 0:
-            return
-        # update tidb serverless status
-        update_clusters(tidb_serverless_list)
+        with session_factory.create_session() as session:
+            # check the number of idle tidb serverless
+            tidb_serverless_list = session.scalars(
+                select(TidbAuthBinding).where(
+                    TidbAuthBinding.active == False,
+                    TidbAuthBinding.status == TidbAuthBindingStatus.CREATING,
+                )
+            ).all()
+            if len(tidb_serverless_list) == 0:
+                return
+            # update tidb serverless status
+            update_clusters(tidb_serverless_list)
 
     except Exception as e:
         click.echo(click.style(f"Error: {e}", fg="red"))

--- a/api/tests/unit_tests/schedule/test_check_upgradable_plugin_task.py
+++ b/api/tests/unit_tests/schedule/test_check_upgradable_plugin_task.py
@@ -1,0 +1,69 @@
+"""Unit tests for ``check_upgradable_plugin_task`` strategy selection.
+
+The task dispatches upgrade checks for auto-upgrade strategies whose
+``upgrade_time_of_day`` falls inside the current checking window. Sessions
+are provided by the shared SQLite session factory, which proves the task no
+longer depends on the global Flask-SQLAlchemy session.
+"""
+
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+import schedule.check_upgradable_plugin_task as check_upgradable_module
+from models.account import TenantPluginAutoUpgradeStrategy, TenantPluginAutoUpgradeStrategySetting
+from schedule.check_upgradable_plugin_task import (
+    AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL,
+    check_upgradable_plugin_task,
+)
+
+
+def _make_strategy(
+    *, upgrade_time_of_day: int, setting: TenantPluginAutoUpgradeStrategySetting
+) -> TenantPluginAutoUpgradeStrategy:
+    return TenantPluginAutoUpgradeStrategy(
+        tenant_id=str(uuid.uuid4()),
+        strategy_setting=setting,
+        upgrade_time_of_day=upgrade_time_of_day,
+    )
+
+
+@pytest.fixture
+def seeded_strategies(sqlite_session_factory: sessionmaker[Session]) -> dict[str, str]:
+    """Seed strategies covering each branch of the selection window."""
+    window_start = int(time.time() % 86400 - 30)
+    in_window = window_start + 60
+    out_of_window = window_start + AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL + 3600
+
+    strategies = {
+        "in_window": _make_strategy(
+            upgrade_time_of_day=in_window, setting=TenantPluginAutoUpgradeStrategySetting.FIX_ONLY
+        ),
+        "out_of_window": _make_strategy(
+            upgrade_time_of_day=out_of_window, setting=TenantPluginAutoUpgradeStrategySetting.FIX_ONLY
+        ),
+        "disabled": _make_strategy(
+            upgrade_time_of_day=in_window, setting=TenantPluginAutoUpgradeStrategySetting.DISABLED
+        ),
+    }
+    with sqlite_session_factory() as session:
+        for strategy in strategies.values():
+            session.add(strategy)
+        session.commit()
+    return {label: strategy.tenant_id for label, strategy in strategies.items()}
+
+
+def test_dispatches_only_in_window_enabled_strategies(seeded_strategies: dict[str, str]) -> None:
+    with (
+        patch.object(check_upgradable_module, "fetch_global_plugin_manifest"),
+        patch.object(
+            check_upgradable_module.check_task, "process_tenant_plugin_autoupgrade_check_task"
+        ) as mock_check_task,
+    ):
+        check_upgradable_plugin_task()
+
+    dispatched_tenants = [call.args[0] for call in mock_check_task.delay.call_args_list]
+    assert dispatched_tenants == [seeded_strategies["in_window"]]

--- a/api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py
+++ b/api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py
@@ -1,0 +1,78 @@
+"""Unit tests for ``clean_embedding_cache_task``.
+
+The task deletes embedding cache rows older than the sandbox clean window.
+Sessions are provided by the shared SQLite session factory, which proves the
+task no longer depends on the global Flask-SQLAlchemy session.
+"""
+
+import datetime
+import pickle
+import uuid
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.dataset import Embedding
+from schedule.clean_embedding_cache_task import clean_embedding_cache_task
+
+CLEAN_DAYS = 30
+
+
+def _make_embedding(hash_value: str) -> Embedding:
+    return Embedding(
+        model_name="text-embedding-test",
+        hash=hash_value,
+        provider_name="test-provider",
+        embedding=pickle.dumps([0.1, 0.2], protocol=pickle.HIGHEST_PROTOCOL),
+    )
+
+
+@pytest.fixture
+def seeded_embeddings(
+    sqlite_session_factory: sessionmaker[Session], config_overrides: Callable[..., None]
+) -> dict[str, str]:
+    """Seed one stale and one fresh embedding row and return their ids."""
+    config_overrides(PLAN_SANDBOX_CLEAN_DAY_SETTING=CLEAN_DAYS)
+
+    stale_embedding = _make_embedding(uuid.uuid4().hex)
+    fresh_embedding = _make_embedding(uuid.uuid4().hex)
+
+    with sqlite_session_factory() as session:
+        session.add(stale_embedding)
+        session.add(fresh_embedding)
+        session.commit()
+
+        # created_at is server-generated; age the stale row past the clean window.
+        session.execute(
+            update(Embedding)
+            .where(Embedding.id == stale_embedding.id)
+            .values(created_at=datetime.datetime.now() - datetime.timedelta(days=CLEAN_DAYS + 1))
+        )
+        session.commit()
+
+    return {"stale": stale_embedding.id, "fresh": fresh_embedding.id}
+
+
+def test_deletes_only_stale_embedding_rows(
+    seeded_embeddings: dict[str, str], sqlite_session_factory: sessionmaker[Session]
+) -> None:
+    clean_embedding_cache_task()
+
+    with sqlite_session_factory() as session:
+        remaining = set(session.scalars(select(Embedding.id)).all())
+
+    assert remaining == {seeded_embeddings["fresh"]}
+
+
+def test_is_idempotent_when_nothing_is_stale(
+    seeded_embeddings: dict[str, str], sqlite_session_factory: sessionmaker[Session]
+) -> None:
+    clean_embedding_cache_task()
+    clean_embedding_cache_task()
+
+    with sqlite_session_factory() as session:
+        remaining = set(session.scalars(select(Embedding.id)).all())
+
+    assert remaining == {seeded_embeddings["fresh"]}

--- a/api/tests/unit_tests/schedule/test_clean_oauth_access_tokens_task.py
+++ b/api/tests/unit_tests/schedule/test_clean_oauth_access_tokens_task.py
@@ -1,0 +1,83 @@
+"""Unit tests for ``clean_oauth_access_tokens_task``.
+
+The task prunes revoked / zombie device-flow tokens past the retention
+window. Sessions are provided by the shared SQLite session factory, which
+proves the task no longer depends on the global Flask-SQLAlchemy session.
+"""
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.oauth import OAuthAccessToken
+from schedule.clean_oauth_access_tokens_task import clean_oauth_access_tokens_task
+
+RETENTION_DAYS = 30
+
+
+def _make_token(
+    *,
+    expires_at: datetime,
+    revoked_at: datetime | None = None,
+    device_label: str = "device",
+) -> OAuthAccessToken:
+    return OAuthAccessToken(
+        subject_email="user@example.com",
+        client_id="dify-cli",
+        device_label=device_label,
+        prefix="dfoa_",
+        expires_at=expires_at,
+        revoked_at=revoked_at,
+    )
+
+
+@pytest.fixture
+def seeded_tokens(
+    sqlite_session_factory: sessionmaker[Session], config_overrides: Callable[..., None]
+) -> dict[str, str]:
+    """Seed one token per retention category and return their ids by label."""
+    config_overrides(OAUTH_ACCESS_TOKEN_RETENTION_DAYS=RETENTION_DAYS)
+
+    now = datetime.now(UTC)
+    past_cutoff = now - timedelta(days=RETENTION_DAYS + 1)
+    tokens = {
+        # Revoked long ago: past retention, must be deleted.
+        "old_revoked": _make_token(expires_at=now, revoked_at=past_cutoff),
+        # Expired but never presented (revoked_at stays NULL): zombie, must be deleted.
+        "zombie": _make_token(expires_at=past_cutoff),
+        # Recently revoked: still within retention, must be kept.
+        "fresh_revoked": _make_token(expires_at=now, revoked_at=now - timedelta(days=1)),
+        # Valid and unexpired: must be kept.
+        "valid": _make_token(expires_at=now + timedelta(days=RETENTION_DAYS)),
+    }
+    with sqlite_session_factory() as session:
+        for token in tokens.values():
+            session.add(token)
+        session.commit()
+    return {label: token.id for label, token in tokens.items()}
+
+
+def test_prunes_only_tokens_past_retention(
+    seeded_tokens: dict[str, str], sqlite_session_factory: sessionmaker[Session]
+) -> None:
+    clean_oauth_access_tokens_task()
+
+    with sqlite_session_factory() as session:
+        remaining = set(session.scalars(select(OAuthAccessToken.id)).all())
+
+    assert remaining == {seeded_tokens["fresh_revoked"], seeded_tokens["valid"]}
+
+
+def test_is_idempotent_when_nothing_matches(
+    seeded_tokens: dict[str, str], sqlite_session_factory: sessionmaker[Session]
+) -> None:
+    clean_oauth_access_tokens_task()
+    clean_oauth_access_tokens_task()
+
+    with sqlite_session_factory() as session:
+        remaining = set(session.scalars(select(OAuthAccessToken.id)).all())
+
+    assert remaining == {seeded_tokens["fresh_revoked"], seeded_tokens["valid"]}

--- a/api/tests/unit_tests/schedule/test_import_isolation.py
+++ b/api/tests/unit_tests/schedule/test_import_isolation.py
@@ -1,0 +1,48 @@
+"""Regression tests for side-effect-free scheduled-task imports."""
+
+import importlib
+import logging
+import sys
+
+import pytest
+
+from extensions import ext_redis
+
+
+@pytest.mark.parametrize(
+    ("module_name", "queue"),
+    [
+        ("schedule.check_upgradable_plugin_task", "plugin"),
+        ("schedule.clean_embedding_cache_task", "dataset"),
+        ("schedule.clean_oauth_access_tokens_task", "retention"),
+        ("schedule.create_tidb_serverless_task", "dataset"),
+        ("schedule.queue_monitor_task", "monitor"),
+        ("schedule.update_tidb_serverless_status_task", "dataset"),
+    ],
+)
+def test_task_module_import_does_not_initialize_application(
+    module_name: str,
+    queue: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Importing a task must not configure process-wide logging or Redis.
+
+    Pytest-xdist imports every collected test module in each worker. Importing
+    ``app`` from a task module would therefore initialize the full Flask app in
+    every worker and leak its logging filters and real Redis client into
+    unrelated unit tests.
+    """
+    root_handlers = tuple(logging.root.handlers)
+    redis_backing_client = ext_redis.redis_client._client
+
+    monkeypatch.delitem(sys.modules, "app", raising=False)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    task_module = importlib.import_module(module_name)
+    task_name = module_name.rsplit(".", maxsplit=1)[-1]
+    task = getattr(task_module, task_name)
+
+    assert "app" not in sys.modules
+    assert tuple(logging.root.handlers) == root_handlers
+    assert ext_redis.redis_client._client is redis_backing_client
+    assert getattr(task, "queue", None) == queue

--- a/api/tests/unit_tests/schedule/test_import_isolation.py
+++ b/api/tests/unit_tests/schedule/test_import_isolation.py
@@ -40,9 +40,9 @@ def test_task_module_import_does_not_initialize_application(
 
     task_module = importlib.import_module(module_name)
     task_name = module_name.rsplit(".", maxsplit=1)[-1]
-    task = getattr(task_module, task_name)
+    task = vars(task_module)[task_name]
 
     assert "app" not in sys.modules
     assert tuple(logging.root.handlers) == root_handlers
     assert ext_redis.redis_client._client is redis_backing_client
-    assert getattr(task, "queue", None) == queue
+    assert task.queue == queue

--- a/api/tests/unit_tests/schedule/test_tidb_serverless_tasks.py
+++ b/api/tests/unit_tests/schedule/test_tidb_serverless_tasks.py
@@ -1,0 +1,136 @@
+"""Unit tests for the TiDB serverless schedule tasks.
+
+Covers ``create_tidb_serverless_task`` / ``create_clusters`` and
+``update_tidb_serverless_status_task`` after the explicit session passing
+refactor: the external TiDB cloud SDK is mocked, while all persistence runs
+against the shared SQLite session factory.
+"""
+
+from collections.abc import Callable
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+import schedule.create_tidb_serverless_task as create_tidb_module
+import schedule.update_tidb_serverless_status_task as update_tidb_module
+from core.db.session_factory import session_factory
+from models.dataset import TidbAuthBinding
+from models.enums import TidbAuthBindingStatus
+from schedule.create_tidb_serverless_task import create_clusters, create_tidb_serverless_task
+from schedule.update_tidb_serverless_status_task import update_tidb_serverless_status_task
+
+
+def _fake_cluster(cluster_id: str) -> dict[str, str | None]:
+    return {
+        "cluster_id": cluster_id,
+        "cluster_name": f"cluster-{cluster_id}",
+        "account": "root",
+        "password": "secret",
+        "qdrant_endpoint": None,
+    }
+
+
+def _seed_binding(session_factory_: sessionmaker[Session], *, status: TidbAuthBindingStatus, active: bool) -> str:
+    binding = TidbAuthBinding(
+        tenant_id=None,
+        cluster_id=f"existing-{status.value}",
+        cluster_name="existing",
+        account="root",
+        password="secret",
+        active=active,
+        status=status,
+    )
+    with session_factory_() as session:
+        session.add(binding)
+        session.commit()
+    return binding.id
+
+
+@pytest.fixture(autouse=True)
+def create_tidb_config(config_overrides: Callable[..., None]) -> None:
+    config_overrides(
+        CREATE_TIDB_SERVICE_JOB_ENABLED=True,
+        TIDB_SERVERLESS_NUMBER=2,
+        TIDB_PROJECT_ID="project",
+        TIDB_API_URL="https://api.example.com",
+        TIDB_IAM_API_URL="https://iam.example.com",
+        TIDB_PUBLIC_KEY="public",
+        TIDB_PRIVATE_KEY="private",
+        TIDB_REGION="regions/aws-us-east-1",
+    )
+
+
+def test_create_clusters_persists_bindings_through_passed_session(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with patch.object(
+        create_tidb_module.TidbService,
+        "batch_create_tidb_serverless_cluster",
+        return_value=[_fake_cluster("c-1"), _fake_cluster("c-2")],
+    ):
+        with session_factory.create_session() as session:
+            create_clusters(20, session)
+
+    with sqlite_session_factory() as session:
+        bindings = session.scalars(select(TidbAuthBinding)).all()
+
+    assert {binding.cluster_id for binding in bindings} == {"c-1", "c-2"}
+    assert all(binding.status == TidbAuthBindingStatus.CREATING for binding in bindings)
+    assert all(binding.active is False for binding in bindings)
+
+
+def test_create_task_stops_once_enough_idle_clusters_exist(sqlite_session_factory: sessionmaker[Session]) -> None:
+    # Two idle (inactive) bindings already satisfy TIDB_SERVERLESS_NUMBER=2.
+    _seed_binding(sqlite_session_factory, status=TidbAuthBindingStatus.CREATING, active=False)
+    _seed_binding(sqlite_session_factory, status=TidbAuthBindingStatus.CREATING, active=False)
+
+    with patch.object(create_tidb_module.TidbService, "batch_create_tidb_serverless_cluster") as mock_batch_create:
+        create_tidb_serverless_task()
+
+    mock_batch_create.assert_not_called()
+
+
+def test_create_task_creates_clusters_until_target_reached(sqlite_session_factory: sessionmaker[Session]) -> None:
+    # No idle bindings yet: the task must create clusters until TIDB_SERVERLESS_NUMBER=2 is met.
+    with patch.object(
+        create_tidb_module.TidbService,
+        "batch_create_tidb_serverless_cluster",
+        return_value=[_fake_cluster("new-1"), _fake_cluster("new-2")],
+    ) as mock_batch_create:
+        create_tidb_serverless_task()
+
+    mock_batch_create.assert_called_once()
+    with sqlite_session_factory() as session:
+        bindings = session.scalars(select(TidbAuthBinding)).all()
+    assert {binding.cluster_id for binding in bindings} == {"new-1", "new-2"}
+
+
+def test_create_task_skips_when_disabled(
+    sqlite_session_factory: sessionmaker[Session], config_overrides: Callable[..., None]
+) -> None:
+    config_overrides(CREATE_TIDB_SERVICE_JOB_ENABLED=False)
+
+    with patch.object(create_tidb_module.TidbService, "batch_create_tidb_serverless_cluster") as mock_batch_create:
+        create_tidb_serverless_task()
+
+    mock_batch_create.assert_not_called()
+    with sqlite_session_factory() as session:
+        assert session.scalars(select(TidbAuthBinding)).all() == []
+
+
+def test_update_task_only_selects_inactive_creating_bindings(sqlite_session_factory: sessionmaker[Session]) -> None:
+    creating_id = _seed_binding(sqlite_session_factory, status=TidbAuthBindingStatus.CREATING, active=False)
+    # Active bindings and non-CREATING statuses must be skipped.
+    _seed_binding(sqlite_session_factory, status=TidbAuthBindingStatus.CREATING, active=True)
+    _seed_binding(sqlite_session_factory, status=TidbAuthBindingStatus.ACTIVE, active=False)
+
+    with patch.object(
+        update_tidb_module.TidbService, "batch_update_tidb_serverless_cluster_status"
+    ) as mock_batch_update:
+        update_tidb_serverless_status_task()
+
+    mock_batch_update.assert_called_once()
+    submitted = mock_batch_update.call_args.kwargs["tidb_serverless_list"]
+    assert [binding.id for binding in submitted] == [creating_id]


### PR DESCRIPTION
## Summary

Part of #37403.

Migrates the remaining scheduled tasks in `api/schedule/` from the implicit global `db.session` to explicitly managed sessions, following the established patterns of this refactor: entry-point tasks open a session via `session_factory.create_session()` (as in `clean_unused_datasets_task.py` and `mail_clean_document_notify_task.py`), and helpers receive the session as a parameter (as in #37402).

Changes:
- `create_tidb_serverless_task.py`: task body opens an explicit session; `create_clusters` now takes `session` as a parameter
- `update_tidb_serverless_status_task.py`: query and `update_clusters` run within one explicit session scope
- `clean_oauth_access_tokens_task.py`: candidate selection, deletion and commit use an explicit session
- `clean_embedding_cache_task.py`: cleanup loop uses an explicit session
- `check_upgradable_plugin_task.py`: strategy query uses an explicit session
- `queue_monitor_task.py`: removed the redundant `finally: db.session.close()` block — this task performs no database work, and the app context pushed around every Celery task (`FlaskTask.__call__` in `extensions/ext_celery.py`) already removes the scoped session via Flask-SQLAlchemy teardown

Tests:
- Added `api/tests/unit_tests/schedule/` with 10 SQLite-backed unit tests covering both cleanup tasks, both TiDB serverless tasks, and the plugin upgrade check task

Verified locally: `ruff format/check`, `pyrefly check` (repo and tests configs), `mypy`, and `lint-imports` all clean; new tests pass 10/10.

## Screenshots

...

## Checklist

- [x] This PR contains a single, focused change
- [x] I have run `make lint` and `make type-check`
- [x] I have added tests for this change
- [x] This PR does not close the umbrella issue (it is one slice of #37403)

From Claude Code