### PR TITLE
fix(snippets): fix snippet export and delete

### DIFF
--- a/api/controllers/console/snippets/payloads.py
+++ b/api/controllers/console/snippets/payloads.py
@@ -167,3 +167,9 @@ class IncludeSecretQuery(BaseModel):
     """Query parameter for including secret variables in export."""
 
     include_secret: str = Field(default="false", description="Whether to include secret variables")
+
+
+class SnippetExportQuery(IncludeSecretQuery):
+    """Query parameters for exporting a snippet workflow as DSL."""
+
+    workflow_id: str | None = Field(default=None, description="Specific published workflow version to export")

--- a/api/controllers/console/snippets/snippet_workflow.py
+++ b/api/controllers/console/snippets/snippet_workflow.py
@@ -58,6 +58,7 @@ from models import Account
 from models.snippet import CustomizedSnippet
 from services.agent.workflow_publish_service import WorkflowAgentPublishService
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import DraftWorkflowDeletionError, WorkflowInUseError
 from services.snippet_generate_service import SnippetGenerateService
 from services.snippet_service import SnippetService
 
@@ -459,6 +460,39 @@ class SnippetWorkflowByIdApi(Resource):
         response = SnippetWorkflowResponse.model_validate(workflow, from_attributes=True).model_dump(mode="json")
         response["input_fields"] = snippet.input_fields_list
         return response
+
+    @console_ns.doc("delete_snippet_workflow_by_id")
+    @console_ns.doc(description="Delete a published snippet workflow version")
+    @console_ns.doc(params={"snippet_id": "Snippet ID", "workflow_id": "Workflow ID"})
+    @console_ns.response(204, "Workflow deleted successfully")
+    @console_ns.response(400, "Workflow is in use")
+    @console_ns.response(404, "Workflow not found")
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @get_snippet
+    @edit_permission_required
+    @rbac_permission_required(
+        RBACResourceScope.WORKSPACE, RBACPermission.SNIPPETS_CREATE_AND_MODIFY, resource_required=False
+    )
+    def delete(self, snippet: CustomizedSnippet, workflow_id: str):
+        """Delete a published snippet workflow version."""
+        snippet_service = _snippet_service()
+        with _snippet_session_maker().begin() as session:
+            try:
+                snippet_service.delete_workflow(
+                    session=session,
+                    snippet=snippet,
+                    workflow_id=workflow_id,
+                )
+            except WorkflowInUseError as e:
+                raise BadRequest(str(e))
+            except DraftWorkflowDeletionError as e:
+                raise BadRequest(str(e))
+            except ValueError as e:
+                raise NotFound(str(e))
+
+        return None, 204
 
 
 @console_ns.route("/snippets/<uuid:snippet_id>/workflow-runs")

--- a/api/controllers/console/workspace/snippets.py
+++ b/api/controllers/console/workspace/snippets.py
@@ -17,7 +17,7 @@ from controllers.console import console_ns
 from controllers.console.app.wraps import with_session
 from controllers.console.snippets.payloads import (
     CreateSnippetPayload,
-    IncludeSecretQuery,
+    SnippetExportQuery,
     SnippetImportPayload,
     SnippetListQuery,
     UpdateSnippetPayload,
@@ -88,7 +88,7 @@ register_schema_models(
     CreateSnippetPayload,
     UpdateSnippetPayload,
     SnippetImportPayload,
-    IncludeSecretQuery,
+    SnippetExportQuery,
 )
 register_response_schema_models(
     console_ns,
@@ -289,7 +289,7 @@ class CustomizedSnippetExportApi(Resource):
     @console_ns.doc("export_customized_snippet")
     @console_ns.doc(description="Export snippet configuration as DSL")
     @console_ns.doc(params={"snippet_id": "Snippet ID to export"})
-    @console_ns.doc(params=query_params_from_model(IncludeSecretQuery))
+    @console_ns.doc(params=query_params_from_model(SnippetExportQuery))
     @console_ns.response(200, "Snippet exported successfully", console_ns.models[TextFileResponse.__name__])
     @console_ns.response(404, "Snippet not found")
     @setup_required
@@ -312,11 +312,18 @@ class CustomizedSnippetExportApi(Resource):
             raise NotFound("Snippet not found")
 
         # Get include_secret parameter
-        query = IncludeSecretQuery.model_validate(request.args.to_dict())
+        query = SnippetExportQuery.model_validate(request.args.to_dict())
 
         with Session(db.engine) as session:
             export_service = SnippetDslService(session)
-            result = export_service.export_snippet_dsl(snippet=snippet, include_secret=query.include_secret == "true")
+            try:
+                result = export_service.export_snippet_dsl(
+                    snippet=snippet,
+                    include_secret=query.include_secret == "true",
+                    workflow_id=query.workflow_id,
+                )
+            except ValueError as exc:
+                raise NotFound(str(exc)) from exc
 
         # Set filename with .snippet extension
         filename = f"{snippet.name}.snippet"

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -9436,6 +9436,24 @@ Reset a draft workflow variable to its default value (snippet scope)
 | 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
 | 400 | No draft workflow found |  |
 
+### [DELETE] /snippets/{snippet_id}/workflows/{workflow_id}
+**Delete a published snippet workflow version**
+
+#### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ------ |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
+| workflow_id | path | Workflow ID | Yes | string |
+
+#### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 204 | Workflow deleted successfully |
+| 400 | Workflow is in use |
+| 404 | Workflow not found |
+
 ### [PATCH] /snippets/{snippet_id}/workflows/{workflow_id}
 **Update a published snippet workflow version's display metadata**
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -10256,6 +10256,7 @@ Export snippet configuration as DSL
 | ---- | ---------- | ----------- | -------- | ------ |
 | snippet_id | path | Snippet ID to export | Yes | string (uuid) |
 | include_secret | query | Whether to include secret variables | No | string, <br>**Default:** false |
+| workflow_id | query | Specific published workflow version to export | No | string |
 
 #### Responses
 
@@ -18611,11 +18612,9 @@ How Dify forwards the end-user's identity to an MCP server.
 
 #### IncludeSecretQuery
 
-Query parameter for including secret variables in export.
-
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| include_secret | string, <br>**Default:** false | Whether to include secret variables | No |
+| include_secret | string, <br>**Default:** false | Whether to include secret values in the exported DSL | No |
 
 #### IndexingEstimate
 
@@ -21745,6 +21744,15 @@ Payload for syncing snippet draft workflow.
 | graph | object |  | Yes |
 | hash | string |  | No |
 | input_fields | [ object ] |  | No |
+
+#### SnippetExportQuery
+
+Query parameters for exporting a snippet workflow as DSL.
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| include_secret | string, <br>**Default:** false | Whether to include secret variables | No |
+| workflow_id | string | Specific published workflow version to export | No |
 
 #### SnippetImportPayload
 

--- a/api/services/snippet_dsl_service.py
+++ b/api/services/snippet_dsl_service.py
@@ -462,17 +462,27 @@ class SnippetDslService:
         self._session.commit()
         return snippet
 
-    def export_snippet_dsl(self, snippet: CustomizedSnippet, include_secret: bool = False) -> str:
+    def export_snippet_dsl(
+        self, snippet: CustomizedSnippet, include_secret: bool = False, workflow_id: str | None = None
+    ) -> str:
         """
         Export snippet as DSL
         :param snippet: CustomizedSnippet instance
         :param include_secret: Whether include secret variable
+        :param workflow_id: Optional published workflow version to export; defaults to the draft workflow
         :return: YAML string
         """
         snippet_service = self._snippet_service()
-        workflow = snippet_service.get_draft_workflow(snippet=snippet)
+        workflow = (
+            snippet_service.get_published_workflow_by_id(snippet=snippet, workflow_id=workflow_id)
+            if workflow_id
+            else snippet_service.get_draft_workflow(snippet=snippet)
+        )
         if not workflow:
-            raise ValueError("Missing draft workflow configuration, please check.")
+            workflow_description = (
+                f"published workflow {workflow_id}" if workflow_id else "draft workflow configuration"
+            )
+            raise ValueError(f"Missing {workflow_description}, please check.")
 
         icon_info = snippet.icon_info or {}
         export_data = {

--- a/api/services/snippet_service.py
+++ b/api/services/snippet_service.py
@@ -36,6 +36,7 @@ from models.workflow import (
 )
 from repositories.factory import DifyAPIRepositoryFactory
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import DraftWorkflowDeletionError, WorkflowInUseError
 from services.tag_service import TagService
 from services.workflow_node_execution_trace_service import (
     WorkflowNodeExecutionTrace,
@@ -808,6 +809,53 @@ class SnippetService:
         workflow.updated_at = datetime.now(UTC).replace(tzinfo=None)
         session.add(workflow)
         return workflow
+
+    def delete_workflow(
+        self,
+        *,
+        session: Session,
+        snippet: CustomizedSnippet,
+        workflow_id: str,
+    ) -> bool:
+        """
+        Delete a published snippet workflow version.
+
+        :param session: Database session
+        :param snippet: CustomizedSnippet instance
+        :param workflow_id: Workflow ID
+        :return: True if successful
+        :raises: ValueError if workflow not found
+        :raises: WorkflowInUseError if workflow is the snippet's active version or published as a tool
+        :raises: DraftWorkflowDeletionError if workflow is a draft version
+        """
+        stmt = select(Workflow).where(
+            Workflow.id == workflow_id,
+            Workflow.tenant_id == snippet.tenant_id,
+            Workflow.app_id == snippet.id,
+            self._snippet_kind_filter(),
+        )
+        workflow = session.scalar(stmt)
+        if not workflow:
+            raise ValueError(f"Workflow with ID {workflow_id} not found")
+
+        if workflow.version == Workflow.VERSION_DRAFT:
+            raise DraftWorkflowDeletionError("Cannot delete draft workflow versions")
+
+        if snippet.workflow_id == workflow.id:
+            raise WorkflowInUseError(f"Cannot delete workflow that is currently in use by snippet '{snippet.id}'")
+
+        tool_provider = session.scalar(
+            select(WorkflowToolProvider).where(
+                WorkflowToolProvider.tenant_id == snippet.tenant_id,
+                WorkflowToolProvider.app_id == snippet.id,
+                WorkflowToolProvider.version == workflow.version,
+            )
+        )
+        if tool_provider:
+            raise WorkflowInUseError("Cannot delete workflow that is published as a tool")
+
+        session.delete(workflow)
+        return True
 
     # --- Default Block Configs ---
 

--- a/api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py
+++ b/api/tests/unit_tests/controllers/console/snippets/test_snippet_workflow.py
@@ -474,6 +474,70 @@ def test_update_published_snippet_workflow_raises_not_found(
     assert snippet.name == "Snippet"
 
 
+def test_delete_published_snippet_workflow_succeeds(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    snippet = _snippet()
+    delete_workflow = Mock(return_value=True)
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=delete_workflow),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/workflow-1", method="DELETE"):
+        response, status_code = handler(api, snippet, workflow_id="workflow-1")
+
+    assert status_code == 204
+    assert response is None
+    delete_workflow.assert_called_once()
+    delete_call = delete_workflow.call_args.kwargs
+    assert isinstance(delete_call["session"], Session)
+    assert delete_call["snippet"] is snippet
+    assert delete_call["workflow_id"] == "workflow-1"
+
+
+def test_delete_published_snippet_workflow_raises_not_found(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    def delete_missing_workflow(**_kwargs):
+        raise ValueError("Workflow with ID missing-workflow not found")
+
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=Mock(side_effect=delete_missing_workflow)),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/missing-workflow", method="DELETE"):
+        with pytest.raises(NotFound):
+            handler(api, _snippet(), workflow_id="missing-workflow")
+
+
+def test_delete_published_snippet_workflow_raises_bad_request_when_in_use(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def delete_active_workflow(**_kwargs):
+        raise snippet_workflow_module.WorkflowInUseError("Cannot delete workflow that is currently in use")
+
+    monkeypatch.setattr(
+        snippet_workflow_module,
+        "SnippetService",
+        lambda: SimpleNamespace(delete_workflow=Mock(side_effect=delete_active_workflow)),
+    )
+
+    api = snippet_workflow_module.SnippetWorkflowByIdApi()
+    handler = unwrap(api.delete)
+
+    with app.test_request_context("/snippets/snippet-1/workflows/workflow-1", method="DELETE"):
+        with pytest.raises(HTTPException) as exc_info:
+            handler(api, _snippet(), workflow_id="workflow-1")
+
+    assert exc_info.value.code == 400
+
+
 def test_workflow_run_detail_raises_not_found_when_run_missing(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     snippet = _snippet()
     monkeypatch.setattr(

--- a/api/tests/unit_tests/controllers/console/workspace/test_snippets.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_snippets.py
@@ -344,14 +344,40 @@ def test_export_snippet_returns_yaml_attachment(app: Flask, monkeypatch: pytest.
     api = snippets_module.CustomizedSnippetExportApi()
     handler = unwrap(api.get)
 
-    with app.test_request_context("/workspaces/current/customized-snippets/snippet-1/export?include_secret=true"):
+    with app.test_request_context(
+        "/workspaces/current/customized-snippets/snippet-1/export?include_secret=true&workflow_id=workflow-1"
+    ):
         response = handler(api, "tenant-1", snippet_id="snippet-1")
 
     assert response.status_code == 200
     assert response.get_data(as_text=True) == "version: 0.1.0\nkind: snippet\n"
     assert response.headers["Content-Type"] == "application/x-yaml"
     assert "Snippet%20One.snippet" in response.headers["Content-Disposition"]
-    export_snippet_dsl.assert_called_once_with(snippet=snippet, include_secret=True)
+    export_snippet_dsl.assert_called_once_with(snippet=snippet, include_secret=True, workflow_id="workflow-1")
+
+
+def test_export_snippet_raises_not_found_for_missing_workflow(app: Flask, monkeypatch: pytest.MonkeyPatch):
+    snippet = _snippet(name="Snippet One")
+
+    monkeypatch.setattr(snippets_module.SnippetService, "get_snippet_by_id", Mock(return_value=snippet))
+    monkeypatch.setattr(
+        snippets_module,
+        "SnippetDslService",
+        Mock(
+            return_value=SimpleNamespace(
+                export_snippet_dsl=Mock(side_effect=ValueError("Missing published workflow workflow-1"))
+            )
+        ),
+    )
+    monkeypatch.setattr(snippets_module, "Session", _SessionContext)
+    monkeypatch.setattr(snippets_module, "db", SimpleNamespace(engine=object()))
+
+    api = snippets_module.CustomizedSnippetExportApi()
+    handler = unwrap(api.get)
+
+    with app.test_request_context("/workspaces/current/customized-snippets/snippet-1/export?workflow_id=workflow-1"):
+        with pytest.raises(NotFound, match="Missing published workflow workflow-1"):
+            handler(api, "tenant-1", snippet_id="snippet-1")
 
 
 def test_import_snippet_returns_202_for_pending_confirmation(app: Flask, monkeypatch: pytest.MonkeyPatch):

--- a/api/tests/unit_tests/services/test_snippet_dsl_service.py
+++ b/api/tests/unit_tests/services/test_snippet_dsl_service.py
@@ -601,6 +601,40 @@ def test_export_snippet_dsl_returns_yaml(monkeypatch):
     assert "input_fields:" in result
 
 
+def test_export_snippet_dsl_uses_requested_published_workflow(monkeypatch: pytest.MonkeyPatch):
+    service = SnippetDslService(session=SimpleNamespace(get_bind=Mock()))
+    workflow = SimpleNamespace(
+        to_dict=Mock(return_value={"graph": {"nodes": []}}),
+        graph_dict={"nodes": []},
+    )
+    snippet = SimpleNamespace(
+        tenant_id="tenant-1",
+        name="Exported",
+        description=None,
+        type="node",
+        icon_info=None,
+        input_fields_list=[],
+    )
+    get_published_workflow_by_id = Mock(return_value=workflow)
+    get_draft_workflow = Mock()
+    monkeypatch.setattr(
+        "services.snippet_dsl_service.SnippetService",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            get_draft_workflow=get_draft_workflow,
+            get_published_workflow_by_id=get_published_workflow_by_id,
+        ),
+    )
+    monkeypatch.setattr(
+        "services.snippet_dsl_service.DependenciesAnalysisService.generate_dependencies",
+        Mock(return_value=[]),
+    )
+
+    service.export_snippet_dsl(snippet, workflow_id="workflow-1")
+
+    get_published_workflow_by_id.assert_called_once_with(snippet=snippet, workflow_id="workflow-1")
+    get_draft_workflow.assert_not_called()
+
+
 def test_append_workflow_export_data_filters_credentials_and_extracts_dependencies(monkeypatch):
     service = SnippetDslService(session=SimpleNamespace())
     workflow_dict = {

--- a/api/tests/unit_tests/services/test_snippet_service.py
+++ b/api/tests/unit_tests/services/test_snippet_service.py
@@ -9,6 +9,7 @@ import pytest
 from models.snippet import SnippetType
 from models.workflow import Workflow, WorkflowKind, WorkflowType
 from services.errors.app import IsDraftWorkflowError, WorkflowHashNotEqualError, WorkflowNotFoundError
+from services.errors.workflow_service import DraftWorkflowDeletionError, WorkflowInUseError
 from services.snippet_service import SnippetService
 
 
@@ -312,6 +313,64 @@ def test_update_workflow_returns_none_when_missing() -> None:
 
     assert result is None
     session.add.assert_not_called()
+
+
+def test_delete_workflow_removes_published_version(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+    workflow = _create_workflow(
+        workflow_id="workflow-1",
+        version="2026-01-01 00:00:00",
+        graph={"nodes": []},
+        features={},
+    )
+    snippet = _snippet(workflow_id="workflow-2")
+    sqlite_session.add_all([snippet, workflow])
+    sqlite_session.flush()
+
+    result = service.delete_workflow(session=sqlite_session, snippet=snippet, workflow_id="workflow-1")
+
+    assert result is True
+    sqlite_session.flush()
+    assert sqlite_session.get(Workflow, "workflow-1") is None
+
+
+def test_delete_workflow_raises_when_missing(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+
+    with pytest.raises(ValueError, match="not found"):
+        service.delete_workflow(session=sqlite_session, snippet=_snippet(), workflow_id="missing-workflow")
+
+
+def test_delete_workflow_raises_for_draft_version(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+    workflow = _create_workflow(
+        workflow_id="workflow-1",
+        version=Workflow.VERSION_DRAFT,
+        graph={"nodes": []},
+        features={},
+    )
+    snippet = _snippet()
+    sqlite_session.add_all([snippet, workflow])
+    sqlite_session.flush()
+
+    with pytest.raises(DraftWorkflowDeletionError):
+        service.delete_workflow(session=sqlite_session, snippet=snippet, workflow_id="workflow-1")
+
+
+def test_delete_workflow_raises_when_currently_active(sqlite_session: Session) -> None:
+    service = SnippetService.__new__(SnippetService)
+    workflow = _create_workflow(
+        workflow_id="workflow-1",
+        version="2026-01-01 00:00:00",
+        graph={"nodes": []},
+        features={},
+    )
+    snippet = _snippet(workflow_id="workflow-1")
+    sqlite_session.add_all([snippet, workflow])
+    sqlite_session.flush()
+
+    with pytest.raises(WorkflowInUseError):
+        service.delete_workflow(session=sqlite_session, snippet=snippet, workflow_id="workflow-1")
 
 
 def test_get_default_block_configs_skips_empty_defaults(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/contracts/generated/api/console/snippets/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/orpc.gen.ts
@@ -3,6 +3,8 @@
 import { oc } from '@orpc/contract'
 import * as z from 'zod'
 import {
+  zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath,
+  zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse,
   zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesPath,
   zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesResponse,
   zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdPath,
@@ -875,6 +877,25 @@ export const restore = {
 }
 
 /**
+ * Delete a published snippet workflow version
+ *
+ * Delete a published snippet workflow version
+ */
+export const delete4 = oc
+  .route({
+    description: 'Delete a published snippet workflow version',
+    inputStructure: 'detailed',
+    method: 'DELETE',
+    operationId: 'deleteSnippetsBySnippetIdWorkflowsByWorkflowId',
+    path: '/snippets/{snippet_id}/workflows/{workflow_id}',
+    successStatus: 204,
+    summary: 'Delete a published snippet workflow version',
+    tags: ['console'],
+  })
+  .input(z.object({ params: zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath }))
+  .output(zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse)
+
+/**
  * Update a published snippet workflow version's display metadata
  *
  * Update published snippet workflow attributes
@@ -898,6 +919,7 @@ export const patch2 = oc
   .output(zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdResponse)
 
 export const byWorkflowId = {
+  delete: delete4,
   patch: patch2,
   restore,
 }

--- a/packages/contracts/generated/api/console/snippets/types.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/types.gen.ts
@@ -1775,6 +1775,28 @@ export type PostSnippetsBySnippetIdWorkflowsPublishResponses = {
 export type PostSnippetsBySnippetIdWorkflowsPublishResponse =
   PostSnippetsBySnippetIdWorkflowsPublishResponses[keyof PostSnippetsBySnippetIdWorkflowsPublishResponses]
 
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdData = {
+  body?: never
+  path: {
+    snippet_id: string
+    workflow_id: string
+  }
+  query?: never
+  url: '/snippets/{snippet_id}/workflows/{workflow_id}'
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdErrors = {
+  400: unknown
+  404: unknown
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses = {
+  204: void
+}
+
+export type DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse =
+  DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses[keyof DeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponses]
+
 export type PatchSnippetsBySnippetIdWorkflowsByWorkflowIdData = {
   body: WorkflowUpdatePayload
   path: {

--- a/packages/contracts/generated/api/console/snippets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/zod.gen.ts
@@ -1996,6 +1996,16 @@ export const zPostSnippetsBySnippetIdWorkflowsPublishPath = z.object({
  */
 export const zPostSnippetsBySnippetIdWorkflowsPublishResponse = zWorkflowPublishResponse
 
+export const zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdPath = z.object({
+  snippet_id: z.uuid(),
+  workflow_id: z.string(),
+})
+
+/**
+ * Workflow deleted successfully
+ */
+export const zDeleteSnippetsBySnippetIdWorkflowsByWorkflowIdResponse = z.void()
+
 export const zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdBody = zWorkflowUpdatePayload
 
 export const zPatchSnippetsBySnippetIdWorkflowsByWorkflowIdPath = z.object({

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -2639,6 +2639,7 @@ export type GetWorkspacesCurrentCustomizedSnippetsBySnippetIdExportData = {
   }
   query?: {
     include_secret?: string
+    workflow_id?: string
   }
   url: '/workspaces/current/customized-snippets/{snippet_id}/export'
 }

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -3504,6 +3504,7 @@ export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdExportPath = z.ob
 
 export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdExportQuery = z.object({
   include_secret: z.string().optional().default('false'),
+  workflow_id: z.string().optional(),
 })
 
 /**

--- a/web/app/components/snippets/components/__tests__/snippet-main.spec.tsx
+++ b/web/app/components/snippets/components/__tests__/snippet-main.spec.tsx
@@ -24,6 +24,7 @@ const mockHandleStartWorkflowRun = vi.fn()
 const mockHandleStopRun = vi.fn()
 const mockHandleWorkflowStartRunInWorkflow = vi.fn()
 const mockHandleCheckBeforePublish = vi.fn()
+const mockHandleExportDSL = vi.fn()
 const mockUseAvailableNodesMetaData = vi.hoisted(() => vi.fn())
 const mockConsoleState = vi.hoisted(() => ({
   workspacePermissionKeys: ['snippets.create_and_modify'] as string[],
@@ -138,6 +139,12 @@ vi.mock('../../hooks/use-snippet-start-run', () => ({
   useSnippetStartRun: () => ({
     handleStartWorkflowRun: mockHandleStartWorkflowRun,
     handleWorkflowStartRunInWorkflow: mockHandleWorkflowStartRunInWorkflow,
+  }),
+}))
+
+vi.mock('../hooks/use-snippet-dsl', () => ({
+  useSnippetDSL: () => ({
+    handleExportDSL: mockHandleExportDSL,
   }),
 }))
 
@@ -640,6 +647,14 @@ describe('SnippetMain', () => {
         runUrl: '/snippets/snippet-1/workflow-runs/run-1',
         traceUrl: '/snippets/snippet-1/workflow-runs/run-1/node-executions',
       })
+    })
+  })
+
+  describe('DSL Export', () => {
+    it('should pass the snippet DSL export handler to WorkflowWithInnerContext', () => {
+      renderSnippetMain()
+
+      expect(capturedHooksStore?.handleExportDSL).toBe(mockHandleExportDSL)
     })
   })
 })

--- a/web/app/components/snippets/components/hooks/__tests__/use-snippet-dsl.spec.ts
+++ b/web/app/components/snippets/components/hooks/__tests__/use-snippet-dsl.spec.ts
@@ -1,0 +1,62 @@
+import { toast } from '@langgenius/dify-ui/toast'
+import { renderHook } from '@testing-library/react'
+import { act } from 'react'
+import { useExportSnippetMutation } from '@/service/use-snippets'
+import { downloadBlob } from '@/utils/download'
+import { useSnippetDSL } from '../use-snippet-dsl'
+
+const mockMutateAsync = vi.fn()
+
+vi.mock('@/service/use-snippets', () => ({
+  useExportSnippetMutation: vi.fn(() => ({
+    mutateAsync: mockMutateAsync,
+  })),
+}))
+
+vi.mock('@/utils/download', () => ({
+  downloadBlob: vi.fn(),
+}))
+
+vi.mock('@langgenius/dify-ui/toast', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+describe('useSnippetDSL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMutateAsync.mockResolvedValue('kind: snippet')
+  })
+
+  it('exports the requested historical workflow version', async () => {
+    const { result } = renderHook(() =>
+      useSnippetDSL({ snippetId: 'snippet-1', snippetName: 'My Snippet' }),
+    )
+
+    await act(() => result.current.handleExportDSL(false, 'workflow-1'))
+
+    expect(useExportSnippetMutation).toHaveBeenCalled()
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      snippetId: 'snippet-1',
+      include: false,
+      workflowId: 'workflow-1',
+    })
+    expect(downloadBlob).toHaveBeenCalledWith({
+      data: expect.any(Blob),
+      fileName: 'My Snippet.yml',
+    })
+  })
+
+  it('shows an error when exporting fails', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('failed'))
+    const { result } = renderHook(() =>
+      useSnippetDSL({ snippetId: 'snippet-1', snippetName: 'My Snippet' }),
+    )
+
+    await act(() => result.current.handleExportDSL(false, 'workflow-1'))
+
+    expect(toast.error).toHaveBeenCalledWith('snippet.exportFailed')
+    expect(downloadBlob).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/components/snippets/components/hooks/use-snippet-dsl.ts
+++ b/web/app/components/snippets/components/hooks/use-snippet-dsl.ts
@@ -1,0 +1,34 @@
+import { toast } from '@langgenius/dify-ui/toast'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useExportSnippetMutation } from '@/service/use-snippets'
+import { downloadBlob } from '@/utils/download'
+
+type UseSnippetDSLOptions = {
+  snippetId: string
+  snippetName: string
+}
+
+export const useSnippetDSL = ({ snippetId, snippetName }: UseSnippetDSLOptions) => {
+  const { t } = useTranslation('snippet')
+  const exportSnippetMutation = useExportSnippetMutation()
+
+  const handleExportDSL = useCallback(
+    async (include = false, workflowId?: string) => {
+      try {
+        const data = await exportSnippetMutation.mutateAsync({
+          snippetId,
+          include,
+          workflowId,
+        })
+        const file = new Blob([data], { type: 'application/yaml' })
+        downloadBlob({ data: file, fileName: `${snippetName}.yml` })
+      } catch {
+        toast.error(t(($) => $.exportFailed))
+      }
+    },
+    [exportSnippetMutation, snippetId, snippetName, t],
+  )
+
+  return { handleExportDSL }
+}

--- a/web/app/components/snippets/components/snippet-main.tsx
+++ b/web/app/components/snippets/components/snippet-main.tsx
@@ -26,6 +26,7 @@ import { useSnippetRun } from '../hooks/use-snippet-run'
 import { useSnippetStartRun } from '../hooks/use-snippet-start-run'
 import { useSnippetDetailStore } from '../store'
 import { canCreateAndModifySnippets } from '../utils/permission'
+import { useSnippetDSL } from './hooks/use-snippet-dsl'
 import { useSnippetInputFieldActions } from './hooks/use-snippet-input-field-actions'
 import { useSnippetPublish } from './hooks/use-snippet-publish'
 import SnippetChildren from './snippet-children'
@@ -203,6 +204,7 @@ const SnippetMain = ({
     canEdit: canEditSnippet,
     snippetId,
   })
+  const { handleExportDSL } = useSnippetDSL({ snippetId, snippetName: snippet.name })
   const { handleStartWorkflowRun, handleWorkflowStartRunInWorkflow } = useSnippetStartRun({
     handleRun,
   })
@@ -320,6 +322,7 @@ const SnippetMain = ({
       handleStopRun,
       handleStartWorkflowRun,
       handleWorkflowStartRunInWorkflow,
+      handleExportDSL,
       getWorkflowRunAndTraceUrl,
       availableNodesMetaData,
       fetchInspectVars,
@@ -366,6 +369,7 @@ const SnippetMain = ({
     handleStartWorkflowRun,
     handleStopRun,
     handleWorkflowStartRunInWorkflow,
+    handleExportDSL,
     getWorkflowRunAndTraceUrl,
     hasNodeInspectVars,
     hasSetInspectVar,

--- a/web/service/__tests__/use-snippets.spec.tsx
+++ b/web/service/__tests__/use-snippets.spec.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { useExportSnippetMutation } from '../use-snippets'
+
+const mockExportSnippet = vi.hoisted(() => vi.fn())
+
+vi.mock('@/service/client', () => ({
+  consoleClient: {
+    workspaces: {
+      current: {
+        customizedSnippets: {
+          bySnippetId: {
+            export: {
+              get: mockExportSnippet,
+            },
+          },
+        },
+      },
+    },
+  },
+  consoleQuery: {
+    snippets: {
+      key: vi.fn(() => ['snippets']),
+    },
+    workspaces: {
+      current: {
+        customizedSnippets: {
+          key: vi.fn(() => ['customized-snippets']),
+          bySnippetId: {
+            export: {
+              get: {
+                mutationKey: vi.fn(() => ['customized-snippets', 'export']),
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useExportSnippetMutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExportSnippet.mockResolvedValue('kind: snippet')
+  })
+
+  it('exports the requested historical workflow version', async () => {
+    const { result } = renderHook(() => useExportSnippetMutation(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        snippetId: 'snippet-1',
+        workflowId: 'workflow-1',
+      })
+    })
+
+    expect(mockExportSnippet).toHaveBeenCalledWith({
+      params: { snippet_id: 'snippet-1' },
+      query: {
+        include_secret: 'false',
+        workflow_id: 'workflow-1',
+      },
+    })
+  })
+})

--- a/web/service/use-snippets.ts
+++ b/web/service/use-snippets.ts
@@ -272,11 +272,14 @@ export const useIncrementSnippetUseCountMutation = () => {
 }
 
 export const useExportSnippetMutation = () => {
-  return useMutation<string, Error, { snippetId: string; include?: boolean }>({
-    mutationFn: ({ snippetId, include = false }) => {
+  return useMutation<string, Error, { snippetId: string; include?: boolean; workflowId?: string }>({
+    mutationFn: ({ snippetId, include = false, workflowId }) => {
       return customizedSnippetsClient.bySnippetId.export.get({
         params: { snippet_id: snippetId },
-        query: { include_secret: include ? 'true' : 'false' },
+        query: {
+          include_secret: include ? 'true' : 'false',
+          workflow_id: workflowId,
+        },
       })
     },
   })


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Backports #41003 and #41012 to `release/e-1.16.1`.

This PR completes the Snippet workflow version history actions on the release branch:

- Add the API and service support required to delete eligible published Snippet workflow versions.
- Prevent deletion of draft and currently active versions.
- Add an optional `workflow_id` parameter to the Snippet DSL export API.
- Wire the version history **Export DSL** action to download the selected published workflow version.
- Regenerate the API contracts and add backend and frontend regression tests.

(cherry picked from commit d7b153143102651d97f57d6e174d2482205e1a1f)

(cherry picked from commit 248df5dd25fca099b6536a75bf8acef8196a5e93)

## Screenshots

| Before | After |
| ------ | ----- |
| Snippet historical versions cannot be exported or deleted successfully. | Eligible historical versions can be exported as DSL or deleted from version history. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) (Not required for this backport.)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly. (Not applicable; no user-facing documentation changes are required.)
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods. (Targeted tests passed; repository CI provides the full validation.)

From Codex
