### PR TITLE
refactor(web): migrate conversation rename input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -699,11 +699,6 @@
       "count": 2
     }
   },
-  "web/app/components/base/chat/chat-with-history/sidebar/rename-modal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/base/chat/chat/__tests__/hooks.spec.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/web/app/components/base/chat/chat-with-history/sidebar/__tests__/rename-modal.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/__tests__/rename-modal.spec.tsx
@@ -22,8 +22,7 @@ describe('RenameModal', () => {
     render(<RenameModal {...defaultProps} />)
 
     expect(screen.getByText('common.chat.renameConversation')).toBeInTheDocument()
-    expect(screen.getByText('common.chat.conversationName')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('common.chat.conversationNamePlaceholder')).toHaveValue(
+    expect(screen.getByRole('textbox', { name: 'common.chat.conversationName' })).toHaveValue(
       'Original Name',
     )
     expect(screen.getByText('common.operation.cancel')).toBeInTheDocument()
@@ -50,9 +49,19 @@ describe('RenameModal', () => {
     const input = screen.getByRole('textbox')
     await user.clear(input)
     await user.type(input, 'Updated Name')
-    await user.click(screen.getByText('common.operation.save'))
+    await user.keyboard('{Enter}')
 
     expect(defaultProps.onSave).toHaveBeenCalledWith('Updated Name')
+  })
+
+  it('does not resubmit while save is pending', async () => {
+    const user = userEvent.setup()
+    render(<RenameModal {...defaultProps} saveLoading />)
+
+    await user.click(screen.getByRole('textbox', { name: 'common.chat.conversationName' }))
+    await user.keyboard('{Enter}')
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
   })
 
   it('calls onSave with initial name when unchanged', async () => {

--- a/web/app/components/base/chat/chat-with-history/sidebar/rename-modal.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/rename-modal.tsx
@@ -2,10 +2,12 @@
 import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Form } from '@langgenius/dify-ui/form'
+import { Input } from '@langgenius/dify-ui/input'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 
 type IRenameModalProps = {
   isShow: boolean
@@ -27,29 +29,32 @@ const RenameModal: FC<IRenameModalProps> = ({ isShow, saveLoading, name, onClose
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $['chat.renameConversation'], { ns: 'common' })}
         </DialogTitle>
-        <div className="mt-6 text-sm leading-5.25 font-medium text-text-primary">
-          {t(($) => $['chat.conversationName'], { ns: 'common' })}
-        </div>
-        <Input
-          className="mt-2 h-10 w-full"
-          value={tempName}
-          onChange={(e) => setTempName(e.target.value)}
-          placeholder={conversationNamePlaceholder}
-        />
+        <Form
+          onFormSubmit={() => {
+            if (!saveLoading) onSave(tempName)
+          }}
+        >
+          <Field name="conversationName" className="mt-6 gap-0">
+            <FieldLabel className="py-0 text-sm leading-5.25 font-medium text-text-primary">
+              {t(($) => $['chat.conversationName'], { ns: 'common' })}
+            </FieldLabel>
+            <Input
+              className="mt-2 h-10"
+              value={tempName}
+              onValueChange={setTempName}
+              placeholder={conversationNamePlaceholder}
+            />
+          </Field>
 
-        <div className="mt-10 flex justify-end">
-          <Button className="mr-2 shrink-0" onClick={onClose}>
-            {t(($) => $['operation.cancel'], { ns: 'common' })}
-          </Button>
-          <Button
-            variant="primary"
-            className="shrink-0"
-            onClick={() => onSave(tempName)}
-            loading={saveLoading}
-          >
-            {t(($) => $['operation.save'], { ns: 'common' })}
-          </Button>
-        </div>
+          <div className="mt-10 flex justify-end">
+            <Button type="button" className="mr-2 shrink-0" onClick={onClose}>
+              {t(($) => $['operation.cancel'], { ns: 'common' })}
+            </Button>
+            <Button type="submit" variant="primary" className="shrink-0" loading={saveLoading}>
+              {t(($) => $['operation.save'], { ns: 'common' })}
+            </Button>
+          </div>
+        </Form>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

- replace the legacy conversation rename input with Dify UI `Form`, `Field`, and `Input`
- associate the visible conversation-name label with the input and support native Enter submission
- preserve the existing 40 px input, label typography, spacing, local draft lifetime, and pending-save behavior

## Testing

- `vp test run --project unit app/components/base/chat/chat-with-history/sidebar/__tests__/rename-modal.spec.tsx`
- `pnpm run lint:a11y app/components/base/chat/chat-with-history/sidebar/rename-modal.tsx`
- `vp check web` (0 errors; existing repository warnings remain)

## Stack

- base layer of #41031
- followed by #41029 and #41030

From Codex
