### PR TITLE
refactor(web): migrate document rename input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2085,11 +2085,6 @@
       "count": 1
     }
   },
-  "web/app/components/datasets/documents/components/rename-modal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/documents/create-from-pipeline/data-source-options/option-card.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -699,11 +699,6 @@
       "count": 2
     }
   },
-  "web/app/components/base/chat/chat-with-history/sidebar/rename-modal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/base/chat/chat/__tests__/hooks.spec.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/web/app/components/base/chat/chat-with-history/sidebar/__tests__/rename-modal.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/__tests__/rename-modal.spec.tsx
@@ -22,8 +22,7 @@ describe('RenameModal', () => {
     render(<RenameModal {...defaultProps} />)
 
     expect(screen.getByText('common.chat.renameConversation')).toBeInTheDocument()
-    expect(screen.getByText('common.chat.conversationName')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('common.chat.conversationNamePlaceholder')).toHaveValue(
+    expect(screen.getByRole('textbox', { name: 'common.chat.conversationName' })).toHaveValue(
       'Original Name',
     )
     expect(screen.getByText('common.operation.cancel')).toBeInTheDocument()
@@ -50,9 +49,19 @@ describe('RenameModal', () => {
     const input = screen.getByRole('textbox')
     await user.clear(input)
     await user.type(input, 'Updated Name')
-    await user.click(screen.getByText('common.operation.save'))
+    await user.keyboard('{Enter}')
 
     expect(defaultProps.onSave).toHaveBeenCalledWith('Updated Name')
+  })
+
+  it('does not resubmit while save is pending', async () => {
+    const user = userEvent.setup()
+    render(<RenameModal {...defaultProps} saveLoading />)
+
+    await user.click(screen.getByRole('textbox', { name: 'common.chat.conversationName' }))
+    await user.keyboard('{Enter}')
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
   })
 
   it('calls onSave with initial name when unchanged', async () => {

--- a/web/app/components/base/chat/chat-with-history/sidebar/rename-modal.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/rename-modal.tsx
@@ -2,10 +2,12 @@
 import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Form } from '@langgenius/dify-ui/form'
+import { Input } from '@langgenius/dify-ui/input'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 
 type IRenameModalProps = {
   isShow: boolean
@@ -27,29 +29,32 @@ const RenameModal: FC<IRenameModalProps> = ({ isShow, saveLoading, name, onClose
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $['chat.renameConversation'], { ns: 'common' })}
         </DialogTitle>
-        <div className="mt-6 text-sm leading-5.25 font-medium text-text-primary">
-          {t(($) => $['chat.conversationName'], { ns: 'common' })}
-        </div>
-        <Input
-          className="mt-2 h-10 w-full"
-          value={tempName}
-          onChange={(e) => setTempName(e.target.value)}
-          placeholder={conversationNamePlaceholder}
-        />
+        <Form
+          onFormSubmit={() => {
+            if (!saveLoading) onSave(tempName)
+          }}
+        >
+          <Field name="conversationName" className="mt-6 gap-0">
+            <FieldLabel className="py-0 text-sm leading-5.25 font-medium text-text-primary">
+              {t(($) => $['chat.conversationName'], { ns: 'common' })}
+            </FieldLabel>
+            <Input
+              className="mt-2 h-10"
+              value={tempName}
+              onValueChange={setTempName}
+              placeholder={conversationNamePlaceholder}
+            />
+          </Field>
 
-        <div className="mt-10 flex justify-end">
-          <Button className="mr-2 shrink-0" onClick={onClose}>
-            {t(($) => $['operation.cancel'], { ns: 'common' })}
-          </Button>
-          <Button
-            variant="primary"
-            className="shrink-0"
-            onClick={() => onSave(tempName)}
-            loading={saveLoading}
-          >
-            {t(($) => $['operation.save'], { ns: 'common' })}
-          </Button>
-        </div>
+          <div className="mt-10 flex justify-end">
+            <Button type="button" className="mr-2 shrink-0" onClick={onClose}>
+              {t(($) => $['operation.cancel'], { ns: 'common' })}
+            </Button>
+            <Button type="submit" variant="primary" className="shrink-0" loading={saveLoading}>
+              {t(($) => $['operation.save'], { ns: 'common' })}
+            </Button>
+          </div>
+        </Form>
       </DialogContent>
     </Dialog>
   )

--- a/web/app/components/datasets/documents/components/__tests__/rename-modal.spec.tsx
+++ b/web/app/components/datasets/documents/components/__tests__/rename-modal.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 // Import after mock
 import { renameDocumentName } from '@/service/datasets'
@@ -44,7 +45,7 @@ describe('RenameModal', () => {
 
     it('should render name label', () => {
       render(<RenameModal {...defaultProps} />)
-      expect(screen.getByText(/list\.table\.name/i)).toBeInTheDocument()
+      expect(screen.getByRole('textbox', { name: /list\.table\.name/i })).toBeInTheDocument()
     })
 
     it('should render input with initial name', () => {
@@ -130,7 +131,7 @@ describe('RenameModal', () => {
   })
 
   describe('Loading State', () => {
-    it('should show loading state while saving', async () => {
+    it('should not submit again while saving', async () => {
       // Create a promise that we can resolve manually
       let resolvePromise: (value: { result: 'success' | 'fail' }) => void
       const pendingPromise = new Promise<{ result: 'success' | 'fail' }>((resolve) => {
@@ -139,18 +140,21 @@ describe('RenameModal', () => {
       mockRenameDocumentName.mockReturnValueOnce(pendingPromise)
 
       render(<RenameModal {...defaultProps} />)
-      const saveButton = screen.getByText(/operation\.save/i)
-      fireEvent.click(saveButton)
+      const user = userEvent.setup()
+      const input = screen.getByRole('textbox', { name: /list\.table\.name/i })
+      await user.click(input)
+      await user.keyboard('{Enter}')
 
-      // The button should be in loading state
       await waitFor(() => {
-        const buttons = screen.getAllByRole('button')
-        const saveBtn = buttons.find((btn) => btn.textContent?.includes('operation.save'))
-        expect(saveBtn).toBeInTheDocument()
+        expect(mockRenameDocumentName).toHaveBeenCalledTimes(1)
       })
+      await user.keyboard('{Enter}')
+      expect(mockRenameDocumentName).toHaveBeenCalledTimes(1)
 
-      // Resolve the promise to clean up
       resolvePromise!({ result: 'success' })
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
+      })
     })
   })
 
@@ -180,6 +184,7 @@ describe('RenameModal', () => {
       render(<RenameModal {...defaultProps} name="" />)
       const input = screen.getByRole('textbox')
       expect(input).toHaveValue('')
+      expect(input).toHaveAttribute('placeholder', 'common.placeholder.input')
     })
 
     it('should handle name with special characters', () => {

--- a/web/app/components/datasets/documents/components/rename-modal.tsx
+++ b/web/app/components/datasets/documents/components/rename-modal.tsx
@@ -2,12 +2,14 @@
 import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Form } from '@langgenius/dify-ui/form'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useBoolean } from 'ahooks'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { renameDocumentName } from '@/service/datasets'
 
 type Props = Readonly<{
@@ -26,6 +28,8 @@ const RenameModal: FC<Props> = ({ documentId, datasetId, name, onClose, onSaved 
     useBoolean(false)
 
   const handleSave = async () => {
+    if (saveLoading) return
+
     setSaveLoadingTrue()
     try {
       await renameDocumentName({
@@ -54,20 +58,28 @@ const RenameModal: FC<Props> = ({ documentId, datasetId, name, onClose, onSaved 
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $['list.table.rename'], { ns: 'datasetDocuments' })}
         </DialogTitle>
+        <Form onFormSubmit={() => void handleSave()}>
+          <Field name="documentName" className="mt-6 gap-0">
+            <FieldLabel className="py-0 text-sm leading-5.25 font-medium text-text-primary">
+              {t(($) => $['list.table.name'], { ns: 'datasetDocuments' })}
+            </FieldLabel>
+            <Input
+              className="mt-2 h-10"
+              value={newName}
+              placeholder={t(($) => $['placeholder.input'], { ns: 'common' }) || ''}
+              onValueChange={setNewName}
+            />
+          </Field>
 
-        <div className="mt-6 text-sm leading-5.25 font-medium text-text-primary">
-          {t(($) => $['list.table.name'], { ns: 'datasetDocuments' })}
-        </div>
-        <Input className="mt-2 h-10" value={newName} onChange={(e) => setNewName(e.target.value)} />
-
-        <div className="mt-10 flex justify-end">
-          <Button className="mr-2 shrink-0" onClick={onClose}>
-            {t(($) => $['operation.cancel'], { ns: 'common' })}
-          </Button>
-          <Button variant="primary" className="shrink-0" onClick={handleSave} loading={saveLoading}>
-            {t(($) => $['operation.save'], { ns: 'common' })}
-          </Button>
-        </div>
+          <div className="mt-10 flex justify-end">
+            <Button type="button" className="mr-2 shrink-0" onClick={onClose}>
+              {t(($) => $['operation.cancel'], { ns: 'common' })}
+            </Button>
+            <Button type="submit" variant="primary" className="shrink-0" loading={saveLoading}>
+              {t(($) => $['operation.save'], { ns: 'common' })}
+            </Button>
+          </div>
+        </Form>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

- replace the legacy document rename input with Dify UI `Form`, `Field`, and `Input`
- give the document name a real label relationship and submit the rename flow with either Enter or the Save button
- prevent implicit form submission from starting another request while the current rename is pending
- preserve the existing API payload, empty-name behavior, 40 px input, 14/21 label typography, and 8 px label-to-input spacing

## Testing

- `vp test run --project unit app/components/datasets/documents/components/__tests__/rename-modal.spec.tsx`
- `pnpm run lint:a11y app/components/datasets/documents/components/rename-modal.tsx`
- verified the real `/datasets/:datasetId/documents` rename dialog on local port 3000, including focus styling and computed geometry
- `vp check web` (0 errors; existing repository warnings remain)

## Stack

- depends on #41028
- followed by #41030

From Codex
