### PR TITLE
refactor(dify-ui): expose slider anatomy

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -379,11 +379,6 @@
       "count": 1
     }
   },
-  "web/app/components/app/configuration/dataset-config/params-config/__tests__/config-content.spec.tsx": {
-    "typescript/no-explicit-any": {
-      "count": 1
-    }
-  },
   "web/app/components/app/configuration/dataset-config/params-config/config-content.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1

--- a/packages/dify-ui/docs/forms.md
+++ b/packages/dify-ui/docs/forms.md
@@ -28,8 +28,8 @@ Choose the label primitive by the control:
 - Text-like inputs, `Textarea`, input-based `Combobox` and `Autocomplete`, a single `Checkbox` or
   `Radio`, `Switch`, and `NumberField` use `FieldLabel`.
 - Trigger-based `Select` fields use `SelectLabel`.
-- `Slider` fields use `SliderLabel`; use per-thumb `aria-label` only when the thumbs need distinct
-  names.
+- `Slider` fields follow the [Base UI Slider anatomy] and use `SliderLabel`; only multi-thumb
+  sliders add per-thumb `aria-label` to distinguish the thumbs.
 - `SelectGroupLabel` and `AutocompleteGroupLabel` label option groups inside popup content. They
   are not field labels.
 
@@ -62,6 +62,7 @@ Keep form state, schemas, server validation, and reset behavior outside these pr
 their observable state through the public field and control props instead of replacing the
 semantic structure.
 
+[Base UI Slider anatomy]: https://base-ui.com/react/components/slider#anatomy
 [Base UI forms handbook]: https://base-ui.com/react/handbook/forms
 [`Button`]: ../src/button/README.md
 [`InputGroup`]: ../src/input-group/README.md

--- a/packages/dify-ui/src/slider/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/slider/__tests__/index.spec.tsx
@@ -1,3 +1,4 @@
+import type { SliderProps, SliderThumbProps } from '../index'
 import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
 import {
@@ -5,47 +6,59 @@ import {
   SliderControl,
   SliderIndicator,
   SliderLabel,
-  SliderRoot,
   SliderThumb,
   SliderTrack,
 } from '../index'
 
 const asHTMLElement = (element: HTMLElement | SVGElement) => element as HTMLElement
 
+type TestSliderProps = SliderProps<number> & {
+  label?: string
+  thumbProps?: SliderThumbProps
+}
+
+function TestSlider({ label = 'Value', thumbProps, ...props }: TestSliderProps) {
+  return (
+    <Slider {...props}>
+      <SliderLabel>{label}</SliderLabel>
+      <SliderControl>
+        <SliderTrack>
+          <SliderIndicator />
+          <SliderThumb {...thumbProps} />
+        </SliderTrack>
+      </SliderControl>
+    </Slider>
+  )
+}
+
 describe('Slider', () => {
   it('should render with correct default ARIA limits and current value', async () => {
-    const screen = await render(<Slider value={50} onValueChange={vi.fn()} aria-label="Value" />)
+    const screen = await render(<TestSlider value={50} onValueChange={vi.fn()} />)
 
-    await expect.element(screen.getByLabelText('Value')).toHaveAttribute('min', '0')
-    await expect.element(screen.getByLabelText('Value')).toHaveAttribute('max', '100')
-    await expect.element(screen.getByLabelText('Value')).toHaveAttribute('aria-valuenow', '50')
+    const slider = screen.getByRole('slider', { name: 'Value' })
+
+    await expect.element(slider).toHaveAttribute('min', '0')
+    await expect.element(slider).toHaveAttribute('max', '100')
+    await expect.element(slider).toHaveAttribute('aria-valuenow', '50')
   })
 
   it('should apply custom min, max, and step values', async () => {
     const screen = await render(
-      <Slider value={10} min={5} max={20} step={5} onValueChange={vi.fn()} aria-label="Value" />,
+      <TestSlider value={10} min={5} max={20} step={5} onValueChange={vi.fn()} />,
     )
 
-    await expect.element(screen.getByLabelText('Value')).toHaveAttribute('min', '5')
-    await expect.element(screen.getByLabelText('Value')).toHaveAttribute('max', '20')
-    await expect.element(screen.getByLabelText('Value')).toHaveAttribute('aria-valuenow', '10')
-  })
+    const slider = screen.getByRole('slider', { name: 'Value' })
 
-  it('should clamp non-finite values to min', async () => {
-    const screen = await render(
-      <Slider value={Number.NaN} min={5} onValueChange={vi.fn()} aria-label="Value" />,
-    )
-
-    await expect.element(screen.getByLabelText('Value')).toHaveAttribute('aria-valuenow', '5')
+    await expect.element(slider).toHaveAttribute('min', '5')
+    await expect.element(slider).toHaveAttribute('max', '20')
+    await expect.element(slider).toHaveAttribute('aria-valuenow', '10')
   })
 
   it('should call onValueChange when arrow keys are pressed', async () => {
     const onValueChange = vi.fn()
-    const screen = await render(
-      <Slider value={20} onValueChange={onValueChange} aria-label="Value" />,
-    )
+    const screen = await render(<TestSlider value={20} onValueChange={onValueChange} />)
 
-    const slider = screen.getByLabelText('Value')
+    const slider = screen.getByRole('slider', { name: 'Value' })
     asHTMLElement(slider.element()).focus()
     await userEvent.keyboard('{ArrowRight}')
 
@@ -58,17 +71,10 @@ describe('Slider', () => {
   it('should round floating point keyboard updates to the configured step', async () => {
     const onValueChange = vi.fn()
     const screen = await render(
-      <Slider
-        value={0.2}
-        min={0}
-        max={1}
-        step={0.1}
-        onValueChange={onValueChange}
-        aria-label="Value"
-      />,
+      <TestSlider value={0.2} min={0} max={1} step={0.1} onValueChange={onValueChange} />,
     )
 
-    const slider = screen.getByLabelText('Value')
+    const slider = screen.getByRole('slider', { name: 'Value' })
     asHTMLElement(slider.element()).focus()
     await userEvent.keyboard('{ArrowRight}')
 
@@ -79,41 +85,43 @@ describe('Slider', () => {
   })
 
   it('should not trigger onValueChange when disabled', async () => {
-    const screen = await render(<Slider value={20} disabled aria-label="Value" />)
+    const screen = await render(<TestSlider value={20} disabled />)
+    const slider = screen.getByRole('slider', { name: 'Value' })
 
-    await expect.element(screen.getByLabelText('Value')).toBeDisabled()
+    await expect.element(slider).toBeDisabled()
+    expect(slider.element().parentElement).toHaveAttribute('data-disabled')
+    expect(screen.container.querySelector('[role="group"]')).toHaveAttribute('data-disabled')
   })
 
-  it('should apply custom class names on root', async () => {
-    const screen = await render(
-      <Slider value={10} onValueChange={vi.fn()} className="outer-test" aria-label="Value" />,
-    )
+  it('should expose vertical orientation through native state attributes', async () => {
+    const screen = await render(<TestSlider value={20} orientation="vertical" />)
+    const slider = screen.getByRole('slider', { name: 'Value' })
 
-    expect(screen.container.querySelector('.outer-test')).toBeInTheDocument()
+    await expect.element(slider).toHaveAttribute('aria-orientation', 'vertical')
+    expect(slider.element().parentElement).toHaveAttribute('data-orientation', 'vertical')
+    expect(screen.container.querySelector('[role="group"]')).toHaveAttribute(
+      'data-orientation',
+      'vertical',
+    )
   })
 
   it('should not render prehydration script tags', async () => {
-    const screen = await render(<Slider value={10} onValueChange={vi.fn()} aria-label="Value" />)
+    const screen = await render(<TestSlider value={10} onValueChange={vi.fn()} />)
 
     expect(screen.container.querySelector('script')).not.toBeInTheDocument()
   })
 
-  it('should expose SliderLabel for composed slider fields', async () => {
+  it('should forward thumb value text to the range input', async () => {
     const screen = await render(
-      <SliderRoot defaultValue={50}>
-        <SliderLabel>Temperature</SliderLabel>
-        <SliderControl>
-          <SliderTrack>
-            <SliderIndicator />
-          </SliderTrack>
-          <SliderThumb />
-        </SliderControl>
-      </SliderRoot>,
+      <TestSlider
+        defaultValue={50}
+        label="Temperature"
+        thumbProps={{ 'aria-valuetext': '50 degrees' }}
+      />,
     )
 
     await expect
       .element(screen.getByRole('slider', { name: 'Temperature' }))
-      .toHaveAttribute('aria-valuenow', '50')
-    await expect.element(screen.getByText('Temperature')).toBeInTheDocument()
+      .toHaveAttribute('aria-valuetext', '50 degrees')
   })
 })

--- a/packages/dify-ui/src/slider/index.stories.tsx
+++ b/packages/dify-ui/src/slider/index.stories.tsx
@@ -1,15 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { SliderProps } from '.'
 import * as React from 'react'
-import {
-  Slider,
-  SliderControl,
-  SliderIndicator,
-  SliderLabel,
-  SliderRoot,
-  SliderThumb,
-  SliderTrack,
-} from '.'
+import { Slider, SliderControl, SliderIndicator, SliderLabel, SliderThumb, SliderTrack } from '.'
 
 const meta = {
   title: 'Base/Form/Slider',
@@ -18,7 +10,7 @@ const meta = {
     layout: 'centered',
     docs: {
       description: {
-        component: 'Single-value horizontal slider built on Base UI.',
+        component: 'Styled Base UI slider anatomy for single-value and range controls.',
       },
     },
   },
@@ -40,22 +32,30 @@ const meta = {
       control: 'boolean',
     },
   },
-} satisfies Meta<typeof Slider>
+} satisfies Meta<SliderProps<number>>
 
 export default meta
 
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<SliderProps<number>>
 
 function SliderDemo({
   value: initialValue = 50,
   defaultValue: _defaultValue,
   ...args
-}: SliderProps) {
+}: SliderProps<number>) {
   const [value, setValue] = React.useState(initialValue)
 
   return (
     <div className="w-[320px] space-y-3">
-      <Slider {...args} value={value} onValueChange={setValue} aria-label="Demo slider" />
+      <Slider {...args} value={value} onValueChange={setValue}>
+        <SliderLabel className="sr-only">Demo slider</SliderLabel>
+        <SliderControl>
+          <SliderTrack>
+            <SliderIndicator />
+            <SliderThumb />
+          </SliderTrack>
+        </SliderControl>
+      </Slider>
       <div className="text-center system-sm-medium text-text-secondary">{value}</div>
     </div>
   )
@@ -92,20 +92,31 @@ export const Disabled: Story = {
   },
 }
 
+export const Vertical: Story = {
+  render: () => (
+    <Slider defaultValue={40} orientation="vertical">
+      <SliderLabel className="sr-only">Volume</SliderLabel>
+      <SliderControl>
+        <SliderTrack>
+          <SliderIndicator />
+          <SliderThumb />
+        </SliderTrack>
+      </SliderControl>
+    </Slider>
+  ),
+}
+
 export const ComposedWithLabel: Story = {
   render: () => (
-    <SliderRoot
-      defaultValue={50}
-      className="group/slider relative inline-flex w-[320px] flex-col gap-1 data-disabled:opacity-30"
-    >
+    <Slider defaultValue={50} className="w-[320px] flex-col gap-1">
       <SliderLabel>Temperature</SliderLabel>
       <SliderControl>
         <SliderTrack>
           <SliderIndicator />
+          <SliderThumb />
         </SliderTrack>
-        <SliderThumb />
       </SliderControl>
-    </SliderRoot>
+    </Slider>
   ),
 }
 
@@ -116,22 +127,22 @@ function RangeSliderDemo() {
 
   return (
     <div className="w-[320px] space-y-3">
-      <SliderRoot<PriceRange>
+      <Slider<PriceRange>
         value={range}
         onValueChange={setRange}
         min={0}
         max={100}
-        className="group/slider relative inline-flex w-full flex-col gap-1 data-disabled:opacity-30"
+        className="flex-col gap-1"
       >
         <SliderLabel>Price range</SliderLabel>
         <SliderControl>
           <SliderTrack>
             <SliderIndicator />
+            <SliderThumb index={0} aria-label="Minimum price" />
+            <SliderThumb index={1} aria-label="Maximum price" />
           </SliderTrack>
-          <SliderThumb aria-label="Minimum price" />
-          <SliderThumb aria-label="Maximum price" />
         </SliderControl>
-      </SliderRoot>
+      </Slider>
       <div className="text-center system-sm-medium text-text-secondary">
         {range[0]} – {range[1]}
       </div>

--- a/packages/dify-ui/src/slider/index.tsx
+++ b/packages/dify-ui/src/slider/index.tsx
@@ -4,12 +4,27 @@ import { Slider as BaseSlider } from '@base-ui/react/slider'
 import { cn } from '../cn'
 import { formLabelClassName } from '../form-control-shared'
 
-const SliderRoot = BaseSlider.Root
+type SliderValue = number | readonly number[]
+type SliderProps<Value extends SliderValue = SliderValue> = Omit<
+  BaseSlider.Root.Props<Value>,
+  'className'
+> & { className?: string }
 
-type SliderValue = number
-type SliderRangeValue = readonly number[]
-type SliderRootValue = SliderValue | SliderRangeValue
-type SliderRootProps<Value extends SliderRootValue = SliderRootValue> = BaseSlider.Root.Props<Value>
+function Slider<Value extends SliderValue = SliderValue>({
+  className,
+  ...props
+}: SliderProps<Value>) {
+  return (
+    <BaseSlider.Root
+      className={cn(
+        'group/slider relative inline-flex w-full data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+        'data-disabled:opacity-30',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
 type SliderLabelProps = Omit<BaseSlider.Label.Props, 'className'> & { className?: string }
 
@@ -17,139 +32,79 @@ function SliderLabel({ className, ...props }: SliderLabelProps) {
   return <BaseSlider.Label className={cn(formLabelClassName, className)} {...props} />
 }
 
-const sliderControlClassName = cn(
-  'relative flex h-5 w-full touch-none items-center select-none',
-  'data-disabled:cursor-not-allowed',
-)
-
 type SliderControlProps = Omit<BaseSlider.Control.Props, 'className'> & { className?: string }
 
 function SliderControl({ className, ...props }: SliderControlProps) {
-  return <BaseSlider.Control className={cn(sliderControlClassName, className)} {...props} />
+  return (
+    <BaseSlider.Control
+      className={cn(
+        'relative flex h-5 w-full touch-none items-center select-none',
+        'data-[orientation=vertical]:h-32 data-[orientation=vertical]:w-5 data-[orientation=vertical]:justify-center',
+        'data-disabled:cursor-not-allowed',
+        className,
+      )}
+      {...props}
+    />
+  )
 }
-
-const sliderTrackClassName = cn(
-  'relative h-1 w-full overflow-hidden rounded-full',
-  'bg-components-slider-track',
-)
 
 type SliderTrackProps = Omit<BaseSlider.Track.Props, 'className'> & { className?: string }
 
 function SliderTrack({ className, ...props }: SliderTrackProps) {
-  return <BaseSlider.Track className={cn(sliderTrackClassName, className)} {...props} />
+  return (
+    <BaseSlider.Track
+      className={cn(
+        'relative h-1 w-full rounded-full',
+        'data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1',
+        'bg-components-slider-track',
+        className,
+      )}
+      {...props}
+    />
+  )
 }
-
-const sliderIndicatorClassName = cn('h-full rounded-full', 'bg-components-slider-range')
 
 type SliderIndicatorProps = Omit<BaseSlider.Indicator.Props, 'className'> & {
   className?: string
 }
 
 function SliderIndicator({ className, ...props }: SliderIndicatorProps) {
-  return <BaseSlider.Indicator className={cn(sliderIndicatorClassName, className)} {...props} />
+  return (
+    <BaseSlider.Indicator
+      className={cn('h-full rounded-full', 'bg-components-slider-range', className)}
+      {...props}
+    />
+  )
 }
-
-const sliderThumbClassName = cn(
-  'block h-5 w-2 shrink-0 rounded-[3px] border-[0.5px]',
-  'border-components-slider-knob-border bg-components-slider-knob shadow-sm',
-  'transition-[background-color,border-color,box-shadow,opacity] motion-reduce:transition-none',
-  'hover:bg-components-slider-knob-hover',
-  'has-focus-visible:ring-2 has-focus-visible:ring-state-accent-solid has-focus-visible:ring-offset-0',
-  'active:shadow-md',
-  'group-data-disabled/slider:border-components-slider-knob-border group-data-disabled/slider:bg-components-slider-knob-disabled group-data-disabled/slider:shadow-none',
-)
 
 type SliderThumbProps = Omit<BaseSlider.Thumb.Props, 'className'> & { className?: string }
 
 function SliderThumb({ className, ...props }: SliderThumbProps) {
-  return <BaseSlider.Thumb className={cn(sliderThumbClassName, className)} {...props} />
-}
-
-type SliderSlotClassNames = {
-  control?: string
-  track?: string
-  indicator?: string
-  thumb?: string
-}
-
-type SliderBaseProps = Pick<
-  SliderRootProps<SliderValue>,
-  'onValueChange' | 'min' | 'max' | 'step' | 'disabled' | 'name'
-> &
-  Pick<SliderThumbProps, 'aria-label' | 'aria-labelledby'> & {
-    className?: string
-    slotClassNames?: SliderSlotClassNames
-  }
-
-type ControlledSliderProps = SliderBaseProps & {
-  value: SliderValue
-  defaultValue?: never
-}
-
-type UncontrolledSliderProps = SliderBaseProps & {
-  value?: never
-  defaultValue?: SliderValue
-}
-
-type SliderProps = ControlledSliderProps | UncontrolledSliderProps
-
-const sliderRootClassName = 'group/slider relative inline-flex w-full data-disabled:opacity-30'
-
-const getSafeValue = (value: number | undefined, min: number) => {
-  if (value === undefined) return undefined
-
-  return Number.isFinite(value) ? value : min
-}
-
-function Slider({
-  value,
-  defaultValue,
-  onValueChange,
-  min = 0,
-  max = 100,
-  step = 1,
-  disabled = false,
-  name,
-  className,
-  slotClassNames,
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledby,
-}: SliderProps) {
   return (
-    <SliderRoot
-      value={getSafeValue(value, min)}
-      defaultValue={getSafeValue(defaultValue, min)}
-      onValueChange={onValueChange}
-      min={min}
-      max={max}
-      step={step}
-      disabled={disabled}
-      name={name}
-      thumbAlignment="center"
-      className={cn(sliderRootClassName, className)}
-    >
-      <SliderControl className={slotClassNames?.control}>
-        <SliderTrack className={slotClassNames?.track}>
-          <SliderIndicator className={slotClassNames?.indicator} />
-        </SliderTrack>
-        <SliderThumb
-          aria-label={ariaLabel}
-          aria-labelledby={ariaLabelledby}
-          className={slotClassNames?.thumb}
-        />
-      </SliderControl>
-    </SliderRoot>
+    <BaseSlider.Thumb
+      className={cn(
+        'block h-5 w-2 shrink-0 rounded-[3px] border-[0.5px]',
+        'data-[orientation=vertical]:h-2 data-[orientation=vertical]:w-5',
+        'border-components-slider-knob-border bg-components-slider-knob shadow-sm',
+        'transition-[background-color,border-color,box-shadow,opacity] motion-reduce:transition-none',
+        'hover:bg-components-slider-knob-hover',
+        'has-focus-visible:ring-2 has-focus-visible:ring-state-accent-solid has-focus-visible:ring-offset-0',
+        'active:shadow-md group-data-dragging/slider:has-focus:shadow-md',
+        'data-disabled:border-components-slider-knob-border data-disabled:bg-components-slider-knob-disabled data-disabled:shadow-none',
+        className,
+      )}
+      {...props}
+    />
   )
 }
 
-export { Slider, SliderControl, SliderIndicator, SliderLabel, SliderRoot, SliderThumb, SliderTrack }
+export { Slider, SliderControl, SliderIndicator, SliderLabel, SliderThumb, SliderTrack }
 
 export type {
   SliderControlProps,
   SliderIndicatorProps,
   SliderLabelProps,
   SliderProps,
-  SliderRootProps,
   SliderThumbProps,
   SliderTrackProps,
 }

--- a/web/app/components/app/configuration/config/agent/agent-setting/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-setting/__tests__/index.spec.tsx
@@ -111,4 +111,17 @@ describe('AgentSetting', () => {
 
     expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ max_iteration: 6 }))
   })
+
+  it('should save the minimum iteration when the number input is empty', async () => {
+    const { onSave } = renderModal()
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } })
+
+    expect(screen.getByRole('slider')).toHaveValue('1')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.save' }))
+    })
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ max_iteration: 1 }))
+  })
 })

--- a/web/app/components/app/configuration/config/agent/agent-setting/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-setting/index.tsx
@@ -3,7 +3,14 @@ import type { AgentConfig } from '@/models/debug'
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { Fieldset, FieldsetLegend } from '@langgenius/dify-ui/fieldset'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CuteRobot } from '@/app/components/base/icons/src/vender/solid/communication'
@@ -27,9 +34,15 @@ export function AgentSetting({ isChatModel, payload, isFunctionCall, onCancel, o
   const maximumIterationsLabel = t(($) => $['agent.setting.maximumIterations.name'], {
     ns: 'appDebug',
   })
+  const sliderValue = Number.isFinite(tempPayload.max_iteration)
+    ? tempPayload.max_iteration
+    : maxIterationsMin
 
   const handleSave = () => {
-    onSave(tempPayload)
+    onSave({
+      ...tempPayload,
+      max_iteration: sliderValue,
+    })
   }
 
   return (
@@ -84,15 +97,22 @@ export function AgentSetting({ isChatModel, payload, isFunctionCall, onCancel, o
                 className="mr-3 w-39"
                 min={maxIterationsMin}
                 max={MAX_ITERATIONS_NUM}
-                value={tempPayload.max_iteration}
+                value={sliderValue}
                 onValueChange={(value) => {
                   setTempPayload({
                     ...tempPayload,
                     max_iteration: value,
                   })
                 }}
-                aria-label={maximumIterationsLabel}
-              />
+              >
+                <SliderLabel className="sr-only">{maximumIterationsLabel}</SliderLabel>
+                <SliderControl>
+                  <SliderTrack>
+                    <SliderIndicator />
+                    <SliderThumb />
+                  </SliderTrack>
+                </SliderControl>
+              </Slider>
 
               <input
                 aria-label={maximumIterationsLabel}

--- a/web/app/components/app/configuration/dataset-config/params-config/__tests__/config-content.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/__tests__/config-content.spec.tsx
@@ -210,8 +210,8 @@ describe('ConfigContent', () => {
       await waitFor(() => {
         expect(onChange).toHaveBeenCalled()
       })
-      const [nextConfigs] = (onChange.mock.calls[0] ?? []) as [any]
-      expect(nextConfigs.retrieval_model).toBe(RETRIEVE_TYPE.multiWay)
+      const nextConfigs = onChange.mock.calls[0]?.[0]
+      expect(nextConfigs?.retrieval_model).toBe(RETRIEVE_TYPE.multiWay)
     })
   })
 
@@ -246,11 +246,10 @@ describe('ConfigContent', () => {
       )
 
       // Assert
-      // Assert
       expect(screen.getByText('dataset.weightedScore.title'))!.toBeInTheDocument()
       expect(screen.getByText('common.modelProvider.rerankModel.key'))!.toBeInTheDocument()
-      expect(screen.getByText('dataset.weightedScore.semantic'))!.toBeInTheDocument()
-      expect(screen.getByText('dataset.weightedScore.keyword'))!.toBeInTheDocument()
+      expect(screen.getByTitle('dataset.weightedScore.semantic'))!.toBeVisible()
+      expect(screen.getByTitle('dataset.weightedScore.keyword'))!.toBeVisible()
     })
   })
 
@@ -296,7 +295,9 @@ describe('ConfigContent', () => {
         />,
       )
 
-      const weightedScoreSlider = screen.getByLabelText('dataset.weightedScore.semantic')
+      const weightedScoreSlider = screen.getByRole('slider', {
+        name: 'dataset.weightedScore.semantic',
+      })
       weightedScoreSlider.focus()
       const callsBefore = onChange.mock.calls.length
       await user.keyboard('{ArrowRight}')

--- a/web/app/components/app/configuration/dataset-config/params-config/__tests__/weighted-score.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/__tests__/weighted-score.spec.tsx
@@ -3,7 +3,8 @@ import userEvent from '@testing-library/user-event'
 import WeightedScore from '../weighted-score'
 
 describe('WeightedScore', () => {
-  const getSliderInput = () => screen.getByLabelText('dataset.weightedScore.semantic')
+  const getSliderInput = () =>
+    screen.getByRole('slider', { name: 'dataset.weightedScore.semantic' })
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -20,10 +21,14 @@ describe('WeightedScore', () => {
       render(<WeightedScore value={value} onChange={onChange} />)
 
       // Assert
-      expect(screen.getByText('dataset.weightedScore.semantic')).toBeInTheDocument()
-      expect(screen.getByText('dataset.weightedScore.keyword')).toBeInTheDocument()
+      expect(screen.getByTitle('dataset.weightedScore.semantic')).toBeInTheDocument()
+      expect(screen.getByTitle('dataset.weightedScore.keyword')).toBeInTheDocument()
       expect(screen.getByText('0.3')).toBeInTheDocument()
       expect(screen.getByText('0.7')).toBeInTheDocument()
+      expect(getSliderInput()).toHaveAttribute(
+        'aria-valuetext',
+        'dataset.weightedScore.semantic: 0.3, dataset.weightedScore.keyword: 0.7',
+      )
     })
 
     it('should format a weight of 1 as 1.0', () => {

--- a/web/app/components/app/configuration/dataset-config/params-config/weighted-score.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/weighted-score.tsx
@@ -1,12 +1,14 @@
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { noop } from 'es-toolkit/function'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
-
-const weightedScoreSliderSlotClassNames = {
-  track: 'bg-util-colors-teal-teal-500',
-  indicator: 'bg-util-colors-blue-light-blue-light-500',
-}
 
 const formatNumber = (value: number) => {
   if (value > 0 && value < 1) return `0.${value * 10}`
@@ -26,6 +28,10 @@ type WeightedScoreProps = {
 }
 const WeightedScore = ({ value, onChange = noop, readonly = false }: WeightedScoreProps) => {
   const { t } = useTranslation()
+  const semanticLabel = t(($) => $['weightedScore.semantic'], { ns: 'dataset' })
+  const keywordLabel = t(($) => $['weightedScore.keyword'], { ns: 'dataset' })
+  const semanticWeight = value.value[0]!
+  const keywordWeight = value.value[1]!
 
   return (
     <div>
@@ -36,30 +42,34 @@ const WeightedScore = ({ value, onChange = noop, readonly = false }: WeightedSco
             max={1.0}
             min={0}
             step={0.1}
-            value={value.value[0]}
+            value={semanticWeight}
             onValueChange={(v) => !readonly && onChange({ value: [v, (10 - v * 10) / 10] })}
             disabled={readonly}
-            aria-label={t(($) => $['weightedScore.semantic'], { ns: 'dataset' })}
-            slotClassNames={weightedScoreSliderSlotClassNames}
-          />
+          >
+            <SliderLabel className="sr-only">{semanticLabel}</SliderLabel>
+            <SliderControl>
+              <SliderTrack className="bg-util-colors-teal-teal-500">
+                <SliderIndicator className="bg-util-colors-blue-light-blue-light-500" />
+                <SliderThumb
+                  getAriaValueText={(_formattedValue, sliderValue) =>
+                    `${semanticLabel}: ${formatNumber(sliderValue)}, ${keywordLabel}: ${formatNumber((10 - sliderValue * 10) / 10)}`
+                  }
+                />
+              </SliderTrack>
+            </SliderControl>
+          </Slider>
         </div>
         <div className="mt-3 flex justify-between">
           <div className="flex w-22.5 shrink-0 items-center system-xs-semibold-uppercase text-util-colors-blue-light-blue-light-500">
-            <div
-              className="mr-1 truncate uppercase"
-              title={t(($) => $['weightedScore.semantic'], { ns: 'dataset' }) || ''}
-            >
-              {t(($) => $['weightedScore.semantic'], { ns: 'dataset' })}
+            <div className="mr-1 truncate uppercase" title={semanticLabel || ''}>
+              {semanticLabel}
             </div>
-            {formatNumber(value.value[0]!)}
+            {formatNumber(semanticWeight)}
           </div>
           <div className="flex w-22.5 shrink-0 items-center justify-end system-xs-semibold-uppercase text-util-colors-teal-teal-500">
-            {formatNumber(value.value[1]!)}
-            <div
-              className="ml-1 truncate uppercase"
-              title={t(($) => $['weightedScore.keyword'], { ns: 'dataset' }) || ''}
-            >
-              {t(($) => $['weightedScore.keyword'], { ns: 'dataset' })}
+            {formatNumber(keywordWeight)}
+            <div className="ml-1 truncate uppercase" title={keywordLabel || ''}>
+              {keywordLabel}
             </div>
           </div>
         </div>

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/__tests__/index.spec.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/__tests__/index.spec.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import ScoreSlider from '..'
+
+describe('ScoreSlider', () => {
+  it('should expose the business score instead of the internal percentage', () => {
+    render(<ScoreSlider value={90} onChange={vi.fn()} />)
+
+    const slider = screen.getByRole('slider', {
+      name: 'appDebug.feature.annotation.scoreThreshold.title',
+    })
+    expect(slider).toHaveAttribute('aria-valuenow', '90')
+    expect(slider).toHaveAttribute('aria-valuetext', '0.90')
+    expect(screen.getByText('0.90')).toBeInTheDocument()
+  })
+})

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/index.tsx
@@ -1,6 +1,13 @@
 'use client'
 import type { FC } from 'react'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -33,8 +40,19 @@ const ScoreSlider: FC<Props> = ({ className, value, onChange }) => {
           max={SCORE_MAX}
           step={1}
           onValueChange={onChange}
-          aria-label={t(($) => $['feature.annotation.scoreThreshold.title'], { ns: 'appDebug' })}
-        />
+        >
+          <SliderLabel className="sr-only">
+            {t(($) => $['feature.annotation.scoreThreshold.title'], { ns: 'appDebug' })}
+          </SliderLabel>
+          <SliderControl>
+            <SliderTrack>
+              <SliderIndicator />
+              <SliderThumb
+                getAriaValueText={(_formattedValue, sliderValue) => (sliderValue / 100).toFixed(2)}
+              />
+            </SliderTrack>
+          </SliderControl>
+        </Slider>
         <div
           className="pointer-events-none absolute -top-4 system-sm-semibold text-text-primary"
           style={{

--- a/web/app/components/base/param-item/__tests__/index-slider.spec.tsx
+++ b/web/app/components/base/param-item/__tests__/index-slider.spec.tsx
@@ -24,6 +24,9 @@ describe('ParamItem Slider onChange', () => {
     render(<ParamItem {...defaultProps} value={0.5} min={0} max={1} />)
     const slider = getSlider()
 
+    expect(slider).toHaveAttribute('aria-valuenow', '50')
+    expect(slider).toHaveAttribute('aria-valuetext', '0.5')
+
     slider.focus()
     await user.keyboard('{ArrowRight}')
 

--- a/web/app/components/base/param-item/index.tsx
+++ b/web/app/components/base/param-item/index.tsx
@@ -9,7 +9,14 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from '@langgenius/dify-ui/number-field'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { Switch } from '@langgenius/dify-ui/switch'
 import { Infotip } from '@/app/components/base/infotip'
 
@@ -97,8 +104,21 @@ const ParamItem: FC<Props> = ({
             min={min < 1 ? min * 100 : min}
             max={max < 5 ? max * 100 : max}
             onValueChange={(value) => onChange(id, value / (max < 5 ? 100 : 1))}
-            aria-label={name}
-          />
+          >
+            <SliderLabel className="sr-only">{name}</SliderLabel>
+            <SliderControl>
+              <SliderTrack>
+                <SliderIndicator />
+                <SliderThumb
+                  getAriaValueText={
+                    max < 5
+                      ? (_formattedValue, sliderValue) => (sliderValue / 100).toString()
+                      : undefined
+                  }
+                />
+              </SliderTrack>
+            </SliderControl>
+          </Slider>
         </div>
       </div>
     </Fieldset>

--- a/web/app/components/datasets/settings/index-method/keyword-number.tsx
+++ b/web/app/components/datasets/settings/index-method/keyword-number.tsx
@@ -7,7 +7,14 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from '@langgenius/dify-ui/number-field'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import * as React from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -47,8 +54,15 @@ const KeyWordNumber = ({ keywordNumber, onKeywordNumberChange }: KeyWordNumberPr
         min={MIN_KEYWORD_NUMBER}
         max={MAX_KEYWORD_NUMBER}
         onValueChange={onKeywordNumberChange}
-        aria-label={label}
-      />
+      >
+        <SliderLabel className="sr-only">{label}</SliderLabel>
+        <SliderControl>
+          <SliderTrack>
+            <SliderIndicator />
+            <SliderThumb />
+          </SliderTrack>
+        </SliderControl>
+      </Slider>
       <NumberField
         className="w-18.5 shrink-0"
         min={MIN_KEYWORD_NUMBER}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/parameter-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/parameter-item.tsx
@@ -14,7 +14,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { Switch } from '@langgenius/dify-ui/switch'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -203,8 +210,15 @@ function ParameterItem({
             max={parameterRule.max}
             step={step}
             onValueChange={handleSlideChange}
-            aria-label={sliderLabel}
-          />
+          >
+            <SliderLabel className="sr-only">{sliderLabel}</SliderLabel>
+            <SliderControl>
+              <SliderTrack>
+                <SliderIndicator />
+                <SliderThumb />
+              </SliderTrack>
+            </SliderControl>
+          </Slider>
           <input
             aria-label={sliderLabel}
             ref={numberInputRef}
@@ -247,8 +261,15 @@ function ParameterItem({
             max={parameterRule.max}
             step={0.1}
             onValueChange={handleSlideChange}
-            aria-label={sliderLabel}
-          />
+          >
+            <SliderLabel className="sr-only">{sliderLabel}</SliderLabel>
+            <SliderControl>
+              <SliderTrack>
+                <SliderIndicator />
+                <SliderThumb />
+              </SliderTrack>
+            </SliderControl>
+          </Slider>
           <input
             aria-label={sliderLabel}
             ref={numberInputRef}

--- a/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
+++ b/web/app/components/workflow/nodes/_base/components/agent-strategy.tsx
@@ -17,7 +17,14 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from '@langgenius/dify-ui/number-field'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { noop } from 'es-toolkit/function'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -165,8 +172,15 @@ export const AgentStrategy = memo((props: AgentStrategyProps) => {
                   className="w-full"
                   min={def.min}
                   max={def.max}
-                  aria-label={label}
-                />
+                >
+                  <SliderLabel className="sr-only">{label}</SliderLabel>
+                  <SliderControl>
+                    <SliderTrack>
+                      <SliderIndicator />
+                      <SliderThumb />
+                    </SliderTrack>
+                  </SliderControl>
+                </Slider>
                 <NumberField
                   value={value}
                   min={def.min}

--- a/web/app/components/workflow/nodes/_base/components/input-number-with-slider.tsx
+++ b/web/app/components/workflow/nodes/_base/components/input-number-with-slider.tsx
@@ -1,6 +1,13 @@
 'use client'
 import { Fieldset, FieldsetLegend } from '@langgenius/dify-ui/fieldset'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import * as React from 'react'
 import { useCallback } from 'react'
 
@@ -23,6 +30,8 @@ function InputNumberWithSlider({
   readonly,
   onChange,
 }: InputNumberWithSliderProps) {
+  const sliderValue = Number.isFinite(value) ? value : (min ?? 0)
+
   const handleBlur = useCallback(() => {
     if (value === undefined || value === null || Number.isNaN(value)) {
       onChange(defaultValue)
@@ -60,14 +69,21 @@ function InputNumberWithSlider({
         />
         <Slider
           className="grow"
-          value={value}
+          value={sliderValue}
           min={min}
           max={max}
           step={1}
           onValueChange={onChange}
           disabled={readonly}
-          aria-label={label}
-        />
+        >
+          <SliderLabel className="sr-only">{label}</SliderLabel>
+          <SliderControl>
+            <SliderTrack>
+              <SliderIndicator />
+              <SliderThumb />
+            </SliderTrack>
+          </SliderControl>
+        </Slider>
       </div>
     </Fieldset>
   )

--- a/web/app/components/workflow/nodes/_base/components/memory-config.tsx
+++ b/web/app/components/workflow/nodes/_base/components/memory-config.tsx
@@ -3,7 +3,14 @@ import type { FC } from 'react'
 import type { Memory } from '../../../types'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Fieldset, FieldsetLegend } from '@langgenius/dify-ui/fieldset'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { Switch } from '@langgenius/dify-ui/switch'
 import { produce } from 'immer'
 import * as React from 'react'
@@ -175,8 +182,15 @@ const MemoryConfig: FC<Props> = ({
                   step={1}
                   onValueChange={handleWindowSizeChange}
                   disabled={readonly || !payload.window?.enabled}
-                  aria-label={windowSizeLabel}
-                />
+                >
+                  <SliderLabel className="sr-only">{windowSizeLabel}</SliderLabel>
+                  <SliderControl>
+                    <SliderTrack>
+                      <SliderIndicator />
+                      <SliderThumb />
+                    </SliderTrack>
+                  </SliderControl>
+                </Slider>
                 <Input
                   aria-label={windowSizeLabel}
                   value={(payload.window?.size || WINDOW_SIZE_DEFAULT) as number}

--- a/web/app/components/workflow/nodes/_base/components/retry/__tests__/retry-on-panel.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/retry/__tests__/retry-on-panel.spec.tsx
@@ -34,10 +34,11 @@ describe('RetryOnPanel', () => {
     ).toBeChecked()
 
     const maxRetriesLabel = 'workflow.nodes.common.retry.maxRetries'
-    const maxRetriesGroup = screen.getByRole('group', { name: maxRetriesLabel })
-    expect(within(maxRetriesGroup).getByRole('slider', { name: maxRetriesLabel })).toHaveAttribute(
-      'aria-valuenow',
-      '3',
+    const maxRetriesSlider = screen.getByRole('slider', { name: maxRetriesLabel })
+    const maxRetriesGroup = maxRetriesSlider.closest('fieldset')!
+    expect(maxRetriesSlider).toHaveAttribute(
+      'aria-valuetext',
+      '3 workflow.nodes.common.retry.times',
     )
     const maxRetriesInput = within(maxRetriesGroup).getByRole('textbox', {
       name: maxRetriesLabel,
@@ -47,10 +48,12 @@ describe('RetryOnPanel', () => {
     expect(within(maxRetriesGroup).getByText('workflow.nodes.common.retry.times')).toBeVisible()
 
     const retryIntervalLabel = 'workflow.nodes.common.retry.retryInterval'
-    const retryIntervalGroup = screen.getByRole('group', { name: retryIntervalLabel })
-    expect(
-      within(retryIntervalGroup).getByRole('slider', { name: retryIntervalLabel }),
-    ).toHaveAttribute('aria-valuenow', '1000')
+    const retryIntervalSlider = screen.getByRole('slider', { name: retryIntervalLabel })
+    const retryIntervalGroup = retryIntervalSlider.closest('fieldset')!
+    expect(retryIntervalSlider).toHaveAttribute(
+      'aria-valuetext',
+      '1000 workflow.nodes.common.retry.ms',
+    )
     expect(
       within(retryIntervalGroup).getByRole('textbox', { name: retryIntervalLabel }),
     ).toHaveValue('1000')

--- a/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
+++ b/web/app/components/workflow/nodes/_base/components/retry/retry-on-panel.tsx
@@ -6,7 +6,14 @@ import {
   NumberFieldInput,
   NumberFieldUnit,
 } from '@langgenius/dify-ui/number-field'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { Switch } from '@langgenius/dify-ui/switch'
 import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -82,8 +89,19 @@ const RetryOnPanel = ({ id, data }: RetryOnPanelProps) => {
                 onValueChange={handleMaxRetriesChange}
                 min={1}
                 max={10}
-                aria-label={maxRetriesLabel}
-              />
+              >
+                <SliderLabel className="sr-only">{maxRetriesLabel}</SliderLabel>
+                <SliderControl>
+                  <SliderTrack>
+                    <SliderIndicator />
+                    <SliderThumb
+                      getAriaValueText={(_formattedValue, sliderValue) =>
+                        `${sliderValue} ${t(($) => $['nodes.common.retry.times'], { ns: 'workflow' })}`
+                      }
+                    />
+                  </SliderTrack>
+                </SliderControl>
+              </Slider>
               <NumberField
                 className="w-25 shrink-0"
                 value={retry_config?.max_retries || 3}
@@ -111,8 +129,19 @@ const RetryOnPanel = ({ id, data }: RetryOnPanelProps) => {
                 onValueChange={handleRetryIntervalChange}
                 min={100}
                 max={5000}
-                aria-label={retryIntervalLabel}
-              />
+              >
+                <SliderLabel className="sr-only">{retryIntervalLabel}</SliderLabel>
+                <SliderControl>
+                  <SliderTrack>
+                    <SliderIndicator />
+                    <SliderThumb
+                      getAriaValueText={(_formattedValue, sliderValue) =>
+                        `${sliderValue} ${t(($) => $['nodes.common.retry.ms'], { ns: 'workflow' })}`
+                      }
+                    />
+                  </SliderTrack>
+                </SliderControl>
+              </Slider>
               <NumberField
                 className="w-25 shrink-0"
                 value={retry_config?.retry_interval || 1000}

--- a/web/app/components/workflow/nodes/iteration/panel.tsx
+++ b/web/app/components/workflow/nodes/iteration/panel.tsx
@@ -11,7 +11,14 @@ import {
   SelectLabel,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { Switch } from '@langgenius/dify-ui/switch'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -150,8 +157,15 @@ const Panel: FC<NodePanelProps<IterationNodeType>> = ({ id, data }) => {
                 max={MAX_PARALLEL_LIMIT}
                 min={MIN_ITERATION_PARALLEL_NUM}
                 className="mt-4 flex-1 shrink-0"
-                aria-label={maxParallelismLabel}
-              />
+              >
+                <SliderLabel className="sr-only">{maxParallelismLabel}</SliderLabel>
+                <SliderControl>
+                  <SliderTrack>
+                    <SliderIndicator />
+                    <SliderThumb />
+                  </SliderTrack>
+                </SliderControl>
+              </Slider>
             </Fieldset>
           </Field>
         </div>

--- a/web/app/components/workflow/nodes/knowledge-base/components/index-method.tsx
+++ b/web/app/components/workflow/nodes/knowledge-base/components/index-method.tsx
@@ -1,6 +1,13 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { Fieldset, FieldsetLegend } from '@langgenius/dify-ui/fieldset'
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import { memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Economic, HighQuality } from '@/app/components/base/icons/src/vender/knowledge'
@@ -105,8 +112,15 @@ const IndexMethod = ({
                 className="mr-3 w-24 shrink-0"
                 value={keywordNumber}
                 onValueChange={onKeywordNumberChange}
-                aria-label={keywordNumberLabel}
-              />
+              >
+                <SliderLabel className="sr-only">{keywordNumberLabel}</SliderLabel>
+                <SliderControl>
+                  <SliderTrack>
+                    <SliderIndicator />
+                    <SliderThumb />
+                  </SliderTrack>
+                </SliderControl>
+              </Slider>
               <Input
                 aria-label={keywordNumberLabel}
                 disabled={readonly}

--- a/web/app/components/workflow/nodes/knowledge-base/components/retrieval-setting/__tests__/search-method-option.spec.tsx
+++ b/web/app/components/workflow/nodes/knowledge-base/components/retrieval-setting/__tests__/search-method-option.spec.tsx
@@ -162,8 +162,8 @@ describe('SearchMethodOption', () => {
 
     expect(screen.getByText('Weighted mode'))!.toBeInTheDocument()
     expect(screen.getByText('Rerank mode'))!.toBeInTheDocument()
-    expect(screen.getByText('dataset.weightedScore.semantic'))!.toBeInTheDocument()
-    expect(screen.getByText('dataset.weightedScore.keyword'))!.toBeInTheDocument()
+    expect(screen.getByTitle('dataset.weightedScore.semantic'))!.toBeVisible()
+    expect(screen.getByTitle('dataset.weightedScore.keyword'))!.toBeVisible()
     expect(screen.queryByText('common.modelProvider.rerankModel.key')).not.toBeInTheDocument()
     expect(
       screen.queryByText('datasetSettings.form.retrievalSetting.multiModalTip'),

--- a/web/app/components/workflow/nodes/trigger-schedule/components/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/components/__tests__/integration.spec.tsx
@@ -72,7 +72,9 @@ describe('trigger-schedule components', () => {
       const onChange = vi.fn()
       render(<OnMinuteSelector value={15} onChange={onChange} />)
 
-      const slider = screen.getByLabelText('workflow.nodes.triggerSchedule.onMinute')
+      const slider = screen.getByRole('slider', {
+        name: 'workflow.nodes.triggerSchedule.onMinute',
+      })
       slider.focus()
       await user.keyboard('{ArrowRight}')
 

--- a/web/app/components/workflow/nodes/trigger-schedule/components/__tests__/on-minute-selector.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/components/__tests__/on-minute-selector.spec.tsx
@@ -9,7 +9,9 @@ describe('trigger-schedule/on-minute-selector', () => {
 
     render(<OnMinuteSelector value={15} onChange={onChange} />)
 
-    const slider = screen.getByLabelText('workflow.nodes.triggerSchedule.onMinute')
+    const slider = screen.getByRole('slider', {
+      name: 'workflow.nodes.triggerSchedule.onMinute',
+    })
     slider.focus()
     await user.keyboard('{ArrowRight}')
 

--- a/web/app/components/workflow/nodes/trigger-schedule/components/on-minute-selector.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/components/on-minute-selector.tsx
@@ -1,4 +1,11 @@
-import { Slider } from '@langgenius/dify-ui/slider'
+import {
+  Slider,
+  SliderControl,
+  SliderIndicator,
+  SliderLabel,
+  SliderThumb,
+  SliderTrack,
+} from '@langgenius/dify-ui/slider'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -28,8 +35,17 @@ const OnMinuteSelector = ({ value = 0, onChange }: OnMinuteSelectorProps) => {
             max={59}
             step={1}
             onValueChange={onChange}
-            aria-label={t(($) => $['nodes.triggerSchedule.onMinute'], { ns: 'workflow' })}
-          />
+          >
+            <SliderLabel className="sr-only">
+              {t(($) => $['nodes.triggerSchedule.onMinute'], { ns: 'workflow' })}
+            </SliderLabel>
+            <SliderControl>
+              <SliderTrack>
+                <SliderIndicator />
+                <SliderThumb />
+              </SliderTrack>
+            </SliderControl>
+          </Slider>
         </div>
       </div>
     </div>

--- a/web/app/components/workflow/nodes/trigger-schedule/components/on-minute-selector.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/components/on-minute-selector.tsx
@@ -18,37 +18,25 @@ const OnMinuteSelector = ({ value = 0, onChange }: OnMinuteSelectorProps) => {
   const { t } = useTranslation()
 
   return (
-    <div>
-      <label className="mb-2 block text-xs font-medium text-gray-500">
+    <Slider className="block" value={value} min={0} max={59} step={1} onValueChange={onChange}>
+      <SliderLabel className="mb-2 block text-xs font-medium text-gray-500">
         {t(($) => $['nodes.triggerSchedule.onMinute'], { ns: 'workflow' })}
-      </label>
+      </SliderLabel>
       <div className="relative flex h-8 items-center rounded-lg bg-components-input-bg-normal">
         <div className="flex h-full w-12 shrink-0 items-center justify-center text-[13px] text-components-input-text-filled">
           {value}
         </div>
         <div className="absolute top-0 left-12 h-full w-px bg-components-panel-bg"></div>
         <div className="flex h-full grow items-center pr-3 pl-4">
-          <Slider
-            className="w-full"
-            value={value}
-            min={0}
-            max={59}
-            step={1}
-            onValueChange={onChange}
-          >
-            <SliderLabel className="sr-only">
-              {t(($) => $['nodes.triggerSchedule.onMinute'], { ns: 'workflow' })}
-            </SliderLabel>
-            <SliderControl>
-              <SliderTrack>
-                <SliderIndicator />
-                <SliderThumb />
-              </SliderTrack>
-            </SliderControl>
-          </Slider>
+          <SliderControl>
+            <SliderTrack>
+              <SliderIndicator />
+              <SliderThumb />
+            </SliderTrack>
+          </SliderControl>
         </div>
       </div>
-    </div>
+    </Slider>
   )
 }
 

--- a/web/app/components/workflow/nodes/trigger-schedule/components/on-minute-selector.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/components/on-minute-selector.tsx
@@ -19,7 +19,7 @@ const OnMinuteSelector = ({ value = 0, onChange }: OnMinuteSelectorProps) => {
 
   return (
     <Slider className="block" value={value} min={0} max={59} step={1} onValueChange={onChange}>
-      <SliderLabel className="mb-2 block text-xs font-medium text-gray-500">
+      <SliderLabel className="mb-2 block py-0 text-xs font-medium text-gray-500">
         {t(($) => $['nodes.triggerSchedule.onMinute'], { ns: 'workflow' })}
       </SliderLabel>
       <div className="relative flex h-8 items-center rounded-lg bg-components-input-bg-normal">


### PR DESCRIPTION
## Summary

- replace the auto-composed Dify UI Slider with explicit styled Base UI anatomy and remove `SliderRoot`, `slotClassNames`, and compatibility-only props
- migrate all 15 Web Slider instances so labeling, business value text, invalid-value fallback, and visual customization stay with their owning feature or anatomy part
- preserve the horizontal visual contract and implement the vertical axis through Base UI `data-orientation` state without inline sizing workarounds
- align shared forms guidance, tests, and Storybook examples with Base UI labeling and multi-thumb semantics

## Validation

- `vp test --project unit --run` in `packages/dify-ui`: 254 tests passed
- `vp test --project storybook --run` in `packages/dify-ui`: 212 tests passed
- focused Web Slider regression suite: 66 tests passed
- scoped Web accessibility lint passed
- `pnpm check`: 0 errors
- manually verified horizontal, vertical, range, keyboard, focus, and authenticated Web usage in Storybook and the local app

## Stack

Depends on PR #41044, which establishes the Dify UI documentation ownership model used by this migration.

From Codex