### PR TITLE
refactor(web): migrate subscription confirmation input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4049,11 +4049,6 @@
       "count": 1
     }
   },
-  "web/app/components/workflow/nodes/human-input/components/timeout.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/human-input/types.ts": {
     "erasable-syntax-only/enums": {
       "count": 2

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2870,11 +2870,6 @@
       "count": 1
     }
   },
-  "web/app/components/plugins/plugin-detail-panel/subscription-list/delete-confirm.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/plugins/plugin-detail-panel/subscription-list/index.tsx": {
     "no-barrel-files/no-barrel-files": {
       "count": 2

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/__tests__/delete-confirm.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/__tests__/delete-confirm.spec.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { DeleteConfirm } from '../delete-confirm'
 
 const mockRefetch = vi.fn()
 const mockDelete = vi.fn()
+const mockDeleteState = { isPending: false }
 const mockToastSuccess = vi.hoisted(() => vi.fn())
 const mockToastError = vi.hoisted(() => vi.fn())
 
@@ -12,7 +14,10 @@ vi.mock('../use-subscription-list', () => ({
 }))
 
 vi.mock('@/service/use-triggers', () => ({
-  useDeleteTriggerSubscription: () => ({ mutate: mockDelete, isPending: false }),
+  useDeleteTriggerSubscription: () => ({
+    mutate: mockDelete,
+    isPending: mockDeleteState.isPending,
+  }),
 }))
 
 vi.mock('@langgenius/dify-ui/toast', async (importOriginal) => {
@@ -29,6 +34,7 @@ vi.mock('@langgenius/dify-ui/toast', async (importOriginal) => {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockDeleteState.isPending = false
   mockDelete.mockImplementation((_id: string, options?: { onSuccess?: () => void }) => {
     options?.onSuccess?.()
   })
@@ -58,8 +64,9 @@ describe('DeleteConfirm', () => {
     )
   })
 
-  it('should allow deletion after matching input name', () => {
+  it('should allow deletion by submitting a matching input name', async () => {
     const onClose = vi.fn()
+    const user = userEvent.setup()
 
     render(
       <DeleteConfirm
@@ -71,17 +78,11 @@ describe('DeleteConfirm', () => {
       />,
     )
 
-    fireEvent.change(
-      screen.getByPlaceholderText(
-        /pluginTrigger\.subscription\.list\.item\.actions\.deleteConfirm\.confirmInputPlaceholder/,
-      ),
-      { target: { value: 'Subscription One' } },
-    )
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: /pluginTrigger\.subscription\.list\.item\.actions\.deleteConfirm\.confirm/,
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /pluginTrigger\.subscription\.list\.item\.actions\.deleteConfirm\.confirmInputTip/,
       }),
+      'Subscription One{Enter}',
     )
 
     expect(mockDelete).toHaveBeenCalledWith('sub-1', expect.any(Object))
@@ -111,5 +112,29 @@ describe('DeleteConfirm', () => {
     )
 
     expect(mockToastError).toHaveBeenCalledWith('network error')
+  })
+
+  it('should ignore form submission while deletion is pending', async () => {
+    mockDeleteState.isPending = true
+    const user = userEvent.setup()
+
+    render(
+      <DeleteConfirm
+        isShow
+        currentId="sub-1"
+        currentName="Subscription One"
+        workflowsInUse={1}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await user.type(
+      screen.getByRole('textbox', {
+        name: /pluginTrigger\.subscription\.list\.item\.actions\.deleteConfirm\.confirmInputTip/,
+      }),
+      'Subscription One{Enter}',
+    )
+
+    expect(mockDelete).not.toHaveBeenCalled()
   })
 })

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/delete-confirm.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/delete-confirm.tsx
@@ -7,10 +7,11 @@ import {
   AlertDialogDescription,
   AlertDialogTitle,
 } from '@langgenius/dify-ui/alert-dialog'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { useDeleteTriggerSubscription } from '@/service/use-triggers'
 import { useSubscriptionList } from './use-subscription-list'
 
@@ -38,6 +39,8 @@ export const DeleteConfirm = (props: Props) => {
   }
 
   const onConfirm = () => {
+    if (isDeleting) return
+
     if (workflowsInUse > 0 && inputName !== currentName) {
       toast.error(t(($) => $[`${tPrefix}.confirmInputWarning`], { ns: 'pluginTrigger' }))
       return
@@ -61,45 +64,52 @@ export const DeleteConfirm = (props: Props) => {
   return (
     <AlertDialog open={isShow} onOpenChange={handleOpenChange}>
       <AlertDialogContent backdropProps={{ forceRender: true }}>
-        <div className="flex flex-col gap-2 px-6 pt-6 pb-4">
-          <AlertDialogTitle className="w-full truncate title-2xl-semi-bold text-text-primary">
-            {t(($) => $[`${tPrefix}.title`], { ns: 'pluginTrigger', name: currentName })}
-          </AlertDialogTitle>
-          <AlertDialogDescription className="w-full system-md-regular wrap-break-word whitespace-pre-wrap text-text-tertiary">
-            {workflowsInUse > 0
-              ? t(($) => $[`${tPrefix}.contentWithApps`], {
-                  ns: 'pluginTrigger',
-                  count: workflowsInUse,
-                })
-              : t(($) => $[`${tPrefix}.content`], { ns: 'pluginTrigger' })}
-          </AlertDialogDescription>
-          {workflowsInUse > 0 && (
-            <div className="mt-6">
-              <div className="mb-2 system-sm-medium text-text-secondary">
-                {t(($) => $[`${tPrefix}.confirmInputTip`], {
-                  ns: 'pluginTrigger',
-                  name: currentName,
-                })}
-              </div>
-              <Input
-                value={inputName}
-                onChange={(e) => setInputName(e.target.value)}
-                placeholder={t(($) => $[`${tPrefix}.confirmInputPlaceholder`], {
-                  ns: 'pluginTrigger',
-                  name: currentName,
-                })}
-              />
-            </div>
-          )}
-        </div>
-        <AlertDialogActions>
-          <AlertDialogCancelButton disabled={isDeleting}>
-            {t(($) => $['operation.cancel'], { ns: 'common' })}
-          </AlertDialogCancelButton>
-          <AlertDialogConfirmButton loading={isDeleting} disabled={isDeleting} onClick={onConfirm}>
-            {t(($) => $[`${tPrefix}.confirm`], { ns: 'pluginTrigger' })}
-          </AlertDialogConfirmButton>
-        </AlertDialogActions>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            onConfirm()
+          }}
+        >
+          <div className="flex flex-col gap-2 px-6 pt-6 pb-4">
+            <AlertDialogTitle className="w-full truncate title-2xl-semi-bold text-text-primary">
+              {t(($) => $[`${tPrefix}.title`], { ns: 'pluginTrigger', name: currentName })}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="w-full system-md-regular wrap-break-word whitespace-pre-wrap text-text-tertiary">
+              {workflowsInUse > 0
+                ? t(($) => $[`${tPrefix}.contentWithApps`], {
+                    ns: 'pluginTrigger',
+                    count: workflowsInUse,
+                  })
+                : t(($) => $[`${tPrefix}.content`], { ns: 'pluginTrigger' })}
+            </AlertDialogDescription>
+            {workflowsInUse > 0 && (
+              <Field className="mt-6 gap-2" name="confirmation">
+                <FieldLabel className="py-0">
+                  {t(($) => $[`${tPrefix}.confirmInputTip`], {
+                    ns: 'pluginTrigger',
+                    name: currentName,
+                  })}
+                </FieldLabel>
+                <Input
+                  value={inputName}
+                  onChange={(e) => setInputName(e.target.value)}
+                  placeholder={t(($) => $[`${tPrefix}.confirmInputPlaceholder`], {
+                    ns: 'pluginTrigger',
+                    name: currentName,
+                  })}
+                />
+              </Field>
+            )}
+          </div>
+          <AlertDialogActions>
+            <AlertDialogCancelButton disabled={isDeleting}>
+              {t(($) => $['operation.cancel'], { ns: 'common' })}
+            </AlertDialogCancelButton>
+            <AlertDialogConfirmButton type="submit" loading={isDeleting}>
+              {t(($) => $[`${tPrefix}.confirm`], { ns: 'pluginTrigger' })}
+            </AlertDialogConfirmButton>
+          </AlertDialogActions>
+        </form>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/web/app/components/workflow/nodes/human-input/components/__tests__/timeout.spec.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/__tests__/timeout.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { withSelectorKey } from '@/test/i18n-mock'
 import TimeoutInput from '../timeout'
@@ -7,22 +7,6 @@ const mockUseTranslation = vi.hoisted(() => vi.fn())
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => mockUseTranslation(),
-}))
-
-vi.mock('@/app/components/base/input', () => ({
-  __esModule: true,
-  default: (props: {
-    value: number
-    disabled?: boolean
-    onChange: (event: { target: { value: string } }) => void
-  }) => (
-    <input
-      data-testid="timeout-input"
-      value={props.value}
-      disabled={props.disabled}
-      onChange={(e) => props.onChange({ target: { value: e.target.value } })}
-    />
-  ),
 }))
 
 describe('TimeoutInput', () => {
@@ -35,29 +19,32 @@ describe('TimeoutInput', () => {
     })
   })
 
-  it('should update the numeric timeout value and switch units', async () => {
+  it('should update the timeout with the keyboard and switch units', async () => {
     const user = userEvent.setup()
     render(<TimeoutInput timeout={3} unit="day" onChange={onChange} />)
 
-    fireEvent.change(screen.getByTestId('timeout-input'), { target: { value: '12' } })
+    const timeoutInput = screen.getByRole('textbox', { name: 'nodes.humanInput.timeout.title' })
+    await user.click(timeoutInput)
+    await user.keyboard('{ArrowUp}')
     await user.click(screen.getByRole('radio', { name: 'nodes.humanInput.timeout.hours' }))
 
-    expect(onChange).toHaveBeenNthCalledWith(1, { timeout: 12, unit: 'day' })
+    expect(onChange).toHaveBeenNthCalledWith(1, { timeout: 4, unit: 'day' })
     expect(onChange).toHaveBeenNthCalledWith(2, { timeout: 3, unit: 'hour' })
   })
 
-  it('should fall back to 1 on invalid input and stay read-only when disabled', async () => {
+  it('should fall back to 1 when cleared and stay read-only when disabled', async () => {
     const user = userEvent.setup()
     const { rerender } = render(<TimeoutInput timeout={5} unit="hour" onChange={onChange} />)
 
-    fireEvent.change(screen.getByTestId('timeout-input'), { target: { value: 'abc' } })
+    const timeoutInput = screen.getByRole('textbox', { name: 'nodes.humanInput.timeout.title' })
+    await user.clear(timeoutInput)
     expect(onChange).toHaveBeenCalledWith({ timeout: 1, unit: 'hour' })
 
     rerender(<TimeoutInput timeout={5} unit="hour" onChange={onChange} readonly />)
 
     await user.click(screen.getByRole('radio', { name: 'nodes.humanInput.timeout.days' }))
     expect(onChange).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('timeout-input')).toBeDisabled()
+    expect(screen.getByRole('textbox', { name: 'nodes.humanInput.timeout.title' })).toBeDisabled()
     expect(screen.getByRole('radio', { name: 'nodes.humanInput.timeout.days' })).toBeDisabled()
   })
 })

--- a/web/app/components/workflow/nodes/human-input/components/timeout.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/timeout.tsx
@@ -1,8 +1,7 @@
 import type { FC } from 'react'
+import { NumberField, NumberFieldGroup, NumberFieldInput } from '@langgenius/dify-ui/number-field'
 import { SegmentedControl, SegmentedControlItem } from '@langgenius/dify-ui/segmented-control'
-import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 
 const i18nPrefix = 'nodes.humanInput'
 
@@ -22,21 +21,18 @@ const TimeoutInput: FC<Props> = ({ timeout, unit, onChange, readonly }) => {
   const daysLabel = t(($) => $[`${i18nPrefix}.timeout.days`], { ns: 'workflow' })
   const hoursLabel = t(($) => $[`${i18nPrefix}.timeout.hours`], { ns: 'workflow' })
 
-  const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    if (/^\d*$/.test(value)) onChange({ timeout: Number(value) || 1, unit })
-    else onChange({ timeout: 1, unit })
-  }
   return (
     <div className="flex items-center gap-1">
-      <Input
-        wrapperClassName="w-16"
-        type="number"
+      <NumberField
         value={timeout}
         min={1}
-        onChange={handleValueChange}
+        onValueChange={(value) => onChange({ timeout: value ?? 1, unit })}
         disabled={readonly}
-      />
+      >
+        <NumberFieldGroup className="w-16">
+          <NumberFieldInput aria-label={timeoutLabel} />
+        </NumberFieldGroup>
+      </NumberField>
       <SegmentedControl<'day' | 'hour'>
         value={unit}
         onValueChange={(unit) => onChange({ timeout, unit })}


### PR DESCRIPTION
## Summary

- replace the legacy confirmation input with Dify UI Field and Input
- make the destructive confirmation a real form with Enter submission
- preserve the existing 24px section offset and 8px label-to-input gap
- block repeated form submissions while deletion is pending

## Validation

- `vp test run --project unit app/components/plugins/plugin-detail-panel/subscription-list/__tests__/delete-confirm.spec.tsx`
- targeted `vp check`
- targeted accessibility lint
- full repository `vpr check`