### PR TITLE
fix(api): re-sign bare and backticked file URLs

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1662,16 +1662,21 @@ class Message(Base):
         if not self.answer:
             return self.answer
 
-        pattern = r"\[!?.*?\]\((((http|https):\/\/.+)?\/files\/(tools\/)?[\w-]+.*?timestamp=.*&nonce=.*&sign=.*)\)"
+        # Match the signed file URL itself rather than the markdown that may surround it, so bare,
+        # backticked and fenced occurrences are re-signed too. `url_char` stops the match at the
+        # delimiters that can terminate a URL in an answer (whitespace, markdown link/quote chars).
+        url_char = r"[^\s)\]`\"'<>]"
+        pattern = (
+            rf"(?:https?://{url_char}+)?/files/(?:tools/)?"
+            rf"{url_char}*?timestamp={url_char}*?nonce={url_char}*?sign={url_char}*"
+        )
         matches = re.findall(pattern, self.answer)
 
         if not matches:
             return self.answer
 
-        urls = [match[0] for match in matches]
-
         # remove duplicate urls
-        urls = list(set(urls))
+        urls = list(set(matches))
 
         if not urls:
             return self.answer

--- a/api/tests/unit_tests/models/test_re_sign_file_url_answer.py
+++ b/api/tests/unit_tests/models/test_re_sign_file_url_answer.py
@@ -1,0 +1,54 @@
+import pytest
+
+from models import model as model_module
+from models.model import Message
+
+
+@pytest.fixture
+def patch_file_signers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        model_module.file_helpers,
+        "get_signed_file_url",
+        lambda file_id: f"https://files.example/{file_id}",
+    )
+    monkeypatch.setattr(
+        model_module,
+        "sign_tool_file",
+        lambda tool_file_id, extension: (
+            f"https://files.example/tools/{tool_file_id}{extension}?timestamp=999&nonce=new&sign=new"
+        ),
+    )
+
+
+def test_bare_file_preview_url_is_re_signed(patch_file_signers: None) -> None:
+    upload_id = "bare-1"
+    url = f"http://api:5001/files/{upload_id}/file-preview?timestamp=111&nonce=222&sign=333"
+    message = Message(answer=f"Download:\n{url}")
+
+    result = message.re_sign_file_url_answer
+
+    assert result == f"Download:\nhttps://files.example/{upload_id}"
+    assert "http://api:5001" not in result
+
+
+def test_backticked_tool_file_url_is_re_signed(patch_file_signers: None) -> None:
+    tool_file_id = "5c465079-d1ee-c17e-f8fd-000000000001"
+    url = f"http://api:5001/files/tools/{tool_file_id}.py?timestamp=111&nonce=222&sign=333"
+    message = Message(answer=f"Download:\n`{url}`")
+
+    result = message.re_sign_file_url_answer
+
+    assert result == (
+        "Download:\n`https://files.example/tools/"
+        f"{tool_file_id}.py?timestamp=999&nonce=new&sign=new`"
+    )
+
+
+def test_multiple_bare_file_urls_are_re_signed_independently(patch_file_signers: None) -> None:
+    first = "/files/multi-a/file-preview?timestamp=1&nonce=2&sign=3"
+    second = "/files/multi-b/file-preview?timestamp=4&nonce=5&sign=6"
+    message = Message(answer=f"first {first} then {second}")
+
+    result = message.re_sign_file_url_answer
+
+    assert result == "first https://files.example/multi-a then https://files.example/multi-b"


### PR DESCRIPTION
## Summary

Fixes #40788.

`Message.re_sign_file_url_answer` currently only detects signed file URLs when they are wrapped in Markdown link syntax. If an Agent returns the same signed URL as plain text, inside backticks, or in a fenced block, the URL is not re-signed and an internal Docker hostname such as `http://api:5001` can leak to the client.

This change matches the signed file URL itself instead of requiring the surrounding Markdown wrapper. It keeps the existing re-signing logic intact while allowing bare, backticked, fenced, and Markdown-linked file URLs to be refreshed and rebound to the externally configured file origin.

### Changes

- Update `Message.re_sign_file_url_answer` to match signed `/files/...` URLs independently of surrounding Markdown syntax.
- Bound URL matching at common answer delimiters so multiple signed URLs in one answer are handled independently.
- Add regression coverage for:
  - a bare `file-preview` URL with an internal host;
  - a backticked tool-file URL;
  - multiple bare signed URLs in the same answer.

### Reproduction

With a self-hosted Docker deployment:

```env
FILES_URL=https://example.com
INTERNAL_FILES_URL=http://api:5001
```

an Agent may return:

```text
Download:
`http://api:5001/files/tools/<id>.py?timestamp=...&nonce=...&sign=...`
```

Before this change, the backticked URL is not recognized by `re_sign_file_url_answer` and reaches the client unchanged. After this change, it is re-signed using the existing external file URL path.

### Scope

This PR intentionally does not change `ToolFileManager.sign_file()`. That method is used for internal plugin/tool access and `INTERNAL_FILES_URL` remains valid for that audience. The fix is on the message read/display path where URLs exposed to clients must be re-signed for the external audience.

### Testing

Regression tests are included in `api/tests/unit_tests/models/test_re_sign_file_url_answer.py`.

I was able to validate the change structurally against the current `main` branch and keep the diff isolated to the URL matcher plus regression tests. Full repository test execution was not available in this ChatGPT environment.

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added regression tests for the introduced behavior.
- [ ] I've updated the documentation accordingly.
