### PR TITLE
refactor(dify-ui): compose dialog close controls

### DIFF
--- a/packages/dify-ui/src/dialog/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/dialog/__tests__/index.spec.tsx
@@ -1,8 +1,9 @@
 import { render } from 'vitest-browser-react'
+import { IconButton } from '../../icon-button'
 import {
   createDialogHandle,
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -46,24 +47,22 @@ describe('Dialog wrapper', () => {
     })
   })
 
-  describe('Props', () => {
-    it('should not render close button when DialogCloseButton is not provided', async () => {
+  describe('Composition', () => {
+    it('should compose an explicitly named IconButton as the close control', async () => {
       const screen = await render(
         <Dialog open>
           <DialogContent>
-            <span>Dialog body</span>
-          </DialogContent>
-        </Dialog>,
-      )
-
-      expect(() => screen.getByRole('button', { name: 'Close' }).element()).toThrow()
-    })
-
-    it('should render explicit close button with custom aria-label', async () => {
-      const screen = await render(
-        <Dialog open>
-          <DialogContent>
-            <DialogCloseButton aria-label="Dismiss dialog" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label="Dismiss dialog"
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <span>Dialog body</span>
           </DialogContent>
         </Dialog>,
@@ -74,31 +73,53 @@ describe('Dialog wrapper', () => {
         .toBeInTheDocument()
     })
 
-    it('should render default close button label when aria-label is omitted', async () => {
+    it('should close the dialog when the composed close control is activated', async () => {
       const screen = await render(
-        <Dialog open>
+        <Dialog defaultOpen>
           <DialogContent>
-            <DialogCloseButton />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label="Close dialog"
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <span>Dialog body</span>
           </DialogContent>
         </Dialog>,
       )
 
-      await expect.element(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+      await screen.getByRole('button', { name: 'Close dialog' }).click()
+
+      await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument()
     })
 
-    it('should forward close button props to base primitive', async () => {
+    it('should preserve the disabled state of a composed close control', async () => {
       const screen = await render(
         <Dialog open>
           <DialogContent>
-            <DialogCloseButton data-testid="close-button" disabled />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label="Close dialog"
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                  disabled
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <span>Dialog body</span>
           </DialogContent>
         </Dialog>,
       )
 
-      const closeButton = screen.getByTestId('close-button')
-      await expect.element(closeButton).toBeDisabled()
+      await expect.element(screen.getByRole('button', { name: 'Close dialog' })).toBeDisabled()
     })
   })
 })

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -319,7 +319,7 @@ const FormDialogDemo = () => {
                   href="https://docs.dify.ai/use-dify/workspace/api-extension/api-extension"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex w-fit items-center text-text-accent underline decoration-text-accent/60 decoration-1 underline-offset-2 outline-hidden hover:decoration-text-accent focus-visible:rounded-xs focus-visible:no-underline focus-visible:ring-1 focus-visible:ring-components-input-border-active"
+                  className="inline-flex w-fit items-center text-text-accent underline decoration-text-accent/60 decoration-1 underline-offset-2 outline-hidden hover:decoration-text-accent focus-visible:rounded-xs focus-visible:no-underline focus-visible:ring-2 focus-visible:ring-state-accent-solid"
                 >
                   View API extension docs
                 </a>

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -5,7 +5,7 @@ import {
   createDialogHandle,
   Dialog,
   DialogBackdrop,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogPopup,
@@ -17,6 +17,7 @@ import {
 import { Button } from '../button'
 import { Field, FieldDescription, FieldError, FieldLabel } from '../field'
 import { Form } from '../form'
+import { IconButton } from '../icon-button'
 import { Input } from '../input'
 import {
   ScrollArea,
@@ -34,7 +35,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Compound modal dialog built on Base UI Dialog. Use it for focused flows that interrupt the user, such as editing settings, confirming non-destructive actions, or collecting short-form input. Compose `DialogTitle`, `DialogDescription`, and optional `DialogCloseButton` inside `DialogContent`.',
+          'Compound modal dialog built on Base UI Dialog. Use it for focused flows that interrupt the user, such as editing settings, confirming non-destructive actions, or collecting short-form input. `DialogClose` is unstyled anatomy: compose it with `IconButton` for an icon-only control or `Button` for a visible action.',
       },
     },
   },
@@ -76,10 +77,10 @@ function ReleaseNoteSections() {
   )
 }
 
-function ReleaseNoteFooter({ onClose }: { onClose: () => void }) {
+function ReleaseNoteFooter() {
   return (
     <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
-      <Button onClick={onClose}>Close</Button>
+      <DialogClose render={<Button />}>Close</DialogClose>
     </div>
   )
 }
@@ -89,7 +90,13 @@ export const Default: Story = {
     <Dialog>
       <DialogTrigger render={<Button />}>Open dialog</DialogTrigger>
       <DialogContent>
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton aria-label="Close dialog" size="lg" className="absolute inset-e-6 top-6">
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="flex flex-col gap-2 pr-8">
           <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
             Invite collaborators
@@ -121,7 +128,7 @@ export const Default: Story = {
     })
     await expect(body.getByRole('textbox', { name: 'Email address' })).toBeVisible()
 
-    await userEvent.click(body.getByRole('button', { name: 'Close' }))
+    await userEvent.click(body.getByRole('button', { name: 'Close dialog' }))
     await waitFor(async () => {
       await expect(
         body.queryByRole('dialog', { name: 'Invite collaborators' }),
@@ -164,7 +171,13 @@ const ControlledDemo = () => {
       <span className="text-xs text-text-tertiary">State: {open ? 'open' : 'closed'}</span>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton aria-label="Close dialog" size="lg" className="absolute inset-e-6 top-6">
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <div className="flex flex-col gap-2 pr-8">
             <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
               Rename workspace
@@ -223,7 +236,17 @@ function DetachedTriggersDemo() {
       <Dialog handle={dialogHandle}>
         {({ payload }) => (
           <DialogContent>
-            <DialogCloseButton />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label="Close dialog"
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <div className="grid gap-2 pr-8">
               <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
                 {payload ? `Edit ${payload.name}` : 'Edit workspace'}
@@ -258,7 +281,13 @@ const FormDialogDemo = () => {
     <Dialog open={open} onOpenChange={setOpen} disablePointerDismissal>
       <DialogTrigger render={<Button />}>Configure API extension</DialogTrigger>
       <DialogContent backdropProps={{ forceRender: true }} className="w-160">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton aria-label="Close dialog" size="lg" className="absolute inset-e-6 top-6">
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="grid gap-2 pr-8">
           <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
             Configure API extension
@@ -346,13 +375,23 @@ const OutsideScrollingContentDemo = () => {
                   initialFocus={popupRef}
                   className="relative mx-auto flex w-120 max-w-[calc(100vw-2rem)] flex-col overflow-hidden outline-hidden transition-[translate] duration-700 ease-[cubic-bezier(0.45,1.005,0,1.005)] data-ending-style:translate-y-[max(100dvh,100%)] data-ending-style:scale-100 data-ending-style:opacity-100 data-ending-style:duration-350 data-ending-style:ease-[cubic-bezier(0.375,0.015,0.545,0.455)] data-starting-style:translate-y-[100dvh] data-starting-style:scale-100 data-starting-style:opacity-100"
                 >
-                  <DialogCloseButton />
+                  <DialogClose
+                    render={
+                      <IconButton
+                        aria-label="Close dialog"
+                        size="lg"
+                        className="absolute inset-e-6 top-6"
+                      >
+                        <span aria-hidden className="i-ri-close-line size-4" />
+                      </IconButton>
+                    }
+                  />
                   <ReleaseNoteHeader
                     title="Long release notes"
                     description="This layout lets the outer dialog viewport scroll while the popup keeps its natural height."
                   />
                   <ReleaseNoteSections />
-                  <ReleaseNoteFooter onClose={() => setOpen(false)} />
+                  <ReleaseNoteFooter />
                 </DialogPopup>
               </ScrollAreaContent>
             </ScrollAreaViewport>
@@ -378,10 +417,17 @@ export const OutsidePopupElements: Story = {
         <DialogBackdrop className="min-h-dvh" />
         <DialogViewport className="grid place-items-center px-4 py-12 xl:py-6">
           <DialogPopup className="group/popup pointer-events-none relative flex h-full w-full max-w-280 justify-center border-0 bg-transparent shadow-none transition-opacity data-ending-style:scale-100 data-ending-style:opacity-0 data-starting-style:scale-100 data-starting-style:opacity-0">
-            <DialogCloseButton
-              aria-label="Close"
-              className="pointer-events-auto absolute -top-10 right-0 z-10 flex size-8 items-center justify-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg text-text-tertiary shadow-xs outline-hidden hover:bg-components-button-secondary-bg-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid xl:top-0"
-            ></DialogCloseButton>
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label="Close"
+                  size="lg"
+                  className="pointer-events-auto absolute -top-10 right-0 z-10 flex items-center justify-center border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg text-text-tertiary shadow-xs outline-hidden hover:bg-components-button-secondary-bg-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid xl:top-0"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <div className="pointer-events-auto flex h-full w-full max-w-280 flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-6 shadow-xl transition-[scale] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-starting-style/popup:scale-105">
               <div className="grid gap-2">
                 <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
@@ -413,7 +459,17 @@ const InsideScrollingContentDemo = () => {
         <DialogBackdrop />
         <DialogViewport className="flex items-center justify-center overflow-hidden p-4">
           <DialogPopup className="relative flex h-[min(44rem,calc(100dvh-2rem))] min-h-0 w-120 max-w-[calc(100vw-2rem)] flex-col overflow-hidden">
-            <DialogCloseButton />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label="Close dialog"
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <ReleaseNoteHeader
               title="Release notes"
               description="Highlights from the latest workspace update."
@@ -432,7 +488,7 @@ const InsideScrollingContentDemo = () => {
                 <ScrollAreaThumb />
               </ScrollAreaScrollbar>
             </ScrollArea>
-            <ReleaseNoteFooter onClose={() => setOpen(false)} />
+            <ReleaseNoteFooter />
           </DialogPopup>
         </DialogViewport>
       </DialogPortal>

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -276,81 +276,95 @@ type ApiExtensionFormValues = {
 
 const FormDialogDemo = () => {
   const [open, setOpen] = React.useState(false)
+  const nameInputRef = React.useRef<HTMLInputElement>(null)
 
   return (
     <Dialog open={open} onOpenChange={setOpen} disablePointerDismissal>
       <DialogTrigger render={<Button />}>Configure API extension</DialogTrigger>
-      <DialogContent backdropProps={{ forceRender: true }} className="w-160">
-        <DialogClose
-          render={
-            <IconButton aria-label="Close dialog" size="lg" className="absolute inset-e-6 top-6">
-              <span aria-hidden className="i-ri-close-line size-4" />
-            </IconButton>
-          }
-        />
-        <div className="grid gap-2 pr-8">
-          <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
-            Configure API extension
-          </DialogTitle>
-          <DialogDescription className="text-sm leading-5 text-text-secondary">
-            Save the endpoint and credentials used by this workspace integration.
-          </DialogDescription>
-        </div>
-        <Form<ApiExtensionFormValues>
-          className="grid gap-4 pt-5"
-          onFormSubmit={() => setOpen(false)}
+      <DialogPortal>
+        <DialogBackdrop forceRender />
+        <DialogPopup
+          initialFocus={nameInputRef}
+          className="fixed top-1/2 left-1/2 max-h-[80dvh] w-160 max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto overscroll-contain p-6"
         >
-          <Field name="name">
-            <FieldLabel>Name</FieldLabel>
-            <Input required placeholder="Production API" />
-            <FieldError match="valueMissing">Name is required.</FieldError>
-          </Field>
-          <Field name="endpoint">
-            <FieldLabel>Endpoint</FieldLabel>
-            <Input type="url" required placeholder="https://api.example.com" />
-            <FieldDescription>
-              <a
-                href="https://docs.dify.ai/use-dify/workspace/api-extension/api-extension"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex w-fit items-center text-text-accent outline-hidden focus-visible:ring-1 focus-visible:ring-components-input-border-active"
-              >
-                View API extension docs
-              </a>
-            </FieldDescription>
-            <FieldError match="valueMissing">Endpoint is required.</FieldError>
-            <FieldError match="typeMismatch">Enter a valid URL.</FieldError>
-          </Field>
-          <Field
-            name="apiKey"
-            validate={(value) => {
-              if (typeof value === 'string' && value.length > 0 && value.length < 5)
-                return 'API key must be at least 5 characters.'
-
-              return null
-            }}
-          >
-            <FieldLabel>API key</FieldLabel>
-            <Input required placeholder="sk-..." />
-            <FieldError match="valueMissing">API key is required.</FieldError>
-            <FieldError match="customError" />
-          </Field>
-          <div className="mt-2 flex items-center justify-end gap-2">
-            <Button type="button" onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="primary">
-              Save
-            </Button>
+          <DialogClose
+            render={
+              <IconButton aria-label="Close dialog" size="lg" className="absolute inset-e-6 top-6">
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
+          <div className="grid gap-2 pr-8">
+            <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
+              Configure API extension
+            </DialogTitle>
+            <DialogDescription className="text-sm leading-5 text-text-secondary">
+              Save the endpoint and credentials used by this workspace integration.
+            </DialogDescription>
           </div>
-        </Form>
-      </DialogContent>
+          <Form<ApiExtensionFormValues>
+            className="grid gap-4 pt-5"
+            onFormSubmit={() => setOpen(false)}
+          >
+            <Field name="name">
+              <FieldLabel>Name</FieldLabel>
+              <Input ref={nameInputRef} required placeholder="Production API" />
+              <FieldError match="valueMissing">Name is required.</FieldError>
+            </Field>
+            <Field name="endpoint">
+              <FieldLabel>Endpoint</FieldLabel>
+              <Input type="url" required placeholder="https://api.example.com" />
+              <FieldDescription>
+                <a
+                  href="https://docs.dify.ai/use-dify/workspace/api-extension/api-extension"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex w-fit items-center text-text-accent underline decoration-text-accent/60 decoration-1 underline-offset-2 outline-hidden hover:decoration-text-accent focus-visible:rounded-xs focus-visible:no-underline focus-visible:ring-1 focus-visible:ring-components-input-border-active"
+                >
+                  View API extension docs
+                </a>
+              </FieldDescription>
+              <FieldError match="valueMissing">Endpoint is required.</FieldError>
+              <FieldError match="typeMismatch">Enter a valid URL.</FieldError>
+            </Field>
+            <Field
+              name="apiKey"
+              validate={(value) => {
+                if (typeof value === 'string' && value.length > 0 && value.length < 5)
+                  return 'API key must be at least 5 characters.'
+
+                return null
+              }}
+            >
+              <FieldLabel>API key</FieldLabel>
+              <Input required placeholder="sk-..." />
+              <FieldError match="valueMissing">API key is required.</FieldError>
+              <FieldError match="customError" />
+            </Field>
+            <div className="mt-2 flex items-center justify-end gap-2">
+              <Button type="button" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary">
+                Save
+              </Button>
+            </div>
+          </Form>
+        </DialogPopup>
+      </DialogPortal>
     </Dialog>
   )
 }
 
 export const FormDialog: Story = {
   render: () => <FormDialogDemo />,
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const body = within(canvasElement.ownerDocument.body)
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Configure API extension' }))
+
+    await expect(body.getByRole('textbox', { name: 'Name' })).toHaveFocus()
+  },
 }
 
 const OutsideScrollingContentDemo = () => {

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -3,7 +3,6 @@
 import type * as React from 'react'
 import { Dialog as BaseDialog } from '@base-ui/react/dialog'
 import { cn } from '../cn'
-import { iconButtonVariants } from '../icon-button/variants'
 import { modalBackdropClassName, modalPopupAnimationClassName } from '../overlay-shared'
 
 const Dialog = BaseDialog.Root
@@ -55,30 +54,6 @@ function DialogPopup({ className, ...props }: DialogPopupProps) {
   )
 }
 
-type DialogCloseButtonProps = Omit<BaseDialog.Close.Props, 'children' | 'className'> & {
-  className?: string
-}
-
-function DialogCloseButton({
-  className,
-  'aria-label': ariaLabel = 'Close',
-  ...props
-}: DialogCloseButtonProps) {
-  return (
-    <BaseDialog.Close
-      aria-label={ariaLabel}
-      {...props}
-      className={cn(
-        iconButtonVariants({ size: 'sm' }),
-        'absolute inset-e-6 top-6 z-10 rounded-2xl disabled:cursor-not-allowed disabled:opacity-50',
-        className,
-      )}
-    >
-      <span aria-hidden="true" className="i-ri-close-line size-4 text-text-tertiary" />
-    </BaseDialog.Close>
-  )
-}
-
 type DialogContentProps = {
   children: React.ReactNode
   className?: string
@@ -112,7 +87,6 @@ export {
   Dialog,
   DialogBackdrop,
   DialogClose,
-  DialogCloseButton,
   DialogContent,
   DialogDescription,
   DialogPopup,
@@ -124,7 +98,6 @@ export {
 
 export type {
   DialogBackdropProps,
-  DialogCloseButtonProps,
   DialogCloseProps,
   DialogContentProps,
   DialogDescriptionProps,

--- a/web/app/components/api-key/api-key-modal.tsx
+++ b/web/app/components/api-key/api-key-modal.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type { ApiKeyItem } from '@dify/contracts/api/console/apps/types.gen'
 import {
   AlertDialog,
@@ -13,11 +12,12 @@ import {
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { skipToken, useMutation, useQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
 import { useState } from 'react'
@@ -177,7 +177,17 @@ export function ApiKeyModal({ open, canManage, scope, onOpenChange }: ApiKeyModa
               {t(($) => $['apiKeyModal.apiSecretKeyTips'], { ns: 'appApi' })}
             </DialogDescription>
           </div>
-          <DialogCloseButton aria-label={t(($) => $['operation.close'], { ns: 'common' })} />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           {isLoading && (
             <div className="flex min-h-24 items-center border-y border-divider-subtle px-6">
               <Loading />

--- a/web/app/components/api-key/created-api-key-dialog.tsx
+++ b/web/app/components/api-key/created-api-key-dialog.tsx
@@ -1,13 +1,13 @@
 'use client'
-
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
 import { useTranslation } from 'react-i18next'
 import { CopyFeedback } from '@/app/components/base/copy-feedback'
@@ -32,7 +32,17 @@ export function CreatedApiKeyDialog({ open, onOpenChange, value }: CreatedApiKey
             {t(($) => $['apiKeyModal.generateTips'], { ns: 'appApi' })}
           </DialogDescription>
         </div>
-        <DialogCloseButton aria-label={t(($) => $['operation.close'], { ns: 'common' })} />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="px-6 pb-4">
           <InputGroup>
             <InputGroupInput

--- a/web/app/components/app/app-access-control/__tests__/access-control.spec.tsx
+++ b/web/app/components/app/app-access-control/__tests__/access-control.spec.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderWithConsoleQuery as render } from '@/test/console/query-data'
 import AccessControlDialog from '../access-control-dialog'
 
@@ -15,6 +16,7 @@ describe('AccessControlDialog', () => {
   })
 
   it('should trigger onClose when clicking the close control', async () => {
+    const user = userEvent.setup()
     const handleClose = vi.fn()
     render(
       <AccessControlDialog show onClose={handleClose}>
@@ -22,10 +24,8 @@ describe('AccessControlDialog', () => {
       </AccessControlDialog>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
-    await waitFor(() => {
-      expect(handleClose).toHaveBeenCalledTimes(1)
-    })
+    expect(handleClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/app/components/app/app-access-control/access-control-dialog.tsx
+++ b/web/app/components/app/app-access-control/access-control-dialog.tsx
@@ -1,7 +1,9 @@
 import type { ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 
 type DialogProps = {
   className?: string
@@ -11,6 +13,7 @@ type DialogProps = {
 }
 
 const AccessControlDialog = ({ className, children, show, onClose }: DialogProps) => {
+  const { t } = useTranslation()
   const close = useCallback(() => {
     onClose?.()
   }, [onClose])
@@ -23,7 +26,17 @@ const AccessControlDialog = ({ className, children, show, onClose }: DialogProps
           className,
         )}
       >
-        <DialogCloseButton className="top-5 right-5 size-8" />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute top-5 right-5"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         {children}
       </DialogContent>
     </Dialog>

--- a/web/app/components/app/configuration/config/agent/agent-setting/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-setting/index.tsx
@@ -1,8 +1,9 @@
 'use client'
 import type { AgentConfig } from '@/models/debug'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { Fieldset, FieldsetLegend } from '@langgenius/dify-ui/fieldset'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import {
   Slider,
   SliderControl,
@@ -57,9 +58,16 @@ export function AgentSetting({ isChatModel, payload, isFunctionCall, onCancel, o
           <DialogTitle className="text-base leading-6 font-semibold text-text-primary">
             {t(($) => $['agent.setting.name'], { ns: 'appDebug' })}
           </DialogTitle>
-          <DialogCloseButton
-            className="static z-auto size-6 shrink-0"
-            aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="sm"
+                className="static z-auto size-6 shrink-0 rounded-2xl"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
           />
         </div>
         {/* Body */}

--- a/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
@@ -3,7 +3,8 @@ import type { FC } from 'react'
 import type { DataSet } from '@/models/datasets'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useInfiniteScroll } from 'ahooks'
 import { useAtomValue } from 'jotai'
 import * as React from 'react'
@@ -104,7 +105,17 @@ const SelectDataSet: FC<ISelectDataSetProps> = ({
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $['feature.dataSet.selectTitle'], { ns: 'appDebug' })}
         </DialogTitle>
-        <DialogCloseButton aria-label={t(($) => $['operation.close'], { ns: 'common' })} />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         {isLoading && datasets.length === 0 && (
           <div className="flex h-50">
             <Loading type="area" />

--- a/web/app/components/app/deploy/deployment-dialog/deployment-configuration/index.tsx
+++ b/web/app/components/app/deploy/deployment-dialog/deployment-configuration/index.tsx
@@ -1,10 +1,10 @@
 'use client'
-
 import type { DeploymentVersion } from '../../version'
 import type { DeploymentDialogRequest } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { DialogCloseButton, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { DialogClose, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useTranslation } from 'react-i18next'
 import { useDeployWorkflow } from '../../use-deploy-workflow'
 import { DeploymentConfigurationContent } from './content'
@@ -77,10 +77,17 @@ export function DeploymentConfiguration({
       }}
     >
       {!embedded && (
-        <DialogCloseButton
-          type="button"
-          aria-label={tCommon(($) => $['operation.close'])}
-          className="top-5 right-5 size-8 rounded-lg"
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={tCommon(($) => $['operation.close'])}
+              size="lg"
+              className="absolute top-5 right-5"
+              type="button"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
         />
       )}
       <header className={cn('shrink-0', embedded ? 'px-3 pt-3.5 pb-1' : 'px-5 pt-5 pr-14 pb-1')}>

--- a/web/app/components/app/deploy/deployment-dialog/version-selection/index.tsx
+++ b/web/app/components/app/deploy/deployment-dialog/version-selection/index.tsx
@@ -1,11 +1,11 @@
 'use client'
-
 import type { ReactNode } from 'react'
 import type { DeploymentVersion } from '../../version'
 import type { DeploymentDialogRequest } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { DialogCloseButton, DialogDescription, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { DialogClose, DialogDescription, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useAtomValue } from 'jotai'
 import { useTranslation } from 'react-i18next'
 import { useFormatTimeFromNow } from '@/hooks/use-format-time-from-now'
@@ -210,10 +210,17 @@ export function VersionSelection({
 
   return (
     <>
-      <DialogCloseButton
-        type="button"
-        aria-label={tCommon(($) => $['operation.close'])}
-        className="top-5 right-5 size-8 rounded-lg"
+      <DialogClose
+        render={
+          <IconButton
+            aria-label={tCommon(($) => $['operation.close'])}
+            size="lg"
+            className="absolute top-5 right-5"
+            type="button"
+          >
+            <span aria-hidden className="i-ri-close-line size-4" />
+          </IconButton>
+        }
       />
       <header className="shrink-0 px-6 pt-6 pr-14 pb-3">
         <DialogTitle className="title-2xl-semi-bold text-text-primary">{title}</DialogTitle>

--- a/web/app/components/app/overview/customize/index.tsx
+++ b/web/app/components/app/overview/customize/index.tsx
@@ -3,11 +3,12 @@ import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDocLink } from '@/context/i18n'
@@ -73,7 +74,17 @@ const CustomizeModal: FC<IShareLinkProps> = ({
         <DialogDescription className="mt-2 shrink-0 body-md-regular text-text-secondary">
           {t(($) => $[`${prefixCustomize}.explanation`], { ns: 'appOverview' })}
         </DialogDescription>
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="mt-4 min-h-0 flex-1 overflow-y-auto overscroll-contain">
           <div className="w-full rounded-lg border-[0.5px] border-components-panel-border px-6 py-5">
             <span className="inline-flex shrink-0 rounded-[5px] border border-text-accent-secondary bg-components-badge-bg-dimm px-1 py-0.5 system-2xs-medium-uppercase text-text-accent-secondary">

--- a/web/app/components/app/overview/embedded/__tests__/index.spec.tsx
+++ b/web/app/components/app/overview/embedded/__tests__/index.spec.tsx
@@ -118,15 +118,14 @@ describe('Embedded', () => {
   })
 
   it('calls onClose when the close button is clicked', async () => {
+    const user = userEvent.setup()
     const onClose = vi.fn()
 
     await act(async () => {
       render(<Embedded {...baseProps} onClose={onClose} />)
     })
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-    })
+    await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/web/app/components/app/overview/embedded/index.tsx
+++ b/web/app/components/app/overview/embedded/index.tsx
@@ -6,7 +6,7 @@ import type {
 } from '../app-card-utils'
 import type { SiteInfo } from '@/models/share'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -376,7 +376,17 @@ const Embedded = ({
         <DialogTitle className="shrink-0 title-2xl-semi-bold text-text-primary">
           {t(($) => $[`${prefixEmbedded}.title`], { ns: 'appOverview' })}
         </DialogTitle>
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
           {isShow && (
             <EmbeddedContent

--- a/web/app/components/app/overview/settings/index.tsx
+++ b/web/app/components/app/overview/settings/index.tsx
@@ -4,9 +4,10 @@ import type { AppIconSelection } from '@/app/components/base/app-icon-picker'
 import type { AppIconType, Language, SiteConfig } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { Field, FieldDescription, FieldLabel } from '@langgenius/dify-ui/field'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import {
   ScrollArea,
@@ -365,7 +366,17 @@ const SettingsModal: FC<ISettingsModalProps> = ({
               <DialogTitle className="grow title-2xl-semi-bold text-text-primary">
                 {t(($) => $[`${prefixSettings}.title`], { ns: 'appOverview' })}
               </DialogTitle>
-              <DialogCloseButton className="relative top-auto right-auto shrink-0" />
+              <DialogClose
+                render={
+                  <IconButton
+                    aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                    size="sm"
+                    className="relative top-auto right-auto shrink-0 rounded-2xl"
+                  >
+                    <span aria-hidden className="i-ri-close-line size-4" />
+                  </IconButton>
+                }
+              />
             </div>
             <div className="mt-0.5 system-xs-regular text-text-tertiary">
               <span>{t(($) => $[`${prefixSettings}.modalTip`], { ns: 'appOverview' })}</span>

--- a/web/app/components/base/chat/chat/answer/operation.tsx
+++ b/web/app/components/base/chat/chat/answer/operation.tsx
@@ -4,7 +4,7 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -479,7 +479,17 @@ function Operation({
                   {t(($) => $['feedback.subtitle'], { ns: 'common' }) ||
                     'Please tell us what went wrong with this response'}
                 </DialogDescription>
-                <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+                <DialogClose
+                  render={
+                    <IconButton
+                      aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                      size="lg"
+                      className="absolute top-5 right-5"
+                    >
+                      <span aria-hidden className="i-ri-close-line size-4" />
+                    </IconButton>
+                  }
+                />
               </div>
               <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
                 <label

--- a/web/app/components/base/features/new-feature-panel/follow-up-setting-modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/follow-up-setting-modal.tsx
@@ -2,9 +2,10 @@ import type { SuggestedQuestionsAfterAnswer } from '@/app/components/base/featur
 import type { FormValue } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import type { CompletionParams, Model, ModelModeType } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { Field, FieldItem } from '@langgenius/dify-ui/field'
 import { Fieldset, FieldsetLegend } from '@langgenius/dify-ui/fieldset'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { RadioControl, RadioGroup, RadioItem } from '@langgenius/dify-ui/radio'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { produce } from 'immer'
@@ -115,7 +116,17 @@ const FollowUpSettingModal = ({ data, onSave, onCancel }: FollowUpSettingModalPr
       }}
     >
       <DialogContent className="w-160! max-w-none! p-8! pb-6!">
-        <DialogCloseButton className="top-8 right-8" />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute top-8 right-8"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="pr-8 text-xl font-semibold text-text-primary">
           {t(($) => $['feature.suggestedQuestionsAfterAnswer.modal.title'], { ns: 'appDebug' })}
         </DialogTitle>

--- a/web/app/components/billing/annotation-full/modal.tsx
+++ b/web/app/components/billing/annotation-full/modal.tsx
@@ -1,7 +1,8 @@
 'use client'
 import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import GridMask from '@/app/components/base/grid-mask'
@@ -24,7 +25,17 @@ const AnnotationFullModal: FC<Props> = ({ show, onHide }) => {
       }}
     >
       <DialogContent className="w-full overflow-hidden! border-none p-0! text-left align-middle">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <GridMask
           wrapperClassName="rounded-lg"

--- a/web/app/components/billing/pricing/plans/cloud-plan-item/index.tsx
+++ b/web/app/components/billing/pricing/plans/cloud-plan-item/index.tsx
@@ -4,11 +4,12 @@ import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
@@ -200,9 +201,16 @@ const CloudPlanItem: FC<CloudPlanItemProps> = ({ plan, currentPlan, planRange, c
       <List plan={plan} />
       <Dialog open={showEducationPricingConfirm} onOpenChange={setShowEducationPricingConfirm}>
         <DialogContent backdropProps={{ forceRender: true }} className="w-130">
-          <DialogCloseButton
-            aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-            className="top-6 right-6"
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute top-6 right-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
           />
           <div className="flex flex-col gap-2 pr-10">
             <DialogTitle className="w-full title-2xl-semi-bold text-text-primary">

--- a/web/app/components/datasets/documents/detail/batch-modal/index.tsx
+++ b/web/app/components/datasets/documents/detail/batch-modal/index.tsx
@@ -2,7 +2,8 @@
 import type { FC } from 'react'
 import type { ChunkingMode, FileItem } from '@/models/datasets'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,9 +35,16 @@ const BatchModalContent: FC<BatchModalContentProps> = ({ docForm, onCancel, onCo
       <DialogTitle className="relative pb-1 text-xl leading-7.5 font-medium text-text-primary">
         {t(($) => $['list.batchModal.title'], { ns: 'datasetDocuments' })}
       </DialogTitle>
-      <DialogCloseButton
-        className="top-4 right-4"
-        aria-label={t(($) => $['list.batchModal.cancel'], { ns: 'datasetDocuments' })}
+      <DialogClose
+        render={
+          <IconButton
+            aria-label={t(($) => $['list.batchModal.cancel'], { ns: 'datasetDocuments' })}
+            size="lg"
+            className="absolute top-4 right-4"
+          >
+            <span aria-hidden className="i-ri-close-line size-4" />
+          </IconButton>
+        }
       />
       <CSVUploader file={currentCSV} updateFile={handleFile} />
       <CSVDownloader docForm={docForm} />

--- a/web/app/components/datasets/hit-testing/components/__tests__/chunk-detail-modal.spec.tsx
+++ b/web/app/components/datasets/hit-testing/components/__tests__/chunk-detail-modal.spec.tsx
@@ -1,5 +1,6 @@
 import type { HitTesting } from '@/models/datasets'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import ChunkDetailModal from '../chunk-detail-modal'
 
@@ -129,9 +130,12 @@ describe('ChunkDetailModal', () => {
     expect(screen.getByTestId('mask')).toBeInTheDocument()
   })
 
-  it('should call onHide when close button is clicked', () => {
+  it('should call onHide when close button is clicked', async () => {
+    const user = userEvent.setup()
     render(<ChunkDetailModal payload={makePayload()} onHide={onHide} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
+
     expect(onHide).toHaveBeenCalled()
   })
 

--- a/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
+++ b/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
@@ -2,7 +2,8 @@
 import type { FileAppearanceTypeEnum } from '@/app/components/base/file-uploader/types'
 import type { HitTesting } from '@/models/datasets'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -64,11 +65,19 @@ const ChunkDetailModal = ({ payload, onHide }: ChunkDetailModalProps) => {
           isParentChildRetrieval ? 'w-300 max-w-none! min-w-300!' : 'w-200 max-w-none! min-w-200!',
         )}
       >
-        <DialogCloseButton
-          onClick={(e) => {
-            e.stopPropagation()
-            onHide()
-          }}
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
         />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $[`${i18nPrefix}chunkDetail`], { ns: 'datasetHitTesting' })}

--- a/web/app/components/datasets/hit-testing/components/result-item-external.tsx
+++ b/web/app/components/datasets/hit-testing/components/result-item-external.tsx
@@ -2,7 +2,8 @@
 import type { FC } from 'react'
 import type { ExternalKnowledgeBaseHitTesting } from '@/models/datasets'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useBoolean } from 'ahooks'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -56,7 +57,17 @@ const ResultItemExternal: FC<Props> = ({ payload, positionId }) => {
           }}
         >
           <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-full min-w-200! flex-col overflow-hidden! border-none text-left align-middle">
-            <DialogCloseButton />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <DialogTitle className="shrink-0 title-2xl-semi-bold text-text-primary">
               {t(($) => $[`${i18nPrefix}chunkDetail`], { ns: 'datasetHitTesting' })}
             </DialogTitle>

--- a/web/app/components/datasets/metadata/edit-metadata-batch/modal.tsx
+++ b/web/app/components/datasets/metadata/edit-metadata-batch/modal.tsx
@@ -3,7 +3,8 @@ import type { FC } from 'react'
 import type { BuiltInMetadataItem, MetadataItemInBatchEdit, MetadataItemWithEdit } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { Checkbox } from '@langgenius/dify-ui/checkbox'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { produce } from 'immer'
 import * as React from 'react'
@@ -129,7 +130,17 @@ const EditMetadataBatchModal: FC<Props> = ({
       }}
     >
       <DialogContent className="w-full max-w-160! overflow-hidden! border-none text-left align-middle">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $[`${i18nPrefix}.editMetadata`], { ns: 'dataset' })}
         </DialogTitle>

--- a/web/app/components/explore/create-app-modal/index.tsx
+++ b/web/app/components/explore/create-app-modal/index.tsx
@@ -2,7 +2,8 @@
 import type { Hotkey } from '@tanstack/react-hotkeys'
 import type { AppIconType } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { Kbd, KbdGroup } from '@langgenius/dify-ui/kbd'
 import { Switch } from '@langgenius/dify-ui/switch'
@@ -138,7 +139,17 @@ const CreateAppModal = ({
     <>
       <Dialog open={show} onOpenChange={(open) => !open && onHide()} disablePointerDismissal>
         <DialogContent backdropProps={{ forceRender: true }} className="px-8">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           {isEditModal && (
             <DialogTitle className="text-xl leading-7.5 font-semibold text-text-primary">
               {t(($) => $.editAppTitle, { ns: 'app' })}

--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -17,7 +17,7 @@ import {
 import {
   Dialog,
   DialogBackdrop,
-  DialogCloseButton,
+  DialogClose,
   DialogPopup,
   DialogPortal,
   DialogTitle,
@@ -587,10 +587,9 @@ function GotoAnythingDialog() {
                 hasQuery={!!searchQuery.trim()}
               />
             </Autocomplete>
-            <DialogCloseButton
-              className="sr-only"
-              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-            />
+            <DialogClose className="sr-only">
+              {t(($) => $['operation.close'], { ns: 'common' })}
+            </DialogClose>
           </DialogPopup>
         </DialogPortal>
       </Dialog>

--- a/web/app/components/header/account-setting/access-rules-page/permission-set-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/access-rules-page/permission-set-modal/__tests__/index.spec.tsx
@@ -216,7 +216,7 @@ describe('PermissionSetModal', () => {
     })
   })
 
-  // View mode is read-only and uses close-only footer actions.
+  // View mode is read-only and has no confirmation action.
   describe('Read-only Mode', () => {
     it('should disable editing and hide confirm action in view mode', () => {
       renderModal(
@@ -239,7 +239,6 @@ describe('PermissionSetModal', () => {
       expect(
         screen.queryByRole('button', { name: 'common.operation.confirm' }),
       ).not.toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'common.operation.close' })).toBeInTheDocument()
       expect(
         screen.queryByRole('button', { name: 'permission.permissionList.clearAll' }),
       ).not.toBeInTheDocument()

--- a/web/app/components/header/account-setting/access-rules-page/permission-set-modal/index.tsx
+++ b/web/app/components/header/account-setting/access-rules-page/permission-set-modal/index.tsx
@@ -1,14 +1,14 @@
 'use client'
-
 import type { AccessPolicyResourceType } from '@/models/access-control'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { useState } from 'react'
@@ -72,7 +72,17 @@ const PermissionSetModalBody = ({
       backdropProps={{ forceRender: true }}
     >
       <div className="relative shrink-0 px-6 pt-6 pb-4">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="pr-8">
           <DialogTitle className="system-xl-semibold text-text-primary">
             {t(($) => $[`permissionSet.modal.${mode}.${resourceType}.title`], { ns: 'permission' })}

--- a/web/app/components/header/account-setting/api-based-extension-page/__tests__/modal.spec.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/__tests__/modal.spec.tsx
@@ -2,6 +2,7 @@ import type { ApiBasedExtensionResponse } from '@dify/contracts/api/console/api-
 import type { TFunction } from 'i18next'
 import type { ReactElement } from 'react'
 import { fireEvent, render as RTLRender, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as reactI18next from 'react-i18next'
 import { useDocLink } from '@/context/i18n'
 import { withSelectorKey } from '@/test/i18n-mock'
@@ -295,11 +296,13 @@ describe('ApiBasedExtensionModal', () => {
     })
 
     it('should request closing when clicking close button', async () => {
+      const user = userEvent.setup()
+
       // Arrange
       renderModal()
 
       // Act
-      fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+      await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
       // Assert
       await waitFor(() => {

--- a/web/app/components/header/account-setting/api-based-extension-page/modal.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/modal.tsx
@@ -3,9 +3,10 @@ import type {
   ApiBasedExtensionResponse,
 } from '@dify/contracts/api/console/api-based-extension/types.gen'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { Field, FieldDescription, FieldError, FieldLabel } from '@langgenius/dify-ui/field'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation } from '@tanstack/react-query'
@@ -91,7 +92,17 @@ export function ApiBasedExtensionModal(props: ApiBasedExtensionModalProps) {
         backdropProps={{ forceRender: true }}
         className="w-160 border-none p-8 pb-6 text-left"
       >
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <DialogTitle className="mb-2 pr-8 text-xl font-semibold text-text-primary">
           {mode === 'edit'

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -170,11 +170,7 @@ export default function AccountSetting({
   ]
 
   return (
-    <MenuDialog
-      title={t(($) => $['settings.settings'], { ns: 'common' })}
-      closeButtonLabel={t(($) => $['operation.close'], { ns: 'common' })}
-      onClose={onCancelAction}
-    >
+    <MenuDialog title={t(($) => $['settings.settings'], { ns: 'common' })} onClose={onCancelAction}>
       <div className="flex h-screen w-full max-w-full pl-0 sm:pl-58">
         <div className="flex w-11 shrink-0 flex-col pr-6 pl-4 sm:w-56">
           <div className="mt-6 mb-8 flex h-9.5 items-center px-3 title-2xl-semi-bold whitespace-nowrap text-text-primary">

--- a/web/app/components/header/account-setting/members-page/assign-roles-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/assign-roles-modal/index.tsx
@@ -1,14 +1,14 @@
 'use client'
-
 import type { Role } from '@/models/access-control'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import WorkspaceRoleCheckboxList from '../../workspace-role-checkbox-list'
@@ -59,7 +59,17 @@ const AssignRolesModalBody = ({
       backdropProps={{ forceRender: true }}
     >
       <div className="relative shrink-0 px-6 pt-6 pb-4">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="pr-8">
           <DialogTitle className="system-xl-semibold text-text-primary">{title}</DialogTitle>
           <DialogDescription className="mt-1 system-sm-regular text-text-tertiary">

--- a/web/app/components/header/account-setting/members-page/edit-workspace-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/edit-workspace-modal/index.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useAtomValue } from 'jotai'
@@ -58,7 +59,17 @@ const EditWorkspaceModal = ({ onCancel }: IEditWorkspaceModalProps) => {
       }}
     >
       <DialogContent backdropProps={{ forceRender: true }}>
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <form
           className="flex flex-col"

--- a/web/app/components/header/account-setting/members-page/invite-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/index.tsx
@@ -1,18 +1,18 @@
 'use client'
-
 import type { MemberInviteResponse } from '@dify/contracts/api/console/workspaces/types.gen'
 import type { ReactElement } from 'react'
 import type { EmailRecipient } from './email-recipients'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
   DialogTrigger,
 } from '@langgenius/dify-ui/dialog'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -207,7 +207,17 @@ export function InviteModal({
           </DialogDescription>
         </div>
         <InviteForm isEmailSetup={isEmailSetup} onOpenChange={onOpenChange} onSend={onSend} />
-        <DialogCloseButton aria-label={t(($) => $['operation.close'], { ns: 'common' })} />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
       </DialogContent>
     </Dialog>
   )

--- a/web/app/components/header/account-setting/members-page/invited-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/invited-modal/index.tsx
@@ -5,7 +5,8 @@ import type {
   MemberInviteSuccessResponse,
 } from '@dify/contracts/api/console/workspaces/types.gen'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
@@ -51,7 +52,17 @@ const InvitedModal = ({ invitationResults, onCancel }: IInvitedModalProps) => {
       }}
     >
       <DialogContent backdropProps={{ forceRender: true }} className="w-120 p-8">
-        <DialogCloseButton className="top-8 right-8" />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute top-8 right-8"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="mb-3 flex justify-between">
           <div className="flex h-12 w-12 items-center justify-center rounded-xl border-[0.5px] border-components-panel-border bg-background-section-burn shadow-xl">
             <div className="i-heroicons-check-circle-solid h-5.5 w-5.5 text-[#039855]" />

--- a/web/app/components/header/account-setting/members-page/member-details-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/member-details-modal/index.tsx
@@ -1,10 +1,10 @@
 'use client'
-
 import type { Role } from '@/models/access-control'
 import type { Member } from '@/models/common'
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
@@ -109,7 +109,17 @@ const MemberDetailsModal = ({
       >
         <DialogContent className="w-110 overflow-visible p-0" backdropProps={{ forceRender: true }}>
           <div className="relative px-6 pt-6 pb-5">
-            <DialogCloseButton />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
             <DialogTitle className="pr-8 system-xl-semibold text-text-primary">
               {t(($) => $['members.memberDetails.title'], {
                 ns: 'common',

--- a/web/app/components/header/account-setting/menu-dialog.tsx
+++ b/web/app/components/header/account-setting/menu-dialog.tsx
@@ -9,15 +9,17 @@ import {
   DialogViewport,
 } from '@langgenius/dify-ui/dialog'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { useTranslation } from 'react-i18next'
 
 type MenuDialogProps = {
   children: ReactNode
-  closeButtonLabel: string
   title: string
   onClose: () => void
 }
 
-const MenuDialog = ({ children, closeButtonLabel, title, onClose }: MenuDialogProps) => {
+const MenuDialog = ({ children, title, onClose }: MenuDialogProps) => {
+  const { t } = useTranslation()
+
   return (
     <Dialog
       open
@@ -33,7 +35,11 @@ const MenuDialog = ({ children, closeButtonLabel, title, onClose }: MenuDialogPr
             <div className="pointer-events-auto absolute top-6 right-6 z-10 flex shrink-0 flex-col items-center">
               <DialogClose
                 render={
-                  <IconButton variant="tertiary" size="xl" aria-label={closeButtonLabel}>
+                  <IconButton
+                    variant="tertiary"
+                    size="xl"
+                    aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  >
                     <span aria-hidden className="i-ri-close-line size-5" />
                   </IconButton>
                 }

--- a/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-modal/index.tsx
@@ -15,7 +15,8 @@ import {
   AlertDialogTitle,
 } from '@langgenius/dify-ui/alert-dialog'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Badge from '@/app/components/base/badge'
@@ -309,7 +310,17 @@ const ModelModal: FC<ModelModalProps> = ({
         backdropProps={{ forceRender: true }}
         className="flex w-160 max-w-160 flex-col overflow-hidden p-0"
       >
-        <DialogCloseButton className="top-5 right-5 size-8" />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute top-5 right-5"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="shrink-0 p-6 pb-3">
           {modalTitle}
           {modalDesc}

--- a/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
@@ -2,7 +2,8 @@ import type { FC } from 'react'
 import type { DefaultModel, DefaultModelResponse } from '../declarations'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useAtomValue } from 'jotai'
 import { useState } from 'react'
@@ -196,7 +197,17 @@ const SystemModel: FC<SystemModelSelectorProps> = ({
           backdropProps={{ forceRender: true }}
           className="flex max-h-[calc(100dvh-2rem)] w-120 max-w-120 flex-col overflow-hidden rounded-2xl p-0"
         >
-          <DialogCloseButton className="top-5 right-5" />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute top-5 right-5"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <div className="shrink-0 px-6 pt-6 pr-14 pb-3">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">
               {t(($) => $['modelProvider.systemModelSettingsTitle'], { ns: 'common' })}

--- a/web/app/components/header/account-setting/permissions-page/role-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/permissions-page/role-modal/__tests__/index.spec.tsx
@@ -155,7 +155,6 @@ describe('RoleModal', () => {
       expect(
         screen.queryByRole('button', { name: 'common.operation.confirm' }),
       ).not.toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'common.operation.close' })).toBeInTheDocument()
       expect(
         screen.queryByRole('button', { name: 'permission.permissionList.clearAll' }),
       ).not.toBeInTheDocument()

--- a/web/app/components/header/account-setting/permissions-page/role-modal/index.tsx
+++ b/web/app/components/header/account-setting/permissions-page/role-modal/index.tsx
@@ -1,14 +1,14 @@
 'use client'
-
 import type { Role } from '@/models/access-control'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { useCallback, useState } from 'react'
@@ -68,7 +68,17 @@ const RoleModal = ({ mode, open, role, onClose, onSubmit }: RoleModalProps) => {
         backdropProps={{ forceRender: true }}
       >
         <div className="relative shrink-0 px-6 pt-6 pb-4">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <div className="pr-8">
             <DialogTitle className="system-xl-semibold text-text-primary">
               {t(($) => $[`role.modal.${mode}.title`], { ns: 'permission' })}

--- a/web/app/components/header/account-setting/update-setting-dialog.tsx
+++ b/web/app/components/header/account-setting/update-setting-dialog.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type {
   TimePickerProps,
   TriggerParams,
@@ -10,11 +9,12 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogTitle,
   DialogTrigger,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
@@ -263,7 +263,17 @@ const UpdateSettingDialog = ({ category, disabled = false }: Props) => {
             <DialogTitle className="min-w-0 flex-1 title-2xl-semi-bold text-text-primary">
               {t(($) => $['autoUpdate.autoUpdateSettings'], { ns: 'plugin' })}
             </DialogTitle>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           {isSettingsLoading && (
             <div

--- a/web/app/components/integrations/modal.tsx
+++ b/web/app/components/integrations/modal.tsx
@@ -28,11 +28,7 @@ export default function IntegrationsSettingModal({
   }, [])
 
   return (
-    <MenuDialog
-      title={t(($) => $['settings.integrations'], { ns: 'common' })}
-      closeButtonLabel={t(($) => $['operation.close'], { ns: 'common' })}
-      onClose={onCancel}
-    >
+    <MenuDialog title={t(($) => $['settings.integrations'], { ns: 'common' })} onClose={onCancel}>
       <div className="mx-auto flex h-dvh w-[min(1440px,calc(100vw-48px))] shrink-0 py-6">
         <div className="relative flex min-h-0 w-full shrink-0 overflow-hidden rounded-2xl border border-divider-subtle bg-components-panel-bg shadow-2xl">
           <IntegrationsPage

--- a/web/app/components/main-nav/components/help-menu/account-about-dialog.tsx
+++ b/web/app/components/main-nav/components/help-menu/account-about-dialog.tsx
@@ -1,9 +1,9 @@
 'use client'
-
 import type { DeploymentEdition } from '@dify/contracts/api/console/system-features/types.gen'
 import type { LangGeniusVersionInfo } from '@/context/app-context-types'
 import { buttonVariants } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import dayjs from 'dayjs'
 import { useTranslation } from 'react-i18next'
 import { DifyLogo } from '@/app/components/base/logo/dify-logo'
@@ -32,7 +32,17 @@ export default function AccountAboutDialog({
         <DialogTitle className="sr-only">
           {t(($) => $['userProfile.about'], { ns: 'common' })}
         </DialogTitle>
-        <DialogCloseButton aria-label={t(($) => $['operation.close'], { ns: 'common' })} />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="flex flex-col items-center gap-4 px-6 py-12">
           <DifyLogo alt="Dify" size="large" className="mx-auto" />
 

--- a/web/app/components/plugins/install-plugin/install-bundle/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-bundle/index.tsx
@@ -2,7 +2,8 @@
 import type { FC } from 'react'
 import type { Dependency, InstallStatus, Plugin, VersionProps } from '../../types'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -74,7 +75,17 @@ const InstallBundle: FC<Props> = ({
           ),
         )}
       >
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <div className="flex items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
           <div className="self-stretch title-2xl-semi-bold text-text-primary">{getTitle()}</div>

--- a/web/app/components/plugins/install-plugin/install-from-github/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-github/index.tsx
@@ -1,12 +1,12 @@
 'use client'
-
 import type { PluginCategoryEnum, PluginDeclaration, UpdateFromGitHubPayload } from '../../types'
 import type { InstallState } from '@/app/components/plugins/types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
 import { Field, FieldLabel } from '@langgenius/dify-ui/field'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import * as React from 'react'
@@ -187,7 +187,17 @@ const InstallFromGitHub: React.FC<InstallFromGitHubProps> = ({
           ),
         )}
       >
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <div className="flex shrink-0 items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
           <div className="flex grow flex-col items-start gap-1">

--- a/web/app/components/plugins/install-plugin/install-from-local-package/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/index.tsx
@@ -1,8 +1,8 @@
 'use client'
-
 import type { Dependency, PluginCategoryEnum, PluginDeclaration } from '../../types'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -97,7 +97,17 @@ const InstallFromLocalPackage: React.FC<InstallFromLocalPackageProps> = ({
           ),
         )}
       >
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <div className="flex items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
           <div className="self-stretch title-2xl-semi-bold text-text-primary">{getTitle()}</div>

--- a/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
@@ -1,8 +1,8 @@
 'use client'
-
 import type { Dependency, Plugin, PluginCategoryEnum, PluginManifestInMarket } from '../../types'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -133,7 +133,17 @@ const InstallFromMarketplace: React.FC<InstallFromMarketplaceProps> = ({
             )}
           </>
         )}
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
       </DialogContent>
     </Dialog>
   )

--- a/web/app/components/plugins/plugin-auth/authorize/__tests__/add-oauth-button.spec.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/__tests__/add-oauth-button.spec.tsx
@@ -225,7 +225,7 @@ describe('AddOAuthButton', () => {
         name: /datasetSettings\.form\.permissionsOnlyMe/,
       }),
     ).toBeDisabled()
-    expect(within(dialog).getByRole('button', { name: 'Close' })).toBeDisabled()
+    expect(within(dialog).getByRole('button', { name: 'common.operation.close' })).toBeDisabled()
 
     await act(async () => {
       resolveOAuthRequest?.({ authorization_url: 'https://auth.example.com' })

--- a/web/app/components/plugins/plugin-auth/authorize/api-key-modal.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/api-key-modal.tsx
@@ -2,7 +2,8 @@ import type { PluginPayload } from '../types'
 import type { FormRefObject, FormSchema } from '@/app/components/base/form/types'
 import type { CredentialPermission } from '@/models/permission'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -161,7 +162,17 @@ const ApiKeyModal = ({
             <div className="mt-1 system-xs-regular text-text-tertiary">
               {t(($) => $['auth.useApiAuthDesc'], { ns: 'plugin' })}
             </div>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
             {pluginPayload.detail && (

--- a/web/app/components/plugins/plugin-auth/authorize/oauth-client-settings.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/oauth-client-settings.tsx
@@ -1,7 +1,8 @@
 import type { PluginPayload } from '../types'
 import type { FormRefObject, FormSchema } from '@/app/components/base/form/types'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useForm, useStore } from '@tanstack/react-form'
 import { memo, useCallback, useRef, useState } from 'react'
@@ -150,7 +151,17 @@ const OAuthClientSettings = ({
             <DialogTitle className="title-2xl-semi-bold text-text-primary">
               {t(($) => $['auth.oauthClientSettings'], { ns: 'plugin' })}
             </DialogTitle>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3 pt-0">
             {pluginPayload.detail && (

--- a/web/app/components/plugins/plugin-auth/authorize/oauth-visibility-dialog.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/oauth-visibility-dialog.tsx
@@ -2,11 +2,12 @@ import type { CredentialPermission } from '@/models/permission'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import PermissionSelector from './permission-selector'
@@ -45,7 +46,18 @@ const OAuthVisibilityDialog = ({
             <DialogDescription className="mt-1 system-xs-regular text-text-tertiary">
               {t(($) => $['auth.oauthCredentialPermissionDescription'], { ns: 'plugin' })}
             </DialogDescription>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" disabled={loading} />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                  disabled={loading}
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           <div className="px-6 py-3">
             <PermissionSelector

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/oauth-client.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/oauth-client.spec.tsx
@@ -3,6 +3,7 @@ import type {
   TriggerSubscriptionBuilder,
 } from '@/app/components/workflow/block-selector/types'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { TriggerCredentialType } from '@/app/components/workflow/block-selector/types'
@@ -172,7 +173,7 @@ describe('OAuthClientSettingsModal', () => {
   }
   const title = 'pluginTrigger.modal.oauth.title'
   const getDialog = () => screen.getByRole('dialog', { name: title })
-  const getCloseButton = () => screen.getByRole('button', { name: 'Close' })
+  const getCloseButton = () => screen.getByRole('button', { name: 'common.operation.close' })
   const getCancelButton = () => screen.getByRole('button', { name: 'common.operation.cancel' })
   const getSaveOnlyButton = () => screen.getByRole('button', { name: 'plugin.auth.saveOnly' })
   const getConfirmButton = () =>
@@ -525,11 +526,12 @@ describe('OAuthClientSettingsModal', () => {
   })
 
   describe('Modal Actions', () => {
-    it('should call onOpenChange when close button is clicked', () => {
+    it('should call onOpenChange when close button is clicked', async () => {
+      const user = userEvent.setup()
       const mockOnOpenChange = vi.fn()
       render(<OAuthClientSettingsModal {...defaultProps} onOpenChange={mockOnOpenChange} />)
 
-      fireEvent.click(getCloseButton())
+      await user.click(getCloseButton())
 
       expect(mockOnOpenChange.mock.calls[0]?.[0]).toBe(false)
     })

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/common-modal.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/common-modal.tsx
@@ -2,7 +2,8 @@
 import type { TriggerSubscriptionBuilder } from '@/app/components/workflow/block-selector/types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useTranslation } from 'react-i18next'
 import { EncryptedBottom } from '@/app/components/base/encrypted-bottom'
 import { SupportedCreationMethods } from '@/app/components/plugins/types'
@@ -79,9 +80,16 @@ function CommonCreateModalContent({ onClose, createType, builder }: Omit<Props, 
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $[MODAL_TITLE_KEY_MAP[createType]], { ns: 'pluginTrigger' })}
         </DialogTitle>
-        <DialogCloseButton
-          className="top-5 right-5 size-8 rounded-lg [&>span]:size-5"
-          onClick={onClose}
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute top-5 right-5"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
         />
       </div>
 

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/oauth-client.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/oauth-client.tsx
@@ -4,7 +4,8 @@ import type {
   TriggerSubscriptionBuilder,
 } from '@/app/components/workflow/block-selector/types'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -70,7 +71,17 @@ export const OAuthClientSettingsModal = ({
         <div data-testid="modal" className="flex max-h-[80dvh] flex-col">
           <div className="relative shrink-0 p-6 pr-14 pb-3">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">{title}</DialogTitle>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           <div data-testid="modal-content" className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
             <div className="mb-2 system-sm-medium text-text-secondary">

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/__tests__/index.spec.tsx
@@ -1,6 +1,7 @@
 import type { PluginDetail } from '@/app/components/plugins/types'
 import type { TriggerSubscription } from '@/app/components/workflow/block-selector/types'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { FormTypeEnum } from '@/app/components/base/form/types'
 import { PluginCategoryEnum, PluginSource } from '@/app/components/plugins/types'
@@ -489,10 +490,11 @@ describe('Edit Modal Components', () => {
         expect(onClose).toHaveBeenCalledTimes(1)
       })
 
-      it('should call onClose when close button is clicked', () => {
+      it('should call onClose when close button is clicked', async () => {
+        const user = userEvent.setup()
         const onClose = vi.fn()
         render(<ManualEditModal {...createProps({ onClose })} />)
-        fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+        await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
         expect(onClose).toHaveBeenCalledTimes(1)
       })
 

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/apikey-edit-modal.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/apikey-edit-modal.tsx
@@ -3,7 +3,8 @@ import type { FormRefObject, FormSchema } from '@/app/components/base/form/types
 import type { ParametersSchema, PluginDetail } from '@/app/components/plugins/types'
 import type { TriggerSubscription } from '@/app/components/workflow/block-selector/types'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { isEqual } from 'es-toolkit/predicate'
 import { useMemo, useRef, useState } from 'react'
@@ -332,7 +333,17 @@ export const ApiKeyEditModal = ({ onClose, subscription, pluginDetail }: Props) 
         >
           <div className="relative shrink-0 p-6 pr-14 pb-3">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">{title}</DialogTitle>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           <div data-testid="modal-content" className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
             {pluginDetail && <ReadmeEntrance pluginDetail={pluginDetail} presentation="dialog" />}

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/manual-edit-modal.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/manual-edit-modal.tsx
@@ -3,7 +3,8 @@ import type { FormRefObject, FormSchema } from '@/app/components/base/form/types
 import type { ParametersSchema, PluginDetail } from '@/app/components/plugins/types'
 import type { TriggerSubscription } from '@/app/components/workflow/block-selector/types'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { isEqual } from 'es-toolkit/predicate'
 import { useMemo, useRef } from 'react'
@@ -163,7 +164,17 @@ export const ManualEditModal = ({ onClose, subscription, pluginDetail }: Props) 
         >
           <div className="relative shrink-0 p-6 pr-14 pb-3">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">{title}</DialogTitle>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           <div data-testid="modal-content" className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
             {pluginDetail && <ReadmeEntrance pluginDetail={pluginDetail} presentation="dialog" />}

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/oauth-edit-modal.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/edit/oauth-edit-modal.tsx
@@ -3,7 +3,8 @@ import type { FormRefObject, FormSchema } from '@/app/components/base/form/types
 import type { ParametersSchema, PluginDetail } from '@/app/components/plugins/types'
 import type { TriggerSubscription } from '@/app/components/workflow/block-selector/types'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { isEqual } from 'es-toolkit/predicate'
 import { useMemo, useRef } from 'react'
@@ -188,7 +189,17 @@ export const OAuthEditModal = ({ onClose, subscription, pluginDetail }: Props) =
         >
           <div className="relative shrink-0 p-6 pr-14 pb-3">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">{title}</DialogTitle>
-            <DialogCloseButton className="top-5 right-5 size-8 rounded-lg" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute top-5 right-5"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
           <div data-testid="modal-content" className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
             {pluginDetail && <ReadmeEntrance pluginDetail={pluginDetail} presentation="dialog" />}

--- a/web/app/components/plugins/plugin-mutation-model/index.tsx
+++ b/web/app/components/plugins/plugin-mutation-model/index.tsx
@@ -2,9 +2,11 @@ import type { UseMutationResult } from '@tanstack/react-query'
 import type { FC, ReactNode } from 'react'
 import type { Plugin } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import Card from '@/app/components/plugins/card'
 
 type Props = Readonly<{
@@ -32,6 +34,8 @@ const PluginMutationModal: FC<Props> = ({
   mutate,
   modalBottomLeft,
 }: Props) => {
+  const { t } = useTranslation()
+
   return (
     <Dialog
       open
@@ -40,7 +44,17 @@ const PluginMutationModal: FC<Props> = ({
       }}
     >
       <DialogContent className="w-full min-w-140 overflow-hidden! border-none text-left align-middle">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">{modelTitle}</DialogTitle>
 
         <div className="mt-3 mb-2 system-md-regular text-text-secondary">{description}</div>

--- a/web/app/components/plugins/plugin-page/plugin-info.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-info.tsx
@@ -1,6 +1,7 @@
 'use client'
 import type { FC } from 'react'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import KeyValueItem from '../base/key-value-item'
@@ -25,7 +26,17 @@ const PlugInfo: FC<Props> = ({ repository, release, packageName, onHide }) => {
       }}
     >
       <DialogContent className="w-full max-w-120! overflow-hidden! border-none text-left align-middle">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $[`${i18nPrefix}.title`], { ns: 'plugin' })}
         </DialogTitle>

--- a/web/app/components/plugins/readme-panel/dialog.tsx
+++ b/web/app/components/plugins/readme-panel/dialog.tsx
@@ -1,7 +1,7 @@
 'use client'
-
 import type { PluginDetail } from '../types'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useTranslation } from 'react-i18next'
 import { ReadmePanelContent } from './content'
 
@@ -26,9 +26,16 @@ export function ReadmeDialog({ detail, open, onOpenChange, triggerId }: ReadmeDi
             </DialogTitle>
           }
           closeButton={
-            <DialogCloseButton
-              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-              className="static size-8 rounded-lg"
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="sm"
+                  className="static size-8 rounded-lg"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
             />
           }
         />

--- a/web/app/components/plugins/update-plugin/from-market-place.tsx
+++ b/web/app/components/plugins/update-plugin/from-market-place.tsx
@@ -2,7 +2,8 @@
 import type { UpdateFromMarketPlacePayload } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -150,7 +151,17 @@ const UpdatePluginModal = ({
         backdropProps={{ forceRender: true }}
         className={cn('min-w-140', doShowDowngradeWarningModal && 'min-w-160')}
       >
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         {doShowDowngradeWarningModal && (
           <DowngradeWarningModal
             onCancel={onCancel}

--- a/web/app/components/share/text-generation/info-modal.tsx
+++ b/web/app/components/share/text-generation/info-modal.tsx
@@ -1,7 +1,9 @@
 import type { SiteInfo } from '@/models/share'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
 import { appDefaultIconBackground } from '@/config'
 
@@ -12,6 +14,7 @@ type Props = Readonly<{
 }>
 
 const InfoModal = ({ isShow, onClose, data }: Props) => {
+  const { t } = useTranslation()
   const [currentYear] = React.useState(() => new Date().getFullYear())
 
   return (
@@ -22,7 +25,17 @@ const InfoModal = ({ isShow, onClose, data }: Props) => {
       }}
     >
       <DialogContent className="w-full max-w-100 min-w-100 overflow-hidden! border-none p-0! text-left align-middle">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <div className={cn('flex flex-col items-center gap-4 px-4 pt-10 pb-8')}>
           <AppIcon

--- a/web/app/components/snippets/create-snippet-dialog.tsx
+++ b/web/app/components/snippets/create-snippet-dialog.tsx
@@ -1,16 +1,16 @@
 'use client'
-
 import type { Hotkey } from '@tanstack/react-hotkeys'
 import type { SnippetCanvasData, SnippetInputField } from '@/models/snippet'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
   DialogBackdrop,
-  DialogCloseButton,
+  DialogClose,
   DialogPopup,
   DialogPortal,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { useHotkey } from '@tanstack/react-hotkeys'
@@ -112,7 +112,17 @@ export function CreateSnippetDialog({
             initialFocus={nameInputRef}
             className="fixed top-1/2 left-1/2 max-h-[80dvh] w-120 max-w-120 -translate-x-1/2 -translate-y-1/2 overflow-y-auto overscroll-contain p-0"
           >
-            <DialogCloseButton />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  size="lg"
+                  className="absolute inset-e-6 top-6"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
 
             <div className="px-6 pt-6 pb-3">
               <DialogTitle className="title-2xl-semi-bold text-text-primary">

--- a/web/app/components/workflow-app/components/workflow-onboarding-modal/__tests__/index.spec.tsx
+++ b/web/app/components/workflow-app/components/workflow-onboarding-modal/__tests__/index.spec.tsx
@@ -30,7 +30,7 @@ describe('WorkflowOnboardingModal', () => {
     const onClose = vi.fn()
     render(<WorkflowOnboardingModal isShow onClose={onClose} onSelectStartNode={vi.fn()} />)
 
-    await user.click(screen.getByRole('button', { name: 'Close' }))
+    await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/web/app/components/workflow-app/components/workflow-onboarding-modal/index.tsx
+++ b/web/app/components/workflow-app/components/workflow-onboarding-modal/index.tsx
@@ -3,11 +3,12 @@ import type { FC } from 'react'
 import type { BlockDefaultValue } from '@/app/components/workflow/block-selector/types'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useTranslation } from 'react-i18next'
 import { BlockEnum } from '@/app/components/workflow/types'
 import StartNodeSelectionPanel from './start-node-selection-panel'
@@ -31,7 +32,17 @@ const WorkflowOnboardingModal: FC<WorkflowOnboardingModalProps> = ({
         className="w-154.5 max-w-154.5 rounded-2xl border border-effects-highlight bg-background-default-subtle shadow-lg"
         backdropClassName="bg-workflow-canvas-canvas-overlay"
       >
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
 
         <div className="pb-4">
           <div className="mb-6">

--- a/web/app/components/workflow/nodes/agent-v2/components/save-inline-agent-to-roster-dialog.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/save-inline-agent-to-roster-dialog.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type {
   AgentComposerAgentResponse,
   AgentComposerBindingResponse,
@@ -12,12 +11,13 @@ import type {
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
@@ -143,7 +143,17 @@ export function SaveInlineAgentToRosterDialog({
     <>
       <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
         <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-130 flex-col overflow-hidden! p-0!">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <div className="shrink-0 pt-6 pr-14 pb-3 pl-6">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">
               {t(($) => $['roster.saveToRosterDialog.title'])}

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/email-configure-modal.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/email-configure-modal.tsx
@@ -1,7 +1,8 @@
 import type { EmailConfig } from '../../types'
 import type { Node, NodeOutPutVar } from '@/app/components/workflow/types'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Switch } from '@langgenius/dify-ui/switch'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiBugLine } from '@remixicon/react'
@@ -92,7 +93,17 @@ const EmailConfigureModal = ({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[calc(100dvh-64px)]! w-180!">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="space-y-1 pr-8">
           <DialogTitle className="title-2xl-semi-bold text-text-primary">
             {t(($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.title`], { ns: 'workflow' })}

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/test-email-sender.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/test-email-sender.tsx
@@ -2,7 +2,8 @@ import type { EmailConfig, FormInputItem } from '../../types'
 import type { Node, NodeOutPutVar, Var } from '@/app/components/workflow/types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiArrowRightSFill } from '@remixicon/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -333,7 +334,17 @@ const EmailSenderModal = ({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="space-y-1 pr-8">
           <DialogTitle className="title-2xl-semi-bold text-text-primary">
             {t(($) => $[`${i18nPrefix}.deliveryMethod.emailSender.title`], { ns: 'workflow' })}

--- a/web/app/education/expire-notice/modal.tsx
+++ b/web/app/education/expire-notice/modal.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { Button, buttonVariants } from '@langgenius/dify-ui/button'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -39,7 +40,17 @@ const ExpireNoticeModal: React.FC<Props> = ({ expireAt, expired, onClose }) => {
       }}
     >
       <DialogContent className="w-full max-w-150 overflow-hidden! border-none text-left align-middle">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {expired
             ? t(($) => $[`${i18nPrefix}.expired.title`], { ns: 'education' })

--- a/web/features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx
@@ -341,7 +341,7 @@ describe('Agent access surface cards', () => {
         name: 'appOverview.overview.appInfo.embedded.title',
       })
 
-      await user.click(within(dialog).getByRole('button', { name: 'Close' }))
+      await user.click(within(dialog).getByRole('button', { name: 'common.operation.close' }))
 
       await waitFor(() => {
         expect(

--- a/web/features/agent-v2/agent-detail/access/components/agent-api-key-modal.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/agent-api-key-modal.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type { ApiKeyItem } from '@dify/contracts/api/console/agent/types.gen'
 import {
   AlertDialog,
@@ -13,11 +12,12 @@ import {
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
@@ -130,7 +130,17 @@ export function AgentApiKeyModal({
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="flex w-full max-w-200! flex-col overflow-hidden px-8">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <DialogTitle className="title-2xl-semi-bold text-text-primary">
             {t(($) => $['apiKeyModal.apiSecretKey'])}
           </DialogTitle>
@@ -273,7 +283,17 @@ function AgentApiKeyGenerateModal({
       }}
     >
       <DialogContent className="w-full max-w-120! overflow-hidden px-8">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $['apiKeyModal.apiSecretKey'])}
         </DialogTitle>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/files/upload-dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/files/upload-dialog.tsx
@@ -12,7 +12,7 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -324,7 +324,17 @@ export function AgentFileUploadDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
       <DialogContent backdropProps={{ forceRender: true }} backdropClassName="fixed">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $['agentDetail.configure.files.upload.title'])}
         </DialogTitle>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/__tests__/index.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/__tests__/index.spec.tsx
@@ -282,7 +282,7 @@ describe('AgentKnowledgeRetrieval', () => {
         }),
       )
 
-      await user.click(screen.getByRole('button', { name: 'Close' }))
+      await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
       expect(
         screen.queryByRole('button', {
@@ -733,7 +733,7 @@ describe('AgentKnowledgeRetrieval', () => {
           name: 'agentV2.agentDetail.configure.knowledgeRetrieval.add',
         }),
       )
-      await user.click(screen.getByRole('button', { name: 'Close' }))
+      await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
       expect(
         screen.queryByRole('dialog', {
@@ -765,7 +765,7 @@ describe('AgentKnowledgeRetrieval', () => {
         }),
         'temporary query',
       )
-      await user.click(within(dialog).getByRole('button', { name: 'Close' }))
+      await user.click(within(dialog).getByRole('button', { name: 'common.operation.close' }))
 
       await user.click(
         screen.getByRole('button', {

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/dialog.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type { AgentKnowledgeDatasetConfig } from '@dify/contracts/api/console/agent/types.gen'
 import type { ReactNode } from 'react'
 import type {
@@ -12,7 +11,8 @@ import type { ModelConfig } from '@/app/components/workflow/types'
 import type { AgentKnowledgeRetrievalItem } from '@/features/agent-v2/agent-composer/form-state'
 import type { DataSet, MetadataInDoc } from '@/models/datasets'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { RadioGroup, RadioItem } from '@langgenius/dify-ui/radio'
 import { Textarea } from '@langgenius/dify-ui/textarea'
@@ -454,7 +454,17 @@ function AgentKnowledgeRetrievalDialogContent({
           name={name}
           onCommit={(nextName) => applyDialogStatePatch({ name: nextName })}
         />
-        <DialogCloseButton className="static size-7 shrink-0 rounded-md" />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="sm"
+              className="static size-7 shrink-0 rounded-md"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
       </div>
       {nameError && (
         <div role="alert" className="px-4 pt-1 system-xs-regular text-text-destructive">

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/detail-dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/detail-dialog.tsx
@@ -1,15 +1,15 @@
 'use client'
-
 import type { ReactNode } from 'react'
 import type { AgentFileNode } from '@/features/agent-v2/agent-composer/form-state'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
 import { FileTreeFile } from '@langgenius/dify-ui/file-tree'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import {
   ScrollArea,
   ScrollAreaContent,
@@ -413,7 +413,17 @@ export function AgentSkillDetailDialog({
                 />
               </button>
             )}
-            <DialogCloseButton className="static size-7 shrink-0 rounded-md" />
+            <DialogClose
+              render={
+                <IconButton
+                  aria-label={tCommon(($) => $['operation.close'])}
+                  size="sm"
+                  className="static size-7 shrink-0 rounded-md"
+                >
+                  <span aria-hidden className="i-ri-close-line size-4" />
+                </IconButton>
+              }
+            />
           </div>
         </div>
         <ScrollArea className="relative min-h-0 flex-1 overflow-hidden has-[>_:first-child:focus-visible]:outline-2 has-[>_:first-child:focus-visible]:outline-offset-0 has-[>_:first-child:focus-visible]:outline-state-accent-solid">

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/upload-dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/upload-dialog.tsx
@@ -9,7 +9,7 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -328,7 +328,17 @@ export function AgentSkillUploadDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
       <DialogContent backdropProps={{ forceRender: true }} backdropClassName="fixed">
-        <DialogCloseButton />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute inset-e-6 top-6"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $['agentDetail.configure.skills.upload.title'])}
         </DialogTitle>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/cli-tool/dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/cli-tool/dialog.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type {
   AgentCliTool,
   EnvScope,
@@ -8,13 +7,14 @@ import type {
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
 import { Field, FieldDescription, FieldLabel } from '@langgenius/dify-ui/field'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useCallback, useState } from 'react'
@@ -163,7 +163,17 @@ export function CliToolDialog({
     <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
       <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-160 flex-col overflow-hidden p-0">
         <div className="relative px-6 pt-6 pb-3">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <DialogTitle className="title-2xl-semi-bold text-text-primary">
             {t(
               ($) =>

--- a/web/features/agent-v2/roster/components/create-agent-dialog.tsx
+++ b/web/features/agent-v2/roster/components/create-agent-dialog.tsx
@@ -1,17 +1,17 @@
 'use client'
-
 import type { AgentAppCreatePayload } from '@dify/contracts/api/console/agent/types.gen'
 import type { AgentFormValues, AgentIconSelection } from './agent-form'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
   DialogTrigger,
 } from '@langgenius/dify-ui/dialog'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
@@ -103,7 +103,17 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
           </DialogTrigger>
         )}
         <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-130 flex-col overflow-hidden! p-0!">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <div className="shrink-0 pt-6 pr-14 pb-3 pl-6">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">
               {t(($) => $['roster.createDialog.title'])}

--- a/web/features/agent-v2/roster/components/duplicate-agent-dialog.tsx
+++ b/web/features/agent-v2/roster/components/duplicate-agent-dialog.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type {
   AgentAppCopyPayload,
   AgentAppPartial,
@@ -8,13 +7,14 @@ import type { AgentFormValues, AgentIconSelection } from './agent-form'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
 import { Field, FieldLabel } from '@langgenius/dify-ui/field'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { toast } from '@langgenius/dify-ui/toast'
@@ -135,7 +135,17 @@ export function DuplicateAgentDialog({
     <>
       <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
         <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-130 flex-col overflow-hidden! p-0!">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <div className="shrink-0 pt-6 pr-14 pb-3 pl-6">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">
               {t(($) => $['roster.duplicateDialog.title'])}

--- a/web/features/agent-v2/roster/components/edit-agent-dialog.tsx
+++ b/web/features/agent-v2/roster/components/edit-agent-dialog.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import type {
   AgentAppPartial,
   AgentAppUpdatePayload,
@@ -8,12 +7,13 @@ import type { AgentFormValues, AgentIconSelection } from './agent-form'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
-  DialogCloseButton,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
 import { Form } from '@langgenius/dify-ui/form'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
@@ -134,7 +134,17 @@ export function EditAgentDialog({ agent, formKey, open, onOpenChange }: EditAgen
     <>
       <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
         <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-130 flex-col overflow-hidden! p-0!">
-          <DialogCloseButton />
+          <DialogClose
+            render={
+              <IconButton
+                aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                size="lg"
+                className="absolute inset-e-6 top-6"
+              >
+                <span aria-hidden className="i-ri-close-line size-4" />
+              </IconButton>
+            }
+          />
           <div className="shrink-0 pt-6 pr-14 pb-3 pl-6">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">
               {t(($) => $['roster.editDialog.title'])}

--- a/web/features/tag-management/__tests__/tag-management-modal.spec.tsx
+++ b/web/features/tag-management/__tests__/tag-management-modal.spec.tsx
@@ -126,11 +126,6 @@ describe('TagManagementModal', () => {
       expect(screen.getByText(i18n.manageTags)).toBeInTheDocument()
     })
 
-    it('should render the close button', () => {
-      render(<TagManagementModal {...defaultProps} />)
-      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
-    })
-
     it('should render the new tag input with placeholder', () => {
       render(<TagManagementModal {...defaultProps} />)
       expect(screen.getByRole('textbox', { name: i18n.addNew })).toBeInTheDocument()
@@ -178,7 +173,7 @@ describe('TagManagementModal', () => {
       const onClose = vi.fn()
       render(<TagManagementModal {...defaultProps} onClose={onClose} />)
 
-      await user.click(screen.getByRole('button', { name: 'Close' }))
+      await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
       expect(onClose).toHaveBeenCalledTimes(1)
     })

--- a/web/features/tag-management/components/tag-management-modal.tsx
+++ b/web/features/tag-management/components/tag-management-modal.tsx
@@ -1,6 +1,7 @@
 'use client'
 import type { TagType } from '@dify/contracts/api/console/tags/types.gen'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
@@ -76,7 +77,17 @@ export const TagManagementModal = ({
         <div className="relative pb-2 text-xl/7.5 font-semibold text-text-primary">
           {t(($) => $['tag.manageTags'], { ns: 'common' })}
         </div>
-        <DialogCloseButton className="top-4 right-4" />
+        <DialogClose
+          render={
+            <IconButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              size="lg"
+              className="absolute top-4 right-4"
+            >
+              <span aria-hidden className="i-ri-close-line size-4" />
+            </IconButton>
+          }
+        />
         <div className="mt-3 flex flex-wrap gap-2">
           <input
             aria-label={t(($) => $['tag.addNew'], { ns: 'common' }) || ''}


### PR DESCRIPTION
## Summary

- remove the styled `DialogCloseButton` compatibility API and keep `DialogClose` as the raw Base UI anatomy part
- compose close controls at their visual owners with Dify UI `IconButton` or `Button`
- standardize structural top-right closes on the 32px `lg` IconButton recipe while preserving special inline and full-screen surfaces
- move accessible labels to localized Web owners and route close state through `Dialog.Root onOpenChange`
- preserve the Settings dialog close control outside its scroll container so Safari cannot clip it

## Contract

`DialogContent` remains the convenience recipe for Portal, Backdrop, Popup, default surface, geometry, and scroll containment. It does not create a close control because close placement, visual treatment, accessible naming, and optionality belong to each dialog composition.

## Verification

- `pnpm check` (0 errors)
- `pnpm --dir web lint:tss` (5966 passed)
- Dify UI Browser Mode: 76 files / 465 tests passed
- focused Web unit tests: 4 files / 87 tests passed
- AST inventory: 78 DialogClose uses, 0 unnamed icon-only controls, 0 legacy DialogCloseButton refs
- `git diff --check`
