### PR TITLE
refactor(dify-ui): simplify popover content API

### DIFF
--- a/packages/dify-ui/src/combobox/index.stories.tsx
+++ b/packages/dify-ui/src/combobox/index.stories.tsx
@@ -609,7 +609,7 @@ const InlinePopoverDemo = () => {
         }}
       >
         <PopoverTrigger render={<Button variant="secondary" />}>Choose reviewer</PopoverTrigger>
-        <PopoverContent placement="bottom-start" sideOffset={4} popupClassName="w-80 p-0">
+        <PopoverContent placement="bottom-start" sideOffset={4} className="w-80 p-0">
           <PopoverTitle className="sr-only">Choose reviewer</PopoverTitle>
           <Combobox
             inline

--- a/packages/dify-ui/src/input-group/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/input-group/__tests__/index.spec.tsx
@@ -2,7 +2,7 @@ import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
 import { Button } from '../../button'
 import { Field, FieldLabel } from '../../field'
-import { Popover, PopoverContent, PopoverTrigger } from '../../popover'
+import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from '../../popover'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../index'
 
 function InputGroupInputTypeExamples() {
@@ -108,7 +108,8 @@ describe('InputGroup', () => {
         <InputGroupAddon align="inline-end">
           <Popover>
             <PopoverTrigger>More</PopoverTrigger>
-            <PopoverContent popupProps={{ 'aria-label': 'File actions' }}>
+            <PopoverContent>
+              <PopoverTitle className="sr-only">File actions</PopoverTitle>
               <span>File details</span>
             </PopoverContent>
           </Popover>

--- a/packages/dify-ui/src/popover/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/popover/__tests__/index.spec.tsx
@@ -28,7 +28,7 @@ describe('PopoverContent', () => {
         const screen = await renderWithSafeViewport(
           <Popover>
             <PopoverTrigger>Open</PopoverTrigger>
-            <PopoverContent popupClassName="duration-[30s]">
+            <PopoverContent className="duration-[30s]">
               <PopoverTitle>Popover content</PopoverTitle>
               <button type="button">Focusable content</button>
             </PopoverContent>

--- a/packages/dify-ui/src/popover/index.stories.tsx
+++ b/packages/dify-ui/src/popover/index.stories.tsx
@@ -185,7 +185,7 @@ export const Infotip: Story = {
         />
         <PopoverContent
           placement="top"
-          popupClassName="max-w-[300px] px-3 py-2 system-xs-regular text-text-tertiary"
+          className="max-w-[300px] px-3 py-2 system-xs-regular text-text-tertiary"
         >
           Set which resource to use first when running models. The Trial quota will be used after
           the paid quota is exhausted.

--- a/packages/dify-ui/src/popover/index.tsx
+++ b/packages/dify-ui/src/popover/index.tsx
@@ -74,7 +74,6 @@ type PopoverContentProps = {
   sideOffset?: number
   alignOffset?: number
   className?: string
-  popupClassName?: string
 }
 
 function PopoverContent({
@@ -83,20 +82,14 @@ function PopoverContent({
   sideOffset = 8,
   alignOffset = 0,
   className,
-  popupClassName,
 }: PopoverContentProps) {
   return (
     <PopoverPortal>
-      <PopoverPositioner
-        placement={placement}
-        sideOffset={sideOffset}
-        alignOffset={alignOffset}
-        className={className}
-      >
+      <PopoverPositioner placement={placement} sideOffset={sideOffset} alignOffset={alignOffset}>
         <PopoverPopup
           className={cn(
             'rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
-            popupClassName,
+            className,
           )}
         >
           {children}

--- a/packages/dify-ui/src/popover/index.tsx
+++ b/packages/dify-ui/src/popover/index.tsx
@@ -75,7 +75,6 @@ type PopoverContentProps = {
   alignOffset?: number
   className?: string
   popupClassName?: string
-  popupProps?: Omit<PopoverPopupProps, 'children' | 'className'>
 }
 
 function PopoverContent({
@@ -85,7 +84,6 @@ function PopoverContent({
   alignOffset = 0,
   className,
   popupClassName,
-  popupProps,
 }: PopoverContentProps) {
   return (
     <PopoverPortal>
@@ -100,7 +98,6 @@ function PopoverContent({
             'rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
             popupClassName,
           )}
-          {...popupProps}
         >
           {children}
         </PopoverPopup>

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-button.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-button.tsx
@@ -26,7 +26,7 @@ const ConfigBtn: FC<Props> = ({ className, hasConfigured, children, ...popupProp
       <PopoverContent
         placement="bottom-end"
         sideOffset={12}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <ConfigPopup {...popupProps} />
       </PopoverContent>

--- a/web/app/components/access-rules-editor/add-access-subject-popover.tsx
+++ b/web/app/components/access-rules-editor/add-access-subject-popover.tsx
@@ -77,7 +77,7 @@ function AddAccessSubjectPopover({
       <PopoverContent
         placement="bottom-end"
         sideOffset={8}
-        popupClassName="w-[344px] max-w-[calc(100vw-32px)] overflow-hidden bg-components-panel-bg-blur p-0 shadow-lg backdrop-blur-[5px]"
+        className="w-[344px] max-w-[calc(100vw-32px)] overflow-hidden bg-components-panel-bg-blur p-0 shadow-lg backdrop-blur-[5px]"
       >
         <PopoverTitle className="sr-only">{addMembersTitle}</PopoverTitle>
         <div className="p-2 pb-1">

--- a/web/app/components/access-rules-editor/add-access-subject-popover.tsx
+++ b/web/app/components/access-rules-editor/add-access-subject-popover.tsx
@@ -6,7 +6,7 @@ import { Avatar } from '@langgenius/dify-ui/avatar'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@langgenius/dify-ui/input-group'
-import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
+import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
@@ -60,6 +60,7 @@ function AddAccessSubjectPopover({
   }, [])
 
   const addExceptionLabel = t(($) => $['accessRule.addException'], { ns: 'permission' })
+  const addMembersTitle = t(($) => $['accessRule.addMembersTitle'], { ns: 'permission' })
   const addLabel = t(($) => $['operation.add'], { ns: 'common' })
   const addedLabel = t(($) => $['operation.added'], { ns: 'common' })
 
@@ -77,11 +78,8 @@ function AddAccessSubjectPopover({
         placement="bottom-end"
         sideOffset={8}
         popupClassName="w-[344px] max-w-[calc(100vw-32px)] overflow-hidden bg-components-panel-bg-blur p-0 shadow-lg backdrop-blur-[5px]"
-        popupProps={{
-          role: 'dialog',
-          'aria-label': t(($) => $['accessRule.addMembersTitle'], { ns: 'permission' }),
-        }}
       >
+        <PopoverTitle className="sr-only">{addMembersTitle}</PopoverTitle>
         <div className="p-2 pb-1">
           <InputGroup>
             <InputGroupInput

--- a/web/app/components/app/app-access-control/add-member-or-group-pop/index.tsx
+++ b/web/app/components/app/app-access-control/add-member-or-group-pop/index.tsx
@@ -137,7 +137,7 @@ export default function AddMemberOrGroupDialog({
       <PopoverContent
         placement="bottom-end"
         alignOffset={300}
-        popupClassName="relative flex max-h-[400px] w-[400px] flex-col overflow-hidden bg-components-panel-bg-blur p-0 backdrop-blur-[5px]"
+        className="relative flex max-h-[400px] w-[400px] flex-col overflow-hidden bg-components-panel-bg-blur p-0 backdrop-blur-[5px]"
       >
         <PopoverTitle className="sr-only">{searchLabel}</PopoverTitle>
         <ScrollArea className="relative min-h-0 flex-1 overflow-hidden">

--- a/web/app/components/app/app-publisher/publisher-content/publisher-panel/index.tsx
+++ b/web/app/components/app/app-publisher/publisher-content/publisher-panel/index.tsx
@@ -44,7 +44,7 @@ export function PublisherPanel({
         placement="bottom-end"
         sideOffset={4}
         alignOffset={crossAxisOffset}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="flex max-h-[calc(100dvh-32px)] w-88 flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl shadow-shadow-shadow-5">
           {showBuiltInPublisher ? (

--- a/web/app/components/app/configuration/config-vision/param-config.tsx
+++ b/web/app/components/app/configuration/config-vision/param-config.tsx
@@ -24,7 +24,7 @@ const ParamsConfig: FC = () => {
       <PopoverContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-80 space-y-3 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg p-4 shadow-lg sm:w-103">
           <ParamConfigContent />

--- a/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
@@ -274,7 +274,7 @@ const AgentTools: FC = () => {
                           </button>
                         }
                       />
-                      <PopoverContent popupClassName="px-3 py-2 system-xs-regular text-text-tertiary">
+                      <PopoverContent className="px-3 py-2 system-xs-regular text-text-tertiary">
                         {t(($) => $.toolRemoved, { ns: 'tools' })}
                       </PopoverContent>
                     </Popover>

--- a/web/app/components/app/configuration/configuration-view/legacy-agent-badge.tsx
+++ b/web/app/components/app/configuration/configuration-view/legacy-agent-badge.tsx
@@ -23,7 +23,7 @@ export function LegacyAgentBadge() {
       <PopoverContent
         placement="bottom-start"
         sideOffset={6}
-        popupClassName="max-w-[300px] px-3 py-2 system-xs-regular text-text-tertiary"
+        className="max-w-[300px] px-3 py-2 system-xs-regular text-text-tertiary"
       >
         <div>{description}</div>
         <Link

--- a/web/app/components/app/configuration/dataset-config/context-var/var-picker.tsx
+++ b/web/app/components/app/configuration/dataset-config/context-var/var-picker.tsx
@@ -79,7 +79,7 @@ const VarPicker: FC<Props> = ({
       <PopoverContent
         placement="bottom-end"
         sideOffset={8}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         {options.length > 0 ? (
           <div className="max-h-[50vh] w-60 overflow-y-auto rounded-lg border border-components-panel-border bg-components-panel-bg p-1 shadow-lg">

--- a/web/app/components/app/deploy/shared/version-label.tsx
+++ b/web/app/components/app/deploy/shared/version-label.tsx
@@ -61,7 +61,7 @@ export function VersionLabel({
         />
         <PopoverContent
           placement="top"
-          popupClassName="w-[296px] max-w-[calc(100vw-32px)] border-0 bg-components-tooltip-bg px-4 py-3.5 text-start inset-ring-[0.5px] inset-ring-components-panel-border backdrop-blur-[5px]"
+          className="w-[296px] max-w-[calc(100vw-32px)] border-0 bg-components-tooltip-bg px-4 py-3.5 text-start inset-ring-[0.5px] inset-ring-components-panel-border backdrop-blur-[5px]"
         >
           <div className="flex flex-col gap-1">
             <PopoverTitle className="system-sm-semibold text-text-secondary">{name}</PopoverTitle>

--- a/web/app/components/app/log/model-info.tsx
+++ b/web/app/components/app/log/model-info.tsx
@@ -69,7 +69,7 @@ const ModelInfo: FC<Props> = ({ model }) => {
           <PopoverContent
             placement="bottom-end"
             sideOffset={4}
-            popupClassName="border-none bg-transparent shadow-none"
+            className="border-none bg-transparent shadow-none"
           >
             <div className="relative w-70 overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg px-4 pt-3 pb-2 shadow-xl">
               <div className="mb-1 h-6 system-sm-semibold-uppercase text-text-secondary">

--- a/web/app/components/app/type-selector/index.tsx
+++ b/web/app/components/app/type-selector/index.tsx
@@ -63,7 +63,7 @@ const AppTypeSelector = ({ value, onChange }: AppSelectorProps) => {
         <PopoverContent
           placement="bottom-start"
           sideOffset={4}
-          popupClassName="w-[240px] rounded-xl border border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]"
+          className="w-[240px] rounded-xl border border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]"
         >
           <ul className="relative w-full p-1">
             {allTypes.map((mode) => (

--- a/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
@@ -22,7 +22,7 @@ const ViewFormDropdown = () => {
         placement="bottom-end"
         sideOffset={4}
         alignOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-100 rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg backdrop-blur-xs">
           <div className="flex items-center gap-3 rounded-t-2xl border-b border-divider-subtle px-6 py-4">

--- a/web/app/components/base/chat/chat/citation/popup.tsx
+++ b/web/app/components/base/chat/chat/citation/popup.tsx
@@ -54,7 +54,7 @@ const Popup: FC<PopupProps> = ({ data, showHitInfo = false }) => {
         placement="top-start"
         sideOffset={8}
         alignOffset={-2}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div
           data-testid="popup-content"

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
@@ -31,7 +31,7 @@ const ViewFormDropdown = ({ iconColor }: Props) => {
         placement="bottom-end"
         sideOffset={4}
         alignOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div
           data-testid="view-form-dropdown-content"

--- a/web/app/components/base/date-and-time-picker/date-picker/index.tsx
+++ b/web/app/components/base/date-and-time-picker/date-picker/index.tsx
@@ -287,7 +287,7 @@ const DatePicker = ({
       <PopoverContent
         placement="bottom-end"
         sideOffset={0}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="mt-1 w-63 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg shadow-shadow-shadow-5">
           {/* Header */}

--- a/web/app/components/base/date-and-time-picker/time-picker/index.tsx
+++ b/web/app/components/base/date-and-time-picker/time-picker/index.tsx
@@ -26,7 +26,6 @@ const TimePicker = ({
   renderTrigger,
   title,
   minuteFilter,
-  popupClassName,
   notClearable = false,
   triggerFullWidth = false,
   showTimezone = false,
@@ -270,8 +269,7 @@ const TimePicker = ({
       <PopoverContent
         placement={placement}
         sideOffset={0}
-        className={popupClassName}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="mt-1 w-63 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg shadow-shadow-shadow-5">
           {/* Header */}

--- a/web/app/components/base/date-and-time-picker/types.ts
+++ b/web/app/components/base/date-and-time-picker/types.ts
@@ -74,7 +74,6 @@ export type TimePickerProps = {
   ) => React.ReactElement
   title?: string
   minuteFilter?: (minutes: string[]) => string[]
-  popupClassName?: string
   notClearable?: boolean
   triggerFullWidth?: boolean
   showTimezone?: boolean

--- a/web/app/components/base/features/new-feature-panel/file-upload/setting-modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/file-upload/setting-modal.tsx
@@ -32,7 +32,7 @@ const FileUploadSettings = ({
       <PopoverContent
         placement="left"
         sideOffset={32}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="max-h-[calc(100vh-20px)] w-90 overflow-y-auto rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-4 shadow-2xl">
           <SettingContent

--- a/web/app/components/base/features/new-feature-panel/text-to-speech/voice-settings.tsx
+++ b/web/app/components/base/features/new-feature-panel/text-to-speech/voice-settings.tsx
@@ -32,7 +32,7 @@ const VoiceSettings = ({
       <PopoverContent
         placement={placementLeft ? 'left' : 'top'}
         sideOffset={placementLeft ? 32 : 4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-90 rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-4 shadow-2xl">
           <ParamConfigContent onClose={() => onOpen(false)} onChange={onChange} />

--- a/web/app/components/base/file-uploader/file-from-link-or-local/index.tsx
+++ b/web/app/components/base/file-uploader/file-from-link-or-local/index.tsx
@@ -53,7 +53,7 @@ const FileFromLinkOrLocal = ({
       <PopoverContent
         placement="top"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-70 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-3 shadow-lg">
           {showFromLink && (

--- a/web/app/components/base/image-uploader/text-generation-image-uploader.tsx
+++ b/web/app/components/base/image-uploader/text-generation-image-uploader.tsx
@@ -45,7 +45,7 @@ const PasteImageLinkButton: FC<PasteImageLinkButtonProps> = ({ onUpload, disable
       <PopoverContent
         placement="top-start"
         sideOffset={0}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-[320px] rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg p-2 shadow-lg">
           <ImageLinkInput onUpload={handleUpload} />

--- a/web/app/components/base/infotip/index.tsx
+++ b/web/app/components/base/infotip/index.tsx
@@ -97,7 +97,7 @@ export function Infotip({
       <PopoverContent
         placement={placement}
         sideOffset={sideOffset}
-        popupClassName={cn(
+        className={cn(
           'max-w-75 rounded-md px-3 py-2 system-xs-regular text-text-tertiary',
           popupClassName,
         )}

--- a/web/app/components/base/prompt-editor/plugins/context-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/context-block/component.tsx
@@ -66,7 +66,7 @@ const ContextBlockComponent: FC<ContextBlockComponentProps> = ({
             placement="bottom-end"
             sideOffset={3}
             alignOffset={-147}
-            popupClassName="border-none bg-transparent shadow-none"
+            className="border-none bg-transparent shadow-none"
           >
             <div className="w-90 rounded-xl bg-white shadow-lg">
               <div className="p-4">

--- a/web/app/components/base/prompt-editor/plugins/history-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/history-block/component.tsx
@@ -65,7 +65,7 @@ const HistoryBlockComponent: FC<HistoryBlockComponentProps> = ({
           placement="top-end"
           sideOffset={4}
           alignOffset={-148}
-          popupClassName="border-none bg-transparent shadow-none"
+          className="border-none bg-transparent shadow-none"
         >
           <div className="w-90 rounded-xl bg-white shadow-lg">
             <div className="p-4">

--- a/web/app/components/billing/pricing/plans/cloud-plan-item/list/item/tooltip.tsx
+++ b/web/app/components/billing/pricing/plans/cloud-plan-item/list/item/tooltip.tsx
@@ -21,7 +21,7 @@ const Tooltip = ({ content }: TooltipProps) => {
       </PopoverTrigger>
       <PopoverContent
         placement="top-end"
-        popupClassName="w-[260px] rounded-none border-0 bg-saas-dify-blue-static px-5 py-[18px] system-xs-regular text-text-primary-on-surface shadow-none"
+        className="w-[260px] rounded-none border-0 bg-saas-dify-blue-static px-5 py-[18px] system-xs-regular text-text-primary-on-surface shadow-none"
       >
         {content}
       </PopoverContent>

--- a/web/app/components/datasets/common/document-picker/preview-document-picker.tsx
+++ b/web/app/components/datasets/common/document-picker/preview-document-picker.tsx
@@ -61,7 +61,7 @@ const PreviewDocumentPicker: FC<Props> = ({ className, value, files, onChange })
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-98 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg backdrop-blur-[5px]">
           {files?.length > 1 && (

--- a/web/app/components/datasets/documents/components/operations.tsx
+++ b/web/app/components/datasets/documents/components/operations.tsx
@@ -344,7 +344,7 @@ const Operations = ({
               </div>
             }
           />
-          <PopoverContent popupClassName="px-3 py-2 font-semibold system-xs-regular text-text-tertiary">
+          <PopoverContent className="px-3 py-2 system-xs-regular font-semibold text-text-tertiary">
             {t(($) => $['list.action.enableWarning'], { ns: 'datasetDocuments' })}
           </PopoverContent>
         </Popover>

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/base/credential-selector/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/base/credential-selector/index.tsx
@@ -52,7 +52,7 @@ const CredentialSelector = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <List
           currentCredentialId={currentCredentialId}

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/list/item.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/list/item.tsx
@@ -90,7 +90,7 @@ const Item = ({
           </PopoverTrigger>
           <PopoverContent
             placement="top-end"
-            popupClassName="px-3 py-2 system-xs-regular text-text-tertiary"
+            className="px-3 py-2 system-xs-regular text-text-tertiary"
           >
             {disabledTip}
           </PopoverContent>

--- a/web/app/components/datasets/documents/create-from-pipeline/processing/embedding-process/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/processing/embedding-process/index.tsx
@@ -235,7 +235,7 @@ const EmbeddingProcess = ({
                     >
                       <RiErrorWarningFill className="size-4 shrink-0 text-text-destructive" />
                     </PopoverTrigger>
-                    <PopoverContent popupClassName="max-w-60 rounded-xl border-[0.5px] border-components-panel-border px-4 py-[14px] body-xs-regular text-text-secondary">
+                    <PopoverContent className="max-w-60 rounded-xl border-[0.5px] border-components-panel-border px-4 py-[14px] body-xs-regular text-text-secondary">
                       {indexingStatusDetail.error}
                     </PopoverContent>
                   </Popover>

--- a/web/app/components/datasets/external-api/external-api-modal/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-modal/index.tsx
@@ -170,7 +170,7 @@ const AddExternalAPIModal: FC<AddExternalAPIModalProps> = ({
                     />
                     <PopoverContent
                       placement="bottom"
-                      popupClassName="flex w-[320px] items-center self-stretch px-3 py-2"
+                      className="flex w-[320px] items-center self-stretch px-3 py-2"
                     >
                       <div className="p-1">
                         <div className="flex items-start self-stretch pt-1 pr-3 pb-0.5 pl-2">

--- a/web/app/components/datasets/extra-info/api-access/index.tsx
+++ b/web/app/components/datasets/extra-info/api-access/index.tsx
@@ -51,7 +51,7 @@ const ApiAccess = ({ expand, apiEnabled }: ApiAccessProps) => {
           placement="top-start"
           sideOffset={4}
           alignOffset={-4}
-          popupClassName="border-none bg-transparent shadow-none"
+          className="border-none bg-transparent shadow-none"
         >
           <Card apiEnabled={apiEnabled} />
         </PopoverContent>

--- a/web/app/components/datasets/extra-info/service-api/index.tsx
+++ b/web/app/components/datasets/extra-info/service-api/index.tsx
@@ -44,7 +44,7 @@ export function ServiceApi({ apiBaseUrl }: ServiceApiProps) {
           placement="top-start"
           sideOffset={4}
           alignOffset={-4}
-          popupClassName="border-none bg-transparent shadow-none"
+          className="border-none bg-transparent shadow-none"
         >
           <ServiceApiCard
             apiBaseUrl={apiBaseUrl}

--- a/web/app/components/datasets/extra-info/statistics.tsx
+++ b/web/app/components/datasets/extra-info/statistics.tsx
@@ -51,10 +51,7 @@ const Statistics = ({ expand, documentCount, relatedApps }: StatisticsProps) => 
               </button>
             }
           />
-          <PopoverContent
-            placement="top-start"
-            popupClassName="border-0 bg-transparent p-0 shadow-none"
-          >
+          <PopoverContent placement="top-start" className="border-0 bg-transparent p-0 shadow-none">
             {hasRelatedApps ? (
               <LinkedAppsPanel relatedApps={relatedApps.data} isMobile={!expand} />
             ) : (

--- a/web/app/components/datasets/metadata/metadata-dataset/create-metadata-modal.tsx
+++ b/web/app/components/datasets/metadata/metadata-dataset/create-metadata-modal.tsx
@@ -32,7 +32,7 @@ export function CreateMetadataModal({
         placement="left-start"
         sideOffset={popupLeft}
         alignOffset={-38}
-        popupClassName="w-[320px]"
+        className="w-[320px]"
       >
         <CreateContent
           {...createContentProps}

--- a/web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-picker.tsx
+++ b/web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-picker.tsx
@@ -129,7 +129,7 @@ export function DatasetMetadataPicker({
         placement={placement}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
-        popupClassName="w-[320px] bg-components-panel-bg-blur backdrop-blur-[5px]"
+        className="w-[320px] bg-components-panel-bg-blur backdrop-blur-[5px]"
       >
         <PopoverTitle className="sr-only">
           {t(($) => $['metadata.addMetadata'], { ns: 'dataset' })}

--- a/web/app/components/datasets/settings/index-method/index.tsx
+++ b/web/app/components/datasets/settings/index-method/index.tsx
@@ -75,7 +75,7 @@ const IndexMethod = ({
           <PopoverContent
             placement="right"
             sideOffset={4}
-            popupClassName="rounded-lg border-0 bg-components-tooltip-bg p-3 text-xs font-medium text-text-secondary shadow-lg"
+            className="rounded-lg border-0 bg-components-tooltip-bg p-3 text-xs font-medium text-text-secondary shadow-lg"
           >
             {t(($) => $['form.indexMethodChangeToEconomyDisabledTip'], { ns: 'datasetSettings' })}
           </PopoverContent>

--- a/web/app/components/datasets/settings/permission-selector/index.tsx
+++ b/web/app/components/datasets/settings/permission-selector/index.tsx
@@ -161,7 +161,7 @@ const PermissionSelector = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <PopoverTitle className="sr-only">{permissionLabel}</PopoverTitle>
         <div className="relative w-120 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg shadow-shadow-shadow-5">

--- a/web/app/components/header/account-setting/api-based-extension-page/selector.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/selector.tsx
@@ -1,5 +1,11 @@
 import { cn } from '@langgenius/dify-ui/cn'
-import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
+import {
+  Popover,
+  PopoverPopup,
+  PopoverPortal,
+  PopoverPositioner,
+  PopoverTrigger,
+} from '@langgenius/dify-ui/popover'
 import { useQuery } from '@tanstack/react-query'
 import { useQueryState } from 'nuqs'
 import { useState } from 'react'
@@ -81,63 +87,66 @@ export function ApiBasedExtensionSelector({ value, onChange }: ApiBasedExtension
             </button>
           )}
         />
-        <PopoverContent
-          placement="bottom-start"
-          sideOffset={4}
-          className="w-[calc(100%-32px)] max-w-xl"
-          popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-        >
-          <div className="z-10 w-full rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg">
-            <div className="p-1">
-              <div className="flex items-center justify-between px-3 pt-2 pb-1">
-                <div className="text-xs font-medium text-text-tertiary">
-                  {t(($) => $['apiBasedExtension.selector.title'], { ns: 'common' })}
+        <PopoverPortal>
+          <PopoverPositioner
+            placement="bottom-start"
+            sideOffset={4}
+            className="w-[calc(100%-32px)] max-w-xl"
+          >
+            <PopoverPopup className="rounded-xl border-0 bg-transparent p-0 shadow-none backdrop-blur-none">
+              <div className="z-10 w-full rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg">
+                <div className="p-1">
+                  <div className="flex items-center justify-between px-3 pt-2 pb-1">
+                    <div className="text-xs font-medium text-text-tertiary">
+                      {t(($) => $['apiBasedExtension.selector.title'], { ns: 'common' })}
+                    </div>
+                    <button
+                      type="button"
+                      className="flex cursor-pointer items-center border-none bg-transparent p-0 text-xs text-text-accent"
+                      onClick={() => {
+                        setOpen(false)
+                        setSettingsDestination('custom-endpoint')
+                      }}
+                    >
+                      {t(($) => $['apiBasedExtension.selector.manage'], { ns: 'common' })}
+                      <span
+                        className="ml-0.5 i-custom-vender-line-arrows-arrow-up-right size-3"
+                        aria-hidden="true"
+                      />
+                    </button>
+                  </div>
+                  <div className="max-h-62.5 overflow-y-auto">
+                    {apiBasedExtensions.map((item) => (
+                      <button
+                        type="button"
+                        key={item.id}
+                        className="w-full cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left hover:bg-state-base-hover"
+                        onClick={() => handleSelect(item.id)}
+                      >
+                        <div className="text-sm text-text-primary">{item.name}</div>
+                        <div className="text-xs text-text-tertiary">{item.api_endpoint}</div>
+                      </button>
+                    ))}
+                  </div>
                 </div>
-                <button
-                  type="button"
-                  className="flex cursor-pointer items-center border-none bg-transparent p-0 text-xs text-text-accent"
-                  onClick={() => {
-                    setOpen(false)
-                    setSettingsDestination('custom-endpoint')
-                  }}
-                >
-                  {t(($) => $['apiBasedExtension.selector.manage'], { ns: 'common' })}
-                  <span
-                    className="ml-0.5 i-custom-vender-line-arrows-arrow-up-right size-3"
-                    aria-hidden="true"
-                  />
-                </button>
-              </div>
-              <div className="max-h-62.5 overflow-y-auto">
-                {apiBasedExtensions.map((item) => (
+                <div className="h-px bg-divider-regular" />
+                <div className="p-1">
                   <button
                     type="button"
-                    key={item.id}
-                    className="w-full cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left hover:bg-state-base-hover"
-                    onClick={() => handleSelect(item.id)}
+                    className="flex h-8 w-full cursor-pointer items-center border-none bg-transparent px-3 text-left text-sm text-text-accent"
+                    onClick={() => {
+                      setOpen(false)
+                      setAddModalOpen(true)
+                    }}
                   >
-                    <div className="text-sm text-text-primary">{item.name}</div>
-                    <div className="text-xs text-text-tertiary">{item.api_endpoint}</div>
+                    <span className="mr-2 i-ri-add-line size-4" aria-hidden="true" />
+                    {t(($) => $['operation.add'], { ns: 'common' })}
                   </button>
-                ))}
+                </div>
               </div>
-            </div>
-            <div className="h-px bg-divider-regular" />
-            <div className="p-1">
-              <button
-                type="button"
-                className="flex h-8 w-full cursor-pointer items-center border-none bg-transparent px-3 text-left text-sm text-text-accent"
-                onClick={() => {
-                  setOpen(false)
-                  setAddModalOpen(true)
-                }}
-              >
-                <span className="mr-2 i-ri-add-line size-4" aria-hidden="true" />
-                {t(($) => $['operation.add'], { ns: 'common' })}
-              </button>
-            </div>
-          </div>
-        </PopoverContent>
+            </PopoverPopup>
+          </PopoverPositioner>
+        </PopoverPortal>
       </Popover>
       {addModalOpen && (
         <ApiBasedExtensionModal

--- a/web/app/components/header/account-setting/data-source-page-new/configure.tsx
+++ b/web/app/components/header/account-setting/data-source-page-new/configure.tsx
@@ -57,7 +57,7 @@ const Configure = ({ item, pluginPayload, onUpdate, disabled }: ConfigureProps) 
           placement="bottom-end"
           sideOffset={4}
           alignOffset={-4}
-          popupClassName="border-none bg-transparent shadow-none"
+          className="border-none bg-transparent shadow-none"
         >
           <div className="w-60 space-y-1.5 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-2 shadow-lg">
             {!!canOAuth && oAuthTrigger}

--- a/web/app/components/header/account-setting/members-page/member-details-modal/permission-role-chip.tsx
+++ b/web/app/components/header/account-setting/members-page/member-details-modal/permission-role-chip.tsx
@@ -106,7 +106,7 @@ const PermissionRoleChip = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={8}
-        popupClassName="overflow-hidden border-components-panel-border bg-components-tooltip-bg p-0 shadow-lg backdrop-blur-[5px]"
+        className="overflow-hidden border-components-panel-border bg-components-tooltip-bg p-0 shadow-lg backdrop-blur-[5px]"
       >
         {permissionSummary}
       </PopoverContent>

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
@@ -77,7 +77,7 @@ const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
       <PopoverContent
         placement="bottom"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="min-w-93 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-2 pb-1">

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/add-custom-model.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/add-custom-model.tsx
@@ -114,7 +114,7 @@ const AddCustomModel = ({
       <PopoverContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-[320px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <div className="max-h-76 overflow-y-auto p-1">

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/authorized/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/authorized/index.tsx
@@ -53,7 +53,6 @@ type AuthorizedProps = {
   onOpenChange?: (open: boolean) => void
   offset?: number | PopoverOffsetOptions
   placement?: Placement
-  triggerPopupSameWidth?: boolean
   popupClassName?: string
   showItemSelectedIcon?: boolean
   onItemClick?: (credential: Credential, model?: CustomModel) => void
@@ -78,7 +77,6 @@ const Authorized = ({
   onOpenChange,
   offset = 8,
   placement = 'bottom-end',
-  triggerPopupSameWidth = false,
   popupClassName,
   showItemSelectedIcon,
   onItemClick,
@@ -157,9 +155,6 @@ const Authorized = ({
     typeof offset === 'number'
       ? 0
       : (resolvedOffset?.crossAxis ?? resolvedOffset?.alignmentAxis ?? 0)
-  const popupProps = triggerPopupSameWidth
-    ? { style: { width: 'var(--anchor-width, auto)' } }
-    : undefined
   const handleTriggerClick = useCallback(
     (event: MouseEvent<HTMLElement>) => {
       if (!triggerOnlyOpenModal) return
@@ -178,10 +173,7 @@ const Authorized = ({
         <PopoverTrigger
           nativeButton={false}
           render={(props, state) => (
-            <div
-              {...props}
-              className={cn(triggerPopupSameWidth ? 'w-full' : 'inline-block', props.className)}
-            >
+            <div {...props} className={cn('inline-block', props.className)}>
               {renderTrigger(state.open)}
             </div>
           )}
@@ -191,7 +183,6 @@ const Authorized = ({
           placement={placement}
           sideOffset={sideOffset}
           alignOffset={alignOffset}
-          popupProps={popupProps}
           popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
         >
           <div

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/authorized/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/authorized/index.tsx
@@ -183,7 +183,7 @@ const Authorized = ({
           placement={placement}
           sideOffset={sideOffset}
           alignOffset={alignOffset}
-          popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
+          className="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
         >
           <div
             className={cn(

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/credential-selector.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/credential-selector.tsx
@@ -68,7 +68,7 @@ const CredentialSelector = ({
       </PopoverTrigger>
       <PopoverContent
         sideOffset={0}
-        popupClassName="w-(--anchor-width) rounded-xl border-[0.5px] border-ccomponents-panel-border bg-components-panel-bg-blur p-0"
+        className="border-ccomponents-panel-border w-(--anchor-width) rounded-xl border-[0.5px] bg-components-panel-bg-blur p-0"
       >
         <div className="max-h-80 overflow-y-auto p-1">
           {credentials.map((credential) => (

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/credential-selector.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/credential-selector.tsx
@@ -68,8 +68,7 @@ const CredentialSelector = ({
       </PopoverTrigger>
       <PopoverContent
         sideOffset={0}
-        popupClassName="border-ccomponents-panel-border rounded-xl border-[0.5px] bg-components-panel-bg-blur p-0"
-        popupProps={{ style: { width: 'var(--anchor-width, auto)' } }}
+        popupClassName="w-(--anchor-width) rounded-xl border-[0.5px] border-ccomponents-panel-border bg-components-panel-bg-blur p-0"
       >
         <div className="max-h-80 overflow-y-auto p-1">
           {credentials.map((credential) => (

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -178,7 +178,7 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
       <PopoverContent
         placement={placement ?? (isInWorkflow ? 'left' : trigger ? 'bottom-end' : 'left-start')}
         sideOffset={4}
-        popupClassName={cn(popupClassName, 'w-100 rounded-2xl')}
+        className={cn(popupClassName, 'w-100 rounded-2xl')}
       >
         <div className="relative px-3 pt-3.5 pb-1">
           <div className="pr-8 pl-1 system-xl-semibold text-text-primary">

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/index.tsx
@@ -155,7 +155,7 @@ function ModelSelectorRoot({
       />
       <PopoverContent
         placement="bottom-start"
-        popupClassName={cn(
+        className={cn(
           'flex max-h-[min(624px,var(--available-height,624px))] w-(--anchor-width) max-w-[min(28rem,var(--available-width))] flex-col overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
           popupClassName,
         )}

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-list-item.tsx
@@ -154,7 +154,7 @@ const ModelListItem = ({
                 </span>
               }
             />
-            <PopoverContent popupClassName="px-3 py-2 font-semibold system-xs-regular text-text-tertiary">
+            <PopoverContent className="px-3 py-2 system-xs-regular font-semibold text-text-tertiary">
               {t(($) => $['modelProvider.modelHasBeenDeprecated'], { ns: 'common' })}
             </PopoverContent>
           </Popover>

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/quota-panel.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/quota-panel.tsx
@@ -61,7 +61,7 @@ const QuotaInfotip: FC<QuotaInfotipProps> = ({ tipText }) => {
       </PopoverTrigger>
       <PopoverContent
         placement="top"
-        popupClassName="max-w-[300px] rounded-md px-3 py-2 system-xs-regular text-text-tertiary"
+        className="max-w-[300px] rounded-md px-3 py-2 system-xs-regular text-text-tertiary"
       >
         {tipText}
       </PopoverContent>

--- a/web/app/components/integrations/sidebar-actions.tsx
+++ b/web/app/components/integrations/sidebar-actions.tsx
@@ -181,7 +181,7 @@ export function IntegrationSidebarUtilityActions({
           <PopoverContent
             placement="top-start"
             sideOffset={4}
-            popupClassName="border-0 bg-transparent p-0 shadow-none"
+            className="border-0 bg-transparent p-0 shadow-none"
           >
             <PermissionQuickPanel permission={permission} onChange={onPermissionChange} />
           </PopoverContent>

--- a/web/app/components/main-nav/components/workspace-card.tsx
+++ b/web/app/components/main-nav/components/workspace-card.tsx
@@ -328,7 +328,7 @@ export function WorkspaceCard() {
           placement="bottom-start"
           sideOffset={-workspaceMenuTriggerHeight}
           alignOffset={workspaceMenuAlignOffset}
-          popupClassName="w-[280px] overflow-hidden bg-components-panel-bg-blur! p-0! backdrop-blur-[5px]"
+          className="w-[280px] overflow-hidden bg-components-panel-bg-blur! p-0! backdrop-blur-[5px]"
         >
           <WorkspaceMenuHeader
             name={currentWorkspace.name}

--- a/web/app/components/plugins/marketplace/search-box/tags-filter.tsx
+++ b/web/app/components/plugins/marketplace/search-box/tags-filter.tsx
@@ -47,7 +47,7 @@ function TagsFilter({ tags, onTagsChange, usedInMarketplace = false }: TagsFilte
         placement="bottom-start"
         sideOffset={4}
         alignOffset={-6}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-60 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-2 pb-1">

--- a/web/app/components/plugins/plugin-auth/authorized/index.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/index.tsx
@@ -233,7 +233,7 @@ const Authorized = ({
           placement={placement}
           sideOffset={sideOffset}
           alignOffset={alignOffset}
-          popupClassName={cn(
+          className={cn(
             'border-0 bg-transparent p-0 shadow-none backdrop-blur-none',
             triggerPopupSameWidth && 'w-(--anchor-width)',
           )}

--- a/web/app/components/plugins/plugin-auth/authorized/index.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/index.tsx
@@ -199,9 +199,6 @@ const Authorized = ({
     typeof offset === 'number'
       ? 0
       : (resolvedOffset?.crossAxis ?? resolvedOffset?.alignmentAxis ?? 0)
-  const popupProps = triggerPopupSameWidth
-    ? { style: { width: 'var(--anchor-width, auto)' } }
-    : undefined
 
   return (
     <>
@@ -236,8 +233,10 @@ const Authorized = ({
           placement={placement}
           sideOffset={sideOffset}
           alignOffset={alignOffset}
-          popupProps={popupProps}
-          popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
+          popupClassName={cn(
+            'border-0 bg-transparent p-0 shadow-none backdrop-blur-none',
+            triggerPopupSameWidth && 'w-(--anchor-width)',
+          )}
         >
           <div
             className={cn(

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/index.tsx
@@ -142,7 +142,7 @@ export function AppSelector({
       <PopoverContent
         placement={placement}
         sideOffset={offset}
-        popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="relative min-h-20 w-97.25 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="flex flex-col gap-1 px-4 py-3">

--- a/web/app/components/plugins/plugin-detail-panel/endpoint-list.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/endpoint-list.tsx
@@ -88,7 +88,7 @@ const EndpointListContent = ({ declaration, detail }: EndpointListContentProps) 
             />
             <PopoverContent
               placement="right"
-              popupClassName="w-[240px] p-4 rounded-xl bg-components-panel-bg-blur border-[0.5px] border-components-panel-border"
+              className="w-[240px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-4"
             >
               <div className="flex flex-col gap-2">
                 <div className="flex h-8 w-8 items-center justify-center rounded-lg border-[0.5px] border-components-panel-border-subtle bg-background-default-subtle">

--- a/web/app/components/plugins/plugin-detail-panel/model-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/model-selector/index.tsx
@@ -209,7 +209,7 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
         <PopoverContent
           placement={isInWorkflow ? 'left' : 'bottom-end'}
           sideOffset={4}
-          popupClassName={cn(popupClassName, 'w-97.25 rounded-2xl')}
+          className={cn(popupClassName, 'w-97.25 rounded-2xl')}
         >
           <div className="max-h-105 overflow-y-auto p-4 pt-3">
             {currentModel?.model_type === ModelTypeEnum.textGeneration && selectedModel && (

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/selector-entry.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/selector-entry.tsx
@@ -115,7 +115,7 @@ export const SubscriptionSelectorEntry = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="rounded-xl border border-components-panel-border bg-components-panel-bg shadow-lg">
           <SubscriptionList

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/subscription-card.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/subscription-card.tsx
@@ -67,7 +67,7 @@ const SubscriptionCard = ({ data, pluginDetail }: Props) => {
               </PopoverTrigger>
               <PopoverContent
                 placement="left"
-                popupClassName="max-w-[320px] break-all px-3 py-2 system-xs-regular text-text-tertiary"
+                className="max-w-[320px] px-3 py-2 system-xs-regular break-all text-text-tertiary"
               >
                 {data.endpoint}
               </PopoverContent>

--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/components/tool-item.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/components/tool-item.tsx
@@ -242,7 +242,7 @@ export function ToolItem({
             >
               <span className="i-ri-error-warning-fill size-4 text-text-destructive" />
             </PopoverTrigger>
-            <PopoverContent popupClassName="px-3 py-2 system-xs-regular text-text-tertiary">
+            <PopoverContent className="px-3 py-2 system-xs-regular text-text-tertiary">
               {errorTip}
             </PopoverContent>
           </Popover>

--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
@@ -173,7 +173,7 @@ function ToolSelector({
       <PopoverContent
         placement={placement}
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div
           className={cn(

--- a/web/app/components/plugins/plugin-item/index.tsx
+++ b/web/app/components/plugins/plugin-item/index.tsx
@@ -168,7 +168,7 @@ const PluginItem: FC<Props> = ({
                   >
                     <RiErrorWarningLine color="red" className="size-4 text-text-accent" />
                   </PopoverTrigger>
-                  <PopoverContent popupClassName="px-3 py-2 system-xs-regular text-text-tertiary">
+                  <PopoverContent className="px-3 py-2 system-xs-regular text-text-tertiary">
                     {t(($) => $.difyVersionNotCompatible, {
                       ns: 'plugin',
                       minimalDifyVersion: declarationMeta.minimum_dify_version,

--- a/web/app/components/plugins/plugin-page/debug-info.tsx
+++ b/web/app/components/plugins/plugin-page/debug-info.tsx
@@ -60,7 +60,7 @@ function DebugInfo({
       />
       <PopoverContent
         placement={popupPlacement}
-        popupClassName="border-0 bg-transparent p-0 shadow-none"
+        className="border-0 bg-transparent p-0 shadow-none"
       >
         <PluginSidecarPanel
           title={title}

--- a/web/app/components/plugins/plugin-page/filter-management/category-filter.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/category-filter.tsx
@@ -66,7 +66,7 @@ const CategoriesFilter = ({ value, onChange }: CategoriesFilterProps) => {
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-60 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-2 pb-1">

--- a/web/app/components/plugins/plugin-page/filter-management/tag-filter.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/tag-filter.tsx
@@ -65,7 +65,7 @@ const TagsFilter = ({ value, onChange }: TagsFilterProps) => {
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-60 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-2 pb-1">

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/tool-picker.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/tool-picker.tsx
@@ -112,7 +112,7 @@ const ToolPicker: FC<Props> = ({
       <PopoverContent
         placement="top"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="relative min-h-20 w-108 max-w-[calc(100vw-32px)] overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg backdrop-blur-xs">
           <div className="flex flex-col overflow-hidden rounded-t-lg border-b border-divider-subtle bg-background-section-burn">

--- a/web/app/components/plugins/update-plugin/plugin-version-picker.tsx
+++ b/web/app/components/plugins/update-plugin/plugin-version-picker.tsx
@@ -94,7 +94,7 @@ const PluginVersionPicker: FC<Props> = ({
         placement={placement}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
-        popupClassName="relative w-[209px] bg-components-panel-bg-blur p-1 backdrop-blur-[5px]"
+        className="relative w-[209px] bg-components-panel-bg-blur p-1 backdrop-blur-[5px]"
       >
         <div className="px-3 pt-1 pb-0.5 system-xs-medium-uppercase text-text-tertiary">
           {t(($) => $['detailPanel.switchVersion'], { ns: 'plugin' })}

--- a/web/app/components/rag-pipeline/components/rag-pipeline-header/publisher/index.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-header/publisher/index.tsx
@@ -113,7 +113,7 @@ const Publisher = () => {
           placement="bottom-end"
           sideOffset={4}
           alignOffset={40}
-          popupClassName={cn('border-none bg-transparent shadow-none', confirmVisible && 'hidden')}
+          className={cn('border-none bg-transparent shadow-none', confirmVisible && 'hidden')}
         >
           <Popup
             onRequestClose={closePopover}

--- a/web/app/components/snippet-list/components/snippet-create-button.tsx
+++ b/web/app/components/snippet-list/components/snippet-create-button.tsx
@@ -38,7 +38,7 @@ const SnippetCreateButton = () => {
         <PopoverContent
           placement="bottom-end"
           sideOffset={6}
-          popupClassName="w-[228px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg backdrop-blur-xs"
+          className="w-[228px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg backdrop-blur-xs"
         >
           <div className="px-2 pt-2 pb-1 text-xs leading-4.5 font-medium text-text-tertiary">
             {t(($) => $.createFrom)}

--- a/web/app/components/tools/labels/filter.tsx
+++ b/web/app/components/tools/labels/filter.tsx
@@ -72,7 +72,7 @@ const LabelFilter: FC<LabelFilterProps> = ({ value, onChange }) => {
         <PopoverContent
           placement="bottom-start"
           sideOffset={4}
-          popupClassName="w-[240px] rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]"
+          className="w-[240px] rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]"
         >
           <div className="relative">
             <div className="p-2">

--- a/web/app/components/tools/labels/selector.tsx
+++ b/web/app/components/tools/labels/selector.tsx
@@ -52,7 +52,7 @@ function LabelSelector({ value, onChange }: LabelSelectorProps) {
         <PopoverContent
           placement="bottom-start"
           sideOffset={4}
-          popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+          className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
         >
           <div className="relative w-147.75 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
             <div className="border-b-[0.5px] border-divider-regular p-2">

--- a/web/app/components/tools/mcp/detail/tool-item.tsx
+++ b/web/app/components/tools/mcp/detail/tool-item.tsx
@@ -72,7 +72,7 @@ const MCPToolItem = ({ tool }: Props) => {
       />
       <PopoverContent
         placement="left"
-        popupClassName="w-[360px]! rounded-xl! border-[0.5px]! border-components-panel-border! px-4! py-3.5! shadow-lg!"
+        className="w-[360px]! rounded-xl! border-[0.5px]! border-components-panel-border! px-4! py-3.5! shadow-lg!"
       >
         <div>
           <div className="mb-1 title-xs-semi-bold text-text-primary">{tool.label[language]}</div>

--- a/web/app/components/workflow/block-selector/agent-selector.tsx
+++ b/web/app/components/workflow/block-selector/agent-selector.tsx
@@ -280,7 +280,7 @@ export function AgentBlockItem({
       <PopoverContent
         placement="right-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <PopoverTitle className="sr-only">
           {t(($) => $['roster.nodeSelector.dialogLabel'], { ns: 'agentV2' })}

--- a/web/app/components/workflow/block-selector/snippets/snippet-tags-filter.tsx
+++ b/web/app/components/workflow/block-selector/snippets/snippet-tags-filter.tsx
@@ -89,7 +89,7 @@ const SnippetTagsFilter = ({ embedded = false, value, onChange }: SnippetTagsFil
       <PopoverContent
         placement="bottom-end"
         sideOffset={6}
-        popupClassName="w-[240px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-0 shadow-lg backdrop-blur-xs"
+        className="w-[240px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-0 shadow-lg backdrop-blur-xs"
       >
         <PopoverTitle className="sr-only">{triggerLabel}</PopoverTitle>
         <div className="p-2 pb-1">

--- a/web/app/components/workflow/block-selector/tool-picker.tsx
+++ b/web/app/components/workflow/block-selector/tool-picker.tsx
@@ -216,7 +216,7 @@ function ToolPicker({
       <PopoverContent
         placement={placement}
         sideOffset={sideOffset}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <PopoverTitle className="sr-only">
           {t(($) => $['detailPanel.toolSelector.title'], { ns: 'plugin' })}

--- a/web/app/components/workflow/header/checklist/index.tsx
+++ b/web/app/components/workflow/header/checklist/index.tsx
@@ -88,7 +88,7 @@ const WorkflowChecklist = ({ disabled, showGoTo = true, onItemClick }: WorkflowC
         placement="bottom-start"
         sideOffset={12}
         alignOffset={-30}
-        popupClassName="w-[420px] rounded-2xl bg-background-default-subtle"
+        className="w-[420px] rounded-2xl bg-background-default-subtle"
       >
         <div className="overflow-y-auto" style={{ maxHeight: 'calc(2 / 3 * 100vh)' }}>
           <div className="flex flex-col gap-0.5 px-3 pt-3.5 pb-1">

--- a/web/app/components/workflow/header/online-users.tsx
+++ b/web/app/components/workflow/header/online-users.tsx
@@ -193,7 +193,7 @@ const OnlineUsers = () => {
                 placement="bottom-start"
                 sideOffset={8}
                 alignOffset={-48}
-                popupClassName={cn(
+                className={cn(
                   'mt-1.5 flex max-h-50 w-60 flex-col overflow-y-auto',
                   'rounded-xl border-[0.5px] border-components-panel-border',
                   'bg-components-panel-bg-blur p-1 shadow-lg shadow-shadow-shadow-5 backdrop-blur-[10px]',

--- a/web/app/components/workflow/header/view-history.tsx
+++ b/web/app/components/workflow/header/view-history.tsx
@@ -82,7 +82,7 @@ const ViewHistory = ({ withText, onClearLogAndMessageModal, historyUrl }: ViewHi
         placement={withText ? 'bottom-start' : 'bottom-end'}
         sideOffset={4}
         alignOffset={withText ? -8 : 10}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div
           className="ml-2 flex w-60 flex-col overflow-y-auto rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl"

--- a/web/app/components/workflow/header/view-workflow-history.tsx
+++ b/web/app/components/workflow/header/view-workflow-history.tsx
@@ -173,10 +173,7 @@ const ViewWorkflowHistory = () => {
           }
         />
       </TipPopup>
-      <PopoverContent
-        placement="bottom-end"
-        popupClassName="border-none bg-transparent shadow-none"
-      >
+      <PopoverContent placement="bottom-end" className="border-none bg-transparent shadow-none">
         <div className="flex max-w-90 min-w-60 flex-col overflow-y-auto rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-xl backdrop-blur-[5px]">
           <div className="sticky top-0 flex items-center justify-between px-4 pt-3">
             <div className="system-mg-regular grow text-text-secondary">

--- a/web/app/components/workflow/nodes/_base/components/agent-strategy-selector.tsx
+++ b/web/app/components/workflow/nodes/_base/components/agent-strategy-selector.tsx
@@ -242,7 +242,7 @@ export const AgentStrategySelector = memo((props: AgentStrategySelectorProps) =>
       <PopoverContent
         placement="bottom"
         sideOffset={0}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-97 overflow-hidden rounded-md border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow">
           <header className="flex gap-1 p-2">

--- a/web/app/components/workflow/nodes/_base/components/mcp-tool-not-support-tooltip.tsx
+++ b/web/app/components/workflow/nodes/_base/components/mcp-tool-not-support-tooltip.tsx
@@ -18,7 +18,7 @@ const McpToolNotSupportTooltip: FC = () => {
       >
         <RiAlertFill className="size-4 text-text-warning-secondary" />
       </PopoverTrigger>
-      <PopoverContent popupClassName="w-[256px] px-3 py-2 system-xs-regular text-text-tertiary">
+      <PopoverContent className="w-[256px] px-3 py-2 system-xs-regular text-text-tertiary">
         {tip}
       </PopoverContent>
     </Popover>

--- a/web/app/components/workflow/nodes/_base/components/prompt/editor.tsx
+++ b/web/app/components/workflow/nodes/_base/components/prompt/editor.tsx
@@ -193,7 +193,7 @@ const Editor: FC<Props> = ({
                       </button>
                     }
                   />
-                  <PopoverContent popupClassName="max-w-[300px] px-3 py-2 system-xs-regular text-text-tertiary">
+                  <PopoverContent className="max-w-[300px] px-3 py-2 system-xs-regular text-text-tertiary">
                     {titleTooltip}
                   </PopoverContent>
                 </Popover>
@@ -238,7 +238,7 @@ const Editor: FC<Props> = ({
                           </button>
                         }
                       />
-                      <PopoverContent popupClassName="px-3 py-2 system-xs-regular text-text-tertiary">
+                      <PopoverContent className="px-3 py-2 system-xs-regular text-text-tertiary">
                         <div>
                           <div>{t(($) => $['common.enableJinja'], { ns: 'workflow' })}</div>
                           <a

--- a/web/app/components/workflow/nodes/_base/components/switch-plugin-version.tsx
+++ b/web/app/components/workflow/nodes/_base/components/switch-plugin-version.tsx
@@ -155,7 +155,7 @@ export const SwitchPluginVersion: FC<SwitchPluginVersionProps> = (props) => {
         }
         render={content}
       />
-      <PopoverContent popupClassName="px-3 py-2 system-xs-regular text-text-tertiary">
+      <PopoverContent className="px-3 py-2 system-xs-regular text-text-tertiary">
         {tooltip}
       </PopoverContent>
     </Popover>

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-reference-picker.trigger.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-reference-picker.trigger.spec.tsx
@@ -50,7 +50,7 @@ const renderWithPopover = (
   render(
     <Popover onOpenChange={onOpenChange}>
       <VarReferencePickerTrigger {...createProps(overrides)} />
-      <PopoverContent popupClassName="border-none bg-transparent p-0 shadow-none">
+      <PopoverContent className="border-none bg-transparent p-0 shadow-none">
         <div>picker-content</div>
       </PopoverContent>
     </Popover>,

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.tsx
@@ -420,9 +420,8 @@ const VarReferencePicker: FC<Props> = ({
         )}
         <PopoverContent
           placement={isAddBtnTrigger ? 'bottom-end' : 'bottom-start'}
-          sideOffset={0}
-          className="mt-1"
-          popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+          sideOffset={4}
+          className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
         >
           {!isConstant && (
             <VarReferencePopup

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
@@ -295,7 +295,7 @@ const Item: FC<ItemProps> = ({
       <PopoverContent
         placement="left-start"
         sideOffset={0}
-        popupClassName={cn(
+        className={cn(
           VAR_REFERENCE_CHILD_POPUP_CLASS_NAME,
           'border-none bg-transparent p-0 shadow-none backdrop-blur-none',
         )}

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
@@ -437,7 +437,7 @@ export function AgentRosterField({
           <PopoverContent
             placement="bottom-end"
             sideOffset={4}
-            popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+            className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
           >
             <PopoverTitle className="sr-only">
               {t(($) => $['roster.nodeSelector.dialogLabel'], { ns: 'agentV2' })}

--- a/web/app/components/workflow/nodes/human-input/components/button-style-dropdown.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/button-style-dropdown.tsx
@@ -59,7 +59,7 @@ const ButtonStyleDropdown: FC<Props> = ({ text = 'Button Text', data, onChange, 
         placement="bottom-end"
         sideOffset={4}
         alignOffset={44}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-4 shadow-lg backdrop-blur-xs">
           <div className="system-md-medium text-text-primary">

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/method-selector.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/method-selector.tsx
@@ -66,7 +66,7 @@ const MethodSelector: FC<MethodSelectorProps> = ({ data, onAdd, onShowUpgradeTip
       <PopoverContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-90 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-1">

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/member-selector.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/member-selector.tsx
@@ -52,7 +52,7 @@ const MemberSelector: FC<Props> = ({ value, email, onSelect, list = [] }) => {
         placement="bottom-end"
         sideOffset={4}
         alignOffset={35}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <MemberList
           searchValue={searchValue}

--- a/web/app/components/workflow/nodes/if-else/components/condition-add.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-add.tsx
@@ -49,7 +49,7 @@ const ConditionAdd = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-74 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <VarReferenceVars vars={variables} isSupportFileVar onChange={handleSelectVariable} />

--- a/web/app/components/workflow/nodes/if-else/components/condition-list/condition-var-selector.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-list/condition-var-selector.tsx
@@ -45,7 +45,7 @@ const ConditionVarSelector = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-74 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <VarReferenceVars vars={nodesOutputVars} isSupportFileVar onChange={onChange} />

--- a/web/app/components/workflow/nodes/if-else/components/condition-number-input.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-number-input.tsx
@@ -108,7 +108,7 @@ const ConditionNumberInput = ({
             <PopoverContent
               placement="bottom-start"
               sideOffset={2}
-              popupClassName="border-none bg-transparent shadow-none"
+              className="border-none bg-transparent shadow-none"
             >
               <div
                 className={cn(

--- a/web/app/components/workflow/nodes/knowledge-base/components/chunk-structure/selector.tsx
+++ b/web/app/components/workflow/nodes/knowledge-base/components/chunk-structure/selector.tsx
@@ -48,7 +48,7 @@ const Selector = ({ options, value, onChange, readonly, trigger }: SelectorProps
         placement="bottom-end"
         sideOffset={0}
         alignOffset={-8}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-101 rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-xl backdrop-blur-[5px]">
           <div className="px-3 pt-3.5 system-sm-semibold text-text-primary">

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/add-condition.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/add-condition.tsx
@@ -44,7 +44,7 @@ const AddCondition = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={12}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-[320px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <div className="p-2 pb-1">

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-common-variable-selector.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-common-variable-selector.tsx
@@ -62,7 +62,7 @@ const ConditionCommonVariableSelector = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-50 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg">
           {variables.map((v) => (

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-operator.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-operator.tsx
@@ -62,7 +62,7 @@ const ConditionOperator = ({
       <PopoverContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg">
           {options.map((option) => (

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-value-method.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-value-method.tsx
@@ -29,7 +29,7 @@ const ConditionValueMethod = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-28 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg">
           {options.map((option) => (

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-variable-selector.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-variable-selector.tsx
@@ -65,7 +65,7 @@ const ConditionVariableSelector = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-74 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <VarReferenceVars vars={nodesOutputVars} isSupportFileVar onChange={handleChange} />

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-trigger.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-trigger.tsx
@@ -51,7 +51,7 @@ const MetadataTrigger = ({
       <PopoverContent
         placement="left"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <MetadataPanel
           metadataFilteringConditions={metadataFilteringConditions}

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/retrieval-config.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/retrieval-config.tsx
@@ -139,7 +139,7 @@ const RetrievalConfig: FC<Props> = ({
         placement="bottom-end"
         sideOffset={0}
         alignOffset={-2}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-101 rounded-2xl border border-components-panel-border bg-components-panel-bg px-4 pt-3 pb-4 shadow-xl">
           <ConfigRetrievalContent

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-importer.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-importer.tsx
@@ -85,7 +85,7 @@ const JsonImporter: FC<JsonImporterProps> = ({ onSubmit, updateBtnWidth }) => {
         placement="bottom-end"
         sideOffset={4}
         alignOffset={16}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="flex w-100 flex-col rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-2xl shadow-shadow-shadow-9">
           {/* Title */}

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/index.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/index.tsx
@@ -155,7 +155,7 @@ const JsonSchemaGenerator: FC<JsonSchemaGeneratorProps> = ({ onApply, crossAxisO
         placement="bottom-end"
         sideOffset={4}
         alignOffset={crossAxisOffset ?? 0}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         {view === GENERATOR_VIEWS.promptEditor && (
           <PromptEditor

--- a/web/app/components/workflow/nodes/loop/components/condition-add.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-add.tsx
@@ -42,7 +42,7 @@ const ConditionAdd = ({ className, variables, onSelectVariable, disabled }: Cond
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-74 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <VarReferenceVars vars={variables} isSupportFileVar onChange={handleSelectVariable} />

--- a/web/app/components/workflow/nodes/loop/components/condition-list/condition-var-selector.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-list/condition-var-selector.tsx
@@ -45,7 +45,7 @@ const ConditionVarSelector = ({
       <PopoverContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
+        className="border-none bg-transparent p-0 shadow-none backdrop-blur-none"
       >
         <div className="w-74 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           <VarReferenceVars vars={nodesOutputVars} isSupportFileVar onChange={onChange} />

--- a/web/app/components/workflow/nodes/loop/components/condition-number-input.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-number-input.tsx
@@ -108,7 +108,7 @@ const ConditionNumberInput = ({
             <PopoverContent
               placement="bottom-start"
               sideOffset={2}
-              popupClassName="border-none bg-transparent shadow-none"
+              className="border-none bg-transparent shadow-none"
             >
               <div
                 className={cn(

--- a/web/app/components/workflow/nodes/question-classifier/node.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/node.tsx
@@ -47,7 +47,7 @@ const TruncatedClassItem: FC<TruncatedClassItemProps> = ({ topic, index, nodeId,
           >
             {content}
           </PopoverTrigger>
-          <PopoverContent popupClassName="max-w-[300px] px-3 py-2 system-xs-regular wrap-break-word text-text-tertiary">
+          <PopoverContent className="max-w-[300px] px-3 py-2 system-xs-regular wrap-break-word text-text-tertiary">
             <ReadonlyInputWithSelectVar value={topic.name} nodeId={nodeId} />
           </PopoverContent>
         </Popover>

--- a/web/app/components/workflow/nodes/variable-assigner/components/add-variable/index.tsx
+++ b/web/app/components/workflow/nodes/variable-assigner/components/add-variable/index.tsx
@@ -62,7 +62,7 @@ const AddVariable = ({
         <PopoverContent
           placement="right"
           sideOffset={4}
-          popupClassName="border-none bg-transparent shadow-none"
+          className="border-none bg-transparent shadow-none"
         >
           <AddVariablePopup onSelect={handleSelectVariable} availableVars={availableVars} />
         </PopoverContent>

--- a/web/app/components/workflow/note-node/note-editor/toolbar/color-picker.tsx
+++ b/web/app/components/workflow/note-node/note-editor/toolbar/color-picker.tsx
@@ -62,7 +62,7 @@ const ColorPicker = ({ theme, onThemeChange }: ColorPickerProps) => {
       <PopoverContent
         placement="top"
         sideOffset={4}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="grid grid-cols-3 grid-rows-2 gap-0.5 rounded-lg border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-lg">
           {COLOR_LIST.map((color) => (

--- a/web/app/components/workflow/note-node/note-editor/toolbar/font-size-selector.tsx
+++ b/web/app/components/workflow/note-node/note-editor/toolbar/font-size-selector.tsx
@@ -46,7 +46,7 @@ const FontSizeSelector = () => {
       <PopoverContent
         placement="bottom-start"
         sideOffset={2}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="w-30 rounded-md border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 text-text-secondary shadow-xl">
           {FONT_SIZE_LIST.map((font) => (

--- a/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal-trigger.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal-trigger.tsx
@@ -42,7 +42,7 @@ const VariableModalTrigger = ({ open, setOpen, showTip, chatVar, onClose, onSave
         placement="left-start"
         sideOffset={8}
         alignOffset={showTip ? -278 : -48}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <VariableModal
           chatVar={chatVar}

--- a/web/app/components/workflow/panel/env-panel/variable-trigger.tsx
+++ b/web/app/components/workflow/panel/env-panel/variable-trigger.tsx
@@ -41,7 +41,7 @@ const VariableTrigger = ({ open, setOpen, env, onClose, onSave }: Props) => {
         placement="left-start"
         sideOffset={8}
         alignOffset={-104}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <VariableModal
           env={env}

--- a/web/app/components/workflow/panel/version-history-panel/filter/index.tsx
+++ b/web/app/components/workflow/panel/version-history-panel/filter/index.tsx
@@ -56,7 +56,7 @@ const Filter: FC<FilterProps> = ({
         placement="bottom-end"
         sideOffset={4}
         alignOffset={55}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="flex w-62 flex-col rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg shadow-shadow-shadow-5 backdrop-blur-[5px]">
           <div className="flex flex-col p-1">

--- a/web/app/components/workflow/workflow-preview/components/nodes/base.tsx
+++ b/web/app/components/workflow/workflow-preview/components/nodes/base.tsx
@@ -81,7 +81,7 @@ const BaseCard = ({ id, data, children }: NodeCardProps) => {
                 >
                   {t(($) => $['nodes.iteration.parallelModeUpper'], { ns: 'workflow' })}
                 </PopoverTrigger>
-                <PopoverContent popupClassName="w-[180px] px-3 py-2 system-xs-regular text-text-tertiary">
+                <PopoverContent className="w-[180px] px-3 py-2 system-xs-regular text-text-tertiary">
                   <div className="font-extrabold">
                     {t(($) => $['nodes.iteration.parallelModeEnableTitle'], { ns: 'workflow' })}
                   </div>

--- a/web/app/signin/one-more-step.tsx
+++ b/web/app/signin/one-more-step.tsx
@@ -149,7 +149,7 @@ const OneMoreStep = () => {
                 />
                 <PopoverContent
                   placement="top"
-                  popupClassName="w-[256px] px-3 py-2 text-xs font-medium text-text-tertiary"
+                  className="w-[256px] px-3 py-2 text-xs font-medium text-text-tertiary"
                 >
                   <div>
                     <div className="font-medium">{t(($) => $.sendUsMail, { ns: 'login' })}</div>

--- a/web/features/agent-v2/agent-detail/configure/components/community-edition-tip.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/community-edition-tip.tsx
@@ -50,7 +50,7 @@ export function CommunityEditionTip({
       />
       <PopoverContent
         placement={placement}
-        popupClassName={cn('px-3 py-2 system-xs-regular text-text-tertiary', popupClassName)}
+        className={cn('px-3 py-2 system-xs-regular text-text-tertiary', popupClassName)}
       >
         {tip}
       </PopoverContent>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/index.tsx
@@ -339,7 +339,7 @@ function AddToolMenu({
       <PopoverContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName={
+        className={
           view === 'menu'
             ? 'w-[280px] bg-components-panel-bg-blur p-1 shadow-lg backdrop-blur-[5px]'
             : 'w-[400px] overflow-hidden border-none bg-transparent p-0 shadow-none'

--- a/web/features/agent-v2/agent-detail/configure/components/preview/header.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/header.tsx
@@ -56,7 +56,7 @@ function ModeInfoTip({ children, ariaLabel }: { children: ReactNode; ariaLabel: 
       <PopoverContent
         placement="bottom"
         sideOffset={2}
-        popupClassName="w-60 max-w-60 rounded-xl bg-components-tooltip-bg px-4 py-3.5 text-start text-text-secondary backdrop-blur-[5px]"
+        className="w-60 max-w-60 rounded-xl bg-components-tooltip-bg px-4 py-3.5 text-start text-text-secondary backdrop-blur-[5px]"
       >
         {children}
       </PopoverContent>
@@ -98,7 +98,7 @@ function PreviewModeItem({
       <PopoverContent
         placement="bottom"
         sideOffset={6}
-        popupClassName="max-w-[260px] rounded-md bg-components-tooltip-bg px-3 py-2 system-xs-regular text-text-tertiary shadow-lg"
+        className="max-w-[260px] rounded-md bg-components-tooltip-bg px-3 py-2 system-xs-regular text-text-tertiary shadow-lg"
       >
         {disabledTip}
       </PopoverContent>

--- a/web/features/agent-v2/agent-detail/configure/components/preview/versions-panel/filter.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/versions-panel/filter.tsx
@@ -65,7 +65,7 @@ export function VersionFilter({
         placement="bottom-end"
         sideOffset={4}
         alignOffset={55}
-        popupClassName="border-none bg-transparent shadow-none"
+        className="border-none bg-transparent shadow-none"
       >
         <div className="flex w-62 flex-col rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg shadow-shadow-shadow-5 backdrop-blur-[5px]">
           <div className="flex flex-col p-1">

--- a/web/features/new-rag/components/knowledge-view-switcher.tsx
+++ b/web/features/new-rag/components/knowledge-view-switcher.tsx
@@ -69,7 +69,7 @@ export function KnowledgeViewSwitcher({ value, onChange }: KnowledgeViewSwitcher
         <PopoverContent
           placement="bottom"
           sideOffset={13}
-          popupClassName="relative flex max-h-[calc(100dvh-2rem)] min-h-[162px] w-80 max-w-[calc(100vw-2rem)] flex-col"
+          className="relative flex max-h-[calc(100dvh-2rem)] min-h-[162px] w-80 max-w-[calc(100vw-2rem)] flex-col"
         >
           <span
             aria-hidden


### PR DESCRIPTION
## Summary

- remove the nested `popupProps` escape hatch from `PopoverContent`
- make `PopoverContent.className` style the popup surface and remove implicit Positioner styling
- migrate the one real Positioner customization to explicit Popover anatomy
- preserve accessible popup naming with `PopoverTitle` and keep existing visual styles unchanged

## Verification

- `vp check packages/dify-ui`
- `vp check` for all 119 changed Web files
- Dify UI unit: 38 files, 253 tests
- Dify UI Storybook: 2 files, 18 tests
- Web unit: 2,087 files, 23,086 tests passed, 1 skipped
- AST audit: no `PopoverContent.popupClassName`, spread props, or duplicate JSX attributes remain