### PR TITLE
fix(api): fall back to None for missing webhook file parameters

### DIFF
--- a/api/core/workflow/nodes/trigger_webhook/node.py
+++ b/api/core/workflow/nodes/trigger_webhook/node.py
@@ -169,11 +169,11 @@ class TriggerWebhookNode(Node[WebhookData]):
                             if file_var:
                                 outputs[param_name] = file_var
                             else:
-                                outputs[param_name] = files
+                                outputs[param_name] = None
                         else:
-                            outputs[param_name] = files
+                            outputs[param_name] = None
                     else:
-                        outputs[param_name] = files
+                        outputs[param_name] = None
                 case _:
                     # Get regular body parameter
                     outputs[param_name] = webhook_data.get("body", {}).get(param_name)

--- a/api/tests/unit_tests/core/workflow/nodes/webhook/test_webhook_file_conversion.py
+++ b/api/tests/unit_tests/core/workflow/nodes/webhook/test_webhook_file_conversion.py
@@ -446,3 +446,148 @@ def test_webhook_node_file_conversion_with_non_dict_wrapper():
     assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
     # Verify fallback to original value
     assert result.outputs["_webhook_raw"]["files"]["file"] == "just a string"
+
+
+def test_webhook_node_missing_file_param_outputs_none():
+    """A declared file parameter absent from the request should be None, not the whole files mapping."""
+    data = WebhookData(
+        title="Test Webhook Missing File Param",
+        method=Method.POST,
+        content_type=ContentType.FORM_DATA,
+        body=[
+            WebhookBodyParameter(name="other_file", type="file", required=False),
+            WebhookBodyParameter(name="missing_file", type="file", required=False),
+        ],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": {
+                    "other_file": create_test_file_dict("other.jpg"),
+                },
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+
+    with (
+        patch.object(node._file_reference_factory, "build_from_mapping") as mock_file_factory,
+        patch("core.workflow.nodes.trigger_webhook.node.build_segment_with_type") as mock_segment_factory,
+        patch("core.workflow.nodes.trigger_webhook.node.FileVariable") as mock_file_variable,
+    ):
+        mock_file_obj = Mock()
+        mock_file_factory.return_value = mock_file_obj
+
+        mock_segment = Mock()
+        mock_segment.value = mock_file_obj
+        mock_segment_factory.return_value = mock_segment
+
+        mock_file_var = Mock()
+        mock_file_variable.return_value = mock_file_var
+
+        result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.outputs["other_file"] == mock_file_var
+    # the missing parameter must not pick up another parameter's file
+    assert result.outputs["missing_file"] is None
+
+
+def test_webhook_node_none_file_entry_outputs_none():
+    """A file parameter sent as None should resolve to None, not the whole files mapping."""
+    data = WebhookData(
+        title="Test Webhook None File Entry",
+        method=Method.POST,
+        content_type=ContentType.FORM_DATA,
+        body=[
+            WebhookBodyParameter(name="none_entry", type="file", required=False),
+        ],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": {"none_entry": None},
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+    result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.outputs["none_entry"] is None
+
+
+def test_webhook_node_non_dict_file_entry_outputs_none():
+    """A file parameter sent as a non-dict value should resolve to None, not the whole files mapping."""
+    data = WebhookData(
+        title="Test Webhook Non-dict File Entry",
+        method=Method.POST,
+        content_type=ContentType.FORM_DATA,
+        body=[
+            WebhookBodyParameter(name="bad_entry", type="file", required=False),
+        ],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": {"bad_entry": "not_a_dict"},
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+    result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.outputs["bad_entry"] is None
+
+
+def test_webhook_node_file_var_build_failure_outputs_none():
+    """When the file variable cannot be built, the parameter should be None, not the whole files mapping."""
+    file_dict = create_test_file_dict("broken.jpg")
+
+    data = WebhookData(
+        title="Test Webhook File Build Failure",
+        method=Method.POST,
+        content_type=ContentType.FORM_DATA,
+        body=[
+            WebhookBodyParameter(name="broken_file", type="file", required=False),
+        ],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": {
+                    "broken_file": file_dict,
+                },
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+
+    with patch.object(node._file_reference_factory, "build_from_mapping") as mock_file_factory:
+        mock_file_factory.side_effect = ValueError("invalid file mapping")
+
+        result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.outputs["broken_file"] is None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41071

When a webhook trigger declares a file-type body parameter and the request doesn't include that file, `_extract_configured_outputs` was assigning the entire `files` mapping to the parameter's output. With two declared file parameters and only one uploaded, the missing one ended up holding the other file's dict, so downstream nodes referencing it got an object with an unexpected shape instead of an unset value. The same applied to non-dict entries and to failures inside `generate_file_var`.

Query and body parameters already fall back to `None` in the same function, so the file branch now does the same. Covered by four new cases in `test_webhook_file_conversion.py`.

## Screenshots

Behavior-only change, no UI impact.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
