### PR TITLE
docs: remove stale community deployment options from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,30 +149,13 @@ If you'd like to configure a highly available setup, there are community-contrib
 
 - [Helm Chart by @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NEW! YAML files (Supports Dify v1.6.0) by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Using Terraform for Deployment
-
-Deploy Dify to Cloud Platform with a single click using [terraform](https://www.terraform.io/)
-
-##### Azure Global
-
-- [Azure Terraform by @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform by @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Using AWS CDK for Deployment
 
 Deploy Dify to AWS with [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK by @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK by @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Using Alibaba Cloud Computing Nest
@@ -182,10 +165,6 @@ Quickly deploy Dify to Alibaba cloud with [Alibaba Cloud Computing Nest](https:/
 #### Using Alibaba Cloud Data Management
 
 One-Click deploy Dify to Alibaba Cloud with [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Deploy to AKS with Azure Devops Pipeline
-
-One-Click deploy Dify to AKS with [Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### Using Sealos for Deployment
 

--- a/docs/ar-SA/README.md
+++ b/docs/ar-SA/README.md
@@ -135,30 +135,13 @@ docker compose up -d
 
 - [رسم بياني Helm من قبل @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [رسم بياني Helm من قبل @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [رسم بياني Helm من قبل @magicsong](https://github.com/magicsong/ai-charts)
 - [ملف YAML من قبل @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [ملف YAML من قبل @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 جديد! ملفات YAML (تدعم Dify v1.6.0) بواسطة @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### استخدام Terraform للتوزيع
-
-انشر Dify إلى منصة السحابة بنقرة واحدة باستخدام [terraform](https://www.terraform.io/)
-
-##### Azure Global
-
-- [Azure Terraform بواسطة @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform بواسطة @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### استخدام AWS CDK للنشر
 
 انشر Dify على AWS باستخدام [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK بواسطة @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK بواسطة @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### استخدام Alibaba Cloud للنشر
@@ -168,10 +151,6 @@ docker compose up -d
 #### استخدام Alibaba Cloud Data Management للنشر
 
 انشر ​​Dify على علي بابا كلاود بنقرة واحدة باستخدام [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### استخدام Azure Devops Pipeline للنشر على AKS
-
-انشر Dify على AKS بنقرة واحدة باستخدام [Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### استخدام Sealos للنشر
 

--- a/docs/bn-BD/README.md
+++ b/docs/bn-BD/README.md
@@ -152,10 +152,8 @@ Dify-এর PostgreSQL ডাটাবেসকে ডেটা সোর্স 
 
 - [Helm Chart by @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 নতুন! YAML ফাইলসমূহ (Dify v1.6.0 সমর্থিত) তৈরি করেছেন @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
 
 #### টেরাফর্ম ব্যবহার করে ডিপ্লয়
 
@@ -163,19 +161,12 @@ Dify-এর PostgreSQL ডাটাবেসকে ডেটা সোর্স 
 
 ##### অ্যাজুর গ্লোবাল
 
-- [Azure Terraform by @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
 ##### গুগল ক্লাউড
-
-- [Google Cloud Terraform by @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### AWS CDK ব্যবহার করে ডিপ্লয়
 
 [CDK](https://aws.amazon.com/cdk/) দিয়ে AWS-এ Dify ডিপ্লয় করুন
 
-##### AWS
-
-- [AWS CDK by @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK by @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud ব্যবহার করে ডিপ্লয়
@@ -185,10 +176,6 @@ Dify-এর PostgreSQL ডাটাবেসকে ডেটা সোর্স 
 #### Alibaba Cloud Data Management ব্যবহার করে ডিপ্লয়
 
 [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### AKS-এ ডিপ্লয় করার জন্য Azure Devops Pipeline ব্যবহার
-
-[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS) ব্যবহার করে Dify কে AKS-এ এক ক্লিকে ডিপ্লয় করুন
 
 #### Sealos ব্যবহার করে ডিপ্লয়
 

--- a/docs/de-DE/README.md
+++ b/docs/de-DE/README.md
@@ -150,30 +150,13 @@ Falls Sie eine hochverfügbare Konfiguration einrichten möchten, gibt es von de
 
 - [Helm Chart by @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NEW! YAML files (Supports Dify v1.6.0) by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Terraform für die Bereitstellung verwenden
-
-Stellen Sie Dify mit nur einem Klick mithilfe von [terraform](https://www.terraform.io/) auf einer Cloud-Plattform bereit.
-
-##### Azure Global
-
-- [Azure Terraform by @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform by @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Verwendung von AWS CDK für die Bereitstellung
 
 Bereitstellung von Dify auf AWS mit [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK by @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK by @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -183,10 +166,6 @@ Bereitstellung von Dify auf AWS mit [CDK](https://aws.amazon.com/cdk/)
 #### Alibaba Cloud Data Management
 
 Ein-Klick-Bereitstellung von Dify in der Alibaba Cloud mit [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Verwendung von Azure Devops Pipeline für AKS-Bereitstellung
-
-Stellen Sie Dify mit einem Klick in AKS bereit, indem Sie [Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS) verwenden
 
 #### Bereitstellung mit Sealos
 

--- a/docs/es-ES/README.md
+++ b/docs/es-ES/README.md
@@ -148,30 +148,13 @@ Si desea configurar una configuración de alta disponibilidad, la comunidad prop
 
 - [Gráfico Helm por @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Gráfico Helm por @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Gráfico Helm por @magicsong](https://github.com/magicsong/ai-charts)
 - [Ficheros YAML por @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [Ficheros YAML por @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 ¡NUEVO! Archivos YAML (compatible con Dify v1.6.0) por @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Uso de Terraform para el despliegue
-
-Despliega Dify en una plataforma en la nube con un solo clic utilizando [terraform](https://www.terraform.io/)
-
-##### Azure Global
-
-- [Azure Terraform por @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform por @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Usando AWS CDK para el Despliegue
 
 Despliegue Dify en AWS usando [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK por @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK por @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -181,10 +164,6 @@ Despliegue Dify en AWS usando [CDK](https://aws.amazon.com/cdk/)
 #### Alibaba Cloud Data Management
 
 Despliega Dify en Alibaba Cloud con un solo clic con [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Uso de Azure Devops Pipeline para implementar en AKS
-
-Implementa Dify en AKS con un clic usando [Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### Implementación con Sealos
 

--- a/docs/fr-FR/README.md
+++ b/docs/fr-FR/README.md
@@ -146,30 +146,13 @@ Si vous souhaitez configurer une configuration haute disponibilité, la communau
 
 - [Helm Chart par @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart par @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart par @magicsong](https://github.com/magicsong/ai-charts)
 - [Fichier YAML par @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [Fichier YAML par @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NOUVEAU ! Fichiers YAML (compatible avec Dify v1.6.0) par @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Utilisation de Terraform pour le déploiement
-
-Déployez Dify sur une plateforme cloud en un clic en utilisant [terraform](https://www.terraform.io/)
-
-##### Azure Global
-
-- [Azure Terraform par @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform par @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Utilisation d'AWS CDK pour le déploiement
 
 Déployez Dify sur AWS en utilisant [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK par @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK par @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -179,10 +162,6 @@ Déployez Dify sur AWS en utilisant [CDK](https://aws.amazon.com/cdk/)
 #### Alibaba Cloud Data Management
 
 Déployez Dify en un clic sur Alibaba Cloud avec [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Utilisation d'Azure Devops Pipeline pour déployer sur AKS
-
-Déployez Dify sur AKS en un clic en utilisant [Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### Déploiement avec Sealos
 

--- a/docs/hi-IN/README.md
+++ b/docs/hi-IN/README.md
@@ -157,30 +157,13 @@ Grafana में Dify के PostgreSQL डेटाबेस को डेट�
 
 - [Helm Chart by @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NEW! YAML files (Supports Dify v1.6.0) by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### डिप्लॉयमेंट के लिए Terraform का उपयोग
-
-[terraform](https://www.terraform.io/) का उपयोग करके एक क्लिक में Dify को क्लाउड प्लेटफ़ॉर्म पर डिप्लॉय करें।
-
-##### Azure Global
-
-- [Azure Terraform by @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform by @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### डिप्लॉयमेंट के लिए AWS CDK का उपयोग
 
 [CDK](https://aws.amazon.com/cdk/) का उपयोग करके Dify को AWS पर डिप्लॉय करें।
 
-##### AWS
-
-- [AWS CDK by @KevinZhao (EKS आधारित)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK by @tmokmss (ECS आधारित)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud Computing Nest का उपयोग
@@ -190,10 +173,6 @@ Grafana में Dify के PostgreSQL डेटाबेस को डेट�
 #### Alibaba Cloud Data Management का उपयोग
 
 [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/) के साथ एक क्लिक में Dify को Alibaba Cloud पर डिप्लॉय करें।
-
-#### Azure Devops Pipeline के साथ AKS पर डिप्लॉय करें
-
-[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS) के साथ एक क्लिक में Dify को AKS पर डिप्लॉय करें।
 
 #### Sealos के साथ डिप्लॉय करें
 

--- a/docs/it-IT/README.md
+++ b/docs/it-IT/README.md
@@ -150,30 +150,13 @@ Se desiderate configurare un'installazione ad alta disponibilità, ci sono [Helm
 
 - [Helm Chart di @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart di @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart di @magicsong](https://github.com/magicsong/ai-charts)
 - [File YAML di @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [File YAML di @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NUOVO! File YAML (Supporta Dify v1.6.0) di @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Utilizzo di Terraform per la Distribuzione
-
-Distribuite Dify con un solo clic su una piattaforma cloud utilizzando [terraform](https://www.terraform.io/).
-
-##### Azure Global
-
-- [Azure Terraform di @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform di @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Utilizzo di AWS CDK per la Distribuzione
 
 Distribuzione di Dify su AWS con [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK di @KevinZhao (basato su EKS)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK di @tmokmss (basato su ECS)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -183,10 +166,6 @@ Distribuzione di Dify su AWS con [CDK](https://aws.amazon.com/cdk/)
 #### Alibaba Cloud Data Management
 
 Distribuzione con un clic di Dify su Alibaba Cloud con [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Utilizzo di Azure DevOps Pipeline per la Distribuzione su AKS
-
-Distribuite Dify con un clic in AKS utilizzando [Azure DevOps Pipeline Helm Chart di @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### Distribuzione con Sealos
 

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -147,30 +147,13 @@ Grafanaにダッシュボードをインポートし、DifyのPostgreSQLデー�
 
 - [Helm Chart by @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 新着！YAML ファイル（Dify v1.6.0 対応）by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Terraformを使用したデプロイ
-
-[terraform](https://www.terraform.io/) を使用して、ワンクリックでDifyをクラウドプラットフォームにデプロイします
-
-##### Azure Global
-
-- [@nikawangによるAzure Terraform](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [@sotazumによるGoogle Cloud Terraform](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### AWS CDK を使用したデプロイ
 
 [CDK](https://aws.amazon.com/cdk/) を使用して、DifyをAWSにデプロイします
 
-##### AWS
-
-- [@KevinZhaoによるAWS CDK (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [@tmokmssによるAWS CDK (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -180,10 +163,6 @@ Grafanaにダッシュボードをインポートし、DifyのPostgreSQLデー�
 #### Alibaba Cloud Data Management
 
 [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/) を利用して、DifyをAlibaba Cloudへワンクリックでデプロイできます
-
-#### AKSへのデプロイにAzure Devops Pipelineを使用
-
-[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)を使用してDifyをAKSにワンクリックでデプロイ
 
 #### Sealosを使用したデプロイ
 

--- a/docs/ko-KR/README.md
+++ b/docs/ko-KR/README.md
@@ -140,30 +140,13 @@ Dify를 Kubernetes에 배포하고 프리미엄 스케일링 설정을 구성했
 
 - [Helm Chart by @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NEW! YAML files (Supports Dify v1.6.0) by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Terraform을 사용한 배포
-
-[terraform](https://www.terraform.io/)을 사용하여 단 한 번의 클릭으로 Dify를 클라우드 플랫폼에 배포하십시오
-
-##### Azure Global
-
-- [nikawang의 Azure Terraform](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [sotazum의 Google Cloud Terraform](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### AWS CDK를 사용한 배포
 
 [CDK](https://aws.amazon.com/cdk/)를 사용하여 AWS에 Dify 배포
 
-##### AWS
-
-- [KevinZhao의 AWS CDK (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [tmokmss의 AWS CDK (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -173,10 +156,6 @@ Dify를 Kubernetes에 배포하고 프리미엄 스케일링 설정을 구성했
 #### Alibaba Cloud Data Management
 
 [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)를 통해 원클릭으로 Dify를 Alibaba Cloud에 배포할 수 있습니다
-
-#### AKS에 배포하기 위해 Azure Devops Pipeline 사용
-
-[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)을 사용하여 Dify를 AKS에 원클릭으로 배포
 
 #### Sealos를 사용한 배포
 

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -145,30 +145,13 @@ Se deseja configurar uma instalação de alta disponibilidade, há [Helm Charts]
 
 - [Helm Chart de @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart de @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart de @magicsong](https://github.com/magicsong/ai-charts)
 - [Arquivo YAML por @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [Arquivo YAML por @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NOVO! Arquivos YAML (Compatível com Dify v1.6.0) por @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Usando o Terraform para Implantação
-
-Implante o Dify na Plataforma Cloud com um único clique usando [terraform](https://www.terraform.io/)
-
-##### Azure Global
-
-- [Azure Terraform por @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform por @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Usando AWS CDK para Implantação
 
 Implante o Dify na AWS usando [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK por @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK por @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -178,10 +161,6 @@ Implante o Dify na AWS usando [CDK](https://aws.amazon.com/cdk/)
 #### Alibaba Cloud Data Management
 
 Implante o Dify na Alibaba Cloud com um clique usando o [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Usando Azure Devops Pipeline para Implantar no AKS
-
-Implante o Dify no AKS com um clique usando [Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### Implantação com Sealos
 

--- a/docs/sl-SI/README.md
+++ b/docs/sl-SI/README.md
@@ -149,27 +149,11 @@ Uvoz nadzorne plošče v Grafana, z uporabo Difyjeve PostgreSQL baze podatkov ko
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NEW! YAML files (Supports Dify v1.6.0) by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Uporaba Terraform za uvajanje
-
-namestite Dify v Cloud Platform z enim klikom z uporabo [terraform](https://www.terraform.io/)
-
-##### Azure Global
-
-- [Azure Terraform by @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform by @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Uporaba AWS CDK za uvajanje
 
 Uvedite Dify v AWS z uporabo [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK by @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK by @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -179,10 +163,6 @@ Uvedite Dify v AWS z uporabo [CDK](https://aws.amazon.com/cdk/)
 #### Alibaba Cloud Data Management
 
 Z enim klikom namestite Dify na Alibaba Cloud z [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Uporaba Azure Devops Pipeline za uvajanje v AKS
-
-Z enim klikom namestite Dify v AKS z uporabo [Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### Namestitev s Sealos
 

--- a/docs/tlh/README.md
+++ b/docs/tlh/README.md
@@ -138,30 +138,13 @@ If you'd like to configure a highly-available setup, there are community-contrib
 
 - [Helm Chart by @LeoQuote](https://github.com/douban/charts/tree/master/charts/dify)
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
 - [YAML file by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NEW! YAML files (Supports Dify v1.6.0) by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Terraform atorlugu pilersitsineq
-
-wa'logh nIqHom neH ghun deployment toy'wI' [terraform](https://www.terraform.io/) lo'laH.
-
-##### Azure Global
-
-- [Azure Terraform mung @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform qachlot @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### AWS CDK atorlugh pilersitsineq
 
 wa'logh nIqHom neH ghun deployment toy'wI' [CDK](https://aws.amazon.com/cdk/) lo'laH.
 
-##### AWS
-
-- [AWS CDK qachlot @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK qachlot @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -171,10 +154,6 @@ wa'logh nIqHom neH ghun deployment toy'wI' [CDK](https://aws.amazon.com/cdk/) lo
 #### Alibaba Cloud Data Management
 
 [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### AKS 'e' Deploy je Azure Devops Pipeline lo'laH
-
-[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS) lo'laH Dify AKS 'e' wa'DIch click 'e' Deploy
 
 #### Sealos lo'laH Deploy
 

--- a/docs/tr-TR/README.md
+++ b/docs/tr-TR/README.md
@@ -142,27 +142,11 @@ Yüksek kullanılabilirliğe sahip bir kurulum yapılandırmak isterseniz, Dify'
 - [@BorisPolonsky tarafından Helm Chart](https://github.com/BorisPolonsky/dify-helm)
 - [@Winson-030 tarafından YAML dosyası](https://github.com/Winson-030/dify-kubernetes)
 - [@wyy-holding tarafından YAML dosyası](https://github.com/wyy-holding/dify-k8s)
-- [🚀 YENİ! YAML dosyaları (Dify v1.6.0 destekli) @Zhoneym tarafından](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Dağıtım için Terraform Kullanımı
-
-Dify'ı bulut platformuna tek tıklamayla dağıtın [terraform](https://www.terraform.io/) kullanarak
-
-##### Azure Global
-
-- [Azure Terraform tarafından @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform tarafından @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### AWS CDK ile Dağıtım
 
 [CDK](https://aws.amazon.com/cdk/) kullanarak Dify'ı AWS'ye dağıtın
 
-##### AWS
-
-- [AWS CDK tarafından @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK tarafından @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -172,10 +156,6 @@ Dify'ı bulut platformuna tek tıklamayla dağıtın [terraform](https://www.ter
 #### Alibaba Cloud Data Management
 
 [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/) kullanarak Dify'ı tek tıkla Alibaba Cloud'a dağıtın
-
-#### AKS'ye Dağıtım için Azure Devops Pipeline Kullanımı
-
-[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS) kullanarak Dify'ı tek tıkla AKS'ye dağıtın
 
 #### Sealos ile Dağıtım
 

--- a/docs/vi-VN/README.md
+++ b/docs/vi-VN/README.md
@@ -143,27 +143,11 @@ Nếu bạn muốn cấu hình một cài đặt có độ sẵn sàng cao, có 
 - [Helm Chart bởi @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
 - [Tệp YAML bởi @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 - [Tệp YAML bởi @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-- [🚀 MỚI! Tệp YAML (Hỗ trợ Dify v1.6.0) bởi @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### Sử dụng Terraform để Triển khai
-
-Triển khai Dify lên nền tảng đám mây với một cú nhấp chuột bằng cách sử dụng [terraform](https://www.terraform.io/)
-
-##### Azure Global
-
-- [Azure Terraform bởi @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform bởi @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### Sử dụng AWS CDK để Triển khai
 
 Triển khai Dify trên AWS bằng [CDK](https://aws.amazon.com/cdk/)
 
-##### AWS
-
-- [AWS CDK bởi @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK bởi @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### Alibaba Cloud
@@ -173,10 +157,6 @@ Triển khai Dify trên AWS bằng [CDK](https://aws.amazon.com/cdk/)
 #### Alibaba Cloud Data Management
 
 Triển khai Dify lên Alibaba Cloud chỉ với một cú nhấp chuột bằng [Alibaba Cloud Data Management](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)
-
-#### Sử dụng Azure Devops Pipeline để Triển khai lên AKS
-
-Triển khai Dify lên AKS chỉ với một cú nhấp chuột bằng [Azure Devops Pipeline Helm Chart bởi @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS)
 
 #### Triển khai với Sealos
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -149,33 +149,14 @@ docker compose up -d
 
 - [Helm Chart by @BorisPolonsky](https://github.com/BorisPolonsky/dify-helm)
 
-- [Helm Chart by @magicsong](https://github.com/magicsong/ai-charts)
-
 - [YAML 文件 by @Winson-030](https://github.com/Winson-030/dify-kubernetes)
 
 - [YAML file by @wyy-holding](https://github.com/wyy-holding/dify-k8s)
-
-- [🚀 NEW! YAML 文件 (支持 Dify v1.6.0) by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-#### 使用 Terraform 部署
-
-使用 [terraform](https://www.terraform.io/) 一键将 Dify 部署到云平台
-
-##### Azure Global
-
-- [Azure Terraform by @nikawang](https://github.com/nikawang/dify-azure-terraform)
-
-##### Google Cloud
-
-- [Google Cloud Terraform by @sotazum](https://github.com/DeNA/dify-google-cloud-terraform)
 
 #### 使用 AWS CDK 部署
 
 使用 [CDK](https://aws.amazon.com/cdk/) 将 Dify 部署到 AWS
 
-##### AWS
-
-- [AWS CDK by @KevinZhao (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [AWS CDK by @tmokmss (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### 使用 阿里云计算巢 部署
@@ -185,10 +166,6 @@ docker compose up -d
 #### 使用 阿里云数据管理DMS 部署
 
 使用 [阿里云数据管理DMS](https://help.aliyun.com/zh/dms/dify-in-invitational-preview) 将 Dify 一键部署到 阿里云
-
-#### 使用 Azure Devops Pipeline 部署到AKS
-
-使用[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS) 将 Dify 一键部署到 AKS
 
 #### 使用 Sealos 部署
 

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -153,27 +153,11 @@ Dify 的所有功能都提供相應的 API，因此您可以輕鬆地將 Dify �
 - [由 @BorisPolonsky 提供的 Helm Chart](https://github.com/BorisPolonsky/dify-helm)
 - [由 @Winson-030 提供的 YAML 文件](https://github.com/Winson-030/dify-kubernetes)
 - [由 @wyy-holding 提供的 YAML 文件](https://github.com/wyy-holding/dify-k8s)
-- [🚀 NEW! YAML 檔案（支援 Dify v1.6.0）by @Zhoneym](https://github.com/Zhoneym/DifyAI-Kubernetes)
-
-### 使用 Terraform 進行部署
-
-使用 [terraform](https://www.terraform.io/) 一鍵部署 Dify 到雲端平台
-
-### Azure 全球
-
-- [由 @nikawang 提供的 Azure Terraform](https://github.com/nikawang/dify-azure-terraform)
-
-### Google Cloud
-
-- [由 @sotazum 提供的 Google Cloud Terraform](https://github.com/DeNA/dify-google-cloud-terraform)
 
 ### 使用 AWS CDK 進行部署
 
 使用 [CDK](https://aws.amazon.com/cdk/) 部署 Dify 到 AWS
 
-### AWS
-
-- [由 @KevinZhao 提供的 AWS CDK (EKS based)](https://github.com/aws-samples/solution-for-deploying-dify-on-aws)
 - [由 @tmokmss 提供的 AWS CDK (ECS based)](https://github.com/aws-samples/dify-self-hosted-on-aws)
 
 #### 使用 阿里云计算巢進行部署
@@ -183,10 +167,6 @@ Dify 的所有功能都提供相應的 API，因此您可以輕鬆地將 Dify �
 #### 使用 阿里雲數據管理DMS 進行部署
 
 透過 [阿里雲數據管理DMS](https://www.alibabacloud.com/help/en/dms/dify-in-invitational-preview/)，一鍵將 Dify 部署至阿里雲
-
-#### 使用 Azure Devops Pipeline 部署到AKS
-
-使用[Azure Devops Pipeline Helm Chart by @LeoZhang](https://github.com/Ruiruiz30/Dify-helm-chart-AKS) 將 Dify 一鍵部署到 AKS
 
 #### 使用 Sealos 部署
 


### PR DESCRIPTION
Fixes #41061

## Summary

Several community-contributed deployment methods listed in the root and localized READMEs have not been updated in over a year. Keeping them implies they still work on current Dify releases (1.14.x), which is misleading for self-hosted users.

This PR audits external repo activity and removes entries whose last GitHub push was more than 12 months ago.

## Removed (stale >1 year)

| Method | Last activity |
|--------|---------------|
| Helm Chart `@magicsong/ai-charts` | 2025-04 |
| YAML `@Zhoneym/DifyAI-Kubernetes` (v1.6.0 only) | 2025-07 |
| Azure Terraform `@nikawang` | 2024-09 |
| Google Cloud Terraform `@sotazum/DeNA` | 2025-06 |
| AWS CDK EKS `@KevinZhao` | 2025-08 |
| AKS Azure DevOps `@LeoZhang` | 2025-06 |

## Kept (actively maintained or official)

- `@LeoQuote` / `@BorisPolonsky` Helm charts
- `@Winson-030` / `@wyy-holding` Kubernetes YAML
- AWS CDK ECS `@tmokmss` (updated 2026-08)
- Alibaba Cloud Computing Nest & Data Management
- Sealos App Store
- Grafana dashboard link

## Test plan

- [x] Verified stale repo links removed from all 17 README files
- [x] Verified maintained deployment options remain in root README
- [x] No orphan Terraform / AKS section headers left behind