### PR TITLE
fix(api): snapshot due trigger refresh subscriptions

### DIFF
--- a/api/schedule/trigger_provider_refresh_task.py
+++ b/api/schedule/trigger_provider_refresh_task.py
@@ -1,9 +1,8 @@
 import logging
-import math
 from collections.abc import Iterable, Sequence
 
 from celery import group
-from sqlalchemy import ColumnElement, and_, func, or_, select
+from sqlalchemy import ColumnElement, and_, or_, select
 from sqlalchemy.engine.row import Row
 from sqlalchemy.orm import Session
 
@@ -57,27 +56,26 @@ def trigger_provider_refresh() -> None:
 
     with Session(db.engine, expire_on_commit=False) as session:
         filter: ColumnElement[bool] = _build_due_filter(now_ts=now)
-        total_due: int = int(session.scalar(statement=select(func.count()).where(filter)) or 0)
+        # Keep the list of due subscriptions stable for this publisher run.
+        # Refresh workers update the same rows, so OFFSET pagination over a
+        # changing due set can skip rows after an earlier page is processed.
+        subscription_rows: Sequence[Row[tuple[str, str]]] = session.execute(
+            select(TriggerSubscription.tenant_id, TriggerSubscription.id)
+            .where(filter)
+            .order_by(TriggerSubscription.updated_at.asc(), TriggerSubscription.id.asc())
+        ).all()
+        total_due = len(subscription_rows)
         logger.info("Trigger refresh scan start: due=%d", total_due)
         if total_due == 0:
             return
 
-        pages: int = math.ceil(total_due / batch_size)
+        pages = (total_due + batch_size - 1) // batch_size
         for page in range(pages):
-            offset: int = page * batch_size
-            subscription_rows: Sequence[Row[tuple[str, str]]] = session.execute(
-                select(TriggerSubscription.tenant_id, TriggerSubscription.id)
-                .where(filter)
-                .order_by(TriggerSubscription.updated_at.asc())
-                .offset(offset)
-                .limit(batch_size)
-            ).all()
-            if not subscription_rows:
-                logger.debug("Trigger refresh page %d/%d empty", page + 1, pages)
-                continue
+            offset = page * batch_size
+            page_rows = subscription_rows[offset : offset + batch_size]
 
             subscriptions: list[tuple[str, str]] = [
-                (str(tenant_id), str(subscription_id)) for tenant_id, subscription_id in subscription_rows
+                (str(tenant_id), str(subscription_id)) for tenant_id, subscription_id in page_rows
             ]
             lock_keys: list[str] = build_trigger_refresh_lock_keys(subscriptions)
             acquired: list[bool] = _acquire_locks(keys=lock_keys, ttl_seconds=lock_ttl)

--- a/api/tests/unit_tests/tasks/test_trigger_provider_refresh_task.py
+++ b/api/tests/unit_tests/tasks/test_trigger_provider_refresh_task.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+MODULE = "schedule.trigger_provider_refresh_task"
+
+
+class _SnapshotSession:
+    """Returns an initial due-row snapshot when queried once.
+
+    The legacy OFFSET publisher queries again after workers can update its first
+    page. Its second query therefore observes the shifted due set and skips the
+    middle rows. A snapshot publisher reads all due ids before it starts
+    enqueueing work.
+    """
+
+    def __init__(self) -> None:
+        self.execute_calls = 0
+        self.rows = [
+            ("tenant-1", "sub-1"),
+            ("tenant-1", "sub-2"),
+            ("tenant-1", "sub-3"),
+            ("tenant-1", "sub-4"),
+            ("tenant-1", "sub-5"),
+        ]
+
+    def __enter__(self) -> _SnapshotSession:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def execute(self, _statement: object) -> SimpleNamespace:
+        self.execute_calls += 1
+        if self.execute_calls == 1:
+            # This is the complete result a snapshot query must retain.
+            return SimpleNamespace(all=lambda: self.rows)
+        if self.execute_calls == 2:
+            # After page one refreshes, rows 1 and 2 no longer satisfy the
+            # due filter. OFFSET 2 now starts at sub-5, skipping sub-3/sub-4.
+            return SimpleNamespace(all=lambda: [("tenant-1", "sub-5")])
+        return SimpleNamespace(all=lambda: [])
+
+
+@pytest.fixture
+def publisher(monkeypatch: pytest.MonkeyPatch):
+    import schedule.trigger_provider_refresh_task as task_module
+
+    session = _SnapshotSession()
+    dispatched: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(task_module, "db", SimpleNamespace(engine=object()))
+    monkeypatch.setattr(task_module, "Session", lambda *_args, **_kwargs: session)
+    monkeypatch.setattr(task_module, "current_timestamp", lambda: 1_000)
+    monkeypatch.setattr(
+        task_module,
+        "dify_config",
+        SimpleNamespace(
+            TRIGGER_PROVIDER_REFRESH_BATCH_SIZE=2,
+            TRIGGER_PROVIDER_CREDENTIAL_THRESHOLD_SECONDS=60,
+            TRIGGER_PROVIDER_SUBSCRIPTION_THRESHOLD_SECONDS=60,
+        ),
+    )
+    monkeypatch.setattr(task_module, "_acquire_locks", lambda **_kwargs: [True] * 2)
+    monkeypatch.setattr(
+        task_module,
+        "trigger_subscription_refresh",
+        SimpleNamespace(s=lambda *, tenant_id, subscription_id: (tenant_id, subscription_id)),
+    )
+
+    def record_group(jobs: list[tuple[str, str]]) -> SimpleNamespace:
+        dispatched.extend(jobs)
+        return SimpleNamespace(apply_async=lambda: "queued")
+
+    monkeypatch.setattr(task_module, "group", record_group)
+    return task_module, session, dispatched
+
+
+def test_provider_refresh_enqueues_the_initial_due_snapshot_despite_updates(publisher) -> None:
+    task_module, session, dispatched = publisher
+
+    task_module.trigger_provider_refresh.run()
+
+    assert dispatched == session.rows


### PR DESCRIPTION
## Summary
- snapshot due trigger subscriptions before enqueuing refresh work
- keep chronological ordering with an id tie-breaker and retain batch-sized dispatches
- add a regression test for concurrent updates shifting the due set

## Test plan
- [x] `make test TARGET_TESTS=api/tests/unit_tests/tasks/test_trigger_provider_refresh_task.py`
- [x] `uv run --project api --dev ruff check api/schedule/trigger_provider_refresh_task.py api/tests/unit_tests/tasks/test_trigger_provider_refresh_task.py`
- [x] `uv run --project api --dev ruff format --check api/schedule/trigger_provider_refresh_task.py api/tests/unit_tests/tasks/test_trigger_provider_refresh_task.py`

No associated issue; this is a self-contained scheduler reliability fix.