### PR TITLE
fix(api): enforce admin and RBAC permissions on data source integrates GET endpoint (#41079)

### DIFF
--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -139,6 +139,8 @@ register_response_schema_models(
 class DataSourceApi(Resource):
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[DataSourceIntegrateListResponse.__name__])
     @with_current_tenant_id

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -16,6 +16,7 @@ from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddA
     [
         (ToolBuiltinProviderAddApi.post, RBACPermission.CREDENTIAL_CREATE),
         (DataSourceApi.patch, RBACPermission.CREDENTIAL_MANAGE),
+        (DataSourceApi.get, RBACPermission.CREDENTIAL_MANAGE),
     ],
 )
 def test_workspace_credential_mutations_require_management_permission(


### PR DESCRIPTION
## Summary

Fixes #41079

The `GET /console/api/data-source/integrates` endpoint in `DataSourceApi` was missing authorization decorators:
- `@is_admin_or_owner_required`
- `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)`

This allowed workspace members without admin/owner roles or credential management RBAC permissions to view workspace data source integration metadata.

Added missing permission decorators to match its sibling `patch` method and added corresponding unit test assertion.

## Screenshots

N/A (Backend API permission enforcement)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
