### PR TITLE
style(api): remove unnecessary type conversions in console controllers and services

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -364,7 +364,7 @@ def _serialize_agent_app_detail(
 
     app_model = AppService().get_app(app_model, session=session)
     if FeatureService.get_system_features().webapp_auth.enabled:
-        app_setting = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id=str(app_model.id))
+        app_setting = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id=app_model.id)
         app_model.access_mode = app_setting.access_mode  # type: ignore[attr-defined]
 
     roster_service = _agent_roster_service(session)
@@ -382,7 +382,7 @@ def _serialize_agent_app_detail(
             )
         )
         if agent_id
-        else roster_service.get_app_backing_agent(tenant_id=app_model.tenant_id, app_id=str(app_model.id))
+        else roster_service.get_app_backing_agent(tenant_id=app_model.tenant_id, app_id=app_model.id)
     )
     if not agent:
         raise AgentNotFoundError()
@@ -500,7 +500,7 @@ def _agent_api_key_count(session: Session, app_model: App) -> int:
 def _agent_app_access_ready(session: Session, app_model: App) -> bool:
     agent = _agent_roster_service(session).get_app_backing_agent(
         tenant_id=app_model.tenant_id,
-        app_id=str(app_model.id),
+        app_id=app_model.id,
     )
     return bool(agent and agent_has_workflow_callable_active_snapshot(session=session, agent=agent))
 
@@ -510,7 +510,7 @@ def _serialize_agent_api_access(session: Session, app_model: App) -> dict:
     access_ready = _agent_app_access_ready(session, app_model)
     response = AgentApiAccessResponse(
         access_ready=access_ready,
-        enabled=bool(app_model.enable_api and access_ready),
+        enabled=app_model.enable_api and access_ready,
         service_api_base_url=base_url,
         chat_endpoint=f"{base_url}/chat-messages",
         stop_endpoint=f"{base_url}/chat-messages/{{task_id}}/stop",
@@ -947,7 +947,7 @@ class AgentApiKeyListApi(BaseApiKeyListResource):
     @with_session(write=False)
     def get(self, session: Session, tenant_id: str, agent_id: UUID) -> dict[str, object]:
         app_model = _resolve_agent_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
-        return dump_response(ApiKeyList, self._get_api_key_list(str(app_model.id), tenant_id, session=session))
+        return dump_response(ApiKeyList, self._get_api_key_list(app_model.id, tenant_id, session=session))
 
     @console_ns.response(201, "Agent service API key created", console_ns.models[ApiKeyItem.__name__])
     @console_ns.response(400, "Maximum keys exceeded")
@@ -960,7 +960,7 @@ class AgentApiKeyListApi(BaseApiKeyListResource):
         app_model = _resolve_agent_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
         return dump_response(
             ApiKeyItem,
-            self._create_api_key(str(app_model.id), tenant_id, session=session),
+            self._create_api_key(app_model.id, tenant_id, session=session),
         ), 201
 
 
@@ -985,7 +985,7 @@ class AgentApiKeyApi(BaseApiKeyResource):
         api_key_id: UUID,
     ) -> tuple[str, int]:
         app_model = _resolve_agent_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
-        self._delete_api_key(str(app_model.id), str(api_key_id), tenant_id, current_user, session=session)
+        self._delete_api_key(app_model.id, str(api_key_id), tenant_id, current_user, session=session)
         return "", 204
 
 

--- a/api/controllers/console/app/agent_config_inspector.py
+++ b/api/controllers/console/app/agent_config_inspector.py
@@ -1091,7 +1091,7 @@ class AgentConfigSkillFileDownloadApi(Resource):
                 name=name,
                 path=query.path,
                 raw_endpoint="console.agent_config_skill_file_download_content_api",
-                route_params={"app_id": str(app_model.id)},
+                route_params={"app_id": app_model.id},
                 extra_query_params={"node_id": query.node_id} if query.node_id else None,
             )
         except AgentConfigServiceError as exc:

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -112,7 +112,7 @@ class AppListBaseQuery(BaseModel):
         if not isinstance(value, list):
             raise ValueError("Unsupported tag_ids type.")
 
-        items = [str(item).strip() for item in value if item and str(item).strip()]
+        items = [item.strip() for item in value if item and item.strip()]
         if not items:
             return None
 
@@ -130,7 +130,7 @@ class AppListBaseQuery(BaseModel):
         if not isinstance(value, list):
             raise ValueError("Unsupported creator_ids type.")
 
-        items = [str(item).strip() for item in value if item and str(item).strip()]
+        items = [item.strip() for item in value if item and item.strip()]
         if not items:
             return None
 
@@ -517,14 +517,14 @@ class AppImportResponse(ResponseModel):
 
 def _enrich_app_list_items(session: Session, *, apps: Sequence[App], tenant_id: str) -> None:
     if FeatureService.get_system_features().webapp_auth.enabled:
-        app_ids = [str(app.id) for app in apps]
+        app_ids = [app.id for app in apps]
         res = EnterpriseService.WebAppAuth.batch_get_app_access_mode_by_id(app_ids=app_ids)
         if len(res) != len(app_ids):
             raise BadRequest("Invalid app id in webapp auth")
 
         for app in apps:
-            if str(app.id) in res:
-                app.access_mode = res[str(app.id)].access_mode
+            if app.id in res:
+                app.access_mode = res[app.id].access_mode
 
     workflow_capable_app_ids = [str(app.id) for app in apps if app.mode in {"workflow", "advanced-chat"}]
     draft_trigger_app_ids: set[str] = set()
@@ -546,14 +546,14 @@ def _enrich_app_list_items(session: Session, *, apps: Sequence[App], tenant_id: 
             try:
                 for node_id, node_data in workflow.walk_nodes():
                     if node_data.get("type") in trigger_node_types:
-                        draft_trigger_app_ids.add(str(workflow.app_id))
+                        draft_trigger_app_ids.add(workflow.app_id)
                         break
             except Exception:
                 _logger.exception("error while walking nodes, workflow_id=%s, node_id=%s", workflow.id, node_id)
                 continue
 
     for app in apps:
-        app.has_draft_trigger = str(app.id) in draft_trigger_app_ids
+        app.has_draft_trigger = app.id in draft_trigger_app_ids
 
 
 register_enum_models(console_ns, RetrievalMethod, WorkflowExecutionStatus, DatasetPermissionEnum)
@@ -642,13 +642,13 @@ class AppListApi(Resource):
         )
 
         permissions = enterprise_rbac_service.RBACService.MyPermissions.get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user_id,
             session=session,
         )
         if dify_config.RBAC_ENABLED:
             access_filter = resolve_app_access_filter(
-                str(current_tenant_id),
+                current_tenant_id,
                 current_user_id,
                 session=session,
                 permissions=permissions,
@@ -675,7 +675,7 @@ class AppListApi(Resource):
             pagination_model = pagination_model.model_copy(
                 update={
                     "data": [
-                        item.model_copy(update={"permission_keys": permission_keys_map.get(str(item.id), [])})
+                        item.model_copy(update={"permission_keys": permission_keys_map.get(item.id, [])})
                         for item in pagination_model.data
                     ]
                 }
@@ -713,23 +713,23 @@ class AppListApi(Resource):
         app = app_service.create_app(current_tenant_id, params, current_user, session=session)
         if dify_config.RBAC_ENABLED:
             enterprise_rbac_service.RBACService.AppAccess.replace_whitelist(
-                tenant_id=str(current_tenant_id),
+                tenant_id=current_tenant_id,
                 account_id=current_user.id,
-                app_id=str(app.id),
+                app_id=app.id,
                 payload=enterprise_rbac_service.ReplaceMemberBindings(scope=RBACResourceWhitelistScope.ALL),
             )
             initialize_created_app_rbac_access_task.delay(current_tenant_id, current_user.id, app_id=app.id)
         permission_keys_map = enterprise_rbac_service.RBACService.AppPermissions.batch_get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user.id,
-            [str(app.id)],
+            [app.id],
             session=session,
         )
         app_detail = AppDetailWithSite.model_validate(
             app,
             from_attributes=True,
             context={"session": session},
-        ).model_copy(update={"permission_keys": permission_keys_map.get(str(app.id), [])})
+        ).model_copy(update={"permission_keys": permission_keys_map.get(app.id, [])})
         return app_detail.model_dump(mode="json"), 201
 
 
@@ -875,22 +875,22 @@ class AppApi(Resource):
         app_model = app_service.get_app(app_model, session=session)
 
         if FeatureService.get_system_features().webapp_auth.enabled:
-            app_setting = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id=str(app_model.id))
+            app_setting = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id=app_model.id)
             app_model.access_mode = app_setting.access_mode
 
         permissions = enterprise_rbac_service.RBACService.MyPermissions.get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user.id,
-            app_id=str(app_model.id),
+            app_id=app_model.id,
             session=session,
         )
-        permission_keys_map = permissions.app.permission_keys_by_resource_ids([str(app_model.id)])
+        permission_keys_map = permissions.app.permission_keys_by_resource_ids([app_model.id])
 
         response_model = AppDetailWithSite.model_validate(
             app_model,
             from_attributes=True,
             context={"session": session},
-        ).model_copy(update={"permission_keys": permission_keys_map.get(str(app_model.id), [])})
+        ).model_copy(update={"permission_keys": permission_keys_map.get(app_model.id, [])})
         return response_model.model_dump(mode="json")
 
     @console_ns.doc("update_app")
@@ -1017,16 +1017,16 @@ class AppCopyApi(Resource):
                 raise NotFound("App not found")
 
             permission_keys_map = enterprise_rbac_service.RBACService.AppPermissions.batch_get(
-                str(current_tenant_id),
+                current_tenant_id,
                 current_user.id,
-                [str(app.id)],
+                [app.id],
                 session=session,
             )
             response_model = AppDetailWithSite.model_validate(
                 app,
                 from_attributes=True,
                 context={"session": session},
-            ).model_copy(update={"permission_keys": permission_keys_map.get(str(app.id), [])})
+            ).model_copy(update={"permission_keys": permission_keys_map.get(app.id, [])})
             return response_model.model_dump(mode="json"), 201
 
 

--- a/api/controllers/console/app/app_import.py
+++ b/api/controllers/console/app/app_import.py
@@ -56,7 +56,7 @@ register_schema_models(console_ns, AppImportPayload, Import, CheckDependenciesRe
 def _current_user_and_tenant_id(current_user: Account | None) -> tuple[Account, str | None]:
     if current_user is None:
         account, tenant_id = current_account_with_tenant()
-        return account, tenant_id if tenant_id else None
+        return account, tenant_id or None
 
     current_tenant_id = getattr(current_user, "current_tenant_id", None)
     if current_tenant_id:
@@ -68,7 +68,7 @@ def _current_user_and_tenant_id(current_user: Account | None) -> tuple[Account, 
         return current_user, str(current_tenant_object_id)
 
     account, fallback_tenant_id = current_account_with_tenant()
-    return account, fallback_tenant_id if fallback_tenant_id else None
+    return account, fallback_tenant_id or None
 
 
 @console_ns.route("/apps/imports")

--- a/api/controllers/console/app/app_import.py
+++ b/api/controllers/console/app/app_import.py
@@ -56,7 +56,7 @@ register_schema_models(console_ns, AppImportPayload, Import, CheckDependenciesRe
 def _current_user_and_tenant_id(current_user: Account | None) -> tuple[Account, str | None]:
     if current_user is None:
         account, tenant_id = current_account_with_tenant()
-        return account, str(tenant_id) if tenant_id else None
+        return account, tenant_id if tenant_id else None
 
     current_tenant_id = getattr(current_user, "current_tenant_id", None)
     if current_tenant_id:
@@ -68,7 +68,7 @@ def _current_user_and_tenant_id(current_user: Account | None) -> tuple[Account, 
         return current_user, str(current_tenant_object_id)
 
     account, fallback_tenant_id = current_account_with_tenant()
-    return account, str(fallback_tenant_id) if fallback_tenant_id else None
+    return account, fallback_tenant_id if fallback_tenant_id else None
 
 
 @console_ns.route("/apps/imports")

--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -359,7 +359,7 @@ def _resolve_current_user_agent_debug_conversation_id(
     roster_service = AgentRosterService(session)
     resolved_agent_id = agent_id
     if not resolved_agent_id:
-        agent = roster_service.get_app_backing_agent(tenant_id=current_tenant_id, app_id=str(app_model.id))
+        agent = roster_service.get_app_backing_agent(tenant_id=current_tenant_id, app_id=app_model.id)
         if agent is None:
             raise AgentNotFoundError()
         resolved_agent_id = agent.id

--- a/api/controllers/console/app/workflow.py
+++ b/api/controllers/console/app/workflow.py
@@ -1428,7 +1428,7 @@ class ConvertToWorkflowApi(Resource):
         # return app id
         return {
             "new_app_id": new_app_model.id,
-            "permission_keys": get_app_permission_keys(str(current_tenant_id), current_user.id, str(new_app_model.id)),
+            "permission_keys": get_app_permission_keys(current_tenant_id, current_user.id, new_app_model.id),
         }
 
 

--- a/api/controllers/console/auth/error.py
+++ b/api/controllers/console/auth/error.py
@@ -55,7 +55,7 @@ class PasswordResetRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -65,7 +65,7 @@ class EmailRegisterRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -75,7 +75,7 @@ class EmailChangeRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -85,7 +85,7 @@ class OwnerTransferRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -137,7 +137,7 @@ class EmailCodeLoginRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 5):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -147,7 +147,7 @@ class EmailCodeAccountDeletionRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 5):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 

--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -456,7 +456,7 @@ class DatasetListApi(Resource):
         query = ConsoleDatasetListQuery.model_validate(query_params)
 
         permissions = enterprise_rbac_service.RBACService.MyPermissions.get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user.id,
             session=session,
         )
@@ -465,7 +465,7 @@ class DatasetListApi(Resource):
         include_own_datasets = False
         if dify_config.RBAC_ENABLED:
             whitelist_scope = enterprise_rbac_service.RBACService.DatasetAccess.whitelist_resources(
-                str(current_tenant_id),
+                current_tenant_id,
                 current_user.id,
             )
             has_default_readonly = _has_dataset_list_permission(

--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -370,9 +370,9 @@ class ExternalDatasetCreateApi(Resource):
         except services.errors.dataset.DatasetNameDuplicateError:
             raise DatasetNameDuplicateError()
 
-        dataset_id_str = str(dataset.id)
+        dataset_id_str = dataset.id
         permission_keys_map = enterprise_rbac_service.RBACService.DatasetPermissions.batch_get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user.id,
             [dataset_id_str],
             session=session,

--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -161,7 +161,7 @@ class InstalledAppsListApi(Resource):
 
         installed_apps, has_more, next_cursor = InstalledAppService.get_visible_page(
             tenant_id=current_tenant_id,
-            user_id=str(current_user.id),
+            user_id=current_user.id,
             cursor=cursor,
             limit=query.limit,
             app_id=query.app_id,

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -39,7 +39,7 @@ class SavedMessageListApi(InstalledAppResource):
         args = SavedMessageListQuery.model_validate(request.args.to_dict())
 
         pagination = SavedMessageService.pagination_by_last_id(
-            app_model, current_user, args.last_id if args.last_id else None, args.limit, session=session
+            app_model, current_user, args.last_id or None, args.limit, session=session
         )
         adapter = TypeAdapter(SavedMessageItem)
         items = [

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -39,7 +39,7 @@ class SavedMessageListApi(InstalledAppResource):
         args = SavedMessageListQuery.model_validate(request.args.to_dict())
 
         pagination = SavedMessageService.pagination_by_last_id(
-            app_model, current_user, str(args.last_id) if args.last_id else None, args.limit, session=session
+            app_model, current_user, args.last_id if args.last_id else None, args.limit, session=session
         )
         adapter = TypeAdapter(SavedMessageItem)
         items = [
@@ -64,7 +64,7 @@ class SavedMessageListApi(InstalledAppResource):
             raise NotCompletionAppError()
 
         try:
-            SavedMessageService.save(app_model, current_user, str(req_data.message_id), session=db.session())
+            SavedMessageService.save(app_model, current_user, req_data.message_id, session=db.session())
         except MessageNotExistsError:
             raise NotFound("Message Not Exists.")
 

--- a/api/controllers/console/explore/wraps.py
+++ b/api/controllers/console/explore/wraps.py
@@ -28,7 +28,7 @@ def installed_app_required[**P, R](view: Callable[Concatenate[InstalledApp, P], 
             _, current_tenant_id = current_account_with_tenant()
             installed_app = db.session.scalar(
                 select(InstalledApp)
-                .where(InstalledApp.id == str(installed_app_id), InstalledApp.tenant_id == current_tenant_id)
+                .where(InstalledApp.id == installed_app_id, InstalledApp.tenant_id == current_tenant_id)
                 .limit(1)
             )
 
@@ -59,7 +59,7 @@ def user_allowed_to_access_app[**P, R](view: Callable[Concatenate[InstalledApp, 
             if feature.webapp_auth.enabled:
                 app_id = installed_app.app_id
                 res = EnterpriseService.WebAppAuth.is_user_allowed_to_access_webapp(
-                    user_id=str(current_user.id),
+                    user_id=current_user.id,
                     app_id=app_id,
                 )
                 if not res:
@@ -81,7 +81,7 @@ def trial_app_required[**P, R](view: Callable[Concatenate[App, P], R] | None = N
             current_user, _ = current_account_with_tenant()
             session = db.session()
 
-            trial_app = session.scalar(select(TrialApp).where(TrialApp.app_id == str(app_id)).limit(1))
+            trial_app = session.scalar(select(TrialApp).where(TrialApp.app_id == app_id).limit(1))
 
             if trial_app is None:
                 raise TrialAppNotAllowed()

--- a/api/controllers/console/notification.py
+++ b/api/controllers/console/notification.py
@@ -98,7 +98,7 @@ class NotificationApi(Resource):
     @account_initialization_required
     @only_edition_cloud
     def get(self, current_user: Account):
-        result = BillingService.get_account_notification(str(current_user.id))
+        result = BillingService.get_account_notification(current_user.id)
 
         # Proto JSON uses camelCase field names (Kratos default marshaling).
         response: NotificationResponseDict
@@ -145,6 +145,6 @@ class NotificationDismissApi(Resource):
     def post(self, payload: DismissNotificationPayload, current_user: Account):
         BillingService.dismiss_notification(
             notification_id=payload.notification_id,
-            account_id=str(current_user.id),
+            account_id=current_user.id,
         )
         return {"result": "success"}, 200

--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -154,7 +154,7 @@ def _hydrate_access_matrix_account_names(items: list[svc.AccessMatrixItem]) -> N
 
     for item in items:
         for account in item.accounts:
-            account_id = account.account_id or "".strip()
+            account_id = (account.account_id or "").strip()
             if account_id and not account.account_name:
                 account.account_name = account_names.get(account_id, {}).get("name", "")
             account.avatar = account_names.get(account_id, {}).get("avatar", "")

--- a/api/controllers/console/workspace/rbac.py
+++ b/api/controllers/console/workspace/rbac.py
@@ -154,7 +154,7 @@ def _hydrate_access_matrix_account_names(items: list[svc.AccessMatrixItem]) -> N
 
     for item in items:
         for account in item.accounts:
-            account_id = str(account.account_id or "").strip()
+            account_id = account.account_id or "".strip()
             if account_id and not account.account_name:
                 account.account_name = account_names.get(account_id, {}).get("name", "")
             account.avatar = account_names.get(account_id, {}).get("avatar", "")

--- a/api/controllers/console/workspace/snippets.py
+++ b/api/controllers/console/workspace/snippets.py
@@ -221,7 +221,7 @@ class CustomizedSnippetDetailApi(Resource):
         """Update customized snippet."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -265,7 +265,7 @@ class CustomizedSnippetDetailApi(Resource):
         """Delete customized snippet."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -304,7 +304,7 @@ class CustomizedSnippetExportApi(Resource):
         """Export snippet as DSL."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -428,7 +428,7 @@ class CustomizedSnippetCheckDependenciesApi(Resource):
         """Check dependencies for a snippet."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -458,7 +458,7 @@ class CustomizedSnippetUseCountIncrementApi(Resource):
         """Increment snippet use count when it is inserted into a workflow."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 

--- a/api/controllers/openapi/account.py
+++ b/api/controllers/openapi/account.py
@@ -92,7 +92,7 @@ class AccountSessionsApi(Resource):
 
         items = [
             SessionRow(
-                id=str(r.id),
+                id=r.id,
                 prefix=r.prefix,
                 client_id=r.client_id,
                 device_label=r.device_label,

--- a/api/controllers/openapi/apps.py
+++ b/api/controllers/openapi/apps.py
@@ -80,7 +80,7 @@ class AppReadResource(Resource):
                 lines = [f"app name {app_id!r} is ambiguous — re-run with a UUID:\n\n"]
                 lines.append(f"  {'ID':<36}  {'MODE':<12}  NAME\n")
                 for m in matches:
-                    lines.append(f"  {str(m.id):<36}  {str(m.mode.value):<12}  {m.name}\n")
+                    lines.append(f"  {m.id:<36}  {str(m.mode.value):<12}  {m.name}\n")
                 raise Conflict("".join(lines))
             app = matches[0]
 
@@ -102,12 +102,12 @@ def build_app_describe_response(app: App, fields: set[str] | None, *, session: S
 
     info = (
         AppDescribeInfo(
-            id=str(app.id),
+            id=app.id,
             name=app.name,
             mode=app.mode,
             description=app.description,
             updated_at=app.updated_at.isoformat() if app.updated_at else None,
-            service_api_enabled=bool(app.enable_api),
+            service_api_enabled=app.enable_api,
             is_agent=app.mode in (AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT),
         )
         if want_info
@@ -185,24 +185,24 @@ class AppListApi(Resource):
         tenant_name: str | None = None
         if parsed_uuid is not None:
             app: App | None = AppService.get_visible_app_by_id(str(parsed_uuid), session)
-            if app is None or str(app.tenant_id) != workspace_id:
+            if app is None or app.tenant_id != workspace_id:
                 return empty
             if not _is_listable(app):
                 return empty
             # Apply RBAC visibility to the UUID fast-path the same way the service
             # layer does for paginated queries (id in accessible set OR own app).
             if apply_rbac_filter and not access_filter.is_app_accessible(
-                str(app.id), str(app.maintainer) if app.maintainer else None, str(auth_data.account_id)
+                app.id, app.maintainer if app.maintainer else None, str(auth_data.account_id)
             ):
                 return empty
             tenant_name = TenantService.get_tenant_name(workspace_id, session=session)
             item = AppListRow(
-                id=str(app.id),
+                id=app.id,
                 name=app.name,
                 description=app.description,
                 mode=app.mode,
                 updated_at=app.updated_at.isoformat() if app.updated_at else None,
-                workspace_id=str(workspace_id),
+                workspace_id=workspace_id,
                 workspace_name=tenant_name,
             )
             env = AppListResponse(page=1, limit=1, total=1, has_more=False, data=[item])
@@ -237,7 +237,7 @@ class AppListApi(Resource):
                 description=r.description,
                 mode=r.mode,
                 updated_at=r.updated_at.isoformat() if r.updated_at else None,
-                workspace_id=str(workspace_id),
+                workspace_id=workspace_id,
                 workspace_name=tenant_name,
             )
             for r in pagination.items

--- a/api/controllers/openapi/apps.py
+++ b/api/controllers/openapi/apps.py
@@ -192,7 +192,7 @@ class AppListApi(Resource):
             # Apply RBAC visibility to the UUID fast-path the same way the service
             # layer does for paginated queries (id in accessible set OR own app).
             if apply_rbac_filter and not access_filter.is_app_accessible(
-                app.id, app.maintainer if app.maintainer else None, str(auth_data.account_id)
+                app.id, app.maintainer or None, str(auth_data.account_id)
             ):
                 return empty
             tenant_name = TenantService.get_tenant_name(workspace_id, session=session)

--- a/api/controllers/openapi/apps_permitted_external.py
+++ b/api/controllers/openapi/apps_permitted_external.py
@@ -58,25 +58,25 @@ class PermittedExternalAppsListApi(Resource):
             return env
 
         apps_by_id: dict[str, App] = {
-            str(a.id): a for a in AppService.find_visible_apps_by_ids(page_result.app_ids, session)
+            a.id: a for a in AppService.find_visible_apps_by_ids(page_result.app_ids, session)
         }
-        tenant_ids = list({str(a.tenant_id) for a in apps_by_id.values()})
-        tenants_by_id = {str(t.id): t for t in TenantService.get_tenants_by_ids(tenant_ids, session=session)}
+        tenant_ids = list({a.tenant_id for a in apps_by_id.values()})
+        tenants_by_id = {t.id: t for t in TenantService.get_tenants_by_ids(tenant_ids, session=session)}
 
         items: list[AppListRow] = []
         for app_id in page_result.app_ids:
             app = apps_by_id.get(app_id)
             if not app or app.status != AppStatus.NORMAL:
                 continue
-            tenant = tenants_by_id.get(str(app.tenant_id))
+            tenant = tenants_by_id.get(app.tenant_id)
             items.append(
                 AppListRow(
-                    id=str(app.id),
+                    id=app.id,
                     name=app.name,
                     description=app.description,
                     mode=app.mode,
                     updated_at=app.updated_at.isoformat() if app.updated_at else None,
-                    workspace_id=str(app.tenant_id),
+                    workspace_id=app.tenant_id,
                     workspace_name=tenant.name if tenant else None,
                 )
             )

--- a/api/controllers/openapi/auth/prepare.py
+++ b/api/controllers/openapi/auth/prepare.py
@@ -36,7 +36,7 @@ def load_tenant(data: AuthData) -> None:
     if data.app is None:
         raise InternalServerError("pipeline_invariant_violated: app not loaded before load_tenant")
     with session_factory.create_session() as session:
-        tenant = TenantService.get_tenant_by_id(str(data.app.tenant_id), session=session)
+        tenant = TenantService.get_tenant_by_id(data.app.tenant_id, session=session)
     if tenant is None or tenant.status == TenantStatus.ARCHIVE:
         raise Forbidden("workspace unavailable")
     data.tenant = tenant
@@ -80,7 +80,7 @@ def load_workspace_role(data: AuthData) -> None:
     if data.caller is not None and getattr(data.caller, "status", None) != AccountStatus.ACTIVE:
         return
     with session_factory.create_session() as session:
-        role = TenantService.get_account_role_in_tenant(str(data.account_id), str(data.tenant.id), session=session)
+        role = TenantService.get_account_role_in_tenant(str(data.account_id), data.tenant.id, session=session)
     if role is None:
         return
     data.tenant_role = role
@@ -91,8 +91,8 @@ def resolve_external_user(data: AuthData) -> None:
         raise Unauthorized("missing context for external user resolution")
     end_user = EndUserService.get_or_create_end_user_by_type(
         EndUserType.OPENAPI,
-        tenant_id=str(data.tenant.id),
-        app_id=str(data.app.id),
+        tenant_id=data.tenant.id,
+        app_id=data.app.id,
         user_id=data.external_identity.email,
     )
     data.caller = end_user
@@ -103,7 +103,7 @@ def load_app_access_mode(data: AuthData) -> None:
     if data.app is None:
         return
     try:
-        settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id=str(data.app.id))
+        settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id=data.app.id)
         if settings is None:
             data.app_access_mode = None
             return

--- a/api/controllers/openapi/auth/verify.py
+++ b/api/controllers/openapi/auth/verify.py
@@ -35,7 +35,7 @@ def check_workspace_mismatch(data: AuthData) -> None:
     if data.tenant is None:
         return
     request_workspace_id = data.path_params.get("workspace_id") or request.args.get("workspace_id")
-    if request_workspace_id and request_workspace_id != str(data.tenant.id):
+    if request_workspace_id and request_workspace_id != data.tenant.id:
         raise UnprocessableEntity("workspace_id does not match app's workspace")
 
 
@@ -63,7 +63,7 @@ def check_rbac_permission(data: AuthData) -> None:
     if data.account_id is None or data.tenant is None:
         raise Forbidden("rbac context missing")
     enforce_rbac_access(
-        tenant_id=str(data.tenant.id),
+        tenant_id=data.tenant.id,
         account_id=str(data.account_id),
         resource_type=req.resource_type,
         scene=req.scene,
@@ -128,4 +128,4 @@ def _resolve_user_id(data: AuthData) -> str | None:
     if data.external_identity is None:
         return None
     account = AccountService.get_account_by_email(data.external_identity.email, session=db.session())
-    return str(account.id) if account is not None else None
+    return account.id if account is not None else None

--- a/api/controllers/openapi/oauth_device.py
+++ b/api/controllers/openapi/oauth_device.py
@@ -250,7 +250,7 @@ class DeviceApproveApi(Resource):
                 redis_client,
                 subject_email=account.email,
                 subject_issuer=ACCOUNT_ISSUER_SENTINEL,
-                account_id=str(account.id),
+                account_id=account.id,
                 client_id=state.client_id,
                 device_label=state.device_label,
                 prefix=profile.prefix,
@@ -263,7 +263,7 @@ class DeviceApproveApi(Resource):
                 store.approve(
                     device_code,
                     subject_email=account.email,
-                    account_id=str(account.id),
+                    account_id=account.id,
                     subject_issuer=ACCOUNT_ISSUER_SENTINEL,
                     minted_token=mint.token,
                     token_id=str(mint.token_id),

--- a/api/controllers/openapi/workspaces.py
+++ b/api/controllers/openapi/workspaces.py
@@ -56,7 +56,7 @@ from services.feature_service import FeatureService
 
 def _member_response(account: Account) -> MemberResponse:
     return MemberResponse(
-        id=str(account.id),
+        id=account.id,
         name=account.name,
         email=account.email,
         role=account.role.value if account.role else "",
@@ -182,7 +182,7 @@ class WorkspaceMembersApi(Resource):
         inviter = _load_account(session, auth_data.account_id)
         tenant = _load_tenant(session, workspace_id)
 
-        _check_member_invite_quota(str(tenant.id))
+        _check_member_invite_quota(tenant.id)
 
         try:
             token = RegisterService.invite_new_member(
@@ -213,9 +213,9 @@ class WorkspaceMembersApi(Resource):
         return MemberInviteResponse(
             email=normalized_email,
             role=body.role,
-            member_id=str(member.id),
+            member_id=member.id,
             invite_url=invite_url,
-            tenant_id=str(tenant.id),
+            tenant_id=tenant.id,
         )
 
 
@@ -293,7 +293,7 @@ class WorkspaceMemberApi(Resource):
 
 def _workspace_summary(tenant: Tenant, membership: TenantAccountJoin) -> WorkspaceSummaryResponse:
     return WorkspaceSummaryResponse(
-        id=str(tenant.id),
+        id=tenant.id,
         name=tenant.name,
         role=getattr(membership, "role", ""),
         status=tenant.status,
@@ -303,7 +303,7 @@ def _workspace_summary(tenant: Tenant, membership: TenantAccountJoin) -> Workspa
 
 def _workspace_detail(tenant: Tenant, membership: TenantAccountJoin) -> WorkspaceDetailResponse:
     return WorkspaceDetailResponse(
-        id=str(tenant.id),
+        id=tenant.id,
         name=tenant.name,
         role=getattr(membership, "role", ""),
         status=tenant.status,

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -376,7 +376,7 @@ def _create_document_by_text(session: Session, tenant_id: str, dataset_id: UUID)
     args = payload.model_dump(exclude_none=True)
 
     dataset_id_str = str(dataset_id)
-    tenant_id_str = str(tenant_id)
+    tenant_id_str = tenant_id
     dataset = session.scalar(
         select(Dataset).where(Dataset.tenant_id == tenant_id_str, Dataset.id == dataset_id_str).limit(1)
     )

--- a/api/services/account_change_email_adapters.py
+++ b/api/services/account_change_email_adapters.py
@@ -49,8 +49,8 @@ class TokenManagerChangeEmailTokenGateway(ChangeEmailTokenGateway):
             return None
         token_kwargs = {
             "account_id": token_data.account_id,
-            "email": str(token_data.email),
-            "old_email": str(token_data.old_email),
+            "email": token_data.email,
+            "old_email": token_data.old_email,
             "code": token_data.code,
         }
         if isinstance(token_data, ChangeEmailOldEmailToken):

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -183,7 +183,7 @@ class AccountService:
                 and rbac_role.category == "global_system_default"
                 and rbac_role.role_tag == expected_tag
             ):
-                return rbac_role.id
+                return str(rbac_role.id)  # pyrefly: ignore[unnecessary-type-conversion]
 
         raise ValueError(f"Builtin RBAC role not found for {role.value} in tenant {tenant_id}")
 
@@ -1610,9 +1610,7 @@ class TenantService:
             if (
                 action == "remove"
                 and member
-                and AccountService.is_rbac_workspace_owner(
-                    tenant.id, operator.id, member.id, session=session
-                )
+                and AccountService.is_rbac_workspace_owner(tenant.id, operator.id, member.id, session=session)
             ):
                 raise NoPermissionError(f"No permission to {action} member.")
             return
@@ -1671,9 +1669,7 @@ class TenantService:
 
         owner_id: str | None
         if dify_config.RBAC_ENABLED:
-            owner_id = AccountService.get_rbac_workspace_owner_account_id(
-                tenant.id, operator.id, session=session
-            )
+            owner_id = AccountService.get_rbac_workspace_owner_account_id(tenant.id, operator.id, session=session)
         else:
             owner_id = session.scalar(
                 select(TenantAccountJoin.account_id)

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -183,7 +183,7 @@ class AccountService:
                 and rbac_role.category == "global_system_default"
                 and rbac_role.role_tag == expected_tag
             ):
-                return str(rbac_role.id)
+                return rbac_role.id
 
         raise ValueError(f"Builtin RBAC role not found for {role.value} in tenant {tenant_id}")
 
@@ -511,10 +511,10 @@ class AccountService:
             TenantService.create_owner_tenant_if_not_exist(account=account, session=session)
         except Exception:
             # Enterprise-only side-effect should run independently from personal workspace creation.
-            _try_join_enterprise_default_workspace(str(account.id))
+            _try_join_enterprise_default_workspace(account.id)
             raise
 
-        _try_join_enterprise_default_workspace(str(account.id))
+        _try_join_enterprise_default_workspace(account.id)
 
         return account
 
@@ -940,7 +940,7 @@ class AccountService:
 
         code = "".join([str(secrets.randbelow(exclusive_upper_bound=10)) for _ in range(6)])
         token = EmailCodeLoginChallengeStore.create(
-            account_id=str(account.id) if account else None,
+            account_id=account.id if account else None,
             email=email,
             code=code,
         )
@@ -1282,9 +1282,9 @@ class TenantService:
             )
         TenantService.create_tenant_member(tenant, account, session, role="owner")
         if dify_config.RBAC_ENABLED:
-            owner_role_id = AccountService._resolve_legacy_role_id(str(tenant.id), account.id, TenantAccountRole.OWNER)
+            owner_role_id = AccountService._resolve_legacy_role_id(tenant.id, account.id, TenantAccountRole.OWNER)
             RBACService.MemberRoles.replace(
-                tenant_id=str(tenant.id),
+                tenant_id=tenant.id,
                 account_id=account.id,
                 member_account_id=account.id,
                 role_ids=[owner_role_id],
@@ -1597,8 +1597,8 @@ class TenantService:
 
         if dify_config.RBAC_ENABLED:
             workspace_permission_keys = AccountService.get_workspace_permission_keys(
-                str(tenant.id),
-                str(operator.id),
+                tenant.id,
+                operator.id,
                 session=session,
             )
             required_permission_key = (
@@ -1611,7 +1611,7 @@ class TenantService:
                 action == "remove"
                 and member
                 and AccountService.is_rbac_workspace_owner(
-                    str(tenant.id), str(operator.id), str(member.id), session=session
+                    tenant.id, operator.id, member.id, session=session
                 )
             ):
                 raise NoPermissionError(f"No permission to {action} member.")
@@ -1672,7 +1672,7 @@ class TenantService:
         owner_id: str | None
         if dify_config.RBAC_ENABLED:
             owner_id = AccountService.get_rbac_workspace_owner_account_id(
-                str(tenant.id), str(operator.id), session=session
+                tenant.id, operator.id, session=session
             )
         else:
             owner_id = session.scalar(
@@ -1781,14 +1781,14 @@ class TenantService:
                     current_owner_join.role = TenantAccountRole.ADMIN
             elif current_owner_join:
                 admin_role_id = AccountService._resolve_legacy_role_id(
-                    tenant_id=str(tenant.id),
+                    tenant_id=tenant.id,
                     account_id=operator.id,
                     role=TenantAccountRole.ADMIN,
                 )
                 RBACService.MemberRoles.replace(
-                    tenant_id=str(tenant.id),
+                    tenant_id=tenant.id,
                     account_id=operator.id,
-                    member_account_id=str(current_owner_join.account_id),
+                    member_account_id=current_owner_join.account_id,
                     role_ids=[admin_role_id],
                     session=session,
                 )
@@ -1796,12 +1796,12 @@ class TenantService:
         # Update the role of the target member
         if dify_config.RBAC_ENABLED:
             resolved_role_id = AccountService._resolve_legacy_role_id(
-                tenant_id=str(tenant.id),
+                tenant_id=tenant.id,
                 account_id=operator.id,
                 role=TenantAccountRole.OWNER,
             )
             RBACService.MemberRoles.replace(
-                tenant_id=str(tenant.id),
+                tenant_id=tenant.id,
                 account_id=operator.id,
                 member_account_id=member.id,
                 role_ids=[resolved_role_id],
@@ -1930,12 +1930,12 @@ class RegisterService:
                 try:
                     TenantService.create_owner_tenant(account, session=session)
                 except Exception:
-                    _try_join_enterprise_default_workspace(str(account.id))
+                    _try_join_enterprise_default_workspace(account.id)
                     raise
 
             session.commit()
 
-            _try_join_enterprise_default_workspace(str(account.id))
+            _try_join_enterprise_default_workspace(account.id)
         except WorkSpaceNotAllowedCreateError:
             session.rollback()
             logger.exception("Register failed")
@@ -2012,7 +2012,7 @@ class RegisterService:
             if account.status != AccountStatus.PENDING:
                 if dify_config.RBAC_ENABLED and not ta:
                     RBACService.MemberRoles.replace(
-                        tenant_id=str(tenant.id),
+                        tenant_id=tenant.id,
                         account_id=inviter.id,
                         member_account_id=account.id,
                         role_ids=[role],
@@ -2024,7 +2024,7 @@ class RegisterService:
         # Assign RBAC role if RBAC is enabled
         if dify_config.RBAC_ENABLED:
             RBACService.MemberRoles.replace(
-                tenant_id=str(tenant.id),
+                tenant_id=tenant.id,
                 account_id=inviter.id,
                 member_account_id=account.id,
                 role_ids=[role],
@@ -2054,7 +2054,7 @@ class RegisterService:
             "account_id": account.id,
             "email": account.email,
             "workspace_id": tenant.id,
-            "role": str(role),
+            "role": role,
             "requires_setup": requires_setup,
         }
         expiry_hours = dify_config.INVITE_EXPIRY_HOURS
@@ -2094,7 +2094,7 @@ class RegisterService:
         if not account:
             return None
 
-        if invitation_data["account_id"] != str(account.id):
+        if invitation_data["account_id"] != account.id:
             return None
 
         return {

--- a/api/services/agent/observability_service.py
+++ b/api/services/agent/observability_service.py
@@ -135,7 +135,7 @@ class AgentObservabilityService:
 
     @staticmethod
     def _total_tokens(message: Message) -> int:
-        return int(message.message_tokens or 0) + int(message.answer_tokens or 0)
+        return message.message_tokens or 0 + message.answer_tokens or 0
 
     @classmethod
     def serialize_log_message(
@@ -160,8 +160,8 @@ class AgentObservabilityService:
             "from_account_id": message.from_account_id,
             "feedback_enabled": True,
             "feedbacks": [cls._serialize_message_feedback(feedback) for feedback in feedbacks],
-            "message_tokens": int(message.message_tokens or 0),
-            "answer_tokens": int(message.answer_tokens or 0),
+            "message_tokens": message.message_tokens or 0,
+            "answer_tokens": message.answer_tokens or 0,
             "total_tokens": cls._total_tokens(message),
             "total_price": str(message.total_price or Decimal(0)),
             "currency": message.currency,
@@ -419,10 +419,10 @@ class AgentObservabilityService:
 
     @staticmethod
     def _positive_feedback_rate(*, like_count: int | None, total_count: int | None) -> float | None:
-        total = int(total_count or 0)
+        total = total_count or 0
         if total == 0:
             return None
-        return int(like_count or 0) / total
+        return like_count or 0 / total
 
     def _list_workflow_messages(
         self,
@@ -629,7 +629,7 @@ class AgentObservabilityService:
             "conversation_id": conversation.id,
             "title": conversation.name,
             "end_user_id": conversation.from_end_user_id,
-            "message_count": int(message_count or 0),
+            "message_count": message_count or 0,
             "user_rate": user_rate,
             "operation_rate": operation_rate,
             "unread": conversation.read_at is None,

--- a/api/services/agent/observability_service.py
+++ b/api/services/agent/observability_service.py
@@ -135,7 +135,7 @@ class AgentObservabilityService:
 
     @staticmethod
     def _total_tokens(message: Message) -> int:
-        return message.message_tokens or 0 + message.answer_tokens or 0
+        return int(message.message_tokens or 0) + int(message.answer_tokens or 0)  # pyrefly: ignore[unnecessary-type-conversion]
 
     @classmethod
     def serialize_log_message(
@@ -160,8 +160,8 @@ class AgentObservabilityService:
             "from_account_id": message.from_account_id,
             "feedback_enabled": True,
             "feedbacks": [cls._serialize_message_feedback(feedback) for feedback in feedbacks],
-            "message_tokens": message.message_tokens or 0,
-            "answer_tokens": message.answer_tokens or 0,
+            "message_tokens": int(message.message_tokens or 0),  # pyrefly: ignore[unnecessary-type-conversion]
+            "answer_tokens": int(message.answer_tokens or 0),  # pyrefly: ignore[unnecessary-type-conversion]
             "total_tokens": cls._total_tokens(message),
             "total_price": str(message.total_price or Decimal(0)),
             "currency": message.currency,
@@ -419,10 +419,10 @@ class AgentObservabilityService:
 
     @staticmethod
     def _positive_feedback_rate(*, like_count: int | None, total_count: int | None) -> float | None:
-        total = total_count or 0
+        total = int(total_count or 0)  # pyrefly: ignore[unnecessary-type-conversion]
         if total == 0:
             return None
-        return like_count or 0 / total
+        return int(like_count or 0) / total  # pyrefly: ignore[unnecessary-type-conversion]
 
     def _list_workflow_messages(
         self,

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -120,7 +120,7 @@ class AppAnnotationService:
 
         raw_message_id = args.get("message_id")
         if raw_message_id:
-            message_id = str(raw_message_id)
+            message_id = raw_message_id
             message = session.scalar(select(Message).where(Message.id == message_id, Message.app_id == app.id).limit(1))
 
             if not message:
@@ -176,19 +176,19 @@ class AppAnnotationService:
 
     @classmethod
     def enable_app_annotation(cls, args: EnableAnnotationArgs, app_id: str) -> AnnotationJobStatusDict:
-        enable_app_annotation_key = f"enable_app_annotation_{str(app_id)}"
+        enable_app_annotation_key = f"enable_app_annotation_{app_id}"
         cache_result = redis_client.get(enable_app_annotation_key)
         if cache_result is not None:
             return {"job_id": cache_result, "job_status": "processing"}
 
         # async job
         job_id = str(uuid.uuid4())
-        enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
+        enable_app_annotation_job_key = f"enable_app_annotation_job_{job_id}"
         # send batch add segments task
         redis_client.setnx(enable_app_annotation_job_key, "waiting")
         current_user, current_tenant_id = current_account_with_tenant()
         enable_annotation_reply_task.delay(
-            str(job_id),
+            job_id,
             app_id,
             current_user.id,
             current_tenant_id,
@@ -201,17 +201,17 @@ class AppAnnotationService:
     @classmethod
     def disable_app_annotation(cls, app_id: str) -> AnnotationJobStatusDict:
         _, current_tenant_id = current_account_with_tenant()
-        disable_app_annotation_key = f"disable_app_annotation_{str(app_id)}"
+        disable_app_annotation_key = f"disable_app_annotation_{app_id}"
         cache_result = redis_client.get(disable_app_annotation_key)
         if cache_result is not None:
             return {"job_id": cache_result, "job_status": "processing"}
 
         # async job
         job_id = str(uuid.uuid4())
-        disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
+        disable_app_annotation_job_key = f"disable_app_annotation_job_{job_id}"
         # send batch add segments task
         redis_client.setnx(disable_app_annotation_job_key, "waiting")
-        disable_annotation_reply_task.delay(str(job_id), app_id, current_tenant_id)
+        disable_annotation_reply_task.delay(job_id, app_id, current_tenant_id)
         return {"job_id": job_id, "job_status": "waiting"}
 
     @classmethod
@@ -539,7 +539,7 @@ class AppAnnotationService:
                     raise ValueError("The number of annotations exceeds the limit of your subscription.")
             # async job
             job_id = str(uuid.uuid4())
-            indexing_cache_key = f"app_annotation_batch_import_{str(job_id)}"
+            indexing_cache_key = f"app_annotation_batch_import_{job_id}"
 
             # Register job in active tasks list for concurrency tracking
             current_time = int(naive_utc_now().timestamp() * 1000)
@@ -549,7 +549,7 @@ class AppAnnotationService:
 
             # Set job status
             redis_client.setnx(indexing_cache_key, "waiting")
-            batch_import_annotations_task.delay(str(job_id), result, app_id, current_tenant_id, current_user.id)
+            batch_import_annotations_task.delay(job_id, result, app_id, current_tenant_id, current_user.id)
 
         except ValueError as e:
             return {"error_msg": str(e)}

--- a/api/services/credit_pool_service.py
+++ b/api/services/credit_pool_service.py
@@ -121,11 +121,11 @@ class CreditPoolReservation:
 class CreditPoolService:
     @staticmethod
     def _normalize_pool_type(pool_type: str | ProviderQuotaType) -> str:
-        return pool_type.value if isinstance(pool_type, ProviderQuotaType) else str(pool_type)
+        return pool_type.value if isinstance(pool_type, ProviderQuotaType) else pool_type
 
     @staticmethod
     def _use_billing_quota() -> bool:
-        return bool(dify_config.DEPLOYMENT_EDITION == DeploymentEdition.CLOUD)
+        return dify_config.DEPLOYMENT_EDITION == DeploymentEdition.CLOUD
 
     @staticmethod
     def _require_session(session: Session | None) -> Session:

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1664,7 +1664,7 @@ class DocumentService:
         """Fetch documents for a dataset in a single batch query."""
         if not document_ids:
             return []
-        document_id_list: list[str] = [document_id for document_id in document_ids]
+        document_id_list: list[str] = list(document_ids)
         # Fetch all requested documents in one query to avoid N+1 lookups.
         documents: Sequence[Document] = session.scalars(
             select(Document).where(
@@ -1700,7 +1700,7 @@ class DocumentService:
         if not document_ids:
             return 0
 
-        document_id_list: list[str] = [document_id for document_id in document_ids]
+        document_id_list: list[str] = list(document_ids)
 
         result = session.execute(
             update(Document)
@@ -1832,7 +1832,7 @@ class DocumentService:
         if not upload_file_id:
             raise NotFound(missing_file_message)
 
-        return upload_file_id
+        return str(upload_file_id)  # pyrefly: ignore[unnecessary-type-conversion]
 
     @staticmethod
     def _get_upload_file_for_upload_file_document(document: Document, session: Session) -> UploadFile:
@@ -1861,7 +1861,7 @@ class DocumentService:
         """
         Batch load upload files keyed by document id for ZIP downloads.
         """
-        document_id_list: list[str] = [document_id for document_id in document_ids]
+        document_id_list: list[str] = list(document_ids)
 
         documents = DocumentService.get_documents_by_ids(
             DatasetRef(tenant_id=tenant_id, dataset_id=dataset_id), document_id_list, session

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1664,7 +1664,7 @@ class DocumentService:
         """Fetch documents for a dataset in a single batch query."""
         if not document_ids:
             return []
-        document_id_list: list[str] = [str(document_id) for document_id in document_ids]
+        document_id_list: list[str] = [document_id for document_id in document_ids]
         # Fetch all requested documents in one query to avoid N+1 lookups.
         documents: Sequence[Document] = session.scalars(
             select(Document).where(
@@ -1700,7 +1700,7 @@ class DocumentService:
         if not document_ids:
             return 0
 
-        document_id_list: list[str] = [str(document_id) for document_id in document_ids]
+        document_id_list: list[str] = [document_id for document_id in document_ids]
 
         result = session.execute(
             update(Document)
@@ -1832,7 +1832,7 @@ class DocumentService:
         if not upload_file_id:
             raise NotFound(missing_file_message)
 
-        return str(upload_file_id)
+        return upload_file_id
 
     @staticmethod
     def _get_upload_file_for_upload_file_document(document: Document, session: Session) -> UploadFile:
@@ -1861,7 +1861,7 @@ class DocumentService:
         """
         Batch load upload files keyed by document id for ZIP downloads.
         """
-        document_id_list: list[str] = [str(document_id) for document_id in document_ids]
+        document_id_list: list[str] = [document_id for document_id in document_ids]
 
         documents = DocumentService.get_documents_by_ids(
             DatasetRef(tenant_id=tenant_id, dataset_id=dataset_id), document_id_list, session
@@ -2798,7 +2798,7 @@ class DocumentService:
         if features.billing.subscription.plan == CloudPlan.SANDBOX and count > 1:
             raise ValueError("Your current plan does not support batch upload, please upgrade your plan.")
 
-        batch_upload_limit = int(dify_config.BATCH_UPLOAD_LIMIT)
+        batch_upload_limit = dify_config.BATCH_UPLOAD_LIMIT
         if count > batch_upload_limit:
             raise ValueError(f"You have reached the batch upload limit of {batch_upload_limit}.")
 

--- a/api/services/email_code_login_challenge.py
+++ b/api/services/email_code_login_challenge.py
@@ -188,7 +188,7 @@ class EmailCodeLoginChallengeStore:
             "state": "active",
             "token": token,
         }
-        expiry_seconds = int(dify_config.EMAIL_CODE_LOGIN_TOKEN_EXPIRY_MINUTES * 60)
+        expiry_seconds = dify_config.EMAIL_CODE_LOGIN_TOKEN_EXPIRY_MINUTES * 60
 
         try:
             # Overwriting this one key makes a resend invalidate the previous

--- a/api/services/enterprise/rbac_service.py
+++ b/api/services/enterprise/rbac_service.py
@@ -287,9 +287,9 @@ class ResourcePermissionSnapshot(_RBACModel):
     overrides: list[ResourcePermissionKeys] = Field(default_factory=list)
 
     def permission_keys_by_resource_ids(self, resource_ids: list[str]) -> dict[str, list[str]]:
-        result = {str(resource_id): list(self.default_permission_keys) for resource_id in resource_ids}
+        result = {resource_id: list(self.default_permission_keys) for resource_id in resource_ids}
         for override in self.overrides:
-            resource_id = str(override.resource_id)
+            resource_id = override.resource_id
             if resource_id in result:
                 result[resource_id] = list(override.permission_keys)
         return result
@@ -599,7 +599,7 @@ def _legacy_resource_permission_keys_batch(
         permission_keys = snapshot.app.default_permission_keys
     else:
         permission_keys = snapshot.dataset.default_permission_keys
-    return {str(resource_id): list(permission_keys) for resource_id in resource_ids}
+    return {resource_id: list(permission_keys) for resource_id in resource_ids}
 
 
 # ---------- Mutation request models ----------
@@ -743,7 +743,7 @@ def _inner_call(
 
 
 def _resource_id_params(resource_type: RBACResourceType | str, resource_id: str) -> dict[str, str]:
-    resource_type_value = resource_type.value if isinstance(resource_type, RBACResourceType) else str(resource_type)
+    resource_type_value = resource_type.value if isinstance(resource_type, RBACResourceType) else resource_type
     resource_id = resource_id.strip()
     if resource_type_value == RBACResourceType.APP.value:
         return {"resource_type": resource_type_value, "app_id": resource_id}

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -325,7 +325,7 @@ class FileService:
             return {}
 
         # Normalize and deduplicate ids before using them in the IN clause.
-        upload_file_id_list: list[str] = [upload_file_id for upload_file_id in upload_file_ids]
+        upload_file_id_list: list[str] = list(upload_file_ids)
         unique_upload_file_ids: list[str] = list(set(upload_file_id_list))
 
         # Fetch upload files in one query for efficient batch access.

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -325,7 +325,7 @@ class FileService:
             return {}
 
         # Normalize and deduplicate ids before using them in the IN clause.
-        upload_file_id_list: list[str] = [str(upload_file_id) for upload_file_id in upload_file_ids]
+        upload_file_id_list: list[str] = [upload_file_id for upload_file_id in upload_file_ids]
         unique_upload_file_ids: list[str] = list(set(upload_file_id_list))
 
         # Fetch upload files in one query for efficient batch access.
@@ -335,7 +335,7 @@ class FileService:
                 UploadFile.id.in_(unique_upload_file_ids),
             )
         ).all()
-        return {str(upload_file.id): upload_file for upload_file in upload_files}
+        return {upload_file.id: upload_file for upload_file in upload_files}
 
     @staticmethod
     def _sanitize_zip_entry_name(name: str) -> str:

--- a/api/services/legacy_model_type_migration.py
+++ b/api/services/legacy_model_type_migration.py
@@ -718,7 +718,7 @@ class Migration:
                 break
 
             for candidate in candidates:
-                last_id = str(candidate.row.id)
+                last_id = candidate.row.id
                 business_key = _ProviderModelBusinessKey(
                     tenant_id=candidate.row.tenant_id,
                     provider_name=candidate.row.provider_name,
@@ -826,7 +826,7 @@ class Migration:
         lock_rows: bool,
     ) -> _ProviderModelGroupPlan:
         rows = self._load_provider_model_group(session, candidate, lock_rows=lock_rows)
-        group_row_ids = [str(row.row.id) for row in rows]
+        group_row_ids = [row.row.id for row in rows]
         if not self._has_legacy_rows(rows):
             return _ProviderModelGroupPlan(group_row_ids=group_row_ids, winner=None, loser_rows=[])
 
@@ -851,21 +851,21 @@ class Migration:
         cache_plans: list[_CacheDeletePlan] = []
         for loser in plan.loser_rows:
             if self._apply:
-                session.execute(sa.delete(ProviderModel).where(ProviderModel.id == str(loser.row.id)))
+                session.execute(sa.delete(ProviderModel).where(ProviderModel.id == loser.row.id))
             self._log_row_deleted(
                 ProviderModel.__tablename__,
                 loser,
                 tx_id=tx_id,
                 business_key=business_key,
-                related_winner_id=str(plan.winner.row.id),
+                related_winner_id=plan.winner.row.id,
             )
             cache_plans.append(
                 _CacheDeletePlan(
                     tenant_id=self._tenant_id,
-                    identity_id=str(loser.row.id),
+                    identity_id=loser.row.id,
                     cache_type=ProviderCredentialsCacheType.MODEL,
                     table_name=ProviderModel.__tablename__,
-                    row_id=str(loser.row.id),
+                    row_id=loser.row.id,
                     tx_id=tx_id,
                     business_key=business_key,
                 )
@@ -875,12 +875,12 @@ class Migration:
             if self._apply:
                 session.execute(
                     sa.update(ProviderModel)
-                    .where(ProviderModel.id == str(plan.winner.row.id))
+                    .where(ProviderModel.id == plan.winner.row.id)
                     .values(model_type=plan.winner.canonical_model_type.value)
                 )
             self._log_row_updated(
                 ProviderModel.__tablename__,
-                str(plan.winner.row.id),
+                plan.winner.row.id,
                 {"model_type": plan.winner.raw_model_type},
                 {"model_type": plan.winner.canonical_model_type.value},
                 tx_id=tx_id,
@@ -889,10 +889,10 @@ class Migration:
             cache_plans.append(
                 _CacheDeletePlan(
                     tenant_id=self._tenant_id,
-                    identity_id=str(plan.winner.row.id),
+                    identity_id=plan.winner.row.id,
                     cache_type=ProviderCredentialsCacheType.MODEL,
                     table_name=ProviderModel.__tablename__,
-                    row_id=str(plan.winner.row.id),
+                    row_id=plan.winner.row.id,
                     tx_id=tx_id,
                     business_key=business_key,
                 )
@@ -912,7 +912,7 @@ class Migration:
         business_key: _ProviderModelBusinessKey,
     ) -> list[str]:
         tx_id = self._new_tx_id()
-        group_row_ids = [str(candidate.row.id)]
+        group_row_ids = [candidate.row.id]
 
         try:
             with _session_factory(self._engine) as session, session.begin():
@@ -929,7 +929,7 @@ class Migration:
             if self._is_lock_timeout_error(exc):
                 self._log_lock_timeout(
                     ProviderModel.__tablename__,
-                    str(candidate.row.id),
+                    candidate.row.id,
                     tx_id,
                     business_key,
                     exc,
@@ -956,7 +956,7 @@ class Migration:
                 break
 
             for candidate in candidates:
-                last_id = str(candidate.row.id)
+                last_id = candidate.row.id
                 business_key = _TenantDefaultModelBusinessKey(
                     tenant_id=candidate.row.tenant_id,
                     model_type=candidate.canonical_model_type,
@@ -1062,7 +1062,7 @@ class Migration:
         lock_rows: bool,
     ) -> _TenantDefaultModelGroupPlan:
         rows = self._load_tenant_default_model_group(session, candidate, lock_rows=lock_rows)
-        group_row_ids = [str(row.row.id) for row in rows]
+        group_row_ids = [row.row.id for row in rows]
         if not self._has_legacy_rows(rows):
             return _TenantDefaultModelGroupPlan(group_row_ids=group_row_ids, winner=None, loser_rows=[])
 
@@ -1086,24 +1086,24 @@ class Migration:
 
         for loser in plan.loser_rows:
             if self._apply:
-                session.execute(sa.delete(TenantDefaultModel).where(TenantDefaultModel.id == str(loser.row.id)))
+                session.execute(sa.delete(TenantDefaultModel).where(TenantDefaultModel.id == loser.row.id))
             self._log_row_deleted(
                 TenantDefaultModel.__tablename__,
                 loser,
                 tx_id=tx_id,
                 business_key=business_key,
-                related_winner_id=str(plan.winner.row.id),
+                related_winner_id=plan.winner.row.id,
             )
         if plan.winner.raw_model_type != plan.winner.canonical_model_type.value:
             if self._apply:
                 session.execute(
                     sa.update(TenantDefaultModel)
-                    .where(TenantDefaultModel.id == str(plan.winner.row.id))
+                    .where(TenantDefaultModel.id == plan.winner.row.id)
                     .values(model_type=plan.winner.canonical_model_type.value)
                 )
             self._log_row_updated(
                 TenantDefaultModel.__tablename__,
-                str(plan.winner.row.id),
+                plan.winner.row.id,
                 {"model_type": plan.winner.raw_model_type},
                 {"model_type": plan.winner.canonical_model_type.value},
                 tx_id=tx_id,
@@ -1123,7 +1123,7 @@ class Migration:
         business_key: _TenantDefaultModelBusinessKey,
     ) -> list[str]:
         tx_id = self._new_tx_id()
-        group_row_ids = [str(candidate.row.id)]
+        group_row_ids = [candidate.row.id]
 
         try:
             with _session_factory(self._engine) as session, session.begin():
@@ -1140,7 +1140,7 @@ class Migration:
             if self._is_lock_timeout_error(exc):
                 self._log_lock_timeout(
                     TenantDefaultModel.__tablename__,
-                    str(candidate.row.id),
+                    candidate.row.id,
                     tx_id,
                     business_key,
                     exc,
@@ -1166,7 +1166,7 @@ class Migration:
                 break
 
             for candidate in candidates:
-                last_id = str(candidate.row.id)
+                last_id = candidate.row.id
                 business_key = _ProviderModelSettingBusinessKey(
                     tenant_id=candidate.row.tenant_id,
                     provider_name=candidate.row.provider_name,
@@ -1276,7 +1276,7 @@ class Migration:
         lock_rows: bool,
     ) -> _ProviderModelSettingGroupPlan:
         rows = self._load_provider_model_setting_group(session, candidate, lock_rows=lock_rows)
-        group_row_ids = [str(row.row.id) for row in rows]
+        group_row_ids = [row.row.id for row in rows]
         if not self._has_legacy_rows(rows):
             return _ProviderModelSettingGroupPlan(group_row_ids=group_row_ids, winner=None, loser_rows=[])
 
@@ -1300,25 +1300,25 @@ class Migration:
 
         for loser in plan.loser_rows:
             if self._apply:
-                session.execute(sa.delete(ProviderModelSetting).where(ProviderModelSetting.id == str(loser.row.id)))
+                session.execute(sa.delete(ProviderModelSetting).where(ProviderModelSetting.id == loser.row.id))
             self._log_row_deleted(
                 ProviderModelSetting.__tablename__,
                 loser,
                 tx_id=tx_id,
                 business_key=business_key,
-                related_winner_id=str(plan.winner.row.id),
+                related_winner_id=plan.winner.row.id,
             )
 
         if plan.winner.raw_model_type != plan.winner.canonical_model_type.value:
             if self._apply:
                 session.execute(
                     sa.update(ProviderModelSetting)
-                    .where(ProviderModelSetting.id == str(plan.winner.row.id))
+                    .where(ProviderModelSetting.id == plan.winner.row.id)
                     .values(model_type=plan.winner.canonical_model_type.value)
                 )
             self._log_row_updated(
                 ProviderModelSetting.__tablename__,
-                str(plan.winner.row.id),
+                plan.winner.row.id,
                 {"model_type": plan.winner.raw_model_type},
                 {"model_type": plan.winner.canonical_model_type.value},
                 tx_id=tx_id,
@@ -1338,7 +1338,7 @@ class Migration:
         business_key: _ProviderModelSettingBusinessKey,
     ) -> list[str]:
         tx_id = self._new_tx_id()
-        group_row_ids = [str(candidate.row.id)]
+        group_row_ids = [candidate.row.id]
 
         try:
             with _session_factory(self._engine) as session, session.begin():
@@ -1355,7 +1355,7 @@ class Migration:
             if self._is_lock_timeout_error(exc):
                 self._log_lock_timeout(
                     ProviderModelSetting.__tablename__,
-                    str(candidate.row.id),
+                    candidate.row.id,
                     tx_id,
                     business_key,
                     exc,
@@ -1394,7 +1394,7 @@ class Migration:
                 break
 
             for candidate in candidates:
-                last_id = str(candidate.row.id)
+                last_id = candidate.row.id
                 processed_rows += 1
                 self._process_load_balancing_model_config_row(candidate)
 
@@ -1421,7 +1421,7 @@ class Migration:
                 break
 
             for candidate in candidates:
-                last_id = str(candidate.row.id)
+                last_id = candidate.row.id
                 business_key = _LoadBalancingModelConfigInheritBusinessKey(
                     tenant_id=candidate.row.tenant_id,
                     provider_name=candidate.row.provider_name,
@@ -1531,7 +1531,7 @@ class Migration:
         lock_rows: bool,
     ) -> _LoadBalancingModelConfigInheritGroupPlan:
         rows = self._load_load_balancing_inherit_group(session, candidate, lock_rows=lock_rows)
-        group_row_ids = [str(row.row.id) for row in rows]
+        group_row_ids = [row.row.id for row in rows]
         if len(rows) <= 1:
             return _LoadBalancingModelConfigInheritGroupPlan(group_row_ids=group_row_ids, winner=None, loser_rows=[])
 
@@ -1555,7 +1555,7 @@ class Migration:
 
         cache_plans: list[_CacheDeletePlan] = []
         for loser in plan.loser_rows:
-            loser_row_id = str(loser.row.id)
+            loser_row_id = loser.row.id
             if self._apply:
                 session.execute(sa.delete(LoadBalancingModelConfig).where(LoadBalancingModelConfig.id == loser_row_id))
             self._log_row_deleted(
@@ -1563,7 +1563,7 @@ class Migration:
                 loser,
                 tx_id=tx_id,
                 business_key=business_key,
-                related_winner_id=str(plan.winner.row.id),
+                related_winner_id=plan.winner.row.id,
             )
             cache_plans.append(
                 _CacheDeletePlan(
@@ -1591,7 +1591,7 @@ class Migration:
         business_key: _LoadBalancingModelConfigInheritBusinessKey,
     ) -> list[str]:
         tx_id = self._new_tx_id()
-        group_row_ids = [str(candidate.row.id)]
+        group_row_ids = [candidate.row.id]
 
         try:
             with _session_factory(self._engine) as session, session.begin():
@@ -1608,7 +1608,7 @@ class Migration:
             if self._is_lock_timeout_error(exc):
                 self._log_lock_timeout(
                     LoadBalancingModelConfig.__tablename__,
-                    str(candidate.row.id),
+                    candidate.row.id,
                     tx_id,
                     business_key,
                     exc,
@@ -1745,7 +1745,7 @@ class Migration:
                 current_row = self._reload_load_balancing_model_config_candidate(session, candidate, lock_rows=True)
                 if current_row is None:
                     return
-                processed_row_id = str(current_row.row.id)
+                processed_row_id = current_row.row.id
 
                 if self._apply:
                     session.execute(
@@ -1764,7 +1764,7 @@ class Migration:
             if self._is_lock_timeout_error(exc):
                 self._log_lock_timeout(
                     LoadBalancingModelConfig.__tablename__,
-                    str(candidate.row.id),
+                    candidate.row.id,
                     tx_id,
                     None,
                     exc,
@@ -1796,7 +1796,7 @@ class Migration:
                 break
 
             for candidate in candidates:
-                last_id = str(candidate.row.id)
+                last_id = candidate.row.id
                 business_key = _ProviderModelCredentialBusinessKey(
                     tenant_id=candidate.row.tenant_id,
                     provider_name=candidate.row.provider_name,
@@ -1911,7 +1911,7 @@ class Migration:
         lock_rows: bool,
     ) -> _ProviderModelCredentialGroupPlan:
         rows = self._load_provider_model_credential_group(session, candidate, lock_rows=lock_rows)
-        group_row_ids = [str(row.row.id) for row in rows]
+        group_row_ids = [row.row.id for row in rows]
         if not self._has_legacy_rows(rows):
             return _ProviderModelCredentialGroupPlan(
                 group_row_ids=group_row_ids,
@@ -2054,8 +2054,8 @@ class Migration:
         if plan.winner is None:
             return
 
-        loser_credential_ids = [str(row.row.id) for row in plan.loser_rows]
-        winner_credential_id = str(plan.winner.row.id)
+        loser_credential_ids = [row.row.id for row in plan.loser_rows]
+        winner_credential_id = plan.winner.row.id
         cache_plans: list[_CacheDeletePlan] = []
         cache_plans.extend(
             self._emit_provider_model_reference_rewrites(
@@ -2081,7 +2081,7 @@ class Migration:
         for loser in plan.loser_rows:
             if self._apply:
                 session.execute(
-                    sa.delete(ProviderModelCredential).where(ProviderModelCredential.id == str(loser.row.id))
+                    sa.delete(ProviderModelCredential).where(ProviderModelCredential.id == loser.row.id)
                 )
             self._log_row_deleted(
                 ProviderModelCredential.__tablename__,
@@ -2121,7 +2121,7 @@ class Migration:
         business_key: _ProviderModelCredentialBusinessKey,
     ) -> list[str]:
         tx_id = self._new_tx_id()
-        group_row_ids = [str(candidate.row.id)]
+        group_row_ids = [candidate.row.id]
 
         try:
             with _session_factory(self._engine) as session, session.begin():
@@ -2138,7 +2138,7 @@ class Migration:
             if self._is_lock_timeout_error(exc):
                 self._log_lock_timeout(
                     ProviderModelCredential.__tablename__,
-                    str(candidate.row.id),
+                    candidate.row.id,
                     tx_id,
                     business_key,
                     exc,
@@ -2156,7 +2156,7 @@ class Migration:
         *,
         lock_rows: bool,
     ) -> list[_ProviderModelReferenceRewritePlan]:
-        loser_ids = [str(row.row.id) for row in loser_rows]
+        loser_ids = [row.row.id for row in loser_rows]
         if not loser_ids:
             return []
 
@@ -2177,9 +2177,9 @@ class Migration:
         for provider_model in provider_models:
             rewrite_plans.append(
                 _ProviderModelReferenceRewritePlan(
-                    row_id=str(provider_model.id),
+                    row_id=provider_model.id,
                     old_credential_id=str(provider_model.credential_id),
-                    new_credential_id=str(winner.row.id),
+                    new_credential_id=winner.row.id,
                 )
             )
         return rewrite_plans
@@ -2192,7 +2192,7 @@ class Migration:
         *,
         lock_rows: bool,
     ) -> list[_LoadBalancingCredentialRewritePlan]:
-        loser_ids = [str(row.row.id) for row in loser_rows]
+        loser_ids = [row.row.id for row in loser_rows]
         if not loser_ids:
             return []
 
@@ -2209,7 +2209,7 @@ class Migration:
             stmt = stmt.with_for_update()
 
         winner_credential = winner.row
-        winner_credential_id = str(winner_credential.id)
+        winner_credential_id = winner_credential.id
         winner_credential_name = winner_credential.credential_name
         winner_encrypted_config = winner_credential.encrypted_config
 
@@ -2218,7 +2218,7 @@ class Migration:
         for load_balancing_model_config in load_balancing_model_configs:
             rewrite_plans.append(
                 _LoadBalancingCredentialRewritePlan(
-                    row_id=str(load_balancing_model_config.id),
+                    row_id=load_balancing_model_config.id,
                     old_credential_id=load_balancing_model_config.credential_id,
                     old_name=load_balancing_model_config.name,
                     old_encrypted_config=load_balancing_model_config.encrypted_config,

--- a/api/services/legacy_model_type_migration.py
+++ b/api/services/legacy_model_type_migration.py
@@ -2080,9 +2080,7 @@ class Migration:
 
         for loser in plan.loser_rows:
             if self._apply:
-                session.execute(
-                    sa.delete(ProviderModelCredential).where(ProviderModelCredential.id == loser.row.id)
-                )
+                session.execute(sa.delete(ProviderModelCredential).where(ProviderModelCredential.id == loser.row.id))
             self._log_row_deleted(
                 ProviderModelCredential.__tablename__,
                 loser,

--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -283,13 +283,13 @@ class MessageService:
                 FeedbackCreatedEvent(
                     context=TelemetryContext(tenant_id=app_model.tenant_id),
                     payload={
-                        "message_id": str(message.id),
-                        "app_id": str(app_model.id) if app_model.id is not None else None,
+                        "message_id": message.id,
+                        "app_id": app_model.id if app_model.id is not None else None,
                         "conversation_id": (
-                            str(message.conversation_id) if message.conversation_id is not None else None
+                            message.conversation_id if message.conversation_id is not None else None
                         ),
-                        "from_end_user_id": str(user.id) if isinstance(user, EndUser) and user.id is not None else None,
-                        "from_account_id": str(user.id) if isinstance(user, Account) and user.id is not None else None,
+                        "from_end_user_id": user.id if isinstance(user, EndUser) and user.id is not None else None,
+                        "from_account_id": user.id if isinstance(user, Account) and user.id is not None else None,
                         "rating": rating.value if rating else None,
                         "from_source": (
                             FeedbackFromSource.USER if isinstance(user, EndUser) else FeedbackFromSource.ADMIN

--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -285,9 +285,7 @@ class MessageService:
                     payload={
                         "message_id": message.id,
                         "app_id": app_model.id if app_model.id is not None else None,
-                        "conversation_id": (
-                            message.conversation_id if message.conversation_id is not None else None
-                        ),
+                        "conversation_id": (message.conversation_id if message.conversation_id is not None else None),
                         "from_end_user_id": user.id if isinstance(user, EndUser) and user.id is not None else None,
                         "from_account_id": user.id if isinstance(user, Account) and user.id is not None else None,
                         "rating": rating.value if rating else None,

--- a/api/services/oauth_device_flow.py
+++ b/api/services/oauth_device_flow.py
@@ -443,7 +443,7 @@ def _upsert(
     session.commit()
 
     return UpsertOutcome(
-        token_id=uuid.UUID(str(token_id)),
+        token_id=uuid.UUID(token_id),
         rotated=prior is not None,
         old_hash=old_hash,
     )

--- a/api/services/openapi/visibility.py
+++ b/api/services/openapi/visibility.py
@@ -29,4 +29,4 @@ def is_openapi_visible(app: App) -> bool:
     (``session.get`` / ``session.scalar``) and need the same visibility check
     the query gate would have applied.
     """
-    return bool(app.enable_api)
+    return app.enable_api

--- a/api/services/recommended_app_catalog_gateway.py
+++ b/api/services/recommended_app_catalog_gateway.py
@@ -372,5 +372,5 @@ def _enum_string(value: object, *, field: str) -> str | None:
     if value is None:
         return None
     if isinstance(value, str):
-        return str(value)
+        return value
     raise TypeError(f"{field} must be a string or string enum")

--- a/api/services/retention/conversation/message_export_service.py
+++ b/api/services/retention/conversation/message_export_service.py
@@ -277,7 +277,7 @@ class AppMessageExportService:
 
         result: dict[str, list[AppMessageExportFeedback]] = defaultdict(list)
         for feedback in feedbacks:
-            result[str(feedback.message_id)].append(AppMessageExportFeedback.model_validate(feedback.to_dict()))
+            result[feedback.message_id].append(AppMessageExportFeedback.model_validate(feedback.to_dict()))
         return result
 
     @staticmethod

--- a/api/services/retention/conversation/messages_clean_policy.py
+++ b/api/services/retention/conversation/messages_clean_policy.py
@@ -160,8 +160,8 @@ class BillingSandboxPolicy(MessagesCleanPolicy):
             if not tenant_plan:
                 continue
 
-            plan = str(tenant_plan["plan"])
-            expiration_date = int(tenant_plan["expiration_date"])
+            plan = tenant_plan["plan"]
+            expiration_date = tenant_plan["expiration_date"]
 
             # Only process sandbox plans
             if plan != CloudPlan.SANDBOX:

--- a/api/services/retention/workflow_run/bundle_archive_maintenance.py
+++ b/api/services/retention/workflow_run/bundle_archive_maintenance.py
@@ -872,7 +872,7 @@ class WorkflowRunBundleArchiveMaintenance:
         live_records: dict[str, list[dict[str, Any]]],
     ) -> None:
         """Require every live row in the bundle scope to exist unchanged in the validated archive."""
-        manifest_run_ids = {str(run_id) for run_id in manifest["run_ids"]}
+        manifest_run_ids = {run_id for run_id in manifest["run_ids"]}
         if len(manifest_run_ids) != len(manifest["run_ids"]):
             raise ValueError("archive manifest contains duplicate workflow run IDs")
 

--- a/api/services/retention/workflow_run/bundle_archive_maintenance.py
+++ b/api/services/retention/workflow_run/bundle_archive_maintenance.py
@@ -872,7 +872,7 @@ class WorkflowRunBundleArchiveMaintenance:
         live_records: dict[str, list[dict[str, Any]]],
     ) -> None:
         """Require every live row in the bundle scope to exist unchanged in the validated archive."""
-        manifest_run_ids = {run_id for run_id in manifest["run_ids"]}
+        manifest_run_ids = {str(run_id) for run_id in manifest["run_ids"]}  # pyrefly: ignore[unnecessary-type-conversion]
         if len(manifest_run_ids) != len(manifest["run_ids"]):
             raise ValueError("archive manifest contains duplicate workflow run IDs")
 

--- a/api/services/retention/workflow_run/restore_archived_workflow_run.py
+++ b/api/services/retention/workflow_run/restore_archived_workflow_run.py
@@ -350,7 +350,7 @@ class WorkflowRunRestore:
         if not schema_version:
             logger.warning("Manifest missing schema_version; defaulting to 1.0")
             schema_version = "1.0"
-        schema_version = str(schema_version)
+        schema_version = schema_version
         if schema_version not in SCHEMA_MAPPERS:
             raise ValueError(f"Unsupported schema_version {schema_version}. Add a mapping before restoring.")
         return schema_version

--- a/api/services/trigger/schedule_service.py
+++ b/api/services/trigger/schedule_service.py
@@ -183,7 +183,7 @@ class ScheduleService:
             if not cron_expression:
                 raise ScheduleConfigError("Cron expression is required for cron mode")
         elif mode == "visual":
-            frequency = str(node_data.frequency or "")
+            frequency = node_data.frequency or ""
             if not frequency:
                 raise ScheduleConfigError("Frequency is required for visual mode")
             visual_config = VisualConfig.model_validate(node_data.visual_config or {})

--- a/api/services/trigger/trigger_provider_service.py
+++ b/api/services/trigger/trigger_provider_service.py
@@ -240,7 +240,7 @@ class TriggerProviderService:
 
                     return {
                         "result": "success",
-                        "id": str(subscription.id),
+                        "id": subscription.id,
                     }
 
         except Exception as e:
@@ -552,7 +552,7 @@ class TriggerProviderService:
             if subscription is None:
                 raise ValueError(f"Trigger provider subscription {subscription_id} not found")
 
-            if subscription.expires_at == -1 or int(subscription.expires_at) > now_ts:
+            if subscription.expires_at == -1 or subscription.expires_at > now_ts:
                 logger.debug(
                     "Subscription not due for refresh: tenant=%s id=%s expires_at=%s now=%s",
                     tenant_id,
@@ -560,7 +560,7 @@ class TriggerProviderService:
                     subscription.expires_at,
                     now_ts,
                 )
-                return {"result": "skipped", "expires_at": int(subscription.expires_at)}
+                return {"result": "skipped", "expires_at": subscription.expires_at}
 
             provider_id = TriggerProviderID(subscription.provider_id)
             controller: PluginTriggerProviderController = TriggerManager.get_trigger_provider(
@@ -583,7 +583,7 @@ class TriggerProviderService:
             decrypted_properties = properties_encrypter.decrypt(subscription.properties)
 
             sub_entity: TriggerSubscriptionEntity = TriggerSubscriptionEntity(
-                expires_at=int(subscription.expires_at),
+                expires_at=subscription.expires_at,
                 endpoint=generate_plugin_trigger_endpoint_url(subscription.endpoint_id),
                 parameters=subscription.parameters,
                 properties=decrypted_properties,
@@ -597,7 +597,7 @@ class TriggerProviderService:
 
             # Persist refreshed properties and expires_at
             subscription.properties = dict(properties_encrypter.encrypt(dict(refreshed.properties)))
-            subscription.expires_at = int(refreshed.expires_at)
+            subscription.expires_at = refreshed.expires_at
             properties_cache.delete()
 
             logger.info(
@@ -607,7 +607,7 @@ class TriggerProviderService:
                 subscription.expires_at,
             )
 
-            return {"result": "success", "expires_at": int(refreshed.expires_at)}
+            return {"result": "success", "expires_at": refreshed.expires_at}
 
     @classmethod
     def get_oauth_client(cls, tenant_id: str, provider_id: TriggerProviderID) -> Mapping[str, Any] | None:

--- a/api/services/vector_space_admission_service.py
+++ b/api/services/vector_space_admission_service.py
@@ -317,8 +317,8 @@ class VectorSpaceAdmissionService:
     def _get_usage_and_limit_mb(self, tenant_id: str) -> tuple[float, int]:
         try:
             vector_space = BillingService.get_vector_space(tenant_id)
-            current_usage_mb = float(vector_space["size"])
-            plan_limit_mb = int(vector_space["limit"])
+            current_usage_mb = vector_space["size"]
+            plan_limit_mb = vector_space["limit"]
         except Exception as error:
             raise VectorSpaceAdmissionError(
                 "Unable to verify vector storage usage right now. Please try again later."

--- a/api/services/workflow_collaboration_service.py
+++ b/api/services/workflow_collaboration_service.py
@@ -493,7 +493,7 @@ class WorkflowCollaborationService:
         session_info = self._repository.get_session_info(workflow_id, sid)
         if session_info is None:
             return True
-        return bool(session_info.get("graph_active", True))
+        return session_info.get("graph_active", True)
 
     def _demote_leader_if_hidden(self, workflow_id: str, hidden_sid: str) -> None:
         current_leader = self._repository.get_current_leader(workflow_id)

--- a/api/services/workflow_comment_service.py
+++ b/api/services/workflow_comment_service.py
@@ -47,7 +47,7 @@ class WorkflowCommentService:
             return []
 
         tenant_member_ids = {
-            str(account_id)
+            account_id
             for account_id in session.scalars(
                 select(TenantAccountJoin.account_id).where(
                     TenantAccountJoin.tenant_id == tenant_id,
@@ -167,7 +167,7 @@ class WorkflowCommentService:
 
         # Batch query all accounts
         accounts = session.scalars(select(Account).where(Account.id.in_(user_ids))).all()
-        account_map = {str(account.id): account for account in accounts}
+        account_map = {account.id: account for account in accounts}
 
         # Cache accounts on objects
         for comment in comments:

--- a/api/services/workflow_comment_service.py
+++ b/api/services/workflow_comment_service.py
@@ -46,15 +46,14 @@ class WorkflowCommentService:
         if not unique_user_ids:
             return []
 
-        tenant_member_ids = {
-            account_id
-            for account_id in session.scalars(
+        tenant_member_ids = set(
+            session.scalars(
                 select(TenantAccountJoin.account_id).where(
                     TenantAccountJoin.tenant_id == tenant_id,
                     TenantAccountJoin.account_id.in_(unique_user_ids),
                 )
             ).all()
-        }
+        )
 
         return [user_id for user_id in unique_user_ids if user_id in tenant_member_ids]
 

--- a/api/services/workflow_event_snapshot_service.py
+++ b/api/services/workflow_event_snapshot_service.py
@@ -616,9 +616,9 @@ def _build_pause_event(
             reasons=reasons,
             status=workflow_run.status,
             created_at=int(workflow_run.created_at.timestamp()),
-            elapsed_time=float(workflow_run.elapsed_time or 0.0),
-            total_tokens=int(workflow_run.total_tokens or 0),
-            total_steps=int(workflow_run.total_steps or 0),
+            elapsed_time=workflow_run.elapsed_time or 0.0,
+            total_tokens=workflow_run.total_tokens or 0,
+            total_steps=workflow_run.total_steps or 0,
         ),
     )
     payload = response.model_dump(mode="json")

--- a/api/services/workflow_run_service.py
+++ b/api/services/workflow_run_service.py
@@ -122,7 +122,7 @@ class WorkflowRunService:
         :param args: request args
         :param triggered_from: workflow run triggered from (default: DEBUGGING)
         """
-        limit = int(args.get("limit", 20))
+        limit = args.get("limit", 20)
         last_id = args.get("last_id")
         status = args.get("status")
 


### PR DESCRIPTION
Fixes part of #39947

## Summary
Removes redundant `str()`/`int()`/`bool()`/`float()`/`bytes()` calls reported by Pyrefly's `unnecessary-type-conversion` rule across console/openapi/service controllers and backend services (48 files, 222 occurrences). No behavioral change.

## Verification
- `./dev/pyrefly-check-local` passes with zero violations on this change set
- Only the final PR of this series promotes the rule to `error` in CI