### PR TITLE
fix(dify-agent): seal event stream after terminal transition

### DIFF
--- a/.github/workflows/dify-agent-tests.yml
+++ b/.github/workflows/dify-agent-tests.yml
@@ -43,5 +43,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra server --dev
 
+      - name: Install Redis for integration tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends redis-server
+          redis-server --version
+
       - name: Run unit tests
         run: uv run pytest

--- a/dify-agent/docs/dify-agent/guide/index.md
+++ b/dify-agent/docs/dify-agent/guide/index.md
@@ -304,8 +304,15 @@ and attempts to finalize them as failed. Success and failure use an atomic Redis
 transition. Cancellation first atomically records a private intent; after the
 owner exits the runner, a second atomic transition appends `run_cancelled`,
 updates the run record, and deletes the intent. The first accepted success,
-failure, or cancellation intent wins. A hard process crash can still leave
-active runs, including runs with accepted cancellation intent, stuck as
+failure, or cancellation intent wins.
+
+Every non-terminal event write atomically verifies the same run record is still
+`running` before appending. Whichever terminal finalizer updates the record also
+seals the event stream: a later terminal or non-terminal attempt leaves both the
+record and stream unchanged. An accepted cancellation intent does not seal the
+stream by itself because the owner may still be cleaning up; sealing occurs when
+`run_cancelled` is durably finalized. A hard process crash can therefore leave
+active runs, including runs with an accepted cancellation intent, stuck as
 `running`; there is no in-service recovery or worker handoff.
 
 Horizontal scaling is possible by running multiple API processes against the same
@@ -318,17 +325,18 @@ response confirms that cancellation intent is durable; `GET /runs/{run_id}` may
 still report `running` until cleanup finishes. Retrying an accepted or completed
 cancellation is idempotent.
 
-Atomic terminal finalization currently assumes the configured Redis URL targets
-one Redis deployment that can execute all run-coordination keys in a Lua script.
-The record and event key names are unchanged, and cancellation adds a private
-cancel-intent key. These keys do not contain a shared Redis Cluster hash tag, so
-Redis Cluster is not supported for this transition. During
-a rolling upgrade, older processes can still use the former split event/status
-writes; treat the single-terminal invariant as active only after those processes
-have exited. Deploy atomic terminal finalization everywhere first, then ensure
-every process that can own a runner has the cancellation observer before relying
-on route-independent cancellation. Operators should then alert on more than one
-terminal event per run and on disagreement between the run record status and
+Atomic run coordination currently assumes the configured Redis URL targets one
+Redis deployment that can execute the record, event, and private cancellation-
+intent keys in a Lua script. These keys do not contain a shared Redis Cluster
+hash tag, so Redis Cluster is not supported for these transitions. During a
+rolling upgrade, older processes can still use split terminal writes or append
+non-terminal events without checking the durable run status. Treat both the
+single-terminal and terminal-is-last invariants as active only after those
+processes have exited. Deploy the atomic finalizers and guarded event writer
+everywhere first, then ensure every process that can own a runner has the
+cancellation observer before relying on route-independent cancellation.
+Operators should alert on more than one terminal event per run, any event cursor
+after a terminal cursor, and disagreement between the run record status and
 terminal event type.
 
 ## Run inputs and session snapshots
@@ -436,7 +444,10 @@ progress:
 Successful runs emit `run_started`, zero or more `pydantic_ai_event`, and
 `run_succeeded`. Failed runs end with `run_failed`, and accepted cancellations
 end with `run_cancelled`. Each run can append at most one of these terminal
-events. Event envelopes retain `id`, `run_id`, `type`, `data`, and `created_at`;
+events, and that terminal is the last retained event. Accepted non-terminal
+writes refresh the record and stream retention; a late write rejected by a
+terminal does not refresh either TTL. Event envelopes retain `id`, `run_id`,
+`type`, `data`, and `created_at`;
 `data` is typed per event type,
 including Pydantic AI's `AgentStreamEvent` payload for `pydantic_ai_event` and a
 terminal event may contain a `CompositorSessionSnapshot` for resumption.

--- a/dify-agent/src/dify_agent/runtime/event_sink.py
+++ b/dify-agent/src/dify_agent/runtime/event_sink.py
@@ -1,8 +1,10 @@
 """Event sink contracts used by the runner and storage adapters.
 
-Non-terminal events remain append-only. Successful and failed terminal events
-use ``finalize_run`` so the event and matching run status are committed as one
-compare-and-set transition. Cancellation has a dedicated intent-aware finalizer.
+Non-terminal events are appended only while a run is still ``running``.
+Successful and failed terminal events use ``finalize_run`` so the event and
+matching run status are committed as one compare-and-set transition that also
+seals the event stream. Cancellation has a dedicated intent-aware finalizer
+with the same terminal ordering guarantee.
 Tests can use ``InMemoryRunEventSink`` without Redis; production storage
 implements the same contract with Redis streams in
 ``dify_agent.storage.redis_run_store``.
@@ -47,11 +49,30 @@ class RunFinalizationResult:
     event_id: str | None = None
 
 
+class RunEventStreamSealedError(RuntimeError):
+    """Raised when a terminal transition already sealed a run's event stream."""
+
+    run_id: str
+    status: RunStatus
+
+    def __init__(self, *, run_id: str, status: RunStatus) -> None:
+        if status == "running":
+            raise ValueError("a running run cannot have a sealed event stream")
+        self.run_id = run_id
+        self.status = status
+        super().__init__(f"run {run_id!r} event stream is sealed by terminal status {status!r}")
+
+
 class RunEventSink(Protocol):
-    """Boundary used by runtime code to publish observable run progress."""
+    """Interface used by runtime code to publish observable run progress."""
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
-        """Persist a non-terminal event and return its cursor id."""
+        """Persist a non-terminal event while its run is still running.
+
+        Returns the event's opaque cursor. If a terminal transition already
+        sealed the stream, the event is not persisted and
+        ``RunEventStreamSealedError`` is raised with the winning status.
+        """
         ...
 
     async def finalize_run(self, event: TerminalRunEvent) -> RunFinalizationResult:
@@ -75,6 +96,9 @@ class InMemoryRunEventSink:
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
         """Store a non-terminal event and assign a monotonic per-run cursor."""
+        current_status = self.statuses.get(event.run_id, "running")
+        if current_status != "running":
+            raise RunEventStreamSealedError(run_id=event.run_id, status=current_status)
         event_id = str(len(self.events[event.run_id]) + 1)
         stored = event.model_copy(update={"id": event_id})
         self.events[event.run_id].append(stored)
@@ -208,6 +232,7 @@ __all__ = [
     "InMemoryRunEventSink",
     "NonTerminalRunEvent",
     "RunEventSink",
+    "RunEventStreamSealedError",
     "RunFinalizationResult",
     "TerminalRunEvent",
     "emit_pydantic_ai_event",

--- a/dify-agent/src/dify_agent/runtime/runner.py
+++ b/dify-agent/src/dify_agent/runtime/runner.py
@@ -75,6 +75,7 @@ from dify_agent.runtime.event_coalescer import (
 )
 from dify_agent.runtime.event_sink import (
     RunEventSink,
+    RunEventStreamSealedError,
     emit_pydantic_ai_event,
     emit_run_failed,
     emit_run_started,
@@ -248,10 +249,18 @@ class AgentRunRunner:
         self._terminal_usage = None
         if self.is_cancelled():
             return
-        _ = await emit_run_started(self.sink, run_id=self.run_id)
+
+        try:
+            _ = await emit_run_started(self.sink, run_id=self.run_id)
+        except RunEventStreamSealedError:
+            return
 
         try:
             outcome = await self._run_agent()
+        except RunEventStreamSealedError:
+            # Another writer finalized the run before this in-flight event
+            # reached storage. Do not attempt another terminal transition.
+            return
         except Exception as exc:
             if self.is_cancelled():
                 return

--- a/dify-agent/src/dify_agent/storage/redis_run_store.py
+++ b/dify-agent/src/dify_agent/storage/redis_run_store.py
@@ -30,6 +30,7 @@ from dify_agent.runtime.cancellation import RunCancellationIntent
 from dify_agent.runtime.event_sink import (
     NonTerminalRunEvent,
     RunEventSink,
+    RunEventStreamSealedError,
     RunFinalizationResult,
     TerminalRunEvent,
     terminal_event_status_fields,
@@ -43,6 +44,25 @@ _TERMINAL_RUN_EVENT_TYPES = {"run_succeeded", "run_failed", "run_cancelled"}
 
 class RunNotFoundError(LookupError):
     """Raised when a requested run record does not exist."""
+
+
+_APPEND_RUN_EVENT_SCRIPT = """
+local record_json = redis.call("GET", KEYS[1])
+if not record_json then
+    return {-1, "", ""}
+end
+
+local record = cjson.decode(record_json)
+if record.status ~= "running" then
+    return {0, tostring(record.status), ""}
+end
+
+local ttl = tonumber(ARGV[2])
+local event_id = redis.call("XADD", KEYS[2], "MAXLEN", "~", ARGV[3], "*", "payload", ARGV[1])
+redis.call("EXPIRE", KEYS[2], ttl)
+redis.call("EXPIRE", KEYS[1], ttl)
+return {1, "running", event_id}
+"""
 
 
 _FINALIZE_RUN_SCRIPT = """
@@ -147,11 +167,12 @@ class RedisRunStore(RunEventSink):
     """Async Redis implementation for run records and event logs.
 
     ``run_retention_seconds`` is applied to both the run record key and the
-    per-run Redis stream. Every public stream write applies an approximate
-    maximum length before refreshing both TTLs, so active runs cannot grow one
-    Redis key without bound without paying the CPU cost of exact per-entry
-    trimming. The transaction also ensures a newly created stream is not left
-    without expiration if the client is interrupted between commands.
+    per-run Redis stream. Non-terminal writes atomically verify that the run is
+    still ``running`` before ``XADD`` and both TTL refreshes. Every accepted
+    public stream write applies an approximate maximum length, so active runs
+    cannot grow one Redis key without bound without paying the CPU cost of exact
+    per-entry trimming. Terminal writes atomically seal the stream while updating
+    the matching record. Rejected writes do not trim the stream or refresh TTLs.
     Event writes refresh the record TTL so long-running runs that keep producing
     events do not lose their status record mid-run.
     """
@@ -199,21 +220,33 @@ class RedisRunStore(RunEventSink):
         return RunRecord.model_validate_json(value)
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
-        """Append a non-terminal event JSON payload with refreshed TTLs."""
-        events_key = run_events_key(self.prefix, event.run_id)
+        """Atomically append a non-terminal event only while its run is active."""
         payload = RUN_EVENT_ADAPTER.dump_json(event, exclude={"id"}).decode()
-        async with self.redis.pipeline(transaction=True) as pipeline:
-            _ = pipeline.xadd(
-                events_key,
-                {"payload": payload},
-                maxlen=self.run_event_stream_max_length,
-                approximate=True,
-            )
-            _ = pipeline.expire(events_key, self.run_retention_seconds)
-            _ = pipeline.expire(run_record_key(self.prefix, event.run_id), self.run_retention_seconds)
-            results = cast(list[object], await pipeline.execute())
-        event_id = results[0]
-        return event_id.decode() if isinstance(event_id, bytes) else str(event_id)
+        evaluation = cast(
+            Awaitable[object],
+            self.redis.eval(
+                _APPEND_RUN_EVENT_SCRIPT,
+                2,
+                run_record_key(self.prefix, event.run_id),
+                run_events_key(self.prefix, event.run_id),
+                payload,
+                str(self.run_retention_seconds),
+                str(self.run_event_stream_max_length),
+            ),
+        )
+        raw_result = await evaluation
+        result = cast(list[object], raw_result)
+        applied = int(cast(int | bytes | str, result[0]))
+        if applied == -1:
+            raise RunNotFoundError(event.run_id)
+
+        persisted_status = cast(RunStatus, _decode_redis_text(result[1]))
+        event_id = _decode_redis_text(result[2]) or None
+        if applied == 0:
+            raise RunEventStreamSealedError(run_id=event.run_id, status=persisted_status)
+        if applied != 1 or persisted_status != "running" or event_id is None:
+            raise RuntimeError(f"unexpected append-event result for run {event.run_id!r}: {result!r}")
+        return event_id
 
     async def finalize_run(self, event: TerminalRunEvent) -> RunFinalizationResult:
         """Atomically append the first success/failure event and update its run record."""

--- a/dify-agent/tests/integration/dify_agent/storage/test_terminal_finalization.py
+++ b/dify-agent/tests/integration/dify_agent/storage/test_terminal_finalization.py
@@ -1,4 +1,4 @@
-"""Real-Redis contracts for terminal finalization and cancellation observation."""
+"""Real-Redis contracts for terminal sealing and cancellation observation."""
 
 import asyncio
 from collections.abc import Iterator
@@ -26,9 +26,10 @@ from dify_agent.protocol.schemas import (
     utc_now,
 )
 from dify_agent.runtime.cancellation import RunCancellationIntent
+from dify_agent.runtime.event_sink import RunEventStreamSealedError
 from dify_agent.runtime.run_scheduler import RunScheduler
 from dify_agent.storage.redis_keys import run_cancel_intent_key, run_events_key, run_record_key
-from dify_agent.storage.redis_run_store import RedisRunStore
+from dify_agent.storage.redis_run_store import RedisRunStore, RunNotFoundError
 
 
 pytestmark = pytest.mark.integration
@@ -170,6 +171,8 @@ def test_event_stream_is_trimmed_and_keeps_the_terminal_event(redis_url: str) ->
             run_id = record.run_id
             for _ in range(1000):
                 _ = await store.append_event(RunStartedEvent(run_id=record.run_id))
+            active_stream_length = await client.xlen(run_events_key(prefix, record.run_id))
+            assert max_length <= active_stream_length <= max_length * 2
             result = await store.finalize_run(
                 RunSucceededEvent(
                     run_id=record.run_id,
@@ -217,6 +220,124 @@ def test_terminal_first_rejects_late_cancellation(redis_url: str, terminal_statu
             assert await store.get_cancellation_intent(record.run_id) is None
             events = await store.get_events(record.run_id)
             assert [event.type for event in events.events] == [f"run_{terminal_status}"]
+        finally:
+            await client.aclose()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("terminal_status", ["succeeded", "failed", "cancelled"])
+def test_terminal_rejects_late_non_terminal_from_another_redis_client(redis_url: str, terminal_status: str) -> None:
+    async def scenario() -> None:
+        terminal_client = Redis.from_url(redis_url)
+        late_writer_client = Redis.from_url(redis_url)
+        prefix = f"terminal-stream-seal-{uuid4().hex}"
+        terminal_store = RedisRunStore(terminal_client, prefix=prefix, run_retention_seconds=60)
+        late_writer_store = RedisRunStore(late_writer_client, prefix=prefix, run_retention_seconds=60)
+        try:
+            record = await terminal_store.create_run()
+            if terminal_status == "cancelled":
+                cancellation_status = await terminal_store.request_cancellation(
+                    record.run_id,
+                    CancelRunRequest(reason="remote_cancel"),
+                )
+                assert cancellation_status == "running"
+                intent = await terminal_store.get_cancellation_intent(record.run_id)
+                assert intent is not None
+                finalization = await terminal_store.finalize_cancellation(record.run_id, intent)
+            else:
+                finalization = await terminal_store.finalize_run(
+                    _success_or_failure_event(terminal_status, record.run_id)
+                )
+            assert finalization.applied is True
+            assert finalization.event_id is not None
+
+            record_key = run_record_key(prefix, record.run_id)
+            events_key = run_events_key(prefix, record.run_id)
+            sealed_record = await terminal_client.get(record_key)
+            sealed_events = await terminal_client.xrange(events_key)
+            shortened_ttl_ms = 30_000
+            for key in (record_key, events_key):
+                assert await terminal_client.pexpire(key, shortened_ttl_ms)
+
+            with pytest.raises(RunEventStreamSealedError) as captured:
+                _ = await late_writer_store.append_event(RunStartedEvent(run_id=record.run_id))
+
+            assert captured.value.run_id == record.run_id
+            assert captured.value.status == terminal_status
+            assert await terminal_client.get(record_key) == sealed_record
+            assert await terminal_client.xrange(events_key) == sealed_events
+            for key in (record_key, events_key):
+                assert 0 < await terminal_client.pttl(key) <= shortened_ttl_ms
+            page = await terminal_store.get_events(record.run_id)
+            after_terminal = await late_writer_store.get_events(record.run_id, after=finalization.event_id)
+            assert [event.type for event in page.events] == [f"run_{terminal_status}"]
+            assert after_terminal.events == []
+            assert after_terminal.next_cursor == finalization.event_id
+        finally:
+            await terminal_client.aclose()
+            await late_writer_client.aclose()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("cancellation_pending", [False, True])
+def test_non_terminal_refreshes_retention_while_run_is_running(redis_url: str, cancellation_pending: bool) -> None:
+    async def scenario() -> None:
+        client = Redis.from_url(redis_url)
+        prefix = f"active-event-retention-{uuid4().hex}"
+        retention_seconds = 60
+        store = RedisRunStore(client, prefix=prefix, run_retention_seconds=retention_seconds)
+        try:
+            record = await store.create_run()
+            _ = await store.append_event(RunStartedEvent(run_id=record.run_id))
+            record_key = run_record_key(prefix, record.run_id)
+            events_key = run_events_key(prefix, record.run_id)
+            if cancellation_pending:
+                assert await store.request_cancellation(record.run_id, CancelRunRequest(reason="pending")) == "running"
+            shortened_ttl_ms = 30_000
+            for key in (record_key, events_key):
+                assert await client.pexpire(key, shortened_ttl_ms)
+
+            event_id = await store.append_event(RunStartedEvent(run_id=record.run_id))
+
+            assert (await store.get_run(record.run_id)).status == "running"
+            events = (await store.get_events(record.run_id)).events
+            assert [event.type for event in events] == ["run_started", "run_started"]
+            assert events[-1].id == event_id
+            for key in (record_key, events_key):
+                assert shortened_ttl_ms < await client.pttl(key) <= retention_seconds * 1000
+            if cancellation_pending:
+                assert await store.get_cancellation_intent(record.run_id) is not None
+        finally:
+            await client.aclose()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("with_retained_events", [False, True])
+def test_non_terminal_rejects_missing_record_without_mutating_stream(
+    redis_url: str, with_retained_events: bool
+) -> None:
+    async def scenario() -> None:
+        client = Redis.from_url(redis_url)
+        prefix = f"missing-event-record-{uuid4().hex}"
+        store = RedisRunStore(client, prefix=prefix, run_retention_seconds=60)
+        try:
+            record = await store.create_run()
+            record_key = run_record_key(prefix, record.run_id)
+            events_key = run_events_key(prefix, record.run_id)
+            if with_retained_events:
+                _ = await store.append_event(RunStartedEvent(run_id=record.run_id))
+            _ = await client.delete(record_key)
+            retained_events = await client.xrange(events_key)
+
+            with pytest.raises(RunNotFoundError):
+                _ = await store.append_event(RunStartedEvent(run_id=record.run_id))
+
+            assert await client.exists(record_key) == 0
+            assert await client.xrange(events_key) == retained_events
+            assert await client.exists(events_key) == int(with_retained_events)
         finally:
             await client.aclose()
 
@@ -303,6 +424,51 @@ def test_cancellation_finalization_without_intent_is_unapplied(redis_url: str) -
             assert (await store.get_run(record.run_id)).status == "running"
         finally:
             await client.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_non_terminal_and_terminal_race_always_leaves_terminal_last(redis_url: str) -> None:
+    async def scenario() -> None:
+        writer_client = Redis.from_url(redis_url)
+        terminal_client = Redis.from_url(redis_url)
+        prefix = f"terminal-stream-race-{uuid4().hex}"
+        writer_store = RedisRunStore(writer_client, prefix=prefix, run_retention_seconds=60)
+        terminal_store = RedisRunStore(terminal_client, prefix=prefix, run_retention_seconds=60)
+        try:
+            for _attempt in range(32):
+                record = await writer_store.create_run()
+                cancellation_status = await terminal_store.request_cancellation(
+                    record.run_id,
+                    CancelRunRequest(reason="concurrent_cancel"),
+                )
+                assert cancellation_status == "running"
+                intent = await terminal_store.get_cancellation_intent(record.run_id)
+                assert intent is not None
+                append_outcome, finalization = await asyncio.gather(
+                    writer_store.append_event(RunStartedEvent(run_id=record.run_id)),
+                    terminal_store.finalize_cancellation(record.run_id, intent),
+                    return_exceptions=True,
+                )
+
+                assert not isinstance(finalization, BaseException)
+                assert finalization.applied is True
+                assert finalization.event_id is not None
+                if isinstance(append_outcome, BaseException):
+                    assert isinstance(append_outcome, RunEventStreamSealedError)
+                    expected_types = ["run_cancelled"]
+                else:
+                    expected_types = ["run_started", "run_cancelled"]
+
+                page = await terminal_store.get_events(record.run_id)
+                assert [event.type for event in page.events] == expected_types
+                assert page.events[-1].type == "run_cancelled"
+                after_terminal = await writer_store.get_events(record.run_id, after=finalization.event_id)
+                assert after_terminal.events == []
+                assert after_terminal.next_cursor == finalization.event_id
+        finally:
+            await writer_client.aclose()
+            await terminal_client.aclose()
 
     asyncio.run(scenario())
 

--- a/dify-agent/tests/local/dify_agent/runtime/test_event_sink.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_event_sink.py
@@ -1,0 +1,52 @@
+import asyncio
+
+import pytest
+
+from agenton.compositor import CompositorSessionSnapshot
+from dify_agent.protocol.schemas import (
+    RunFailedEvent,
+    RunFailedEventData,
+    RunStartedEvent,
+    RunSucceededEvent,
+    RunSucceededEventData,
+)
+from dify_agent.runtime.event_sink import InMemoryRunEventSink, RunEventStreamSealedError, TerminalRunEvent
+
+
+def _terminal_event(event_type: str, run_id: str) -> TerminalRunEvent:
+    if event_type == "run_succeeded":
+        return RunSucceededEvent(
+            run_id=run_id,
+            data=RunSucceededEventData(
+                output="done",
+                session_snapshot=CompositorSessionSnapshot(layers=[]),
+            ),
+        )
+    if event_type == "run_failed":
+        return RunFailedEvent(run_id=run_id, data=RunFailedEventData(error="model failed"))
+    raise AssertionError(f"unexpected terminal event type: {event_type}")
+
+
+@pytest.mark.parametrize(
+    ("terminal_type", "terminal_status"),
+    [
+        ("run_succeeded", "succeeded"),
+        ("run_failed", "failed"),
+    ],
+)
+def test_terminal_event_seals_in_memory_stream(terminal_type: str, terminal_status: str) -> None:
+    async def scenario() -> tuple[InMemoryRunEventSink, RunEventStreamSealedError]:
+        sink = InMemoryRunEventSink()
+        run_id = "run-1"
+        _ = await sink.append_event(RunStartedEvent(run_id=run_id))
+        _ = await sink.finalize_run(_terminal_event(terminal_type, run_id))
+
+        with pytest.raises(RunEventStreamSealedError) as captured:
+            _ = await sink.append_event(RunStartedEvent(run_id=run_id))
+        return sink, captured.value
+
+    sink, error = asyncio.run(scenario())
+
+    assert error.run_id == "run-1"
+    assert error.status == terminal_status
+    assert [event.type for event in sink.events["run-1"]] == ["run_started", terminal_type]

--- a/dify-agent/tests/local/dify_agent/runtime/test_run_scheduler.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_run_scheduler.py
@@ -28,6 +28,7 @@ from dify_agent.protocol.schemas import (
 from dify_agent.runtime.cancellation import RunCancellationIntent
 from dify_agent.runtime.event_sink import (
     NonTerminalRunEvent,
+    RunEventStreamSealedError,
     RunFinalizationResult,
     TerminalRunEvent,
     emit_run_failed,
@@ -121,6 +122,9 @@ class FakeStore:
         return record
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
+        current_status = self.statuses[event.run_id]
+        if current_status != "running":
+            raise RunEventStreamSealedError(run_id=event.run_id, status=current_status)
         event_id = str(len(self.events[event.run_id]) + 1)
         self.events[event.run_id].append(event.model_copy(update={"id": event_id}))
         return event_id

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator, Generator, Iterable, Mapping
 from contextlib import contextmanager
 from decimal import Decimal
 from typing import Any, ClassVar, cast
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -11,6 +12,7 @@ from pydantic import JsonValue
 from pydantic_ai import Tool
 from pydantic_ai.exceptions import ModelHTTPError, UnexpectedModelBehavior, UsageLimitExceeded
 from pydantic_ai.messages import (
+    FinalResultEvent,
     ToolReturnPart,
     ModelMessage,
     ModelRequest,
@@ -69,7 +71,7 @@ from dify_agent.protocol.schemas import (
     RunLayerSpec,
     RunSucceededEvent,
 )
-from dify_agent.runtime.event_sink import InMemoryRunEventSink
+from dify_agent.runtime.event_sink import InMemoryRunEventSink, emit_pydantic_ai_event, emit_run_failed
 from dify_agent.runtime.compositor_factory import create_default_layer_providers
 from dify_agent.runtime.runner import (
     AgentRunRunner,
@@ -254,6 +256,71 @@ def test_cancelled_runner_does_not_emit_late_failure(
         assert [event.type for event in sink.events["run-cancelled"]] == ["run_started"]
 
     asyncio.run(scenario())
+
+
+def test_runner_returns_when_terminal_wins_before_run_started(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def scenario() -> InMemoryRunEventSink:
+        sink = InMemoryRunEventSink()
+        _ = await emit_run_failed(sink, run_id="run-terminal", error="remote terminal")
+        finalize_run = AsyncMock(wraps=sink.finalize_run)
+        monkeypatch.setattr(sink, "finalize_run", finalize_run)
+        async with httpx.AsyncClient() as client:
+            runner = AgentRunRunner(
+                sink=sink,
+                request=_request(),
+                run_id="run-terminal",
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+            )
+
+            run_agent = AsyncMock()
+            monkeypatch.setattr(runner, "_run_agent", run_agent)
+            await runner.run()
+            run_agent.assert_not_awaited()
+            finalize_run.assert_not_awaited()
+        return sink
+
+    sink = asyncio.run(scenario())
+
+    assert sink.statuses["run-terminal"] == "failed"
+    assert [event.type for event in sink.events["run-terminal"]] == ["run_failed"]
+
+
+def test_runner_stops_when_terminal_wins_before_stream_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def scenario() -> InMemoryRunEventSink:
+        sink = InMemoryRunEventSink()
+        finalize_run = AsyncMock(wraps=sink.finalize_run)
+        monkeypatch.setattr(sink, "finalize_run", finalize_run)
+        model_progress: list[str] = []
+        async with httpx.AsyncClient() as client:
+            runner = AgentRunRunner(
+                sink=sink,
+                request=_request(),
+                run_id="run-terminal",
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+            )
+
+            async def emit_after_terminal() -> None:
+                model_progress.append("started")
+                _ = await emit_run_failed(sink, run_id="run-terminal", error="remote terminal")
+                _ = await emit_pydantic_ai_event(
+                    sink,
+                    run_id="run-terminal",
+                    data=FinalResultEvent(tool_name=None, tool_call_id=None),
+                )
+                model_progress.append("continued after sealed event")
+
+            monkeypatch.setattr(runner, "_run_agent", emit_after_terminal)
+            await runner.run()
+            assert model_progress == ["started"]
+            finalize_run.assert_awaited_once()
+        return sink
+
+    sink = asyncio.run(scenario())
+
+    assert sink.statuses["run-terminal"] == "failed"
+    assert [event.type for event in sink.events["run-terminal"]] == ["run_started", "run_failed"]
 
 
 def _request(

--- a/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
+++ b/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
@@ -23,7 +23,7 @@ from dify_agent.protocol.schemas import (
     utc_now,
 )
 from dify_agent.runtime.cancellation import RunCancellationIntent
-from dify_agent.runtime.event_sink import RunFinalizationResult
+from dify_agent.runtime.event_sink import RunEventStreamSealedError, RunFinalizationResult
 from dify_agent.storage.redis_run_store import (
     DEFAULT_RUN_EVENT_STREAM_MAX_LENGTH,
     DEFAULT_RUN_RETENTION_SECONDS,
@@ -53,34 +53,11 @@ class FakeRedis:
         self.commands.append(("get", key))
         return self.values.get(key)
 
-    async def xadd(
-        self,
-        key: str,
-        fields: Mapping[str, object],
-        *,
-        maxlen: int | None = None,
-        approximate: bool = True,
-    ) -> str:
-        self.commands.append(("xadd", key, dict(fields), maxlen, approximate))
-        return self._append_stream_entry(key, fields, maxlen=maxlen)
-
-    def pipeline(self, transaction: bool = True, shard_hint: str | None = None) -> "FakeRedisPipeline":
-        self.commands.append(("pipeline", transaction, shard_hint))
-        return FakeRedisPipeline(self)
-
-    def _append_stream_entry(
-        self,
-        key: str,
-        fields: Mapping[str, object],
-        *,
-        maxlen: int | None = None,
-    ) -> str:
+    def _append_stream_entry(self, key: str, fields: Mapping[str, object]) -> str:
         entries = self.streams.setdefault(key, [])
         next_sequence = self._stream_id_value(entries[-1][0])[0] + 1 if entries else 1
         event_id = f"{next_sequence}-0"
         entries.append((event_id, dict(fields)))
-        if maxlen is not None and len(entries) > maxlen:
-            del entries[: len(entries) - maxlen]
         self.stream_changed.set()
         return event_id
 
@@ -142,42 +119,6 @@ class FakeRedis:
     def _stream_id_value(event_id: str) -> tuple[int, int]:
         timestamp, sequence = event_id.split("-", maxsplit=1)
         return int(timestamp), int(sequence)
-
-
-class FakeRedisPipeline:
-    redis: FakeRedis
-    results: list[object]
-
-    def __init__(self, redis: FakeRedis) -> None:
-        self.redis = redis
-        self.results = []
-
-    async def __aenter__(self) -> "FakeRedisPipeline":
-        return self
-
-    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
-        del exc_type, exc, traceback
-
-    def xadd(
-        self,
-        key: str,
-        fields: Mapping[str, object],
-        *,
-        maxlen: int | None = None,
-        approximate: bool = True,
-    ) -> "FakeRedisPipeline":
-        self.redis.commands.append(("xadd", key, dict(fields), maxlen, approximate))
-        self.results.append(self.redis._append_stream_entry(key, fields, maxlen=maxlen))
-        return self
-
-    def expire(self, key: str, seconds: int) -> "FakeRedisPipeline":
-        self.redis.commands.append(("expire", key, seconds))
-        self.results.append(True)
-        return self
-
-    async def execute(self) -> list[object]:
-        self.redis.commands.append(("execute",))
-        return list(self.results)
 
 
 def _terminal_event(
@@ -374,7 +315,11 @@ def test_wait_for_cancellation_ignores_public_events() -> None:
         redis.commands.clear()
         observer = asyncio.create_task(store.wait_for_cancellation(record.run_id))
         await asyncio.sleep(0)
-        _ = await store.append_event(RunStartedEvent(run_id=record.run_id))
+        started = RunStartedEvent(run_id=record.run_id)
+        _ = redis._append_stream_entry(
+            f"test:runs:{record.run_id}:events",
+            {"payload": RUN_EVENT_ADAPTER.dump_json(started, exclude={"id"}).decode()},
+        )
         await asyncio.sleep(0)
         assert observer.done() is False
         xread_commands = [command for command in redis.commands if command[0] == "xread"]
@@ -395,49 +340,71 @@ def test_wait_for_cancellation_ignores_public_events() -> None:
     assert asyncio.run(scenario()).reason == "cancelled"
 
 
-def test_append_event_serializes_typed_event_without_id_and_expires_run_keys() -> None:
-    redis = FakeRedis()
-    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
-
-    event_id = asyncio.run(store.append_event(RunStartedEvent(id="local", run_id="run-1")))
-
-    assert event_id == "1-0"
-    pipeline_commands = [command for command in redis.commands if command[0] == "pipeline"]
-    assert len(pipeline_commands) == 1
-    assert pipeline_commands[0][1] is True
-    xadd_commands = [command for command in redis.commands if command[0] == "xadd"]
-    assert len(xadd_commands) == 1
-    fields = xadd_commands[0][2]
-    assert isinstance(fields, dict)
-    assert '"id"' not in str(fields["payload"])
-    assert '"type":"run_started"' in str(fields["payload"])
-    assert xadd_commands[0][3:] == (DEFAULT_RUN_EVENT_STREAM_MAX_LENGTH, True)
-    expire_commands = {command for command in redis.commands if command[0] == "expire"}
-    assert expire_commands == {
-        ("expire", "test:runs:run-1:events", 60),
-        ("expire", "test:runs:run-1:record", 60),
-    }
-    assert ("execute",) in redis.commands
-
-
-def test_append_event_keeps_only_the_configured_number_of_entries() -> None:
+@pytest.mark.parametrize("max_length", [DEFAULT_RUN_EVENT_STREAM_MAX_LENGTH, 2])
+@pytest.mark.parametrize("decode_responses", [True, False])
+def test_append_event_maps_guarded_eval_result_and_serializes_event_without_id(
+    max_length: int, decode_responses: bool
+) -> None:
     redis = FakeRedis()
     store = RedisRunStore(
         redis,  # pyright: ignore[reportArgumentType]
         prefix="test",
         run_retention_seconds=60,
-        run_event_stream_max_length=2,
+        run_event_stream_max_length=max_length,
     )
 
-    async def scenario() -> None:
-        for _ in range(3):
+    async def scenario() -> tuple[str, str]:
+        record = await store.create_run()
+        redis.commands.clear()
+        redis.eval_result = [1, "running", "1-0"] if decode_responses else [1, b"running", b"1-0"]
+        event_id = await store.append_event(RunStartedEvent(id="local", run_id=record.run_id))
+        return record.run_id, event_id
+
+    run_id, event_id = asyncio.run(scenario())
+
+    assert event_id == "1-0"
+    eval_command = redis.commands[0]
+    assert eval_command[0] == "eval"
+    assert eval_command[2] == 2
+    assert eval_command[3] == f"test:runs:{run_id}:record"
+    assert eval_command[4] == f"test:runs:{run_id}:events"
+    assert eval_command[6:] == ("60", str(max_length))
+    payload = json.loads(cast(str, eval_command[5]))
+    assert "id" not in payload
+    assert payload["type"] == "run_started"
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    ["succeeded", "failed", "cancelled"],
+)
+def test_append_event_maps_sealed_status_without_creating_a_stream(terminal_status: str) -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+    redis.eval_result = [0, terminal_status, ""]
+
+    async def scenario() -> RunEventStreamSealedError:
+        with pytest.raises(RunEventStreamSealedError) as captured:
             _ = await store.append_event(RunStartedEvent(run_id="run-1"))
+        return captured.value
 
-    asyncio.run(scenario())
+    error = asyncio.run(scenario())
 
-    assert len(redis.streams["test:runs:run-1:events"]) == 2
-    xadd_commands = [command for command in redis.commands if command[0] == "xadd"]
-    assert all(command[3:] == (2, True) for command in xadd_commands)
+    assert error.run_id == "run-1"
+    assert error.status == terminal_status
+    assert redis.streams == {}
+    assert [command[0] for command in redis.commands] == ["eval"]
+
+
+def test_append_event_rejects_missing_run_without_creating_stream() -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test")  # pyright: ignore[reportArgumentType]
+    redis.eval_result = [-1, "", ""]
+
+    with pytest.raises(RunNotFoundError):
+        asyncio.run(store.append_event(RunStartedEvent(run_id="missing")))
+
+    assert redis.streams == {}
 
 
 def test_get_events_round_trips_run_succeeded_output_and_session_snapshot() -> None:
@@ -485,7 +452,11 @@ def test_iter_events_ends_after_replaying_terminal_event(terminal_type: str) -> 
 
     async def scenario() -> list[str]:
         record = await store.create_run()
-        _ = await store.append_event(RunStartedEvent(run_id=record.run_id))
+        started = RunStartedEvent(run_id=record.run_id)
+        _ = redis._append_stream_entry(
+            f"test:runs:{record.run_id}:events",
+            {"payload": RUN_EVENT_ADAPTER.dump_json(started, exclude={"id"}).decode()},
+        )
         terminal = _terminal_event(terminal_type, record.run_id)
         _ = redis._append_stream_entry(
             f"test:runs:{record.run_id}:events",


### PR DESCRIPTION
## Summary

Fixes #40765.

Dify Agent atomically commits terminal run events and status transitions, but non-terminal events could still be appended through a separate Redis operation without checking the durable run status.

This creates a cross-process race where a terminal transition such as `run_cancelled` can be followed by a late non-terminal event, violating the invariant that a terminal event must be the last retained event in the run stream.

## Changes

This PR seals the event stream once a terminal transition has been committed.

* Replaces the non-terminal Redis append path with an atomic Lua operation that validates the durable run status before `XADD`.
* Rejects late non-terminal events after the run has reached a terminal state.
* Introduces `RunEventStreamSealedError` to represent this distributed coordination outcome.
* Updates the runner to stop emitting when another process has already sealed the stream.
* Aligns the in-memory event sink and scheduler test adapter with the same behavior.
* Preserves the existing cancellation model: cancellation intent alone does not seal the stream; durable terminal finalization does.
* Updates the Dify Agent documentation to describe the terminal-event ordering invariant.

The resulting ordering has a single Redis linearization point:

* If a non-terminal append wins first, it receives an earlier cursor and the terminal event follows.
* If terminal finalization wins first, the late append is rejected without consuming a stream cursor or refreshing retention.
* The first terminal event remains both the only terminal event and the last retained event.

No event schema, cursor format, Redis key name, or external protocol changes are introduced.

## Tests

Added and updated coverage for:

* rejecting non-terminal events after terminal finalization;
* preserving terminal-event tail ordering;
* runner behavior when the event stream is already sealed;
* in-memory event sink parity;
* deterministic late writes from a second Redis client;
* concurrent append/finalize races.

The Dify Agent CI workflow now installs `redis-server` so the real-Redis integration coverage can run in CI instead of being skipped because Redis is unavailable.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
