### PR TITLE
fix(web): open credential modal for customizable models

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-selector/__tests__/popup-item.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/__tests__/popup-item.spec.tsx
@@ -10,6 +10,7 @@ import {
   ConfigurationMethodEnum,
   CustomConfigurationStatusEnum,
   ModelFeatureEnum,
+  ModelModalModeEnum,
   ModelStatusEnum,
   ModelTypeEnum,
   PreferredProviderTypeEnum,
@@ -319,6 +320,18 @@ describe('PopupItem', () => {
       expect(mockSetShowModelModal).toHaveBeenCalled()
     })
 
+    expect(mockSetShowModelModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          currentConfigurationMethod: ConfigurationMethodEnum.predefinedModel,
+          currentCustomConfigurationModelFixedFields: undefined,
+          isModelCredential: undefined,
+          model: undefined,
+          mode: undefined,
+        }),
+      }),
+    )
+
     const call = mockSetShowModelModal.mock.calls[0]![0] as { onSaveCallback?: () => void }
     call.onSaveCallback?.()
 
@@ -353,6 +366,45 @@ describe('PopupItem', () => {
 
     expect(mockUpdateModelProviders).toHaveBeenCalled()
     expect(mockUpdateModelList).toHaveBeenCalledTimes(1)
+  })
+
+  it('should open model credential modal for an unconfigured customizable model', async () => {
+    renderPopupItem(
+      <PopupItem
+        {...previewCardProps()}
+        model={makeModel({
+          models: [
+            makeModelItem({
+              fetch_from: ConfigurationMethodEnum.customizableModel,
+              status: ModelStatusEnum.noConfigure,
+            }),
+          ],
+        })}
+        onHide={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'COMMON.OPERATION.ADD' }))
+
+    await waitFor(() => {
+      expect(mockSetShowModelModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            currentConfigurationMethod: ConfigurationMethodEnum.customizableModel,
+            currentCustomConfigurationModelFixedFields: {
+              __model_name: 'gpt-4',
+              __model_type: ModelTypeEnum.textGeneration,
+            },
+            isModelCredential: true,
+            model: {
+              model: 'gpt-4',
+              model_type: ModelTypeEnum.textGeneration,
+            },
+            mode: ModelModalModeEnum.configModelCredential,
+          }),
+        }),
+      )
+    })
   })
 
   it('should show selected state when defaultModel matches', () => {

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
@@ -1,5 +1,6 @@
 import type { ModelType } from '@dify/contracts/api/console/workspaces/types.gen'
 import type { ComponentProps } from 'react'
+import type { ModelTypeEnum } from '../declarations'
 import type {
   ModelSelectorModel,
   ModelSelectorModelPredicate,
@@ -19,7 +20,7 @@ import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
 import { useCredentialPermissions } from '@/hooks/use-credential-permissions'
 import { renderI18nObject } from '@/i18n-config'
-import { ConfigurationMethodEnum, ModelStatusEnum } from '../declarations'
+import { ConfigurationMethodEnum, ModelModalModeEnum, ModelStatusEnum } from '../declarations'
 import {
   useLanguage,
   useLazyModelProviderDetail,
@@ -82,21 +83,38 @@ function PopupItem({
   const isApiKeyActive = state.variant === 'api-active' || state.variant === 'api-fallback'
   const { credentialName } = state
 
-  const handleOpenModelModal = async () => {
+  const handleOpenModelModal = async (modelItem: ModelSelectorModel) => {
     if (!canCreateCredential || !currentProvider) return
 
     const detail = await loadProviderDetail()
     if (!detail) return
+    const isCustomizableModel = modelItem.fetch_from === ConfigurationMethodEnum.customizableModel
+    const modelType = modelItem.model_type as ModelTypeEnum
     setShowModelModal({
       payload: {
         currentProvider: detail,
-        currentConfigurationMethod: ConfigurationMethodEnum.predefinedModel,
+        currentConfigurationMethod: isCustomizableModel
+          ? ConfigurationMethodEnum.customizableModel
+          : ConfigurationMethodEnum.predefinedModel,
+        currentCustomConfigurationModelFixedFields: isCustomizableModel
+          ? {
+              __model_name: modelItem.model,
+              __model_type: modelType,
+            }
+          : undefined,
+        isModelCredential: isCustomizableModel || undefined,
+        model: isCustomizableModel
+          ? {
+              model: modelItem.model,
+              model_type: modelType,
+            }
+          : undefined,
+        mode: isCustomizableModel ? ModelModalModeEnum.configModelCredential : undefined,
       },
       onSaveCallback: () => {
         updateModelProviders()
 
-        const modelType = model.models[0]!.model_type
-        if (modelType) updateModelList(modelType as ModelType)
+        if (modelItem.model_type) updateModelList(modelItem.model_type as ModelType)
       },
     })
   }
@@ -268,7 +286,7 @@ function PopupItem({
                     variant="ghost-accent"
                     size="small"
                     className="h-auto shrink-0 p-0 text-xs opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 hover:bg-transparent focus-visible:opacity-100"
-                    onClick={() => void handleOpenModelModal()}
+                    onClick={() => void handleOpenModelModal(modelItem)}
                   >
                     {t(($) => $['operation.add'], { ns: 'common' }).toLocaleUpperCase()}
                   </Button>

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/types.ts
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/types.ts
@@ -2,6 +2,7 @@ import type {
   I18nObject,
   ProviderModelWithStatusEntity,
 } from '@dify/contracts/api/console/workspaces/types.gen'
+import type { ConfigurationMethodEnum } from '../declarations'
 
 export type ModelSelectorValue = {
   provider: string
@@ -19,6 +20,7 @@ export type ModelSelectorModel = Pick<
   | 'model_properties'
 > & {
   features?: readonly string[] | null
+  fetch_from: ConfigurationMethodEnum
   model_type: string
   status: string
 }


### PR DESCRIPTION
## Summary

- route customizable models to model credential configuration instead of provider credential configuration
- pass the selected model identity to the modal and refresh the selected model type after saving
- preserve the existing predefined-model flow and add regression coverage for both paths

Fixes #40985

## Screenshots

N/A — this changes modal routing and is covered by unit tests.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the relevant frontend lint, formatting, type-check, accessibility, and unit-test checks.

## Testing

- `pnpm --dir web exec vp test run --project unit app/components/header/account-setting/model-provider-page/model-selector/__tests__/popup-item.spec.tsx` (19 passed)
- `pnpm --dir web run type-check --pretty false`
- targeted `vp lint` and `vp fmt --check`
- `pnpm --dir web run lint:a11y app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx`
