### PR TITLE
fix(web): do not use builtin credential routes for providers that have none

### DIFF
--- a/web/app/components/plugins/plugin-auth/hooks/__tests__/use-get-api.spec.ts
+++ b/web/app/components/plugins/plugin-auth/hooks/__tests__/use-get-api.spec.ts
@@ -47,6 +47,67 @@ describe('useGetApi', () => {
     })
   })
 
+  describe('tool category with a non-builtin provider type', () => {
+    // A custom API / MCP / workflow provider is keyed by a UUID, not a plugin id.
+    // Sending it to the builtin credential routes makes the plugin daemon fail the
+    // lookup, which surfaces to the user as a 500 on the agent configure page.
+    it.each(['api', 'mcp', 'workflow'] as const)(
+      'does not build builtin credential paths for a %s provider',
+      (providerType) => {
+        const api = useGetApi({ category: AuthCategory.tool, provider, providerType })
+
+        expect(api.getCredentialInfo).toBe('')
+        expect(api.setDefaultCredential).toBe('')
+        expect(api.getCredentials).toBe('')
+        expect(api.addCredential).toBe('')
+        expect(api.updateCredential).toBe('')
+        expect(api.deleteCredential).toBe('')
+        expect(api.getOauthUrl).toBe('')
+        expect(api.getCredentialSchema(CredentialTypeEnum.API_KEY)).toBe('')
+      },
+    )
+
+    // A plugin-backed tool provider serves its credentials from the builtin routes:
+
+    // tool-provider-catalog registers 'plugin' alongside 'builtin' for the same list.
+
+    it.each(['builtin', 'plugin'] as const)(
+      'still builds builtin paths for a %s provider',
+
+      (providerType) => {
+        const api = useGetApi({ category: AuthCategory.tool, provider, providerType })
+
+        expect(api.getCredentialInfo).toBe(
+          `/workspaces/current/tool-provider/builtin/${provider}/credential/info`,
+        )
+
+        expect(api.getCredentialSchema(CredentialTypeEnum.API_KEY)).toBe(
+          `/workspaces/current/tool-provider/builtin/${provider}/credential/schema/api-key`,
+        )
+      },
+    )
+
+    it('still builds builtin paths when providerType is explicitly builtin', () => {
+      const api = useGetApi({ category: AuthCategory.tool, provider, providerType: 'builtin' })
+      expect(api.getCredentialInfo).toBe(
+        `/workspaces/current/tool-provider/builtin/${provider}/credential/info`,
+      )
+      expect(api.getCredentialSchema(CredentialTypeEnum.API_KEY)).toBe(
+        `/workspaces/current/tool-provider/builtin/${provider}/credential/schema/api-key`,
+      )
+    })
+
+    it('still builds builtin paths when providerType is omitted', () => {
+      const api = useGetApi({ category: AuthCategory.tool, provider })
+      expect(api.getCredentialInfo).toBe(
+        `/workspaces/current/tool-provider/builtin/${provider}/credential/info`,
+      )
+      expect(api.getCredentialSchema(CredentialTypeEnum.API_KEY)).toBe(
+        `/workspaces/current/tool-provider/builtin/${provider}/credential/schema/api-key`,
+      )
+    })
+  })
+
   describe('datasource category', () => {
     it('returns correct API paths for datasource category', () => {
       const api = useGetApi({ category: AuthCategory.datasource, provider })

--- a/web/app/components/plugins/plugin-auth/hooks/use-get-api.ts
+++ b/web/app/components/plugins/plugin-auth/hooks/use-get-api.ts
@@ -1,8 +1,24 @@
 import type { CredentialTypeEnum, PluginPayload } from '../types'
+import { CollectionType } from '@/app/components/tools/types'
 import { AuthCategory } from '../types'
 
-export const useGetApi = ({ category = AuthCategory.tool, provider }: PluginPayload) => {
-  if (category === AuthCategory.tool) {
+// These providers are identified by a UUID rather than a plugin id and have no credential
+// endpoints, so the builtin routes 500 for them.
+const TOOL_PROVIDER_TYPES_WITHOUT_CREDENTIALS: string[] = [
+  CollectionType.custom,
+  CollectionType.workflow,
+  CollectionType.mcp,
+]
+
+export const useGetApi = ({
+  category = AuthCategory.tool,
+  provider,
+  providerType,
+}: PluginPayload) => {
+  const usesBuiltInCredentialRoutes =
+    providerType === undefined || !TOOL_PROVIDER_TYPES_WITHOUT_CREDENTIALS.includes(providerType)
+
+  if (category === AuthCategory.tool && usesBuiltInCredentialRoutes) {
     return {
       getCredentialInfo: `/workspaces/current/tool-provider/builtin/${provider}/credential/info`,
       setDefaultCredential: `/workspaces/current/tool-provider/builtin/${provider}/default-credential`,


### PR DESCRIPTION
# Summary

Fixes #39169 — opening an agent's configure page returns a 500 (`PluginNotFoundError`) when the agent uses a custom API tool.

**Root cause.** `useGetApi` returned the *builtin* tool-provider credential routes for every provider in the tool category, ignoring `providerType`:

```ts
// web/app/components/plugins/plugin-auth/hooks/use-get-api.ts
export const useGetApi = ({ category = AuthCategory.tool, provider }: PluginPayload) => {
  if (category === AuthCategory.tool) {
    return {
      getCredentialSchema: (t) => `/workspaces/current/tool-provider/builtin/${provider}/credential/schema/${t}`,
```

A custom API tool provider is keyed by a `tool_api_providers` UUID, not a plugin id, so the client requests `.../builtin/<uuid>/credential/schema/api-key`. `ToolBuiltinProviderCredentialsSchemaApi` (`api/controllers/console/workspace/tool_providers.py:843-861`) passes `provider` straight to `BuiltinToolManageService.list_builtin_provider_credentials_schema`, the plugin daemon fails the lookup, and it surfaces as a 500 — matching the traceback in the issue.

This fires on mount from `features/agent-v2/.../provider-tool/item.tsx:62-76`, where the payload is fed into `usePluginAuth(pluginPayload, true)` unconditionally.

**Fix.** Credential endpoints are registered only under `/tool-provider/builtin/...`; there is no equivalent for `api`, `mcp` or `workflow`. So exclude exactly those three and let them fall through to the existing no-op route set.

Important detail: this is a deny-list, not an allow-list of `builtin`. `providerType` is a `ToolProviderType`, which also includes `'plugin'` — and plugin-backed providers **do** serve credentials from the builtin routes. `tool-provider-catalog.ts:48-49` registers `'plugin'` alongside `CollectionType.builtIn` for the same provider list, and `:92` treats the two as one class. Gating on `=== builtin` alone would have silently broken credential loading for plugin-backed agent tools, which is worse than the bug being fixed. There's a regression test pinning that.

An absent `providerType` also keeps the builtin routes, so existing callers are unaffected.

# Screenshots / Test

```
pnpm test app/components/plugins/plugin-auth/hooks/__tests__/use-get-api.spec.ts   # 16 passed
pnpm type-check                                                                    # clean
pnpm lint:tss                                                                      # 5961 passed
```

Five tests added:
- `api` / `mcp` / `workflow` build no builtin paths — these **fail before this change** with `expected '/workspaces/current/tool-provider/bui…' to be ''`
- `builtin` / `plugin` still build them — the `plugin` case **fails against an allow-list implementation**, which is why it's here
- an omitted `providerType` still builds them (back-compat)

I verified the revert actually applied before trusting each of those runs.

# Follow-up (deliberately not in this PR)

`tool_providers.py:854` has no guard that `provider` is builtin. `PluginNotFoundError` extends `PluginDaemonError`, not `ValueError`, so `handle_value_error` doesn't catch it and the generic handler returns 500. A malformed provider id should arguably be a 400. The same applies to `credential/info` (`:1342`) and `credentials` (`:641`). This PR stops the client sending those requests, which resolves the reported symptom, but the backend would still 500 for any other caller. Happy to open a separate PR if you'd like that hardened.

---

> [!NOTE]
> This contribution was AI-assisted (Claude Code). The `'plugin'` regression above was found during review and fixed before submitting; every claim here was verified against the source rather than assumed.
