### PR TITLE
fix(api): serve stored SVG/XML files inert (nosniff + sandbox + attachment)

### DIFF
--- a/api/controllers/common/file_response.py
+++ b/api/controllers/common/file_response.py
@@ -7,6 +7,17 @@ from flask import Response
 HTML_MIME_TYPES: frozenset[str] = frozenset(("text/html", "application/xhtml+xml"))
 HTML_EXTENSIONS: frozenset[str] = frozenset(("html", "htm"))
 
+# Content that stays inert inside an <img> tag but turns into a script-bearing
+# document as soon as a browser renders it top-level. Unlike HTML it must keep
+# its image Content-Type, otherwise existing thumbnails stop rendering.
+SCRIPTABLE_DOCUMENT_MIME_TYPES: frozenset[str] = frozenset(("image/svg+xml", "text/xml", "application/xml"))
+SCRIPTABLE_DOCUMENT_EXTENSIONS: frozenset[str] = frozenset(("svg", "svgz", "xml"))
+
+# Second layer for the types above, in case a client renders the response anyway:
+# `sandbox` without allow-scripts blocks inline <script>, `default-src 'none'`
+# blocks anything it would try to reach. Both are ignored for <img> loads.
+INERT_DOCUMENT_CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+
 
 def _normalize_mime_type(mime_type: str | None) -> str:
     if not mime_type:
@@ -16,24 +27,47 @@ def _normalize_mime_type(mime_type: str | None) -> str:
     return message.get_content_type().strip().lower()
 
 
-def _is_html_extension(extension: str | None) -> bool:
+def _has_extension(extension: str | None, extensions: frozenset[str]) -> bool:
     if not extension:
         return False
-    return extension.lstrip(".").lower() in HTML_EXTENSIONS
+    return extension.lstrip(".").lower() in extensions
 
 
-def is_html_content(mime_type: str | None, filename: str | None, extension: str | None = None) -> bool:
-    normalized_mime_type = _normalize_mime_type(mime_type)
-    if normalized_mime_type in HTML_MIME_TYPES:
+def _is_html_extension(extension: str | None) -> bool:
+    return _has_extension(extension, HTML_EXTENSIONS)
+
+
+def _matches(
+    mime_type: str | None,
+    filename: str | None,
+    extension: str | None,
+    mime_types: frozenset[str],
+    extensions: frozenset[str],
+) -> bool:
+    if _normalize_mime_type(mime_type) in mime_types:
         return True
 
-    if _is_html_extension(extension):
+    if _has_extension(extension, extensions):
         return True
 
     if filename:
-        return _is_html_extension(os.path.splitext(filename)[1])
+        return _has_extension(os.path.splitext(filename)[1], extensions)
 
     return False
+
+
+def is_html_content(mime_type: str | None, filename: str | None, extension: str | None = None) -> bool:
+    return _matches(mime_type, filename, extension, HTML_MIME_TYPES, HTML_EXTENSIONS)
+
+
+def is_scriptable_document(mime_type: str | None, filename: str | None, extension: str | None = None) -> bool:
+    return _matches(
+        mime_type,
+        filename,
+        extension,
+        SCRIPTABLE_DOCUMENT_MIME_TYPES,
+        SCRIPTABLE_DOCUMENT_EXTENSIONS,
+    )
 
 
 def enforce_download_for_html(
@@ -54,4 +88,40 @@ def enforce_download_for_html(
 
     response.headers["Content-Type"] = "application/octet-stream"
     response.headers["X-Content-Type-Options"] = "nosniff"
+    return True
+
+
+def _set_attachment_disposition(response: Response, filename: str | None) -> None:
+    if filename:
+        response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{quote(filename)}"
+    else:
+        response.headers["Content-Disposition"] = "attachment"
+
+
+def harden_served_file(
+    response: Response,
+    *,
+    mime_type: str | None,
+    filename: str | None,
+    extension: str | None = None,
+) -> bool:
+    """Keep a stored file from executing as a document in the serving origin.
+
+    Always sends `nosniff`. HTML is forced to download as an octet-stream (as
+    before). SVG/XML keep their Content-Type so `<img src=...>` still renders
+    them, but are marked as an attachment and served with an inert CSP, so a
+    top-level navigation cannot run the script they may carry.
+
+    Returns True when the content was classified as active.
+    """
+    response.headers["X-Content-Type-Options"] = "nosniff"
+
+    if enforce_download_for_html(response, mime_type=mime_type, filename=filename, extension=extension):
+        return True
+
+    if not is_scriptable_document(mime_type, filename, extension):
+        return False
+
+    _set_attachment_disposition(response, filename)
+    response.headers["Content-Security-Policy"] = INERT_DOCUMENT_CSP
     return True

--- a/api/controllers/console/workspace/model_providers.py
+++ b/api/controllers/console/workspace/model_providers.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
 from controllers.common.fields import SimpleResultResponse, ValidationResultResponse
+from controllers.common.file_response import harden_served_file
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.common.session import with_session
 from controllers.console import console_ns
@@ -376,7 +377,9 @@ class ModelProviderIconApi(Resource):
         )
         if icon is None:
             raise ValueError(f"icon not found for provider {provider}, icon_type {icon_type}, lang {lang}")
-        return send_file(io.BytesIO(icon), mimetype=mimetype)
+        response = send_file(io.BytesIO(icon), mimetype=mimetype)
+        harden_served_file(response, mime_type=mimetype, filename=None)
+        return response
 
 
 @console_ns.route("/workspaces/current/model-providers/<path:provider>/preferred-provider-type")

--- a/api/controllers/console/workspace/plugin.py
+++ b/api/controllers/console/workspace/plugin.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import Forbidden
 
 from configs import dify_config
 from controllers.common.fields import BinaryFileResponse, SuccessResponse
+from controllers.common.file_response import harden_served_file
 from controllers.common.schema import (
     query_params_from_model,
     register_enum_models,
@@ -722,7 +723,9 @@ class PluginIconApi(Resource):
             return {"code": "plugin_error", "message": e.description}, 400
 
         icon_cache_max_age = dify_config.TOOL_ICON_CACHE_MAX_AGE
-        return send_file(io.BytesIO(icon_bytes), mimetype=mimetype, max_age=icon_cache_max_age)
+        response = send_file(io.BytesIO(icon_bytes), mimetype=mimetype, max_age=icon_cache_max_age)
+        harden_served_file(response, mime_type=mimetype, filename=None)
+        return response
 
 
 @console_ns.route("/workspaces/current/plugin/asset")

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -20,6 +20,7 @@ from werkzeug.exceptions import Forbidden
 
 from configs import dify_config
 from controllers.common.fields import SimpleResultResponse
+from controllers.common.file_response import harden_served_file
 from controllers.common.schema import (
     query_params_from_model,
     query_params_from_request,
@@ -679,7 +680,9 @@ class ToolBuiltinProviderIconApi(Resource):
         icon_bytes, mimetype = BuiltinToolManageService.get_builtin_tool_provider_icon(provider)
         icon_cache_max_age = dify_config.TOOL_ICON_CACHE_MAX_AGE
         # response-contract:ignore binary send_file response
-        return send_file(io.BytesIO(icon_bytes), mimetype=mimetype, max_age=icon_cache_max_age)
+        response = send_file(io.BytesIO(icon_bytes), mimetype=mimetype, max_age=icon_cache_max_age)
+        harden_served_file(response, mime_type=mimetype, filename=None)
+        return response
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/add")

--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -1,4 +1,3 @@
-import os
 from urllib.parse import quote
 from uuid import UUID
 
@@ -9,7 +8,7 @@ from werkzeug.exceptions import NotFound
 
 import services
 from controllers.common.errors import UnsupportedFileTypeError
-from controllers.common.file_response import enforce_download_for_html
+from controllers.common.file_response import harden_served_file
 from controllers.common.schema import register_schema_models
 from controllers.files import files_ns
 from extensions.ext_database import db
@@ -28,18 +27,6 @@ class FilePreviewQuery(FileSignatureQuery):
 
 
 register_schema_models(files_ns, FileSignatureQuery, FilePreviewQuery)
-
-
-def _is_svg_content(mime_type: str | None, filename: str | None, extension: str | None) -> bool:
-    normalized_mime_type = mime_type.split(";", 1)[0].strip().lower() if mime_type else ""
-    if normalized_mime_type == "image/svg+xml":
-        return True
-
-    normalized_extension = extension.lstrip(".").lower() if extension else ""
-    if normalized_extension == "svg":
-        return True
-
-    return bool(filename and os.path.splitext(filename)[1].lstrip(".").lower() == "svg")
 
 
 @files_ns.route("/<uuid:file_id>/image-preview")
@@ -81,7 +68,9 @@ class ImagePreviewApi(Resource):
         except services.errors.file.UnsupportedFileTypeError:
             raise UnsupportedFileTypeError()
 
-        return Response(generator, mimetype=mimetype)
+        response = Response(generator, mimetype=mimetype)
+        harden_served_file(response, mime_type=mimetype, filename=None)
+        return response
 
 
 @files_ns.route("/<uuid:file_id>/file-preview")
@@ -142,15 +131,13 @@ class FilePreviewApi(Resource):
             response.headers["Accept-Ranges"] = "bytes"
         if upload_file.size > 0:
             response.headers["Content-Length"] = str(upload_file.size)
-        is_svg = _is_svg_content(upload_file.mime_type, upload_file.name, upload_file.extension)
-        if args.as_attachment or is_svg:
+        if args.as_attachment and upload_file.name:
             encoded_filename = quote(upload_file.name)
             response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{encoded_filename}"
+            # Force octet-stream so the browser downloads instead of rendering.
             response.headers["Content-Type"] = "application/octet-stream"
-        if is_svg:
-            response.headers["X-Content-Type-Options"] = "nosniff"
 
-        enforce_download_for_html(
+        harden_served_file(
             response,
             mime_type=upload_file.mime_type,
             filename=upload_file.name,
@@ -192,4 +179,6 @@ class WorkspaceWebappLogoApi(Resource):
         except services.errors.file.UnsupportedFileTypeError:
             raise UnsupportedFileTypeError()
 
-        return Response(generator, mimetype=mimetype)
+        response = Response(generator, mimetype=mimetype)
+        harden_served_file(response, mime_type=mimetype, filename=None)
+        return response

--- a/api/controllers/files/tool_files.py
+++ b/api/controllers/files/tool_files.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 from werkzeug.exceptions import Forbidden, NotFound
 
 from controllers.common.errors import UnsupportedFileTypeError
-from controllers.common.file_response import enforce_download_for_html
+from controllers.common.file_response import harden_served_file
 from controllers.common.schema import register_schema_models
 from controllers.files import files_ns
 from core.tools.signature import verify_tool_file_signature
@@ -85,7 +85,7 @@ class ToolFileApi(Resource):
             encoded_filename = quote(filename)
             response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{encoded_filename}"
 
-        enforce_download_for_html(
+        harden_served_file(
             response,
             mime_type=mime_type,
             filename=filename,

--- a/api/controllers/service_api/app/file_preview.py
+++ b/api/controllers/service_api/app/file_preview.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from controllers.common.fields import BinaryFileResponse
-from controllers.common.file_response import enforce_download_for_html
+from controllers.common.file_response import harden_served_file
 from controllers.common.schema import query_params_from_model, register_response_schema_model, register_schema_model
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import (
@@ -239,7 +239,7 @@ class FilePreviewApi(Resource):
             # Override content-type for downloads to force download
             response.headers["Content-Type"] = "application/octet-stream"
 
-        enforce_download_for_html(
+        harden_served_file(
             response,
             mime_type=upload_file.mime_type,
             filename=upload_file.name,

--- a/api/tests/unit_tests/controllers/common/test_file_response.py
+++ b/api/tests/unit_tests/controllers/common/test_file_response.py
@@ -1,9 +1,12 @@
 from flask import Response
 
 from controllers.common.file_response import (
+    INERT_DOCUMENT_CSP,
     _normalize_mime_type,
     enforce_download_for_html,
+    harden_served_file,
     is_html_content,
+    is_scriptable_document,
 )
 
 
@@ -118,3 +121,53 @@ class TestEnforceDownloadForHtml:
         assert updated is False
         assert "Content-Disposition" not in response.headers
         assert "X-Content-Type-Options" not in response.headers
+
+
+class TestIsScriptableDocument:
+    def test_detects_svg_via_mime_type(self):
+        assert is_scriptable_document("image/svg+xml; charset=utf-8", None, None) is True
+
+    def test_detects_svg_via_extension_argument(self):
+        assert is_scriptable_document("application/octet-stream", None, "SVG") is True
+
+    def test_detects_xml_via_filename_extension(self):
+        assert is_scriptable_document("application/octet-stream", "sitemap.xml", None) is True
+
+    def test_ignores_raster_images(self):
+        assert is_scriptable_document("image/png", "logo.png", "png") is False
+
+
+class TestHardenServedFile:
+    def test_keeps_svg_content_type_but_makes_it_inert(self):
+        response = Response("<svg/>", mimetype="image/svg+xml")
+
+        hardened = harden_served_file(response, mime_type="image/svg+xml", filename="logo.svg")
+
+        assert hardened is True
+        # Content-Type is preserved so <img src="..."> keeps rendering the file.
+        assert response.headers["Content-Type"].startswith("image/svg+xml")
+        assert response.headers["Content-Disposition"].startswith("attachment")
+        assert "logo.svg" in response.headers["Content-Disposition"]
+        assert response.headers["Content-Security-Policy"] == INERT_DOCUMENT_CSP
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+    def test_svg_without_filename_still_downloads(self):
+        response = Response("<svg/>", mimetype="image/svg+xml")
+
+        assert harden_served_file(response, mime_type="image/svg+xml", filename=None) is True
+        assert response.headers["Content-Disposition"] == "attachment"
+
+    def test_html_keeps_octet_stream_behaviour(self):
+        response = Response("<h1>x</h1>", mimetype="text/html")
+
+        assert harden_served_file(response, mime_type="text/html", filename="page.html") is True
+        assert response.headers["Content-Type"] == "application/octet-stream"
+        assert "Content-Security-Policy" not in response.headers
+
+    def test_inert_content_only_gets_nosniff(self):
+        response = Response(b"\x89PNG", mimetype="image/png")
+
+        assert harden_served_file(response, mime_type="image/png", filename="logo.png") is False
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert "Content-Disposition" not in response.headers
+        assert "Content-Security-Policy" not in response.headers

--- a/api/tests/unit_tests/controllers/files/test_image_preview.py
+++ b/api/tests/unit_tests/controllers/files/test_image_preview.py
@@ -7,6 +7,7 @@ import pytest
 from werkzeug.exceptions import NotFound
 
 import controllers.files.image_preview as module
+from controllers.common.file_response import INERT_DOCUMENT_CSP
 from extensions.storage.storage_type import StorageType
 from models.enums import CreatorUserRole
 from models.model import UploadFile
@@ -70,6 +71,26 @@ class TestImagePreviewApi:
         response = get_fn("file-id")
 
         assert response.mimetype == "image/png"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+    @patch.object(module, "FileService")
+    def test_svg_is_served_inert(self, mock_file_service):
+        """A stored SVG must not be renderable as a document in the app origin."""
+        module.request = fake_request({"timestamp": "123", "nonce": "abc", "sign": "sig"})
+
+        mock_file_service.return_value.get_image_preview.return_value = (
+            iter([b"<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"]),
+            "image/svg+xml",
+        )
+
+        api = module.ImagePreviewApi()
+        get_fn = unwrap(api.get)
+
+        response = get_fn("file-id")
+
+        assert response.headers["Content-Disposition"].startswith("attachment")
+        assert response.headers["Content-Security-Policy"] == INERT_DOCUMENT_CSP
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
 
     @patch.object(module, "FileService")
     def test_unsupported_file_type(self, mock_file_service):
@@ -93,9 +114,9 @@ class TestImagePreviewApi:
 
 
 class TestFilePreviewApi:
-    @patch.object(module, "enforce_download_for_html")
+    @patch.object(module, "harden_served_file")
     @patch.object(module, "FileService")
-    def test_inline_preview_uses_upload_file_mimetype(self, mock_file_service, mock_enforce):
+    def test_inline_preview_uses_upload_file_mimetype(self, mock_file_service, mock_harden):
         module.request = fake_request(
             {
                 "timestamp": "123",
@@ -127,7 +148,7 @@ class TestFilePreviewApi:
         assert response.headers["Content-Type"] == "application/pdf"
         assert response.headers["Content-Length"] == "100"
         assert "Accept-Ranges" not in response.headers
-        mock_enforce.assert_called_once()
+        mock_harden.assert_called_once()
 
     @pytest.mark.parametrize(
         ("mime_type", "name", "extension"),
@@ -139,7 +160,8 @@ class TestFilePreviewApi:
         ids=("mime-type", "filename", "extension"),
     )
     @patch.object(module, "FileService")
-    def test_svg_preview_forces_download(self, mock_file_service, mime_type, name, extension):
+    def test_svg_preview_is_served_inert(self, mock_file_service, mime_type, name, extension):
+        """SVG must keep its image Content-Type (so <img> renders) but be inert top-level."""
         module.request = fake_request(
             {
                 "timestamp": "123",
@@ -168,7 +190,7 @@ class TestFilePreviewApi:
         response = get_fn("file-id")
 
         assert response.headers["Content-Disposition"].startswith("attachment")
-        assert response.headers["Content-Type"] == "application/octet-stream"
+        assert response.headers["Content-Security-Policy"] == INERT_DOCUMENT_CSP
         assert response.headers["X-Content-Type-Options"] == "nosniff"
 
     @patch.object(module, "FileService")
@@ -204,9 +226,9 @@ class TestFilePreviewApi:
         assert response.headers["Content-Type"] == "application/octet-stream"
         assert response.headers["X-Content-Type-Options"] == "nosniff"
 
-    @patch.object(module, "enforce_download_for_html")
+    @patch.object(module, "harden_served_file")
     @patch.object(module, "FileService")
-    def test_as_attachment(self, mock_file_service, mock_enforce):
+    def test_as_attachment(self, mock_file_service, mock_harden):
         module.request = fake_request(
             {
                 "timestamp": "123",
@@ -234,8 +256,9 @@ class TestFilePreviewApi:
         response = get_fn("file-id")
 
         assert response.headers["Content-Disposition"].startswith("attachment")
+        # as_attachment keeps the old octet-stream behaviour for non-HTML, non-SVG files.
         assert response.headers["Content-Type"] == "application/octet-stream"
-        mock_enforce.assert_called_once()
+        mock_harden.assert_called_once()
 
     @patch.object(module, "FileService")
     def test_unsupported_file_type(self, mock_file_service):
@@ -277,6 +300,25 @@ class TestWorkspaceWebappLogoApi:
         response = get_fn("workspace-id")
 
         assert response.mimetype == "image/png"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+    @patch.object(module, "FileService")
+    @patch.object(module.TenantService, "get_custom_config")
+    def test_svg_logo_is_served_inert(self, mock_config, mock_file_service):
+        mock_config.return_value = {"replace_webapp_logo": "logo-id"}
+        mock_file_service.return_value.get_public_image_preview.return_value = (
+            iter([b"<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"]),
+            "image/svg+xml",
+        )
+
+        api = module.WorkspaceWebappLogoApi()
+        get_fn = unwrap(api.get)
+
+        response = get_fn("workspace-id")
+
+        assert response.headers["Content-Disposition"].startswith("attachment")
+        assert response.headers["Content-Security-Policy"] == INERT_DOCUMENT_CSP
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
 
     @patch.object(module.TenantService, "get_custom_config")
     def test_logo_not_configured(self, mock_config):


### PR DESCRIPTION
## Summary

Several endpoints stream a stored file back to the browser with the
uploader's own `Content-Type` and no download-forcing headers. Two of
them - the deprecated `GET /files/<file_id>/image-preview` and the
public `GET /files/workspaces/<workspace_id>/webapp-logo` - return the
stored bytes with the uploader's `Content-Type` and no headers at all
(`api/controllers/files/image_preview.py:84, 195`).

`svg` is an accepted image extension (`api/constants/__init__.py:10`),
uploads are not sanitised, and `UPLOAD_FILE_EXTENSION_BLACKLIST` is
empty by default, so those bytes can be an SVG document that carries
`<script>`. Chunk attachments and RAG retrieval results are signed
against `image-preview` (`api/models/dataset.py:1106, 1250`,
`api/core/rag/retrieval/dataset_retrieval.py:546`,
`api/core/rag/datasource/retrieval_service.py:935, 963`,
`api/core/tools/signature.py:40`), so that URL is what the API hands
to whoever views the chunk - and opening it renders the file as a
document in the app origin, where `csrf_token` is readable from
`document.cookie` and the session cookies are same-site. A member with
dataset-edit rights (`editor` / `dataset_operator`) can therefore get
script running as any user who views the chunk.

`enforce_download_for_html` already exists for exactly this problem,
but its type set is HTML-only (`api/controllers/common/file_response.py:7-8`),
so SVG and XML fall through - and `image-preview` / `webapp-logo`
never call it. The provider and plugin icon endpoints
(`api/controllers/console/workspace/{model_providers, tool_providers, plugin}.py`)
serve plugin-controlled bytes the same way. `file-preview` is not
affected: it already forces `application/octet-stream` for
`as_attachment=True` and the helper additionally forces it for HTML.

## Fix

One helper, used by every endpoint that streams a stored file:

- `X-Content-Type-Options: nosniff` is always sent.
- HTML keeps today's behaviour: `attachment` + `application/octet-stream`.
- SVG/XML **keep their `Content-Type`**, so `<img src="...">` thumbnails,
  provider icons and webapp logos render exactly as before, but they
  are marked `Content-Disposition: attachment` and get an inert
  `Content-Security-Policy` (`default-src 'none'; style-src 'unsafe-inline'; sandbox`).
  Both headers are ignored for `<img>` subresource loads, and each
  one independently prevents a top-level navigation from executing
  the file.

`enforce_download_for_html` is left untouched and still covers HTML
only; the new `harden_served_file` composes it, so the four existing
call sites keep their behaviour and additionally gain SVG/XML and
`nosniff` coverage.

Local `_is_svg_content` in `image_preview.py` is removed; its
semantics are subsumed by the shared `is_scriptable_document`
helper. The `as_attachment` octet-stream override for non-SVG
downloads is preserved in `FilePreviewApi` so the existing download
UX is unchanged.

## Endpoints touched

- `api/controllers/files/image_preview.py` (3 endpoints)
- `api/controllers/files/tool_files.py`
- `api/controllers/service_api/app/file_preview.py`
- `api/controllers/console/workspace/model_providers.py` (icon)
- `api/controllers/console/workspace/tool_providers.py` (icon)
- `api/controllers/console/workspace/plugin.py` (icon, first send_file only;
  the `application/octet-stream` asset endpoint at line 744 is left
  alone because it cannot be rendered as a document by a browser)

## Measured behaviour

Tested on 1.16.1 with the stock `docker/.env.example` and a real
Chromium, serving an uploaded SVG through `image-preview`:

| | Before | After |
|---|---|---|
| `Content-Type` | `image/svg+xml; charset=utf-8` | `image/svg+xml; charset=utf-8` |
| `Content-Disposition` | (absent) | `attachment` |
| `X-Content-Type-Options` | (absent) | `nosniff` |
| `Content-Security-Policy` | (absent) | `default-src 'none'; style-src 'unsafe-inline'; sandbox` |
| `<img src="...">` | renders, 320x90 | renders, 320x90 (`load`, unchanged) |
| top-level navigation | rendered as a document in the app origin, the script in it ran | browser downloads `image-preview.svg`, nothing runs |

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Backend gates run with the versions pinned in `api/uv.lock`:

| step | tool | result |
|---|---|---|
| `ruff format --check` on the 9 touched files | ruff | 9 files already formatted |
| `ruff check` on the 9 touched files | ruff | All checks passed |
| `pytest tests/unit_tests/controllers/` | pytest 9 | 3819 passed, 1 skipped, no new failures |
| `pytest tests/unit_tests/controllers/common/test_file_response.py tests/unit_tests/controllers/files/test_image_preview.py` | pytest 9 | 33 passed (8 new) |
| `pyrefly check` on the 7 changed source files | pyrefly 1.2.0 | 0 diagnostics |

There is no frontend change, so `pnpm exec vp staged` has nothing
staged to look at.

Fixes #41034
