### PR TITLE
refactor(dify-ui): simplify overlay content APIs

### DIFF
--- a/packages/dify-ui/src/alert-dialog/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/alert-dialog/__tests__/index.spec.tsx
@@ -1,18 +1,31 @@
+import * as React from 'react'
+import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
-import { AlertDialog, AlertDialogActions, AlertDialogContent, AlertDialogTitle } from '../index'
+import {
+  AlertDialog,
+  AlertDialogCancelButton,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '../index'
 
 describe('AlertDialog wrapper', () => {
   describe('Props', () => {
-    it('should apply custom className to popup', async () => {
+    it('should move focus to the requested initial target', async () => {
+      const initialFocusRef = React.createRef<HTMLButtonElement>()
       const screen = await render(
         <AlertDialog open>
-          <AlertDialogContent className="custom-class">
+          <AlertDialogContent initialFocus={initialFocusRef}>
             <AlertDialogTitle>Title</AlertDialogTitle>
+            <button ref={initialFocusRef} type="button">
+              Focus target
+            </button>
           </AlertDialogContent>
         </AlertDialog>,
       )
 
-      await expect.element(screen.getByRole('alertdialog')).toHaveClass('custom-class')
+      await expect.element(screen.getByRole('button', { name: 'Focus target' })).toHaveFocus()
     })
 
     it('should not render a close button by default', async () => {
@@ -26,20 +39,87 @@ describe('AlertDialog wrapper', () => {
 
       expect(() => screen.getByRole('button', { name: 'Close' }).element()).toThrow()
     })
-  })
 
-  describe('Composition Helpers', () => {
-    it('should forward className to the actions wrapper', async () => {
+    it('should apply backdrop props to a nested alert dialog backdrop', async () => {
       const screen = await render(
         <AlertDialog open>
           <AlertDialogContent>
-            <AlertDialogTitle>Action Required</AlertDialogTitle>
-            <AlertDialogActions data-testid="actions" className="custom-actions" />
+            <AlertDialogTitle>Parent confirmation</AlertDialogTitle>
+            <AlertDialog open>
+              <AlertDialogContent
+                backdropProps={{
+                  className: 'bg-transparent',
+                  forceRender: true,
+                  id: 'nested-alert-dialog-backdrop',
+                }}
+              >
+                <AlertDialogTitle>Nested confirmation</AlertDialogTitle>
+              </AlertDialogContent>
+            </AlertDialog>
           </AlertDialogContent>
         </AlertDialog>,
       )
 
-      await expect.element(screen.getByTestId('actions')).toHaveClass('custom-actions')
+      const backdrop = document.querySelector('#nested-alert-dialog-backdrop')
+      expect(backdrop).toBeInstanceOf(HTMLElement)
+      expect(getComputedStyle(backdrop as HTMLElement).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+      await expect
+        .element(screen.getByRole('alertdialog', { name: 'Nested confirmation' }))
+        .not.toHaveAttribute('id', 'nested-alert-dialog-backdrop')
+    })
+  })
+
+  describe('Dismissal', () => {
+    it('should remain open when the user clicks outside the alert dialog', async () => {
+      const screen = await render(
+        <AlertDialog defaultOpen>
+          <AlertDialogContent>
+            <AlertDialogTitle>Delete project?</AlertDialogTitle>
+            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+            <AlertDialogCancelButton>Cancel</AlertDialogCancelButton>
+          </AlertDialogContent>
+        </AlertDialog>,
+      )
+
+      await userEvent.click(document.body)
+
+      await expect
+        .element(screen.getByRole('alertdialog', { name: 'Delete project?' }))
+        .toBeInTheDocument()
+    })
+
+    it('should close when the user activates the cancel action', async () => {
+      const screen = await render(
+        <AlertDialog defaultOpen>
+          <AlertDialogContent>
+            <AlertDialogTitle>Delete project?</AlertDialogTitle>
+            <AlertDialogCancelButton>Cancel</AlertDialogCancelButton>
+          </AlertDialogContent>
+        </AlertDialog>,
+      )
+
+      await screen.getByRole('button', { name: 'Cancel' }).click()
+
+      await expect.element(screen.getByRole('alertdialog')).not.toBeInTheDocument()
+    })
+
+    it('should close with Escape and restore focus to the trigger', async () => {
+      const screen = await render(
+        <AlertDialog>
+          <AlertDialogTrigger>Delete project</AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogTitle>Delete project?</AlertDialogTitle>
+            <AlertDialogCancelButton>Cancel</AlertDialogCancelButton>
+          </AlertDialogContent>
+        </AlertDialog>,
+      )
+
+      const trigger = screen.getByRole('button', { name: 'Delete project' })
+      await trigger.click()
+      await userEvent.keyboard('{Escape}')
+
+      await expect.element(screen.getByRole('alertdialog')).not.toBeInTheDocument()
+      await expect.element(trigger).toHaveFocus()
     })
   })
 })

--- a/packages/dify-ui/src/alert-dialog/index.tsx
+++ b/packages/dify-ui/src/alert-dialog/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import type * as React from 'react'
 import type { ButtonProps } from '../button'
 import { AlertDialog as BaseAlertDialog } from '@base-ui/react/alert-dialog'
+import * as React from 'react'
 import { Button } from '../button'
 import { cn } from '../cn'
 import { modalBackdropClassName, modalPopupAnimationClassName } from '../overlay-shared'

--- a/packages/dify-ui/src/alert-dialog/index.tsx
+++ b/packages/dify-ui/src/alert-dialog/index.tsx
@@ -17,31 +17,36 @@ type AlertDialogTriggerProps<Payload = unknown> = BaseAlertDialog.Trigger.Props<
 type AlertDialogTitleProps = BaseAlertDialog.Title.Props
 type AlertDialogDescriptionProps = BaseAlertDialog.Description.Props
 
-type AlertDialogContentProps = {
+type AlertDialogBackdropProps = Omit<BaseAlertDialog.Backdrop.Props, 'className'> & {
+  className?: string
+}
+
+function AlertDialogBackdrop({ className, ...props }: AlertDialogBackdropProps) {
+  return <BaseAlertDialog.Backdrop {...props} className={cn(modalBackdropClassName, className)} />
+}
+
+type AlertDialogContentProps = Omit<BaseAlertDialog.Popup.Props, 'children' | 'className'> & {
   children: React.ReactNode
   className?: string
-  backdropClassName?: string
-  backdropProps?: Omit<BaseAlertDialog.Backdrop.Props, 'className'>
+  backdropProps?: AlertDialogBackdropProps
 }
 
 function AlertDialogContent({
   children,
   className,
-  backdropClassName,
   backdropProps,
+  ...props
 }: AlertDialogContentProps) {
   return (
     <BaseAlertDialog.Portal>
-      <BaseAlertDialog.Backdrop
-        {...backdropProps}
-        className={cn(modalBackdropClassName, backdropClassName)}
-      />
+      <AlertDialogBackdrop {...backdropProps} />
       <BaseAlertDialog.Popup
         className={cn(
           'fixed top-1/2 left-1/2 z-50 max-h-[calc(100vh-2rem)] w-120 max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto overscroll-contain rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
           modalPopupAnimationClassName,
           className,
         )}
+        {...props}
       >
         {children}
       </BaseAlertDialog.Popup>

--- a/packages/dify-ui/src/autocomplete/index.tsx
+++ b/packages/dify-ui/src/autocomplete/index.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import type { Placement } from '../placement'
 import { Autocomplete as BaseAutocomplete } from '@base-ui/react/autocomplete'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 import { textControlCompoundInputFocusClassName } from '../form-control-shared'
 import {

--- a/packages/dify-ui/src/button/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/button/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
 import { Button } from '../index'

--- a/packages/dify-ui/src/checkbox/index.tsx
+++ b/packages/dify-ui/src/checkbox/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import type { Checkbox as BaseCheckboxNS } from '@base-ui/react/checkbox'
-import type * as React from 'react'
 import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox'
+import * as React from 'react'
 import { cn } from '../cn'
 
 const checkboxRootClassName = cn(

--- a/packages/dify-ui/src/combobox/index.tsx
+++ b/packages/dify-ui/src/combobox/index.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import type { Placement } from '../placement'
 import { Combobox as BaseCombobox } from '@base-ui/react/combobox'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 import { formLabelClassName, textControlCompoundInputFocusClassName } from '../form-control-shared'
 import {

--- a/packages/dify-ui/src/combobox/index.tsx
+++ b/packages/dify-ui/src/combobox/index.tsx
@@ -568,5 +568,4 @@ export type {
   ComboboxStatusProps,
   ComboboxTriggerProps,
   ComboboxValueProps,
-  Placement,
 }

--- a/packages/dify-ui/src/context-menu/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/context-menu/__tests__/index.spec.tsx
@@ -21,20 +21,14 @@ describe('context-menu wrapper', () => {
       const screen = await renderWithSafeViewport(
         <ContextMenu open>
           <ContextMenuTrigger aria-label="context trigger">Open</ContextMenuTrigger>
-          <ContextMenuContent
-            positionerProps={{ role: 'group', 'aria-label': 'content positioner' }}
-          >
+          <ContextMenuContent>
             <ContextMenuItem>Content action</ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>,
       )
 
-      await expect
-        .element(screen.getByRole('group', { name: 'content positioner' }))
-        .toHaveAttribute('data-side', 'bottom')
-      await expect
-        .element(screen.getByRole('group', { name: 'content positioner' }))
-        .toHaveAttribute('data-align', 'start')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-side', 'bottom')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-align', 'start')
       await expect
         .element(screen.getByRole('menuitem', { name: 'Content action' }))
         .toBeInTheDocument()
@@ -44,61 +38,34 @@ describe('context-menu wrapper', () => {
       const screen = await renderWithSafeViewport(
         <ContextMenu open>
           <ContextMenuTrigger aria-label="context trigger">Open</ContextMenuTrigger>
-          <ContextMenuContent
-            placement="top-end"
-            sideOffset={12}
-            alignOffset={-3}
-            positionerProps={{ role: 'group', 'aria-label': 'custom content positioner' }}
-          >
+          <ContextMenuContent placement="top-end" sideOffset={12} alignOffset={-3}>
             <ContextMenuItem>Custom content</ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>,
       )
 
-      await expect
-        .element(screen.getByRole('group', { name: 'custom content positioner' }))
-        .toHaveAttribute('data-side', 'top')
-      await expect
-        .element(screen.getByRole('group', { name: 'custom content positioner' }))
-        .toHaveAttribute('data-align', 'start')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-side', 'top')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-align', 'start')
       await expect
         .element(screen.getByRole('menuitem', { name: 'Custom content' }))
         .toBeInTheDocument()
     })
 
-    it('should forward passthrough attributes and handlers when positionerProps and popupProps are provided', async () => {
-      const handlePositionerMouseEnter = vi.fn()
+    it('should forward popup attributes and handlers directly', async () => {
       const handlePopupClick = vi.fn()
 
       const screen = await render(
         <ContextMenu open>
           <ContextMenuTrigger aria-label="context trigger">Open</ContextMenuTrigger>
-          <ContextMenuContent
-            positionerProps={{
-              role: 'group',
-              'aria-label': 'context content positioner',
-              id: 'context-content-positioner',
-              onMouseEnter: handlePositionerMouseEnter,
-            }}
-            popupProps={{
-              role: 'menu',
-              id: 'context-content-popup',
-              onClick: handlePopupClick,
-            }}
-          >
+          <ContextMenuContent id="context-content-popup" onClick={handlePopupClick}>
             <ContextMenuItem>Passthrough content</ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>,
       )
 
-      await screen.getByRole('group', { name: 'context content positioner' }).hover()
       await screen.getByRole('menu').click()
 
-      await expect
-        .element(screen.getByRole('group', { name: 'context content positioner' }))
-        .toHaveAttribute('id', 'context-content-positioner')
       await expect.element(screen.getByRole('menu')).toHaveAttribute('id', 'context-content-popup')
-      expect(handlePositionerMouseEnter).toHaveBeenCalled()
       expect(handlePopupClick).toHaveBeenCalledTimes(1)
     })
   })
@@ -111,9 +78,7 @@ describe('context-menu wrapper', () => {
           <ContextMenuContent>
             <ContextMenuSub open>
               <ContextMenuSubTrigger>More actions</ContextMenuSubTrigger>
-              <ContextMenuSubContent
-                positionerProps={{ role: 'group', 'aria-label': 'sub positioner' }}
-              >
+              <ContextMenuSubContent>
                 <ContextMenuItem>Sub action</ContextMenuItem>
               </ContextMenuSubContent>
             </ContextMenuSub>
@@ -122,10 +87,10 @@ describe('context-menu wrapper', () => {
       )
 
       await expect
-        .element(screen.getByRole('group', { name: 'sub positioner' }))
+        .element(screen.getByRole('menu', { name: 'More actions' }))
         .toHaveAttribute('data-side', 'right')
       await expect
-        .element(screen.getByRole('group', { name: 'sub positioner' }))
+        .element(screen.getByRole('menu', { name: 'More actions' }))
         .toHaveAttribute('data-align', 'start')
       await expect.element(screen.getByRole('menuitem', { name: 'Sub action' })).toBeInTheDocument()
     })

--- a/packages/dify-ui/src/context-menu/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/context-menu/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { render } from 'vitest-browser-react'
 import {
   ContextMenu,

--- a/packages/dify-ui/src/context-menu/index.stories.tsx
+++ b/packages/dify-ui/src/context-menu/index.stories.tsx
@@ -50,7 +50,7 @@ export const Default: Story = {
   render: () => (
     <ContextMenu>
       <TriggerArea />
-      <ContextMenuContent popupClassName="w-36">
+      <ContextMenuContent className="w-36">
         <ContextMenuItem>Edit</ContextMenuItem>
         <ContextMenuItem>Duplicate</ContextMenuItem>
         <ContextMenuItem>Archive</ContextMenuItem>
@@ -63,13 +63,13 @@ export const WithSubmenu: Story = {
   render: () => (
     <ContextMenu>
       <TriggerArea />
-      <ContextMenuContent popupClassName="w-36">
+      <ContextMenuContent className="w-36">
         <ContextMenuItem>Copy</ContextMenuItem>
         <ContextMenuItem>Paste</ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuSub>
           <ContextMenuSubTrigger>Share</ContextMenuSubTrigger>
-          <ContextMenuSubContent popupClassName="w-36">
+          <ContextMenuSubContent className="w-36">
             <ContextMenuItem>Email</ContextMenuItem>
             <ContextMenuItem>Slack</ContextMenuItem>
             <ContextMenuItem>Copy link</ContextMenuItem>
@@ -84,7 +84,7 @@ export const WithGroupLabel: Story = {
   render: () => (
     <ContextMenu>
       <TriggerArea />
-      <ContextMenuContent popupClassName="w-44">
+      <ContextMenuContent className="w-44">
         <ContextMenuGroup>
           <ContextMenuLabel>Actions</ContextMenuLabel>
           <ContextMenuItem>Rename</ContextMenuItem>
@@ -108,7 +108,7 @@ const WithRadioItemsDemo = () => {
   return (
     <ContextMenu>
       <TriggerArea label={`Right-click to set density: ${density}`} />
-      <ContextMenuContent popupClassName="w-44">
+      <ContextMenuContent className="w-44">
         <ContextMenuRadioGroup<Density> value={density} onValueChange={setDensity}>
           <ContextMenuRadioItem<Density> value="compact">
             Compact
@@ -140,7 +140,7 @@ const WithCheckboxItemsDemo = () => {
   return (
     <ContextMenu>
       <TriggerArea label="Right-click to configure panel visibility" />
-      <ContextMenuContent popupClassName="w-44">
+      <ContextMenuContent className="w-44">
         <ContextMenuCheckboxItem checked={showToolbar} onCheckedChange={setShowToolbar}>
           Toolbar
           <ContextMenuCheckboxItemIndicator />
@@ -166,7 +166,7 @@ export const WithLinkItems: Story = {
   render: () => (
     <ContextMenu>
       <TriggerArea label="Right-click to open links" />
-      <ContextMenuContent popupClassName="w-56">
+      <ContextMenuContent className="w-56">
         <ContextMenuLinkItem href="https://docs.dify.ai" rel="noopener noreferrer" target="_blank">
           Dify Docs
         </ContextMenuLinkItem>
@@ -195,7 +195,7 @@ export const Complex: Story = {
   render: () => (
     <ContextMenu>
       <TriggerArea label="Right-click to inspect all menu capabilities" />
-      <ContextMenuContent popupClassName="w-44">
+      <ContextMenuContent className="w-44">
         <ContextMenuItem>
           <span aria-hidden className="i-ri-pencil-line size-4 shrink-0 text-text-tertiary" />
           Rename
@@ -210,7 +210,7 @@ export const Complex: Story = {
             <span aria-hidden className="i-ri-share-line size-4 shrink-0 text-text-tertiary" />
             Share
           </ContextMenuSubTrigger>
-          <ContextMenuSubContent popupClassName="w-36">
+          <ContextMenuSubContent className="w-36">
             <ContextMenuItem>Email</ContextMenuItem>
             <ContextMenuItem>Slack</ContextMenuItem>
             <ContextMenuItem>Copy Link</ContextMenuItem>

--- a/packages/dify-ui/src/context-menu/index.tsx
+++ b/packages/dify-ui/src/context-menu/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import type * as React from 'react'
 import type { MenuItemVariant } from '../overlay-shared'
 import type { Placement } from '../placement'
 import { ContextMenu as BaseContextMenu } from '@base-ui/react/context-menu'
+import * as React from 'react'
 import { cn } from '../cn'
 import {
   floatingGroupLabelClassName,

--- a/packages/dify-ui/src/context-menu/index.tsx
+++ b/packages/dify-ui/src/context-menu/index.tsx
@@ -45,40 +45,21 @@ function ContextMenuRadioGroup<Value = unknown>(
   return <BaseContextMenu.RadioGroup {...props} />
 }
 
-type ContextMenuContentProps = {
-  children: React.ReactNode
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
-  className?: string
-  popupClassName?: string
-  positionerProps?: Omit<
-    BaseContextMenu.Positioner.Props,
-    'children' | 'className' | 'side' | 'align' | 'sideOffset' | 'alignOffset'
-  >
-  popupProps?: Omit<BaseContextMenu.Popup.Props, 'children' | 'className'>
-}
+type ContextMenuContentProps = Omit<BaseContextMenu.Popup.Props, 'children' | 'className'> &
+  Pick<BaseContextMenu.Positioner.Props, 'sideOffset' | 'alignOffset'> & {
+    children: React.ReactNode
+    placement?: Placement
+    className?: string
+  }
 
-type ContextMenuPopupRenderProps = Required<Pick<ContextMenuContentProps, 'children'>> & {
-  placement: Placement
-  sideOffset: number
-  alignOffset: number
-  className?: string
-  popupClassName?: string
-  positionerProps?: ContextMenuContentProps['positionerProps']
-  popupProps?: ContextMenuContentProps['popupProps']
-}
-
-function renderContextMenuPopup({
+function ContextMenuContent({
   children,
-  placement,
-  sideOffset,
-  alignOffset,
+  placement = 'bottom-start',
+  sideOffset = 0,
+  alignOffset = 0,
   className,
-  popupClassName,
-  positionerProps,
-  popupProps,
-}: ContextMenuPopupRenderProps) {
+  ...props
+}: ContextMenuContentProps) {
   const { side, align } = parsePlacement(placement)
 
   return (
@@ -88,40 +69,17 @@ function renderContextMenuPopup({
         align={align}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
-        className={cn('z-50 outline-hidden', className)}
-        {...positionerProps}
+        className="z-50 outline-hidden"
       >
         <BaseContextMenu.Popup
-          className={cn(menuPopupClassName, floatingPopupAnimationClassName, popupClassName)}
-          {...popupProps}
+          className={cn(menuPopupClassName, floatingPopupAnimationClassName, className)}
+          {...props}
         >
           {children}
         </BaseContextMenu.Popup>
       </BaseContextMenu.Positioner>
     </BaseContextMenu.Portal>
   )
-}
-
-function ContextMenuContent({
-  children,
-  placement = 'bottom-start',
-  sideOffset = 0,
-  alignOffset = 0,
-  className,
-  popupClassName,
-  positionerProps,
-  popupProps,
-}: ContextMenuContentProps) {
-  return renderContextMenuPopup({
-    children,
-    placement,
-    sideOffset,
-    alignOffset,
-    className,
-    popupClassName,
-    positionerProps,
-    popupProps,
-  })
 }
 
 type ContextMenuItemProps = Omit<BaseContextMenu.Item.Props, 'className'> & {
@@ -247,16 +205,7 @@ function ContextMenuSubTrigger({
   )
 }
 
-type ContextMenuSubContentProps = {
-  children: React.ReactNode
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
-  className?: string
-  popupClassName?: string
-  positionerProps?: ContextMenuContentProps['positionerProps']
-  popupProps?: ContextMenuContentProps['popupProps']
-}
+type ContextMenuSubContentProps = ContextMenuContentProps
 
 function ContextMenuSubContent({
   children,
@@ -264,20 +213,28 @@ function ContextMenuSubContent({
   sideOffset = 4,
   alignOffset = 0,
   className,
-  popupClassName,
-  positionerProps,
-  popupProps,
+  ...props
 }: ContextMenuSubContentProps) {
-  return renderContextMenuPopup({
-    children,
-    placement,
-    sideOffset,
-    alignOffset,
-    className,
-    popupClassName,
-    positionerProps,
-    popupProps,
-  })
+  const { side, align } = parsePlacement(placement)
+
+  return (
+    <BaseContextMenu.Portal>
+      <BaseContextMenu.Positioner
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
+        className="z-50 outline-hidden"
+      >
+        <BaseContextMenu.Popup
+          className={cn(menuPopupClassName, floatingPopupAnimationClassName, className)}
+          {...props}
+        >
+          {children}
+        </BaseContextMenu.Popup>
+      </BaseContextMenu.Positioner>
+    </BaseContextMenu.Portal>
+  )
 }
 
 type ContextMenuLabelProps = Omit<BaseContextMenu.GroupLabel.Props, 'className'> & {

--- a/packages/dify-ui/src/dialog/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/dialog/__tests__/index.spec.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { render } from 'vitest-browser-react'
 import { IconButton } from '../../icon-button'
 import {
@@ -12,6 +13,22 @@ import {
 
 describe('Dialog wrapper', () => {
   describe('Rendering', () => {
+    it('should move focus to the requested initial target', async () => {
+      const initialFocusRef = React.createRef<HTMLButtonElement>()
+      const screen = await render(
+        <Dialog open>
+          <DialogContent initialFocus={initialFocusRef}>
+            <DialogTitle>Dialog Title</DialogTitle>
+            <button ref={initialFocusRef} type="button">
+              Focus target
+            </button>
+          </DialogContent>
+        </Dialog>,
+      )
+
+      await expect.element(screen.getByRole('button', { name: 'Focus target' })).toHaveFocus()
+    })
+
     it('should render dialog content when dialog is open', async () => {
       const screen = await render(
         <Dialog open>
@@ -24,6 +41,34 @@ describe('Dialog wrapper', () => {
 
       await expect.element(screen.getByRole('dialog')).toHaveTextContent('Dialog Title')
       await expect.element(screen.getByRole('dialog')).toHaveTextContent('Dialog Description')
+    })
+
+    it('should apply backdrop props to a nested dialog backdrop', async () => {
+      const screen = await render(
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>Parent dialog</DialogTitle>
+            <Dialog open>
+              <DialogContent
+                backdropProps={{
+                  className: 'bg-transparent',
+                  forceRender: true,
+                  id: 'nested-dialog-backdrop',
+                }}
+              >
+                <DialogTitle>Nested dialog</DialogTitle>
+              </DialogContent>
+            </Dialog>
+          </DialogContent>
+        </Dialog>,
+      )
+
+      const backdrop = document.querySelector('#nested-dialog-backdrop')
+      expect(backdrop).toBeInstanceOf(HTMLElement)
+      expect(getComputedStyle(backdrop as HTMLElement).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+      await expect
+        .element(screen.getByRole('dialog', { name: 'Nested dialog' }))
+        .not.toHaveAttribute('id', 'nested-dialog-backdrop')
     })
 
     it('should connect a detached trigger to the dialog', async () => {

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import type * as React from 'react'
 import { Dialog as BaseDialog } from '@base-ui/react/dialog'
+import * as React from 'react'
 import { cn } from '../cn'
 import { modalBackdropClassName, modalPopupAnimationClassName } from '../overlay-shared'
 

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -54,27 +54,22 @@ function DialogPopup({ className, ...props }: DialogPopupProps) {
   )
 }
 
-type DialogContentProps = {
+type DialogContentProps = Omit<DialogPopupProps, 'children' | 'className'> & {
   children: React.ReactNode
   className?: string
-  backdropClassName?: string
-  backdropProps?: Omit<BaseDialog.Backdrop.Props, 'className'>
+  backdropProps?: DialogBackdropProps
 }
 
-function DialogContent({
-  children,
-  className,
-  backdropClassName,
-  backdropProps,
-}: DialogContentProps) {
+function DialogContent({ children, className, backdropProps, ...props }: DialogContentProps) {
   return (
     <DialogPortal>
-      <DialogBackdrop {...backdropProps} className={backdropClassName} />
+      <DialogBackdrop {...backdropProps} />
       <DialogPopup
         className={cn(
           'fixed top-1/2 left-1/2 max-h-[80dvh] w-120 max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto overscroll-contain p-6',
           className,
         )}
+        {...props}
       >
         {children}
       </DialogPopup>

--- a/packages/dify-ui/src/drawer/index.tsx
+++ b/packages/dify-ui/src/drawer/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import type * as React from 'react'
 import { Drawer as BaseDrawer } from '@base-ui/react/drawer'
+import * as React from 'react'
 import { cn } from '../cn'
 import { iconButtonVariants } from '../icon-button/variants'
 

--- a/packages/dify-ui/src/dropdown-menu/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/dropdown-menu/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { render } from 'vitest-browser-react'
 import {
   DropdownMenu,

--- a/packages/dify-ui/src/dropdown-menu/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/dropdown-menu/__tests__/index.spec.tsx
@@ -5,6 +5,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLinkItem,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -21,20 +24,14 @@ describe('dropdown-menu wrapper', () => {
       const screen = await renderWithSafeViewport(
         <DropdownMenu open>
           <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
-          <DropdownMenuContent
-            positionerProps={{ role: 'group', 'aria-label': 'content positioner' }}
-          >
+          <DropdownMenuContent>
             <DropdownMenuItem>Content action</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>,
       )
 
-      await expect
-        .element(screen.getByRole('group', { name: 'content positioner' }))
-        .toHaveAttribute('data-side', 'bottom')
-      await expect
-        .element(screen.getByRole('group', { name: 'content positioner' }))
-        .toHaveAttribute('data-align', 'end')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-side', 'bottom')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-align', 'end')
       await expect
         .element(screen.getByRole('menuitem', { name: 'Content action' }))
         .toBeInTheDocument()
@@ -44,62 +41,57 @@ describe('dropdown-menu wrapper', () => {
       const screen = await renderWithSafeViewport(
         <DropdownMenu open>
           <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
-          <DropdownMenuContent
-            placement="top-start"
-            sideOffset={12}
-            alignOffset={-3}
-            positionerProps={{ role: 'group', 'aria-label': 'custom content positioner' }}
-          >
+          <DropdownMenuContent placement="top-start" sideOffset={12} alignOffset={-3}>
             <DropdownMenuItem>Custom content</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>,
       )
 
-      await expect
-        .element(screen.getByRole('group', { name: 'custom content positioner' }))
-        .toHaveAttribute('data-side', 'top')
-      await expect
-        .element(screen.getByRole('group', { name: 'custom content positioner' }))
-        .toHaveAttribute('data-align', 'start')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-side', 'top')
+      await expect.element(screen.getByRole('menu')).toHaveAttribute('data-align', 'start')
       await expect
         .element(screen.getByRole('menuitem', { name: 'Custom content' }))
         .toBeInTheDocument()
     })
 
-    it('should forward passthrough attributes and handlers when positionerProps and popupProps are provided', async () => {
-      const handlePositionerMouseEnter = vi.fn()
+    it('should forward popup attributes and handlers directly', async () => {
       const handlePopupClick = vi.fn()
 
       const screen = await render(
         <DropdownMenu open>
           <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
-          <DropdownMenuContent
-            positionerProps={{
-              role: 'group',
-              'aria-label': 'dropdown content positioner',
-              id: 'dropdown-content-positioner',
-              onMouseEnter: handlePositionerMouseEnter,
-            }}
-            popupProps={{
-              role: 'menu',
-              id: 'dropdown-content-popup',
-              onClick: handlePopupClick,
-            }}
-          >
+          <DropdownMenuContent id="dropdown-content-popup" onClick={handlePopupClick}>
             <DropdownMenuItem>Passthrough content</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>,
       )
 
-      await screen.getByRole('group', { name: 'dropdown content positioner' }).hover()
       await screen.getByRole('menu').click()
 
-      await expect
-        .element(screen.getByRole('group', { name: 'dropdown content positioner' }))
-        .toHaveAttribute('id', 'dropdown-content-positioner')
       await expect.element(screen.getByRole('menu')).toHaveAttribute('id', 'dropdown-content-popup')
-      expect(handlePositionerMouseEnter).toHaveBeenCalledTimes(1)
       expect(handlePopupClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should support explicit anatomy when the positioner needs custom props', async () => {
+      const screen = await renderWithSafeViewport(
+        <DropdownMenu open>
+          <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner data-testid="custom-positioner" placement="top-start">
+              <DropdownMenuPopup>
+                <DropdownMenuItem>Anatomy action</DropdownMenuItem>
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
+        </DropdownMenu>,
+      )
+
+      await expect
+        .element(screen.getByTestId('custom-positioner'))
+        .toHaveAttribute('data-side', 'top')
+      await expect
+        .element(screen.getByRole('menuitem', { name: 'Anatomy action' }))
+        .toBeInTheDocument()
     })
   })
 
@@ -111,9 +103,7 @@ describe('dropdown-menu wrapper', () => {
           <DropdownMenuContent>
             <DropdownMenuSub open>
               <DropdownMenuSubTrigger>More actions</DropdownMenuSubTrigger>
-              <DropdownMenuSubContent
-                positionerProps={{ role: 'group', 'aria-label': 'sub positioner' }}
-              >
+              <DropdownMenuSubContent>
                 <DropdownMenuItem>Sub action</DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
@@ -122,16 +112,15 @@ describe('dropdown-menu wrapper', () => {
       )
 
       await expect
-        .element(screen.getByRole('group', { name: 'sub positioner' }))
+        .element(screen.getByRole('menu', { name: 'More actions' }))
         .toHaveAttribute('data-side', 'left')
       await expect
-        .element(screen.getByRole('group', { name: 'sub positioner' }))
+        .element(screen.getByRole('menu', { name: 'More actions' }))
         .toHaveAttribute('data-align', 'start')
       await expect.element(screen.getByRole('menuitem', { name: 'Sub action' })).toBeInTheDocument()
     })
 
-    it('should apply custom placement and forward passthrough props for sub-content when custom props are provided', async () => {
-      const handlePositionerFocus = vi.fn()
+    it('should apply custom placement and forward popup props for sub-content', async () => {
       const handlePopupClick = vi.fn()
 
       const screen = await render(
@@ -144,17 +133,8 @@ describe('dropdown-menu wrapper', () => {
                 placement="right-end"
                 sideOffset={6}
                 alignOffset={2}
-                positionerProps={{
-                  role: 'group',
-                  'aria-label': 'dropdown sub positioner',
-                  id: 'dropdown-sub-positioner',
-                  onFocus: handlePositionerFocus,
-                }}
-                popupProps={{
-                  role: 'menu',
-                  id: 'dropdown-sub-popup',
-                  onClick: handlePopupClick,
-                }}
+                id="dropdown-sub-popup"
+                onClick={handlePopupClick}
               >
                 <DropdownMenuItem>Custom sub action</DropdownMenuItem>
               </DropdownMenuSubContent>
@@ -163,29 +143,17 @@ describe('dropdown-menu wrapper', () => {
         </DropdownMenu>,
       )
 
-      screen
-        .getByRole('group', { name: 'dropdown sub positioner' })
-        .element()
-        .dispatchEvent(
-          new FocusEvent('focus', {
-            bubbles: true,
-          }),
-        )
       await screen.getByRole('menu', { name: 'More actions' }).click()
 
       await expect
-        .element(screen.getByRole('group', { name: 'dropdown sub positioner' }))
+        .element(screen.getByRole('menu', { name: 'More actions' }))
         .toHaveAttribute('data-side', 'right')
       await expect
-        .element(screen.getByRole('group', { name: 'dropdown sub positioner' }))
+        .element(screen.getByRole('menu', { name: 'More actions' }))
         .toHaveAttribute('data-align', 'end')
-      await expect
-        .element(screen.getByRole('group', { name: 'dropdown sub positioner' }))
-        .toHaveAttribute('id', 'dropdown-sub-positioner')
       await expect
         .element(screen.getByRole('menu', { name: 'More actions' }))
         .toHaveAttribute('id', 'dropdown-sub-popup')
-      expect(handlePositionerFocus).toHaveBeenCalledTimes(1)
       expect(handlePopupClick).toHaveBeenCalledTimes(1)
     })
   })

--- a/packages/dify-ui/src/dropdown-menu/index.tsx
+++ b/packages/dify-ui/src/dropdown-menu/index.tsx
@@ -150,9 +150,8 @@ function DropdownMenuPopup({ className, ...props }: DropdownMenuPopupProps) {
 }
 
 type DropdownMenuContentProps = Omit<DropdownMenuPopupProps, 'children' | 'className'> &
-  Pick<DropdownMenuPositionerProps, 'sideOffset' | 'alignOffset'> & {
+  Pick<DropdownMenuPositionerProps, 'alignOffset' | 'placement' | 'sideOffset'> & {
     children: React.ReactNode
-    placement?: Placement
     className?: string
   }
 
@@ -316,5 +315,4 @@ export type {
   DropdownMenuSubProps,
   DropdownMenuSubTriggerProps,
   DropdownMenuTriggerProps,
-  Placement,
 }

--- a/packages/dify-ui/src/dropdown-menu/index.tsx
+++ b/packages/dify-ui/src/dropdown-menu/index.tsx
@@ -12,17 +12,20 @@ import {
   floatingSeparatorClassName,
   menuItemClassName,
   menuItemDestructiveClassName,
-  menuPopupClassName,
+  menuPopupBaseClassName,
+  menuPopupSurfaceClassName,
 } from '../overlay-shared'
 import { parsePlacement } from '../placement'
 
 const DropdownMenu = Menu.Root
+const DropdownMenuPortal = Menu.Portal
 const DropdownMenuTrigger = Menu.Trigger
 const DropdownMenuSub = Menu.SubmenuRoot
 const DropdownMenuGroup = Menu.Group
 
 type DropdownMenuProps<Payload = unknown> = Menu.Root.Props<Payload>
 type DropdownMenuTriggerProps<Payload = unknown> = Menu.Trigger.Props<Payload>
+type DropdownMenuPortalProps = Menu.Portal.Props
 type DropdownMenuSubProps = Menu.SubmenuRoot.Props
 type DropdownMenuGroupProps = Menu.Group.Props
 type DropdownMenuRadioGroupProps<Value = unknown> = Omit<
@@ -107,62 +110,51 @@ function DropdownMenuLabel({ className, ...props }: DropdownMenuLabelProps) {
   return <Menu.GroupLabel className={cn(floatingGroupLabelClassName, className)} {...props} />
 }
 
-type DropdownMenuContentProps = {
-  children: React.ReactNode
+type DropdownMenuPositionerProps = Omit<Menu.Positioner.Props, 'className' | 'side' | 'align'> & {
+  className?: string
   placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
-  className?: string
-  popupClassName?: string
-  positionerProps?: Omit<
-    Menu.Positioner.Props,
-    'children' | 'className' | 'side' | 'align' | 'sideOffset' | 'alignOffset'
-  >
-  popupProps?: Omit<Menu.Popup.Props, 'children' | 'className'>
 }
 
-type DropdownMenuPopupRenderProps = Required<Pick<DropdownMenuContentProps, 'children'>> & {
-  placement: Placement
-  sideOffset: number
-  alignOffset: number
-  className?: string
-  popupClassName?: string
-  positionerProps?: DropdownMenuContentProps['positionerProps']
-  popupProps?: DropdownMenuContentProps['popupProps']
-}
-
-function renderDropdownMenuPopup({
-  children,
-  placement,
-  sideOffset,
-  alignOffset,
+function DropdownMenuPositioner({
   className,
-  popupClassName,
-  positionerProps,
-  popupProps,
-}: DropdownMenuPopupRenderProps) {
+  placement = 'bottom-end',
+  sideOffset = 4,
+  alignOffset = 0,
+  ...props
+}: DropdownMenuPositionerProps) {
   const { side, align } = parsePlacement(placement)
 
   return (
-    <Menu.Portal>
-      <Menu.Positioner
-        side={side}
-        align={align}
-        sideOffset={sideOffset}
-        alignOffset={alignOffset}
-        className={cn('z-50 outline-hidden', className)}
-        {...positionerProps}
-      >
-        <Menu.Popup
-          className={cn(menuPopupClassName, floatingPopupAnimationClassName, popupClassName)}
-          {...popupProps}
-        >
-          {children}
-        </Menu.Popup>
-      </Menu.Positioner>
-    </Menu.Portal>
+    <Menu.Positioner
+      side={side}
+      align={align}
+      sideOffset={sideOffset}
+      alignOffset={alignOffset}
+      className={cn('z-50 outline-hidden', className)}
+      {...props}
+    />
   )
 }
+
+type DropdownMenuPopupProps = Omit<Menu.Popup.Props, 'className'> & {
+  className?: string
+}
+
+function DropdownMenuPopup({ className, ...props }: DropdownMenuPopupProps) {
+  return (
+    <Menu.Popup
+      className={cn(menuPopupBaseClassName, floatingPopupAnimationClassName, className)}
+      {...props}
+    />
+  )
+}
+
+type DropdownMenuContentProps = Omit<DropdownMenuPopupProps, 'children' | 'className'> &
+  Pick<DropdownMenuPositionerProps, 'sideOffset' | 'alignOffset'> & {
+    children: React.ReactNode
+    placement?: Placement
+    className?: string
+  }
 
 function DropdownMenuContent({
   children,
@@ -170,20 +162,21 @@ function DropdownMenuContent({
   sideOffset = 4,
   alignOffset = 0,
   className,
-  popupClassName,
-  positionerProps,
-  popupProps,
+  ...props
 }: DropdownMenuContentProps) {
-  return renderDropdownMenuPopup({
-    children,
-    placement,
-    sideOffset,
-    alignOffset,
-    className,
-    popupClassName,
-    positionerProps,
-    popupProps,
-  })
+  return (
+    <DropdownMenuPortal>
+      <DropdownMenuPositioner
+        placement={placement}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
+      >
+        <DropdownMenuPopup className={cn(menuPopupSurfaceClassName, className)} {...props}>
+          {children}
+        </DropdownMenuPopup>
+      </DropdownMenuPositioner>
+    </DropdownMenuPortal>
+  )
 }
 
 type DropdownMenuSubTriggerProps = Omit<Menu.SubmenuTrigger.Props, 'className'> & {
@@ -212,16 +205,7 @@ function DropdownMenuSubTrigger({
   )
 }
 
-type DropdownMenuSubContentProps = {
-  children: React.ReactNode
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
-  className?: string
-  popupClassName?: string
-  positionerProps?: DropdownMenuContentProps['positionerProps']
-  popupProps?: DropdownMenuContentProps['popupProps']
-}
+type DropdownMenuSubContentProps = DropdownMenuContentProps
 
 function DropdownMenuSubContent({
   children,
@@ -229,20 +213,21 @@ function DropdownMenuSubContent({
   sideOffset = 4,
   alignOffset = 0,
   className,
-  popupClassName,
-  positionerProps,
-  popupProps,
+  ...props
 }: DropdownMenuSubContentProps) {
-  return renderDropdownMenuPopup({
-    children,
-    placement,
-    sideOffset,
-    alignOffset,
-    className,
-    popupClassName,
-    positionerProps,
-    popupProps,
-  })
+  return (
+    <DropdownMenuPortal>
+      <DropdownMenuPositioner
+        placement={placement}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
+      >
+        <DropdownMenuPopup className={cn(menuPopupSurfaceClassName, className)} {...props}>
+          {children}
+        </DropdownMenuPopup>
+      </DropdownMenuPositioner>
+    </DropdownMenuPortal>
+  )
 }
 
 type DropdownMenuItemProps = Omit<Menu.Item.Props, 'className'> & {
@@ -298,6 +283,9 @@ export {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuLinkItem,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuRadioItemIndicator,
@@ -316,6 +304,9 @@ export type {
   DropdownMenuItemProps,
   DropdownMenuLabelProps,
   DropdownMenuLinkItemProps,
+  DropdownMenuPopupProps,
+  DropdownMenuPortalProps,
+  DropdownMenuPositionerProps,
   DropdownMenuProps,
   DropdownMenuRadioGroupProps,
   DropdownMenuRadioItemIndicatorProps,

--- a/packages/dify-ui/src/dropdown-menu/index.tsx
+++ b/packages/dify-ui/src/dropdown-menu/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import type * as React from 'react'
 import type { MenuItemVariant } from '../overlay-shared'
 import type { Placement } from '../placement'
 import { Menu } from '@base-ui/react/menu'
+import * as React from 'react'
 import { cn } from '../cn'
 import {
   floatingGroupLabelClassName,

--- a/packages/dify-ui/src/icon-button/index.tsx
+++ b/packages/dify-ui/src/icon-button/index.tsx
@@ -2,8 +2,8 @@
 
 import type { Button as BaseButtonNS } from '@base-ui/react/button'
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import { Button as BaseButton } from '@base-ui/react/button'
+import * as React from 'react'
 import { cn } from '../cn'
 import { iconButtonVariants } from './variants'
 

--- a/packages/dify-ui/src/input-group/index.tsx
+++ b/packages/dify-ui/src/input-group/index.tsx
@@ -2,9 +2,9 @@
 
 import type { Input as BaseInputNS } from '@base-ui/react/input'
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import { Input as BaseInput } from '@base-ui/react/input'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 
 const interactiveElementSelector =

--- a/packages/dify-ui/src/kbd/index.stories.tsx
+++ b/packages/dify-ui/src/kbd/index.stories.tsx
@@ -210,7 +210,7 @@ export const InContextMenu: Story = {
       >
         Context menu trigger
       </ContextMenuTrigger>
-      <ContextMenuContent popupClassName="w-60">
+      <ContextMenuContent className="w-60">
         {MENU_ITEMS.map(({ label, icon, hotkey }) => (
           <ContextMenuItem key={label} className="justify-between gap-4">
             <span aria-hidden className={`${icon} size-4 shrink-0 text-text-tertiary`} />

--- a/packages/dify-ui/src/kbd/index.tsx
+++ b/packages/dify-ui/src/kbd/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 
 const kbdVariants = cva(

--- a/packages/dify-ui/src/number-field/index.tsx
+++ b/packages/dify-ui/src/number-field/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import { NumberField as BaseNumberField } from '@base-ui/react/number-field'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 import { textControlCompoundInputFocusClassName } from '../form-control-shared'
 

--- a/packages/dify-ui/src/overlay-shared.ts
+++ b/packages/dify-ui/src/overlay-shared.ts
@@ -8,8 +8,11 @@ export const floatingItemIndicatorClassName = 'ms-auto flex shrink-0 items-cente
 export const floatingGroupLabelClassName =
   'px-3 pb-0.5 pt-1 text-text-tertiary system-xs-medium-uppercase'
 export const floatingSeparatorClassName = 'my-1 h-px bg-divider-subtle'
-export const menuPopupClassName =
-  'max-h-(--available-height) overflow-y-auto overflow-x-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur py-1 text-sm text-text-secondary shadow-lg outline-hidden focus:outline-hidden focus-visible:outline-hidden backdrop-blur-[5px]'
+export const menuPopupBaseClassName =
+  'max-h-(--available-height) overflow-y-auto overflow-x-hidden text-sm text-text-secondary outline-hidden focus:outline-hidden focus-visible:outline-hidden'
+export const menuPopupSurfaceClassName =
+  'rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur py-1 shadow-lg backdrop-blur-[5px]'
+export const menuPopupClassName = `${menuPopupBaseClassName} ${menuPopupSurfaceClassName}`
 export const floatingPopupAnimationClassName =
   'origin-(--transform-origin) transition-[transform,scale,opacity] data-ending-style:scale-95 data-starting-style:scale-95 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:transition-none motion-reduce:transition-none'
 export const modalBackdropClassName =

--- a/packages/dify-ui/src/popover/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/popover/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
 import {
@@ -16,6 +16,25 @@ const renderWithSafeViewport = (ui: React.ReactNode) =>
   render(<div style={{ minHeight: '100vh', minWidth: '100vw', padding: '240px' }}>{ui}</div>)
 
 describe('PopoverContent', () => {
+  describe('Popup props', () => {
+    it('should move focus to the requested initial target', async () => {
+      const initialFocusRef = React.createRef<HTMLButtonElement>()
+      const screen = await renderWithSafeViewport(
+        <Popover open>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent initialFocus={initialFocusRef}>
+            <PopoverTitle>Popover content</PopoverTitle>
+            <button ref={initialFocusRef} type="button">
+              Focus target
+            </button>
+          </PopoverContent>
+        </Popover>,
+      )
+
+      await expect.element(screen.getByRole('button', { name: 'Focus target' })).toHaveFocus()
+    })
+  })
+
   describe('Animation', () => {
     it('should restore focus without waiting for an instant close transition', async () => {
       const animationSettings = globalThis as typeof globalThis & {

--- a/packages/dify-ui/src/popover/index.stories.tsx
+++ b/packages/dify-ui/src/popover/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import type { Placement } from '.'
+import type { PopoverContentProps } from '.'
 import * as React from 'react'
 import {
   createPopoverHandle,
@@ -195,7 +195,9 @@ export const Infotip: Story = {
   ),
 }
 
-const PLACEMENTS: Placement[] = [
+type PopoverPlacement = NonNullable<PopoverContentProps['placement']>
+
+const PLACEMENTS: PopoverPlacement[] = [
   'top-start',
   'top',
   'top-end',
@@ -211,7 +213,7 @@ const PLACEMENTS: Placement[] = [
 ]
 
 const PlacementsDemo = () => {
-  const [placement, setPlacement] = React.useState<Placement>('bottom')
+  const [placement, setPlacement] = React.useState<PopoverPlacement>('bottom')
 
   return (
     <div className="flex flex-col items-center gap-4 p-20">

--- a/packages/dify-ui/src/popover/index.tsx
+++ b/packages/dify-ui/src/popover/index.tsx
@@ -69,9 +69,8 @@ function PopoverPopup({ className, ...props }: PopoverPopupProps) {
 }
 
 type PopoverContentProps = Omit<PopoverPopupProps, 'children' | 'className'> &
-  Pick<PopoverPositionerProps, 'sideOffset' | 'alignOffset'> & {
+  Pick<PopoverPositionerProps, 'alignOffset' | 'placement' | 'sideOffset'> & {
     children: React.ReactNode
-    placement?: Placement
     className?: string
   }
 
@@ -114,7 +113,6 @@ export {
   PopoverTrigger,
 }
 export type {
-  Placement,
   PopoverArrowProps,
   PopoverCloseProps,
   PopoverContentProps,

--- a/packages/dify-ui/src/popover/index.tsx
+++ b/packages/dify-ui/src/popover/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import type * as React from 'react'
 import type { Placement } from '../placement'
 import { Popover as BasePopover } from '@base-ui/react/popover'
+import * as React from 'react'
 import { cn } from '../cn'
 import { floatingPopupAnimationClassName } from '../overlay-shared'
 import { parsePlacement } from '../placement'

--- a/packages/dify-ui/src/popover/index.tsx
+++ b/packages/dify-ui/src/popover/index.tsx
@@ -68,13 +68,12 @@ function PopoverPopup({ className, ...props }: PopoverPopupProps) {
   )
 }
 
-type PopoverContentProps = {
-  children: React.ReactNode
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
-  className?: string
-}
+type PopoverContentProps = Omit<PopoverPopupProps, 'children' | 'className'> &
+  Pick<PopoverPositionerProps, 'sideOffset' | 'alignOffset'> & {
+    children: React.ReactNode
+    placement?: Placement
+    className?: string
+  }
 
 function PopoverContent({
   children,
@@ -82,6 +81,7 @@ function PopoverContent({
   sideOffset = 8,
   alignOffset = 0,
   className,
+  ...props
 }: PopoverContentProps) {
   return (
     <PopoverPortal>
@@ -91,6 +91,7 @@ function PopoverContent({
             'rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
             className,
           )}
+          {...props}
         >
           {children}
         </PopoverPopup>

--- a/packages/dify-ui/src/preview-card/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/preview-card/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { render } from 'vitest-browser-react'
 import {
   PreviewCard,

--- a/packages/dify-ui/src/preview-card/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/preview-card/__tests__/index.spec.tsx
@@ -1,6 +1,13 @@
 import type * as React from 'react'
 import { render } from 'vitest-browser-react'
-import { PreviewCard, PreviewCardContent, PreviewCardTrigger } from '..'
+import {
+  PreviewCard,
+  PreviewCardContent,
+  PreviewCardPopup,
+  PreviewCardPortal,
+  PreviewCardPositioner,
+  PreviewCardTrigger,
+} from '..'
 
 const renderWithSafeViewport = (ui: React.ReactNode) =>
   render(<div style={{ minHeight: '100vh', minWidth: '100vw', padding: '240px' }}>{ui}</div>)
@@ -11,65 +18,51 @@ describe('PreviewCardContent', () => {
       const screen = await renderWithSafeViewport(
         <PreviewCard open>
           <PreviewCardTrigger href="#default-preview">Open</PreviewCardTrigger>
-          <PreviewCardContent
-            positionerProps={{ id: 'default-positioner' }}
-            popupProps={{ id: 'default-popup' }}
-          >
-            <span>Default content</span>
-          </PreviewCardContent>
+          <PreviewCardContent>Default content</PreviewCardContent>
         </PreviewCard>,
       )
 
-      await expect.element(screen.getByText('Default content')).toBeInTheDocument()
-      expect(document.getElementById('default-positioner')).toHaveAttribute('data-side', 'bottom')
-      expect(document.getElementById('default-positioner')).toHaveAttribute('data-align', 'center')
-      expect(document.getElementById('default-popup')).toHaveTextContent('Default content')
+      await expect
+        .element(screen.getByText('Default content'))
+        .toHaveAttribute('data-side', 'bottom')
+      await expect
+        .element(screen.getByText('Default content'))
+        .toHaveAttribute('data-align', 'center')
     })
 
     it('should apply parsed custom placement and custom offsets when placement props are provided', async () => {
       const screen = await renderWithSafeViewport(
         <PreviewCard open>
           <PreviewCardTrigger href="#custom-preview">Open</PreviewCardTrigger>
-          <PreviewCardContent
-            placement="top-end"
-            sideOffset={14}
-            alignOffset={6}
-            positionerProps={{ id: 'custom-positioner' }}
-            popupProps={{ id: 'custom-popup' }}
-          >
-            <span>Custom placement content</span>
+          <PreviewCardContent placement="top-end" sideOffset={14} alignOffset={6}>
+            Custom placement content
           </PreviewCardContent>
         </PreviewCard>,
       )
 
-      await expect.element(screen.getByText('Custom placement content')).toBeInTheDocument()
-      expect(document.getElementById('custom-positioner')).toHaveAttribute('data-side', 'top')
-      expect(document.getElementById('custom-positioner')).toHaveAttribute('data-align', 'end')
-      expect(document.getElementById('custom-popup')).toHaveTextContent('Custom placement content')
+      await expect
+        .element(screen.getByText('Custom placement content'))
+        .toHaveAttribute('data-side', 'top')
+      await expect
+        .element(screen.getByText('Custom placement content'))
+        .toHaveAttribute('data-align', 'end')
     })
   })
 
-  describe('Passthrough props', () => {
-    it('should forward positionerProps and popupProps when passthrough props are provided', async () => {
-      const screen = await render(
+  describe('Surface', () => {
+    it('should provide the default preview card surface', async () => {
+      const screen = await renderWithSafeViewport(
         <PreviewCard open>
-          <PreviewCardTrigger href="#passthrough-preview">Open</PreviewCardTrigger>
-          <PreviewCardContent
-            positionerProps={{
-              id: 'preview-positioner-id',
-            }}
-            popupProps={{
-              id: 'preview-popup-id',
-            }}
-          >
-            <span>Preview body</span>
-          </PreviewCardContent>
+          <PreviewCardTrigger href="#default-surface">Open</PreviewCardTrigger>
+          <PreviewCardContent>Default surface</PreviewCardContent>
         </PreviewCard>,
       )
 
-      await expect.element(screen.getByText('Preview body')).toBeInTheDocument()
-      expect(document.getElementById('preview-positioner-id')).toBeInTheDocument()
-      expect(document.getElementById('preview-popup-id')).toBeInTheDocument()
+      const popupStyle = getComputedStyle(screen.getByText('Default surface').element())
+      expect(popupStyle.borderTopWidth).not.toBe('0px')
+      expect(popupStyle.borderTopLeftRadius).not.toBe('0px')
+      expect(popupStyle.backgroundColor).not.toBe('rgba(0, 0, 0, 0)')
+      expect(popupStyle.boxShadow).not.toBe('none')
     })
   })
 
@@ -88,5 +81,32 @@ describe('PreviewCardContent', () => {
         .element(screen.getByRole('link', { name: 'Preview destination' }))
         .toHaveAttribute('href', '/preview-destination')
     })
+  })
+})
+
+describe('PreviewCard anatomy', () => {
+  it('should compose an unstyled popup with explicit positioning', async () => {
+    const screen = await renderWithSafeViewport(
+      <PreviewCard open>
+        <PreviewCardTrigger href="#anatomy-preview">Open</PreviewCardTrigger>
+        <PreviewCardPortal>
+          <PreviewCardPositioner placement="top-end" data-testid="preview-positioner">
+            <PreviewCardPopup>Anatomy surface</PreviewCardPopup>
+          </PreviewCardPositioner>
+        </PreviewCardPortal>
+      </PreviewCard>,
+    )
+
+    await expect
+      .element(screen.getByTestId('preview-positioner'))
+      .toHaveAttribute('data-side', 'top')
+    await expect
+      .element(screen.getByTestId('preview-positioner'))
+      .toHaveAttribute('data-align', 'end')
+    const popupStyle = getComputedStyle(screen.getByText('Anatomy surface').element())
+    expect(popupStyle.borderTopWidth).toBe('0px')
+    expect(popupStyle.borderTopLeftRadius).toBe('0px')
+    expect(popupStyle.backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    expect(popupStyle.boxShadow).toBe('none')
   })
 })

--- a/packages/dify-ui/src/preview-card/index.stories.tsx
+++ b/packages/dify-ui/src/preview-card/index.stories.tsx
@@ -76,7 +76,7 @@ function LinkPreviewDemo() {
 
       <PreviewCard handle={previewCardHandle}>
         {({ payload = typographyPreviewPayload }) => (
-          <PreviewCardContent popupClassName="w-[240px] p-2">
+          <PreviewCardContent className="w-[240px] p-2">
             <div className="flex flex-col gap-2">
               <img
                 width="224"
@@ -149,7 +149,7 @@ const PlacementsDemo = () => {
         <PreviewCardTrigger href="#preview-card-placement" className={triggerButtonClassName}>
           Hover me
         </PreviewCardTrigger>
-        <PreviewCardContent placement={placement} popupClassName="w-56 p-3">
+        <PreviewCardContent placement={placement} className="w-56 p-3">
           <div className="flex flex-col gap-1">
             <div className="text-sm font-semibold text-text-primary">
               placement="
@@ -182,7 +182,7 @@ const CustomDelayDemo = () => (
     >
       Snappy trigger
     </PreviewCardTrigger>
-    <PreviewCardContent popupClassName="w-64 p-3">
+    <PreviewCardContent className="w-64 p-3">
       <div className="flex flex-col gap-1">
         <div className="text-sm font-semibold text-text-primary">Fast hover</div>
         <div className="text-xs text-text-secondary">

--- a/packages/dify-ui/src/preview-card/index.tsx
+++ b/packages/dify-ui/src/preview-card/index.tsx
@@ -71,9 +71,8 @@ function PreviewCardPopup({ className, ...props }: PreviewCardPopupProps) {
 }
 
 type PreviewCardContentProps = Omit<PreviewCardPopupProps, 'children' | 'className'> &
-  Pick<PreviewCardPositionerProps, 'sideOffset' | 'alignOffset'> & {
+  Pick<PreviewCardPositionerProps, 'alignOffset' | 'placement' | 'sideOffset'> & {
     children: React.ReactNode
-    placement?: Placement
     className?: string
   }
 

--- a/packages/dify-ui/src/preview-card/index.tsx
+++ b/packages/dify-ui/src/preview-card/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import type * as React from 'react'
 import type { Placement } from '../placement'
 import { PreviewCard as BasePreviewCard } from '@base-ui/react/preview-card'
+import * as React from 'react'
 import { cn } from '../cn'
 import { floatingPopupAnimationClassName } from '../overlay-shared'
 import { parsePlacement } from '../placement'

--- a/packages/dify-ui/src/preview-card/index.tsx
+++ b/packages/dify-ui/src/preview-card/index.tsx
@@ -20,6 +20,7 @@ import { parsePlacement } from '../placement'
  *   accessible across input modes.
  */
 const PreviewCard = BasePreviewCard.Root
+const PreviewCardPortal = BasePreviewCard.Portal
 const PreviewCardTrigger = BasePreviewCard.Trigger
 const PreviewCardViewport = BasePreviewCard.Viewport
 const createPreviewCardHandle = BasePreviewCard.createHandle
@@ -27,21 +28,54 @@ const createPreviewCardHandle = BasePreviewCard.createHandle
 type PreviewCardProps<Payload = unknown> = BasePreviewCard.Root.Props<Payload>
 type PreviewCardHandle<Payload = unknown> = BasePreviewCard.Handle<Payload>
 type PreviewCardTriggerProps<Payload = unknown> = BasePreviewCard.Trigger.Props<Payload>
+type PreviewCardPortalProps = BasePreviewCard.Portal.Props
 type PreviewCardViewportProps = BasePreviewCard.Viewport.Props
 
-type PreviewCardContentProps = {
-  children: React.ReactNode
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
+type PreviewCardPositionerProps = Omit<
+  BasePreviewCard.Positioner.Props,
+  'className' | 'side' | 'align'
+> & {
   className?: string
-  popupClassName?: string
-  positionerProps?: Omit<
-    BasePreviewCard.Positioner.Props,
-    'children' | 'className' | 'side' | 'align' | 'sideOffset' | 'alignOffset'
-  >
-  popupProps?: Omit<BasePreviewCard.Popup.Props, 'children' | 'className'>
+  placement?: Placement
 }
+
+function PreviewCardPositioner({
+  className,
+  placement = 'bottom',
+  sideOffset = 8,
+  alignOffset = 0,
+  ...props
+}: PreviewCardPositionerProps) {
+  const { side, align } = parsePlacement(placement)
+
+  return (
+    <BasePreviewCard.Positioner
+      side={side}
+      align={align}
+      sideOffset={sideOffset}
+      alignOffset={alignOffset}
+      className={cn('z-50 outline-hidden', className)}
+      {...props}
+    />
+  )
+}
+
+type PreviewCardPopupProps = Omit<BasePreviewCard.Popup.Props, 'className'> & {
+  className?: string
+}
+
+function PreviewCardPopup({ className, ...props }: PreviewCardPopupProps) {
+  return (
+    <BasePreviewCard.Popup className={cn(floatingPopupAnimationClassName, className)} {...props} />
+  )
+}
+
+type PreviewCardContentProps = Omit<PreviewCardPopupProps, 'children' | 'className'> &
+  Pick<PreviewCardPositionerProps, 'sideOffset' | 'alignOffset'> & {
+    children: React.ReactNode
+    placement?: Placement
+    className?: string
+  }
 
 function PreviewCardContent({
   children,
@@ -49,34 +83,26 @@ function PreviewCardContent({
   sideOffset = 8,
   alignOffset = 0,
   className,
-  popupClassName,
-  positionerProps,
-  popupProps,
+  ...props
 }: PreviewCardContentProps) {
-  const { side, align } = parsePlacement(placement)
-
   return (
-    <BasePreviewCard.Portal>
-      <BasePreviewCard.Positioner
-        side={side}
-        align={align}
+    <PreviewCardPortal>
+      <PreviewCardPositioner
+        placement={placement}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
-        className={cn('z-50 outline-hidden', className)}
-        {...positionerProps}
       >
-        <BasePreviewCard.Popup
+        <PreviewCardPopup
           className={cn(
             'rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
-            floatingPopupAnimationClassName,
-            popupClassName,
+            className,
           )}
-          {...popupProps}
+          {...props}
         >
           {children}
-        </BasePreviewCard.Popup>
-      </BasePreviewCard.Positioner>
-    </BasePreviewCard.Portal>
+        </PreviewCardPopup>
+      </PreviewCardPositioner>
+    </PreviewCardPortal>
   )
 }
 
@@ -84,12 +110,18 @@ export {
   createPreviewCardHandle,
   PreviewCard,
   PreviewCardContent,
+  PreviewCardPopup,
+  PreviewCardPortal,
+  PreviewCardPositioner,
   PreviewCardTrigger,
   PreviewCardViewport,
 }
 export type {
   PreviewCardContentProps,
   PreviewCardHandle,
+  PreviewCardPopupProps,
+  PreviewCardPortalProps,
+  PreviewCardPositionerProps,
   PreviewCardProps,
   PreviewCardTriggerProps,
   PreviewCardViewportProps,

--- a/packages/dify-ui/src/radio/index.tsx
+++ b/packages/dify-ui/src/radio/index.tsx
@@ -2,9 +2,9 @@
 
 import type { Radio as BaseRadioNS } from '@base-ui/react/radio'
 import type { RadioGroup as BaseRadioGroupNS } from '@base-ui/react/radio-group'
-import type * as React from 'react'
 import { Radio as BaseRadio } from '@base-ui/react/radio'
 import { RadioGroup as BaseRadioGroup } from '@base-ui/react/radio-group'
+import * as React from 'react'
 import { cn } from '../cn'
 
 type RadioGroupProps<Value = string> = Omit<BaseRadioGroupNS.Props<Value>, 'className'> & {

--- a/packages/dify-ui/src/scroll-area/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/scroll-area/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, UIEvent } from 'react'
+import * as React from 'react'
 import { render } from 'vitest-browser-react'
 import {
   ScrollArea,
@@ -34,9 +34,9 @@ const stubElementMetric = (
 const renderScrollArea = (
   options: {
     rootClassName?: string
-    contentStyle?: CSSProperties
+    contentStyle?: React.CSSProperties
     viewportClassName?: string
-    viewportStyle?: CSSProperties
+    viewportStyle?: React.CSSProperties
     verticalScrollbarClassName?: string
     horizontalScrollbarClassName?: string
     verticalThumbClassName?: string
@@ -134,7 +134,7 @@ describe('scroll area', () => {
       let rootElement: HTMLDivElement | null = null
       let viewportElement: HTMLDivElement | null = null
       let scrollOwner: HTMLDivElement | null = null
-      const onScroll = vi.fn((event: UIEvent<HTMLDivElement>) => {
+      const onScroll = vi.fn((event: React.UIEvent<HTMLDivElement>) => {
         scrollOwner = event.currentTarget
       })
 

--- a/packages/dify-ui/src/scroll-area/index.stories.tsx
+++ b/packages/dify-ui/src/scroll-area/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import type * as React from 'react'
+import * as React from 'react'
 import {
   ScrollArea,
   ScrollAreaContent,

--- a/packages/dify-ui/src/segmented-control/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/segmented-control/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from 'react'
+import * as React from 'react'
 import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
 import { SegmentedControl, SegmentedControlDivider, SegmentedControlItem } from '../index'
@@ -101,7 +101,7 @@ describe('SegmentedControl', () => {
   })
 
   it('uses non-submitting native buttons for its items', async () => {
-    const onSubmit = vi.fn((event: FormEvent) => event.preventDefault())
+    const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault())
     const screen = await render(
       <form onSubmit={onSubmit}>
         <SegmentedControl defaultValue="one" aria-label="View">

--- a/packages/dify-ui/src/segmented-control/index.tsx
+++ b/packages/dify-ui/src/segmented-control/index.tsx
@@ -2,9 +2,9 @@
 
 import type { Radio as BaseRadioNS } from '@base-ui/react/radio'
 import type { RadioGroup as BaseRadioGroupNS } from '@base-ui/react/radio-group'
-import type * as React from 'react'
 import { Radio as BaseRadio } from '@base-ui/react/radio'
 import { RadioGroup as BaseRadioGroup } from '@base-ui/react/radio-group'
+import * as React from 'react'
 import { cn } from '../cn'
 
 type SegmentedControlSelectionProps<Value> =

--- a/packages/dify-ui/src/select/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/select/__tests__/index.spec.tsx
@@ -10,6 +10,10 @@ import {
   SelectItemIndicator,
   SelectItemText,
   SelectLabel,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '../index'
@@ -168,7 +172,7 @@ describe('Select wrappers', () => {
               <SelectTrigger aria-label="deployment target">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent popupProps={{ ref: popupRef }}>
+              <SelectContent ref={popupRef}>
                 <SelectItem value="english">
                   <SelectItemText>
                     Production deployment with a long provider and region identifier
@@ -214,7 +218,7 @@ describe('Select wrappers', () => {
               <SelectTrigger aria-label="package version">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent popupClassName="w-[512px]" popupProps={{ ref: popupRef }}>
+              <SelectContent ref={popupRef} className="w-lg">
                 <SelectItem value="stable">
                   <SelectItemText>Stable package version</SelectItemText>
                 </SelectItem>
@@ -232,7 +236,7 @@ describe('Select wrappers', () => {
       }
     })
 
-    it('should render SelectGroupLabel for grouped options without naming the trigger', async () => {
+    it('should render a group label without replacing the trigger name', async () => {
       const screen = await renderWithSafeViewport(
         <Select open defaultValue="seattle">
           <SelectTrigger aria-label="city select">
@@ -240,7 +244,7 @@ describe('Select wrappers', () => {
           </SelectTrigger>
           <SelectContent>
             <SelectGroup>
-              <SelectGroupLabel className="custom-label">Popular cities</SelectGroupLabel>
+              <SelectGroupLabel>Popular cities</SelectGroupLabel>
               <SelectItem value="seattle">
                 <SelectItemText>Seattle</SelectItemText>
                 <SelectItemIndicator />
@@ -253,71 +257,45 @@ describe('Select wrappers', () => {
       await expect
         .element(screen.getByRole('combobox', { name: 'city select' }))
         .toBeInTheDocument()
-      await expect.element(screen.getByText('Popular cities')).toHaveClass('custom-label')
+      await expect.element(screen.getByText('Popular cities')).toBeInTheDocument()
     })
 
     it('should use positioning attributes when placement is not provided', async () => {
-      const positionerRef = React.createRef<HTMLDivElement>()
-
-      await renderOpenSelect({
-        contentProps: {
-          positionerProps: { ref: positionerRef },
-        },
-      })
+      const screen = await renderOpenSelect()
 
       await vi.waitFor(() => {
-        expect(positionerRef.current).toHaveAttribute('data-side', 'bottom')
-        expect(positionerRef.current).toHaveAttribute('data-align', 'start')
+        const positioner = screen.getByRole('listbox').element().closest('[data-side]')
+        expect(positioner).toHaveAttribute('data-side', 'bottom')
+        expect(positioner).toHaveAttribute('data-align', 'start')
       })
     })
 
     it('should preserve positioning attributes when placement props are provided', async () => {
-      const positionerRef = React.createRef<HTMLDivElement>()
-
-      await renderOpenSelect({
+      const screen = await renderOpenSelect({
         contentProps: {
           placement: 'top-end',
           sideOffset: 12,
           alignOffset: 6,
-          positionerProps: { ref: positionerRef },
         },
       })
 
       await vi.waitFor(() => {
-        expect(positionerRef.current).toHaveAttribute('data-side', 'top')
-        expect(positionerRef.current).toHaveAttribute('data-align', 'end')
+        const positioner = screen.getByRole('listbox').element().closest('[data-side]')
+        expect(positioner).toHaveAttribute('data-side', 'top')
+        expect(positioner).toHaveAttribute('data-align', 'end')
       })
     })
 
-    it('should forward passthrough props to positioner popup and list when passthrough props are provided', async () => {
+    it('should forward popup props directly', async () => {
       const onPopupClick = vi.fn()
-      const onListFocus = vi.fn()
-      const positionerRef = React.createRef<HTMLDivElement>()
       const popupRef = React.createRef<HTMLDivElement>()
-      const listRef = React.createRef<HTMLDivElement>()
 
       const screen = await render(
         <Select open defaultValue="seattle">
           <SelectTrigger aria-label="city select">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent
-            positionerProps={{
-              id: 'select-positioner',
-              ref: positionerRef,
-            }}
-            popupProps={{
-              id: 'select-popup',
-              ref: popupRef,
-              onClick: onPopupClick,
-            }}
-            listProps={{
-              'aria-label': 'select list',
-              id: 'select-list',
-              ref: listRef,
-              onFocus: onListFocus,
-            }}
-          >
+          <SelectContent id="select-popup" ref={popupRef} onClick={onPopupClick}>
             <SelectItem value="seattle">
               <SelectItemText>Seattle</SelectItemText>
               <SelectItemIndicator />
@@ -326,20 +304,42 @@ describe('Select wrappers', () => {
         </Select>,
       )
 
-      popupRef.current?.click()
-      listRef.current?.dispatchEvent(
-        new FocusEvent('focusin', {
-          bubbles: true,
-        }),
+      await screen.getByRole('listbox').click()
+
+      expect(popupRef.current).toHaveAttribute('id', 'select-popup')
+      await expect.element(screen.getByRole('listbox')).toBeVisible()
+      expect(onPopupClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should preserve selection behavior when composed through explicit anatomy', async () => {
+      const onValueChange = vi.fn()
+      const screen = await renderWithSafeViewport(
+        <Select open defaultValue="seattle" onValueChange={onValueChange}>
+          <SelectTrigger aria-label="city select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectPortal>
+            <SelectPositioner>
+              <SelectPopup>
+                <SelectList>
+                  <SelectItem value="seattle">
+                    <SelectItemText>Seattle</SelectItemText>
+                    <SelectItemIndicator />
+                  </SelectItem>
+                  <SelectItem value="new-york">
+                    <SelectItemText>New York</SelectItemText>
+                    <SelectItemIndicator />
+                  </SelectItem>
+                </SelectList>
+              </SelectPopup>
+            </SelectPositioner>
+          </SelectPortal>
+        </Select>,
       )
 
-      expect(positionerRef.current).toHaveAttribute('id', 'select-positioner')
-      expect(popupRef.current).toHaveAttribute('id', 'select-popup')
-      await expect
-        .element(screen.getByRole('listbox', { name: 'select list' }))
-        .toHaveAttribute('id', 'select-list')
-      expect(onPopupClick).toHaveBeenCalledTimes(1)
-      expect(onListFocus).toHaveBeenCalled()
+      await screen.getByRole('option', { name: 'New York' }).click()
+
+      expect(onValueChange.mock.calls[0]?.[0]).toBe('new-york')
     })
   })
 

--- a/packages/dify-ui/src/select/index.stories.tsx
+++ b/packages/dify-ui/src/select/index.stories.tsx
@@ -60,7 +60,7 @@ export const Default: Story = {
         <SelectTrigger aria-label="City">
           <SelectValue placeholder="Select a city" />
         </SelectTrigger>
-        <SelectContent listProps={{ 'aria-label': 'City options' }}>
+        <SelectContent>
           <SelectItem value="seattle">
             <SelectItemText>Seattle</SelectItemText>
             <SelectItemIndicator />
@@ -368,7 +368,7 @@ const MultipleControlledDemo = () => {
             }}
           </SelectValue>
         </SelectTrigger>
-        <SelectContent listProps={{ 'aria-label': 'Deployment region options' }}>
+        <SelectContent>
           {deploymentRegionItems.map((item) => (
             <SelectItem<DeploymentRegion> key={item.value} value={item.value}>
               <SelectItemText>{item.label}</SelectItemText>

--- a/packages/dify-ui/src/select/index.tsx
+++ b/packages/dify-ui/src/select/index.tsx
@@ -183,9 +183,8 @@ function SelectList({ className, ...props }: SelectListProps) {
 }
 
 type SelectContentProps = Omit<SelectPopupProps, 'children' | 'className'> &
-  Pick<SelectPositionerProps, 'sideOffset' | 'alignOffset'> & {
+  Pick<SelectPositionerProps, 'alignOffset' | 'placement' | 'sideOffset'> & {
     children: React.ReactNode
-    placement?: Placement
     className?: string
   }
 

--- a/packages/dify-ui/src/select/index.tsx
+++ b/packages/dify-ui/src/select/index.tsx
@@ -121,25 +121,73 @@ function SelectSeparator({ className, ...props }: SelectSeparatorProps) {
   return <BaseSelect.Separator className={cn(floatingSeparatorClassName, className)} {...props} />
 }
 
-type SelectContentPositionerProps = Omit<
-  BaseSelect.Positioner.Props,
-  'children' | 'className' | 'side' | 'align' | 'sideOffset' | 'alignOffset'
->
-type SelectContentPopupProps = Omit<BaseSelect.Popup.Props, 'children' | 'className'>
-type SelectContentListProps = Omit<BaseSelect.List.Props, 'children' | 'className'>
+const SelectPortal = BaseSelect.Portal
+type SelectPortalProps = BaseSelect.Portal.Props
 
-type SelectContentProps = {
-  children: React.ReactNode
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
+type SelectPositionerProps = Omit<BaseSelect.Positioner.Props, 'className' | 'side' | 'align'> & {
   className?: string
-  popupClassName?: string
-  listClassName?: string
-  positionerProps?: SelectContentPositionerProps
-  popupProps?: SelectContentPopupProps
-  listProps?: SelectContentListProps
+  placement?: Placement
 }
+
+function SelectPositioner({
+  placement = 'bottom-start',
+  sideOffset = 4,
+  alignOffset = 0,
+  alignItemWithTrigger = false,
+  className,
+  ...props
+}: SelectPositionerProps) {
+  const { side, align } = parsePlacement(placement)
+
+  return (
+    <BaseSelect.Positioner
+      side={side}
+      align={align}
+      sideOffset={sideOffset}
+      alignOffset={alignOffset}
+      alignItemWithTrigger={alignItemWithTrigger}
+      className={cn('z-50 outline-hidden', className)}
+      {...props}
+    />
+  )
+}
+
+type SelectPopupProps = Omit<BaseSelect.Popup.Props, 'className'> & {
+  className?: string
+}
+
+function SelectPopup({ className, ...props }: SelectPopupProps) {
+  return (
+    <BaseSelect.Popup
+      className={cn(
+        'max-w-(--available-width) min-w-[min(var(--anchor-width),var(--available-width))] overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg outline-hidden',
+        floatingPopupAnimationClassName,
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+type SelectListProps = Omit<BaseSelect.List.Props, 'className'> & {
+  className?: string
+}
+
+function SelectList({ className, ...props }: SelectListProps) {
+  return (
+    <BaseSelect.List
+      className={cn('max-h-80 overflow-auto p-1 outline-hidden', className)}
+      {...props}
+    />
+  )
+}
+
+type SelectContentProps = Omit<SelectPopupProps, 'children' | 'className'> &
+  Pick<SelectPositionerProps, 'sideOffset' | 'alignOffset'> & {
+    children: React.ReactNode
+    placement?: Placement
+    className?: string
+  }
 
 function SelectContent({
   children,
@@ -147,42 +195,16 @@ function SelectContent({
   sideOffset = 4,
   alignOffset = 0,
   className,
-  popupClassName,
-  listClassName,
-  positionerProps,
-  popupProps,
-  listProps,
+  ...props
 }: SelectContentProps) {
-  const { side, align } = parsePlacement(placement)
-
   return (
-    <BaseSelect.Portal>
-      <BaseSelect.Positioner
-        side={side}
-        align={align}
-        sideOffset={sideOffset}
-        alignOffset={alignOffset}
-        alignItemWithTrigger={false}
-        className={cn('z-50 outline-hidden', className)}
-        {...positionerProps}
-      >
-        <BaseSelect.Popup
-          className={cn(
-            'max-w-(--available-width) min-w-[min(var(--anchor-width),var(--available-width))] overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg outline-hidden',
-            floatingPopupAnimationClassName,
-            popupClassName,
-          )}
-          {...popupProps}
-        >
-          <BaseSelect.List
-            className={cn('max-h-80 overflow-auto p-1 outline-hidden', listClassName)}
-            {...listProps}
-          >
-            {children}
-          </BaseSelect.List>
-        </BaseSelect.Popup>
-      </BaseSelect.Positioner>
-    </BaseSelect.Portal>
+    <SelectPortal>
+      <SelectPositioner placement={placement} sideOffset={sideOffset} alignOffset={alignOffset}>
+        <SelectPopup className={className} {...props}>
+          <SelectList>{children}</SelectList>
+        </SelectPopup>
+      </SelectPositioner>
+    </SelectPortal>
   )
 }
 
@@ -233,6 +255,10 @@ export {
   SelectItemIndicator,
   SelectItemText,
   SelectLabel,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectSeparator,
   SelectTrigger,
   SelectValue,
@@ -246,6 +272,10 @@ export type {
   SelectItemProps,
   SelectItemTextProps,
   SelectLabelProps,
+  SelectListProps,
+  SelectPopupProps,
+  SelectPortalProps,
+  SelectPositionerProps,
   SelectProps,
   SelectSeparatorProps,
   SelectTriggerProps,

--- a/packages/dify-ui/src/select/index.tsx
+++ b/packages/dify-ui/src/select/index.tsx
@@ -2,10 +2,10 @@
 
 import type { ComponentRenderFn, HTMLProps } from '@base-ui/react/types'
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import type { Placement } from '../placement'
 import { Select as BaseSelect } from '@base-ui/react/select'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 import { formLabelClassName } from '../form-control-shared'
 import {

--- a/packages/dify-ui/src/status-dot/index.tsx
+++ b/packages/dify-ui/src/status-dot/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 
 const statusDotVariants = cva('block shrink-0 border border-solid', {

--- a/packages/dify-ui/src/switch/index.tsx
+++ b/packages/dify-ui/src/switch/index.tsx
@@ -2,9 +2,9 @@
 
 import type { Switch as BaseSwitchNS } from '@base-ui/react/switch'
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import { Switch as BaseSwitch } from '@base-ui/react/switch'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 
 const switchRootStateClassName =

--- a/packages/dify-ui/src/textarea/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/textarea/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { render } from 'vitest-browser-react'
 import { Field, FieldDescription, FieldError, FieldLabel } from '../../field'
 import { Form } from '../../form'

--- a/packages/dify-ui/src/textarea/index.tsx
+++ b/packages/dify-ui/src/textarea/index.tsx
@@ -2,9 +2,9 @@
 
 import type { Field as BaseFieldNS } from '@base-ui/react/field'
 import type { VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 import { Field as BaseField } from '@base-ui/react/field'
 import { cva } from 'class-variance-authority'
+import * as React from 'react'
 import { cn } from '../cn'
 import { textControlFocusClassName } from '../form-control-shared'
 

--- a/packages/dify-ui/src/toast/index.tsx
+++ b/packages/dify-ui/src/toast/index.tsx
@@ -6,8 +6,8 @@ import type {
   ToastManagerUpdateOptions,
   ToastObject,
 } from '@base-ui/react/toast'
-import type * as React from 'react'
 import { Toast as BaseToast } from '@base-ui/react/toast'
+import * as React from 'react'
 import { cn } from '../cn'
 import { iconButtonVariants } from '../icon-button/variants'
 

--- a/packages/dify-ui/src/tooltip/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/tooltip/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { render } from 'vitest-browser-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../index'
 

--- a/packages/dify-ui/src/tooltip/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/tooltip/__tests__/index.spec.tsx
@@ -11,48 +11,30 @@ describe('TooltipContent', () => {
       const screen = await renderWithSafeViewport(
         <Tooltip open>
           <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
-          <TooltipContent role="tooltip" aria-label="default tooltip">
-            Tooltip body
-          </TooltipContent>
+          <TooltipContent>Tooltip body</TooltipContent>
         </Tooltip>,
       )
 
-      await expect
-        .element(screen.getByRole('tooltip', { name: 'default tooltip' }))
-        .toHaveAttribute('data-side', 'top')
-      await expect
-        .element(screen.getByRole('tooltip', { name: 'default tooltip' }))
-        .toHaveAttribute('data-align', 'center')
-      await expect
-        .element(screen.getByRole('tooltip', { name: 'default tooltip' }))
-        .toHaveTextContent('Tooltip body')
+      await expect.element(screen.getByText('Tooltip body')).toHaveAttribute('data-side', 'top')
+      await expect.element(screen.getByText('Tooltip body')).toHaveAttribute('data-align', 'center')
     })
 
     it('should apply custom placement when placement props are provided', async () => {
       const screen = await renderWithSafeViewport(
         <Tooltip open>
           <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
-          <TooltipContent
-            placement="bottom-start"
-            sideOffset={16}
-            alignOffset={6}
-            role="tooltip"
-            aria-label="custom tooltip"
-          >
+          <TooltipContent placement="bottom-start" sideOffset={16} alignOffset={6}>
             Custom tooltip body
           </TooltipContent>
         </Tooltip>,
       )
 
       await expect
-        .element(screen.getByRole('tooltip', { name: 'custom tooltip' }))
+        .element(screen.getByText('Custom tooltip body'))
         .toHaveAttribute('data-side', 'bottom')
       await expect
-        .element(screen.getByRole('tooltip', { name: 'custom tooltip' }))
+        .element(screen.getByText('Custom tooltip body'))
         .toHaveAttribute('data-align', 'start')
-      await expect
-        .element(screen.getByRole('tooltip', { name: 'custom tooltip' }))
-        .toHaveTextContent('Custom tooltip body')
     })
   })
 
@@ -65,8 +47,6 @@ describe('TooltipContent', () => {
           <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
           <TooltipContent
             id="tooltip-popup-id"
-            role="tooltip"
-            aria-label="help text"
             data-track-id="tooltip-track"
             onMouseEnter={onMouseEnter}
           >
@@ -75,36 +55,12 @@ describe('TooltipContent', () => {
         </Tooltip>,
       )
 
-      const popup = screen.getByRole('tooltip', { name: 'help text' })
+      const popup = screen.getByText('Tooltip body')
       await popup.hover()
 
       await expect.element(popup).toHaveAttribute('id', 'tooltip-popup-id')
       await expect.element(popup).toHaveAttribute('data-track-id', 'tooltip-track')
-      // Intent of the assertion is "handler is wired up". The exact call count
-      // depends on vitest-browser's pointer simulation and Base UI's internal
-      // pointer tracking (both of which may fire more than one enter event for
-      // a single `.hover()` action), so assert presence, not count.
       expect(onMouseEnter).toHaveBeenCalled()
-    })
-
-    it('should apply className to the popup and positionerClassName to the positioner', async () => {
-      const screen = await render(
-        <Tooltip open>
-          <TooltipTrigger aria-label="tooltip trigger">Trigger</TooltipTrigger>
-          <TooltipContent
-            className="popup-class"
-            positionerClassName="positioner-class"
-            role="tooltip"
-            aria-label="styled tooltip"
-          >
-            Tooltip body
-          </TooltipContent>
-        </Tooltip>,
-      )
-
-      const popup = screen.getByRole('tooltip', { name: 'styled tooltip' }).element()
-      expect(popup).toHaveClass('popup-class')
-      expect(popup.parentElement).toHaveClass('positioner-class')
     })
   })
 })

--- a/packages/dify-ui/src/tooltip/index.tsx
+++ b/packages/dify-ui/src/tooltip/index.tsx
@@ -33,21 +33,18 @@ type TooltipProviderProps = BaseTooltip.Provider.Props
 type TooltipProps<Payload = unknown> = BaseTooltip.Root.Props<Payload>
 type TooltipTriggerProps<Payload = unknown> = BaseTooltip.Trigger.Props<Payload>
 
-type TooltipContentProps = {
-  children: React.ReactNode
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
-  positionerClassName?: string
-  className?: string
-} & Omit<BaseTooltip.Popup.Props, 'children' | 'className'>
+type TooltipContentProps = Omit<BaseTooltip.Popup.Props, 'children' | 'className'> &
+  Pick<BaseTooltip.Positioner.Props, 'sideOffset' | 'alignOffset'> & {
+    children: React.ReactNode
+    placement?: Placement
+    className?: string
+  }
 
 function TooltipContent({
   children,
   placement = 'top',
   sideOffset = 8,
   alignOffset = 0,
-  positionerClassName,
   className,
   ...props
 }: TooltipContentProps) {
@@ -60,7 +57,7 @@ function TooltipContent({
         align={align}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
-        className={cn('z-50 outline-hidden', positionerClassName)}
+        className="z-50 outline-hidden"
       >
         <BaseTooltip.Popup
           className={cn(

--- a/packages/dify-ui/src/tooltip/index.tsx
+++ b/packages/dify-ui/src/tooltip/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import type * as React from 'react'
 import type { Placement } from '../placement'
 import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip'
+import * as React from 'react'
 import { cn } from '../cn'
 import { parsePlacement } from '../placement'
 

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/range-selector.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/time-range-picker/range-selector.tsx
@@ -4,10 +4,13 @@ import type { PeriodParamsWithTimeRange, TimeRange } from '@/app/components/app/
 import type { I18nKeysByPrefix } from '@/types/i18n'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { RiArrowDownSLine } from '@remixicon/react'
@@ -86,18 +89,24 @@ const RangeSelector: FC<Props> = ({ isCustomRange, ranges, onSelect }) => {
           <RiArrowDownSLine className="size-4 text-text-quaternary group-data-popup-open:text-text-secondary" />
         </div>
       </SelectTrigger>
-      <SelectContent className="-translate-x-6" popupClassName="w-[200px]" listClassName="p-1">
-        {items.map((item) => (
-          <SelectItem
-            key={item.value}
-            value={item.value}
-            className="relative h-8 py-0 pr-2 pl-7 system-md-regular"
-          >
-            <SelectItemText className="px-0">{item.name}</SelectItemText>
-            <SelectItemIndicator className="absolute top-2 left-2 ml-0" />
-          </SelectItem>
-        ))}
-      </SelectContent>
+      <SelectPortal>
+        <SelectPositioner className="-translate-x-6">
+          <SelectPopup className="w-[200px]">
+            <SelectList className="p-1">
+              {items.map((item) => (
+                <SelectItem
+                  key={item.value}
+                  value={item.value}
+                  className="relative h-8 py-0 pr-2 pl-7 system-md-regular"
+                >
+                  <SelectItemText className="px-0">{item.name}</SelectItemText>
+                  <SelectItemIndicator className="absolute top-2 left-2 ml-0" />
+                </SelectItem>
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
     </Select>
   )
 }

--- a/web/app/account/(commonLayout)/avatar.tsx
+++ b/web/app/account/(commonLayout)/avatar.tsx
@@ -58,7 +58,7 @@ export default function AppSelector() {
       <DropdownMenuContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="w-60 max-w-80 divide-y divide-divider-subtle bg-components-panel-bg-blur p-0"
+        className="w-60 max-w-80 divide-y divide-divider-subtle bg-components-panel-bg-blur p-0"
       >
         <div className="p-1">
           <div className="flex flex-nowrap items-center px-3 py-2">

--- a/web/app/account/(commonLayout)/delete-account/components/feed-back.tsx
+++ b/web/app/account/(commonLayout)/delete-account/components/feed-back.tsx
@@ -61,7 +61,7 @@ export default function FeedBack(props: DeleteAccountProps) {
     >
       <DialogContent
         className="max-w-120 overflow-hidden!"
-        backdropClassName="bg-background-overlay-backdrop backdrop-blur-[6px]"
+        backdropProps={{ className: 'bg-background-overlay-backdrop backdrop-blur-[6px]' }}
       >
         <DialogTitle className="pr-8 pb-3 title-2xl-semi-bold text-text-primary">
           {t(($) => $['account.feedbackTitle'], { ns: 'common' })}

--- a/web/app/account/(commonLayout)/delete-account/index.tsx
+++ b/web/app/account/(commonLayout)/delete-account/index.tsx
@@ -39,7 +39,7 @@ export default function DeleteAccount(props: DeleteAccountProps) {
     >
       <DialogContent
         className="max-w-120 overflow-hidden!"
-        backdropClassName="bg-background-overlay-backdrop backdrop-blur-[6px]"
+        backdropProps={{ className: 'bg-background-overlay-backdrop backdrop-blur-[6px]' }}
       >
         <DialogTitle className="pr-8 pb-3 title-2xl-semi-bold text-text-primary">
           {t(($) => $['account.delete'], { ns: 'common' })}

--- a/web/app/components/app-sidebar/app-info/app-operations.tsx
+++ b/web/app/components/app-sidebar/app-info/app-operations.tsx
@@ -42,7 +42,7 @@ const AppOperations = ({ appName, operationGroups }: AppOperationsProps) => {
       >
         <span aria-hidden className="i-ri-more-fill size-4" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-40">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-40">
         {visibleGroups.map((group, groupIndex) => (
           <Fragment key={group.map((operation) => operation.id).join('-')}>
             {groupIndex > 0 && <DropdownMenuSeparator />}

--- a/web/app/components/app-sidebar/dataset-info/dropdown.tsx
+++ b/web/app/components/app-sidebar/dataset-info/dropdown.tsx
@@ -11,7 +11,9 @@ import {
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
-  DropdownMenuContent,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
@@ -183,22 +185,22 @@ const DropDown = ({ expand, triggerClassName }: DropDownProps) => {
           </IconButton>
         }
       />
-      <DropdownMenuContent
-        placement={expand ? 'bottom-end' : 'right-start'}
-        sideOffset={4}
-        popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-      >
-        <Menu
-          showEdit={datasetACLCapabilities.canEdit}
-          showDelete={datasetACLCapabilities.canDelete}
-          showExportPipeline={datasetACLCapabilities.canImportExportDSL}
-          showAccessConfig={datasetACLCapabilities.canAccessConfig}
-          openRenameModal={openRenameModal}
-          handleExportPipeline={handleExportPipeline}
-          detectIsUsedByApp={detectIsUsedByApp}
-          openAccessConfig={openAccessConfig}
-        />
-      </DropdownMenuContent>
+      <DropdownMenuPortal>
+        <DropdownMenuPositioner placement={expand ? 'bottom-end' : 'right-start'} sideOffset={4}>
+          <DropdownMenuPopup>
+            <Menu
+              showEdit={datasetACLCapabilities.canEdit}
+              showDelete={datasetACLCapabilities.canDelete}
+              showExportPipeline={datasetACLCapabilities.canImportExportDSL}
+              showAccessConfig={datasetACLCapabilities.canAccessConfig}
+              openRenameModal={openRenameModal}
+              handleExportPipeline={handleExportPipeline}
+              detectIsUsedByApp={detectIsUsedByApp}
+              openAccessConfig={openAccessConfig}
+            />
+          </DropdownMenuPopup>
+        </DropdownMenuPositioner>
+      </DropdownMenuPortal>
       {showRenameModal && (
         <RenameDatasetModal
           show={showRenameModal}

--- a/web/app/components/app-sidebar/snippet-info/dropdown.tsx
+++ b/web/app/components/app-sidebar/snippet-info/dropdown.tsx
@@ -137,7 +137,7 @@ const SnippetInfoDropdown = ({ snippet }: SnippetInfoDropdownProps) => {
             </IconButton>
           }
         />
-        <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-[180px] p-1">
+        <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-[180px] p-1">
           {canCreateAndModifySnippet && (
             <>
               <DropdownMenuItem className="mx-0 gap-2" onClick={handleOpenEditDialog}>

--- a/web/app/components/app/annotation/header-opts/index.tsx
+++ b/web/app/components/app/annotation/header-opts/index.tsx
@@ -95,11 +95,7 @@ const OperationsMenu: FC<OperationsMenuProps> = ({
           />
           {t(($) => $['table.header.bulkExport'], { ns: 'appAnnotation' })}
         </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent
-          placement="left-start"
-          sideOffset={4}
-          popupClassName="min-w-[100px]"
-        >
+        <DropdownMenuSubContent placement="left-start" sideOffset={4} className="min-w-[100px]">
           <DropdownMenuItem
             disabled={annotationUnavailable}
             onClick={() => {
@@ -194,7 +190,7 @@ const HeaderOptions: FC<Props> = ({ appId, onAdd, onAdded, controlUpdateList }) 
         >
           <span aria-hidden className="i-ri-more-fill size-4" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-[155px]">
+        <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-[155px]">
           <OperationsMenu
             list={list}
             onClose={() => setIsOperationsMenuOpen(false)}

--- a/web/app/components/app/app-publisher/environment-tabs/index.tsx
+++ b/web/app/components/app/app-publisher/environment-tabs/index.tsx
@@ -155,7 +155,7 @@ export function PublisherEnvironmentTabs({
           <DropdownMenuContent
             placement="bottom-end"
             sideOffset={4}
-            popupClassName="w-42 rounded-xl p-0"
+            className="w-42 rounded-xl p-0"
           >
             {overflowEnvironments.length > 0 && (
               <DropdownMenuGroup className="p-1">

--- a/web/app/components/app/app-publisher/publish-with-multiple-model.tsx
+++ b/web/app/components/app/app-publisher/publish-with-multiple-model.tsx
@@ -70,7 +70,7 @@ const PublishWithMultipleModel: FC<PublishWithMultipleModelProps> = ({
           <RiArrowDownSLine className="size-3" />
         </>
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-[288px] p-1">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-[288px] p-1">
         <div className="flex h-5.5 items-center px-3 text-xs font-medium text-text-tertiary">
           {t(($) => $.publishAs, { ns: 'appDebug' })}
         </div>

--- a/web/app/components/app/configuration/config-var/config-modal/form-fields.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/form-fields.tsx
@@ -7,10 +7,13 @@ import type { InputVar, UploadFileSetting } from '@/app/components/workflow/type
 import { Checkbox } from '@langgenius/dify-ui/checkbox'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -163,20 +166,26 @@ const ConfigModalFormFields: FC<ConfigModalFormFieldsProps> = ({
                 placeholder={t(($) => $['variableConfig.selectDefaultValue'], { ns: 'appDebug' })}
               />
             </SelectTrigger>
-            <SelectContent listClassName="max-h-[140px] overflow-y-auto">
-              <SelectItem value={CHECKBOX_DEFAULT_TRUE_VALUE}>
-                <SelectItemText>
-                  {t(($) => $['variableConfig.startChecked'], { ns: 'appDebug' })}
-                </SelectItemText>
-                <SelectItemIndicator />
-              </SelectItem>
-              <SelectItem value={CHECKBOX_DEFAULT_FALSE_VALUE}>
-                <SelectItemText>
-                  {t(($) => $['variableConfig.noDefaultSelected'], { ns: 'appDebug' })}
-                </SelectItemText>
-                <SelectItemIndicator />
-              </SelectItem>
-            </SelectContent>
+            <SelectPortal>
+              <SelectPositioner>
+                <SelectPopup>
+                  <SelectList className="max-h-[140px] overflow-y-auto">
+                    <SelectItem value={CHECKBOX_DEFAULT_TRUE_VALUE}>
+                      <SelectItemText>
+                        {t(($) => $['variableConfig.startChecked'], { ns: 'appDebug' })}
+                      </SelectItemText>
+                      <SelectItemIndicator />
+                    </SelectItem>
+                    <SelectItem value={CHECKBOX_DEFAULT_FALSE_VALUE}>
+                      <SelectItemText>
+                        {t(($) => $['variableConfig.noDefaultSelected'], { ns: 'appDebug' })}
+                      </SelectItemText>
+                      <SelectItemIndicator />
+                    </SelectItem>
+                  </SelectList>
+                </SelectPopup>
+              </SelectPositioner>
+            </SelectPortal>
           </Select>
         </Field>
       )}
@@ -205,22 +214,28 @@ const ConfigModalFormFields: FC<ConfigModalFormFieldsProps> = ({
                     })}
                   />
                 </SelectTrigger>
-                <SelectContent listClassName="max-h-[140px] overflow-y-auto">
-                  <SelectItem value={EMPTY_SELECT_VALUE}>
-                    <SelectItemText>
-                      {t(($) => $['variableConfig.noDefaultValue'], { ns: 'appDebug' })}
-                    </SelectItemText>
-                    <SelectItemIndicator />
-                  </SelectItem>
-                  {options
-                    .filter((option) => option.trim() !== '')
-                    .map((option) => (
-                      <SelectItem key={option} value={option}>
-                        <SelectItemText>{option}</SelectItemText>
-                        <SelectItemIndicator />
-                      </SelectItem>
-                    ))}
-                </SelectContent>
+                <SelectPortal>
+                  <SelectPositioner>
+                    <SelectPopup>
+                      <SelectList className="max-h-[140px] overflow-y-auto">
+                        <SelectItem value={EMPTY_SELECT_VALUE}>
+                          <SelectItemText>
+                            {t(($) => $['variableConfig.noDefaultValue'], { ns: 'appDebug' })}
+                          </SelectItemText>
+                          <SelectItemIndicator />
+                        </SelectItem>
+                        {options
+                          .filter((option) => option.trim() !== '')
+                          .map((option) => (
+                            <SelectItem key={option} value={option}>
+                              <SelectItemText>{option}</SelectItemText>
+                              <SelectItemIndicator />
+                            </SelectItem>
+                          ))}
+                      </SelectList>
+                    </SelectPopup>
+                  </SelectPositioner>
+                </SelectPortal>
               </Select>
             </Field>
           )}

--- a/web/app/components/app/configuration/config-var/config-modal/type-select.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/type-select.tsx
@@ -4,10 +4,13 @@ import type { InputVarType } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import * as React from 'react'
@@ -70,30 +73,37 @@ const TypeSelector: FC<Props> = ({ value, onSelect, items, popupInnerClassName, 
           </div>
         </div>
       </SelectTrigger>
-      <SelectContent
-        sideOffset={4}
-        popupClassName={cn(
-          'w-(--anchor-width) rounded-md px-1 py-1 text-base sm:text-sm',
-          popupInnerClassName,
-        )}
-        listClassName="max-h-80 p-0"
-      >
-        {items.map((item: Item) => (
-          <SelectItem
-            key={item.value}
-            value={item.value}
-            className="h-9 justify-between px-2 text-text-secondary"
-            title={item.name}
+      <SelectPortal>
+        <SelectPositioner sideOffset={4}>
+          <SelectPopup
+            className={cn(
+              'w-(--anchor-width) rounded-md px-1 py-1 text-base sm:text-sm',
+              popupInnerClassName,
+            )}
           >
-            <SelectItemText className="flex items-center space-x-2 px-0">
-              <InputVarTypeIcon type={item.value} className="size-4 shrink-0 text-text-secondary" />
-              <span title={item.name}>{item.name}</span>
-            </SelectItemText>
-            <Badge uppercase={false}>{inputVarTypeToVarType(item.value)}</Badge>
-            <SelectItemIndicator />
-          </SelectItem>
-        ))}
-      </SelectContent>
+            <SelectList className="max-h-80 p-0">
+              {items.map((item: Item) => (
+                <SelectItem
+                  key={item.value}
+                  value={item.value}
+                  className="h-9 justify-between px-2 text-text-secondary"
+                  title={item.name}
+                >
+                  <SelectItemText className="flex items-center space-x-2 px-0">
+                    <InputVarTypeIcon
+                      type={item.value}
+                      className="size-4 shrink-0 text-text-secondary"
+                    />
+                    <span title={item.name}>{item.name}</span>
+                  </SelectItemText>
+                  <Badge uppercase={false}>{inputVarTypeToVarType(item.value)}</Badge>
+                  <SelectItemIndicator />
+                </SelectItem>
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
     </Select>
   )
 }

--- a/web/app/components/app/configuration/config-var/select-var-type.tsx
+++ b/web/app/components/app/configuration/config-var/select-var-type.tsx
@@ -55,7 +55,7 @@ const SelectVarType: FC<Props> = ({ onChange }) => {
         placement="bottom-end"
         sideOffset={8}
         alignOffset={-2}
-        popupClassName="min-w-[192px] rounded-lg border bg-components-panel-bg-blur p-0 backdrop-blur-xs"
+        className="min-w-[192px] rounded-lg border bg-components-panel-bg-blur p-0 backdrop-blur-xs"
       >
         <div className="p-1">
           <SelectItem

--- a/web/app/components/app/configuration/config/automatic/version-selector.tsx
+++ b/web/app/components/app/configuration/config/automatic/version-selector.tsx
@@ -41,7 +41,7 @@ const VersionSelector: React.FC<VersionSelectorProps> = ({ versionLen, value, on
         placement="bottom-start"
         sideOffset={4}
         alignOffset={-12}
-        popupClassName="w-[208px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
+        className="w-[208px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
       >
         <div className="flex h-5.5 items-center px-3 pl-3 system-xs-medium-uppercase text-text-tertiary">
           {t(($) => $['generate.versions'], { ns: 'appDebug' })}

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/debug-item.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/debug-item.tsx
@@ -88,7 +88,7 @@ const DebugItem: FC<DebugItemProps> = ({ modelAndParameter, className, style }) 
               </IconButton>
             }
           />
-          <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[160px]">
+          <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[160px]">
             {showDuplicate && (
               <DropdownMenuItem className="system-md-regular" onClick={handleDuplicate}>
                 {t(($) => $.duplicateModel, { ns: 'appDebug' })}

--- a/web/app/components/app/configuration/tools/external-data-tool-modal.tsx
+++ b/web/app/components/app/configuration/tools/external-data-tool-modal.tsx
@@ -133,7 +133,7 @@ const ExternalDataToolModal: FC<ExternalDataToolModalProps> = ({
             >
               <SelectValue />
             </SelectTrigger>
-            <SelectContent popupClassName="w-[354px]">
+            <SelectContent className="w-[354px]">
               {providers.map((option) => (
                 <SelectItem key={option.key} value={option.key}>
                   <SelectItemText>{option.name}</SelectItemText>

--- a/web/app/components/app/create-app-dialog-shell.tsx
+++ b/web/app/components/app/create-app-dialog-shell.tsx
@@ -27,7 +27,7 @@ export function CreateAppDialogShell({
       }}
     >
       <DialogContent
-        backdropClassName="bg-background-overlay-backdrop backdrop-blur-[6px]"
+        backdropProps={{ className: 'bg-background-overlay-backdrop backdrop-blur-[6px]' }}
         className="top-0 left-0 h-screen max-h-none w-screen max-w-none translate-0 overflow-hidden rounded-none border-none bg-transparent p-4 shadow-none"
       >
         <div className="size-full rounded-2xl border border-effects-highlight bg-background-default-subtle">

--- a/web/app/components/app/create-app-dropdown.tsx
+++ b/web/app/components/app/create-app-dropdown.tsx
@@ -59,7 +59,7 @@ export function CreateAppDropdown({
           disableMotion: menu.controlled,
           highlightPart: menu.controlled ? stepByStepTourHighlightPart : undefined,
           interactionMode: menu.controlled ? 'presentation' : 'interactive',
-          popupClassName: 'w-70 p-0',
+          className: 'w-70 p-0',
         })}
       >
         <div className="py-1">

--- a/web/app/components/app/deploy/deployment-dialog/deployment-configuration/credential-field.tsx
+++ b/web/app/components/app/deploy/deployment-dialog/deployment-configuration/credential-field.tsx
@@ -83,7 +83,7 @@ export function CredentialField({
             </span>
           </span>
         </SelectTrigger>
-        <SelectContent popupClassName="w-(--anchor-width) bg-components-panel-bg-blur backdrop-blur-[5px]">
+        <SelectContent className="w-(--anchor-width) bg-components-panel-bg-blur backdrop-blur-[5px]">
           {slot.candidates.length === 0 ? (
             <div className="flex w-full flex-col items-start gap-2 rounded-[10px] bg-workflow-process-bg px-4 pt-4 pb-5">
               <div className="flex size-10 items-center justify-center rounded-[10px] border-[0.5px] border-components-card-border bg-components-card-bg shadow-lg backdrop-blur-[5px]">

--- a/web/app/components/app/deploy/deployment-dialog/deployment-configuration/environment-variable-field.tsx
+++ b/web/app/components/app/deploy/deployment-dialog/deployment-configuration/environment-variable-field.tsx
@@ -102,7 +102,7 @@ export function EnvironmentVariableField({
           >
             {sourceLabel}
           </SelectTrigger>
-          <SelectContent placement="bottom-end" popupClassName="w-52">
+          <SelectContent placement="bottom-end" className="w-52">
             {availableSources.map((option) => (
               <SelectItem key={option} value={option}>
                 <SelectItemText>{sourceLabels[option]}</SelectItemText>

--- a/web/app/components/app/deploy/environment-table/deploy-menu/index.tsx
+++ b/web/app/components/app/deploy/environment-table/deploy-menu/index.tsx
@@ -40,11 +40,7 @@ export function EnvironmentDeployMenu({
           </Button>
         }
       />
-      <DropdownMenuContent
-        placement="bottom-end"
-        sideOffset={4}
-        popupClassName="w-42 rounded-xl p-1"
-      >
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-42 rounded-xl p-1">
         <DropdownMenuGroup>
           <DropdownMenuLabel className="px-2 py-1 system-xs-medium-uppercase text-text-tertiary">
             {t(($) => $['card.notDeployed'])}

--- a/web/app/components/app/deploy/environment-table/row-actions.tsx
+++ b/web/app/components/app/deploy/environment-table/row-actions.tsx
@@ -147,7 +147,7 @@ export function EnvironmentRowActions({
               </IconButton>
             }
           />
-          <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-50">
+          <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-50">
             {moreActions.map((action, index) => (
               <Fragment key={action.kind}>
                 {action.kind === 'undeploy' && index > 0 && <DropdownMenuSeparator />}

--- a/web/app/components/apps/app-card/action-bar/index.tsx
+++ b/web/app/components/apps/app-card/action-bar/index.tsx
@@ -436,7 +436,7 @@ export const AppCardActionBar = memo(
                   {...getStepByStepTourDropdownMenuContentProps({
                     highlightPart: stepByStepTourActionMenuHighlightPart,
                     interactionMode: operationsMenu.controlled ? 'presentation' : 'interactive',
-                    popupClassName: OPERATIONS_MENU_POPUP_CLASS_NAME,
+                    className: OPERATIONS_MENU_POPUP_CLASS_NAME,
                   })}
                 >
                   <AppCardOperationsMenuContent

--- a/web/app/components/apps/app-sort-filter.tsx
+++ b/web/app/components/apps/app-sort-filter.tsx
@@ -54,7 +54,7 @@ export function AppSortFilter({ value, onChange }: AppSortFilterProps) {
         </span>
         <span aria-hidden className="i-ri-arrow-down-s-line size-4 shrink-0 text-text-tertiary" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-start" sideOffset={4} popupClassName="w-[220px]">
+      <DropdownMenuContent placement="bottom-start" sideOffset={4} className="w-[220px]">
         <DropdownMenuRadioGroup<AppListSortBy>
           value={value}
           onValueChange={(nextValue) => onChange(nextValue)}

--- a/web/app/components/apps/app-type-filter.tsx
+++ b/web/app/components/apps/app-type-filter.tsx
@@ -85,7 +85,7 @@ export function AppTypeFilter({ value, onChange }: AppTypeFilterProps) {
         <span className="px-1 text-text-tertiary">{triggerLabel}</span>
         <span aria-hidden className="i-ri-arrow-down-s-line h-4 w-4 shrink-0 text-text-tertiary" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-start" popupClassName="w-[220px]">
+      <DropdownMenuContent placement="bottom-start" className="w-[220px]">
         <DropdownMenuRadioGroup<AppListCategory>
           value={value}
           onValueChange={(nextValue) => onChange(nextValue)}

--- a/web/app/components/apps/creators-filter.tsx
+++ b/web/app/components/apps/creators-filter.tsx
@@ -161,7 +161,7 @@ const CreatorsFilter = ({ value, onChange }: CreatorsFilterProps) => {
           </>
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-start" popupClassName="w-[280px] p-0">
+      <DropdownMenuContent placement="bottom-start" className="w-[280px] p-0">
         <div className="flex items-center gap-1 p-2 pb-1">
           <div className="relative min-w-0 grow">
             <span

--- a/web/app/components/base/agent-log-modal/index.tsx
+++ b/web/app/components/base/agent-log-modal/index.tsx
@@ -48,7 +48,7 @@ const AgentLogModal: FC<AgentLogModalProps> = ({ currentLogItem, width, floating
         }}
       >
         <DialogContent
-          backdropClassName="bg-transparent!"
+          backdropProps={{ className: 'bg-transparent!' }}
           className="top-16! bottom-4! left-[max(8px,calc(100vw-1136px))]! flex max-h-none! w-120! max-w-[calc(100vw-16px)]! translate-x-0! translate-y-0! flex-col overflow-hidden! rounded-xl! border-[0.5px]! border-components-panel-border! bg-components-panel-bg! p-0! pt-3! pb-3! shadow-xl!"
         >
           <DialogTitle className="text-md shrink-0 px-4 py-1 font-semibold text-text-primary">

--- a/web/app/components/base/chat/chat-with-history/header/mobile-operation-dropdown.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/mobile-operation-dropdown.tsx
@@ -36,7 +36,7 @@ const MobileOperationDropdown = ({
           </IconButton>
         }
       />
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[160px]">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[160px]">
         <DropdownMenuItem
           className="system-md-regular"
           onClick={() => handleMenuAction(handleResetChat)}

--- a/web/app/components/base/chat/chat-with-history/header/operation.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/operation.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { Placement } from '@langgenius/dify-ui/dropdown-menu'
 import type { FC } from 'react'
 import {
   DropdownMenu,
@@ -18,7 +17,6 @@ type Props = Readonly<{
   isShowDelete: boolean
   togglePin: () => void
   onDelete: () => void
-  placement?: Placement
 }>
 
 const deferAction = (action: () => void) => {
@@ -33,7 +31,6 @@ const Operation: FC<Props> = ({
   onRenameConversation,
   isShowDelete,
   onDelete,
-  placement = 'bottom-start',
 }) => {
   const { t } = useTranslation()
 
@@ -43,7 +40,7 @@ const Operation: FC<Props> = ({
         <span className="system-md-semibold">{title}</span>
         <span aria-hidden className="i-ri-arrow-down-s-line size-4" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement={placement} sideOffset={4} className="min-w-[120px]">
+      <DropdownMenuContent placement="bottom-start" sideOffset={4} className="min-w-[120px]">
         <DropdownMenuItem className="system-md-regular" onClick={togglePin}>
           <span className="grow">
             {isPinned

--- a/web/app/components/base/chat/chat-with-history/header/operation.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/operation.tsx
@@ -43,7 +43,7 @@ const Operation: FC<Props> = ({
         <span className="system-md-semibold">{title}</span>
         <span aria-hidden className="i-ri-arrow-down-s-line size-4" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement={placement} sideOffset={4} popupClassName="min-w-[120px]">
+      <DropdownMenuContent placement={placement} sideOffset={4} className="min-w-[120px]">
         <DropdownMenuItem className="system-md-regular" onClick={togglePin}>
           <span className="grow">
             {isPinned

--- a/web/app/components/base/chat/chat-with-history/sidebar/operation.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/operation.tsx
@@ -58,10 +58,8 @@ const Operation: FC<Props> = ({
       <DropdownMenuContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="min-w-[120px]"
-        popupProps={{
-          onClick: (e) => e.stopPropagation(),
-        }}
+        className="min-w-[120px]"
+        onClick={(e) => e.stopPropagation()}
       >
         <DropdownMenuItem
           className="gap-2 px-2 system-md-regular"

--- a/web/app/components/base/chat/chat/answer/human-input-content/field-renderer.tsx
+++ b/web/app/components/base/chat/chat/answer/human-input-content/field-renderer.tsx
@@ -2,10 +2,13 @@ import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import type { FormInputItem } from '@/app/components/workflow/nodes/human-input/types'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -57,14 +60,20 @@ const HumanInputFieldRenderer = ({ field, value, onChange }: Props) => {
         <SelectTrigger size="large" className="w-full" aria-label={field.output_variable_name}>
           <SelectValue />
         </SelectTrigger>
-        <SelectContent listClassName="max-h-[140px] overflow-y-auto">
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              <SelectItemText>{option.name}</SelectItemText>
-              <SelectItemIndicator />
-            </SelectItem>
-          ))}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner>
+            <SelectPopup>
+              <SelectList className="max-h-[140px] overflow-y-auto">
+                {options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    <SelectItemText>{option.name}</SelectItemText>
+                    <SelectItemIndicator />
+                  </SelectItem>
+                ))}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </Select>
     )
   }

--- a/web/app/components/base/chat/chat/answer/human-input-content/submitted-content-item.tsx
+++ b/web/app/components/base/chat/chat/answer/human-input-content/submitted-content-item.tsx
@@ -2,10 +2,13 @@ import type { FormInputItem } from '@/app/components/workflow/nodes/human-input/
 import type { HumanInputFormValue } from '@/types/workflow'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -71,14 +74,20 @@ const SubmittedContentItem = ({ content, formInputFields, values }: SubmittedCon
           >
             <SelectValue />
           </SelectTrigger>
-          <SelectContent listClassName="max-h-[140px] overflow-y-auto">
-            {field.option_source.value.map((option) => (
-              <SelectItem key={option} value={option}>
-                <SelectItemText>{option}</SelectItemText>
-                <SelectItemIndicator />
-              </SelectItem>
-            ))}
-          </SelectContent>
+          <SelectPortal>
+            <SelectPositioner>
+              <SelectPopup>
+                <SelectList className="max-h-[140px] overflow-y-auto">
+                  {field.option_source.value.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      <SelectItemText>{option}</SelectItemText>
+                      <SelectItemIndicator />
+                    </SelectItem>
+                  ))}
+                </SelectList>
+              </SelectPopup>
+            </SelectPositioner>
+          </SelectPortal>
         </Select>
       </div>
     )

--- a/web/app/components/base/chip/index.tsx
+++ b/web/app/components/base/chip/index.tsx
@@ -2,10 +2,13 @@ import type { ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { useTranslation } from 'react-i18next'
@@ -117,22 +120,25 @@ function Chip<T extends ItemValue>({
             />
           </button>
         )}
-        <SelectContent
-          placement="bottom-start"
-          sideOffset={4}
-          popupClassName={cn(
-            'relative w-60 rounded-xl border-[0.5px] bg-components-panel-bg-blur p-0 text-sm text-text-secondary shadow-lg outline-hidden backdrop-blur-[5px] focus:outline-hidden focus-visible:outline-hidden',
-            panelClassName,
-          )}
-          listClassName="max-h-72 p-1"
-        >
-          {items.map((item) => (
-            <SelectItem<T> key={item.value} value={item.value}>
-              <SelectItemText title={item.name}>{item.name}</SelectItemText>
-              {showItemIndicator && <SelectItemIndicator />}
-            </SelectItem>
-          ))}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner placement="bottom-start" sideOffset={4}>
+            <SelectPopup
+              className={cn(
+                'relative w-60 rounded-xl border-[0.5px] bg-components-panel-bg-blur p-0 text-sm text-text-secondary shadow-lg outline-hidden backdrop-blur-[5px] focus:outline-hidden focus-visible:outline-hidden',
+                panelClassName,
+              )}
+            >
+              <SelectList className="max-h-72 p-1">
+                {items.map((item) => (
+                  <SelectItem<T> key={item.value} value={item.value}>
+                    <SelectItemText title={item.name}>{item.name}</SelectItemText>
+                    {showItemIndicator && <SelectItemIndicator />}
+                  </SelectItem>
+                ))}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </div>
     </Select>
   )

--- a/web/app/components/base/date-and-time-picker/time-picker/index.tsx
+++ b/web/app/components/base/date-and-time-picker/time-picker/index.tsx
@@ -29,7 +29,6 @@ const TimePicker = ({
   notClearable = false,
   triggerFullWidth = false,
   showTimezone = false,
-  placement = 'bottom-start',
 }: TimePickerProps) => {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
@@ -267,7 +266,7 @@ const TimePicker = ({
         }}
       />
       <PopoverContent
-        placement={placement}
+        placement="bottom-start"
         sideOffset={0}
         className="border-none bg-transparent shadow-none"
       >

--- a/web/app/components/base/date-and-time-picker/types.ts
+++ b/web/app/components/base/date-and-time-picker/types.ts
@@ -1,4 +1,4 @@
-import type { Placement, PopoverTriggerProps } from '@langgenius/dify-ui/popover'
+import type { PopoverTriggerProps } from '@langgenius/dify-ui/popover'
 import type { Dayjs } from 'dayjs'
 
 export enum ViewType {
@@ -77,7 +77,6 @@ export type TimePickerProps = {
   notClearable?: boolean
   triggerFullWidth?: boolean
   showTimezone?: boolean
-  placement?: Placement
 }
 
 export type TimePickerFooterProps = {

--- a/web/app/components/base/features/new-feature-panel/text-to-speech/param-config-content.tsx
+++ b/web/app/components/base/features/new-feature-panel/text-to-speech/param-config-content.tsx
@@ -3,10 +3,13 @@ import type { OnFeaturesChange } from '@/app/components/base/features/types'
 import type { I18nKeysWithPrefix } from '@/types/i18n'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { Switch } from '@langgenius/dify-ui/switch'
@@ -125,14 +128,20 @@ const VoiceParamConfig = ({ onClose, onChange }: VoiceParamConfigProps) => {
           >
             {languageItem ? formatLanguageName(languageItem) : localLanguagePlaceholder}
           </SelectTrigger>
-          <SelectContent listClassName="max-h-60">
-            {languages.map((item) => (
-              <SelectItem key={item.value} value={item.value}>
-                <SelectItemText>{formatLanguageName(item)}</SelectItemText>
-                <SelectItemIndicator />
-              </SelectItem>
-            ))}
-          </SelectContent>
+          <SelectPortal>
+            <SelectPositioner>
+              <SelectPopup>
+                <SelectList className="max-h-60">
+                  {languages.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                      <SelectItemText>{formatLanguageName(item)}</SelectItemText>
+                      <SelectItemIndicator />
+                    </SelectItem>
+                  ))}
+                </SelectList>
+              </SelectPopup>
+            </SelectPositioner>
+          </SelectPortal>
         </Select>
       </div>
       <div className="mb-3">
@@ -157,14 +166,20 @@ const VoiceParamConfig = ({ onClose, onChange }: VoiceParamConfigProps) => {
               >
                 {voiceItem?.name ?? localVoicePlaceholder}
               </SelectTrigger>
-              <SelectContent listClassName="max-h-60">
-                {voiceItems?.map((item: SelectOption) => (
-                  <SelectItem key={item.value} value={item.value}>
-                    <SelectItemText>{item.name}</SelectItemText>
-                    <SelectItemIndicator />
-                  </SelectItem>
-                ))}
-              </SelectContent>
+              <SelectPortal>
+                <SelectPositioner>
+                  <SelectPopup>
+                    <SelectList className="max-h-60">
+                      {voiceItems?.map((item: SelectOption) => (
+                        <SelectItem key={item.value} value={item.value}>
+                          <SelectItemText>{item.name}</SelectItemText>
+                          <SelectItemIndicator />
+                        </SelectItem>
+                      ))}
+                    </SelectList>
+                  </SelectPopup>
+                </SelectPositioner>
+              </SelectPortal>
             </div>
           </Select>
           {languageItem?.example && (

--- a/web/app/components/base/file-uploader/audio-preview.tsx
+++ b/web/app/components/base/file-uploader/audio-preview.tsx
@@ -20,7 +20,7 @@ const AudioPreview: FC<AudioPreviewProps> = ({ url, title, onCancel }) => {
     >
       <DialogContent
         className="inset-0! top-0! left-0! flex h-dvh! max-h-none! w-screen! max-w-none! translate-0! items-center justify-center overflow-hidden! rounded-none! border-none! bg-black/80 p-8! shadow-none!"
-        backdropClassName="bg-transparent!"
+        backdropProps={{ className: 'bg-transparent!' }}
       >
         <div tabIndex={-1}>
           <audio controls title={title} autoPlay={false} preload="metadata">

--- a/web/app/components/base/file-uploader/pdf-preview.tsx
+++ b/web/app/components/base/file-uploader/pdf-preview.tsx
@@ -54,7 +54,7 @@ const PdfPreview: FC<PdfPreviewProps> = ({ url, onCancel }) => {
     >
       <DialogContent
         className={`inset-0! top-0! left-0! flex h-dvh! max-h-none! w-screen! max-w-none! translate-0! items-center justify-center overflow-hidden! rounded-none! border-none! bg-black/80 shadow-none! ${!isMobile ? 'p-8!' : 'p-0!'}`}
-        backdropClassName="bg-transparent!"
+        backdropProps={{ className: 'bg-transparent!' }}
       >
         <div
           tabIndex={-1}

--- a/web/app/components/base/file-uploader/video-preview.tsx
+++ b/web/app/components/base/file-uploader/video-preview.tsx
@@ -20,7 +20,7 @@ const VideoPreview: FC<VideoPreviewProps> = ({ url, title, onCancel }) => {
     >
       <DialogContent
         className="inset-0! top-0! left-0! flex h-dvh! max-h-none! w-screen! max-w-none! translate-0! items-center justify-center overflow-hidden! rounded-none! border-none! bg-black/80 p-8! shadow-none!"
-        backdropClassName="bg-transparent!"
+        backdropProps={{ className: 'bg-transparent!' }}
       >
         <div tabIndex={-1}>
           <video controls title={title} autoPlay={false} preload="metadata">

--- a/web/app/components/base/form/components/base/base-field.tsx
+++ b/web/app/components/base/form/components/base/base-field.tsx
@@ -300,7 +300,7 @@ const BaseField = ({
                     }
                   </SelectValue>
                 </SelectTrigger>
-                <SelectContent popupClassName="max-h-[320px] bg-components-panel-bg-blur">
+                <SelectContent className="max-h-[320px] bg-components-panel-bg-blur">
                   {memorizedOptions.map((option) => (
                     <SelectItem key={option.value} value={option.value}>
                       <SelectItemText>{option.label}</SelectItemText>
@@ -330,7 +330,7 @@ const BaseField = ({
                     }
                   </SelectValue>
                 </SelectTrigger>
-                <SelectContent popupClassName="max-h-[320px] bg-components-panel-bg-blur">
+                <SelectContent className="max-h-[320px] bg-components-panel-bg-blur">
                   {memorizedOptions.map((option) => (
                     <SelectItem key={option.value} value={option.value}>
                       <SelectItemText>{option.label}</SelectItemText>
@@ -375,7 +375,7 @@ const BaseField = ({
                     }
                   </SelectValue>
                 </SelectTrigger>
-                <SelectContent popupClassName="bg-components-panel-bg-blur">
+                <SelectContent className="bg-components-panel-bg-blur">
                   {dynamicNoticeTitle && (
                     <div
                       className={cn(
@@ -415,7 +415,7 @@ const BaseField = ({
                     }
                   </SelectValue>
                 </SelectTrigger>
-                <SelectContent popupClassName="bg-components-panel-bg-blur">
+                <SelectContent className="bg-components-panel-bg-blur">
                   {dynamicNoticeTitle && (
                     <div
                       className={cn(

--- a/web/app/components/base/form/components/field/input-type-select/index.tsx
+++ b/web/app/components/base/form/components/field/input-type-select/index.tsx
@@ -45,7 +45,7 @@ const InputTypeSelectField = ({
         <SelectTrigger id={field.name} className="gap-x-0.5 px-2">
           <Trigger option={selected} />
         </SelectTrigger>
-        <SelectContent popupClassName="w-[368px] bg-components-panel-bg-blur shadow-shadow-shadow-5">
+        <SelectContent className="w-[368px] bg-components-panel-bg-blur shadow-shadow-shadow-5">
           {inputTypeOptions.map((option: FileTypeSelectOption) => (
             <SelectItem key={option.value} value={option.value} className="gap-x-1">
               <Option option={option} />

--- a/web/app/components/base/form/components/field/select.tsx
+++ b/web/app/components/base/form/components/field/select.tsx
@@ -75,7 +75,7 @@ const SelectField = ({
             {(nextValue) => getDisplayLabel(nextValue, options, placeholderText)}
           </SelectValue>
         </SelectTrigger>
-        <SelectContent popupClassName={cn('bg-components-panel-bg-blur', popupProps?.className)}>
+        <SelectContent className={cn('bg-components-panel-bg-blur', popupProps?.className)}>
           {popupProps?.title && (
             <div
               className={cn(

--- a/web/app/components/base/image-uploader/image-preview.tsx
+++ b/web/app/components/base/image-uploader/image-preview.tsx
@@ -182,7 +182,7 @@ const ImagePreview: FC<ImagePreviewProps> = ({ url, title, onCancel, onPrev, onN
     >
       <DialogContent
         className="image-preview-container inset-0! top-0! left-0! flex h-dvh! max-h-none! w-screen! max-w-none! translate-0! items-center justify-center overflow-hidden! rounded-none! border-none! bg-black/80 p-8! shadow-none!"
-        backdropClassName="bg-transparent!"
+        backdropProps={{ className: 'bg-transparent!' }}
       >
         <div
           data-testid="image-preview-container"

--- a/web/app/components/base/infotip/index.tsx
+++ b/web/app/components/base/infotip/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type { Placement } from '@langgenius/dify-ui/popover'
 import type { MouseEvent, ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
@@ -56,8 +55,6 @@ type InfotipProps = {
   iconSize?: InfotipIconSize
   /** Extra classes on the popup body (width / padding / whitespace overrides). */
   popupClassName?: string
-  /** Popup placement. Defaults to `top`. */
-  placement?: Placement
   /** Distance between the trigger and popup. */
   sideOffset?: number
 }
@@ -69,7 +66,6 @@ export function Infotip({
   iconVariant = 'question',
   iconSize = 'medium',
   popupClassName,
-  placement = 'top',
   sideOffset,
 }: InfotipProps) {
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
@@ -95,7 +91,7 @@ export function Infotip({
         />
       </PopoverTrigger>
       <PopoverContent
-        placement={placement}
+        placement="top"
         sideOffset={sideOffset}
         className={cn(
           'max-w-75 rounded-md px-3 py-2 system-xs-regular text-text-tertiary',

--- a/web/app/components/base/message-log-modal/index.tsx
+++ b/web/app/components/base/message-log-modal/index.tsx
@@ -69,7 +69,7 @@ const MessageLogModal: FC<MessageLogModalProps> = ({
         }}
       >
         <DialogContent
-          backdropClassName="bg-transparent!"
+          backdropProps={{ className: 'bg-transparent!' }}
           className="top-16! bottom-4! left-[max(8px,calc(100vw-1136px))]! flex max-h-none! w-120! max-w-[calc(100vw-16px)]! translate-x-0! translate-y-0! flex-col overflow-hidden! rounded-xl! border-[0.5px]! border-components-panel-border! bg-components-panel-bg! p-0! pt-3! shadow-xl!"
         >
           {modalContent}

--- a/web/app/components/base/notion-page-selector/credential-selector/index.tsx
+++ b/web/app/components/base/notion-page-selector/credential-selector/index.tsx
@@ -1,10 +1,13 @@
 'use client'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { CredentialIcon } from '@/app/components/datasets/common/credential-icon'
@@ -48,23 +51,33 @@ const CredentialSelector = ({ value, items, onSelect }: CredentialSelectorProps)
           </span>
         </span>
       </SelectTrigger>
-      <SelectContent popupClassName="w-80" listClassName="max-h-50">
-        {items.map((item) => {
-          const displayName = getDisplayName(item)
-          return (
-            <SelectItem key={item.credentialId} value={item.credentialId} className="h-9 px-3">
-              <CredentialIcon
-                className="mr-2 shrink-0"
-                avatarUrl={item.workspaceIcon}
-                name={displayName}
-                size={20}
-              />
-              <SelectItemText title={displayName}>{displayName}</SelectItemText>
-              <SelectItemIndicator />
-            </SelectItem>
-          )
-        })}
-      </SelectContent>
+      <SelectPortal>
+        <SelectPositioner>
+          <SelectPopup className="w-80">
+            <SelectList className="max-h-50">
+              {items.map((item) => {
+                const displayName = getDisplayName(item)
+                return (
+                  <SelectItem
+                    key={item.credentialId}
+                    value={item.credentialId}
+                    className="h-9 px-3"
+                  >
+                    <CredentialIcon
+                      className="mr-2 shrink-0"
+                      avatarUrl={item.workspaceIcon}
+                      name={displayName}
+                      size={20}
+                    />
+                    <SelectItemText title={displayName}>{displayName}</SelectItemText>
+                    <SelectItemIndicator />
+                  </SelectItem>
+                )
+              })}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
     </Select>
   )
 }

--- a/web/app/components/base/prompt-editor/plugins/agent-output-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/agent-output-block/component.tsx
@@ -295,7 +295,7 @@ const AgentOutputBlockComponent = ({
         >
           {selected.label}
         </SelectTrigger>
-        <SelectContent popupClassName="w-40">
+        <SelectContent className="w-40">
           {AGENT_OUTPUT_TYPE_OPTIONS.map((option) => (
             <SelectItem key={option.value} value={option.value}>
               <SelectItemText>{option.label}</SelectItemText>

--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/variable-block.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/variable-block.tsx
@@ -3,7 +3,9 @@ import type { WorkflowNodesMap } from '../workflow-variable-block/node'
 import type { ValueSelector, Var } from '@/app/components/workflow/types'
 import {
   PreviewCard,
-  PreviewCardContent,
+  PreviewCardPopup,
+  PreviewCardPortal,
+  PreviewCardPositioner,
   PreviewCardTrigger,
 } from '@langgenius/dify-ui/preview-card'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
@@ -121,21 +123,25 @@ const HITLInputVariableBlockComponent = ({
   return (
     <PreviewCard>
       <PreviewCardTrigger delay={300} closeDelay={200} render={<div>{Item}</div>} />
-      <PreviewCardContent popupClassName="border-0 bg-transparent p-0 shadow-none">
-        <VarFullPathPanel
-          nodeName={node.title}
-          path={variables.slice(1)}
-          varType={
-            getVarType
-              ? getVarType({
-                  nodeId: variables[0]!,
-                  valueSelector: variables,
-                })
-              : Type.string
-          }
-          nodeType={node?.type}
-        />
-      </PreviewCardContent>
+      <PreviewCardPortal>
+        <PreviewCardPositioner>
+          <PreviewCardPopup>
+            <VarFullPathPanel
+              nodeName={node.title}
+              path={variables.slice(1)}
+              varType={
+                getVarType
+                  ? getVarType({
+                      nodeId: variables[0]!,
+                      valueSelector: variables,
+                    })
+                  : Type.string
+              }
+              nodeType={node?.type}
+            />
+          </PreviewCardPopup>
+        </PreviewCardPositioner>
+      </PreviewCardPortal>
     </PreviewCard>
   )
 }

--- a/web/app/components/base/prompt-editor/plugins/workflow-variable-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/workflow-variable-block/component.tsx
@@ -3,7 +3,9 @@ import type { WorkflowNodesMap } from './node'
 import type { NodeOutPutVar, ValueSelector, Var } from '@/app/components/workflow/types'
 import {
   PreviewCard,
-  PreviewCardContent,
+  PreviewCardPopup,
+  PreviewCardPortal,
+  PreviewCardPositioner,
   PreviewCardTrigger,
 } from '@langgenius/dify-ui/preview-card'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
@@ -139,21 +141,25 @@ const WorkflowVariableBlockComponent = ({
   return (
     <PreviewCard>
       <PreviewCardTrigger delay={300} closeDelay={200} render={<div>{Item}</div>} />
-      <PreviewCardContent popupClassName="border-0 bg-transparent p-0 shadow-none">
-        <VarFullPathPanel
-          nodeName={node.title}
-          path={variables.slice(1)}
-          varType={
-            getVarType
-              ? getVarType({
-                  nodeId: variables[0]!,
-                  valueSelector: variables,
-                })
-              : Type.string
-          }
-          nodeType={node?.type}
-        />
-      </PreviewCardContent>
+      <PreviewCardPortal>
+        <PreviewCardPositioner>
+          <PreviewCardPopup>
+            <VarFullPathPanel
+              nodeName={node.title}
+              path={variables.slice(1)}
+              varType={
+                getVarType
+                  ? getVarType({
+                      nodeId: variables[0]!,
+                      valueSelector: variables,
+                    })
+                  : Type.string
+              }
+              nodeType={node?.type}
+            />
+          </PreviewCardPopup>
+        </PreviewCardPositioner>
+      </PreviewCardPortal>
     </PreviewCard>
   )
 }

--- a/web/app/components/base/sort/index.tsx
+++ b/web/app/components/base/sort/index.tsx
@@ -51,7 +51,7 @@ function Sort({ order, value, items, onSelect }: Props) {
           <DropdownMenuContent
             placement="bottom-start"
             sideOffset={4}
-            popupClassName="relative w-[240px] rounded-xl bg-components-panel-bg-blur p-0"
+            className="relative w-[240px] rounded-xl bg-components-panel-bg-blur p-0"
           >
             <DropdownMenuRadioGroup
               value={value}

--- a/web/app/components/base/theme-selector.tsx
+++ b/web/app/components/base/theme-selector.tsx
@@ -48,7 +48,7 @@ export default function ThemeSelector() {
           </IconButton>
         }
       />
-      <DropdownMenuContent placement="bottom-end" sideOffset={6} popupClassName="w-[144px]">
+      <DropdownMenuContent placement="bottom-end" sideOffset={6} className="w-[144px]">
         <DropdownMenuRadioGroup<Theme>
           value={currentTheme}
           onValueChange={(nextTheme) => setTheme(nextTheme)}

--- a/web/app/components/datasets/common/image-previewer/index.tsx
+++ b/web/app/components/datasets/common/image-previewer/index.tsx
@@ -155,7 +155,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
     >
       <DialogContent
         className="image-previewer inset-0! top-0! left-0! flex h-dvh! max-h-none! w-screen! max-w-none! translate-x-0! translate-y-0! items-center justify-center overflow-hidden! rounded-none! border-none! bg-background-overlay-fullscreen p-5! pb-4! shadow-none! backdrop-blur-[6px]"
-        backdropClassName="bg-transparent!"
+        backdropProps={{ className: 'bg-transparent!' }}
       >
         <div className="absolute top-6 right-6 z-10 flex cursor-pointer flex-col items-center gap-y-1">
           <IconButton

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
@@ -2,7 +2,9 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
-  DropdownMenuContent,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import * as React from 'react'
@@ -56,18 +58,18 @@ const Actions = ({
           >
             <span aria-hidden className="i-ri-more-fill size-4 text-text-tertiary" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent
-            placement="bottom-end"
-            sideOffset={4}
-            popupClassName="min-w-[160px] border-0 bg-transparent py-0 shadow-none backdrop-blur-none"
-          >
-            <Operations
-              openEditModal={openEditModal}
-              onExport={handleExportDSL}
-              onDelete={handleDelete}
-              onClose={() => setIsMoreOperationsOpen(false)}
-            />
-          </DropdownMenuContent>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner placement="bottom-end" sideOffset={4}>
+              <DropdownMenuPopup className="min-w-[160px]">
+                <Operations
+                  openEditModal={openEditModal}
+                  onExport={handleExportDSL}
+                  onDelete={handleDelete}
+                  onClose={() => setIsMoreOperationsOpen(false)}
+                />
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
         </DropdownMenu>
       )}
     </div>

--- a/web/app/components/datasets/create/step-two/language-select/index.tsx
+++ b/web/app/components/datasets/create/step-two/language-select/index.tsx
@@ -41,7 +41,7 @@ const LanguageSelect: FC<ILanguageSelectProps> = ({ currentLanguage, onSelect, d
       >
         <SelectValue placeholder={<span>&nbsp;</span>} />
       </SelectTrigger>
-      <SelectContent placement="bottom-start" sideOffset={4} popupClassName="w-max">
+      <SelectContent placement="bottom-start" sideOffset={4} className="w-max">
         {supportedLanguages.map(({ prompt_name }) => (
           <SelectItem key={prompt_name} value={prompt_name}>
             <SelectItemText>{prompt_name}</SelectItemText>

--- a/web/app/components/datasets/documents/components/operations.tsx
+++ b/web/app/components/datasets/documents/components/operations.tsx
@@ -403,7 +403,7 @@ const Operations = ({
             <DropdownMenuContent
               placement="bottom-end"
               sideOffset={4}
-              popupClassName={cn('w-50 py-0', className)}
+              className={cn('w-50 py-0', className)}
             >
               <div className="w-full py-1">
                 {canShowPrimarySection && (

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/breadcrumbs/dropdown/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/breadcrumbs/dropdown/index.tsx
@@ -1,7 +1,9 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
-  DropdownMenuContent,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import * as React from 'react'
@@ -33,17 +35,17 @@ const Dropdown = ({ startIndex, breadcrumbs, onBreadcrumbClick }: DropdownProps)
           </button>
         }
       />
-      <DropdownMenuContent
-        placement="bottom-start"
-        sideOffset={4}
-        popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-      >
-        <Menu
-          breadcrumbs={breadcrumbs}
-          startIndex={startIndex}
-          onBreadcrumbClick={onBreadcrumbClick}
-        />
-      </DropdownMenuContent>
+      <DropdownMenuPortal>
+        <DropdownMenuPositioner placement="bottom-start" sideOffset={4}>
+          <DropdownMenuPopup>
+            <Menu
+              breadcrumbs={breadcrumbs}
+              startIndex={startIndex}
+              onBreadcrumbClick={onBreadcrumbClick}
+            />
+          </DropdownMenuPopup>
+        </DropdownMenuPositioner>
+      </DropdownMenuPortal>
       <span className="system-xs-regular text-divider-deep">/</span>
     </DropdownMenu>
   )

--- a/web/app/components/datasets/documents/detail/completed/components/menu-bar.tsx
+++ b/web/app/components/datasets/documents/detail/completed/components/menu-bar.tsx
@@ -72,7 +72,7 @@ function MenuBar({
         <SelectTrigger className="mr-2 w-25 shrink-0 shadow-none">
           {selectedStatus?.name ?? ''}
         </SelectTrigger>
-        <SelectContent popupClassName="w-[160px]">
+        <SelectContent className="w-[160px]">
           {statusList.map((item) => (
             <SelectItem key={item.value} value={item.value}>
               <SelectItemText>{item.name}</SelectItemText>

--- a/web/app/components/datasets/documents/detail/segment-add/index.tsx
+++ b/web/app/components/datasets/documents/detail/segment-add/index.tsx
@@ -142,7 +142,7 @@ export function SegmentAdd({
         >
           <span aria-hidden className={cn('i-ri-arrow-down-s-line size-4', textColor)} />
         </DropdownMenuTrigger>
-        <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[120px]">
+        <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[120px]">
           <DropdownMenuItem
             className="system-md-regular"
             onClick={() => openSegmentDialog(showBatchModal)}

--- a/web/app/components/datasets/list/dataset-card/components/operations-dropdown.tsx
+++ b/web/app/components/datasets/list/dataset-card/components/operations-dropdown.tsx
@@ -105,10 +105,10 @@ const OperationsDropdown = ({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           placement="bottom-end"
-          popupClassName="min-w-[186px]"
           {...getStepByStepTourDropdownMenuContentProps({
             highlightPart: stepByStepTourHighlightPart,
             interactionMode: operationsMenu.controlled ? 'presentation' : 'interactive',
+            className: 'min-w-[186px]',
           })}
         >
           <Operations

--- a/web/app/components/datasets/list/header.tsx
+++ b/web/app/components/datasets/list/header.tsx
@@ -152,7 +152,7 @@ const DatasetListHeader = ({
                     ? stepByStepTourCreateMenuHighlightPart
                     : undefined,
                   interactionMode: createMenu.controlled ? 'presentation' : 'interactive',
-                  popupClassName: 'w-80',
+                  className: 'w-80',
                 })}
               >
                 {canCreateDataset && (

--- a/web/app/components/explore/item-operation/index.tsx
+++ b/web/app/components/explore/item-operation/index.tsx
@@ -50,7 +50,7 @@ function ItemOperation({
           className="i-ri-more-fill size-4 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 group-focus-visible/operation:opacity-100 group-data-popup-open/operation:opacity-100"
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[120px]">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[120px]">
         <DropdownMenuItem
           className={cn(s.actionItem, 'gap-2 px-3')}
           onClick={(e) => {

--- a/web/app/components/header/account-dropdown/compliance.tsx
+++ b/web/app/components/header/account-dropdown/compliance.tsx
@@ -183,7 +183,7 @@ export default function Compliance() {
           label={t(($) => $['userProfile.compliance'], { ns: 'common' })}
         />
       </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent popupClassName="w-[337px] divide-y divide-divider-subtle bg-components-panel-bg-blur! py-0! backdrop-blur-xs">
+      <DropdownMenuSubContent className="w-[337px] divide-y divide-divider-subtle bg-components-panel-bg-blur! py-0! backdrop-blur-xs">
         <DropdownMenuGroup className="py-1">
           <ComplianceDocRowItem
             icon={<Soc2 aria-hidden className="size-7 shrink-0" />}

--- a/web/app/components/header/account-dropdown/index.tsx
+++ b/web/app/components/header/account-dropdown/index.tsx
@@ -57,7 +57,7 @@ export default function AccountDropdown({ trigger }: AccountDropdownProps) {
           placement="top-start"
           sideOffset={6}
           alignOffset={4}
-          popupClassName={mainNavMenuPopupClassName}
+          className={mainNavMenuPopupClassName}
         >
           <MainNavMenuContent onLogout={handleLogout} />
         </DropdownMenuContent>

--- a/web/app/components/header/account-dropdown/main-nav-menu-content.tsx
+++ b/web/app/components/header/account-dropdown/main-nav-menu-content.tsx
@@ -72,7 +72,7 @@ function AppearanceSubmenu() {
       <DropdownMenuSubContent
         placement="right-start"
         sideOffset={6}
-        popupClassName="w-[139px] max-h-[360px] bg-components-panel-bg-blur p-1 backdrop-blur-[5px]"
+        className="max-h-[360px] w-[139px] bg-components-panel-bg-blur p-1 backdrop-blur-[5px]"
       >
         <DropdownMenuRadioGroup<Theme>
           value={currentTheme}

--- a/web/app/components/header/account-dropdown/workplace-selector/index.tsx
+++ b/web/app/components/header/account-dropdown/workplace-selector/index.tsx
@@ -42,7 +42,7 @@ export const WorkplaceSelectorContent = memo(
     const { t } = useTranslation()
 
     return (
-      <SelectContent popupClassName={popupClassName}>
+      <SelectContent className={popupClassName}>
         <SelectGroup>
           <SelectGroupLabel>
             {t(($) => $['userProfile.workspace'], { ns: 'common' })}

--- a/web/app/components/header/account-setting/access-rules-page/access-rule-row-menu.tsx
+++ b/web/app/components/header/account-setting/access-rules-page/access-rule-row-menu.tsx
@@ -85,7 +85,7 @@ const AccessRuleRowMenu = ({ rule, onView, onEdit }: AccessRuleRowMenuProps) => 
             </IconButton>
           }
         />
-        <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[140px]">
+        <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[140px]">
           {isBuiltIn ? (
             <DropdownMenuItem
               className="system-sm-semibold text-text-secondary"

--- a/web/app/components/header/account-setting/data-source-page-new/operator.tsx
+++ b/web/app/components/header/account-setting/data-source-page-new/operator.tsx
@@ -55,7 +55,7 @@ const Operator = ({
           </IconButton>
         }
       />
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[200px]">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[200px]">
         <DropdownMenuItem
           disabled={!canUseCredential}
           className="h-auto gap-2 py-2"

--- a/web/app/components/header/account-setting/members-page/invite-modal/__tests__/role-selector.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/__tests__/role-selector.spec.tsx
@@ -62,7 +62,7 @@ const mockUseWorkspaceRoleList = ({
 const RoleSelectorWrapper = () => <RoleSelector />
 
 const getTrigger = () => screen.getByRole('combobox', { name: /members\.role/i })
-const getListbox = () => screen.getByRole('listbox', { name: /members\.role/i })
+const getListbox = () => screen.getByRole('listbox')
 
 describe('RoleSelector', () => {
   beforeEach(() => {

--- a/web/app/components/header/account-setting/members-page/invite-modal/role-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/role-selector.tsx
@@ -4,11 +4,14 @@ import type { Role } from '@/models/access-control'
 import { Field, FieldError } from '@langgenius/dify-ui/field'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
   SelectLabel,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -153,44 +156,44 @@ export function RoleSelector({ hasServerError = false, disabled = false }: RoleS
         <SelectTrigger>
           <SelectValue placeholder={t(($) => $['members.selectRole'], { ns: 'common' })} />
         </SelectTrigger>
-        <SelectContent
-          listClassName="max-h-70"
-          listProps={{
-            ref: setListElement,
-            'aria-label': t(($) => $['members.role'], { ns: 'common' }),
-          }}
-        >
-          {rolesLoading ? (
-            <div className="px-3 py-6 text-center system-sm-regular text-text-tertiary">
-              {t(($) => $.loading, { ns: 'common' })}
-            </div>
-          ) : rolesError && roles.length === 0 ? (
-            <div className="px-3 py-6 text-center system-sm-regular text-text-destructive-secondary">
-              {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
-            </div>
-          ) : roles.length === 0 ? (
-            <div className="px-3 py-6 text-center system-sm-regular text-text-tertiary">
-              {t(($) => $['dynamicSelect.noData'], { ns: 'common' })}
-            </div>
-          ) : (
-            <>
-              {roles.map((role) => (
-                <SelectItem key={role.id} value={role} className="h-auto items-start py-2">
-                  <SelectItemText className="grid gap-0.5">
-                    <span className="truncate text-sm leading-5 text-text-secondary">
-                      {role.name}
-                    </span>
-                    <span className="line-clamp-2 text-xs leading-4.5 text-text-tertiary">
-                      {getRoleDescription(role)}
-                    </span>
-                  </SelectItemText>
-                  <SelectItemIndicator className="mt-0.5" />
-                </SelectItem>
-              ))}
-              <div ref={setAnchorElement} className="h-0" />
-            </>
-          )}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner>
+            <SelectPopup>
+              <SelectList className="max-h-70" ref={setListElement}>
+                {rolesLoading ? (
+                  <div className="px-3 py-6 text-center system-sm-regular text-text-tertiary">
+                    {t(($) => $.loading, { ns: 'common' })}
+                  </div>
+                ) : rolesError && roles.length === 0 ? (
+                  <div className="px-3 py-6 text-center system-sm-regular text-text-destructive-secondary">
+                    {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
+                  </div>
+                ) : roles.length === 0 ? (
+                  <div className="px-3 py-6 text-center system-sm-regular text-text-tertiary">
+                    {t(($) => $['dynamicSelect.noData'], { ns: 'common' })}
+                  </div>
+                ) : (
+                  <>
+                    {roles.map((role) => (
+                      <SelectItem key={role.id} value={role} className="h-auto items-start py-2">
+                        <SelectItemText className="grid gap-0.5">
+                          <span className="truncate text-sm leading-5 text-text-secondary">
+                            {role.name}
+                          </span>
+                          <span className="line-clamp-2 text-xs leading-4.5 text-text-tertiary">
+                            {getRoleDescription(role)}
+                          </span>
+                        </SelectItemText>
+                        <SelectItemIndicator className="mt-0.5" />
+                      </SelectItem>
+                    ))}
+                    <div ref={setAnchorElement} className="h-0" />
+                  </>
+                )}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </Select>
       {hasServerError ? (
         <FieldError />

--- a/web/app/components/header/account-setting/members-page/member-menu.tsx
+++ b/web/app/components/header/account-setting/members-page/member-menu.tsx
@@ -133,7 +133,7 @@ const MemberMenu = ({
         <DropdownMenuContent
           placement="bottom-end"
           sideOffset={4}
-          popupClassName="min-w-[180px] rounded-xl"
+          className="min-w-[180px] rounded-xl"
         >
           {canAssignRoles && (
             <DropdownMenuItem

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/authorized/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/authorized/index.tsx
@@ -1,4 +1,4 @@
-import type { Placement } from '@langgenius/dify-ui/popover'
+import type { PopoverContentProps } from '@langgenius/dify-ui/popover'
 import type { MouseEvent } from 'react'
 import type {
   ConfigurationMethodEnum,
@@ -31,7 +31,7 @@ type PopoverOffsetOptions = {
   alignmentAxis?: number
 }
 
-type AuthorizedProps = {
+type AuthorizedProps = Pick<PopoverContentProps, 'placement'> & {
   provider: ModelProvider
   configurationMethod: ConfigurationMethodEnum
   currentCustomConfigurationModelFixedFields?: CustomConfigurationModelFixedFields
@@ -52,7 +52,6 @@ type AuthorizedProps = {
   isOpen?: boolean
   onOpenChange?: (open: boolean) => void
   offset?: number | PopoverOffsetOptions
-  placement?: Placement
   popupClassName?: string
   showItemSelectedIcon?: boolean
   onItemClick?: (credential: Credential, model?: CustomModel) => void

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -1,4 +1,4 @@
-import type { Placement } from '@langgenius/dify-ui/popover'
+import type { PopoverContentProps } from '@langgenius/dify-ui/popover'
 import type { ComponentPropsWithRef, FC, ReactElement } from 'react'
 import type { FormValue, ModelParameterRule } from '../declarations'
 import type {
@@ -25,11 +25,10 @@ import ParameterItem from './parameter-item'
 import PresetsParameter from './presets-parameter'
 import { getSupportedPresetConfig } from './presets-parameter-utils'
 
-export type ModelParameterModalProps = {
+export type ModelParameterModalProps = Pick<PopoverContentProps, 'placement'> & {
   trigger?: ReactElement<ComponentPropsWithRef<'button'>>
   popupClassName?: string
   modelSelectorPopupClassName?: string
-  placement?: Placement
   isAdvancedMode: boolean
   modelId: string
   provider: string

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
@@ -347,7 +347,7 @@ function ModelSelectorPreviewCard({
   return (
     <PreviewCardContent
       placement="right"
-      popupClassName="w-[206px] bg-components-panel-bg-blur p-3 shadow-none backdrop-blur-xs"
+      className="w-[206px] bg-components-panel-bg-blur p-3 shadow-none backdrop-blur-xs"
     >
       <div className="flex flex-col gap-1">
         <div className="flex flex-col items-start gap-2">

--- a/web/app/components/header/account-setting/permissions-page/role-list/__tests__/row-menu.spec.tsx
+++ b/web/app/components/header/account-setting/permissions-page/role-list/__tests__/row-menu.spec.tsx
@@ -1,5 +1,5 @@
 import type { Role } from '@/models/access-control'
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render } from '@/test/console/render'
 import RowMenu from '../row-menu'
@@ -274,30 +274,6 @@ describe('RowMenu', () => {
           onSuccess: expect.any(Function),
         }),
       )
-    })
-
-    it('should close the copy member assignments dialog when clicking the backdrop', async () => {
-      render(
-        <RowMenu
-          roleCategory="global_system_default"
-          role={createRole({ id: 'role-default-editor', name: 'Editor' })}
-        />,
-      )
-
-      const { user, menu } = await openMenu()
-      await user.click(
-        within(menu).getByRole('menuitem', { name: 'permission.common.duplicateAction' }),
-      )
-
-      expect(screen.getByRole('alertdialog')).toBeInTheDocument()
-
-      const backdrop = document.body.querySelector('.bg-background-overlay')
-      expect(backdrop).toBeInTheDocument()
-      fireEvent.click(backdrop!)
-
-      await waitFor(() => {
-        expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-      })
     })
 
     it('should ignore role management actions without manage permission', async () => {

--- a/web/app/components/header/account-setting/permissions-page/role-list/copy-members-confirm-dialog.tsx
+++ b/web/app/components/header/account-setting/permissions-page/role-list/copy-members-confirm-dialog.tsx
@@ -37,12 +37,7 @@ export function CopyMembersConfirmDialog({
 
   return (
     <AlertDialog open onOpenChange={onOpenChange}>
-      <AlertDialogContent
-        backdropProps={{
-          forceRender: true,
-          onClick: () => onOpenChange(false),
-        }}
-      >
+      <AlertDialogContent backdropProps={{ forceRender: true }}>
         <div className="flex flex-col gap-2 px-6 pt-6 pb-4">
           <AlertDialogTitle className="w-full title-2xl-semi-bold text-text-primary">
             {t(($) => $['role.copyMembersTitle'], { ns: 'permission' })}

--- a/web/app/components/header/account-setting/permissions-page/role-list/row-menu.tsx
+++ b/web/app/components/header/account-setting/permissions-page/role-list/row-menu.tsx
@@ -120,7 +120,7 @@ const RowMenu = ({ roleCategory, role, onView, onEdit }: RowMenuProps) => {
             </IconButton>
           }
         />
-        <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[160px]">
+        <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[160px]">
           {hasViewAction && (
             <DropdownMenuItem
               className="system-sm-semibold text-text-secondary"

--- a/web/app/components/header/account-setting/update-setting-dialog-form.tsx
+++ b/web/app/components/header/account-setting/update-setting-dialog-form.tsx
@@ -163,7 +163,6 @@ const UpdateSettingDialogForm = ({
               title={t(($) => $['autoUpdate.updateTime'], { ns: 'plugin' })}
               minuteFilter={minuteFilter}
               renderTrigger={renderTimePickerTrigger}
-              placement="bottom-start"
             />
           </div>
           <div className="flex w-full flex-col items-start gap-2">

--- a/web/app/components/main-nav/components/help-menu.tsx
+++ b/web/app/components/main-nav/components/help-menu.tsx
@@ -179,7 +179,7 @@ const HelpMenu = ({ triggerIcon, triggerClassName, triggerRef, triggerSize }: He
         <DropdownMenuContent
           placement="top-end"
           sideOffset={8}
-          popupClassName="w-60 overflow-hidden bg-components-panel-bg-blur! p-0! backdrop-blur-[5px]"
+          className="w-60 overflow-hidden bg-components-panel-bg-blur! p-0! backdrop-blur-[5px]"
         >
           <>
             <DropdownMenuGroup className="p-1">

--- a/web/app/components/main-nav/components/workspace-switcher.tsx
+++ b/web/app/components/main-nav/components/workspace-switcher.tsx
@@ -87,7 +87,7 @@ function WorkspaceSwitchControls({
           <DropdownMenuContent
             placement="bottom-end"
             sideOffset={4}
-            popupClassName="w-40 bg-components-panel-bg-blur! p-1! backdrop-blur-[5px]"
+            className="w-40 bg-components-panel-bg-blur! p-1! backdrop-blur-[5px]"
           >
             <DropdownMenuRadioGroup<WorkspaceSort>
               value={sort}

--- a/web/app/components/plugins/install-plugin/install-from-github/steps/selectPackage.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-github/steps/selectPackage.tsx
@@ -110,7 +110,7 @@ const SelectPackage: React.FC<SelectPackageProps> = ({
               )}
             </div>
           </SelectTrigger>
-          <SelectContent popupClassName="w-[512px]">
+          <SelectContent className="w-[512px]">
             {versions.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 <SelectItemText>{item.name}</SelectItemText>
@@ -145,7 +145,7 @@ const SelectPackage: React.FC<SelectPackageProps> = ({
               t(($) => $[`${i18nPrefix}.selectPackagePlaceholder`], { ns: 'plugin' }) ??
               ''}
           </SelectTrigger>
-          <SelectContent popupClassName="w-[512px]">
+          <SelectContent className="w-[512px]">
             {packages.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 <SelectItemText>{item.name}</SelectItemText>

--- a/web/app/components/plugins/marketplace/sort-dropdown/index.tsx
+++ b/web/app/components/plugins/marketplace/sort-dropdown/index.tsx
@@ -48,7 +48,7 @@ const SortDropdown = () => {
         <span className="mr-1 system-sm-medium text-text-primary">{selectedOption.text}</span>
         <span aria-hidden className="i-ri-arrow-down-s-line size-4 text-text-tertiary" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-start" sideOffset={4} popupClassName="p-1">
+      <DropdownMenuContent placement="bottom-start" sideOffset={4} className="p-1">
         {options.map((option) => (
           <DropdownMenuItem
             key={`${option.value}-${option.order}`}

--- a/web/app/components/plugins/plugin-auth/authorize/__tests__/api-key-modal.spec.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/__tests__/api-key-modal.spec.tsx
@@ -478,13 +478,16 @@ describe('ApiKeyModal', () => {
     const mockOnClose = vi.fn()
     render(
       <Dialog open>
-        <DialogContent backdropClassName="bg-transparent">
+        <DialogContent>
           <ControlledModalHarness ApiKeyModal={ApiKeyModal} onClose={mockOnClose} />
         </DialogContent>
       </Dialog>,
     )
 
-    const backdrop = document.querySelector('.bg-background-overlay')
+    const backdrop = screen
+      .getAllByRole('presentation', { hidden: true })
+      .filter((element) => element.hasAttribute('data-open'))
+      .at(-1)
     expect(backdrop).toBeInTheDocument()
 
     fireEvent.pointerDown(backdrop!)

--- a/web/app/components/plugins/plugin-auth/authorize/__tests__/oauth-client-settings.spec.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/__tests__/oauth-client-settings.spec.tsx
@@ -172,13 +172,17 @@ describe('OAuthClientSettings', () => {
   it('should render backdrop when nested inside another dialog', () => {
     render(
       <Dialog open>
-        <DialogContent backdropClassName="bg-transparent">
+        <DialogContent>
           <OAuthClientSettings pluginPayload={basePayload} schemas={defaultSchemas} />
         </DialogContent>
       </Dialog>,
     )
 
-    expect(document.querySelector('.bg-background-overlay')).toBeInTheDocument()
+    const openBackdrops = screen
+      .getAllByRole('presentation', { hidden: true })
+      .filter((element) => element.hasAttribute('data-open'))
+
+    expect(openBackdrops).toHaveLength(2)
   })
 
   it('should pass schema defaults to auth form', () => {

--- a/web/app/components/plugins/plugin-auth/authorize/permission-selector.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/permission-selector.tsx
@@ -73,7 +73,7 @@ const PermissionSelector = ({ disabled, permission, onChange }: PermissionSelect
       <DropdownMenuContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName="w-(--anchor-width) max-w-(--available-width)"
+        className="w-(--anchor-width) max-w-(--available-width)"
       >
         <DropdownMenuRadioGroup<CredentialPermission>
           value={permission}

--- a/web/app/components/plugins/plugin-auth/authorized/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/__tests__/index.spec.tsx
@@ -1382,26 +1382,6 @@ describe('Authorized Component', () => {
 
   // ==================== Props Tests ====================
   describe('Props', () => {
-    it('should pass placement to Popover', () => {
-      const pluginPayload = createPluginPayload()
-      const credentials = [createCredential()]
-
-      // Default placement is bottom-start
-      render(
-        <Authorized
-          pluginPayload={pluginPayload}
-          credentials={credentials}
-          isOpen={true}
-          placement="top-end"
-        />,
-        { wrapper: createWrapper() },
-      )
-
-      // Component should render without error
-      // Component should render without error
-      expect(screen.getByText('API Keys'))!.toBeInTheDocument()
-    })
-
     it('should allow credential.use to set default when credential.manage is missing', () => {
       const pluginPayload = createPluginPayload()
       const credentials = [createCredential({ is_default: false })]

--- a/web/app/components/plugins/plugin-auth/authorized/index.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/index.tsx
@@ -1,5 +1,5 @@
 import type { OffsetOptions } from '@floating-ui/react'
-import type { Placement } from '@langgenius/dify-ui/popover'
+import type { PopoverContentProps } from '@langgenius/dify-ui/popover'
 import type { Credential, PluginPayload } from '../types'
 import {
   AlertDialog,
@@ -27,7 +27,7 @@ import {
 import { CredentialTypeEnum } from '../types'
 import Item from './item'
 
-type AuthorizedProps = {
+type AuthorizedProps = Pick<PopoverContentProps, 'placement'> & {
   pluginPayload: PluginPayload
   credentials: Credential[]
   canOAuth?: boolean
@@ -36,7 +36,6 @@ type AuthorizedProps = {
   isOpen?: boolean
   onOpenChange?: (open: boolean) => void
   offset?: number | OffsetOptions
-  placement?: Placement
   triggerPopupSameWidth?: boolean
   popupClassName?: string
   disableSetDefault?: boolean

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/app-picker.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/app-picker.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { AppPartial } from '@dify/contracts/api/console/apps/types.gen'
-import type { Placement } from '@langgenius/dify-ui/combobox'
+import type { ComboboxPositionerProps } from '@langgenius/dify-ui/combobox'
 import type { ReactNode } from 'react'
 import { zIconType } from '@dify/contracts/api/console/apps/zod.gen'
 import { Button } from '@langgenius/dify-ui/button'
@@ -32,11 +32,10 @@ import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
 import { AppModeEnum } from '@/types/app'
 
-type AppPickerProps = {
+type AppPickerProps = Pick<ComboboxPositionerProps, 'placement'> & {
   scope?: string
   disabled: boolean
   trigger: ReactNode
-  placement?: Placement
   offset?: number
   isShow: boolean
   onShowChange: (isShow: boolean) => void

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { AppPartial } from '@dify/contracts/api/console/apps/types.gen'
-import type { Placement } from '@langgenius/dify-ui/popover'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { keepPreviousData, skipToken, useInfiniteQuery, useQuery } from '@tanstack/react-query'
@@ -24,18 +23,11 @@ type AppSelectorProps = {
   value?: AppSelectorValue
   scope?: string
   disabled?: boolean
-  placement?: Placement
   offset?: number
   onSelect: (app: AppSelectorValue) => void
 }
 
-export function AppSelector({
-  value,
-  disabled,
-  placement = 'bottom',
-  offset = 4,
-  onSelect,
-}: AppSelectorProps) {
+export function AppSelector({ value, disabled, offset = 4, onSelect }: AppSelectorProps) {
   const { t } = useTranslation()
   const [isShow, setIsShow] = useState(false)
   const [isShowChooseApp, setIsShowChooseApp] = useState(false)
@@ -140,7 +132,6 @@ export function AppSelector({
         )}
       />
       <PopoverContent
-        placement={placement}
         sideOffset={offset}
         className="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
       >

--- a/web/app/components/plugins/plugin-detail-panel/model-selector/tts-params-panel.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/model-selector/tts-params-panel.tsx
@@ -55,7 +55,7 @@ const TTSParamsPanel = ({ currentModel, language, voice, onChange }: Props) => {
           >
             <SelectValue />
           </SelectTrigger>
-          <SelectContent popupClassName="w-[354px]">
+          <SelectContent className="w-[354px]">
             {supportedLanguages.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 <SelectItemText>{item.name}</SelectItemText>
@@ -82,7 +82,7 @@ const TTSParamsPanel = ({ currentModel, language, voice, onChange }: Props) => {
           >
             <SelectValue />
           </SelectTrigger>
-          <SelectContent popupClassName="w-[354px]">
+          <SelectContent className="w-[354px]">
             {voiceList.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 <SelectItemText>{item.label}</SelectItemText>

--- a/web/app/components/plugins/plugin-detail-panel/operation-dropdown.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/operation-dropdown.tsx
@@ -86,7 +86,7 @@ export function OperationDropdown({
         placement={placement}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
-        popupClassName={cn('w-48 py-1', popupClassName)}
+        className={cn('w-48 py-1', popupClassName)}
       >
         {showInfo && (
           <DropdownMenuItem

--- a/web/app/components/plugins/plugin-detail-panel/operation-dropdown.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/operation-dropdown.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { Placement } from '@langgenius/dify-ui/dropdown-menu'
+import type { DropdownMenuContentProps } from '@langgenius/dify-ui/dropdown-menu'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
@@ -15,22 +15,21 @@ import { useTranslation } from 'react-i18next'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { PluginSource } from '../types'
 
-type OperationDropdownProps = Readonly<{
-  source: PluginSource
-  onInfo: () => void
-  onCheckVersion: () => void
-  onRemove: () => void
-  onViewReadme?: () => void
-  detailUrl: string
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
-  popupClassName?: string
-  triggerSize?: 'm' | 'xs'
-  destructiveRemove?: boolean
-  showCheckVersion?: boolean
-  showRemove?: boolean
-}>
+type OperationDropdownProps = Readonly<
+  Pick<DropdownMenuContentProps, 'alignOffset' | 'placement' | 'sideOffset'> & {
+    source: PluginSource
+    onInfo: () => void
+    onCheckVersion: () => void
+    onRemove: () => void
+    onViewReadme?: () => void
+    detailUrl: string
+    popupClassName?: string
+    triggerSize?: 'm' | 'xs'
+    destructiveRemove?: boolean
+    showCheckVersion?: boolean
+    showRemove?: boolean
+  }
+>
 
 export function OperationDropdown({
   source,

--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/index.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { Placement } from '@langgenius/dify-ui/popover'
 import type { ReactElement, Ref } from 'react'
 import type { Node } from 'reactflow'
 import type { ToolValue } from '@/app/components/workflow/block-selector/types'
@@ -33,7 +32,6 @@ type TriggerProps =
 
 type Props = Readonly<{
   disabled?: boolean
-  placement?: Placement
   scope?: string
   value?: ToolValue
   selectedTools?: ToolValue[]
@@ -55,7 +53,6 @@ function ToolSelector({
   selectedTools,
   isEdit,
   disabled,
-  placement = 'left',
   onSelect,
   onSelectMultiple,
   onDelete,
@@ -171,7 +168,7 @@ function ToolSelector({
       ) : null}
 
       <PopoverContent
-        placement={placement}
+        placement="left"
         sideOffset={4}
         className="border-none bg-transparent shadow-none"
       >

--- a/web/app/components/plugins/plugin-page/debug-info.tsx
+++ b/web/app/components/plugins/plugin-page/debug-info.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { ButtonProps } from '@langgenius/dify-ui/button'
-import type { Placement } from '@langgenius/dify-ui/popover'
+import type { PopoverContentProps } from '@langgenius/dify-ui/popover'
 import type { ReactNode } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
@@ -14,7 +14,7 @@ import { PluginSidecarPanel } from './plugin-sidecar-panel'
 const i18nPrefix = 'debugInfo'
 
 type DebugInfoProps = {
-  popupPlacement?: Placement
+  popupPlacement?: PopoverContentProps['placement']
   triggerClassName?: string
   triggerContent?: ReactNode
   triggerVariant?: ButtonProps['variant']

--- a/web/app/components/plugins/plugin-page/install-plugin-dropdown.tsx
+++ b/web/app/components/plugins/plugin-page/install-plugin-dropdown.tsx
@@ -185,7 +185,7 @@ const InstallPluginDropdown = ({
         <DropdownMenuContent
           placement="bottom-start"
           sideOffset={4}
-          popupClassName={cn('w-50 pb-2', popupClassName)}
+          className={cn('w-50 pb-2', popupClassName)}
         >
           <span className="flex items-start self-stretch px-3 pt-1 pb-0.5 system-xs-medium-uppercase text-text-tertiary">
             {t(($) => $.installFrom, { ns: 'plugin' })}

--- a/web/app/components/plugins/plugin-page/nav-operations.tsx
+++ b/web/app/components/plugins/plugin-page/nav-operations.tsx
@@ -97,7 +97,7 @@ export function SubmitRequestDropdown({ dividerAfterFirst }: SubmitRequestDropdo
           </IconButton>
         }
       />
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[200px] p-1">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[200px] p-1">
         {options.map((option, index) => (
           <Fragment key={option.href}>
             {dividerAfterFirst && index === 1 && <DropdownMenuSeparator className="my-1" />}

--- a/web/app/components/plugins/plugin-page/plugin-tasks/index.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/index.tsx
@@ -1,4 +1,4 @@
-import type { Placement } from '@langgenius/dify-ui/dropdown-menu'
+import type { DropdownMenuPositionerProps } from '@langgenius/dify-ui/dropdown-menu'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
@@ -17,7 +17,7 @@ import { usePluginTaskStatus } from './hooks'
 type PluginTasksProps = {
   animatedSlot?: boolean
   dropdownAnchor?: () => Element | null
-  dropdownPlacement?: Placement
+  dropdownPlacement?: DropdownMenuPositionerProps['placement']
 }
 
 const PluginTasks = ({

--- a/web/app/components/plugins/plugin-page/plugin-tasks/index.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/index.tsx
@@ -2,7 +2,9 @@ import type { Placement } from '@langgenius/dify-ui/dropdown-menu'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
-  DropdownMenuContent,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import { useCallback, useMemo, useState } from 'react'
@@ -140,22 +142,25 @@ const PluginTasks = ({
           }
           disabled={!canOpenMenu}
         />
-        <DropdownMenuContent
-          placement={dropdownPlacement}
-          sideOffset={4}
-          positionerProps={dropdownAnchor ? { anchor: dropdownAnchor } : undefined}
-          popupClassName="overflow-visible border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-        >
-          <PluginTaskList
-            runningPlugins={runningPlugins}
-            successPlugins={successPlugins}
-            errorPlugins={errorPlugins}
-            getIconUrl={getIconUrl}
-            onClearAll={handleClearAll}
-            onClearErrors={handleClearErrors}
-            onClearSingle={handleClearSingle}
-          />
-        </DropdownMenuContent>
+        <DropdownMenuPortal>
+          <DropdownMenuPositioner
+            placement={dropdownPlacement}
+            sideOffset={4}
+            anchor={dropdownAnchor}
+          >
+            <DropdownMenuPopup>
+              <PluginTaskList
+                runningPlugins={runningPlugins}
+                successPlugins={successPlugins}
+                errorPlugins={errorPlugins}
+                getIconUrl={getIconUrl}
+                onClearAll={handleClearAll}
+                onClearErrors={handleClearErrors}
+                onClearSingle={handleClearSingle}
+              />
+            </DropdownMenuPopup>
+          </DropdownMenuPositioner>
+        </DropdownMenuPortal>
       </DropdownMenu>
     </div>
   )

--- a/web/app/components/plugins/update-plugin/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/update-plugin/__tests__/index.spec.tsx
@@ -1054,14 +1054,6 @@ describe('update-plugin', () => {
     })
 
     describe('Props', () => {
-      it('should support custom placement', () => {
-        // Act
-        render(<PluginVersionPicker {...defaultProps} isShow={true} placement="top-end" />)
-
-        // Assert
-        expect(screen.getByText('plugin.detailPanel.switchVersion')).toBeInTheDocument()
-      })
-
       it('should support custom offset', () => {
         // Act
         render(

--- a/web/app/components/plugins/update-plugin/plugin-version-picker.tsx
+++ b/web/app/components/plugins/update-plugin/plugin-version-picker.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { Placement } from '@langgenius/dify-ui/popover'
 import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
@@ -18,7 +17,6 @@ type Props = Readonly<{
   pluginID: string
   currentVersion: string
   trigger: (open: boolean) => React.ReactNode
-  placement?: Placement
   sideOffset?: number
   alignOffset?: number
   onSelect: ({
@@ -39,7 +37,6 @@ const PluginVersionPicker: FC<Props> = ({
   pluginID,
   currentVersion,
   trigger,
-  placement = 'bottom-start',
   sideOffset = 4,
   alignOffset = 0,
   onSelect,
@@ -91,7 +88,7 @@ const PluginVersionPicker: FC<Props> = ({
       />
 
       <PopoverContent
-        placement={placement}
+        placement="bottom-start"
         sideOffset={sideOffset}
         alignOffset={alignOffset}
         className="relative w-[209px] bg-components-panel-bg-blur p-1 backdrop-blur-[5px]"

--- a/web/app/components/share/text-generation/__tests__/menu-dropdown.spec.tsx
+++ b/web/app/components/share/text-generation/__tests__/menu-dropdown.spec.tsx
@@ -240,15 +240,6 @@ describe('MenuDropdown', () => {
     })
   })
 
-  describe('placement prop', () => {
-    it('should accept custom placement', () => {
-      render(<MenuDropdown data={baseSiteInfo} placement="top-start" />)
-
-      const triggerButton = screen.getByRole('button')
-      expect(triggerButton).toBeInTheDocument()
-    })
-  })
-
   describe('toggle behavior', () => {
     it('should close dropdown when clicking trigger again', async () => {
       render(<MenuDropdown data={baseSiteInfo} />)

--- a/web/app/components/share/text-generation/menu-dropdown.tsx
+++ b/web/app/components/share/text-generation/menu-dropdown.tsx
@@ -63,7 +63,7 @@ const MenuDropdown: FC<Props> = ({ data, placement, hideLogout }) => {
         <DropdownMenuContent
           placement={placement || 'bottom-end'}
           sideOffset={4}
-          popupClassName="w-[224px]"
+          className="w-[224px]"
         >
           <div className="px-3 py-1.5 system-md-regular text-text-secondary">
             <div className="flex items-center gap-2">

--- a/web/app/components/share/text-generation/menu-dropdown.tsx
+++ b/web/app/components/share/text-generation/menu-dropdown.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { Placement } from '@langgenius/dify-ui/dropdown-menu'
+import type { DropdownMenuContentProps } from '@langgenius/dify-ui/dropdown-menu'
 import type { FC } from 'react'
 import type { SiteInfo } from '@/models/share'
 import {
@@ -22,11 +22,12 @@ import { resolveWebAppAddress } from '@/service/webapp-address'
 import { webAppLogout } from '@/service/webapp-auth'
 import InfoModal from './info-modal'
 
-type Props = Readonly<{
-  data?: SiteInfo
-  placement?: Placement
-  hideLogout?: boolean
-}>
+type Props = Readonly<
+  Pick<DropdownMenuContentProps, 'placement'> & {
+    data?: SiteInfo
+    hideLogout?: boolean
+  }
+>
 
 const MenuDropdown: FC<Props> = ({ data, placement, hideLogout }) => {
   const webAppAccessMode = useWebAppStore((s) => s.webAppAccessMode)

--- a/web/app/components/snippet-list/components/snippet-card.tsx
+++ b/web/app/components/snippet-list/components/snippet-card.tsx
@@ -216,11 +216,7 @@ const SnippetCard = ({
                     <span aria-hidden className="i-ri-more-fill size-4 text-text-tertiary" />
                   </div>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  placement="bottom-end"
-                  sideOffset={4}
-                  popupClassName="w-[216px]"
-                >
+                <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-[216px]">
                   {canCreateAndModifySnippet && (
                     <>
                       <DropdownMenuItem className="gap-2 px-3" onClick={handleOpenEditDialog}>

--- a/web/app/components/snippet-list/components/snippet-publish-status-filter.tsx
+++ b/web/app/components/snippet-list/components/snippet-publish-status-filter.tsx
@@ -58,7 +58,7 @@ const SnippetPublishStatusFilter = ({ value, onChange }: SnippetPublishStatusFil
         <span className="px-1 text-text-tertiary">{triggerLabel}</span>
         <span aria-hidden className="i-ri-arrow-down-s-line h-4 w-4 shrink-0 text-text-tertiary" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-start" popupClassName="w-[220px]">
+      <DropdownMenuContent placement="bottom-start" className="w-[220px]">
         <DropdownMenuRadioGroup<SnippetPublishStatus>
           value={value}
           onValueChange={(nextValue) => onChange(nextValue)}

--- a/web/app/components/step-by-step-tour/__tests__/dropdown-menu.spec.tsx
+++ b/web/app/components/step-by-step-tour/__tests__/dropdown-menu.spec.tsx
@@ -1,19 +1,15 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@langgenius/dify-ui/dropdown-menu'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {
   getStepByStepTourDropdownMenuContentProps,
   useStepByStepTourControlledDropdown,
 } from '../dropdown-menu'
-
-const STEP_BY_STEP_TOUR_HIGHLIGHT_PART_DATA_ATTR = 'data-step-by-step-tour-highlight-part'
-
-const getHighlightPartValue = (props: unknown): string | undefined => {
-  if (!props || typeof props !== 'object') return undefined
-
-  const value = (props as Record<string, unknown>)[STEP_BY_STEP_TOUR_HIGHLIGHT_PART_DATA_ATTR]
-  return typeof value === 'string' ? value : undefined
-}
-
-const noopKeyboardHandler = () => {}
 
 function TestDropdown({
   allowTriggerCloseWhileControlled,
@@ -35,11 +31,7 @@ function TestDropdown({
       <button type="button" onClick={menu.close}>
         Close from action
       </button>
-      <div
-        aria-label="dropdown"
-        data-controlled={String(menu.controlled)}
-        data-open={String(menu.open)}
-      />
+      <p>{`Menu is ${menu.open ? 'open' : 'closed'} and ${menu.controlled ? 'controlled' : 'uncontrolled'}`}</p>
     </>
   )
 }
@@ -48,49 +40,46 @@ describe('useStepByStepTourControlledDropdown', () => {
   it('keeps ordinary dropdown toggle behavior when no tour controls it', () => {
     render(<TestDropdown />)
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'false')
+    expect(screen.getByText('Menu is closed and uncontrolled')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }))
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByText('Menu is open and uncontrolled')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }))
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'false')
+    expect(screen.getByText('Menu is closed and uncontrolled')).toBeInTheDocument()
   })
 
   it('opens for a tour step without locking the dropdown open', () => {
     render(<TestDropdown controlledOpen />)
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'true')
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-controlled', 'true')
+    expect(screen.getByText('Menu is open and controlled')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }))
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'false')
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-controlled', 'false')
+    expect(screen.getByText('Menu is closed and uncontrolled')).toBeInTheDocument()
   })
 
   it('can keep a tour-opened dropdown locked until the tour leaves the step', () => {
     render(<TestDropdown controlledOpen allowTriggerCloseWhileControlled={false} />)
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByText('Menu is open and controlled')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle menu' }))
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'true')
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-controlled', 'true')
+    expect(screen.getByText('Menu is open and controlled')).toBeInTheDocument()
   })
 
   it('closes when the tour leaves the dropdown step', async () => {
     const { rerender } = render(<TestDropdown controlledOpen />)
 
-    expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByText('Menu is open and controlled')).toBeInTheDocument()
 
     rerender(<TestDropdown />)
 
     await waitFor(() => {
-      expect(screen.getByLabelText('dropdown')).toHaveAttribute('data-open', 'false')
+      expect(screen.getByText('Menu is closed and uncontrolled')).toBeInTheDocument()
     })
   })
 })
@@ -99,84 +88,62 @@ describe('getStepByStepTourDropdownMenuContentProps', () => {
   it('blocks presentation menu interactions without letting clicks bubble through', () => {
     const onAction = vi.fn()
     const onBackgroundClick = vi.fn()
-    const { popupClassName, popupProps, positionerProps } =
-      getStepByStepTourDropdownMenuContentProps({
-        highlightPart: 'tour-menu',
-        interactionMode: 'presentation',
-      })
 
     render(
-      <div role="button" tabIndex={0} onClick={onBackgroundClick} onKeyDown={noopKeyboardHandler}>
-        <div
-          data-testid="positioner"
-          data-step-by-step-tour-highlight-part={getHighlightPartValue(positionerProps)}
-          onClickCapture={positionerProps?.onClickCapture}
-          onKeyDownCapture={positionerProps?.onKeyDownCapture}
-          onMouseDownCapture={positionerProps?.onMouseDownCapture}
-          onPointerDownCapture={positionerProps?.onPointerDownCapture}
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Open menu</DropdownMenuTrigger>
+        <DropdownMenuContent
+          {...getStepByStepTourDropdownMenuContentProps({
+            highlightPart: 'tour-menu',
+            interactionMode: 'presentation',
+          })}
         >
-          <div
-            role="menu"
-            aria-hidden={popupProps?.['aria-hidden']}
-            onClickCapture={popupProps?.onClickCapture}
-            onKeyDownCapture={popupProps?.onKeyDownCapture}
-            onMouseDownCapture={popupProps?.onMouseDownCapture}
-            onPointerDownCapture={popupProps?.onPointerDownCapture}
-          >
-            <button type="button" role="menuitem" onClick={onAction}>
-              Delete
-            </button>
-          </div>
-        </div>
-      </div>,
+          <DropdownMenuItem onClick={onAction}>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
     )
+    document.addEventListener('click', onBackgroundClick)
 
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete', hidden: true }))
 
     expect(onAction).not.toHaveBeenCalled()
     expect(onBackgroundClick).not.toHaveBeenCalled()
     expect(screen.getByRole('menu', { hidden: true })).toHaveAttribute('aria-hidden', 'true')
-    expect(screen.getByTestId('positioner')).toHaveAttribute(
+    expect(screen.getByRole('menu', { hidden: true })).toHaveAttribute(
       'data-step-by-step-tour-highlight-part',
       'tour-menu',
     )
-    expect(popupClassName).toContain('pointer-events-none')
+    document.removeEventListener('click', onBackgroundClick)
   })
 
-  it('leaves interactive menus clickable without bubbling through', () => {
+  it('leaves interactive menus clickable without bubbling through', async () => {
+    const user = userEvent.setup()
     const onAction = vi.fn()
     const onBackgroundClick = vi.fn()
-    const onPopupClick = vi.fn()
-    const { popupProps, positionerProps } = getStepByStepTourDropdownMenuContentProps({
-      highlightPart: 'tour-menu',
-      interactionMode: 'interactive',
-      popupProps: {
-        onClick: onPopupClick,
-      },
-    })
 
     render(
-      <div role="button" tabIndex={0} onClick={onBackgroundClick} onKeyDown={noopKeyboardHandler}>
-        <div data-step-by-step-tour-highlight-part={getHighlightPartValue(positionerProps)}>
-          <div
-            role="menu"
-            tabIndex={-1}
-            aria-hidden={popupProps?.['aria-hidden']}
-            onClick={popupProps?.onClick}
-            onKeyDown={noopKeyboardHandler}
-          >
-            <button type="button" role="menuitem" onClick={onAction}>
-              Create
-            </button>
-          </div>
-        </div>
-      </div>,
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Open menu</DropdownMenuTrigger>
+        <DropdownMenuContent
+          {...getStepByStepTourDropdownMenuContentProps({
+            highlightPart: 'tour-menu',
+            interactionMode: 'interactive',
+          })}
+        >
+          <DropdownMenuItem onClick={onAction}>Create</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
     )
+    document.addEventListener('click', onBackgroundClick)
 
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Create' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Create' }))
 
     expect(onAction).toHaveBeenCalledTimes(1)
-    expect(onPopupClick).toHaveBeenCalledTimes(1)
     expect(onBackgroundClick).not.toHaveBeenCalled()
+    expect(screen.getByRole('menu')).toHaveAttribute(
+      'data-step-by-step-tour-highlight-part',
+      'tour-menu',
+    )
+    document.removeEventListener('click', onBackgroundClick)
   })
 })

--- a/web/app/components/step-by-step-tour/dropdown-menu.ts
+++ b/web/app/components/step-by-step-tour/dropdown-menu.ts
@@ -8,16 +8,11 @@ const STEP_BY_STEP_TOUR_MENU_POPUP_NO_MOTION_CLASS_NAME =
   'transition-none data-starting-style:scale-100 data-starting-style:opacity-100 data-ending-style:scale-100 data-ending-style:opacity-100'
 const STEP_BY_STEP_TOUR_MENU_PRESENTATION_CLASS_NAME = 'pointer-events-none cursor-default'
 
-type DropdownMenuPositionerProps = DropdownMenuContentProps['positionerProps']
-type DropdownMenuPopupProps = DropdownMenuContentProps['popupProps']
-
 type StepByStepTourDropdownMenuContentProps = {
   highlightPart?: string
   disableMotion?: boolean
   interactionMode?: 'interactive' | 'presentation'
-  popupClassName?: string
-  popupProps?: DropdownMenuPopupProps
-  positionerProps?: DropdownMenuPositionerProps
+  className?: string
 }
 
 const blockPresentationMenuEvent = (event: SyntheticEvent) => {
@@ -29,91 +24,43 @@ const stopMenuEventPropagation = (event: SyntheticEvent) => {
   event.stopPropagation()
 }
 
-const composeStepByStepTourEventHandlers = <Event extends SyntheticEvent>(
-  handler: ((event: Event) => void) | undefined,
-  stepByStepTourHandler: (event: Event) => void,
-) => {
-  return (event: Event) => {
-    handler?.(event)
-    stepByStepTourHandler(event)
-  }
-}
-
 export const getStepByStepTourDropdownMenuContentProps = ({
   highlightPart,
   disableMotion = false,
   interactionMode = 'interactive',
-  popupClassName,
-  popupProps,
-  positionerProps,
+  className,
 }: StepByStepTourDropdownMenuContentProps): Pick<
   DropdownMenuContentProps,
-  'popupClassName' | 'popupProps' | 'positionerProps'
-> => {
+  | 'aria-hidden'
+  | 'className'
+  | 'onClick'
+  | 'onClickCapture'
+  | 'onKeyDownCapture'
+  | 'onMouseDownCapture'
+  | 'onPointerDownCapture'
+> & {
+  [STEP_BY_STEP_TOUR_HIGHLIGHT_PART_DATA_ATTR]?: string
+} => {
   const isPresentation = interactionMode === 'presentation'
-  const nextPositionerProps =
-    highlightPart || isPresentation
-      ? ({
-          ...positionerProps,
-          ...(highlightPart
-            ? { [STEP_BY_STEP_TOUR_HIGHLIGHT_PART_DATA_ATTR]: highlightPart }
-            : undefined),
-          ...(isPresentation
-            ? {
-                onClickCapture: composeStepByStepTourEventHandlers(
-                  positionerProps?.onClickCapture,
-                  blockPresentationMenuEvent,
-                ),
-                onMouseDownCapture: composeStepByStepTourEventHandlers(
-                  positionerProps?.onMouseDownCapture,
-                  blockPresentationMenuEvent,
-                ),
-                onPointerDownCapture: composeStepByStepTourEventHandlers(
-                  positionerProps?.onPointerDownCapture,
-                  blockPresentationMenuEvent,
-                ),
-                onKeyDownCapture: composeStepByStepTourEventHandlers(
-                  positionerProps?.onKeyDownCapture,
-                  blockPresentationMenuEvent,
-                ),
-              }
-            : undefined),
-        } as DropdownMenuPositionerProps)
-      : positionerProps
-  const nextPopupProps = isPresentation
-    ? ({
-        ...popupProps,
-        'aria-hidden': true,
-        onClickCapture: composeStepByStepTourEventHandlers(
-          popupProps?.onClickCapture,
-          blockPresentationMenuEvent,
-        ),
-        onMouseDownCapture: composeStepByStepTourEventHandlers(
-          popupProps?.onMouseDownCapture,
-          blockPresentationMenuEvent,
-        ),
-        onPointerDownCapture: composeStepByStepTourEventHandlers(
-          popupProps?.onPointerDownCapture,
-          blockPresentationMenuEvent,
-        ),
-        onKeyDownCapture: composeStepByStepTourEventHandlers(
-          popupProps?.onKeyDownCapture,
-          blockPresentationMenuEvent,
-        ),
-      } as DropdownMenuPopupProps)
-    : ({
-        ...popupProps,
-        onClick: composeStepByStepTourEventHandlers(popupProps?.onClick, stopMenuEventPropagation),
-      } as DropdownMenuPopupProps)
 
   return {
-    popupClassName: cn(
-      popupClassName,
+    ...(highlightPart
+      ? { [STEP_BY_STEP_TOUR_HIGHLIGHT_PART_DATA_ATTR]: highlightPart }
+      : undefined),
+    className: cn(
+      className,
       disableMotion && STEP_BY_STEP_TOUR_MENU_POPUP_NO_MOTION_CLASS_NAME,
       isPresentation && STEP_BY_STEP_TOUR_MENU_PRESENTATION_CLASS_NAME,
     ),
-    popupProps: nextPopupProps,
-    positionerProps: nextPositionerProps,
+    ...(isPresentation
+      ? {
+          'aria-hidden': true,
+          onClickCapture: blockPresentationMenuEvent,
+          onMouseDownCapture: blockPresentationMenuEvent,
+          onPointerDownCapture: blockPresentationMenuEvent,
+          onKeyDownCapture: blockPresentationMenuEvent,
+        }
+      : { onClick: stopMenuEventPropagation }),
   }
 }
 

--- a/web/app/components/tools/edit-custom-collection-modal/get-schema.tsx
+++ b/web/app/components/tools/edit-custom-collection-modal/get-schema.tsx
@@ -51,7 +51,7 @@ const GetSchema: FC<Props> = ({ onChange }) => {
             {t(($) => $['createTool.importFromUrl'], { ns: 'tools' })}
           </span>
         </DropdownMenuTrigger>
-        <DropdownMenuContent placement="bottom-start" sideOffset={2} popupClassName="w-[300px] p-2">
+        <DropdownMenuContent placement="bottom-start" sideOffset={2} className="w-[300px] p-2">
           <div className="relative">
             <Input
               type="text"
@@ -80,7 +80,7 @@ const GetSchema: FC<Props> = ({ onChange }) => {
           </span>
           <span className="i-ri-arrow-down-s-line size-3" aria-hidden />
         </DropdownMenuTrigger>
-        <DropdownMenuContent placement="bottom-end" sideOffset={2} popupClassName="min-w-max">
+        <DropdownMenuContent placement="bottom-end" sideOffset={2} className="min-w-max">
           {examples.map((item) => (
             <DropdownMenuItem
               key={item.key}

--- a/web/app/components/tools/mcp/detail/operation-dropdown.tsx
+++ b/web/app/components/tools/mcp/detail/operation-dropdown.tsx
@@ -34,7 +34,7 @@ const OperationDropdown: FC<Props> = ({ inCard, onOpenChange, onEdit, onRemove }
           </IconButton>
         }
       />
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-[160px]">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-[160px]">
         <DropdownMenuItem onClick={onEdit}>
           <span aria-hidden className="i-ri-edit-line size-4 shrink-0 text-text-tertiary" />
           <div className="ml-2 system-md-regular text-text-secondary">

--- a/web/app/components/workflow-app/components/workflow-onboarding-modal/index.tsx
+++ b/web/app/components/workflow-app/components/workflow-onboarding-modal/index.tsx
@@ -30,7 +30,7 @@ const WorkflowOnboardingModal: FC<WorkflowOnboardingModalProps> = ({
     <Dialog open={isShow} onOpenChange={onClose} disablePointerDismissal>
       <DialogContent
         className="w-154.5 max-w-154.5 rounded-2xl border border-effects-highlight bg-background-default-subtle shadow-lg"
-        backdropClassName="bg-workflow-canvas-canvas-overlay"
+        backdropProps={{ className: 'bg-workflow-canvas-canvas-overlay' }}
       >
         <DialogClose
           render={

--- a/web/app/components/workflow/block-selector/index.tsx
+++ b/web/app/components/workflow/block-selector/index.tsx
@@ -1,4 +1,4 @@
-import type { Placement, PopoverTriggerProps } from '@langgenius/dify-ui/popover'
+import type { PopoverPositionerProps, PopoverTriggerProps } from '@langgenius/dify-ui/popover'
 import type { CSSProperties, KeyboardEvent, MouseEventHandler } from 'react'
 import type {
   CommonNodeType,
@@ -30,15 +30,15 @@ import { BlockEnum, isTriggerNode } from '../types'
 import { useTabs } from './hooks'
 import { BlockSelectorPanels } from './tabs'
 
-export type BlockSelectorProps = {
+export type BlockSelectorProps = Pick<
+  PopoverPositionerProps,
+  'alignOffset' | 'placement' | 'sideOffset'
+> & {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   onSelect: OnSelectBlock
   trigger?: NonNullable<PopoverTriggerProps['render']>
   triggerTooltip?: string
-  placement?: Placement
-  sideOffset?: number
-  alignOffset?: number
   triggerStyle?: CSSProperties
   triggerClassName?: string
   triggerAriaLabel?: string

--- a/web/app/components/workflow/block-selector/marketplace-plugin/action.tsx
+++ b/web/app/components/workflow/block-selector/marketplace-plugin/action.tsx
@@ -65,7 +65,7 @@ function OperationDropdown({ open, onOpenChange, author, name, version }: Props)
           </IconButton>
         }
       />
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-[176px]">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-[176px]">
         <DropdownMenuItem className="system-md-regular" onClick={handleDownload}>
           {t(($) => $['operation.download'], { ns: 'common' })}
         </DropdownMenuItem>

--- a/web/app/components/workflow/block-selector/preview-card.tsx
+++ b/web/app/components/workflow/block-selector/preview-card.tsx
@@ -1,29 +1,37 @@
 import type { ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
-import { PreviewCardContent, PreviewCardViewport } from '@langgenius/dify-ui/preview-card'
+import {
+  PreviewCardPopup,
+  PreviewCardPortal,
+  PreviewCardPositioner,
+  PreviewCardViewport,
+} from '@langgenius/dify-ui/preview-card'
 
 export function BlockSelectorPreviewCardContent({ children }: { children: ReactNode }) {
   return (
-    <PreviewCardContent
-      placement="right"
-      className="h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] data-instant:transition-none motion-reduce:transition-none"
-      popupClassName="relative h-[var(--popup-height,auto)] w-[var(--popup-width,auto)] overflow-hidden border-none transition-[width,height,transform,scale,opacity] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] data-instant:transition-none motion-reduce:transition-none"
-    >
-      <PreviewCardViewport
-        className={cn(
-          'relative h-full w-full overflow-clip',
-          '**:data-current:w-56 **:data-current:translate-y-0 **:data-current:px-3 **:data-current:py-2.5 **:data-current:opacity-100 **:data-current:transition-[translate,opacity] **:data-current:duration-[180ms,90ms] **:data-current:ease-[cubic-bezier(0.22,1,0.36,1)]',
-          '**:data-previous:w-56 **:data-previous:translate-y-0 **:data-previous:px-3 **:data-previous:py-2.5 **:data-previous:opacity-100 **:data-previous:transition-[translate,opacity] **:data-previous:duration-[180ms,90ms] **:data-previous:ease-[cubic-bezier(0.22,1,0.36,1)]',
-          'data-instant:**:data-current:transition-none data-instant:**:data-previous:transition-none',
-          "data-[activation-direction~='up']:**:data-current:data-starting-style:-translate-y-2 data-[activation-direction~='up']:**:data-current:data-starting-style:opacity-0",
-          "data-[activation-direction~='up']:**:data-previous:data-ending-style:translate-y-2 data-[activation-direction~='up']:**:data-previous:data-ending-style:opacity-0",
-          "data-[activation-direction~='down']:**:data-current:data-starting-style:translate-y-2 data-[activation-direction~='down']:**:data-current:data-starting-style:opacity-0",
-          "data-[activation-direction~='down']:**:data-previous:data-ending-style:-translate-y-2 data-[activation-direction~='down']:**:data-previous:data-ending-style:opacity-0",
-          'motion-reduce:**:data-current:transition-none motion-reduce:**:data-previous:transition-none',
-        )}
+    <PreviewCardPortal>
+      <PreviewCardPositioner
+        placement="right"
+        className="h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] data-instant:transition-none motion-reduce:transition-none"
       >
-        {children}
-      </PreviewCardViewport>
-    </PreviewCardContent>
+        <PreviewCardPopup className="relative h-[var(--popup-height,auto)] w-[var(--popup-width,auto)] overflow-hidden rounded-xl bg-components-panel-bg shadow-lg transition-[width,height,transform,scale,opacity] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] data-instant:transition-none motion-reduce:transition-none">
+          <PreviewCardViewport
+            className={cn(
+              'relative h-full w-full overflow-clip',
+              '**:data-current:w-56 **:data-current:translate-y-0 **:data-current:px-3 **:data-current:py-2.5 **:data-current:opacity-100 **:data-current:transition-[translate,opacity] **:data-current:duration-[180ms,90ms] **:data-current:ease-[cubic-bezier(0.22,1,0.36,1)]',
+              '**:data-previous:w-56 **:data-previous:translate-y-0 **:data-previous:px-3 **:data-previous:py-2.5 **:data-previous:opacity-100 **:data-previous:transition-[translate,opacity] **:data-previous:duration-[180ms,90ms] **:data-previous:ease-[cubic-bezier(0.22,1,0.36,1)]',
+              'data-instant:**:data-current:transition-none data-instant:**:data-previous:transition-none',
+              "data-[activation-direction~='up']:**:data-current:data-starting-style:-translate-y-2 data-[activation-direction~='up']:**:data-current:data-starting-style:opacity-0",
+              "data-[activation-direction~='up']:**:data-previous:data-ending-style:translate-y-2 data-[activation-direction~='up']:**:data-previous:data-ending-style:opacity-0",
+              "data-[activation-direction~='down']:**:data-current:data-starting-style:translate-y-2 data-[activation-direction~='down']:**:data-current:data-starting-style:opacity-0",
+              "data-[activation-direction~='down']:**:data-previous:data-ending-style:-translate-y-2 data-[activation-direction~='down']:**:data-previous:data-ending-style:opacity-0",
+              'motion-reduce:**:data-current:transition-none motion-reduce:**:data-previous:transition-none',
+            )}
+          >
+            {children}
+          </PreviewCardViewport>
+        </PreviewCardPopup>
+      </PreviewCardPositioner>
+    </PreviewCardPortal>
   )
 }

--- a/web/app/components/workflow/block-selector/tool-picker.tsx
+++ b/web/app/components/workflow/block-selector/tool-picker.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { Placement } from '@langgenius/dify-ui/popover'
+import type { PopoverContentProps } from '@langgenius/dify-ui/popover'
 import type { ReactElement } from 'react'
 import type { ToolDefaultValue, ToolValue } from './types'
 import type { CustomCollectionBackend } from '@/app/components/tools/types'
@@ -29,14 +29,14 @@ import {
   useInvalidateAllWorkflowTools,
 } from '@/service/use-tools'
 
-type Props = Readonly<{
-  disabled: boolean
-  trigger: ReactElement
-  placement?: Placement
-  sideOffset?: number
-  isShow: boolean
-  onShowChange: (isShow: boolean) => void
-}> &
+type Props = Readonly<
+  Pick<PopoverContentProps, 'placement' | 'sideOffset'> & {
+    disabled: boolean
+    trigger: ReactElement
+    isShow: boolean
+    onShowChange: (isShow: boolean) => void
+  }
+> &
   ToolPickerContentProps
 
 export type ToolPickerContentProps = Readonly<{

--- a/web/app/components/workflow/comment/thread.tsx
+++ b/web/app/components/workflow/comment/thread.tsx
@@ -575,7 +575,7 @@ export const CommentThread: FC<CommentThreadProps> = memo(
                     <DropdownMenuContent
                       placement="bottom-end"
                       sideOffset={4}
-                      popupClassName="w-36 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[10px]"
+                      className="w-36 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[10px]"
                     >
                       <button
                         className="flex w-full items-center justify-start rounded-xl px-3 py-2 text-left text-sm text-text-secondary hover:bg-state-base-hover"
@@ -672,7 +672,7 @@ export const CommentThread: FC<CommentThreadProps> = memo(
                             <DropdownMenuContent
                               placement="bottom-end"
                               sideOffset={4}
-                              popupClassName="w-36 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[10px]"
+                              className="w-36 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[10px]"
                               data-reply-menu
                             >
                               <div

--- a/web/app/components/workflow/edge-contextmenu.tsx
+++ b/web/app/components/workflow/edge-contextmenu.tsx
@@ -16,7 +16,7 @@ export function EdgeContextmenu({ onClose }: { onClose: () => void }) {
   if (!edgeId || !currentEdgeExists) return null
 
   return (
-    <ContextMenuContent popupClassName="rounded-lg" sideOffset={4}>
+    <ContextMenuContent className="rounded-lg" sideOffset={4}>
       <ContextMenuItem
         variant="destructive"
         className="justify-between gap-4 px-3"

--- a/web/app/components/workflow/header/test-run-menu.tsx
+++ b/web/app/components/workflow/header/test-run-menu.tsx
@@ -172,7 +172,7 @@ const TestRunMenu = forwardRef<TestRunMenuRef, TestRunMenuProps>(
           placement="bottom-start"
           sideOffset={8}
           alignOffset={-4}
-          popupClassName="w-[284px] p-1"
+          className="w-[284px] p-1"
         >
           <DropdownMenuGroup>
             <DropdownMenuLabel className="mb-1 px-3 pt-2 text-sm font-medium text-text-primary">

--- a/web/app/components/workflow/node-actions-menu/index.tsx
+++ b/web/app/components/workflow/node-actions-menu/index.tsx
@@ -58,10 +58,7 @@ export function NodeActionsDropdown({
           </button>
         }
       />
-      <DropdownMenuContent
-        placement="bottom-end"
-        popupClassName={NODE_ACTIONS_MENU_WIDTH_CLASS_NAME}
-      >
+      <DropdownMenuContent placement="bottom-end" className={NODE_ACTIONS_MENU_WIDTH_CLASS_NAME}>
         <NodeActionsDropdownContent
           id={id}
           data={data}

--- a/web/app/components/workflow/node-contextmenu.tsx
+++ b/web/app/components/workflow/node-contextmenu.tsx
@@ -16,7 +16,7 @@ export function NodeContextmenu({ onClose }: { onClose: () => void }) {
   if (!nodeId || !currentNode) return null
 
   return (
-    <ContextMenuContent popupClassName={NODE_ACTIONS_MENU_WIDTH_CLASS_NAME} sideOffset={4}>
+    <ContextMenuContent className={NODE_ACTIONS_MENU_WIDTH_CLASS_NAME} sideOffset={4}>
       <NodeActionsContextMenuContent
         id={currentNode.id}
         data={currentNode.data}

--- a/web/app/components/workflow/nodes/_base/components/error-handle/error-handle-type-selector.tsx
+++ b/web/app/components/workflow/nodes/_base/components/error-handle/error-handle-type-selector.tsx
@@ -53,7 +53,7 @@ const ErrorHandleTypeSelector = ({ value, onSelected }: ErrorHandleTypeSelectorP
       <DropdownMenuContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="w-[280px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
+        className="w-[280px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
       >
         <DropdownMenuRadioGroup value={value} onValueChange={onSelected}>
           {options.map((option) => (

--- a/web/app/components/workflow/nodes/_base/components/form-input-item.sections.tsx
+++ b/web/app/components/workflow/nodes/_base/components/form-input-item.sections.tsx
@@ -6,9 +6,12 @@ import { cn } from '@langgenius/dify-ui/cn'
 import {
   SelectItem as DifySelectItem,
   Select,
-  SelectContent,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { RiLoader4Line } from '@remixicon/react'
@@ -65,28 +68,35 @@ export const MultiSelectField: FC<MultiSelectFieldProps> = ({
             {renderLabel()}
           </span>
         </SelectTrigger>
-        <SelectContent
-          popupClassName="w-(--anchor-width) bg-components-panel-bg-blur backdrop-blur-xs"
-          listClassName="max-h-60"
-        >
-          {items.map((item) => (
-            <DifySelectItem key={item.value} value={item.value} className="h-auto py-2 pr-9 pl-3">
-              <div className="flex min-w-0 items-center">
-                {item.icon && (
-                  <img
-                    src={item.icon}
-                    alt=""
-                    width={16}
-                    height={16}
-                    className="mr-2 size-4 shrink-0"
-                  />
-                )}
-                <SelectItemText>{item.name}</SelectItemText>
-              </div>
-              <SelectItemIndicator />
-            </DifySelectItem>
-          ))}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner>
+            <SelectPopup className="w-(--anchor-width) bg-components-panel-bg-blur backdrop-blur-xs">
+              <SelectList className="max-h-60">
+                {items.map((item) => (
+                  <DifySelectItem
+                    key={item.value}
+                    value={item.value}
+                    className="h-auto py-2 pr-9 pl-3"
+                  >
+                    <div className="flex min-w-0 items-center">
+                      {item.icon && (
+                        <img
+                          src={item.icon}
+                          alt=""
+                          width={16}
+                          height={16}
+                          className="mr-2 size-4 shrink-0"
+                        />
+                      )}
+                      <SelectItemText>{item.name}</SelectItemText>
+                    </div>
+                    <SelectItemIndicator />
+                  </DifySelectItem>
+                ))}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </div>
     </Select>
   )

--- a/web/app/components/workflow/nodes/_base/components/next-step/operator.tsx
+++ b/web/app/components/workflow/nodes/_base/components/next-step/operator.tsx
@@ -2,7 +2,9 @@ import type { CommonNodeType, OnSelectBlock } from '@/app/components/workflow/ty
 import { Button } from '@langgenius/dify-ui/button'
 import {
   DropdownMenu,
-  DropdownMenuContent,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
@@ -82,38 +84,37 @@ const Operator = ({ open, onOpenChange, data, nodeId, sourceHandle }: OperatorPr
           </IconButton>
         }
       />
-      <DropdownMenuContent
-        placement="bottom-end"
-        sideOffset={4}
-        alignOffset={-4}
-        popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-      >
-        <div className="min-w-30 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur system-md-regular text-text-secondary shadow-lg">
-          <div className="p-1">
-            <ChangeItem data={data} nodeId={nodeId} sourceHandle={sourceHandle} />
-            <div
-              className="flex h-8 cursor-pointer items-center rounded-lg px-2 hover:bg-state-base-hover"
-              onClick={() => {
-                onOpenChange(false)
-                handleNodeDisconnect(nodeId)
-              }}
-            >
-              {t(($) => $['common.disconnect'], { ns: 'workflow' })}
+      <DropdownMenuPortal>
+        <DropdownMenuPositioner placement="bottom-end" sideOffset={4} alignOffset={-4}>
+          <DropdownMenuPopup>
+            <div className="min-w-30 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur system-md-regular text-text-secondary shadow-lg">
+              <div className="p-1">
+                <ChangeItem data={data} nodeId={nodeId} sourceHandle={sourceHandle} />
+                <div
+                  className="flex h-8 cursor-pointer items-center rounded-lg px-2 hover:bg-state-base-hover"
+                  onClick={() => {
+                    onOpenChange(false)
+                    handleNodeDisconnect(nodeId)
+                  }}
+                >
+                  {t(($) => $['common.disconnect'], { ns: 'workflow' })}
+                </div>
+              </div>
+              <div className="p-1">
+                <div
+                  className="flex h-8 cursor-pointer items-center rounded-lg px-2 hover:bg-state-base-hover"
+                  onClick={() => {
+                    onOpenChange(false)
+                    handleNodeDelete(nodeId)
+                  }}
+                >
+                  {t(($) => $['operation.delete'], { ns: 'common' })}
+                </div>
+              </div>
             </div>
-          </div>
-          <div className="p-1">
-            <div
-              className="flex h-8 cursor-pointer items-center rounded-lg px-2 hover:bg-state-base-hover"
-              onClick={() => {
-                onOpenChange(false)
-                handleNodeDelete(nodeId)
-              }}
-            >
-              {t(($) => $['operation.delete'], { ns: 'common' })}
-            </div>
-          </div>
-        </div>
-      </DropdownMenuContent>
+          </DropdownMenuPopup>
+        </DropdownMenuPositioner>
+      </DropdownMenuPortal>
     </DropdownMenu>
   )
 }

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.trigger.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.trigger.tsx
@@ -13,7 +13,9 @@ import { cn } from '@langgenius/dify-ui/cn'
 import { PopoverTrigger } from '@langgenius/dify-ui/popover'
 import {
   PreviewCard,
-  PreviewCardContent,
+  PreviewCardPopup,
+  PreviewCardPortal,
+  PreviewCardPositioner,
   PreviewCardTrigger,
 } from '@langgenius/dify-ui/preview-card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
@@ -225,9 +227,11 @@ const VarReferencePickerTrigger: FC<Props> = ({
     hoverPopup?.kind === 'full-path' ? (
       <PreviewCard>
         <PreviewCardTrigger delay={300} closeDelay={200} render={pill} />
-        <PreviewCardContent popupClassName="border-0 bg-transparent p-0 shadow-none">
-          {hoverPopup.panel}
-        </PreviewCardContent>
+        <PreviewCardPortal>
+          <PreviewCardPositioner>
+            <PreviewCardPopup>{hoverPopup.panel}</PreviewCardPopup>
+          </PreviewCardPositioner>
+        </PreviewCardPortal>
       </PreviewCard>
     ) : hoverPopup?.kind === 'invalid-variable' ? (
       <Tooltip>

--- a/web/app/components/workflow/nodes/_base/components/variable/var-type-picker.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-type-picker.tsx
@@ -3,10 +3,13 @@ import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -46,22 +49,24 @@ const VarReferencePicker: FC<Props> = ({ readonly, className, value, onChange })
         >
           <SelectValue className="capitalize" />
         </SelectTrigger>
-        <SelectContent
-          sideOffset={4}
-          popupClassName="w-[120px] rounded-lg border-0 p-1 shadow-sm"
-          listClassName="p-0"
-        >
-          {TYPES.map((type) => (
-            <SelectItem<VarType>
-              key={type}
-              value={type}
-              className="h-7.5 rounded-lg pr-2 pl-3 text-[13px] text-text-primary"
-            >
-              <SelectItemText className="px-0 capitalize">{type}</SelectItemText>
-              <SelectItemIndicator />
-            </SelectItem>
-          ))}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner sideOffset={4}>
+            <SelectPopup className="w-[120px] rounded-lg border-0 p-1 shadow-sm">
+              <SelectList className="p-0">
+                {TYPES.map((type) => (
+                  <SelectItem<VarType>
+                    key={type}
+                    value={type}
+                    className="h-7.5 rounded-lg pr-2 pl-3 text-[13px] text-text-primary"
+                  >
+                    <SelectItemText className="px-0 capitalize">{type}</SelectItemText>
+                    <SelectItemIndicator />
+                  </SelectItem>
+                ))}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </Select>
     </div>
   )

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-orchestrate-panel-content.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-orchestrate-panel-content.tsx
@@ -835,7 +835,7 @@ function WorkflowInlineAgentConfigureMoreAction({
           </button>
         }
       />
-      <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="min-w-44 w-max">
+      <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-max min-w-44">
         <DropdownMenuItem className="gap-2 whitespace-nowrap" onClick={onSaveInlineToRoster}>
           <span
             aria-hidden

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/type-select.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/type-select.tsx
@@ -37,7 +37,7 @@ export function OutputTypeSelect({
       >
         {selected.label}
       </SelectTrigger>
-      <SelectContent popupClassName="w-40">
+      <SelectContent className="w-40">
         {OUTPUT_TYPE_OPTIONS.map((option) => (
           <SelectItem key={option.value} value={option.value}>
             <SelectItemText>{option.label}</SelectItemText>

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
@@ -224,7 +224,7 @@ function AgentRosterDrawer({
                           <DropdownMenuContent
                             placement="bottom-end"
                             sideOffset={4}
-                            popupClassName="min-w-44 w-max"
+                            className="w-max min-w-44"
                           >
                             <DropdownMenuItem
                               className="gap-2 whitespace-nowrap"

--- a/web/app/components/workflow/nodes/assigner/components/operation-selector.tsx
+++ b/web/app/components/workflow/nodes/assigner/components/operation-selector.tsx
@@ -83,7 +83,7 @@ const OperationSelector: FC<OperationSelectorProps> = ({
       <DropdownMenuContent
         placement="bottom-start"
         sideOffset={4}
-        popupClassName={cn('w-35', popupClassName)}
+        className={cn('w-35', popupClassName)}
       >
         <DropdownMenuGroup>
           <DropdownMenuLabel>

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
@@ -5,10 +5,13 @@ import type { ValueSelector, Var } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -125,16 +128,22 @@ const KeyValueItem: FC<Props> = ({
             >
               <SelectValue />
             </SelectTrigger>
-            <SelectContent popupClassName="w-[80px]" listClassName="min-w-0">
-              <SelectItem value="text">
-                <SelectItemText>text</SelectItemText>
-                <SelectItemIndicator />
-              </SelectItem>
-              <SelectItem value="file">
-                <SelectItemText>file</SelectItemText>
-                <SelectItemIndicator />
-              </SelectItem>
-            </SelectContent>
+            <SelectPortal>
+              <SelectPositioner>
+                <SelectPopup className="w-[80px]">
+                  <SelectList className="min-w-0">
+                    <SelectItem value="text">
+                      <SelectItemText>text</SelectItemText>
+                      <SelectItemIndicator />
+                    </SelectItem>
+                    <SelectItem value="file">
+                      <SelectItemText>file</SelectItemText>
+                      <SelectItemIndicator />
+                    </SelectItem>
+                  </SelectList>
+                </SelectPopup>
+              </SelectPositioner>
+            </SelectPortal>
           </Select>
         </div>
       )}

--- a/web/app/components/workflow/nodes/human-input/components/variable-in-markdown.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/variable-in-markdown.tsx
@@ -4,10 +4,13 @@ import type { FormInputItem } from '../types'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -159,14 +162,20 @@ const SelectPreview: React.FC<{ label: string; options: string[] }> = ({ label, 
         >
           <SelectValue />
         </SelectTrigger>
-        <SelectContent listClassName="max-h-[140px] overflow-y-auto">
-          {options.map((option) => (
-            <SelectItem key={option} value={option}>
-              <SelectItemText>{option}</SelectItemText>
-              <SelectItemIndicator />
-            </SelectItem>
-          ))}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner>
+            <SelectPopup>
+              <SelectList className="max-h-[140px] overflow-y-auto">
+                {options.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    <SelectItemText>{option}</SelectItemText>
+                    <SelectItemIndicator />
+                  </SelectItem>
+                ))}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </Select>
     </div>
   )

--- a/web/app/components/workflow/nodes/if-else/components/condition-list/condition-item.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-list/condition-item.tsx
@@ -15,6 +15,10 @@ import {
   SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { RiDeleteBinLine } from '@remixicon/react'
@@ -339,24 +343,30 @@ const ConditionItem = ({
                     </div>
                   )}
                 </SelectTrigger>
-                <SelectContent popupClassName="w-[165px]" listClassName="max-h-none p-1">
-                  {subVarOptions.map((option) => (
-                    <SelectItem
-                      key={option.value}
-                      value={option.value}
-                      className="h-8 py-0 pr-5 pl-1"
-                    >
-                      <div className="flex h-6 items-center justify-between">
-                        <div className="flex h-full items-center">
-                          <Variable02 className="mr-1.25 h-3.5 w-3.5 text-text-accent" />
-                          <SelectItemText className="mr-0 px-0 system-sm-medium text-text-secondary">
-                            {option.name}
-                          </SelectItemText>
-                        </div>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
+                <SelectPortal>
+                  <SelectPositioner>
+                    <SelectPopup className="w-[165px]">
+                      <SelectList className="max-h-none p-1">
+                        {subVarOptions.map((option) => (
+                          <SelectItem
+                            key={option.value}
+                            value={option.value}
+                            className="h-8 py-0 pr-5 pl-1"
+                          >
+                            <div className="flex h-6 items-center justify-between">
+                              <div className="flex h-full items-center">
+                                <Variable02 className="mr-1.25 h-3.5 w-3.5 text-text-accent" />
+                                <SelectItemText className="mr-0 px-0 system-sm-medium text-text-secondary">
+                                  {option.name}
+                                </SelectItemText>
+                              </div>
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectList>
+                    </SelectPopup>
+                  </SelectPositioner>
+                </SelectPortal>
               </Select>
             ) : (
               <ConditionVarSelector

--- a/web/app/components/workflow/nodes/if-else/components/condition-list/condition-operator.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-list/condition-operator.tsx
@@ -67,7 +67,7 @@ const ConditionOperator = ({
       <DropdownMenuContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
+        className="rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
       >
         <DropdownMenuRadioGroup value={selectedOption?.value} onValueChange={onSelect}>
           {options.map((option) => (

--- a/web/app/components/workflow/nodes/if-else/components/condition-number-input.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-number-input.tsx
@@ -64,7 +64,7 @@ const ConditionNumberInput = ({
         <DropdownMenuContent
           placement="bottom-start"
           sideOffset={2}
-          popupClassName="w-[112px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
+          className="w-[112px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
         >
           <DropdownMenuRadioGroup value={numberVarType} onValueChange={onNumberVarTypeChange}>
             {options.map((option) => (

--- a/web/app/components/workflow/nodes/if-else/components/condition-wrap.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-wrap.tsx
@@ -16,9 +16,12 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { RiAddLine, RiDeleteBinLine, RiDraggable } from '@remixicon/react'
@@ -192,13 +195,19 @@ const ConditionWrap: FC<Props> = ({
                         {t(($) => $['nodes.ifElse.addSubVariable'], { ns: 'workflow' })}
                       </Button>
                     </SelectTrigger>
-                    <SelectContent popupClassName="w-[165px]" listClassName="max-h-none p-1">
-                      {subVarOptions.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          <SelectItemText>{option.name}</SelectItemText>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
+                    <SelectPortal>
+                      <SelectPositioner>
+                        <SelectPopup className="w-[165px]">
+                          <SelectList className="max-h-none p-1">
+                            {subVarOptions.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                <SelectItemText>{option.name}</SelectItemText>
+                              </SelectItem>
+                            ))}
+                          </SelectList>
+                        </SelectPopup>
+                      </SelectPositioner>
+                    </SelectPortal>
                   </Select>
                 ) : (
                   <ConditionAdd

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-filter/metadata-filter-selector.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-filter/metadata-filter-selector.tsx
@@ -62,7 +62,7 @@ const MetadataFilterSelector = ({
       <DropdownMenuContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="w-[280px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
+        className="w-[280px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
       >
         <DropdownMenuRadioGroup value={value} onValueChange={onSelect}>
           {options.map((option) => (

--- a/web/app/components/workflow/nodes/list-operator/components/sub-variable-picker.tsx
+++ b/web/app/components/workflow/nodes/list-operator/components/sub-variable-picker.tsx
@@ -3,9 +3,12 @@ import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import * as React from 'react'
@@ -62,20 +65,30 @@ const SubVariablePicker: FC<Props> = ({ value, onChange, className }) => {
             )}
           </div>
         </SelectTrigger>
-        <SelectContent popupClassName="w-[165px]" listClassName="max-h-none p-1">
-          {subVarOptions.map((option) => (
-            <SelectItem key={option.value} value={option.value} className="h-8 py-0 pr-5 pl-1">
-              <div className="flex h-6 items-center justify-between">
-                <div className="flex h-full items-center">
-                  <Variable02 className="mr-1.25 h-3.5 w-3.5 text-text-accent" />
-                  <SelectItemText className="mr-0 px-0 system-sm-medium text-text-secondary">
-                    {option.name}
-                  </SelectItemText>
-                </div>
-              </div>
-            </SelectItem>
-          ))}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner>
+            <SelectPopup className="w-[165px]">
+              <SelectList className="max-h-none p-1">
+                {subVarOptions.map((option) => (
+                  <SelectItem
+                    key={option.value}
+                    value={option.value}
+                    className="h-8 py-0 pr-5 pl-1"
+                  >
+                    <div className="flex h-6 items-center justify-between">
+                      <div className="flex h-full items-center">
+                        <Variable02 className="mr-1.25 h-3.5 w-3.5 text-text-accent" />
+                        <SelectItemText className="mr-0 px-0 system-sm-medium text-text-secondary">
+                          {option.name}
+                        </SelectItemText>
+                      </div>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </Select>
     </div>
   )

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/type-selector.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/type-selector.tsx
@@ -2,10 +2,13 @@ import type { FC } from 'react'
 import type { ArrayType, Type } from '../../../../types'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
   SelectValue,
 } from '@langgenius/dify-ui/select'
@@ -21,10 +24,9 @@ type TypeSelectorProps = {
   items: TypeItem[]
   currentValue: Type | ArrayType
   onSelect: (item: TypeItem) => void
-  popupClassName?: string
 }
 
-const TypeSelector: FC<TypeSelectorProps> = ({ items, currentValue, onSelect, popupClassName }) => {
+const TypeSelector: FC<TypeSelectorProps> = ({ items, currentValue, onSelect }) => {
   const [open, setOpen] = useState(false)
 
   return (
@@ -40,29 +42,30 @@ const TypeSelector: FC<TypeSelectorProps> = ({ items, currentValue, onSelect, po
       <SelectTrigger className="h-auto w-auto rounded-[5px] bg-transparent p-0.5 pl-1 hover:bg-state-base-hover data-popup-open:bg-state-base-hover">
         <SelectValue className="system-xs-medium text-text-tertiary" />
       </SelectTrigger>
-      <SelectContent
-        sideOffset={4}
-        className={popupClassName}
-        popupClassName="w-40 rounded-xl border-[0.5px] p-1 shadow-lg shadow-shadow-shadow-5"
-        listClassName="p-0"
-      >
-        {items.map((item) => (
-          <SelectItem<Type | ArrayType>
-            key={item.value}
-            value={item.value}
-            className="gap-x-1 rounded-lg px-2 py-1"
-            render={(props, state) => (
-              <div {...props} className={props.className}>
-                <SelectItemText className="px-1 system-sm-medium text-text-secondary">
-                  {item.text}
-                </SelectItemText>
-                {state.selected && <RiCheckLine className="size-4 text-text-accent" />}
-                <SelectItemIndicator className="hidden" />
-              </div>
-            )}
-          />
-        ))}
-      </SelectContent>
+      <SelectPortal>
+        <SelectPositioner sideOffset={4}>
+          <SelectPopup className="w-40 rounded-xl border-[0.5px] p-1 shadow-lg shadow-shadow-shadow-5">
+            <SelectList className="p-0">
+              {items.map((item) => (
+                <SelectItem<Type | ArrayType>
+                  key={item.value}
+                  value={item.value}
+                  className="gap-x-1 rounded-lg px-2 py-1"
+                  render={(props, state) => (
+                    <div {...props} className={props.className}>
+                      <SelectItemText className="px-1 system-sm-medium text-text-secondary">
+                        {item.text}
+                      </SelectItemText>
+                      {state.selected && <RiCheckLine className="size-4 text-text-accent" />}
+                      <SelectItemIndicator className="hidden" />
+                    </div>
+                  )}
+                />
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
     </Select>
   )
 }

--- a/web/app/components/workflow/nodes/loop/components/condition-list/condition-item.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-list/condition-item.tsx
@@ -15,6 +15,10 @@ import {
   SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { RiDeleteBinLine } from '@remixicon/react'
@@ -260,24 +264,30 @@ const ConditionItem = ({
                     </div>
                   )}
                 </SelectTrigger>
-                <SelectContent popupClassName="w-[165px]" listClassName="max-h-none p-1">
-                  {subVarOptions.map((option) => (
-                    <SelectItem
-                      key={option.value}
-                      value={option.value}
-                      className="h-8 py-0 pr-5 pl-1"
-                    >
-                      <div className="flex h-6 items-center justify-between">
-                        <div className="flex h-full items-center">
-                          <Variable02 className="mr-1.25 h-3.5 w-3.5 text-text-accent" />
-                          <SelectItemText className="mr-0 px-0 system-sm-medium text-text-secondary">
-                            {option.name}
-                          </SelectItemText>
-                        </div>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
+                <SelectPortal>
+                  <SelectPositioner>
+                    <SelectPopup className="w-[165px]">
+                      <SelectList className="max-h-none p-1">
+                        {subVarOptions.map((option) => (
+                          <SelectItem
+                            key={option.value}
+                            value={option.value}
+                            className="h-8 py-0 pr-5 pl-1"
+                          >
+                            <div className="flex h-6 items-center justify-between">
+                              <div className="flex h-full items-center">
+                                <Variable02 className="mr-1.25 h-3.5 w-3.5 text-text-accent" />
+                                <SelectItemText className="mr-0 px-0 system-sm-medium text-text-secondary">
+                                  {option.name}
+                                </SelectItemText>
+                              </div>
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectList>
+                    </SelectPopup>
+                  </SelectPositioner>
+                </SelectPortal>
               </Select>
             ) : (
               <ConditionVarSelector

--- a/web/app/components/workflow/nodes/loop/components/condition-list/condition-operator.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-list/condition-operator.tsx
@@ -67,7 +67,7 @@ const ConditionOperator = ({
       <DropdownMenuContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
+        className="rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
       >
         <DropdownMenuRadioGroup value={selectedOption?.value} onValueChange={onSelect}>
           {options.map((option) => (

--- a/web/app/components/workflow/nodes/loop/components/condition-number-input.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-number-input.tsx
@@ -64,7 +64,7 @@ const ConditionNumberInput = ({
         <DropdownMenuContent
           placement="bottom-start"
           sideOffset={2}
-          popupClassName="w-[112px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
+          className="w-[112px] rounded-xl border-[0.5px] bg-components-panel-bg-blur p-1"
         >
           <DropdownMenuRadioGroup value={numberVarType} onValueChange={onNumberVarTypeChange}>
             {options.map((option) => (

--- a/web/app/components/workflow/nodes/loop/components/condition-wrap.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-wrap.tsx
@@ -17,9 +17,12 @@ import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { RiAddLine } from '@remixicon/react'
@@ -145,13 +148,19 @@ const ConditionWrap: FC<Props> = ({
                     {t(($) => $['nodes.ifElse.addSubVariable'], { ns: 'workflow' })}
                   </Button>
                 </SelectTrigger>
-                <SelectContent popupClassName="w-[165px]" listClassName="max-h-none p-1">
-                  {subVarOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      <SelectItemText>{option.name}</SelectItemText>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
+                <SelectPortal>
+                  <SelectPositioner>
+                    <SelectPopup className="w-[165px]">
+                      <SelectList className="max-h-none p-1">
+                        {subVarOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            <SelectItemText>{option.name}</SelectItemText>
+                          </SelectItem>
+                        ))}
+                      </SelectList>
+                    </SelectPopup>
+                  </SelectPositioner>
+                </SelectPortal>
               </Select>
             ) : (
               <ConditionAdd

--- a/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
@@ -4,10 +4,13 @@ import { Checkbox } from '@langgenius/dify-ui/checkbox'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { RiDeleteBinLine } from '@remixicon/react'
@@ -155,14 +158,20 @@ const renderSelectCell = (
       >
         {selectedOption?.name ?? column.placeholder}
       </SelectTrigger>
-      <SelectContent className="-translate-x-3" popupClassName="w-26 min-w-26">
-        {options.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            <SelectItemText>{option.name}</SelectItemText>
-            <SelectItemIndicator />
-          </SelectItem>
-        ))}
-      </SelectContent>
+      <SelectPortal>
+        <SelectPositioner className="-translate-x-3">
+          <SelectPopup className="w-26 min-w-26">
+            <SelectList>
+              {options.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  <SelectItemText>{option.name}</SelectItemText>
+                  <SelectItemIndicator />
+                </SelectItem>
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
     </Select>
   )
 }

--- a/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/panel.tsx
@@ -86,7 +86,7 @@ const WebhookMethodSelector = ({
       <SelectTrigger aria-label={label} className="h-8 pr-8 text-sm">
         {selectedMethod?.name}
       </SelectTrigger>
-      <SelectContent popupClassName="w-26 min-w-26">
+      <SelectContent className="w-26 min-w-26">
         {HTTP_METHODS.map((item) => (
           <SelectItem key={item.value} value={item.value}>
             <SelectItemText>{item.name}</SelectItemText>

--- a/web/app/components/workflow/note-node/note-editor/toolbar/operator.tsx
+++ b/web/app/components/workflow/note-node/note-editor/toolbar/operator.tsx
@@ -1,8 +1,10 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
@@ -46,60 +48,60 @@ const Operator = ({
       >
         <span aria-hidden className="i-ri-more-fill size-4" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent
-        placement="bottom-end"
-        sideOffset={4}
-        popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-      >
-        <div className="min-w-48 rounded-md border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-xl">
-          <div className="p-1">
-            <DropdownMenuItem
-              className="justify-between rounded-md px-3 text-sm text-text-secondary"
-              onClick={() => {
-                setOpen(false)
-                onCopy()
-              }}
-            >
-              {t(($) => $['common.copy'], { ns: 'workflow' })}
-              <ShortcutKbd shortcut="workflow.copy" />
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="justify-between rounded-md px-3 text-sm text-text-secondary"
-              onClick={() => {
-                setOpen(false)
-                onDuplicate()
-              }}
-            >
-              {t(($) => $['common.duplicate'], { ns: 'workflow' })}
-              <ShortcutKbd shortcut="workflow.duplicate" />
-            </DropdownMenuItem>
-          </div>
-          <DropdownMenuSeparator className="my-0" />
-          <div className="p-1">
-            <div
-              className="flex h-8 cursor-pointer items-center justify-between rounded-md px-3 text-sm text-text-secondary hover:bg-state-base-hover"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div>{t(($) => $['nodes.note.editor.showAuthor'], { ns: 'workflow' })}</div>
-              <Switch size="lg" checked={showAuthor} onCheckedChange={onShowAuthorChange} />
+      <DropdownMenuPortal>
+        <DropdownMenuPositioner placement="bottom-end" sideOffset={4}>
+          <DropdownMenuPopup>
+            <div className="min-w-48 rounded-md border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-xl">
+              <div className="p-1">
+                <DropdownMenuItem
+                  className="justify-between rounded-md px-3 text-sm text-text-secondary"
+                  onClick={() => {
+                    setOpen(false)
+                    onCopy()
+                  }}
+                >
+                  {t(($) => $['common.copy'], { ns: 'workflow' })}
+                  <ShortcutKbd shortcut="workflow.copy" />
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="justify-between rounded-md px-3 text-sm text-text-secondary"
+                  onClick={() => {
+                    setOpen(false)
+                    onDuplicate()
+                  }}
+                >
+                  {t(($) => $['common.duplicate'], { ns: 'workflow' })}
+                  <ShortcutKbd shortcut="workflow.duplicate" />
+                </DropdownMenuItem>
+              </div>
+              <DropdownMenuSeparator className="my-0" />
+              <div className="p-1">
+                <div
+                  className="flex h-8 cursor-pointer items-center justify-between rounded-md px-3 text-sm text-text-secondary hover:bg-state-base-hover"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div>{t(($) => $['nodes.note.editor.showAuthor'], { ns: 'workflow' })}</div>
+                  <Switch size="lg" checked={showAuthor} onCheckedChange={onShowAuthorChange} />
+                </div>
+              </div>
+              <DropdownMenuSeparator className="my-0" />
+              <div className="p-1">
+                <DropdownMenuItem
+                  variant="destructive"
+                  className="justify-between rounded-md px-3 text-sm text-text-secondary"
+                  onClick={() => {
+                    setOpen(false)
+                    onDelete()
+                  }}
+                >
+                  {t(($) => $['operation.delete'], { ns: 'common' })}
+                  <ShortcutKbd shortcut="workflow.delete" />
+                </DropdownMenuItem>
+              </div>
             </div>
-          </div>
-          <DropdownMenuSeparator className="my-0" />
-          <div className="p-1">
-            <DropdownMenuItem
-              variant="destructive"
-              className="justify-between rounded-md px-3 text-sm text-text-secondary"
-              onClick={() => {
-                setOpen(false)
-                onDelete()
-              }}
-            >
-              {t(($) => $['operation.delete'], { ns: 'common' })}
-              <ShortcutKbd shortcut="workflow.delete" />
-            </DropdownMenuItem>
-          </div>
-        </div>
-      </DropdownMenuContent>
+          </DropdownMenuPopup>
+        </DropdownMenuPositioner>
+      </DropdownMenuPortal>
     </DropdownMenu>
   )
 }

--- a/web/app/components/workflow/operator/more-actions.tsx
+++ b/web/app/components/workflow/operator/more-actions.tsx
@@ -169,7 +169,7 @@ function MoreActions() {
             }
           />
         </TipPopup>
-        <DropdownMenuContent placement="right-end" popupClassName="min-w-[180px]">
+        <DropdownMenuContent placement="right-end" className="min-w-[180px]">
           <div className="flex items-center gap-2 px-2 py-1 text-xs font-medium text-text-tertiary">
             <span aria-hidden className="i-ri-export-line size-3" />
             {t(($) => $['common.exportImage'], { ns: 'workflow' })}

--- a/web/app/components/workflow/operator/zoom-in-out.tsx
+++ b/web/app/components/workflow/operator/zoom-in-out.tsx
@@ -1,8 +1,10 @@
 import type { FC } from 'react'
 import {
   DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
@@ -177,75 +179,83 @@ const ZoomInOut: FC<ZoomInOutProps> = ({
           >
             {Number.parseFloat(`${zoom * 100}`).toFixed(0)}%
           </DropdownMenuTrigger>
-          <DropdownMenuContent
-            placement="top-start"
-            sideOffset={4}
-            alignOffset={-2}
-            popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-          >
-            <div className="w-48 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
-              {zoomOptions.map((options, groupIndex) => (
-                <Fragment key={options[0]!.key}>
-                  {groupIndex !== 0 && <DropdownMenuSeparator className="my-0" />}
-                  <div className="p-1">
-                    {options.map((option) => (
-                      <DropdownMenuItem
-                        key={option.key}
-                        className="justify-between px-3 py-1.5 system-md-regular text-text-secondary"
-                        disabled={option.key === ZoomType.toggleUserComments && isCommentMode}
-                        onClick={() => handleZoom(option.key)}
-                      >
-                        <div className="flex items-center gap-2">
-                          {option.key === ZoomType.toggleUserComments && showUserComments && (
-                            <span aria-hidden className="i-ri-check-line size-4 text-text-accent" />
-                          )}
-                          {option.key === ZoomType.toggleUserComments && !showUserComments && (
-                            <span aria-hidden className="size-4" />
-                          )}
-                          {option.key === ZoomType.toggleUserCursors && showUserCursors && (
-                            <span aria-hidden className="i-ri-check-line size-4 text-text-accent" />
-                          )}
-                          {option.key === ZoomType.toggleUserCursors && !showUserCursors && (
-                            <span aria-hidden className="size-4" />
-                          )}
-                          {option.key === ZoomType.toggleMiniMap && showMiniMap && (
-                            <span aria-hidden className="i-ri-check-line size-4 text-text-accent" />
-                          )}
-                          {option.key === ZoomType.toggleMiniMap && !showMiniMap && (
-                            <span aria-hidden className="size-4" />
-                          )}
-                          {option.key === ZoomType.zoomToFit && (
-                            <span
-                              aria-hidden
-                              className="i-ri-fullscreen-line size-4 text-text-tertiary"
-                            />
-                          )}
-                          {option.key !== ZoomType.toggleUserComments &&
-                            option.key !== ZoomType.toggleUserCursors &&
-                            option.key !== ZoomType.toggleMiniMap &&
-                            option.key !== ZoomType.zoomToFit && (
-                              <span aria-hidden className="size-4" />
-                            )}
-                          <span>{option.text}</span>
-                        </div>
-                        <div className="flex items-center space-x-0.5">
-                          {option.key === ZoomType.zoomToFit && (
-                            <ShortcutKbd shortcut="workflow.zoom-to-fit" />
-                          )}
-                          {option.key === ZoomType.zoomTo50 && (
-                            <ShortcutKbd shortcut="workflow.zoom-to-50" />
-                          )}
-                          {option.key === ZoomType.zoomTo100 && (
-                            <ShortcutKbd shortcut="workflow.zoom-to-100" />
-                          )}
-                        </div>
-                      </DropdownMenuItem>
-                    ))}
-                  </div>
-                </Fragment>
-              ))}
-            </div>
-          </DropdownMenuContent>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner placement="top-start" sideOffset={4} alignOffset={-2}>
+              <DropdownMenuPopup>
+                <div className="w-48 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
+                  {zoomOptions.map((options, groupIndex) => (
+                    <Fragment key={options[0]!.key}>
+                      {groupIndex !== 0 && <DropdownMenuSeparator className="my-0" />}
+                      <div className="p-1">
+                        {options.map((option) => (
+                          <DropdownMenuItem
+                            key={option.key}
+                            className="justify-between px-3 py-1.5 system-md-regular text-text-secondary"
+                            disabled={option.key === ZoomType.toggleUserComments && isCommentMode}
+                            onClick={() => handleZoom(option.key)}
+                          >
+                            <div className="flex items-center gap-2">
+                              {option.key === ZoomType.toggleUserComments && showUserComments && (
+                                <span
+                                  aria-hidden
+                                  className="i-ri-check-line size-4 text-text-accent"
+                                />
+                              )}
+                              {option.key === ZoomType.toggleUserComments && !showUserComments && (
+                                <span aria-hidden className="size-4" />
+                              )}
+                              {option.key === ZoomType.toggleUserCursors && showUserCursors && (
+                                <span
+                                  aria-hidden
+                                  className="i-ri-check-line size-4 text-text-accent"
+                                />
+                              )}
+                              {option.key === ZoomType.toggleUserCursors && !showUserCursors && (
+                                <span aria-hidden className="size-4" />
+                              )}
+                              {option.key === ZoomType.toggleMiniMap && showMiniMap && (
+                                <span
+                                  aria-hidden
+                                  className="i-ri-check-line size-4 text-text-accent"
+                                />
+                              )}
+                              {option.key === ZoomType.toggleMiniMap && !showMiniMap && (
+                                <span aria-hidden className="size-4" />
+                              )}
+                              {option.key === ZoomType.zoomToFit && (
+                                <span
+                                  aria-hidden
+                                  className="i-ri-fullscreen-line size-4 text-text-tertiary"
+                                />
+                              )}
+                              {option.key !== ZoomType.toggleUserComments &&
+                                option.key !== ZoomType.toggleUserCursors &&
+                                option.key !== ZoomType.toggleMiniMap &&
+                                option.key !== ZoomType.zoomToFit && (
+                                  <span aria-hidden className="size-4" />
+                                )}
+                              <span>{option.text}</span>
+                            </div>
+                            <div className="flex items-center space-x-0.5">
+                              {option.key === ZoomType.zoomToFit && (
+                                <ShortcutKbd shortcut="workflow.zoom-to-fit" />
+                              )}
+                              {option.key === ZoomType.zoomTo50 && (
+                                <ShortcutKbd shortcut="workflow.zoom-to-50" />
+                              )}
+                              {option.key === ZoomType.zoomTo100 && (
+                                <ShortcutKbd shortcut="workflow.zoom-to-100" />
+                              )}
+                            </div>
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
+                    </Fragment>
+                  ))}
+                </div>
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
         </DropdownMenu>
         <TipPopup
           title={t(($) => $['operator.zoomIn'], { ns: 'workflow' })}

--- a/web/app/components/workflow/panel-contextmenu.tsx
+++ b/web/app/components/workflow/panel-contextmenu.tsx
@@ -74,7 +74,7 @@ export function PanelContextmenu({ onClose }: { onClose: () => void }) {
   if (!isPanelContextMenu) return null
 
   return (
-    <ContextMenuContent popupClassName="w-[200px] rounded-lg" sideOffset={4}>
+    <ContextMenuContent className="w-[200px] rounded-lg" sideOffset={4}>
       <ContextMenuGroup>
         {canEditWorkflow && (
           <AddBlock

--- a/web/app/components/workflow/panel/chat-variable-panel/components/variable-type-select.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/variable-type-select.tsx
@@ -71,7 +71,7 @@ const VariableTypeSelector = <T extends string>({
       </SelectTrigger>
       <SelectContent
         placement="bottom-start"
-        popupClassName={cn('bg-components-panel-bg-blur', popupClassName)}
+        className={cn('bg-components-panel-bg-blur', popupClassName)}
       >
         {list.map((item) => (
           <SelectItem

--- a/web/app/components/workflow/panel/version-history-panel/action-menu/index.tsx
+++ b/web/app/components/workflow/panel/version-history-panel/action-menu/index.tsx
@@ -44,7 +44,7 @@ const ActionMenu: FC<ActionMenuProps> = (props: ActionMenuProps) => {
       <DropdownMenuContent
         placement="bottom-end"
         sideOffset={4}
-        popupClassName="w-max min-w-[184px] max-w-[calc(100vw-24px)] shadow-shadow-shadow-5"
+        className="w-max max-w-[calc(100vw-24px)] min-w-[184px] shadow-shadow-shadow-5"
       >
         {options.map((option) => (
           <ActionMenuItem

--- a/web/app/components/workflow/run/agent-log/agent-log-nav-more.tsx
+++ b/web/app/components/workflow/run/agent-log/agent-log-nav-more.tsx
@@ -35,7 +35,7 @@ const AgentLogNavMore = ({ options, onShowAgentOrToolLog }: AgentLogNavMoreProps
         placement="bottom-start"
         sideOffset={2}
         alignOffset={-54}
-        popupClassName="w-[136px] p-1"
+        className="w-[136px] p-1"
       >
         {options.map((option) => (
           <DropdownMenuItem

--- a/web/app/components/workflow/selection-contextmenu.tsx
+++ b/web/app/components/workflow/selection-contextmenu.tsx
@@ -398,7 +398,7 @@ export function SelectionContextmenu({ onClose }: { onClose: () => void }) {
 
   return (
     <>
-      <ContextMenuContent popupClassName="w-[240px]" sideOffset={4}>
+      <ContextMenuContent className="w-[240px]" sideOffset={4}>
         {canCreateSnippet && (
           <>
             <ContextMenuGroup>

--- a/web/app/components/workflow/workflow-preview/components/zoom-in-out.tsx
+++ b/web/app/components/workflow/workflow-preview/components/zoom-in-out.tsx
@@ -2,8 +2,10 @@ import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
@@ -109,42 +111,41 @@ const ZoomInOut: FC = () => {
           <DropdownMenuTrigger className="flex h-8 w-8.5 items-center justify-center rounded-lg system-sm-medium text-text-tertiary hover:bg-black/5 hover:text-text-secondary data-popup-open:bg-black/5 data-popup-open:text-text-secondary">
             {Number.parseFloat(`${zoom * 100}`).toFixed(0)}%
           </DropdownMenuTrigger>
-          <DropdownMenuContent
-            placement="top-start"
-            sideOffset={4}
-            alignOffset={-2}
-            popupClassName="border-0 bg-transparent p-0 shadow-none backdrop-blur-none"
-          >
-            <div className="w-36.25 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
-              {zoomOptions.map((options, groupIndex) => (
-                <Fragment key={options[0]!.key}>
-                  {groupIndex !== 0 && <DropdownMenuSeparator className="my-0" />}
-                  <div className="p-1">
-                    {options.map((option) => (
-                      <DropdownMenuItem
-                        key={option.key}
-                        className="justify-between px-3 py-1.5 system-md-regular text-text-secondary"
-                        onClick={() => handleZoom(option.key)}
-                      >
-                        <span>{option.text}</span>
-                        <div className="flex items-center space-x-0.5">
-                          {option.key === ZoomType.zoomToFit && (
-                            <ShortcutKbd shortcut="workflow.zoom-to-fit" />
-                          )}
-                          {option.key === ZoomType.zoomTo50 && (
-                            <ShortcutKbd shortcut="workflow.zoom-to-50" />
-                          )}
-                          {option.key === ZoomType.zoomTo100 && (
-                            <ShortcutKbd shortcut="workflow.zoom-to-100" />
-                          )}
-                        </div>
-                      </DropdownMenuItem>
-                    ))}
-                  </div>
-                </Fragment>
-              ))}
-            </div>
-          </DropdownMenuContent>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner placement="top-start" sideOffset={4} alignOffset={-2}>
+              <DropdownMenuPopup>
+                <div className="w-36.25 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
+                  {zoomOptions.map((options, groupIndex) => (
+                    <Fragment key={options[0]!.key}>
+                      {groupIndex !== 0 && <DropdownMenuSeparator className="my-0" />}
+                      <div className="p-1">
+                        {options.map((option) => (
+                          <DropdownMenuItem
+                            key={option.key}
+                            className="justify-between px-3 py-1.5 system-md-regular text-text-secondary"
+                            onClick={() => handleZoom(option.key)}
+                          >
+                            <span>{option.text}</span>
+                            <div className="flex items-center space-x-0.5">
+                              {option.key === ZoomType.zoomToFit && (
+                                <ShortcutKbd shortcut="workflow.zoom-to-fit" />
+                              )}
+                              {option.key === ZoomType.zoomTo50 && (
+                                <ShortcutKbd shortcut="workflow.zoom-to-50" />
+                              )}
+                              {option.key === ZoomType.zoomTo100 && (
+                                <ShortcutKbd shortcut="workflow.zoom-to-100" />
+                              )}
+                            </div>
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
+                    </Fragment>
+                  ))}
+                </div>
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
         </DropdownMenu>
         <TipPopup
           title={t(($) => $['operator.zoomIn'], { ns: 'workflow' })}

--- a/web/app/signin/_locale-menu.tsx
+++ b/web/app/signin/_locale-menu.tsx
@@ -43,7 +43,7 @@ export default function LocaleMenu<T extends string>({
             </DropdownMenuTrigger>
           </div>
         </div>
-        <DropdownMenuContent placement="bottom-end" sideOffset={8} popupClassName="w-[200px]">
+        <DropdownMenuContent placement="bottom-end" sideOffset={8} className="w-[200px]">
           <DropdownMenuRadioGroup<T>
             value={value}
             onValueChange={(nextValue) => onChange?.(nextValue)}

--- a/web/features/agent-v2/agent-detail/configure/components/community-edition-tip.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/community-edition-tip.tsx
@@ -1,15 +1,13 @@
 'use client'
 
-import type { Placement } from '@langgenius/dify-ui/popover'
+import type { PopoverContentProps } from '@langgenius/dify-ui/popover'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 
-type CommunityEditionTipProps = {
+type CommunityEditionTipProps = Pick<PopoverContentProps, 'className' | 'placement'> & {
   tip: string
-  placement?: Placement
-  popupClassName?: string
 }
 
 /**
@@ -20,7 +18,7 @@ type CommunityEditionTipProps = {
 export function CommunityEditionTip({
   tip,
   placement = 'bottom',
-  popupClassName,
+  className,
 }: CommunityEditionTipProps) {
   const { data: deploymentEdition } = useSuspenseQuery({
     ...systemFeaturesQueryOptions(),
@@ -50,7 +48,7 @@ export function CommunityEditionTip({
       />
       <PopoverContent
         placement={placement}
-        className={cn('px-3 py-2 system-xs-regular text-text-tertiary', popupClassName)}
+        className={cn('px-3 py-2 system-xs-regular text-text-tertiary', className)}
       >
         {tip}
       </PopoverContent>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/env.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/env.tsx
@@ -116,7 +116,7 @@ function EnvEditorScope({
       >
         {t(($) => $[scopeLabelKeys[scope]])}
       </SelectTrigger>
-      <SelectContent placement="bottom-start" popupClassName="min-w-24">
+      <SelectContent placement="bottom-start" className="min-w-24">
         {envScopeOptions.map((option) => (
           <SelectItem<EnvScope> key={option} value={option} className="h-7 system-xs-regular">
             <SelectItemText>{t(($) => $[scopeLabelKeys[option]])}</SelectItemText>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/files/upload-dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/files/upload-dialog.tsx
@@ -323,7 +323,7 @@ export function AgentFileUploadDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
-      <DialogContent backdropProps={{ forceRender: true }} backdropClassName="fixed">
+      <DialogContent backdropProps={{ forceRender: true, className: 'fixed' }}>
         <DialogClose
           render={
             <IconButton

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/header.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/header.tsx
@@ -27,7 +27,7 @@ export function AgentOrchestrateHeader({
           <h2 id={headingId} className="truncate title-xl-semi-bold text-text-primary">
             {t(($) => $['agentDetail.configure.title'])}
           </h2>
-          <CommunityEditionTip tip={communityEditionIsolationTip} popupClassName="max-w-[320px]" />
+          <CommunityEditionTip tip={communityEditionIsolationTip} className="max-w-[320px]" />
           {isBuildDraftActive && (
             <span className="flex min-w-4.5 shrink-0 items-center justify-center rounded-[5px] border border-text-accent-secondary bg-components-badge-bg-dimm px-1.25 py-0.75 system-2xs-medium-uppercase text-text-accent-secondary">
               {t(($) => $['agentDetail.configure.buildDraft.modeBadge'])}

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/prompt-editor/option-menu.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/prompt-editor/option-menu.tsx
@@ -37,7 +37,7 @@ export function AgentPromptOptionMenu({
           </button>
         }
       />
-      <DropdownMenuContent placement="bottom-start" sideOffset={4} popupClassName="w-60 p-1">
+      <DropdownMenuContent placement="bottom-start" sideOffset={4} className="w-60 p-1">
         {options.map((option) => (
           <DropdownMenuItem
             key={option.key}

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/detail-dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/detail-dialog.tsx
@@ -350,8 +350,7 @@ export function AgentSkillDetailDialog({
 
   return (
     <DialogContent
-      backdropProps={{ forceRender: true }}
-      backdropClassName="fixed"
+      backdropProps={{ forceRender: true, className: 'fixed' }}
       className="flex h-[min(720px,calc(100dvh-2rem))] max-h-none w-[min(960px,calc(100vw-2rem))] flex-row overflow-hidden rounded-2xl p-0"
     >
       <div

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/upload-dialog.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/upload-dialog.tsx
@@ -327,7 +327,7 @@ export function AgentSkillUploadDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} disablePointerDismissal>
-      <DialogContent backdropProps={{ forceRender: true }} backdropClassName="fixed">
+      <DialogContent backdropProps={{ forceRender: true, className: 'fixed' }}>
         <DialogClose
           render={
             <IconButton

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
@@ -339,7 +339,7 @@ export const AgentProviderToolItem = memo(
                 </span>
                 <span aria-hidden className="i-ri-more-fill size-4" />
               </DropdownMenuTrigger>
-              <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-44">
+              <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-44">
                 <DropdownMenuItem
                   variant="destructive"
                   className="gap-2"

--- a/web/features/agent-v2/agent-detail/configure/components/preview/build-chat.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/build-chat.tsx
@@ -60,7 +60,7 @@ function AgentBuildChatEmptyState({
         <CommunityEditionTip
           tip={communityEditionBuildModeTip}
           placement="top"
-          popupClassName="max-w-[340px]"
+          className="max-w-[340px]"
         />
       </div>
       <p className="mt-1 max-w-full body-md-regular text-text-tertiary">

--- a/web/features/agent-v2/agent-detail/configure/components/preview/working-directory-breadcrumb.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/working-directory-breadcrumb.tsx
@@ -154,7 +154,7 @@ export function AgentWorkingDirectoryBreadcrumb({
                     <DropdownMenuContent
                       placement="bottom-start"
                       sideOffset={4}
-                      popupClassName="w-[136px] p-1"
+                      className="w-[136px] p-1"
                     >
                       {hiddenItems.map((hiddenItem) => (
                         <DropdownMenuItem

--- a/web/features/agent-v2/agent-detail/monitoring/page.tsx
+++ b/web/features/agent-v2/agent-detail/monitoring/page.tsx
@@ -12,10 +12,13 @@ import {
 } from '@langgenius/dify-ui/scroll-area'
 import {
   Select,
-  SelectContent,
   SelectItem,
   SelectItemIndicator,
   SelectItemText,
+  SelectList,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
@@ -239,19 +242,20 @@ function AgentMonitoringSourceFilter({
             className="i-ri-close-circle-fill block size-3.5 text-text-quaternary group-hover/clear:text-text-tertiary"
           />
         </button>
-        <SelectContent
-          placement="bottom-start"
-          sideOffset={4}
-          popupClassName="relative w-61 rounded-xl border-[0.5px] bg-components-panel-bg-blur p-0 text-sm text-text-secondary shadow-lg outline-hidden backdrop-blur-[5px] focus:outline-hidden focus-visible:outline-hidden"
-          listClassName="max-h-72 p-1"
-        >
-          {items.map((item) => (
-            <SelectItem key={item.value} value={item.value}>
-              <SelectItemText title={item.name}>{item.name}</SelectItemText>
-              <SelectItemIndicator />
-            </SelectItem>
-          ))}
-        </SelectContent>
+        <SelectPortal>
+          <SelectPositioner placement="bottom-start" sideOffset={4}>
+            <SelectPopup className="relative w-61 rounded-xl border-[0.5px] bg-components-panel-bg-blur p-0 text-sm text-text-secondary shadow-lg outline-hidden backdrop-blur-[5px] focus:outline-hidden focus-visible:outline-hidden">
+              <SelectList className="max-h-72 p-1">
+                {items.map((item) => (
+                  <SelectItem key={item.value} value={item.value}>
+                    <SelectItemText title={item.name}>{item.name}</SelectItemText>
+                    <SelectItemIndicator />
+                  </SelectItem>
+                ))}
+              </SelectList>
+            </SelectPopup>
+          </SelectPositioner>
+        </SelectPortal>
       </div>
     </Select>
   )

--- a/web/features/agent-v2/agent-detail/monitoring/time-range-picker.tsx
+++ b/web/features/agent-v2/agent-detail/monitoring/time-range-picker.tsx
@@ -218,7 +218,7 @@ export function AgentMonitoringTimeRangePicker({
               ? t(($) => $[selectedOption.nameKey])
               : value.name}
         </SelectTrigger>
-        <SelectContent popupClassName="w-50">
+        <SelectContent className="w-50">
           {timeRangeOptions.map((option) => (
             <SelectItem key={option.value} value={option.value}>
               <SelectItemText>{t(($) => $[option.nameKey])}</SelectItemText>

--- a/web/features/agent-v2/agent-detail/sidebar-actions.tsx
+++ b/web/features/agent-v2/agent-detail/sidebar-actions.tsx
@@ -85,7 +85,7 @@ export function AgentDetailSidebarActions({ agent }: { agent: AgentDetailSidebar
         >
           <span aria-hidden className="i-ri-more-fill size-4" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-40">
+        <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-40">
           <DropdownMenuItem className="gap-2" onClick={handleEditOpen}>
             <span aria-hidden className="i-ri-edit-line size-4 shrink-0 text-text-tertiary" />
             <span>{t(($) => $['roster.editInfo'])}</span>

--- a/web/features/agent-v2/roster/components/agent-roster-list.tsx
+++ b/web/features/agent-v2/roster/components/agent-roster-list.tsx
@@ -235,7 +235,7 @@ function AgentRosterItem({ agent }: { agent: AgentAppPartial }) {
             </span>
             <span aria-hidden className="i-ri-more-fill size-4.5 text-text-tertiary" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-40">
+          <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-40">
             <DropdownMenuItem className="gap-2" onClick={handleEditOpen}>
               <span aria-hidden className="i-ri-edit-line size-4 shrink-0 text-text-tertiary" />
               <span>{t(($) => $['roster.editInfo'])}</span>

--- a/web/features/agent-v2/roster/components/agent-workflow-references-dropdown.tsx
+++ b/web/features/agent-v2/roster/components/agent-workflow-references-dropdown.tsx
@@ -60,7 +60,7 @@ export function AgentWorkflowReferencesDropdown({
         />
         <span className="system-xs-regular text-text-tertiary">{referenceCount}</span>
       </DropdownMenuTrigger>
-      <DropdownMenuContent placement="bottom-start" sideOffset={4} popupClassName="w-[264px] p-1">
+      <DropdownMenuContent placement="bottom-start" sideOffset={4} className="w-[264px] p-1">
         <div className="flex h-7.5 items-center px-2 system-xs-medium text-text-tertiary">
           {t(($) => $['roster.references.label'], { name: agentName })}
         </div>

--- a/web/features/agent-v2/roster/components/roster-sort-select.tsx
+++ b/web/features/agent-v2/roster/components/roster-sort-select.tsx
@@ -40,12 +40,7 @@ export function RosterSortSelect() {
           </span>
         </span>
       </SelectTrigger>
-      <SelectContent
-        placement="bottom-start"
-        sideOffset={4}
-        popupClassName="w-60"
-        listProps={{ 'aria-label': t(($) => $['roster.sort.optionsLabel']) }}
-      >
+      <SelectContent placement="bottom-start" sideOffset={4} className="w-60">
         {rosterSortOptions.map((option) => (
           <SelectItem key={option.value} value={option.value}>
             <SelectItemText title={t(($) => $[option.labelKey])}>

--- a/web/features/new-rag/document-list.tsx
+++ b/web/features/new-rag/document-list.tsx
@@ -198,7 +198,7 @@ const DocumentRow = memo(
             >
               <span aria-hidden className="i-ri-more-fill size-4" />
             </DropdownMenuTrigger>
-            <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-44">
+            <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-44">
               <DropdownMenuItem
                 className="gap-2 px-3"
                 onClick={() => toast.info(t(($) => $['newKnowledge.documentActionsUnavailable']))}

--- a/web/features/new-rag/sources-page.tsx
+++ b/web/features/new-rag/sources-page.tsx
@@ -123,7 +123,7 @@ function SourceActions({
             )}
           />
         </DropdownMenuTrigger>
-        <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-48">
+        <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-48">
           {canSync && (
             <DropdownMenuItem onClick={() => void onSync()} className="gap-2 px-3">
               <span aria-hidden className="i-ri-refresh-line size-4" />


### PR DESCRIPTION
## Summary

- flatten Popup props onto overlay Content components and remove nested `positionerProps`, `popupProps`, `popupClassName`, `listProps`, and `listClassName` escape hatches
- keep convenience surface recipes on Content while exposing anatomy only for consumers that need independent Positioner, Popup, List, Portal, or Backdrop ownership
- migrate Web consumers without changing their visual recipes, preserve Dialog and AlertDialog backdrop customization through merged `backdropProps`, and retain AlertDialog pointer-dismissal semantics
- replace implementation-detail assertions with browser tests for user-visible interaction, focus restoration, placement, selection, and nested backdrop behavior

## Testing

- `vp check packages/dify-ui`
- `cd packages/dify-ui && vp test --project unit` (38 files, 261 tests)
- `vp check web` (0 errors; existing repository warnings only)
- focused affected Web unit suites (10 files, 107 tests)
