### PR TITLE
fix(api): enforce admin and RBAC permissions on default model and provider models GET endpoints (#41099)

### DIFF
--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -210,6 +210,8 @@ class DefaultModelApi(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
     @model_validate(ParserGetDefault)
@@ -263,6 +265,8 @@ class ModelProviderModelApi(Resource):
     )
     @setup_required
     @login_required
+    @is_admin_or_owner_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str, provider: str):

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -7,7 +7,7 @@ from controllers.common.wraps import RBACPermission, RBACResourceScope
 from controllers.console.datasets.data_source import DataSourceApi
 from controllers.console.datasets.rag_pipeline.datasource_auth import DatasourceAuth
 from controllers.console.workspace.model_providers import ModelProviderCredentialApi
-from controllers.console.workspace.models import ModelProviderModelCredentialApi
+from controllers.console.workspace.models import DefaultModelApi, ModelProviderModelApi, ModelProviderModelCredentialApi
 from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddApi, ToolOAuthCustomClient
 
 
@@ -81,4 +81,26 @@ def test_datasource_auth_get_requires_edit_and_rbac() -> None:
     rbac_config = getclosurevars(rbac_wrapper).nonlocals
     assert rbac_config["resource_type"] == RBACResourceScope.DATASET
     assert rbac_config["scene"] == RBACPermission.CREDENTIAL_MANAGE
+    assert rbac_config["resource_required"] is False
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        DefaultModelApi.get,
+        ModelProviderModelApi.get,
+    ],
+)
+def test_workspace_model_preferences_get_require_admin_and_rbac(
+    method: FunctionType,
+) -> None:
+    """GET endpoints that return workspace model preferences must enforce
+    the same admin + RBAC gates as their sibling POST/DELETE methods."""
+    legacy_wrapper = unwrap(method, stop=lambda wrapper: "is_admin_or_owner_required" in wrapper.__code__.co_qualname)
+    assert "is_admin_or_owner_required" in legacy_wrapper.__code__.co_qualname
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
+    assert rbac_config["scene"] == RBACPermission.PLUGIN_PREFERENCES
     assert rbac_config["resource_required"] is False


### PR DESCRIPTION
## Summary

Fixes #41099

The `GET /console/api/workspaces/current/default-model` and `GET /console/api/workspaces/current/model-providers/<provider>/models` endpoints in `workspace/models.py` were missing authorization decorators:
- `@is_admin_or_owner_required`
- `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)`

This allowed workspace members without admin/owner roles or plugin preferences RBAC permissions to read default model settings and model provider configurations.

Added missing permission decorators to match their sibling `post` and `delete` methods and added corresponding unit test assertions.

## Screenshots

N/A (Backend API permission enforcement)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
