### PR TITLE
fix(security): constant-time secret compares; stop echoing webhook errors

### DIFF
--- a/api/controllers/console/admin.py
+++ b/api/controllers/console/admin.py
@@ -1,3 +1,4 @@
+from hmac import compare_digest
 from collections.abc import Callable
 from functools import wraps
 
@@ -17,7 +18,7 @@ def admin_required[**P, R](view: Callable[P, R]) -> Callable[P, R]:
         auth_token = extract_access_token(request)
         if not auth_token:
             raise Unauthorized("Authorization header is missing.")
-        if auth_token != dify_config.ADMIN_API_KEY:
+        if not compare_digest(auth_token, dify_config.ADMIN_API_KEY):
             raise Unauthorized("API key is invalid.")
 
         return view(*args, **kwargs)

--- a/api/controllers/inner_api/wraps.py
+++ b/api/controllers/inner_api/wraps.py
@@ -2,6 +2,7 @@ from base64 import b64encode
 from collections.abc import Callable
 from functools import wraps
 from hashlib import sha1
+from hmac import compare_digest
 from hmac import new as hmac_new
 
 from flask import abort, request
@@ -27,7 +28,7 @@ def inner_api_only[**P, R](view: Callable[P, R]) -> Callable[P, R]:
             abort(404)
 
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY:
+        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY):
             raise InnerApiUnauthorizedError()
 
         return view(*args, **kwargs)
@@ -71,7 +72,7 @@ def enterprise_inner_api_user_auth[**P, R](view: Callable[P, R]) -> Callable[P, 
         signature = hmac_new(inner_api_key.encode("utf-8"), data_to_sign.encode("utf-8"), sha1)
         signature_base64 = b64encode(signature.digest()).decode("utf-8")
 
-        if signature_base64 != token:
+        if not compare_digest(signature_base64, token):
             return view(*args, **kwargs)
 
         with session_factory.create_session() as session:
@@ -89,7 +90,7 @@ def plugin_inner_api_only[**P, R](view: Callable[P, R]) -> Callable[P, R]:
 
         # get header 'X-Inner-Api-Key'
         inner_api_key = request.headers.get("X-Inner-Api-Key")
-        if not inner_api_key or inner_api_key != dify_config.INNER_API_KEY_FOR_PLUGIN:
+        if not inner_api_key or not compare_digest(inner_api_key, dify_config.INNER_API_KEY_FOR_PLUGIN):
             abort(404)
 
         return view(*args, **kwargs)

--- a/api/controllers/trigger/webhook.py
+++ b/api/controllers/trigger/webhook.py
@@ -89,7 +89,7 @@ def handle_webhook(webhook_id: str):
         raise
     except Exception as e:
         logger.exception("Webhook processing failed for %s", webhook_id)
-        return jsonify({"error": "Internal server error", "message": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @bp.route("/webhook-debug/<string:webhook_id>", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+from hmac import compare_digest
 import json
 import os
 import time
@@ -82,7 +83,7 @@ def verify_tool_file_signature(file_id: str, timestamp: str, nonce: str, sign: s
     recalculated_encoded_sign = base64.urlsafe_b64encode(recalculated_sign).decode()
 
     # verify signature
-    if sign != recalculated_encoded_sign:
+    if not compare_digest(sign, recalculated_encoded_sign):
         return False
 
     current_time = int(time.time())
@@ -161,7 +162,7 @@ def verify_plugin_file_signature(
     recalculated_sign = hmac.new(_secret_key(), data_to_sign.encode(), hashlib.sha256).digest()
     recalculated_encoded_sign = base64.urlsafe_b64encode(recalculated_sign).decode()
 
-    if sign != recalculated_encoded_sign:
+    if not compare_digest(sign, recalculated_encoded_sign):
         return False
 
     current_time = int(time.time())


### PR DESCRIPTION
## What changed
1. Secret-material comparisons used plain `!=`: the inner-api key checks (`X-Inner-Api-Key`, plugin inner key), the admin API key check, and both HMAC file-signature verifications. `libs/token.py` already uses `hmac.compare_digest` for the same admin key; this PR aligns the remaining call sites.
2. `controllers/trigger/webhook.py` returned `{message: str(e)}` on 500, echoing internal exception text to an **unauthenticated** caller (the debug endpoint in the same file deliberately avoids this). The exception stays in the server log only.

## Verification
- `python -m py_compile` on all touched files; `compare_digest` args are both ASCII strings (header value / configured key / base64 signature).