### PR TITLE
fix(agent-v2): prevent workflow refresh render loop

### DIFF
--- a/web/app/components/workflow/nodes/agent-v2/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/__tests__/panel.spec.tsx
@@ -1277,6 +1277,27 @@ describe('agent/panel', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('keeps prompt output definitions stable when workflow data is unchanged', () => {
+    const data = createData({
+      agent_task: 'Use [§output:summary:summary§]',
+      agent_declared_outputs: [
+        {
+          name: 'summary',
+          type: 'string',
+        },
+      ],
+    })
+    const { rerender } = render(
+      <AgentV2Panel id="agent-node" data={data} panelProps={panelProps} />,
+    )
+    const initialOutputs = mockPromptEditorProps.at(-1)?.agentOutputBlock?.outputs
+    expect(initialOutputs).toBeDefined()
+
+    rerender(<AgentV2Panel id="agent-node" data={data} panelProps={panelProps} />)
+
+    expect(mockPromptEditorProps.at(-1)?.agentOutputBlock?.outputs).toBe(initialOutputs)
+  })
+
   it('opens the output variable editor from an agent task output token hover', () => {
     render(
       <AgentV2Panel

--- a/web/app/components/workflow/nodes/agent-v2/panel.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/panel.tsx
@@ -9,7 +9,7 @@ import type { AgentV2NodeType } from './types'
 import type { AgentOutputTypeOptionValue } from '@/app/components/base/prompt-editor/plugins/agent-output-block/utils'
 import { useMutation } from '@tanstack/react-query'
 import { produce } from 'immer'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import {
@@ -140,7 +140,11 @@ export function AgentV2Panel({ id, data }: NodePanelProps<AgentV2NodeType>) {
   const [localDeclaredOutputs, setLocalDeclaredOutputs] = useState<DeclaredOutputConfig[] | null>(
     null,
   )
-  const declaredOutputs = localDeclaredOutputs ?? getAgentV2DeclaredOutputs(inputs)
+  const normalizedDeclaredOutputs = useMemo(
+    () => normalizeAgentV2DeclaredOutputs(inputs.agent_declared_outputs ?? []),
+    [inputs.agent_declared_outputs],
+  )
+  const declaredOutputs = localDeclaredOutputs ?? normalizedDeclaredOutputs
   const rosterAgentId =
     inputs.agent_binding?.binding_type === 'roster_agent'
       ? inputs.agent_binding.agent_id


### PR DESCRIPTION
## Problem

Refreshing a workflow after renaming an Agent v2 prompt output reference can leave the builder stuck on the full-page loading screen.

## Root cause

The Agent v2 panel rebuilt its effective declared outputs array on every render. When a restored prompt contained an output token, the Lexical plugin treated each new array reference as changed editor state, replaced the output node, and triggered another React/Lexical update until the page became unresponsive.

## Fix

Memoize the normalized Agent v2 outputs by the persisted agent_declared_outputs reference so the editor receives stable output definitions until the workflow data actually changes.

Fixes dify-2912