### PR TITLE
fix(web): support data-tone attribute on markdown buttons

### DIFF
--- a/web/app/components/base/markdown-blocks/__tests__/button.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/button.spec.tsx
@@ -119,4 +119,36 @@ describe('MarkdownButton (integration)', () => {
       'bg-components-button-destructive-primary-bg',
     )
   })
+
+  it('applies a whitelisted data-tone on top of the variant', () => {
+    renderWithCtx(createButtonNode({ dataVariant: 'ghost', dataTone: 'destructive' }, 'Remove'))
+
+    expect(screen.getByRole('button', { name: 'Remove' })).toHaveClass(
+      'text-components-button-destructive-ghost-text',
+    )
+  })
+
+  it('renders a destructive secondary button when only data-tone is provided', () => {
+    renderWithCtx(createButtonNode({ dataTone: 'destructive' }, 'Stop'))
+
+    expect(screen.getByRole('button', { name: 'Stop' })).toHaveClass(
+      'bg-components-button-destructive-secondary-bg',
+    )
+  })
+
+  it('lets an explicit data-tone override the tone derived from the variant', () => {
+    renderWithCtx(createButtonNode({ dataVariant: 'warning', dataTone: 'default' }, 'Warn'))
+
+    const button = screen.getByRole('button', { name: 'Warn' })
+    expect(button).not.toHaveClass('bg-components-button-destructive-primary-bg')
+    expect(button).toHaveClass('bg-components-button-primary-bg')
+  })
+
+  it('ignores invalid data-tone values', () => {
+    renderWithCtx(createButtonNode({ dataTone: 'warning' }, 'Invalid'))
+
+    expect(screen.getByRole('button', { name: 'Invalid' })).not.toHaveClass(
+      'bg-components-button-destructive-secondary-bg',
+    )
+  })
 })

--- a/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
@@ -818,6 +818,36 @@ describe('MarkdownForm', () => {
 
       expect(screen.getByRole('button', { name: 'Go' }))!.toBeInTheDocument()
     })
+
+    it('should apply a whitelisted tone to the submit button', () => {
+      const node = createRootNode([
+        createElementNode(
+          'button',
+          { dataVariant: 'ghost', dataSize: 'small', dataTone: 'destructive' },
+          [createTextNode('Delete')],
+        ),
+      ])
+
+      render(<MarkdownForm node={node} />)
+
+      expect(screen.getByRole('button', { name: 'Delete' })).toHaveClass(
+        'text-components-button-destructive-ghost-text',
+      )
+    })
+
+    it('should ignore an invalid tone value', () => {
+      const node = createRootNode([
+        createElementNode('button', { dataVariant: 'primary', dataTone: 'warning' }, [
+          createTextNode('Go'),
+        ]),
+      ])
+
+      render(<MarkdownForm node={node} />)
+
+      const button = screen.getByRole('button', { name: 'Go' })
+      expect(button).not.toHaveClass('bg-components-button-destructive-primary-bg')
+      expect(button).toHaveClass('bg-components-button-primary-bg')
+    })
   })
 
   // Standard input types (password, email, number) use the generic Input branch.

--- a/web/app/components/base/markdown-blocks/button-appearance.ts
+++ b/web/app/components/base/markdown-blocks/button-appearance.ts
@@ -18,12 +18,20 @@ const VALID_BUTTON_SIZES: ReadonlySet<string> = new Set([
   'large',
 ] satisfies Array<NonNullable<ButtonProps['size']>>)
 
+const VALID_BUTTON_TONES: ReadonlySet<string> = new Set(['default', 'destructive'] satisfies Array<
+  NonNullable<ButtonProps['tone']>
+>)
+
 function isMarkdownButtonVariant(value: string): value is keyof typeof MARKDOWN_BUTTON_APPEARANCES {
   return Object.hasOwn(MARKDOWN_BUTTON_APPEARANCES, value)
 }
 
 function isButtonSize(value: string): value is NonNullable<ButtonProps['size']> {
   return VALID_BUTTON_SIZES.has(value)
+}
+
+function isButtonTone(value: string): value is NonNullable<ButtonProps['tone']> {
+  return VALID_BUTTON_TONES.has(value)
 }
 
 function normalizeAttribute(value: unknown) {
@@ -33,12 +41,15 @@ function normalizeAttribute(value: unknown) {
 function getMarkdownButtonAppearance(
   dataVariant: unknown,
   dataSize: unknown,
+  dataTone?: unknown,
 ): MarkdownButtonAppearance {
   const variant = normalizeAttribute(dataVariant)
   const size = normalizeAttribute(dataSize)
+  const tone = normalizeAttribute(dataTone)
 
   return {
     ...(isMarkdownButtonVariant(variant) ? MARKDOWN_BUTTON_APPEARANCES[variant] : undefined),
+    ...(isButtonTone(tone) ? { tone } : undefined),
     size: isButtonSize(size) ? size : undefined,
   }
 }

--- a/web/app/components/base/markdown-blocks/button.tsx
+++ b/web/app/components/base/markdown-blocks/button.tsx
@@ -17,6 +17,7 @@ const MarkdownButton = ({ node }: MarkdownButtonProps) => {
   const appearance = getMarkdownButtonAppearance(
     node?.properties.dataVariant,
     node?.properties.dataSize,
+    node?.properties.dataTone,
   )
   const message = getStringProperty(node?.properties.dataMessage)
   const link = getStringProperty(node?.properties.dataLink)

--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -392,6 +392,7 @@ const MarkdownForm = ({ node }: { node: HastElement }) => {
           const appearance = getMarkdownButtonAppearance(
             child.properties.dataVariant,
             child.properties.dataSize,
+            child.properties.dataTone,
           )
 
           return (

--- a/web/app/components/base/markdown/__tests__/streamdown-wrapper-form.spec.tsx
+++ b/web/app/components/base/markdown/__tests__/streamdown-wrapper-form.spec.tsx
@@ -76,6 +76,21 @@ describe('StreamdownWrapper Markdown form field names', () => {
     expect(screen.queryByText('*')).not.toBeInTheDocument()
   })
 
+  it('should pass the data-tone attribute through sanitization to the rendered submit button', async () => {
+    const { default: StreamdownWrapper } = await import('../streamdown-wrapper')
+    const content = `
+<form data-format="json">
+  <input type="hidden" name="task" value="long-running-job" />
+  <button type="submit" data-variant="ghost" data-tone="destructive">Stop task</button>
+</form>`
+
+    render(<StreamdownWrapper latexContent={content} mode="static" />)
+
+    expect(screen.getByRole('button', { name: 'Stop task' })).toHaveClass(
+      'text-components-button-destructive-ghost-text',
+    )
+  })
+
   it('should keep incomplete Markdown repair enabled when no form is present', async () => {
     const { default: StreamdownWrapper } = await import('../streamdown-wrapper')
 

--- a/web/app/components/base/markdown/streamdown-wrapper.tsx
+++ b/web/app/components/base/markdown/streamdown-wrapper.tsx
@@ -56,7 +56,7 @@ const mathPlugin = createMathPlugin({
  * minimise the attack surface when LLM-generated content is rendered.
  */
 const ALLOWED_TAGS: Record<string, string[]> = {
-  button: ['dataVariant', 'dataSize', 'dataMessage', 'dataLink'],
+  button: ['dataVariant', 'dataSize', 'dataTone', 'dataMessage', 'dataLink'],
   form: ['dataFormat'],
   input: ['type', 'name', 'value', 'placeholder', 'checked', 'dataTip', 'dataOptions'],
   textarea: ['name', 'placeholder', 'value'],


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #38895

Answer-node buttons silently ignore the documented `data-tone` attribute. Two things caused it:

1. **Sanitizer gap** – `ALLOWED_TAGS` in `streamdown-wrapper.tsx` did not whitelist `dataTone` for `<button>`, so rehype-sanitize stripped `data-tone` from LLM-generated markdown before it ever reached the renderer.
2. **Renderer gap** – neither `MarkdownButton` (`button.tsx`) nor the submit button rendered by `MarkdownForm` (`form.tsx`) passed a tone to the Dify UI `Button`, so even a surviving attribute would not have changed styling.

Changes:

- Add `dataTone` to the button allowlist in the sanitize schema.
- Extend `getMarkdownButtonAppearance` with an optional, strictly whitelisted `tone` (`default` | `destructive`). An explicit `data-tone` overrides the tone implied by `data-variant` (e.g. `warning` maps to destructive primary today; `data-tone="default"` can opt out).
- Pass `node.properties.dataTone` / `child.properties.dataTone` through both call sites.

Behavior notes:

- `data-variant="warning"` keeps its existing destructive-primary mapping.
- Invalid tone values are ignored (no style change), matching how invalid variants/sizes are handled.
- `data-tone="destructive"` without a variant renders a destructive secondary button (Button's default variant), consistent with the Dify UI compound variants.

Note for reviewers: this is a fresh implementation on current `main` of the change previously attempted in #38967, which was closed only due to merge conflicts (the underlying files have since been refactored to share `getMarkdownButtonAppearance`). Happy to close/rebase further if preferred.

## Screenshots

| Before | After |
| ------ | ----- |
| `<button data-message="stop" data-tone="destructive">` renders as a plain default-styled button (attribute stripped/ignored) | Same markup now renders with the destructive design tokens, e.g. ghost + destructive uses `text-components-button-destructive-ghost-text`; covered by unit assertions |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — *not required here; note that the external docs page mentioned in the issue (template#supported-tags) lives in dify-docs and still lists outdated tags; happy to follow up there*
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From opencode
