### PR TITLE
fix(console): return UUID instead of server_identifier in MCP provide…

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1604,7 +1604,7 @@ class ToolMCPListAllApi(Resource):
         with sessionmaker(db.engine).begin() as session:
             service = MCPToolManageService(session=session)
             # Skip sensitive data decryption for list view to improve performance
-            tools = service.list_providers(tenant_id=tenant_id, include_sensitive=False)
+            tools = service.list_providers(tenant_id=tenant_id, for_list=True, include_sensitive=False)
 
             return _dump_tool_provider_payload_list([tool.to_dict() for tool in tools])
 


### PR DESCRIPTION
## Summary
This PR fixes issue #41109 where the MCP provider list API returns the `server_identifier` as the `id` field, while other management APIs (like update/delete) expect the database UUID. This inconsistency causes management operations to fail after selecting a provider from the list.

## Changes
- Updated `ToolMCPListAllApi.get` in `api/controllers/console/workspace/tool_providers.py` to call `service.list_providers` with `for_list=True`.
- This ensures that the returned `id` field contains the UUID, matching the behavior of other provider types and management endpoints.

## Validation
- Verified the logic in `MCPToolManageService.list_providers` and `ToolTransformService.mcp_provider_to_user_provider`.
- Confirmed that `for_list=True` correctly maps `db_provider.id` (UUID) to the response `id` field.

Fixes #41109