### PR TITLE
refactor(web): migrate duplicate app input form

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -471,11 +471,6 @@
       "count": 1
     }
   },
-  "web/app/components/app/duplicate-modal/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/app/log/filter.tsx": {
     "react/only-export-components": {
       "count": 1

--- a/web/app/components/app/duplicate-modal/__tests__/index.spec.tsx
+++ b/web/app/components/app/duplicate-modal/__tests__/index.spec.tsx
@@ -2,15 +2,19 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DuplicateAppModal from '../index'
 
-const toastErrorMock = vi.fn()
-vi.mock('@/context/provider-context', () => ({
-  useProviderContext: () => ({
+const { mockProviderContext, toastErrorMock } = vi.hoisted(() => ({
+  mockProviderContext: {
     plan: {
       usage: { buildApps: 0 },
       total: { buildApps: 1 },
     },
     enableBilling: true,
-  }),
+  },
+  toastErrorMock: vi.fn(),
+}))
+
+vi.mock('@/context/provider-context', () => ({
+  useProviderContext: () => mockProviderContext,
 }))
 
 vi.mock('@langgenius/dify-ui/toast', () => ({
@@ -20,11 +24,11 @@ vi.mock('@langgenius/dify-ui/toast', () => ({
 }))
 
 vi.mock('@/app/components/base/app-icon', () => ({
-  default: ({ onClick }: { onClick: () => void }) => (
-    <button type="button" onClick={onClick}>
-      open-icon-picker
-    </button>
-  ),
+  default: () => <span>app-icon</span>,
+}))
+
+vi.mock('@/app/components/billing/apps-full-in-dialog', () => ({
+  default: () => <div>apps-full</div>,
 }))
 
 vi.mock('@/app/components/base/app-icon-picker', () => ({
@@ -67,8 +71,30 @@ vi.mock('@/app/components/base/app-icon-picker', () => ({
 }))
 
 describe('DuplicateAppModal', () => {
+  const getIconButton = () =>
+    screen.getByRole('button', {
+      name: /operation\.edit.*appCustomize\.subTitle/,
+    })
+
   beforeEach(() => {
     vi.clearAllMocks()
+    mockProviderContext.plan.usage.buildApps = 0
+    mockProviderContext.plan.total.buildApps = 1
+  })
+
+  it('should render a named dialog', () => {
+    render(
+      <DuplicateAppModal
+        appName="Demo App"
+        icon_type="emoji"
+        icon="🤖"
+        show
+        onConfirm={vi.fn()}
+        onHide={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('dialog', { name: /duplicateTitle/ })).toBeInTheDocument()
   })
 
   it('should validate the name before duplicating and update the input value', async () => {
@@ -88,13 +114,14 @@ describe('DuplicateAppModal', () => {
       />,
     )
 
-    const input = screen.getByRole('textbox')
+    const input = screen.getByRole('textbox', { name: /appCustomize\.subTitle/ })
     await user.clear(input)
     await user.type(input, 'Updated App')
     expect(input).toHaveValue('Updated App')
 
     await user.clear(input)
-    await user.click(screen.getByRole('button', { name: /(?:^|\.)duplicate(?=$|:)/ }))
+    await user.click(screen.getByRole('textbox', { name: /appCustomize\.subTitle/ }))
+    await user.keyboard('{Enter}')
 
     expect(toastErrorMock).toHaveBeenCalledWith(
       expect.stringMatching(/(?:^|\.)appCustomize\.nameRequired(?=$|:)/),
@@ -120,7 +147,7 @@ describe('DuplicateAppModal', () => {
       />,
     )
 
-    await user.click(screen.getByText('open-icon-picker'))
+    await user.click(getIconButton())
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search emojis...')).toBeInTheDocument()
     })
@@ -161,6 +188,50 @@ describe('DuplicateAppModal', () => {
     expect(onHide).toHaveBeenCalledTimes(1)
   })
 
+  it('should call onHide when Escape is pressed', async () => {
+    const onHide = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <DuplicateAppModal
+        appName="Demo App"
+        icon_type="emoji"
+        icon="🤖"
+        show
+        onConfirm={vi.fn()}
+        onHide={onHide}
+      />,
+    )
+
+    await user.keyboard('{Escape}')
+
+    expect(onHide).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not submit with Enter when the app limit is reached', async () => {
+    const onConfirm = vi.fn()
+    const onHide = vi.fn()
+    const user = userEvent.setup()
+    mockProviderContext.plan.usage.buildApps = 1
+
+    render(
+      <DuplicateAppModal
+        appName="Demo App"
+        icon_type="emoji"
+        icon="🤖"
+        show
+        onConfirm={onConfirm}
+        onHide={onHide}
+      />,
+    )
+
+    await user.click(screen.getByRole('textbox', { name: /appCustomize\.subTitle/ }))
+    await user.keyboard('{Enter}')
+
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(onHide).not.toHaveBeenCalled()
+  })
+
   it('should preserve the current image icon when the picker closes without selecting', async () => {
     const onConfirm = vi.fn()
     const user = userEvent.setup()
@@ -177,7 +248,7 @@ describe('DuplicateAppModal', () => {
       />,
     )
 
-    await user.click(screen.getByText('open-icon-picker'))
+    await user.click(getIconButton())
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search emojis...')).toBeInTheDocument()
     })
@@ -189,7 +260,7 @@ describe('DuplicateAppModal', () => {
     await waitFor(() => {
       expect(screen.queryByPlaceholderText('Search emojis...')).not.toBeInTheDocument()
     })
-    await user.click(screen.getByText('open-icon-picker'))
+    await user.click(getIconButton())
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search emojis...')).toBeInTheDocument()
     })

--- a/web/app/components/app/duplicate-modal/index.tsx
+++ b/web/app/components/app/duplicate-modal/index.tsx
@@ -1,14 +1,15 @@
 'use client'
 import type { AppIconType } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
-import { RiCloseLine } from '@remixicon/react'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
-import Input from '@/app/components/base/input'
 import AppsFull from '@/app/components/billing/apps-full-in-dialog'
 import { useProviderContext } from '@/context/provider-context'
 import AppIconPicker from '../../base/app-icon-picker'
@@ -54,6 +55,8 @@ const DuplicateAppModal = ({
   const isAppsFull = enableBilling && plan.usage.buildApps >= plan.total.buildApps
 
   const submit = () => {
+    if (isAppsFull) return
+
     if (!name.trim()) {
       toast.error(t(($) => $['appCustomize.nameRequired'], { ns: 'explore' }))
       return
@@ -69,47 +72,72 @@ const DuplicateAppModal = ({
 
   return (
     <>
-      <Dialog open={show}>
+      <Dialog
+        open={show}
+        onOpenChange={(open) => {
+          if (!open) onHide()
+        }}
+      >
         <DialogContent className="w-full max-w-120! overflow-hidden! border-none px-8 text-left align-middle">
-          <button
-            type="button"
-            className="absolute top-4 right-4 cursor-pointer border-none bg-transparent p-2 focus-visible:ring-1 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
+          <IconButton
+            size="lg"
+            className="absolute top-4 right-4"
             aria-label={t(($) => $['operation.close'], { ns: 'common' })}
             onClick={onHide}
           >
-            <RiCloseLine className="size-4 text-text-tertiary" aria-hidden="true" />
-          </button>
-          <div className="relative mt-3 mb-9 text-xl leading-7.5 font-semibold text-text-primary">
+            <span aria-hidden="true" className="i-ri-close-line size-4" />
+          </IconButton>
+          <DialogTitle className="relative mt-3 mb-9 text-xl leading-7.5 font-semibold text-text-primary">
             {t(($) => $.duplicateTitle, { ns: 'app' })}
-          </div>
-          <div className="mb-9 system-sm-regular text-text-secondary">
-            <div className="mb-2 system-md-medium">
-              {t(($) => $['appCustomize.subTitle'], { ns: 'explore' })}
+          </DialogTitle>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault()
+              submit()
+            }}
+          >
+            <div className="mb-9 system-sm-regular text-text-secondary">
+              <Field className="gap-2" name="name">
+                <FieldLabel className="py-0 system-md-medium">
+                  {t(($) => $['appCustomize.subTitle'], { ns: 'explore' })}
+                </FieldLabel>
+                <div className="flex items-center justify-between space-x-2">
+                  <button
+                    type="button"
+                    aria-label={`${t(($) => $['operation.edit'], { ns: 'common' })} ${t(($) => $['appCustomize.subTitle'], { ns: 'explore' })}`}
+                    onClick={() => {
+                      setShowAppIconPicker(true)
+                    }}
+                    className="shrink-0 cursor-pointer rounded-[10px] focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
+                  >
+                    <AppIcon
+                      size="large"
+                      iconType={appIcon.type}
+                      icon={appIcon.type === 'image' ? appIcon.fileId : appIcon.icon}
+                      background={appIcon.type === 'image' ? undefined : appIcon.background}
+                      imageUrl={appIcon.type === 'image' ? appIcon.url : undefined}
+                    />
+                  </button>
+                  <Input
+                    autoComplete="off"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="h-10"
+                    placeholder={t(($) => $['placeholder.input'], { ns: 'common' }) || ''}
+                  />
+                </div>
+              </Field>
+              {isAppsFull && <AppsFull className="mt-4" loc="app-duplicate-create" />}
             </div>
-            <div className="flex items-center justify-between space-x-2">
-              <AppIcon
-                size="large"
-                onClick={() => {
-                  setShowAppIconPicker(true)
-                }}
-                className="cursor-pointer"
-                iconType={appIcon.type}
-                icon={appIcon.type === 'image' ? appIcon.fileId : appIcon.icon}
-                background={appIcon.type === 'image' ? undefined : appIcon.background}
-                imageUrl={appIcon.type === 'image' ? appIcon.url : undefined}
-              />
-              <Input value={name} onChange={(e) => setName(e.target.value)} className="h-10" />
+            <div className="flex flex-row-reverse">
+              <Button type="submit" disabled={isAppsFull} className="ml-2 w-24" variant="primary">
+                {t(($) => $.duplicate, { ns: 'app' })}
+              </Button>
+              <Button type="button" className="w-24" onClick={onHide}>
+                {t(($) => $['operation.cancel'], { ns: 'common' })}
+              </Button>
             </div>
-            {isAppsFull && <AppsFull className="mt-4" loc="app-duplicate-create" />}
-          </div>
-          <div className="flex flex-row-reverse">
-            <Button disabled={isAppsFull} className="ml-2 w-24" variant="primary" onClick={submit}>
-              {t(($) => $.duplicate, { ns: 'app' })}
-            </Button>
-            <Button className="w-24" onClick={onHide}>
-              {t(($) => $['operation.cancel'], { ns: 'common' })}
-            </Button>
-          </div>
+          </form>
         </DialogContent>
       </Dialog>
       {showAppIconPicker && (


### PR DESCRIPTION
## Summary

- migrate the duplicate app name field from the legacy Web input to Dify UI Field and Input
- use a native form boundary for Enter submission while preserving the existing quota and validation behavior
- give the dialog and icon actions explicit Base UI/Dify UI semantics, accessible names, Escape handling, and visible focus treatment
- remove the obsolete legacy-input lint suppression

## Testing

- `vp test run --project unit app/components/app/duplicate-modal/__tests__/index.spec.tsx`
- `pnpm -C web run lint:a11y app/components/app/duplicate-modal/index.tsx`
- `pnpm -C web type-check`
- `pnpm check`

## Screenshots

No intentional visual change. The existing dimensions, spacing, typography, and resting colors are preserved.

From Codex