### PR TITLE
refactor(web): migrate pipeline template input form

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1899,11 +1899,6 @@
       "count": 1
     }
   },
-  "web/app/components/datasets/create-from-pipeline/list/template-card/edit-pipeline-info.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/create-from-pipeline/list/template-card/operations.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 3

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/edit-pipeline-info.spec.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/edit-pipeline-info.spec.tsx
@@ -1,8 +1,18 @@
+import type { ReactElement } from 'react'
 import type { PipelineTemplate } from '@/models/pipeline'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
+import { fireEvent, screen, render as testingLibraryRender, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { ChunkingMode } from '@/models/datasets'
 import EditPipelineInfo from '../edit-pipeline-info'
+
+const render = (ui: ReactElement) =>
+  testingLibraryRender(
+    <Dialog open>
+      <DialogContent>{ui}</DialogContent>
+    </Dialog>,
+  )
 
 const mockUpdatePipeline = vi.fn()
 const mockInvalidCustomizedTemplateList = vi.fn()
@@ -65,6 +75,10 @@ describe('EditPipelineInfo', () => {
     onClose: vi.fn(),
     pipeline: createPipelineTemplate(),
   }
+  const getIconButton = () =>
+    screen.getByRole('button', {
+      name: 'common.operation.edit datasetPipeline.pipelineNameAndIcon',
+    })
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -74,13 +88,12 @@ describe('EditPipelineInfo', () => {
   describe('Rendering', () => {
     it('should render title', () => {
       render(<EditPipelineInfo {...defaultProps} />)
-      expect(screen.getByText(/editPipelineInfo/i)).toBeInTheDocument()
+      expect(screen.getByRole('dialog', { name: /editPipelineInfo/i })).toBeInTheDocument()
     })
 
     it('should render close button', () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
-      const closeButton = container.querySelector('button[type="button"]')
-      expect(closeButton).toBeInTheDocument()
+      render(<EditPipelineInfo {...defaultProps} />)
+      expect(screen.getByRole('button', { name: 'common.operation.close' })).toBeInTheDocument()
     })
 
     it('should render name input with initial value', () => {
@@ -113,11 +126,11 @@ describe('EditPipelineInfo', () => {
   })
 
   describe('User Interactions', () => {
-    it('should call onClose when close button is clicked', () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
+    it('should call onClose when close button is clicked', async () => {
+      const user = userEvent.setup()
+      render(<EditPipelineInfo {...defaultProps} />)
 
-      const closeButton = container.querySelector('button[type="button"]')
-      fireEvent.click(closeButton!)
+      await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
       expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
     })
@@ -149,7 +162,8 @@ describe('EditPipelineInfo', () => {
       expect(screen.getByDisplayValue('New description')).toBeInTheDocument()
     })
 
-    it('should call updatePipeline when save is clicked with valid name', async () => {
+    it('should submit with Enter from the name input', async () => {
+      const user = userEvent.setup()
       mockUpdatePipeline.mockImplementation((_data, callbacks) => {
         callbacks.onSuccess()
         return Promise.resolve()
@@ -157,8 +171,8 @@ describe('EditPipelineInfo', () => {
 
       render(<EditPipelineInfo {...defaultProps} />)
 
-      const saveButton = screen.getByText(/operation\.save/i)
-      fireEvent.click(saveButton)
+      await user.click(screen.getByRole('textbox', { name: 'datasetPipeline.pipelineNameAndIcon' }))
+      await user.keyboard('{Enter}')
 
       await waitFor(() => {
         expect(mockUpdatePipeline).toHaveBeenCalled()
@@ -231,9 +245,9 @@ describe('EditPipelineInfo', () => {
   // Icon Types Tests (Branch Coverage for lines 29-30, 36-37)
   describe('Icon Types', () => {
     it('should initialize with emoji icon type when pipeline has emoji icon', () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
+      render(<EditPipelineInfo {...defaultProps} />)
       // Should render component with emoji icon
-      expect(container.querySelector('[class*="cursor-pointer"]')).toBeInTheDocument()
+      expect(getIconButton()).toBeInTheDocument()
       expect(screen.getByDisplayValue('Test Pipeline')).toBeInTheDocument()
     })
 
@@ -248,10 +262,10 @@ describe('EditPipelineInfo', () => {
         onClose: vi.fn(),
         pipeline: imagePipeline,
       }
-      const { container } = render(<EditPipelineInfo {...props} />)
+      render(<EditPipelineInfo {...props} />)
       // Component should initialize with image icon state
       expect(screen.getByDisplayValue('Image Pipeline')).toBeInTheDocument()
-      expect(container.querySelector('[class*="cursor-pointer"]')).toBeInTheDocument()
+      expect(getIconButton()).toBeInTheDocument()
     })
 
     it('should render correctly with image icon and then update', () => {
@@ -261,14 +275,13 @@ describe('EditPipelineInfo', () => {
         ...defaultProps,
         pipeline: imagePipeline,
       }
-      const { container } = render(<EditPipelineInfo {...props} />)
+      render(<EditPipelineInfo {...props} />)
 
       // Verify component rendered with image pipeline
       expect(screen.getByDisplayValue('Image Pipeline')).toBeInTheDocument()
 
       // Open icon picker
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      fireEvent.click(getIconButton())
       expect(screen.getByPlaceholderText('Search emojis...')).toBeInTheDocument()
     })
 
@@ -329,11 +342,10 @@ describe('EditPipelineInfo', () => {
         ...defaultProps,
         pipeline: createImagePipelineTemplate(),
       }
-      const { container } = render(<EditPipelineInfo {...props} />)
+      render(<EditPipelineInfo {...props} />)
 
       // Open picker
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      fireEvent.click(getIconButton())
       expect(screen.getByPlaceholderText('Search emojis...')).toBeInTheDocument()
 
       // Close without selection - should revert to original image icon
@@ -354,11 +366,10 @@ describe('EditPipelineInfo', () => {
         ...defaultProps,
         pipeline: createImagePipelineTemplate(),
       }
-      const { container } = render(<EditPipelineInfo {...props} />)
+      render(<EditPipelineInfo {...props} />)
 
       // Open picker and select emoji
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      fireEvent.click(getIconButton())
       const emojiButton = document.querySelector('em-emoji')?.closest('button')
       expect(emojiButton).toBeTruthy()
       fireEvent.click(emojiButton!)
@@ -383,10 +394,9 @@ describe('EditPipelineInfo', () => {
     })
 
     it('should switch to the image tab in the real picker', () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
+      render(<EditPipelineInfo {...defaultProps} />)
 
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      fireEvent.click(getIconButton())
       fireEvent.click(screen.getByRole('button', { name: /iconPicker\.image/ }))
 
       expect(screen.getByRole('button', { name: /iconPicker\.ok/ })).toBeInTheDocument()
@@ -401,17 +411,15 @@ describe('EditPipelineInfo', () => {
     })
 
     it('should open picker when icon is clicked', () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      render(<EditPipelineInfo {...defaultProps} />)
+      fireEvent.click(getIconButton())
 
       expect(screen.getByPlaceholderText('Search emojis...')).toBeInTheDocument()
     })
 
     it('should close picker and update icon when emoji style is selected', async () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      render(<EditPipelineInfo {...defaultProps} />)
+      fireEvent.click(getIconButton())
 
       fireEvent.click(screen.getByRole('button', { name: '#E4FBCC' }))
       fireEvent.click(screen.getByRole('button', { name: /iconPicker\.ok/ }))
@@ -422,9 +430,8 @@ describe('EditPipelineInfo', () => {
     })
 
     it('should keep picker open when only switching to image tab', () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      render(<EditPipelineInfo {...defaultProps} />)
+      fireEvent.click(getIconButton())
 
       fireEvent.click(screen.getByRole('button', { name: /iconPicker\.image/ }))
 
@@ -432,9 +439,8 @@ describe('EditPipelineInfo', () => {
     })
 
     it('should revert icon when picker is closed without selection', async () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      render(<EditPipelineInfo {...defaultProps} />)
+      fireEvent.click(getIconButton())
 
       fireEvent.click(screen.getByRole('button', { name: /iconPicker\.cancel/ }))
 
@@ -449,11 +455,10 @@ describe('EditPipelineInfo', () => {
         return Promise.resolve()
       })
 
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
+      render(<EditPipelineInfo {...defaultProps} />)
 
       // Open picker and select new emoji
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      fireEvent.click(getIconButton())
       fireEvent.click(screen.getByRole('button', { name: '#E4FBCC' }))
       fireEvent.click(screen.getByRole('button', { name: /iconPicker\.ok/ }))
 
@@ -480,12 +485,9 @@ describe('EditPipelineInfo', () => {
         return Promise.resolve()
       })
 
-      const { container } = render(
-        <EditPipelineInfo {...defaultProps} pipeline={createImagePipelineTemplate()} />,
-      )
+      render(<EditPipelineInfo {...defaultProps} pipeline={createImagePipelineTemplate()} />)
 
-      const appIcon = container.querySelector('[class*="cursor-pointer"]')
-      fireEvent.click(appIcon!)
+      fireEvent.click(getIconButton())
       const emojiButton = document.querySelector('em-emoji')?.closest('button')
       expect(emojiButton).toBeTruthy()
       fireEvent.click(emojiButton!)
@@ -569,8 +571,8 @@ describe('EditPipelineInfo', () => {
 
   describe('Layout', () => {
     it('should have close button in header', () => {
-      const { container } = render(<EditPipelineInfo {...defaultProps} />)
-      const closeButton = container.querySelector('button.absolute')
+      render(<EditPipelineInfo {...defaultProps} />)
+      const closeButton = screen.getByRole('button', { name: 'common.operation.close' })
       expect(closeButton).toHaveClass('right-5', 'top-5')
     })
   })

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/edit-pipeline-info.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/edit-pipeline-info.tsx
@@ -1,15 +1,17 @@
 import type { AppIconSelection } from '@/app/components/base/app-icon-picker'
 import type { PipelineTemplate } from '@/models/pipeline'
 import { Button } from '@langgenius/dify-ui/button'
+import { DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { toast } from '@langgenius/dify-ui/toast'
-import { RiCloseLine } from '@remixicon/react'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
 import AppIconPicker from '@/app/components/base/app-icon-picker'
-import Input from '@/app/components/base/input'
 import { useInvalidCustomizedTemplateList, useUpdateTemplateInfo } from '@/service/use-pipeline'
 
 type EditPipelineInfoProps = {
@@ -83,65 +85,79 @@ const EditPipelineInfo = ({ onClose, pipeline }: EditPipelineInfoProps) => {
     updatePipeline,
     invalidCustomizedTemplateList,
     onClose,
+    t,
   ])
 
   return (
-    <div className="relative flex flex-col">
+    <form
+      className="relative flex flex-col"
+      onSubmit={(event) => {
+        event.preventDefault()
+        void handleSave()
+      }}
+    >
       {/* Header */}
       <div className="pt-6 pr-14 pb-3 pl-6">
-        <span className="title-2xl-semi-bold text-text-primary">
+        <DialogTitle className="title-2xl-semi-bold text-text-primary">
           {t(($) => $.editPipelineInfo, { ns: 'datasetPipeline' })}
-        </span>
+        </DialogTitle>
       </div>
-      <button
-        type="button"
-        className="absolute top-5 right-5 flex size-8 items-center justify-center"
+      <IconButton
+        aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+        size="lg"
+        className="absolute top-5 right-5"
         onClick={onClose}
       >
-        <RiCloseLine className="size-5 text-text-tertiary" />
-      </button>
+        <span aria-hidden="true" className="i-ri-close-line size-5" />
+      </IconButton>
       {/* Form */}
       <div className="flex flex-col gap-y-5 px-6 py-3">
         <div className="flex items-end gap-x-3 self-stretch">
-          <div className="flex grow flex-col gap-y-1 pb-1">
-            <label className="flex h-6 items-center system-sm-medium text-text-secondary">
+          <Field className="grow pb-1" name="name">
+            <FieldLabel className="flex h-6 items-center py-0">
               {t(($) => $.pipelineNameAndIcon, { ns: 'datasetPipeline' })}
-            </label>
+            </FieldLabel>
             <Input
+              autoComplete="off"
               onChange={handleAppNameChange}
               value={name}
               placeholder={t(($) => $.knowledgeNameAndIconPlaceholder, { ns: 'datasetPipeline' })}
             />
-          </div>
-          <AppIcon
-            size="xxl"
+          </Field>
+          <button
+            type="button"
+            aria-label={`${t(($) => $['operation.edit'], { ns: 'common' })} ${t(($) => $.pipelineNameAndIcon, { ns: 'datasetPipeline' })}`}
             onClick={handleOpenAppIconPicker}
-            className="cursor-pointer"
-            iconType={appIcon.type}
-            icon={appIcon.type === 'image' ? appIcon.fileId : appIcon.icon}
-            background={appIcon.type === 'image' ? undefined : appIcon.background}
-            imageUrl={appIcon.type === 'image' ? appIcon.url : undefined}
-            showEditIcon
-          />
+            className="shrink-0 cursor-pointer rounded-2xl focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
+          >
+            <AppIcon
+              size="xxl"
+              iconType={appIcon.type}
+              icon={appIcon.type === 'image' ? appIcon.fileId : appIcon.icon}
+              background={appIcon.type === 'image' ? undefined : appIcon.background}
+              imageUrl={appIcon.type === 'image' ? appIcon.url : undefined}
+              showEditIcon
+            />
+          </button>
         </div>
-        <div className="flex flex-col gap-y-1">
-          <label className="flex h-6 items-center system-sm-medium text-text-secondary">
+        <Field name="description">
+          <FieldLabel className="flex h-6 items-center py-0">
             {t(($) => $.knowledgeDescription, { ns: 'datasetPipeline' })}
-          </label>
+          </FieldLabel>
           <Textarea
-            aria-label={t(($) => $.knowledgeDescription, { ns: 'datasetPipeline' })}
+            autoComplete="off"
             onValueChange={handleDescriptionChange}
             value={description}
             placeholder={t(($) => $.knowledgeDescriptionPlaceholder, { ns: 'datasetPipeline' })}
           />
-        </div>
+        </Field>
       </div>
       {/* Actions */}
       <div className="flex items-center justify-end gap-x-2 p-6 pt-5">
-        <Button variant="secondary" onClick={onClose}>
+        <Button type="button" variant="secondary" onClick={onClose}>
           {t(($) => $['operation.cancel'], { ns: 'common' })}
         </Button>
-        <Button variant="primary" onClick={handleSave}>
+        <Button type="submit" variant="primary">
           {t(($) => $['operation.save'], { ns: 'common' })}
         </Button>
       </div>
@@ -157,7 +173,7 @@ const EditPipelineInfo = ({ onClose, pipeline }: EditPipelineInfoProps) => {
           onSelect={handleSelectAppIcon}
         />
       )}
-    </div>
+    </form>
   )
 }
 


### PR DESCRIPTION
## Summary

- migrate the pipeline template name field from the legacy Web input to Dify UI Field and Input
- make the existing name and description labels programmatically associated with their controls
- use a native form boundary for keyboard submission and semantic Dify UI icon actions
- connect the visible title to the owning Base UI dialog and remove the obsolete legacy-input suppression
- update the focused tests to exercise the production dialog boundary and accessible roles

Depends on #41127.

## Testing

- `vp test run --project unit app/components/datasets/create-from-pipeline/list/template-card/__tests__/edit-pipeline-info.spec.tsx`
- `pnpm -C web run lint:a11y app/components/datasets/create-from-pipeline/list/template-card/edit-pipeline-info.tsx`
- `pnpm -C web type-check`
- `pnpm check`

## Screenshots

No intentional visual change. The existing control dimensions, 24px label boxes, 4px field gaps, and action layout are preserved.

From Codex