### PR TITLE
fix: stabilize the agent tool picker placement

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/index.tsx
@@ -337,7 +337,7 @@ function AddToolMenu({
         }
       />
       <PopoverContent
-        placement="bottom-end"
+        placement="top-end"
         sideOffset={4}
         className={
           view === 'menu'


### PR DESCRIPTION
## Summary

- Open the agent tool picker above its trigger to keep its position stable as content changes.
- Preserve the existing end alignment and spacing.

Fixes DIFY-2914

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.