### PR TITLE
fix(agent-v2): add vision-aware file upload settings

### DIFF
--- a/web/app/components/base/features/new-feature-panel/__tests__/index.spec.tsx
+++ b/web/app/components/base/features/new-feature-panel/__tests__/index.spec.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { Features } from '../../types'
 import { render, screen } from '@testing-library/react'
 import { FeaturesProvider } from '../../context'
@@ -86,6 +87,7 @@ const renderPanel = (
     inWorkflow: boolean
     showFileUpload: boolean
     showAnnotationReply: boolean
+    fileUploadExtraContent: ReactNode
   }> = {},
 ) => {
   return render(
@@ -99,6 +101,7 @@ const renderPanel = (
         inWorkflow={props.inWorkflow}
         showFileUpload={props.showFileUpload}
         showAnnotationReply={props.showAnnotationReply}
+        fileUploadExtraContent={props.fileUploadExtraContent}
       />
     </FeaturesProvider>,
   )
@@ -187,6 +190,15 @@ describe('NewFeaturePanel', () => {
 
       expect(screen.queryByText(/feature\.fileUpload\.title/)).not.toBeInTheDocument()
       expect(screen.queryByText(/feature\.imageUpload\.title/)).not.toBeInTheDocument()
+    })
+
+    it('should render extra content after file upload when provided', () => {
+      renderPanel({
+        isChatMode: true,
+        fileUploadExtraContent: <div data-testid="file-upload-extra-content">Extra content</div>,
+      })
+
+      expect(screen.getByTestId('file-upload-extra-content')).toBeInTheDocument()
     })
   })
 

--- a/web/app/components/base/features/new-feature-panel/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/index.tsx
@@ -26,6 +26,7 @@ type Props = Readonly<{
   onClose: () => void
   inWorkflow?: boolean
   showFileUpload?: boolean
+  fileUploadExtraContent?: ReactNode
   showModeration?: boolean
   showAnnotationReply?: boolean
   promptVariables?: PromptVariable[]
@@ -44,6 +45,7 @@ const NewFeaturePanel = ({
   onClose,
   inWorkflow = true,
   showFileUpload = true,
+  fileUploadExtraContent,
   showModeration = true,
   showAnnotationReply = true,
   promptVariables,
@@ -99,7 +101,12 @@ const NewFeaturePanel = ({
           {isChatMode && speech2textDefaultModel && (
             <SpeechToText disabled={disabled} onChange={onChange} />
           )}
-          {showFileUpload && isChatMode && <FileUpload disabled={disabled} onChange={onChange} />}
+          {showFileUpload && isChatMode && (
+            <>
+              <FileUpload disabled={disabled} onChange={onChange} />
+              {fileUploadExtraContent}
+            </>
+          )}
           {showFileUpload && !isChatMode && <ImageUpload disabled={disabled} onChange={onChange} />}
           {isChatMode && <Citation disabled={disabled} onChange={onChange} />}
           {showModeration && (isChatMode || !inWorkflow) && (

--- a/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
@@ -342,7 +342,7 @@ function AgentConfigurePageComposerContent({
     },
     [rebaseComposerDraft],
   )
-  const { currentModel, setConfigureModel, textGenerationModelList } =
+  const { currentModel, setConfigureModel, supportsVision, textGenerationModelList } =
     useAgentConfigureModelOptions()
   const { isPublishing, publishDraft, saveDraft } = useAgentConfigureSync({
     agentId,
@@ -616,6 +616,7 @@ function AgentConfigurePageComposerContent({
             show={showChatFeatures}
             appFeatures={buildDraft.agentSoulConfig?.app_features}
             disabled={isChatFeaturesReadOnly}
+            supportsVision={supportsVision}
             onClose={() => setShowChatFeatures(false)}
           />
           <AgentConfigureClearSessionConfirmDialog

--- a/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/chat-features-panel.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/chat-features-panel.spec.tsx
@@ -1,0 +1,169 @@
+import type {
+  AgentFileUploadFeatureConfig,
+  AgentSoulAppFeaturesConfig,
+} from '@dify/contracts/api/console/agent/types.gen'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createStore, Provider as JotaiProvider } from 'jotai'
+import { SupportUploadFileTypes } from '@/app/components/workflow/types'
+import { defaultAgentSoulConfigFormState } from '@/features/agent-v2/agent-composer/form-state'
+import { agentComposerDraftAtom } from '@/features/agent-v2/agent-composer/store'
+import { Resolution } from '@/types/app'
+import { AgentChatFeaturesPanel } from '../chat-features-panel'
+
+vi.mock('@/app/components/header/account-setting/model-provider-page/hooks', () => ({
+  useDefaultModel: () => ({ data: null }),
+}))
+
+const baseFileUpload: AgentFileUploadFeatureConfig = {
+  enabled: true,
+  allowed_file_types: [SupportUploadFileTypes.image],
+  allowed_file_upload_methods: ['local_file', 'remote_url'],
+  number_limits: 3,
+  image: {
+    enabled: true,
+    detail: Resolution.high,
+  },
+}
+
+const createFileUpload = (
+  overrides: Partial<AgentFileUploadFeatureConfig> = {},
+): AgentFileUploadFeatureConfig => ({
+  ...baseFileUpload,
+  ...overrides,
+  image: {
+    ...baseFileUpload.image,
+    ...overrides.image,
+  },
+})
+
+function renderPanel(
+  options: {
+    fileUpload?: AgentFileUploadFeatureConfig
+    supportsVision?: boolean
+  } = {},
+) {
+  const fileUpload = options.fileUpload ?? createFileUpload()
+  const supportsVision = Object.hasOwn(options, 'supportsVision') ? options.supportsVision : true
+  const store = createStore()
+  const appFeatures: AgentSoulAppFeaturesConfig = { file_upload: fileUpload }
+  store.set(agentComposerDraftAtom, {
+    ...defaultAgentSoulConfigFormState,
+    appFeatures,
+  })
+
+  return {
+    store,
+    ...render(
+      <JotaiProvider store={store}>
+        <AgentChatFeaturesPanel
+          show
+          appFeatures={appFeatures}
+          onClose={vi.fn()}
+          supportsVision={supportsVision}
+        />
+      </JotaiProvider>,
+    ),
+  }
+}
+
+const getVisionWarning = () => screen.queryByText('appDebug.vision.onlySupportVisionModelTip')
+const getResolutionLabel = () => screen.queryByText('appDebug.vision.visionSettings.resolution')
+
+describe('AgentChatFeaturesPanel vision settings', () => {
+  it('shows resolution controls for an image-enabled feature with a vision model', () => {
+    renderPanel({ supportsVision: true })
+
+    expect(getResolutionLabel()).toBeInTheDocument()
+    expect(
+      screen.getByRole('radio', { name: 'appDebug.vision.visionSettings.high' }),
+    ).toHaveAttribute('aria-checked', 'true')
+    expect(getVisionWarning()).not.toBeInTheDocument()
+  })
+
+  it('shows a non-blocking warning without changing enabled file uploads for a non-vision model', () => {
+    const { store } = renderPanel({ supportsVision: false })
+
+    expect(getVisionWarning()).toBeInTheDocument()
+    expect(screen.getByText('appDebug.feature.fileUpload.supportedTypes')).toBeInTheDocument()
+    expect(screen.getByText(SupportUploadFileTypes.image)).toBeInTheDocument()
+    expect(store.get(agentComposerDraftAtom).appFeatures?.file_upload?.allowed_file_types).toEqual([
+      SupportUploadFileTypes.image,
+    ])
+  })
+
+  it('does not show vision settings for document-only file types even when image state is enabled', () => {
+    renderPanel({
+      supportsVision: false,
+      fileUpload: createFileUpload({
+        allowed_file_types: [SupportUploadFileTypes.document],
+        image: { enabled: true },
+      }),
+    })
+
+    expect(getVisionWarning()).not.toBeInTheDocument()
+    expect(getResolutionLabel()).not.toBeInTheDocument()
+    expect(screen.getByText(SupportUploadFileTypes.document)).toBeInTheDocument()
+  })
+
+  it('does not fall back to image state when allowed file types is explicitly empty', () => {
+    renderPanel({
+      supportsVision: false,
+      fileUpload: createFileUpload({
+        allowed_file_types: [],
+        image: { enabled: true },
+      }),
+    })
+
+    expect(getVisionWarning()).not.toBeInTheDocument()
+    expect(getResolutionLabel()).not.toBeInTheDocument()
+  })
+
+  it('falls back to image state when allowed file types are undefined', () => {
+    renderPanel({
+      supportsVision: false,
+      fileUpload: createFileUpload({
+        allowed_file_types: undefined,
+        image: { enabled: true },
+      }),
+    })
+
+    expect(getVisionWarning()).toBeInTheDocument()
+    expect(getResolutionLabel()).not.toBeInTheDocument()
+  })
+
+  it('updates only image resolution and syncs the Agent V2 app features draft', async () => {
+    const user = userEvent.setup()
+    const { store } = renderPanel({
+      fileUpload: createFileUpload({
+        allowed_file_extensions: ['.png'],
+        number_limits: 2,
+      }),
+    })
+
+    await user.click(screen.getByText('appDebug.vision.visionSettings.low'))
+
+    expect(
+      screen.getByRole('radio', { name: 'appDebug.vision.visionSettings.low' }),
+    ).toHaveAttribute('aria-checked', 'true')
+    expect(store.get(agentComposerDraftAtom).appFeatures?.file_upload).toEqual(
+      expect.objectContaining({
+        allowed_file_extensions: ['.png'],
+        allowed_file_types: [SupportUploadFileTypes.image],
+        allowed_file_upload_methods: ['local_file', 'remote_url'],
+        number_limits: 2,
+        image: expect.objectContaining({
+          enabled: true,
+          detail: Resolution.low,
+        }),
+      }),
+    )
+  })
+
+  it('renders neither warning nor resolution controls while model vision capability is unresolved', () => {
+    renderPanel({ supportsVision: undefined })
+
+    expect(getVisionWarning()).not.toBeInTheDocument()
+    expect(getResolutionLabel()).not.toBeInTheDocument()
+  })
+})

--- a/web/features/agent-v2/agent-detail/configure/components/preview/chat-features-panel.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/chat-features-panel.tsx
@@ -6,11 +6,15 @@ import type {
   FileType,
 } from '@dify/contracts/api/console/agent/types.gen'
 import type { Features } from '@/app/components/base/features/types'
+import { produce } from 'immer'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FeaturesProvider } from '@/app/components/base/features'
-import { useFeaturesStore } from '@/app/components/base/features/hooks'
+import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
 import NewFeaturePanel from '@/app/components/base/features/new-feature-panel'
+import { Infotip } from '@/app/components/base/infotip'
+import OptionCard from '@/app/components/workflow/nodes/_base/components/option-card'
+import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { useSetAppFeatures } from '@/features/agent-v2/agent-composer/store-modules/app-features'
 import { Resolution, TransferMethod } from '@/types/app'
 
@@ -18,7 +22,14 @@ type AgentChatFeaturesPanelProps = {
   appFeatures?: AgentSoulAppFeaturesConfig
   disabled?: boolean
   show: boolean
+  supportsVision: boolean | undefined
   onClose: () => void
+}
+
+type AgentVisionSettingsProps = {
+  disabled?: boolean
+  onChange: () => void
+  supportsVision: boolean | undefined
 }
 
 const defaultFeatureState: Features = {
@@ -130,10 +141,128 @@ function toAppFeatures(
   }
 }
 
+function isImageUploadConfigured(file: Features['file']) {
+  if (!file?.enabled) return false
+
+  return file.allowed_file_types !== undefined
+    ? file.allowed_file_types.includes(SupportUploadFileTypes.image)
+    : !!file.image?.enabled
+}
+
+function AgentVisionSettings({ disabled, onChange, supportsVision }: AgentVisionSettingsProps) {
+  const { t } = useTranslation()
+  const file = useFeatures((state) => state.features.file)
+  const featuresStore = useFeaturesStore()
+  const imageUploadConfigured = isImageUploadConfigured(file)
+
+  const handleResolutionChange = useCallback(
+    (detail: Resolution) => {
+      if (disabled || !featuresStore) return
+
+      const { features, setFeatures } = featuresStore.getState()
+      const nextFeatures = produce(features, (draft) => {
+        if (!draft.file) return
+
+        draft.file.image = {
+          ...draft.file.image,
+          detail,
+        }
+      })
+
+      setFeatures(nextFeatures)
+      onChange()
+    },
+    [disabled, featuresStore, onChange],
+  )
+
+  if (!imageUploadConfigured || supportsVision === undefined) return null
+
+  if (!supportsVision) {
+    return (
+      <div
+        role="status"
+        className="mt-1 flex items-start gap-2 rounded-lg border-[0.5px] border-components-badge-status-light-warning-halo bg-state-warning-hover px-3 py-2.5"
+      >
+        <span
+          aria-hidden="true"
+          className="mt-0.5 i-ri-alert-fill size-4 shrink-0 text-text-warning-secondary"
+        />
+        <div className="system-xs-regular text-text-warning">
+          {t(($) => $['vision.onlySupportVisionModelTip'], { ns: 'appDebug' })}
+        </div>
+      </div>
+    )
+  }
+
+  const resolution = file?.image?.detail ?? Resolution.high
+
+  return (
+    <div className="mt-1 rounded-xl border-t-[0.5px] border-l-[0.5px] border-effects-highlight bg-background-section-burn p-2">
+      <div className="mb-2 flex items-center gap-1">
+        <div className="system-xs-medium-uppercase text-text-tertiary">
+          {t(($) => $['vision.visionSettings.resolution'], { ns: 'appDebug' })}
+        </div>
+        <Infotip
+          aria-label={t(($) => $['vision.visionSettings.resolutionTooltip'], {
+            ns: 'appDebug',
+          })}
+          popupClassName="w-[180px]"
+        >
+          {t(($) => $['vision.visionSettings.resolutionTooltip'], { ns: 'appDebug' })
+            .split('\n')
+            .map((item) => (
+              <div key={item}>{item}</div>
+            ))}
+        </Infotip>
+      </div>
+      <div
+        aria-label={t(($) => $['vision.visionSettings.resolution'], { ns: 'appDebug' })}
+        className="flex items-center gap-1"
+        role="radiogroup"
+      >
+        {[
+          {
+            detail: Resolution.high,
+            title: t(($) => $['vision.visionSettings.high'], { ns: 'appDebug' }),
+          },
+          {
+            detail: Resolution.low,
+            title: t(($) => $['vision.visionSettings.low'], { ns: 'appDebug' }),
+          },
+        ].map(({ detail, title }) => (
+          <div
+            key={detail}
+            aria-checked={resolution === detail}
+            aria-disabled={disabled}
+            className="grow outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter' && event.key !== ' ') return
+              event.preventDefault()
+              if (resolution === detail) return
+              handleResolutionChange(detail)
+            }}
+            role="radio"
+            tabIndex={disabled ? -1 : 0}
+          >
+            <OptionCard
+              className="w-full"
+              title={title}
+              selected={resolution === detail}
+              disabled={disabled}
+              onSelect={() => handleResolutionChange(detail)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function AgentChatFeaturesPanelContent({
   appFeatures,
   disabled,
   show,
+  supportsVision,
   onClose,
 }: AgentChatFeaturesPanelProps) {
   const { t } = useTranslation('agentV2')
@@ -163,6 +292,13 @@ function AgentChatFeaturesPanelContent({
       description={t(($) => $['agentDetail.configure.chatFeatures.description'])}
       onChange={handleChange}
       onClose={onClose}
+      fileUploadExtraContent={
+        <AgentVisionSettings
+          disabled={disabled}
+          onChange={handleChange}
+          supportsVision={supportsVision}
+        />
+      }
     />
   )
 }

--- a/web/features/agent-v2/agent-detail/configure/hooks.ts
+++ b/web/features/agent-v2/agent-detail/configure/hooks.ts
@@ -6,7 +6,10 @@ import type {
 } from '@dify/contracts/api/console/agent/types.gen'
 import { skipToken, useQuery } from '@tanstack/react-query'
 import { useAtom, useAtomValue } from 'jotai'
-import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
+import {
+  ModelFeatureEnum,
+  ModelTypeEnum,
+} from '@/app/components/header/account-setting/model-provider-page/declarations'
 import {
   useDefaultModel,
   useTextGenerationCurrentProviderAndModelAndModelList,
@@ -86,13 +89,17 @@ export function useAgentConfigureModelOptions() {
       }
     : undefined
   const currentModel = model ?? defaultModel
-  const { textGenerationModelList } =
+  const { currentModel: resolvedModel, textGenerationModelList } =
     useTextGenerationCurrentProviderAndModelAndModelList(currentModel)
+  const supportsVision = resolvedModel
+    ? (resolvedModel.features?.includes(ModelFeatureEnum.vision) ?? false)
+    : undefined
 
   return {
     currentModel,
     setConfigureModel: setModel,
     textGenerationModelList,
+    supportsVision,
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #41125

Add model-capability awareness to the Agent V2 Chat Features configuration UI.

- expose the selected model's existing vision capability to Agent V2 configuration
- show a non-blocking warning when image uploads are configured for a model without vision support
- show High / Low image resolution controls when the selected model supports vision
- preserve general file-upload behavior and existing attachment configuration
- add focused regression coverage for vision, non-vision, document-only, fallback, unresolved-capability, and resolution-sync cases

The generic `NewFeaturePanel` only gains an optional extra-content slot next to File Upload; model-specific behavior remains inside Agent V2.

## Screenshots

Not included. The change was validated with focused component tests and static/type checks; no local browser session was started.

## Validation

- `pnpm exec vp test run --project unit features/agent-v2/agent-detail/configure/components/preview/__tests__/chat-features-panel.spec.tsx` — 7/7 passed
- `pnpm exec vp test run --project unit app/components/base/features/new-feature-panel/__tests__/index.spec.tsx` — 19/19 passed
- `pnpm --dir web type-check` — passed
- `git diff --check` — passed
- `pnpm exec vp fmt <six changed files> --check` — passed
- `pnpm exec vp check <six changed files>` — no warnings, lint errors, or type errors

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From ChatGPT