### PR TITLE
feat: support multi-select input in start node

### DIFF
--- a/api/core/app/apps/base_app_generator.py
+++ b/api/core/app/apps/base_app_generator.py
@@ -262,6 +262,24 @@ class BaseAppGenerator:
                         f"{variable_entity.variable} in input form must be one of the following: "
                         f"{variable_entity.options}"
                     )
+            case VariableEntityType.MULTI_SELECT:
+                if not isinstance(value, list):
+                    raise ValueError(f"{variable_entity.variable} in input form must be a list of strings")
+
+                if variable_entity.required and not value:
+                    raise ValueError(f"{variable_entity.variable} is required in input form")
+
+                if not all(isinstance(item, str) for item in value):
+                    raise ValueError(f"{variable_entity.variable} in input form must be a list of strings")
+
+                if len(value) != len(set(value)):
+                    raise ValueError(f"{variable_entity.variable} in input form must not contain duplicate values")
+
+                if invalid_options := [item for item in value if item not in variable_entity.options]:
+                    raise ValueError(
+                        f"{variable_entity.variable} in input form must be one of the following: "
+                        f"{variable_entity.options}; invalid values: {invalid_options}"
+                    )
             case VariableEntityType.TEXT_INPUT | VariableEntityType.PARAGRAPH:
                 if variable_entity.max_length and len(value) > variable_entity.max_length:
                     raise ValueError(

--- a/api/core/app/apps/workflow/app_runner.py
+++ b/api/core/app/apps/workflow/app_runner.py
@@ -17,7 +17,11 @@ from core.workflow.node_factory import get_default_root_node_id
 from core.workflow.nodes.agent_v2.workspace_retirement_layer import build_workflow_agent_workspace_retirement_layer
 from core.workflow.snippet_start import get_compatible_start_aliases
 from core.workflow.system_variables import build_bootstrap_variables, build_system_variables
-from core.workflow.variable_pool_initializer import add_node_inputs_to_pool, add_variables_to_pool
+from core.workflow.variable_pool_initializer import (
+    add_node_inputs_to_pool,
+    add_variables_to_pool,
+    build_input_segment_types,
+)
 from core.workflow.workflow_entry import WorkflowEntry
 from extensions.ext_redis import redis_client
 from extensions.otel import WorkflowAppRunnerHandler, trace_span
@@ -127,6 +131,7 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
                 ),
             )
             root_node_id = self._root_node_id or get_default_root_node_id(self._workflow.graph_dict)
+            input_types = build_input_segment_types(app_config.variables)
             add_node_inputs_to_pool(
                 variable_pool,
                 node_id=root_node_id,
@@ -135,6 +140,7 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
                     workflow_kind=getattr(self._workflow, "kind_or_standard", None),
                     root_node_id=root_node_id,
                 ),
+                **({"input_types": input_types} if input_types else {}),
             )
 
             graph_runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=time.perf_counter())

--- a/api/core/workflow/variable_pool_initializer.py
+++ b/api/core/workflow/variable_pool_initializer.py
@@ -2,6 +2,9 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from graphon.runtime import VariablePool
+from graphon.variables.factory import build_segment_with_type
+from graphon.variables.input_entities import VariableEntity, VariableEntityType
+from graphon.variables.types import SegmentType
 from graphon.variables.variables import Variable
 
 
@@ -10,19 +13,36 @@ def add_variables_to_pool(variable_pool: VariablePool, variables: Sequence[Varia
         variable_pool.add(variable.selector, variable)
 
 
+def build_input_segment_types(variables: Sequence[VariableEntity]) -> dict[str, SegmentType]:
+    """Build declared runtime types for input variables that need type preservation."""
+    return {
+        variable.variable: SegmentType.ARRAY_STRING
+        for variable in variables
+        if variable.type == VariableEntityType.MULTI_SELECT
+    }
+
+
 def add_node_inputs_to_pool(
     variable_pool: VariablePool,
     *,
     node_id: str,
     inputs: Mapping[str, Any],
+    input_types: Mapping[str, SegmentType] | None = None,
     aliases: Sequence[str] = (),
 ) -> None:
     """Store node inputs under the primary node id and any compatible aliases."""
+    values_to_add = {}
+    for key, value in inputs.items():
+        expected_type = input_types.get(key) if input_types else None
+        if expected_type is not None and value is not None:
+            value = build_segment_with_type(expected_type, value)
+        values_to_add[key] = value
+
     node_ids: list[str] = [node_id]
     for alias in aliases:
         if alias not in node_ids:
             node_ids.append(alias)
 
     for current_node_id in node_ids:
-        for key, value in inputs.items():
+        for key, value in values_to_add.items():
             variable_pool.add((current_node_id, key), value)

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -118,7 +118,7 @@ class WorkflowEntry:
         :param workflow_id: workflow id
         :param workflow_type: workflow type
         :param graph_config: workflow graph config
-        :param graph: graph
+        :param graph: workflow graph
         :param user_id: user id
         :param user_from: user from
         :param invoke_from: invoke from

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -22,7 +22,11 @@ from core.workflow.system_variables import (
     inject_default_system_variable_mappings,
     preload_node_creation_variables,
 )
-from core.workflow.variable_pool_initializer import add_node_inputs_to_pool, add_variables_to_pool
+from core.workflow.variable_pool_initializer import (
+    add_node_inputs_to_pool,
+    add_variables_to_pool,
+    build_input_segment_types,
+)
 from core.workflow.variable_prefixes import ENVIRONMENT_VARIABLE_NODE_ID
 from extensions.otel.runtime import is_instrument_flag_enabled
 from factories import file_factory
@@ -38,6 +42,7 @@ from graphon.graph_events import GraphEngineEvent, GraphNodeEventBase, GraphRunF
 from graphon.nodes import BuiltinNodeTypes
 from graphon.nodes.base.node import Node
 from graphon.nodes.container_effects import ContainerAwaitRequest
+from graphon.nodes.start.entities import StartNodeData
 from graphon.runtime import GraphRuntimeState, ReadOnlyGraphRuntimeStateWrapper, VariablePool
 from graphon.variable_loader import DUMMY_VARIABLE_LOADER, VariableLoader, load_into_variable_pool
 from models.workflow import Workflow
@@ -238,7 +243,17 @@ class WorkflowEntry:
         )
 
         if is_start_node_type(node_type):
-            add_node_inputs_to_pool(variable_pool, node_id=node_id, inputs=user_inputs)
+            if node_type == BuiltinNodeTypes.START:
+                start_node_data = StartNodeData.model_validate(node_config_data.model_dump(mode="python"))
+                input_types = build_input_segment_types(start_node_data.variables)
+                add_node_inputs_to_pool(
+                    variable_pool,
+                    node_id=node_id,
+                    inputs=user_inputs,
+                    **({"input_types": input_types} if input_types else {}),
+                )
+            else:
+                add_node_inputs_to_pool(variable_pool, node_id=node_id, inputs=user_inputs)
 
         preload_node_creation_variables(
             variable_loader=variable_loader,

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -246,12 +246,15 @@ class WorkflowEntry:
             if node_type == BuiltinNodeTypes.START:
                 start_node_data = StartNodeData.model_validate(node_config_data.model_dump(mode="python"))
                 input_types = build_input_segment_types(start_node_data.variables)
-                add_node_inputs_to_pool(
-                    variable_pool,
-                    node_id=node_id,
-                    inputs=user_inputs,
-                    input_types=input_types,
-                )
+                if input_types:
+                    add_node_inputs_to_pool(
+                        variable_pool,
+                        node_id=node_id,
+                        inputs=user_inputs,
+                        input_types=input_types,
+                    )
+                else:
+                    add_node_inputs_to_pool(variable_pool, node_id=node_id, inputs=user_inputs)
             else:
                 add_node_inputs_to_pool(variable_pool, node_id=node_id, inputs=user_inputs)
 

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -118,7 +118,7 @@ class WorkflowEntry:
         :param workflow_id: workflow id
         :param workflow_type: workflow type
         :param graph_config: workflow graph config
-        :param graph: workflow graph
+        :param graph: graph
         :param user_id: user id
         :param user_from: user from
         :param invoke_from: invoke from
@@ -250,7 +250,7 @@ class WorkflowEntry:
                     variable_pool,
                     node_id=node_id,
                     inputs=user_inputs,
-                    **({"input_types": input_types} if input_types else {}),
+                    input_types=input_types,
                 )
             else:
                 add_node_inputs_to_pool(variable_pool, node_id=node_id, inputs=user_inputs)

--- a/api/tests/unit_tests/core/app/app_config/workflow_ui_based_app/test_workflow_ui_based_app_manager.py
+++ b/api/tests/unit_tests/core/app/app_config/workflow_ui_based_app/test_workflow_ui_based_app_manager.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 from core.app.app_config.workflow_ui_based_app.variables.manager import (
     WorkflowVariablesConfigManager,
 )
+from graphon.variables.input_entities import VariableEntityType
 from models.workflow import Workflow, WorkflowType
 
 
@@ -176,6 +177,23 @@ class TestWorkflowVariablesConfigManagerConvert:
 
         # Assert — string left as-is
         assert result[0]["json_schema"] == "{invalid-json"
+
+    def test_convert_accepts_multi_select_variable(self, mock_workflow):
+        mock_workflow.user_input_form.return_value = [
+            {
+                "variable": "machines",
+                "label": "Machines",
+                "type": "multi-select",
+                "required": True,
+                "options": ["A", "B", "C"],
+            }
+        ]
+
+        result = WorkflowVariablesConfigManager.convert(mock_workflow)
+
+        assert result[0].type == VariableEntityType.MULTI_SELECT
+        assert list(result[0].options) == ["A", "B", "C"]
+        assert result[0].required is True
 
 
 # =============================

--- a/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
@@ -300,6 +300,71 @@ def test_validate_inputs_with_default_value():
     assert result == [{"id": "file1", "name": "doc1.pdf"}, {"id": "file2", "name": "doc2.pdf"}]
 
 
+@pytest.mark.parametrize(
+    ("value", "required", "expected"),
+    [
+        (["A", "C"], True, ["A", "C"]),
+        ([], False, []),
+        (None, False, None),
+        (["C", "A"], True, ["C", "A"]),
+    ],
+)
+def test_validate_inputs_multi_select_accepts_valid_values(value, required, expected):
+    base_app_generator = BaseAppGenerator()
+    variable = VariableEntity(
+        variable="machines",
+        label="Machines",
+        type=VariableEntityType.MULTI_SELECT,
+        required=required,
+        options=["A", "B", "C"],
+    )
+
+    result = base_app_generator._validate_inputs(variable_entity=variable, value=value)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "A",
+        1,
+        {},
+        ["A", 1],
+        ["A", None],
+        ["UNKNOWN"],
+        ["A", "A"],
+    ],
+)
+def test_validate_inputs_multi_select_rejects_invalid_values(value):
+    base_app_generator = BaseAppGenerator()
+    variable = VariableEntity(
+        variable="machines",
+        label="Machines",
+        type=VariableEntityType.MULTI_SELECT,
+        required=False,
+        options=["A", "B", "C"],
+    )
+
+    with pytest.raises(ValueError):
+        base_app_generator._validate_inputs(variable_entity=variable, value=value)
+
+
+@pytest.mark.parametrize("value", [[], None])
+def test_validate_inputs_multi_select_rejects_empty_or_missing_required_value(value):
+    base_app_generator = BaseAppGenerator()
+    variable = VariableEntity(
+        variable="machines",
+        label="Machines",
+        type=VariableEntityType.MULTI_SELECT,
+        required=True,
+        options=["A", "B", "C"],
+    )
+
+    with pytest.raises(ValueError, match="machines is required"):
+        base_app_generator._validate_inputs(variable_entity=variable, value=value)
+
+
 def test_validate_inputs_optional_file_with_empty_string():
     """Test that optional FILE variable with empty string returns None"""
     base_app_generator = BaseAppGenerator()
@@ -544,6 +609,26 @@ class TestBaseAppGeneratorExtras:
                 variables=variables,
                 tenant_id="tenant-id",
             )
+
+    def test_prepare_user_inputs_preserves_multi_select_list(self):
+        base_app_generator = BaseAppGenerator()
+        variables = [
+            VariableEntity(
+                variable="machines",
+                label="machines",
+                type=VariableEntityType.MULTI_SELECT,
+                required=False,
+                options=["A", "B", "C"],
+            )
+        ]
+
+        prepared = base_app_generator._prepare_user_inputs(
+            user_inputs={"machines": ["A", "C"]},
+            variables=variables,
+            tenant_id="tenant-id",
+        )
+
+        assert prepared == {"machines": ["A", "C"]}
 
     def test_convert_to_event_stream(self):
         base_app_generator = BaseAppGenerator()

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_single_node.py
@@ -13,6 +13,8 @@ from core.app.entities.app_invoke_entities import InvokeFrom, WorkflowAppGenerat
 from core.workflow.system_variables import default_system_variables
 from graphon.entities.graph_config import NodeConfigDictAdapter
 from graphon.runtime import GraphRuntimeState, VariablePool
+from graphon.variables.input_entities import VariableEntity, VariableEntityType
+from graphon.variables.types import SegmentType
 from models.workflow import Workflow, WorkflowKind
 
 
@@ -178,6 +180,14 @@ def test_run_adds_inputs_with_snippet_compatible_start_aliases() -> None:
     app_config.app_id = "app"
     app_config.tenant_id = "tenant"
     app_config.workflow_id = "workflow"
+    app_config.variables = [
+        VariableEntity(
+            variable="machines",
+            label="Machines",
+            type=VariableEntityType.MULTI_SELECT,
+            options=["A", "B", "C"],
+        )
+    ]
 
     app_generate_entity = MagicMock(spec=WorkflowAppGenerateEntity)
     app_generate_entity.app_config = app_config
@@ -239,4 +249,5 @@ def test_run_adds_inputs_with_snippet_compatible_start_aliases() -> None:
     add_inputs.assert_called_once()
     assert add_inputs.call_args.kwargs["node_id"] == "root-node"
     assert add_inputs.call_args.kwargs["inputs"] == {"question": "hello"}
+    assert add_inputs.call_args.kwargs["input_types"] == {"machines": SegmentType.ARRAY_STRING}
     assert add_inputs.call_args.kwargs["aliases"] == ("legacy-start",)

--- a/api/tests/unit_tests/core/workflow/test_variable_pool.py
+++ b/api/tests/unit_tests/core/workflow/test_variable_pool.py
@@ -5,7 +5,11 @@ from collections import defaultdict
 import pytest
 
 from core.workflow.system_variables import build_system_variables, system_variables_to_mapping
-from core.workflow.variable_pool_initializer import add_node_inputs_to_pool, add_variables_to_pool
+from core.workflow.variable_pool_initializer import (
+    add_node_inputs_to_pool,
+    add_variables_to_pool,
+    build_input_segment_types,
+)
 from core.workflow.variable_prefixes import (
     CONVERSATION_VARIABLE_NODE_ID,
     ENVIRONMENT_VARIABLE_NODE_ID,
@@ -15,6 +19,7 @@ from factories.variable_factory import build_segment, segment_to_variable
 from graphon.file import File, FileTransferMethod, FileType
 from graphon.runtime import VariablePool
 from graphon.variables import FileSegment, StringSegment
+from graphon.variables.input_entities import VariableEntity, VariableEntityType
 from graphon.variables.segments import (
     ArrayAnySegment,
     ArrayFileSegment,
@@ -26,6 +31,7 @@ from graphon.variables.segments import (
     NoneSegment,
     ObjectSegment,
 )
+from graphon.variables.types import SegmentType
 from graphon.variables.variables import (
     ArrayNumberVariable,
     ArrayObjectVariable,
@@ -97,6 +103,46 @@ def test_add_node_inputs_to_pool_stores_inputs_under_aliases():
     assert primary_value.value == "hello"
     assert alias_value is not None
     assert alias_value.value == "hello"
+
+
+def test_build_input_segment_types_only_declares_multi_select():
+    variables = [
+        VariableEntity(variable="name", label="name", type=VariableEntityType.TEXT_INPUT),
+        VariableEntity(variable="machines", label="machines", type=VariableEntityType.MULTI_SELECT),
+    ]
+
+    assert build_input_segment_types(variables) == {"machines": SegmentType.ARRAY_STRING}
+
+
+@pytest.mark.parametrize("value", [["A", "C"], []])
+def test_add_node_inputs_to_pool_preserves_declared_multi_select_type(value):
+    pool = VariablePool()
+
+    add_node_inputs_to_pool(
+        pool,
+        node_id="start",
+        inputs={"machines": value},
+        input_types={"machines": SegmentType.ARRAY_STRING},
+    )
+
+    segment = pool.get(["start", "machines"])
+    assert isinstance(segment, ArrayStringSegment)
+    assert segment.value == value
+    assert segment.value_type == SegmentType.ARRAY_STRING
+
+
+def test_add_node_inputs_to_pool_keeps_optional_multi_select_none_unset():
+    pool = VariablePool()
+
+    add_node_inputs_to_pool(
+        pool,
+        node_id="start",
+        inputs={"machines": None},
+        input_types={"machines": SegmentType.ARRAY_STRING},
+    )
+
+    segment = pool.get(["start", "machines"])
+    assert isinstance(segment, NoneSegment)
 
 
 class TestVariablePool:

--- a/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
+++ b/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
@@ -18,6 +18,7 @@ from graphon.graph_events import GraphRunFailedEvent, NodeRunSucceededEvent
 from graphon.node_events import NodeRunResult
 from graphon.nodes import BuiltinNodeTypes
 from graphon.runtime import VariablePool
+from graphon.variables.types import SegmentType
 from graphon.variables.variables import StringVariable
 
 
@@ -376,6 +377,77 @@ class TestWorkflowEntrySingleStepRun:
             user_inputs={"question": "hello"},
             variable_pool=sentinel.variable_pool,
             tenant_id="tenant-id",
+        )
+
+    def test_single_step_run_declares_multi_select_input_type_for_start_node(self):
+        class FakeStartNode:
+            id = "node-id"
+            title = "Start"
+            node_type = BuiltinNodeTypes.START
+
+            @staticmethod
+            def version():
+                return "1"
+
+            @staticmethod
+            def extract_variable_selector_to_variable_mapping(**_kwargs):
+                return {}
+
+        start_config = {
+            "id": "node-id",
+            "data": BaseNodeData(
+                type=BuiltinNodeTypes.START,
+                variables=[
+                    {
+                        "variable": "machines",
+                        "label": "Machines",
+                        "type": "multi-select",
+                        "required": False,
+                        "options": ["A", "B", "C"],
+                    }
+                ],
+            ),
+        }
+
+        with (
+            patch.object(workflow_entry, "DifyGraphInitContext", return_value=sentinel.graph_init_context),
+            patch.object(workflow_entry, "GraphRuntimeState", return_value=sentinel.graph_runtime_state),
+            patch.object(workflow_entry, "build_dify_run_context", return_value={"_dify": "context"}),
+            patch.object(workflow_entry, "resolve_workflow_node_class", return_value=FakeStartNode),
+            patch.object(workflow_entry.DifyNodeFactory, "from_graph_init_context") as dify_node_factory,
+            patch.object(workflow_entry, "add_node_inputs_to_pool") as add_node_inputs,
+            patch.object(workflow_entry, "load_into_variable_pool"),
+            patch.object(workflow_entry.WorkflowEntry, "mapping_user_inputs_to_variable_pool"),
+            patch.object(
+                workflow_entry.WorkflowEntry,
+                "_run_node_with_layers",
+                return_value=iter(["event"]),
+            ),
+        ):
+            dify_node_factory.return_value.create_node.return_value = FakeStartNode()
+            workflow = SimpleNamespace(
+                tenant_id="tenant-id",
+                app_id="app-id",
+                id="workflow-id",
+                graph_dict={"nodes": [], "edges": []},
+                get_node_config_by_id=lambda _node_id: start_config,
+            )
+
+            node, generator = workflow_entry.WorkflowEntry.single_step_run(
+                workflow=workflow,
+                node_id="node-id",
+                user_id="user-id",
+                user_inputs={"machines": []},
+                variable_pool=sentinel.variable_pool,
+            )
+
+        assert node.id == "node-id"
+        assert list(generator) == ["event"]
+        add_node_inputs.assert_called_once_with(
+            sentinel.variable_pool,
+            node_id="node-id",
+            inputs={"machines": []},
+            input_types={"machines": SegmentType.ARRAY_STRING},
         )
 
     def test_skips_user_input_mapping_for_datasource_nodes(self):

--- a/web/app/components/app/configuration/config-var/config-modal/__tests__/form-fields.spec.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/__tests__/form-fields.spec.tsx
@@ -214,6 +214,29 @@ describe('ConfigModalFormFields', () => {
     expect(selectProps.payloadChangeHandlers.default).toHaveBeenCalledWith('beta')
   })
 
+  it('should reuse select options for multi-select without default or hidden controls', () => {
+    const multiSelectProps = createBaseProps()
+    multiSelectProps.tempPayload = {
+      ...multiSelectProps.tempPayload,
+      type: InputVarType.multiSelect,
+      default: 'legacy-default',
+      hide: true,
+    }
+    multiSelectProps.options = ['alpha', 'beta']
+
+    render(<ConfigModalFormFields {...multiSelectProps} />)
+
+    expect(screen.getByText('config-select')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'variableConfig.required' })).not.toHaveAttribute(
+      'aria-disabled',
+    )
+    expect(screen.queryByText('variableConfig.defaultValue')).not.toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: 'variableConfig.hidden' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('config-select'))
+    expect(multiSelectProps.payloadChangeHandlers.options).toHaveBeenCalledWith(['alpha', 'beta'])
+  })
+
   it('should wire file, json schema, and visibility controls', async () => {
     const textInputProps = createBaseProps()
     const textInputView = render(<ConfigModalFormFields {...textInputProps} />)

--- a/web/app/components/app/configuration/config-var/config-modal/__tests__/form-fields.spec.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/__tests__/form-fields.spec.tsx
@@ -231,7 +231,9 @@ describe('ConfigModalFormFields', () => {
       'aria-disabled',
     )
     expect(screen.queryByText('variableConfig.defaultValue')).not.toBeInTheDocument()
-    expect(screen.queryByRole('checkbox', { name: 'variableConfig.hidden' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('checkbox', { name: 'variableConfig.hidden' }),
+    ).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByText('config-select'))
     expect(multiSelectProps.payloadChangeHandlers.options).toHaveBeenCalledWith(['alpha', 'beta'])

--- a/web/app/components/app/configuration/config-var/config-modal/__tests__/utils.spec.ts
+++ b/web/app/components/app/configuration/config-var/config-modal/__tests__/utils.spec.ts
@@ -73,6 +73,20 @@ describe('config-modal utils', () => {
       expect(nextPayload.default).toBeUndefined()
     })
 
+    it('should clear unsupported defaults and hidden state when switching to multi-select', () => {
+      const payload = createInputVar({
+        type: InputVarType.textInput,
+        default: 'hello',
+        hide: true,
+      })
+
+      const nextPayload = createPayloadForType(payload, InputVarType.multiSelect)
+
+      expect(nextPayload.type).toBe(InputVarType.multiSelect)
+      expect(nextPayload.default).toBeUndefined()
+      expect(nextPayload.hide).toBe(false)
+    })
+
     it('should normalize empty select defaults to undefined', () => {
       const nextPayload = normalizeSelectDefaultValue(
         createInputVar({
@@ -111,6 +125,7 @@ describe('config-modal utils', () => {
       const options = buildSelectOptions({
         isBasicApp: false,
         supportFile: true,
+        supportMultiSelect: true,
         t,
       })
 
@@ -118,9 +133,13 @@ describe('config-modal utils', () => {
         expect.arrayContaining([
           InputVarType.singleFile,
           InputVarType.multiFiles,
+          InputVarType.multiSelect,
           InputVarType.jsonObject,
         ]),
       )
+
+      const appOptions = buildSelectOptions({ isBasicApp: false, t })
+      expect(appOptions.map((option) => option.value)).not.toContain(InputVarType.multiSelect)
     })
 
     it('should derive checkbox defaults from boolean and string values', () => {
@@ -162,6 +181,43 @@ describe('config-modal utils', () => {
 
       expect(result.errorMessage).toBe('variableConfig.errorMsg.optionRepeat')
       expect(checkVariableName).toHaveBeenCalledWith('question')
+    })
+
+    it('should validate multi-select options with the select rules', () => {
+      const emptyResult = validateConfigModalPayload({
+        tempPayload: createInputVar({
+          type: InputVarType.multiSelect,
+          options: [],
+          hide: true,
+        }),
+        checkVariableName: () => true,
+        payload: createInputVar(),
+        t,
+      })
+      const duplicateResult = validateConfigModalPayload({
+        tempPayload: createInputVar({
+          type: InputVarType.multiSelect,
+          options: ['alpha', 'alpha'],
+        }),
+        checkVariableName: () => true,
+        payload: createInputVar(),
+        t,
+      })
+
+      expect(emptyResult.errorMessage).toBe('variableConfig.errorMsg.atLeastOneOption')
+      expect(duplicateResult.errorMessage).toBe('variableConfig.errorMsg.optionRepeat')
+      expect(
+        validateConfigModalPayload({
+          tempPayload: createInputVar({
+            type: InputVarType.multiSelect,
+            options: ['alpha'],
+            hide: true,
+          }),
+          checkVariableName: () => true,
+          payload: createInputVar(),
+          t,
+        }).payloadToSave,
+      ).toEqual(expect.objectContaining({ hide: false }))
     })
 
     it('should require custom extensions when custom file types are enabled', () => {

--- a/web/app/components/app/configuration/config-var/config-modal/form-fields.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/form-fields.tsx
@@ -181,12 +181,12 @@ const ConfigModalFormFields: FC<ConfigModalFormFieldsProps> = ({
         </Field>
       )}
 
-      {type === InputVarType.select && (
+      {[InputVarType.select, InputVarType.multiSelect].includes(type) && (
         <>
           <Field title={t(($) => $['variableConfig.options'], { ns: 'appDebug' })}>
             <ConfigSelect options={options || []} onChange={onPayloadChange('options')} />
           </Field>
-          {options && options.length > 0 && (
+          {type === InputVarType.select && options && options.length > 0 && (
             <Field title={t(($) => $['variableConfig.defaultValue'], { ns: 'appDebug' })}>
               <Select<string>
                 key={`default-select-${options.join('-')}`}
@@ -279,7 +279,7 @@ const ConfigModalFormFields: FC<ConfigModalFormFieldsProps> = ({
       <label className="mt-5! flex h-6 items-center space-x-2">
         <Checkbox
           checked={tempPayload.required}
-          disabled={!isFileInput && tempPayload.hide}
+          disabled={!isFileInput && type !== InputVarType.multiSelect && tempPayload.hide}
           onCheckedChange={(checked) => onPayloadChange('required')(checked)}
         />
         <span className="system-sm-semibold text-text-secondary">
@@ -287,7 +287,7 @@ const ConfigModalFormFields: FC<ConfigModalFormFieldsProps> = ({
         </span>
       </label>
 
-      {showHiddenField && !isFileInput && (
+      {showHiddenField && !isFileInput && type !== InputVarType.multiSelect && (
         <div className="mt-5! flex h-6 items-center gap-2">
           <label className="flex items-center gap-2">
             <Checkbox

--- a/web/app/components/app/configuration/config-var/config-modal/index.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/index.tsx
@@ -37,6 +37,7 @@ type IConfigModalProps = {
   onClose: () => void
   onConfirm: (newValue: InputVar, moreInfo?: MoreInfo) => void
   supportFile?: boolean
+  supportMultiSelect?: boolean
   showHiddenField?: boolean
 }
 
@@ -48,6 +49,7 @@ const ConfigModal: FC<IConfigModalProps> = ({
   onConfirm,
   showHiddenField,
   supportFile,
+  supportMultiSelect,
 }) => {
   const { modelConfig } = useContext(ConfigContext)
   const { t } = useTranslation()
@@ -113,9 +115,10 @@ const ConfigModal: FC<IConfigModalProps> = ({
       buildSelectOptions({
         isBasicApp,
         supportFile,
+        supportMultiSelect,
         t,
       }),
-    [isBasicApp, supportFile, t],
+    [isBasicApp, supportFile, supportMultiSelect, t],
   )
 
   const handleTypeChange = useCallback((item: SelectItem) => {

--- a/web/app/components/app/configuration/config-var/config-modal/utils.ts
+++ b/web/app/components/app/configuration/config-var/config-modal/utils.ts
@@ -41,6 +41,9 @@ export const normalizeSelectDefaultValue = (inputVar: InputVar) => {
   return inputVar
 }
 
+const isOptionInputType = (type: InputVarType) =>
+  type === InputVarType.select || type === InputVarType.multiSelect
+
 export const getJsonSchemaEditorValue = (
   type: InputVarType,
   jsonSchema?: InputVar['json_schema'],
@@ -79,7 +82,10 @@ export const updatePayloadField = (payload: InputVar, key: string, value: unknow
 export const createPayloadForType = (payload: InputVar, type: InputVarType) => {
   return produce(payload, (draft) => {
     draft.type = type
-    if (type === InputVarType.select) draft.default = undefined
+    if (isOptionInputType(type)) {
+      draft.default = undefined
+      if (type === InputVarType.multiSelect) draft.hide = false
+    }
 
     if ([InputVarType.singleFile, InputVarType.multiFiles].includes(type)) {
       draft.hide = false
@@ -99,10 +105,12 @@ export const createPayloadForType = (payload: InputVar, type: InputVarType) => {
 export const buildSelectOptions = ({
   isBasicApp,
   supportFile,
+  supportMultiSelect,
   t: rawTranslate,
 }: {
   isBasicApp: boolean
   supportFile?: boolean
+  supportMultiSelect?: boolean
   t: SelectorTranslate<'appDebug' | 'workflow'>
 }): SelectItem[] => {
   const t = getStringSelectorTranslate(rawTranslate)
@@ -119,6 +127,14 @@ export const buildSelectOptions = ({
       name: t(($) => $['variableConfig.select'], { ns: 'appDebug' }),
       value: InputVarType.select,
     },
+    ...(supportMultiSelect
+      ? [
+          {
+            name: t(($) => $['variableConfig.multi-select'], { ns: 'appDebug' }),
+            value: InputVarType.multiSelect,
+          },
+        ]
+      : []),
     {
       name: t(($) => $['variableConfig.number'], { ns: 'appDebug' }),
       value: InputVarType.number,
@@ -157,9 +173,11 @@ export const validateConfigModalPayload = ({
   t: rawTranslate,
 }: ValidateConfigModalPayloadOptions): ValidateConfigModalPayloadResult => {
   const t = getStringSelectorTranslate(rawTranslate)
-  const normalizedTempPayload = [InputVarType.singleFile, InputVarType.multiFiles].includes(
-    tempPayload.type,
-  )
+  const normalizedTempPayload = [
+    InputVarType.singleFile,
+    InputVarType.multiFiles,
+    InputVarType.multiSelect,
+  ].includes(tempPayload.type)
     ? { ...tempPayload, hide: false }
     : tempPayload
   const jsonSchemaValue = tempPayload.json_schema
@@ -186,7 +204,7 @@ export const validateConfigModalPayload = ({
     }
   }
 
-  if (normalizedTempPayload.type === InputVarType.select) {
+  if (isOptionInputType(normalizedTempPayload.type)) {
     if (!normalizedTempPayload.options?.length) {
       return {
         errorMessage: t(($) => $['variableConfig.errorMsg.atLeastOneOption'], { ns: 'appDebug' }),

--- a/web/app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx
@@ -384,6 +384,42 @@ describe('ChatWrapper', () => {
     expect(container).not.toBeInTheDocument()
   })
 
+  it('should treat empty required multi-select arrays as incomplete', () => {
+    vi.mocked(useChatWithHistoryContext).mockReturnValue({
+      ...defaultContextValue,
+      inputsForms: [
+        { variable: 'choices', label: 'Choices', type: InputVarType.multiSelect, required: true },
+      ],
+      newConversationInputs: { choices: [] },
+      newConversationInputsRef: {
+        current: { choices: [] },
+      } as ChatWithHistoryContextValue['newConversationInputsRef'],
+      currentConversationId: '',
+    })
+
+    const { unmount } = render(<ChatWrapper />)
+    const chatInput = screen.getAllByRole('textbox').at(-1)!
+    expect(getChatInputDisabledSurface(chatInput)).toBeInTheDocument()
+
+    unmount()
+    vi.mocked(useChatWithHistoryContext).mockReturnValue({
+      ...defaultContextValue,
+      inputsForms: [
+        { variable: 'choices', label: 'Choices', type: InputVarType.multiSelect, required: true },
+      ],
+      newConversationInputs: { choices: ['A', 'C'] },
+      newConversationInputsRef: {
+        current: { choices: ['A', 'C'] },
+      } as ChatWithHistoryContextValue['newConversationInputsRef'],
+      currentConversationId: '',
+    })
+
+    render(<ChatWrapper />)
+    expect(
+      getChatInputDisabledSurface(screen.getAllByRole('textbox').at(-1)!),
+    ).not.toBeInTheDocument()
+  })
+
   it('should disable input when file is uploading', () => {
     vi.mocked(useChatWithHistoryContext).mockReturnValue({
       ...defaultContextValue,

--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -5,6 +5,7 @@ import type { AppConversationData, AppData, AppMeta, ConversationItem } from '@/
 import { ToastHost } from '@langgenius/dify-ui/toast'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
+import { InputVarType } from '@/app/components/workflow/types'
 import {
   AppSourceType,
   delConversation,
@@ -904,6 +905,33 @@ describe('useChatWithHistory', () => {
       })
     })
 
+    it('should return multi-select form item without a default', async () => {
+      mockStoreState.appParams = {
+        user_input_form: [
+          {
+            'multi-select': {
+              variable: 'multi_var',
+              label: 'Multi Select',
+              required: false,
+              options: ['a', 'b'],
+            },
+          },
+        ],
+      } as unknown as ChatConfig
+      mockFetchConversations.mockResolvedValue(createConversationData())
+      mockFetchChatList.mockResolvedValue({ data: [] })
+
+      const { result } = await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        const form = result!.current.inputsForms[0]
+        expect(form.type).toBe(InputVarType.multiSelect)
+        expect(form.options).toEqual(['a', 'b'])
+        expect(form.default).toBeUndefined()
+      })
+      expect(result!.current.newConversationInputs.multi_var).toEqual([])
+    })
+
     it('should return file-list form item', async () => {
       // Arrange
       mockStoreState.appParams = {
@@ -1556,6 +1584,38 @@ describe('useChatWithHistory', () => {
 
       // Assert: callback not called because required field is empty
       expect(callback).not.toHaveBeenCalled()
+    })
+
+    it('should reject an empty required multi-select and accept selected values', async () => {
+      mockStoreState.appParams = {
+        user_input_form: [
+          {
+            'multi-select': {
+              variable: 'choices',
+              label: 'Choices',
+              required: true,
+              options: ['A', 'B'],
+            },
+          },
+        ],
+      } as unknown as ChatConfig
+      mockFetchConversations.mockResolvedValue(createConversationData())
+      mockFetchChatList.mockResolvedValue({ data: [] })
+
+      const { result } = await renderWithClient(() => useChatWithHistory())
+      const callback = vi.fn()
+
+      act(() => {
+        result!.current.handleNewConversationInputsChange({ choices: [] })
+        result!.current.handleStartChat(callback)
+      })
+      expect(callback).not.toHaveBeenCalled()
+
+      act(() => {
+        result!.current.handleNewConversationInputsChange({ choices: ['A'] })
+        result!.current.handleStartChat(callback)
+      })
+      expect(callback).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -11,6 +11,7 @@ import AnswerIcon from '@/app/components/base/answer-icon'
 import AppIcon from '@/app/components/base/app-icon'
 import InputsForm from '@/app/components/base/chat/chat-with-history/inputs-form'
 import SuggestedQuestions from '@/app/components/base/chat/chat/answer/suggested-questions'
+import { isInputValueEmpty } from '@/app/components/base/chat/input-form-utils'
 import { Markdown } from '@/app/components/base/markdown'
 import { InputVarType } from '@/app/components/workflow/types'
 import {
@@ -119,7 +120,7 @@ const ChatWrapper = () => {
 
         if (fileIsUploading) return
 
-        if (!inputsFormValue?.[variable]) hasEmptyInput = label as string
+        if (isInputValueEmpty(type, inputsFormValue?.[variable])) hasEmptyInput = label as string
 
         if (
           (type === InputVarType.singleFile || type === InputVarType.multiFiles) &&

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -34,6 +34,7 @@ import {
 import { TransferMethod } from '@/types/app'
 import { addFileInfos, sortAgentSorts } from '../../../tools/utils'
 import { enrichSubmittedHumanInputFormData } from '../chat/answer/human-input-content/submitted-utils'
+import { isInputValueEmpty } from '../input-form-utils'
 import {
   buildChatItemTree,
   getProcessedSystemVariablesFromUrlParams,
@@ -287,6 +288,12 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
             type: 'checkbox',
           }
         }
+        if (item['multi-select']) {
+          return {
+            ...item['multi-select'],
+            type: InputVarType.multiSelect,
+          }
+        }
         if (item.select) {
           const isInputInOptions = item.select.options.includes(initInputs[item.select.variable])
           return {
@@ -340,7 +347,8 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
   useEffect(() => {
     const conversationInputs: Record<string, any> = {}
     inputsForms.forEach((item: any) => {
-      conversationInputs[item.variable] = item.default || null
+      conversationInputs[item.variable] =
+        item.type === InputVarType.multiSelect ? [] : item.default || null
     })
     handleNewConversationInputsChange(conversationInputs)
   }, [handleNewConversationInputsChange, inputsForms])
@@ -416,7 +424,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
         requiredVars.forEach(({ variable, label, type }) => {
           if (hasEmptyInput) return
           if (fileIsUploading) return
-          if (!newConversationInputsRef.current[variable] && !silent)
+          if (isInputValueEmpty(type, newConversationInputsRef.current[variable]) && !silent)
             hasEmptyInput = label as string
           if (
             (type === InputVarType.singleFile || type === InputVarType.multiFiles) &&
@@ -475,7 +483,8 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
     handleChangeConversation('')
     const conversationInputs: Record<string, any> = {}
     inputsForms.forEach((item: any) => {
-      conversationInputs[item.variable] = item.default || null
+      conversationInputs[item.variable] =
+        item.type === InputVarType.multiSelect ? [] : item.default || null
     })
     handleNewConversationInputsChange(conversationInputs)
     setClearChatList(true)

--- a/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/content.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/content.spec.tsx
@@ -322,6 +322,38 @@ describe('InputsFormContent', () => {
     )
   })
 
+  it('handles multi-select input with native string-array values', async () => {
+    const user = userEvent.setup()
+    const context = createMockContext({
+      inputsForms: [
+        {
+          variable: 'multi',
+          type: InputVarType.multiSelect,
+          label: 'Multi',
+          options: ['A', 'B', 'C'],
+          required: true,
+        },
+      ],
+      currentConversationInputs: { multi: [] },
+      newConversationInputs: { multi: [] },
+    })
+
+    renderWithContext(<InputsFormContent />, context)
+    await user.click(screen.getByRole('combobox', { name: 'Multi' }))
+    await user.click(await screen.findByRole('option', { name: 'A' }))
+    await user.click(await screen.findByRole('option', { name: 'C' }))
+
+    expect(mockSetCurrentConversationInputs).toHaveBeenLastCalledWith(
+      expect.objectContaining({ multi: ['A', 'C'] }),
+    )
+
+    await user.click(await screen.findByRole('option', { name: 'A' }))
+    await user.click(await screen.findByRole('option', { name: 'C' }))
+    expect(mockSetCurrentConversationInputs).toHaveBeenLastCalledWith(
+      expect.objectContaining({ multi: [] }),
+    )
+  })
+
   it('renders select dropdown on the shared dify-ui overlay layer', async () => {
     const user = userEvent.setup()
     const context = createMockContext({

--- a/web/app/components/base/chat/chat-with-history/inputs-form/content.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/content.tsx
@@ -15,6 +15,7 @@ import { FileUploaderInAttachmentWrapper } from '@/app/components/base/file-uplo
 import Input from '@/app/components/base/input'
 import BoolInput from '@/app/components/workflow/nodes/_base/components/before-run-form/bool-input'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
+import { MultiSelectField } from '@/app/components/workflow/nodes/_base/components/form-input-item.sections'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import { InputVarType } from '@/app/components/workflow/types'
 import { useChatWithHistoryContext } from '../context'
@@ -120,6 +121,30 @@ const InputsFormContent = ({ showTip }: Props) => {
                 ))}
               </SelectContent>
             </Select>
+          )}
+          {form.type === InputVarType.multiSelect && (
+            <MultiSelectField
+              disabled={false}
+              items={(form.options || []).map((option: string) => ({
+                name: option,
+                value: option,
+              }))}
+              onChange={(value) => handleFormChange(form.variable, value)}
+              placeholder={form.label}
+              selectedLabel={(Array.isArray(inputsFormValue?.[form.variable])
+                ? inputsFormValue[form.variable].filter(
+                    (item: unknown): item is string => typeof item === 'string',
+                  )
+                : []
+              ).join(', ')}
+              value={
+                Array.isArray(inputsFormValue?.[form.variable])
+                  ? inputsFormValue[form.variable].filter(
+                      (item: unknown): item is string => typeof item === 'string',
+                    )
+                  : []
+              }
+            />
           )}
           {form.type === InputVarType.singleFile && (
             <FileUploaderInAttachmentWrapper

--- a/web/app/components/base/chat/chat/__tests__/check-input-forms-hooks.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/check-input-forms-hooks.spec.tsx
@@ -65,6 +65,31 @@ describe('useCheckInputsForms', () => {
     expect(mockNotify).not.toHaveBeenCalled()
   })
 
+  it('should treat an empty multi-select array as missing only when required', () => {
+    const { result } = renderHook(() => useCheckInputsForms())
+    const requiredForm = [
+      {
+        variable: 'choices',
+        label: 'Choices',
+        required: true,
+        type: InputVarType.multiSelect as string,
+      },
+    ]
+
+    expect(result.current.checkInputsForm({ choices: [] }, requiredForm as InputForm[])).toBe(false)
+
+    vi.clearAllMocks()
+    expect(
+      result.current.checkInputsForm({ choices: [] }, [
+        { ...requiredForm[0], required: false },
+      ] as InputForm[]),
+    ).toBe(true)
+
+    expect(
+      result.current.checkInputsForm({ choices: ['A', 'C'] }, requiredForm as InputForm[]),
+    ).toBe(true)
+  })
+
   it('should notify and return undefined when a file is still uploading (singleFile)', () => {
     const { result } = renderHook(() => useCheckInputsForms())
     const inputsForm = [

--- a/web/app/components/base/chat/chat/__tests__/utils.spec.ts
+++ b/web/app/components/base/chat/chat/__tests__/utils.spec.ts
@@ -66,6 +66,16 @@ describe('chat/chat/utils.ts', () => {
       expect(result).toEqual({ test: null })
     })
 
+    it('forwards multi-select values as native string arrays', () => {
+      const selected = ['A', 'C']
+      const inputs = { choices: selected }
+      const inputsForm = [{ variable: 'choices', type: InputVarType.multiSelect as string }]
+
+      const result = getProcessedInputs(inputs, inputsForm as InputForm[])
+
+      expect(result.choices).toBe(selected)
+    })
+
     it('processes singleFile using transfer_method logic', () => {
       const inputs = {
         file1: { transfer_method: 'local_file', url: '1' },

--- a/web/app/components/base/chat/chat/check-input-forms-hooks.ts
+++ b/web/app/components/base/chat/chat/check-input-forms-hooks.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { InputVarType } from '@/app/components/workflow/types'
 import { TransferMethod } from '@/types/app'
+import { isInputValueEmpty } from '../input-form-utils'
 
 export const useCheckInputsForms = () => {
   const { t } = useTranslation()
@@ -18,7 +19,7 @@ export const useCheckInputsForms = () => {
         requiredVars.forEach(({ variable, label, type }) => {
           if (hasEmptyInput) return
           if (fileIsUploading) return
-          if (!inputs[variable]) hasEmptyInput = label as string
+          if (isInputValueEmpty(type, inputs[variable])) hasEmptyInput = label as string
           if (
             (type === InputVarType.singleFile || type === InputVarType.multiFiles) &&
             inputs[variable]

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/chat-wrapper.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/chat-wrapper.spec.tsx
@@ -440,6 +440,43 @@ describe('EmbeddedChatbot chat-wrapper', () => {
       expect(screen.getByRole('button', { name: 'send message' })).toBeDisabled()
     })
 
+    it('should validate required multi-select arrays as values, not truthiness', () => {
+      vi.mocked(useEmbeddedChatbotContext).mockReturnValue(
+        createContextValue({
+          inputsForms: [
+            {
+              variable: 'choices',
+              label: 'Choices',
+              required: true,
+              type: InputVarType.multiSelect,
+            },
+          ],
+          newConversationInputsRef: { current: { choices: [] } },
+        }),
+      )
+
+      render(<ChatWrapper />)
+      expect(screen.getByRole('button', { name: 'send message' })).toBeDisabled()
+
+      cleanup()
+      vi.mocked(useEmbeddedChatbotContext).mockReturnValue(
+        createContextValue({
+          inputsForms: [
+            {
+              variable: 'choices',
+              label: 'Choices',
+              required: true,
+              type: InputVarType.multiSelect,
+            },
+          ],
+          newConversationInputsRef: { current: { choices: ['A', 'C'] } },
+        }),
+      )
+
+      render(<ChatWrapper />)
+      expect(screen.getByRole('button', { name: 'send message' })).not.toBeDisabled()
+    })
+
     it('should show the user avatar fallback when avatar data is provided', () => {
       vi.mocked(useEmbeddedChatbotContext).mockReturnValue(
         createContextValue({

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
@@ -512,6 +512,30 @@ describe('useEmbeddedChatbot', () => {
       expect(forms.find((f: InputForm) => f.variable === 'f1')?.type).toBe('file')
       expect(forms.find((f: InputForm) => f.variable === 'j1')?.type).toBe('json_object')
     })
+
+    it('should map multi-select inputs to array-valued forms initialized with an empty array', async () => {
+      mockStoreState.appParams = {
+        user_input_form: [
+          {
+            'multi-select': {
+              variable: 'choices',
+              label: 'Choices',
+              required: true,
+              options: ['A', 'B'],
+            },
+          },
+        ],
+      } as unknown as ChatConfig
+
+      const { result } = await renderWithClient(() => useEmbeddedChatbot(AppSourceType.webApp))
+
+      await waitFor(() => {
+        expect(result.current.inputsForms[0]?.type).toBe(InputVarType.multiSelect)
+      })
+      expect(result.current.inputsForms[0]?.options).toEqual(['A', 'B'])
+      expect(result.current.inputsForms[0]?.default).toBeUndefined()
+      expect(result.current.newConversationInputs.choices).toEqual([])
+    })
   })
 
   // Scenario: checkInputsRequired validates empty fields and pending multi-file uploads
@@ -562,6 +586,36 @@ describe('useEmbeddedChatbot', () => {
       })
 
       expect(onStart).not.toHaveBeenCalled()
+    })
+
+    it('should reject an empty required multi-select and accept selected values', async () => {
+      mockStoreState.appParams = {
+        user_input_form: [
+          {
+            'multi-select': {
+              variable: 'choices',
+              required: true,
+              label: 'Choices',
+              options: ['A', 'B'],
+            },
+          },
+        ],
+      } as unknown as ChatConfig
+
+      const { result } = await renderWithClient(() => useEmbeddedChatbot(AppSourceType.webApp))
+      const onStart = vi.fn()
+
+      act(() => {
+        result.current.handleNewConversationInputsChange({ choices: [] })
+        result.current.handleStartChat(onStart)
+      })
+      expect(onStart).not.toHaveBeenCalled()
+
+      act(() => {
+        result.current.handleNewConversationInputsChange({ choices: ['A', 'B'] })
+        result.current.handleStartChat(onStart)
+      })
+      expect(onStart).toHaveBeenCalledTimes(1)
     })
 
     it('should pass checkInputsRequired when allInputsHidden is true', async () => {

--- a/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
@@ -11,6 +11,7 @@ import AnswerIcon from '@/app/components/base/answer-icon'
 import AppIcon from '@/app/components/base/app-icon'
 import SuggestedQuestions from '@/app/components/base/chat/chat/answer/suggested-questions'
 import InputsForm from '@/app/components/base/chat/embedded-chatbot/inputs-form'
+import { isInputValueEmpty } from '@/app/components/base/chat/input-form-utils'
 import LogoAvatar from '@/app/components/base/logo/logo-embedded-chat-avatar'
 import { Markdown } from '@/app/components/base/markdown'
 import { InputVarType } from '@/app/components/workflow/types'
@@ -121,7 +122,7 @@ const ChatWrapper = () => {
 
         if (fileIsUploading) return
 
-        if (!inputsFormValue?.[variable]) hasEmptyInput = label as string
+        if (isInputValueEmpty(type, inputsFormValue?.[variable])) hasEmptyInput = label as string
 
         if (
           (type === InputVarType.singleFile || type === InputVarType.multiFiles) &&

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -23,6 +23,7 @@ import {
 import { useGetTryAppInfo, useGetTryAppParams } from '@/service/use-try-app'
 import { TransferMethod } from '@/types/app'
 import { getProcessedFilesFromResponse } from '../../file-uploader/utils'
+import { isInputValueEmpty } from '../input-form-utils'
 import {
   buildChatItemTree,
   getProcessedInputsFromUrlParams,
@@ -198,6 +199,12 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
             type: 'checkbox',
           }
         }
+        if (item['multi-select']) {
+          return {
+            ...item['multi-select'],
+            type: InputVarType.multiSelect,
+          }
+        }
         if (item.select) {
           const isInputInOptions = item.select.options.includes(initInputs[item.select.variable])
           return {
@@ -252,7 +259,8 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   useEffect(() => {
     const conversationInputs: Record<string, InputValueTypes> = {}
     inputsForms.forEach((item) => {
-      conversationInputs[item.variable] = item.default || null
+      conversationInputs[item.variable] =
+        item.type === InputVarType.multiSelect ? [] : item.default || null
     })
     handleNewConversationInputsChange(conversationInputs)
   }, [handleNewConversationInputsChange, inputsForms])
@@ -327,7 +335,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
         requiredVars.forEach(({ variable, label, type }) => {
           if (hasEmptyInput) return
           if (fileIsUploading) return
-          if (!newConversationInputsRef.current[variable] && !silent)
+          if (isInputValueEmpty(type, newConversationInputsRef.current[variable]) && !silent)
             hasEmptyInput = label as string
           if (
             (type === InputVarType.singleFile || type === InputVarType.multiFiles) &&
@@ -388,13 +396,19 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     currentChatInstanceRef.current.handleStop()
     setShowNewConversationItemInList(true)
     handleChangeConversation('')
-    handleNewConversationInputsChange(await getProcessedInputsFromUrlParams())
+    const inputs = await getProcessedInputsFromUrlParams()
+    inputsForms.forEach((item) => {
+      if (item.type === InputVarType.multiSelect && !Array.isArray(inputs[item.variable]))
+        inputs[item.variable] = []
+    })
+    handleNewConversationInputsChange(inputs)
     setClearChatList(true)
   }, [
     isTryApp,
     setShowNewConversationItemInList,
     handleNewConversationInputsChange,
     setClearChatList,
+    inputsForms,
   ])
   const handleNewConversationCompleted = useCallback(
     (newConversationId: string) => {

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/content.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/content.spec.tsx
@@ -212,6 +212,35 @@ describe('InputsFormContent', () => {
     expect(mockContextValue.handleNewConversationInputsChange).toHaveBeenCalled()
   })
 
+  it('should handle multi-select input as a string array without using a default', async () => {
+    const context = {
+      ...mockContextValue,
+      inputsForms: [
+        {
+          variable: 'multi_var',
+          label: 'Multi Label',
+          type: InputVarType.multiSelect,
+          options: ['Option A', 'Option B'],
+          required: true,
+        },
+      ],
+      currentConversationInputs: {},
+      newConversationInputs: {},
+    }
+    vi.mocked(useEmbeddedChatbotContext).mockReturnValue(context as unknown as any)
+
+    render(<InputsFormContent />)
+    await user.click(screen.getByRole('combobox', { name: 'Multi Label' }))
+    await user.click(await screen.findByRole('option', { name: 'Option A' }))
+
+    expect(mockContextValue.setCurrentConversationInputs).toHaveBeenLastCalledWith(
+      expect.objectContaining({ multi_var: ['Option A'] }),
+    )
+    expect(mockContextValue.handleNewConversationInputsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ multi_var: ['Option A'] }),
+    )
+  })
+
   it('should render select dropdown on the shared dify-ui overlay layer', async () => {
     render(<InputsFormContent />)
     const selectTrigger = screen.getAllByText(/Select Label/i).find((el) => el.tagName === 'SPAN')

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/content.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/content.tsx
@@ -15,6 +15,7 @@ import { FileUploaderInAttachmentWrapper } from '@/app/components/base/file-uplo
 import Input from '@/app/components/base/input'
 import BoolInput from '@/app/components/workflow/nodes/_base/components/before-run-form/bool-input'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
+import { MultiSelectField } from '@/app/components/workflow/nodes/_base/components/form-input-item.sections'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import { InputVarType } from '@/app/components/workflow/types'
 import { useEmbeddedChatbotContext } from '../context'
@@ -124,6 +125,30 @@ const InputsFormContent = ({ showTip }: Props) => {
                 ))}
               </SelectContent>
             </Select>
+          )}
+          {form.type === InputVarType.multiSelect && (
+            <MultiSelectField
+              disabled={false}
+              items={(form.options || []).map((option: string) => ({
+                name: option,
+                value: option,
+              }))}
+              onChange={(value) => handleFormChange(form.variable, value)}
+              placeholder={form.label}
+              selectedLabel={(Array.isArray(inputsFormValue?.[form.variable])
+                ? inputsFormValue[form.variable].filter(
+                    (item: unknown): item is string => typeof item === 'string',
+                  )
+                : []
+              ).join(', ')}
+              value={
+                Array.isArray(inputsFormValue?.[form.variable])
+                  ? inputsFormValue[form.variable].filter(
+                      (item: unknown): item is string => typeof item === 'string',
+                    )
+                  : []
+              }
+            />
           )}
           {form.type === InputVarType.singleFile && (
             <FileUploaderInAttachmentWrapper

--- a/web/app/components/base/chat/input-form-utils.ts
+++ b/web/app/components/base/chat/input-form-utils.ts
@@ -1,0 +1,7 @@
+import { InputVarType } from '@/app/components/workflow/types'
+
+export const isInputValueEmpty = (type: InputVarType, value: unknown) => {
+  if (type === InputVarType.multiSelect) return !Array.isArray(value) || value.length === 0
+
+  return !value
+}

--- a/web/app/components/share/text-generation/result/__tests__/result-request.spec.ts
+++ b/web/app/components/share/text-generation/result/__tests__/result-request.spec.ts
@@ -131,6 +131,94 @@ describe('result-request', () => {
     })
   })
 
+  it('should reject required multi-select inputs when no options are selected', () => {
+    const result = validateResultRequest({
+      completionFiles: [],
+      inputs: {
+        machines: [],
+      },
+      isCallBatchAPI: false,
+      promptConfig: {
+        prompt_template: 'template',
+        prompt_variables: [
+          { key: 'machines', name: 'Machines', type: 'multi-select', required: true },
+        ],
+      },
+      t: createTranslator(),
+    })
+
+    expect(result).toEqual({
+      canSend: false,
+      notification: {
+        type: 'error',
+        message: 'errorMessage.valueOfVarRequired',
+      },
+    })
+  })
+
+  it('should allow required multi-select inputs with selected options', () => {
+    const result = validateResultRequest({
+      completionFiles: [],
+      inputs: {
+        machines: ['A'],
+      },
+      isCallBatchAPI: false,
+      promptConfig: {
+        prompt_template: 'template',
+        prompt_variables: [
+          { key: 'machines', name: 'Machines', type: 'multi-select', required: true },
+        ],
+      },
+      t: createTranslator(),
+    })
+
+    expect(result).toEqual({ canSend: true })
+  })
+
+  it('should allow optional multi-select inputs with no options selected', () => {
+    const result = validateResultRequest({
+      completionFiles: [],
+      inputs: {
+        machines: [],
+      },
+      isCallBatchAPI: false,
+      promptConfig: {
+        prompt_template: 'template',
+        prompt_variables: [
+          { key: 'machines', name: 'Machines', type: 'multi-select', required: false },
+        ],
+      },
+      t: createTranslator(),
+    })
+
+    expect(result).toEqual({ canSend: true })
+  })
+
+  it('should reject malformed non-array required multi-select inputs', () => {
+    const result = validateResultRequest({
+      completionFiles: [],
+      inputs: {
+        machines: 'A',
+      },
+      isCallBatchAPI: false,
+      promptConfig: {
+        prompt_template: 'template',
+        prompt_variables: [
+          { key: 'machines', name: 'Machines', type: 'multi-select', required: true },
+        ],
+      },
+      t: createTranslator(),
+    })
+
+    expect(result).toEqual({
+      canSend: false,
+      notification: {
+        type: 'error',
+        message: 'errorMessage.valueOfVarRequired',
+      },
+    })
+  })
+
   it('should allow required file inputs when a file is selected', () => {
     const result = validateResultRequest({
       completionFiles: [],
@@ -276,5 +364,31 @@ describe('result-request', () => {
         name: 'Alice',
       },
     })
+  })
+
+  it('should preserve multi-select values as native arrays in request data', () => {
+    const selectedMachines = ['Machine A', 'Machine C']
+    const result = buildResultRequestData({
+      completionFiles: [],
+      inputs: {
+        machines: selectedMachines,
+      },
+      promptConfig: {
+        prompt_template: 'template',
+        prompt_variables: [
+          {
+            key: 'machines',
+            name: 'Machines',
+            type: 'multi-select',
+            required: true,
+            options: selectedMachines,
+          },
+        ],
+      },
+      visionConfig,
+    })
+
+    expect(result.inputs.machines).toBe(selectedMachines)
+    expect(result.inputs.machines).toEqual(['Machine A', 'Machine C'])
   })
 })

--- a/web/app/components/share/text-generation/result/result-request.ts
+++ b/web/app/components/share/text-generation/result/result-request.ts
@@ -45,7 +45,8 @@ const isMissingRequiredInput = (
 ) => {
   if (value === undefined || value === null) return true
 
-  if (variable.type === 'file-list') return !Array.isArray(value) || value.length === 0
+  if (variable.type === 'file-list' || variable.type === 'multi-select')
+    return !Array.isArray(value) || value.length === 0
 
   if (['string', 'paragraph', 'number', 'json_object', 'select'].includes(variable.type))
     return typeof value !== 'string' ? false : value.trim() === ''

--- a/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
+++ b/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
@@ -3,6 +3,7 @@ import type { PromptConfig, PromptVariable } from '@/models/debug'
 import type { SiteInfo } from '@/models/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { Resolution, TransferMethod } from '@/types/app'
@@ -174,6 +175,39 @@ describe('RunOnce', () => {
     })
 
     expect(screen.getByText('common.imageUploader.imageUpload'))!.toBeInTheDocument()
+  })
+
+  it('should initialize, update, and clear multi-select values as string arrays', async () => {
+    const promptConfig: PromptConfig = {
+      prompt_template: 'template',
+      prompt_variables: [
+        createPromptVariable({
+          key: 'regions',
+          name: 'Regions',
+          type: 'multi-select',
+          required: true,
+          options: ['Asia', 'Europe', 'Americas'],
+        }),
+      ],
+    }
+    const { onInputsChange } = setup({ promptConfig })
+
+    await waitFor(() => {
+      expect(onInputsChange).toHaveBeenCalledWith({ regions: [] })
+    })
+    onInputsChange.mockClear()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('combobox', { name: 'Regions' }))
+    await user.click(await screen.findByRole('option', { name: 'Asia' }))
+    await user.click(await screen.findByRole('option', { name: 'Americas' }))
+
+    expect(onInputsChange).toHaveBeenLastCalledWith({ regions: ['Asia', 'Americas'] })
+
+    onInputsChange.mockClear()
+    await user.click(await screen.findByRole('option', { name: 'Asia' }))
+    await user.click(await screen.findByRole('option', { name: 'Americas' }))
+    expect(onInputsChange).toHaveBeenCalledWith({ regions: [] })
   })
 
   it('should update inputs when user edits fields', async () => {

--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -26,6 +26,7 @@ import TextGenerationImageUploader from '@/app/components/base/image-uploader/te
 import Input from '@/app/components/base/input'
 import BoolInput from '@/app/components/workflow/nodes/_base/components/before-run-form/bool-input'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
+import { MultiSelectField } from '@/app/components/workflow/nodes/_base/components/form-input-item.sections'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 
@@ -65,6 +66,7 @@ const RunOnce: FC<IRunOnceProps> = ({
       if (item.type === 'string' || item.type === 'paragraph') newInputs[item.key] = ''
       else if (item.type === 'number') newInputs[item.key] = ''
       else if (item.type === 'checkbox') newInputs[item.key] = false
+      else if (item.type === 'multi-select') newInputs[item.key] = []
       else newInputs[item.key] = undefined
     })
     onInputsChange(newInputs)
@@ -102,6 +104,7 @@ const RunOnce: FC<IRunOnceProps> = ({
         newInputs[item.key] = item.default || ''
       else if (item.type === 'number') newInputs[item.key] = item.default ?? ''
       else if (item.type === 'checkbox') newInputs[item.key] = item.default || false
+      else if (item.type === 'multi-select') newInputs[item.key] = []
       else if (item.type === 'file') newInputs[item.key] = undefined
       else if (item.type === 'file-list') newInputs[item.key] = []
       else newInputs[item.key] = undefined
@@ -128,6 +131,9 @@ const RunOnce: FC<IRunOnceProps> = ({
                     typeof inputValue === 'string' && inputValue !== '' ? inputValue : null
                   const defaultSelectValue =
                     typeof item.default === 'string' && item.default !== '' ? item.default : null
+                  const multiSelectValue = Array.isArray(inputValue)
+                    ? inputValue.filter((value): value is string => typeof value === 'string')
+                    : []
 
                   return (
                     <div className="mt-4 w-full" key={item.key}>
@@ -164,6 +170,21 @@ const RunOnce: FC<IRunOnceProps> = ({
                               ))}
                             </SelectContent>
                           </Select>
+                        )}
+                        {item.type === 'multi-select' && (
+                          <MultiSelectField
+                            disabled={false}
+                            items={(item.options || []).map((option) => ({
+                              name: option,
+                              value: option,
+                            }))}
+                            onChange={(value) =>
+                              handleInputsChange({ ...inputsRef.current, [item.key]: value })
+                            }
+                            placeholder={item.name}
+                            selectedLabel={multiSelectValue.join(', ')}
+                            value={multiSelectValue}
+                          />
                         )}
                         {item.type === 'string' && (
                           <Input

--- a/web/app/components/workflow/nodes/_base/components/before-run-form/__tests__/helpers.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/before-run-form/__tests__/helpers.spec.ts
@@ -35,6 +35,8 @@ describe('before-run-form helpers', () => {
     expect(formatValue('12.5', InputVarType.number)).toBe(12.5)
     expect(formatValue('{"foo":1}', InputVarType.json)).toEqual({ foo: 1 })
     expect(formatValue('', InputVarType.checkbox)).toBe(false)
+    const selectedOptions = ['Option A', 'Option C']
+    expect(formatValue(selectedOptions, InputVarType.multiSelect)).toBe(selectedOptions)
     expect(formatValue(['{"foo":1}'], InputVarType.contexts)).toEqual([{ foo: 1 }])
     expect(formatValue(null, InputVarType.singleFile)).toBeNull()
     expect(
@@ -78,6 +80,52 @@ describe('before-run-form helpers', () => {
         t,
       ),
     ).toContain('errorMsg.fieldRequired')
+
+    expect(
+      getFormErrorMessage(
+        [
+          createForm({
+            inputs: [
+              createInput({
+                variable: 'choices',
+                label: 'Choices',
+                type: InputVarType.multiSelect,
+                required: true,
+              }),
+            ],
+            values: createValues({ choices: [] }),
+          }),
+        ],
+        [{}],
+        t,
+      ),
+    ).toContain('errorMsg.fieldRequired')
+
+    expect(
+      getFormErrorMessage(
+        [
+          createForm({
+            inputs: [createInput({ type: InputVarType.multiSelect, required: true })],
+            values: createValues({ field: ['Option A'] }),
+          }),
+        ],
+        [{}],
+        t,
+      ),
+    ).toBe('')
+
+    expect(
+      getFormErrorMessage(
+        [
+          createForm({
+            inputs: [createInput({ type: InputVarType.multiSelect, required: false })],
+            values: createValues({ field: [] }),
+          }),
+        ],
+        [{}],
+        t,
+      ),
+    ).toBe('')
 
     expect(
       getFormErrorMessage(
@@ -210,6 +258,18 @@ describe('before-run-form helpers', () => {
         file: expect.any(Object),
       }),
     )
+
+    expect(
+      buildSubmitData([
+        createForm({
+          inputs: [createInput({ variable: 'choices', type: InputVarType.multiSelect })],
+          values: createValues({ choices: ['Option A', 'Option C'] }),
+        }),
+      ]),
+    ).toEqual({
+      submitData: { choices: ['Option A', 'Option C'] },
+      parseErrorJsonField: '',
+    })
   })
 
   it('should derive the zero-form auto behaviors', () => {

--- a/web/app/components/workflow/nodes/_base/components/before-run-form/form-item.tsx
+++ b/web/app/components/workflow/nodes/_base/components/before-run-form/form-item.tsx
@@ -32,6 +32,7 @@ import { BlockEnum, InputVarType, SupportUploadFileTypes } from '../../../../typ
 import { CodeLanguage } from '../../../code/types'
 import CodeEditor from '../editor/code-editor'
 import TextEditor from '../editor/text-editor'
+import { MultiSelectField } from '../form-input-item.sections'
 import BoolInput from './bool-input'
 
 type Props = Readonly<{
@@ -126,6 +127,9 @@ const FormItem: FC<Props> = ({
   const isContext = type === InputVarType.contexts
   const isIterator = type === InputVarType.iterator
   const isIteratorItemFile = isIterator && payload.isFileItem
+  const multiSelectValue = Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : []
   const singleFileValue = useMemo(() => {
     if (payload.variable === '#files#') return value || []
 
@@ -210,6 +214,17 @@ const FormItem: FC<Props> = ({
               ))}
             </SelectContent>
           </Select>
+        )}
+
+        {type === InputVarType.multiSelect && (
+          <MultiSelectField
+            disabled={false}
+            items={(payload.options || []).map((option) => ({ name: option, value: option }))}
+            onChange={onChange}
+            placeholder={typeof payload.label === 'object' ? payload.label.variable : payload.label}
+            selectedLabel={multiSelectValue.join(', ')}
+            value={multiSelectValue}
+          />
         )}
 
         {isBooleanType && (

--- a/web/app/components/workflow/nodes/_base/components/before-run-form/form.tsx
+++ b/web/app/components/workflow/nodes/_base/components/before-run-form/form.tsx
@@ -14,7 +14,7 @@ export type Props = Readonly<{
   className?: string
   label?: string
   inputs: InputVar[]
-  values: Record<string, string>
+  values: Record<string, unknown>
   onChange: (newValues: Record<string, any>) => void
 }>
 

--- a/web/app/components/workflow/nodes/_base/components/before-run-form/helpers.ts
+++ b/web/app/components/workflow/nodes/_base/components/before-run-form/helpers.ts
@@ -62,7 +62,8 @@ export const getFormErrorMessage = (
           value === null ||
           ((input.type === InputVarType.files ||
             input.type === InputVarType.multiFiles ||
-            input.type === InputVarType.singleFile) &&
+            input.type === InputVarType.singleFile ||
+            input.type === InputVarType.multiSelect) &&
             Array.isArray(value) &&
             value.length === 0))
 

--- a/web/app/components/workflow/nodes/_base/components/input-var-type-icon.tsx
+++ b/web/app/components/workflow/nodes/_base/components/input-var-type-icon.tsx
@@ -25,6 +25,7 @@ const getIcon = (type: InputVarType) => {
         [InputVarType.textInput]: RiTextSnippet,
         [InputVarType.paragraph]: RiAlignLeft,
         [InputVarType.select]: RiCheckboxMultipleLine,
+        [InputVarType.multiSelect]: RiCheckboxMultipleLine,
         [InputVarType.number]: RiHashtag,
         [InputVarType.checkbox]: RiCheckboxLine,
         [InputVarType.jsonObject]: RiBracesLine,

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
@@ -13,7 +13,12 @@ import {
   VarType,
 } from '@/app/components/workflow/types'
 import { AppModeEnum } from '@/types/app'
-import { getNodeUsedVars, toNodeAvailableVars, updateNodeVars } from '../utils'
+import {
+  getNodeUsedVars,
+  inputVarTypeToVarType,
+  toNodeAvailableVars,
+  updateNodeVars,
+} from '../utils'
 
 const createNode = <T>(data: Node<T>['data']): Node<T> => ({
   id: 'node-1',
@@ -49,6 +54,11 @@ const createLLMNodeData = (promptTemplate: PromptItem[]): LLMNodeType => ({
 })
 
 describe('variable utils', () => {
+  it('maps multi-select inputs to array strings', () => {
+    expect(InputVarType.multiSelect).toBe('multi-select')
+    expect(inputVarTypeToVarType(InputVarType.multiSelect)).toBe(VarType.arrayString)
+  })
+
   describe('toNodeAvailableVars', () => {
     it('excludes LLM environment aliases from generic variable pickers', () => {
       const environmentVariables: EnvironmentVariable[] = [

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -127,6 +127,7 @@ export const inputVarTypeToVarType = (type: InputVarType): VarType => {
       {
         [InputVarType.number]: VarType.number,
         [InputVarType.checkbox]: VarType.boolean,
+        [InputVarType.multiSelect]: VarType.arrayString,
         [InputVarType.singleFile]: VarType.file,
         [InputVarType.multiFiles]: VarType.arrayFile,
         [InputVarType.jsonObject]: VarType.object,

--- a/web/app/components/workflow/nodes/start/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/start/__tests__/panel.spec.tsx
@@ -158,6 +158,7 @@ describe('StartPanel', () => {
 
     expect(mockConfigVarModal).toHaveBeenCalledWith(
       expect.objectContaining({
+        supportMultiSelect: true,
         varKeys: ['locale'],
       }),
     )

--- a/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
+++ b/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
@@ -3,10 +3,14 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { InputVarType } from '@/app/components/workflow/types'
 import VarItem from '../var-item'
 
+const mockConfigVarModal = vi.hoisted(() => vi.fn())
+
 vi.mock('@/app/components/app/configuration/config-var/config-modal', () => ({
   __esModule: true,
-  default: ({ isShow }: { isShow: boolean }) =>
-    isShow ? <div role="dialog">edit-variable</div> : null,
+  default: (props: { isShow: boolean }) => {
+    mockConfigVarModal(props)
+    return props.isShow ? <div role="dialog">edit-variable</div> : null
+  },
 }))
 
 const createPayload = (overrides: Partial<InputVar> = {}): InputVar => ({
@@ -28,6 +32,9 @@ describe('StartVarItem', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'common.operation.edit' }))
     expect(screen.getByRole('dialog')).toHaveTextContent('edit-variable')
+    expect(mockConfigVarModal).toHaveBeenCalledWith(
+      expect.objectContaining({ supportMultiSelect: true }),
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'common.operation.remove' }))
     expect(handleRemove).toHaveBeenCalledTimes(1)

--- a/web/app/components/workflow/nodes/start/components/var-item.tsx
+++ b/web/app/components/workflow/nodes/start/components/var-item.tsx
@@ -131,6 +131,7 @@ const VarItem: FC<Props> = ({
         <ConfigVarModal
           isShow
           supportFile
+          supportMultiSelect
           payload={payload}
           onClose={() => setIsShowEditVarModal(false)}
           onConfirm={handlePayloadChange}

--- a/web/app/components/workflow/nodes/start/panel.tsx
+++ b/web/app/components/workflow/nodes/start/panel.tsx
@@ -97,6 +97,7 @@ const Panel: FC<NodePanelProps<StartNodeType>> = ({ id, data }) => {
         <ConfigVarModal
           isCreate
           supportFile
+          supportMultiSelect
           isShow={isShowAddVarModal}
           onClose={hideAddVarModal}
           onConfirm={handleAddVarConfirm}

--- a/web/app/components/workflow/types.ts
+++ b/web/app/components/workflow/types.ts
@@ -218,6 +218,7 @@ export enum InputVarType {
   multiFiles = 'file-list',
   loop = 'loop', // loop input
   checkbox = 'checkbox',
+  multiSelect = 'multi-select',
 }
 
 export type InputVar = {

--- a/web/i18n/ar-TN/app-debug.json
+++ b/web/i18n/ar-TN/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "الحد الأقصى لعدد التحميلات",
   "variableConfig.maxNumberTip": "وثيقة < {{docLimit}}، صورة < {{imgLimit}}، صوت < {{audioLimit}}، فيديو < {{videoLimit}}",
   "variableConfig.multi-files": "قائمة ملفات",
+  "variableConfig.multi-select": "تحديد متعدد",
   "variableConfig.noDefaultSelected": "لا تحدد",
   "variableConfig.noDefaultValue": "لا توجد قيمة افتراضية",
   "variableConfig.notSet": "لم يتم التعيين، حاول كتابة {{input}} في بادئة المطالبة",

--- a/web/i18n/de-DE/app-debug.json
+++ b/web/i18n/de-DE/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Maximale Anzahl von Uploads",
   "variableConfig.maxNumberTip": "Dokument < {{docLimit}}, Bild < {{imgLimit}}, Audio < {{audioLimit}}, Video < {{videoLimit}}",
   "variableConfig.multi-files": "Dateiliste",
+  "variableConfig.multi-select": "Mehrfachauswahl",
   "variableConfig.noDefaultSelected": "Nicht auswählen",
   "variableConfig.noDefaultValue": "Kein Standardwert",
   "variableConfig.notSet": "Nicht gesetzt, versuchen Sie, {{input}} im Vor-Prompt zu tippen",

--- a/web/i18n/en-US/app-debug.json
+++ b/web/i18n/en-US/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Max number of uploads",
   "variableConfig.maxNumberTip": "Document < {{docLimit}}, image < {{imgLimit}}, audio < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "File List",
+  "variableConfig.multi-select": "Multi-select",
   "variableConfig.noDefaultSelected": "Don't select",
   "variableConfig.noDefaultValue": "No default value",
   "variableConfig.notSet": "Not set, try typing {{input}} in the prefix prompt",

--- a/web/i18n/es-ES/app-debug.json
+++ b/web/i18n/es-ES/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Número máximo de cargas",
   "variableConfig.maxNumberTip": "Documento < {{docLimit}}, imagen < {{imgLimit}}, audio < {{audioLimit}}, vídeo < {{videoLimit}}",
   "variableConfig.multi-files": "Lista de archivos",
+  "variableConfig.multi-select": "Selección múltiple",
   "variableConfig.noDefaultSelected": "No seleccionar",
   "variableConfig.noDefaultValue": "Sin valor predeterminado",
   "variableConfig.notSet": "No configurado, intenta escribir {{input}} en la indicación de prefijo",

--- a/web/i18n/fa-IR/app-debug.json
+++ b/web/i18n/fa-IR/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "حداکثر تعداد آپلود",
   "variableConfig.maxNumberTip": "سند < {{docLimit}}، تصویر < {{imgLimit}}، صوت < {{audioLimit}}، ویدئو < {{videoLimit}}",
   "variableConfig.multi-files": "لیست فایل ها",
+  "variableConfig.multi-select": "انتخاب چندگانه",
   "variableConfig.noDefaultSelected": "انتخاب نکنید",
   "variableConfig.noDefaultValue": "بدون مقدار پیش فرض",
   "variableConfig.notSet": "تنظیم نشده است، سعی کنید {{input}} را در پیش‌نویس وارد کنید",

--- a/web/i18n/fr-FR/app-debug.json
+++ b/web/i18n/fr-FR/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Nombre maximal de téléchargements",
   "variableConfig.maxNumberTip": "Document < {{docLimit}}, image < {{imgLimit}}, audio < {{audioLimit}}, vidéo < {{videoLimit}}",
   "variableConfig.multi-files": "Liste des fichiers",
+  "variableConfig.multi-select": "Sélection multiple",
   "variableConfig.noDefaultSelected": "Ne sélectionnez pas",
   "variableConfig.noDefaultValue": "Aucune valeur par défaut",
   "variableConfig.notSet": "Not set, try typing {{input}} in the prefix prompt",

--- a/web/i18n/hi-IN/app-debug.json
+++ b/web/i18n/hi-IN/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "अधिकतम अपलोड संख्या",
   "variableConfig.maxNumberTip": "दस्तावेज़ < {{docLimit}}, छवि < {{imgLimit}}, ऑडियो < {{audioLimit}}, वीडियो < {{videoLimit}}",
   "variableConfig.multi-files": "फ़ाइल सूची",
+  "variableConfig.multi-select": "बहु-चयन",
   "variableConfig.noDefaultSelected": "चुनें मत",
   "variableConfig.noDefaultValue": "कोई डिफ़ॉल्ट मान नहीं",
   "variableConfig.notSet": "सेट नहीं किया गया, प्रारंभिक प्रॉम्प्ट में {{input}} टाइप करने का प्रयास करें",

--- a/web/i18n/id-ID/app-debug.json
+++ b/web/i18n/id-ID/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Jumlah upload maksimal",
   "variableConfig.maxNumberTip": "Dokumen < {{docLimit}}, gambar < {{imgLimit}}, audio < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "Daftar File",
+  "variableConfig.multi-select": "Pilihan ganda",
   "variableConfig.noDefaultSelected": "Jangan pilih",
   "variableConfig.noDefaultValue": "Tidak ada nilai default",
   "variableConfig.notSet": "Belum diatur, coba ketik {{input}} di prompt awalan",

--- a/web/i18n/it-IT/app-debug.json
+++ b/web/i18n/it-IT/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Numero massimo di caricamenti",
   "variableConfig.maxNumberTip": "Documento < {{docLimit}}, immagine < {{imgLimit}}, audio < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "Elenco file",
+  "variableConfig.multi-select": "Selezione multipla",
   "variableConfig.noDefaultSelected": "Non selezionare",
   "variableConfig.noDefaultValue": "Nessun valore predefinito",
   "variableConfig.notSet": "Non impostato, prova a scrivere {{input}} nel prompt di prefisso",

--- a/web/i18n/ja-JP/app-debug.json
+++ b/web/i18n/ja-JP/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "アップロードの最大数",
   "variableConfig.maxNumberTip": "ドキュメント < {{docLimit}}, 画像 < {{imgLimit}}, 音声 < {{audioLimit}}, 映像 < {{videoLimit}}",
   "variableConfig.multi-files": "ファイルリスト",
+  "variableConfig.multi-select": "複数選択",
   "variableConfig.noDefaultSelected": "選ばないでください",
   "variableConfig.noDefaultValue": "デフォルト値なし",
   "variableConfig.notSet": "設定されていません。プレフィックスのプロンプトで {{input}} を入力してみてください。",

--- a/web/i18n/ko-KR/app-debug.json
+++ b/web/i18n/ko-KR/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "최대 업로드 수",
   "variableConfig.maxNumberTip": "문서 < {{docLimit}}, 이미지 < {{imgLimit}}, 오디오 < {{audioLimit}}, 비디오 < {{videoLimit}}",
   "variableConfig.multi-files": "파일 목록",
+  "variableConfig.multi-select": "다중 선택",
   "variableConfig.noDefaultSelected": "선택하지 않음",
   "variableConfig.noDefaultValue": "기본값 없음",
   "variableConfig.notSet": "설정되지 않음. 프롬프트의 프리픽스에 {{input}}을 입력해 보세요.",

--- a/web/i18n/lo-LA/app-debug.json
+++ b/web/i18n/lo-LA/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "ຈຳນວນອັບໂຫຼດສູງສຸດ",
   "variableConfig.maxNumberTip": "ເອກະສານ < {{docLimit}}, ຮູບພາບ < {{imgLimit}}, ສຽງ < {{audioLimit}}, ວິດີໂອ < {{videoLimit}}",
   "variableConfig.multi-files": "ລາຍການໄຟລ໌",
+  "variableConfig.multi-select": "ເລືອກຫຼາຍລາຍການ",
   "variableConfig.noDefaultSelected": "ບໍ່ເລືອກ",
   "variableConfig.noDefaultValue": "ບໍ່ມີຄ່າເລີ່ມຕົ້ນ",
   "variableConfig.notSet": "ບໍ່ໄດ້ຕັ້ງຄ່າ, ລອງພິມ {{input}} ໃນ Prefix prompt",

--- a/web/i18n/nl-NL/app-debug.json
+++ b/web/i18n/nl-NL/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Max number of uploads",
   "variableConfig.maxNumberTip": "Document < {{docLimit}}, image < {{imgLimit}}, audio < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "File List",
+  "variableConfig.multi-select": "Meervoudige selectie",
   "variableConfig.noDefaultSelected": "Don't select",
   "variableConfig.noDefaultValue": "No default value",
   "variableConfig.notSet": "Not set, try typing {{input}} in the prefix prompt",

--- a/web/i18n/pl-PL/app-debug.json
+++ b/web/i18n/pl-PL/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Maksymalna liczba przesyłanych plików",
   "variableConfig.maxNumberTip": "Dokument < {{docLimit}}, obraz < {{imgLimit}}, audio < {{audioLimit}}, wideo < {{videoLimit}}",
   "variableConfig.multi-files": "Lista plików",
+  "variableConfig.multi-select": "Wybór wielokrotny",
   "variableConfig.noDefaultSelected": "Nie wybieraj",
   "variableConfig.noDefaultValue": "Brak wartości domyślnej",
   "variableConfig.notSet": "Nie ustawione, spróbuj wpisać {{input}} w monicie wstępnym",

--- a/web/i18n/pt-BR/app-debug.json
+++ b/web/i18n/pt-BR/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Número máximo de uploads",
   "variableConfig.maxNumberTip": "Documento < {{docLimit}}, imagem < {{imgLimit}}, áudio < {{audioLimit}}, vídeo < {{videoLimit}}",
   "variableConfig.multi-files": "Lista de arquivos",
+  "variableConfig.multi-select": "Seleção múltipla",
   "variableConfig.noDefaultSelected": "Não selecione",
   "variableConfig.noDefaultValue": "Nenhum valor padrão",
   "variableConfig.notSet": "Não definido, tente digitar {{input}} no prompt de prefixo",

--- a/web/i18n/ro-RO/app-debug.json
+++ b/web/i18n/ro-RO/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Numărul maxim de încărcări",
   "variableConfig.maxNumberTip": "Document < {{docLimit}}, imagine < {{imgLimit}}, audio < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "Lista de fișiere",
+  "variableConfig.multi-select": "Selecție multiplă",
   "variableConfig.noDefaultSelected": "Nu selecta",
   "variableConfig.noDefaultValue": "Fără valoare implicită",
   "variableConfig.notSet": "Nesetat, încercați să tastați {{input}} în promptul de prefix",

--- a/web/i18n/ru-RU/app-debug.json
+++ b/web/i18n/ru-RU/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Максимальное количество загрузок",
   "variableConfig.maxNumberTip": "Документ < {{docLimit}}, изображение < {{imgLimit}}, аудио < {{audioLimit}}, видео < {{videoLimit}}",
   "variableConfig.multi-files": "Список файлов",
+  "variableConfig.multi-select": "Множественный выбор",
   "variableConfig.noDefaultSelected": "Не выбирайте",
   "variableConfig.noDefaultValue": "Без значения по умолчанию",
   "variableConfig.notSet": "Не задано, попробуйте ввести {{input}} в префикс промпта",

--- a/web/i18n/sl-SI/app-debug.json
+++ b/web/i18n/sl-SI/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Največje število nalaganj",
   "variableConfig.maxNumberTip": "Dokument < {{docLimit}}, slika < {{imgLimit}}, avdio < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "Seznam datotek",
+  "variableConfig.multi-select": "Večkratna izbira",
   "variableConfig.noDefaultSelected": "Ne izberite",
   "variableConfig.noDefaultValue": "Ni privzete vrednosti",
   "variableConfig.notSet": "Ni nastavljeno, poskusite v predpono vnesti {{input}}",

--- a/web/i18n/th-TH/app-debug.json
+++ b/web/i18n/th-TH/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "จํานวนการอัปโหลดสูงสุด",
   "variableConfig.maxNumberTip": "เอกสาร < {{docLimit}}, รูปภาพ < {{imgLimit}}, เสียง < {{audioLimit}}, วิดีโอ < {{videoLimit}}",
   "variableConfig.multi-files": "รายการไฟล์",
+  "variableConfig.multi-select": "เลือกหลายรายการ",
   "variableConfig.noDefaultSelected": "อย่าเลือก",
   "variableConfig.noDefaultValue": "ไม่มีค่าเริ่มต้น",
   "variableConfig.notSet": "ยังไม่ได้ตั้งค่า ลองพิมพ์ {{input}} ในช่องแจ้งนำหน้า",

--- a/web/i18n/tr-TR/app-debug.json
+++ b/web/i18n/tr-TR/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Maksimum yükleme sayısı",
   "variableConfig.maxNumberTip": "Belge < {{docLimit}}, resim < {{imgLimit}}, ses < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "Dosya Listesi",
+  "variableConfig.multi-select": "Çoklu seçim",
   "variableConfig.noDefaultSelected": "Seçmeyin",
   "variableConfig.noDefaultValue": "Varsayılan değer yok",
   "variableConfig.notSet": "Ayarlanmamış, ön promptta {{input}} yazmayı deneyin",

--- a/web/i18n/uk-UA/app-debug.json
+++ b/web/i18n/uk-UA/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Максимальна кількість завантажень",
   "variableConfig.maxNumberTip": "Документ < {{docLimit}}, зображення < {{imgLimit}}, аудіо < {{audioLimit}}, відео < {{videoLimit}}",
   "variableConfig.multi-files": "Список файлів",
+  "variableConfig.multi-select": "Множинний вибір",
   "variableConfig.noDefaultSelected": "Не вибирати",
   "variableConfig.noDefaultValue": "Без значення за замовчуванням",
   "variableConfig.notSet": "Не встановлено, спробуйте ввести {{input}} у префіксній підказці",

--- a/web/i18n/vi-VN/app-debug.json
+++ b/web/i18n/vi-VN/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "Số lượt tải lên tối đa",
   "variableConfig.maxNumberTip": "Tài liệu < {{docLimit}}, hình ảnh < {{imgLimit}}, âm thanh < {{audioLimit}}, video < {{videoLimit}}",
   "variableConfig.multi-files": "Danh sách tập tin",
+  "variableConfig.multi-select": "Chọn nhiều",
   "variableConfig.noDefaultSelected": "Không chọn",
   "variableConfig.noDefaultValue": "Không có giá trị mặc định",
   "variableConfig.notSet": "Chưa thiết lập, hãy thử nhập {{input}} trong gợi ý tiền tố",

--- a/web/i18n/zh-Hans/app-debug.json
+++ b/web/i18n/zh-Hans/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "最大上传数",
   "variableConfig.maxNumberTip": "文档 < {{docLimit}}, 图片 < {{imgLimit}}, 音频 < {{audioLimit}}, 视频 < {{videoLimit}}",
   "variableConfig.multi-files": "文件列表",
+  "variableConfig.multi-select": "多选",
   "variableConfig.noDefaultSelected": "不默认选中",
   "variableConfig.noDefaultValue": "无默认值",
   "variableConfig.notSet": "未设置，在 Prompt 中输入 {{input}} 试试",

--- a/web/i18n/zh-Hant/app-debug.json
+++ b/web/i18n/zh-Hant/app-debug.json
@@ -352,6 +352,7 @@
   "variableConfig.maxNumberOfUploads": "最大上傳次數",
   "variableConfig.maxNumberTip": "文件 < {{docLimit}}, 圖片 < {{imgLimit}}, 音訊 < {{audioLimit}}, 影片 < {{videoLimit}}",
   "variableConfig.multi-files": "檔案清單",
+  "variableConfig.multi-select": "多選",
   "variableConfig.noDefaultSelected": "請勿選取",
   "variableConfig.noDefaultValue": "無預設值",
   "variableConfig.notSet": "未設定，在 Prompt 中輸入 {{input}} 試試",

--- a/web/types/app.ts
+++ b/web/types/app.ts
@@ -69,7 +69,7 @@ export const AppModeEnum = {
 /**
  * Variable type
  */
-type VariableType = 'string' | 'number' | 'select'
+type VariableType = 'string' | 'number' | 'select' | 'multi-select'
 
 /**
  * Prompt variable parameter
@@ -105,6 +105,8 @@ type SelectTypeFormItem = {
   hide?: boolean
 }
 
+type MultiSelectTypeFormItem = Omit<SelectTypeFormItem, 'default'>
+
 type NumberTypeFormItem = Omit<TextTypeFormItem, 'default' | 'max_length'> & {
   default?: string | number
   max_length?: number
@@ -139,6 +141,9 @@ export type UserInputFormItem =
     }
   | {
       select: SelectTypeFormItem
+    }
+  | {
+      'multi-select': MultiSelectTypeFormItem
     }
   | {
       paragraph: TextTypeFormItem

--- a/web/utils/model-config.spec.ts
+++ b/web/utils/model-config.spec.ts
@@ -31,6 +31,13 @@ const getSelectInput = (item: UserInputFormItem | undefined) => {
   return item.select
 }
 
+const getMultiSelectInput = (item: UserInputFormItem | undefined) => {
+  if (!item || !('multi-select' in item))
+    throw new Error('Expected multi-select user input form item')
+
+  return item['multi-select']
+}
+
 describe('Model Config Utilities', () => {
   describe('userInputsFormToPromptVariables', () => {
     /**
@@ -199,6 +206,33 @@ describe('Model Config Utilities', () => {
         hide: false,
         default: 'USA',
       })
+    })
+
+    it('should convert multi-select input without a default value', () => {
+      const userInputs: UserInputFormItem[] = [
+        {
+          'multi-select': {
+            label: 'Regions',
+            variable: 'regions',
+            required: true,
+            options: ['Asia', 'Europe'],
+            hide: false,
+          },
+        },
+      ]
+
+      const result = userInputsFormToPromptVariables(userInputs)
+
+      expect(result[0]).toEqual({
+        key: 'regions',
+        name: 'Regions',
+        required: true,
+        type: 'multi-select',
+        options: ['Asia', 'Europe'],
+        is_context_var: false,
+        hide: false,
+      })
+      expect(result[0]).not.toHaveProperty('default')
     })
 
     /**
@@ -525,6 +559,31 @@ describe('Model Config Utilities', () => {
           hide: undefined,
         },
       })
+    })
+
+    it('should convert multi-select prompt variable without adding a default', () => {
+      const promptVariables: PromptVariable[] = [
+        {
+          key: 'regions',
+          name: 'Regions',
+          required: false,
+          type: 'multi-select',
+          options: ['Asia', 'Europe'],
+        },
+      ]
+
+      const result = promptVariablesToUserInputsForm(promptVariables)
+
+      expect(result[0]).toEqual({
+        'multi-select': {
+          label: 'Regions',
+          variable: 'regions',
+          required: false,
+          options: ['Asia', 'Europe'],
+          hide: undefined,
+        },
+      })
+      expect(getMultiSelectInput(result[0])).not.toHaveProperty('default')
     })
 
     /**

--- a/web/utils/model-config.ts
+++ b/web/utils/model-config.ts
@@ -56,6 +56,8 @@ const getInputFormContent = (item: Record<string, unknown>) => {
 
   if (isRecord(item.checkbox)) return { type: 'boolean', content: item.checkbox }
 
+  if (isRecord(item['multi-select'])) return { type: 'multi-select', content: item['multi-select'] }
+
   if (isRecord(item.file)) return { type: 'file', content: item.file }
 
   if (isRecord(item['file-list'])) return { type: 'file-list', content: item['file-list'] }
@@ -121,6 +123,16 @@ export const userInputsFormToPromptVariables = (
         is_context_var,
         hide: getBoolean(content.hide),
         default: getDefaultValue(content.default),
+      })
+    } else if (type === 'multi-select') {
+      promptVariables.push({
+        key: variable,
+        name: getString(content.label),
+        required: getBoolean(content.required, true),
+        type,
+        options: getStringArray(content.options),
+        is_context_var,
+        hide: getBoolean(content.hide),
       })
     } else if (type === 'file') {
       promptVariables.push({
@@ -231,6 +243,16 @@ export const promptVariablesToUserInputsForm = (promptVariables: PromptVariable[
             required: item.required !== false, // default true
             options: item.options,
             default: getString(item.default),
+            hide: item.hide,
+          },
+        })
+      } else if (item.type === 'multi-select') {
+        userInputs.push({
+          'multi-select': {
+            label: item.name,
+            variable: item.key,
+            required: item.required !== false,
+            options: item.options,
             hide: item.hide,
           },
         })


### PR DESCRIPTION
> [!IMPORTANT]
>
> This is a Draft PR while the Graphon prerequisite is pending. It depends on langgenius/graphon#259, which adds `VariableEntityType.MULTI_SELECT`.

## Summary

Fixes #40575

Adds a dedicated `multi-select` user input type for Start Nodes.

The implementation keeps selected values as a native `string[]` / `array[string]` throughout the workflow path instead of serializing them into a scalar string.

### What is included

- Add the `multi-select` Start Node input type and map it to `array[string]` downstream.
- Reuse the existing options editor for configuring predefined choices.
- Support optional and required multi-select inputs; an empty array is rejected only when the field is required.
- Validate submitted values on the backend: values must be strings, must belong to the configured options, and duplicates are rejected while preserving selection order.
- Keep optional empty selections as a typed empty string array.
- Add Start Node configuration UI support without introducing a multi-select default value in v1.
- Add runtime support for before-run forms, embedded chat, chat history, and public run-once flows.
- Preserve multi-select payloads as native arrays across frontend submission paths.
- Add focused backend and frontend regression tests.

### Dependency / current Draft status

This PR depends on langgenius/graphon#259.

That Graphon PR introduces `VariableEntityType.MULTI_SELECT` while reusing the existing `ARRAY_STRING` runtime type, so no new Graphon segment/runtime type is required.

The Dify-side feature implementation is complete on this branch. I am intentionally not bumping the Graphon dependency to an unreleased commit. Once Graphon #259 is merged and released, the remaining work for this PR is:

1. bump Dify's Graphon dependency to the released version containing `MULTI_SELECT`;
2. update `api/uv.lock`;
3. run final backend/frontend integration and regression verification;
4. mark this PR ready for review.

Until that release exists, CI may fail where the currently pinned Graphon version does not yet expose `VariableEntityType.MULTI_SELECT`.

### Verification performed on the implementation branch

- Graphon targeted tests: `14 passed`.
- Dify backend targeted tests: approximately 82 focused tests passed.
- Frontend runtime/config regression suite: 14 spec files, 333 tests passed.
- TSS lint: 5982 passed.
- `vp lint`: exited successfully (existing warnings only).
- `vp check --no-fmt`: 0 errors (existing warnings only).
- `git diff --check`: passed.

## Screenshots

Not added yet because this PR is still a Draft waiting on the Graphon prerequisite. UI screenshots can be added before marking it ready for review if requested.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From ChatGPT