### PR TITLE
fix: fix upload for plugin (#41133)

### DIFF
--- a/api/controllers/files/upload.py
+++ b/api/controllers/files/upload.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from werkzeug.exceptions import Forbidden
 
 import services
+from core.tools.signature import sign_tool_file
 from core.tools.tool_file_manager import ToolFileManager
 from dify_graph.file.helpers import verify_plugin_file_signature
 from fields.file_fields import FileResponse
@@ -110,7 +111,7 @@ class PluginUploadFileApi(Resource):
             )
 
             extension = guess_extension(tool_file.mimetype) or ".bin"
-            preview_url = ToolFileManager.sign_file(tool_file_id=tool_file.id, extension=extension)
+            preview_url = sign_tool_file(tool_file_id=tool_file.id, extension=extension, for_external=True)
 
             # Create a dictionary with all the necessary attributes
             result = FileResponse(

--- a/api/tests/unit_tests/controllers/files/test_upload.py
+++ b/api/tests/unit_tests/controllers/files/test_upload.py
@@ -51,10 +51,12 @@ class DummyToolFile:
 class TestPluginUploadFileApi:
     @patch.object(module, "verify_plugin_file_signature", return_value=True)
     @patch.object(module, "get_user", return_value=DummyUser())
+    @patch.object(module, "sign_tool_file", return_value="signed-url")
     @patch.object(module, "ToolFileManager")
     def test_success_upload(
         self,
         mock_tool_file_manager,
+        mock_sign_tool_file,
         mock_get_user,
         mock_verify_signature,
     ):
@@ -74,8 +76,6 @@ class TestPluginUploadFileApi:
         tool_file_manager_instance = mock_tool_file_manager.return_value
         tool_file_manager_instance.create_file_by_raw.return_value = DummyToolFile()
 
-        mock_tool_file_manager.sign_file.return_value = "signed-url"
-
         api = module.PluginUploadFileApi()
         post_fn = unwrap(api.post)
 
@@ -84,6 +84,11 @@ class TestPluginUploadFileApi:
         assert status_code == 201
         assert result["id"] == "file-id"
         assert result["preview_url"] == "signed-url"
+        mock_sign_tool_file.assert_called_once_with(
+            tool_file_id="file-id",
+            extension=".txt",
+            for_external=True,
+        )
 
     def test_missing_file(self):
         module.request = fake_request(


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41134.

This is the `lts/1.13.x` backport of #41133.

Plugin-generated files are uploaded through `/files/upload/for-plugin`. When `INTERNAL_FILES_URL` is configured, the returned `preview_url` previously used the internal service origin. Document extraction plugins could then persist an internal-only URL in knowledge pipeline Markdown and chunk content.

This change explicitly signs the returned `preview_url` for external access through `FILES_URL`. Plugin upload and other internal file-transfer requests continue to use `INTERNAL_FILES_URL`.

A focused regression test verifies that the plugin upload response requests the external URL audience.

(cherry picked from commit bec4ef6ac70f50443e255a7e4a90917e81d766d6)

## Screenshots

| Before | After |
| ------ | ----- |
| `http://dify-api:5001/files/tools/<file-id>...` | `https://<public-files-host>/files/tools/<file-id>...` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Codex