### PR TITLE
fix: show checklist errors for inline agents without models

### DIFF
--- a/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
@@ -225,10 +225,12 @@ function buildConnectedGraph() {
 
 function buildInlineAgentGraph({
   difyTools = [],
+  hasModel = true,
   hasMissingFile = false,
   hasMissingSkill = false,
 }: {
   difyTools?: AgentSoulDifyToolConfig[]
+  hasModel?: boolean
   hasMissingFile?: boolean
   hasMissingSkill?: boolean
 }) {
@@ -250,6 +252,13 @@ function buildInlineAgentGraph({
     }),
     zWorkflowAgentComposerResponse.parse({
       agent_soul: {
+        model: hasModel
+          ? {
+              model_provider: 'langgenius/openai/openai',
+              model: 'gpt-4o-mini',
+              plugin_id: 'langgenius/openai',
+            }
+          : undefined,
         config_files: [
           { file_kind: 'upload_file', name: 'available.pdf' },
           ...(hasMissingFile
@@ -412,6 +421,21 @@ describe('useChecklist', () => {
         expect.objectContaining({
           id: nodeId,
           errorMessages: [scenario.errorMessage],
+          openInlineAgentPanel: true,
+        }),
+      ])
+    })
+  })
+
+  it('should report a missing model from inline agents and open their configuration panel', async () => {
+    const { edges, nodeId, nodes, options } = buildInlineAgentGraph({ hasModel: false })
+    const { result } = renderWorkflowHook(() => useChecklist(nodes, edges), options)
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        expect.objectContaining({
+          id: nodeId,
+          errorMessages: ['workflow.nodes.agent.modelNotSelected'],
           openInlineAgentPanel: true,
         }),
       ])

--- a/web/app/components/workflow/hooks/use-checklist.ts
+++ b/web/app/components/workflow/hooks/use-checklist.ts
@@ -216,6 +216,7 @@ export const useChecklist = (nodes: Node[], edges: Edge[], options?: { flowType?
       const issuesByNodeId: Record<
         string,
         {
+          hasMissingModel: boolean
           hasMissingFiles: boolean
           hasMissingSkills: boolean
           toolIssues: AgentToolPublishIssue[]
@@ -227,15 +228,19 @@ export const useChecklist = (nodes: Node[], edges: Edge[], options?: { flowType?
         const agentSoul = result.data?.agent_soul
         if (!nodeId || !agentSoul) return
 
+        const agentSoulFormState = agentSoulConfigToFormState(agentSoul)
+        const hasMissingModel = !agentSoulFormState.model
         const hasMissingFiles = agentSoul.config_files?.some((file) => file.is_missing === true)
         const hasMissingSkills = agentSoul.config_skills?.some((skill) => skill.is_missing === true)
         const toolIssues = getAgentToolPublishIssues(
-          agentSoulConfigToFormState(agentSoul).tools,
+          agentSoulFormState.tools,
           inlineAgentToolProviderCatalog,
         )
-        if (!hasMissingFiles && !hasMissingSkills && toolIssues.length === 0) return
+        if (!hasMissingModel && !hasMissingFiles && !hasMissingSkills && toolIssues.length === 0)
+          return
 
         issuesByNodeId[nodeId] = {
+          hasMissingModel,
           hasMissingFiles: !!hasMissingFiles,
           hasMissingSkills: !!hasMissingSkills,
           toolIssues,
@@ -429,6 +434,8 @@ export const useChecklist = (nodes: Node[], edges: Edge[], options?: { flowType?
             if (validationError) errorMessages.push(validationError)
           }
 
+          if (inlineAgentIssues?.hasMissingModel)
+            errorMessages.push(t(($) => $['nodes.agent.modelNotSelected'], { ns: 'workflow' }))
           if (inlineAgentIssues?.hasMissingFiles)
             errorMessages.push(
               t(($) => $['agentDetail.configure.files.missing'], { ns: 'agentV2' }),


### PR DESCRIPTION
## Summary

- Add workflow checklist validation for inline agents without a configured model.
- Reuse the inline agent fix navigation to open the corresponding configuration panel.
- Add regression coverage for missing and configured model states.

Fixes DIFY-2918

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.