### PR TITLE
fix(agent): allow saving model-less inline Agent drafts

### DIFF
--- a/api/core/workflow/nodes/agent_v2/validators.py
+++ b/api/core/workflow/nodes/agent_v2/validators.py
@@ -74,6 +74,7 @@ class WorkflowAgentNodeValidator:
             session=session,
             workflow=workflow,
             require_binding=False,
+            require_agent_model=False,
             validate_previous_node_topology=False,
         )
 
@@ -83,6 +84,7 @@ class WorkflowAgentNodeValidator:
             session=session,
             workflow=workflow,
             require_binding=True,
+            require_agent_model=True,
             validate_previous_node_topology=True,
         )
 
@@ -93,6 +95,7 @@ class WorkflowAgentNodeValidator:
         session: Session,
         workflow: Workflow,
         require_binding: bool,
+        require_agent_model: bool,
         validate_previous_node_topology: bool,
     ) -> None:
         graph = workflow.graph_dict
@@ -112,7 +115,12 @@ class WorkflowAgentNodeValidator:
                         f"Workflow Agent node {node_id} requires a binding before publishing."
                     )
                 continue
-            cls.validate_binding(session=session, binding=binding, topology=topology)
+            cls.validate_binding(
+                session=session,
+                binding=binding,
+                topology=topology,
+                require_agent_model=require_agent_model,
+            )
 
         if require_binding:
             for node_id, node_data in cls.iter_tool_nodes(graph):
@@ -125,6 +133,7 @@ class WorkflowAgentNodeValidator:
         session: Session,
         binding: WorkflowAgentNodeBinding,
         topology: _WorkflowGraphTopology | None = None,
+        require_agent_model: bool = True,
     ) -> None:
         """Validate binding ownership, publication state, Agent Soul, and node-job references."""
 
@@ -174,7 +183,7 @@ class WorkflowAgentNodeValidator:
             )
 
         agent_soul = AgentSoulConfig.model_validate(snapshot.config_snapshot_dict)
-        if agent_soul.model is None:
+        if require_agent_model and agent_soul.model is None:
             raise WorkflowAgentNodeValidationError(
                 f"Workflow Agent node {binding.node_id} requires Agent Soul model config."
             )

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
@@ -248,6 +248,24 @@ def test_draft_validation_allows_non_upstream_previous_output_ref():
     )
 
 
+def test_draft_validation_allows_missing_agent_soul_model():
+    node_job = WorkflowNodeJobConfig.model_validate({})
+    snapshot = AgentConfigSnapshot(
+        id="snapshot-1",
+        tenant_id="tenant-1",
+        agent_id="agent-1",
+        version=1,
+        config_snapshot=AgentSoulConfig(),
+    )
+    session = Mock()
+    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+
+    WorkflowAgentNodeValidator.validate_draft_workflow(
+        session=session,
+        workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
+    )
+
+
 def test_draft_validation_rejects_incomplete_previous_output_ref():
     node_job = WorkflowNodeJobConfig.model_validate({"previous_node_output_refs": [{"selector": ["previous-node"]}]})
     session = Mock()


### PR DESCRIPTION
## Summary

- allow Workflow draft synchronization to persist an inline Agent before a model is selected
- keep the existing model requirement for Workflow publish validation
- add regression coverage for the draft-versus-publish validation contract

## Testing

- `uv run --directory api pytest -o addopts='' tests/unit_tests/core/workflow/nodes/agent_v2 -q` (287 passed)
- Ruff check and format check on the changed files
- Pyrefly check on `validators.py`
- Dev Console API E2E: model-less draft save/read succeeds; model-less publish is rejected; model-less node run remains failed; configured-model draft save and publish succeed

Related: [DIFY-2917](https://linear.app/dify/issue/DIFY-2917)