### PR TITLE
chore: show full agent save time on hover

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/publish-bar.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/publish-bar.spec.tsx
@@ -6,6 +6,7 @@ import type { ComponentProps } from 'react'
 import type { Mock } from 'vite-plus/test'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createStore, Provider as JotaiProvider } from 'jotai'
 import { defaultAgentSoulConfigFormState } from '@/features/agent-v2/agent-composer/form-state'
 import {
@@ -419,6 +420,16 @@ describe('AgentConfigurePublishBar', () => {
       screen.getByText(/agentV2\.agentDetail\.configure\.publishBar\.savedAt/),
     ).toBeInTheDocument()
     expect(mockFormatTimeFromNow).toHaveBeenCalledWith(1710000100000)
+  })
+
+  it('should show the complete saved time in a tooltip on hover', async () => {
+    const user = userEvent.setup()
+    renderPublishBar({ draftSavedAt: 1710000100000 })
+
+    const savedTime = screen.getByText(/agentV2\.agentDetail\.configure\.publishBar\.savedAt/)
+    await user.hover(savedTime)
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(savedTime.textContent ?? '')
   })
 
   it('should render published state from the active snapshot and disable publish logic', () => {

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/publish-bar.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/publish-bar.spec.tsx
@@ -429,7 +429,9 @@ describe('AgentConfigurePublishBar', () => {
     const savedTime = screen.getByText(/agentV2\.agentDetail\.configure\.publishBar\.savedAt/)
     await user.hover(savedTime)
 
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(savedTime.textContent ?? '')
+    await waitFor(() => {
+      expect(screen.getAllByText(savedTime.textContent ?? '')).toHaveLength(2)
+    })
   })
 
   it('should render published state from the active snapshot and disable publish logic', () => {

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
@@ -11,6 +11,7 @@ import { Collapsible, CollapsiblePanel } from '@langgenius/dify-ui/collapsible'
 import { Kbd, KbdGroup } from '@langgenius/dify-ui/kbd'
 import { StatusDot } from '@langgenius/dify-ui/status-dot'
 import { toast } from '@langgenius/dify-ui/toast'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { formatForDisplay, useHotkey } from '@tanstack/react-hotkeys'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
@@ -379,7 +380,10 @@ function PublishBarActions({
         <span aria-hidden className="shrink-0">
           ·
         </span>
-        <span className="min-w-0 truncate">{metaLabel}</span>
+        <Tooltip>
+          <TooltipTrigger render={<span className="min-w-0 truncate">{metaLabel}</span>} />
+          <TooltipContent role="tooltip">{metaLabel}</TooltipContent>
+        </Tooltip>
       </div>
       <button
         type="button"

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
@@ -382,7 +382,7 @@ function PublishBarActions({
         </span>
         <Tooltip>
           <TooltipTrigger render={<span className="min-w-0 truncate">{metaLabel}</span>} />
-          <TooltipContent role="tooltip">{metaLabel}</TooltipContent>
+          <TooltipContent>{metaLabel}</TooltipContent>
         </Tooltip>
       </div>
       <button


### PR DESCRIPTION
## Summary

- Show the complete Agent V2 saved timestamp in a tooltip when hovering truncated status metadata.
- Preserve the existing accessible status label and add a hover regression test.

Fixes DIFY-2920

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.