### PR TITLE
fix: Weaviate full-text search results missing score in metadata

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -480,6 +480,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -490,6 +491,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -503,6 +505,12 @@ class WeaviateVector(BaseVector):
             if isinstance(vec, dict):
                 vec = vec.get("default") or next(iter(vec.values()), None)
 
+            if obj.metadata and obj.metadata.score is not None:
+                # Without this, BM25 hits carry no score at all, so callers that
+                # rank documents by metadata["score"] (e.g. hybrid search merging
+                # vector + full-text results) treat every full-text match as 0 and
+                # it gets outranked/dropped regardless of how relevant it actually is.
+                properties["score"] = obj.metadata.score
             docs.append(Document(page_content=text, vector=vec, metadata=properties))
         return docs
 

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -561,6 +561,7 @@ class TestWeaviateVector(unittest.TestCase):
             "doc_type": "image",
         }
         mock_obj.vector = {"default": [0.1] * 128}
+        mock_obj.metadata = SimpleNamespace(score=None)
 
         mock_result = MagicMock()
         mock_result.objects = [mock_obj]
@@ -585,6 +586,42 @@ class TestWeaviateVector(unittest.TestCase):
         assert docs[0].metadata.get("doc_type") == "image"
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_returns_bm25_score_in_metadata(self, mock_weaviate_module):
+        """search_by_full_text must request and propagate the BM25 score, otherwise
+        callers that rank results by metadata["score"] (e.g. hybrid search merging
+        vector + full-text hits) treat every full-text match as 0 regardless of
+        actual relevance, and it silently loses to vector hits."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "bm25 result", "doc_id": "segment-1"}
+        mock_obj.vector = [0.3, 0.4]
+        mock_obj.metadata = SimpleNamespace(score=2.5)
+
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_col.query.bm25.return_value = mock_result
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_full_text(query="bm25")
+
+        # The query must ask Weaviate for the score, not just properties/vector.
+        call_kwargs = mock_col.query.bm25.call_args.kwargs
+        assert call_kwargs.get("return_metadata") is not None
+
+        assert len(docs) == 1
+        assert docs[0].metadata["score"] == pytest.approx(2.5)
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_full_text_uses_document_filter(self, mock_weaviate_module):
         mock_client = MagicMock()
         mock_client.is_ready.return_value = True
@@ -596,6 +633,7 @@ class TestWeaviateVector(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.properties = {"text": "bm25 result", "doc_id": "segment-1"}
         mock_obj.vector = [0.3, 0.4]
+        mock_obj.metadata = SimpleNamespace(score=None)
 
         mock_result = MagicMock()
         mock_result.objects = [mock_obj]
@@ -644,6 +682,7 @@ class TestWeaviateVector(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.properties = {"text": "retry bm25 result", "doc_id": "segment-1"}
         mock_obj.vector = {"default": [0.5, 0.6]}
+        mock_obj.metadata = SimpleNamespace(score=None)
 
         mock_result = MagicMock()
         mock_result.objects = [mock_obj]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41151

`WeaviateVector.search_by_full_text()` built `Document` objects from BM25
query results without ever setting `metadata["score"]`, unlike
`search_by_vector()` which explicitly computes and attaches one. Any caller
that ranks/filters results by `metadata.get("score", 0.0)` — most notably
hybrid search, which merges vector and full-text hits and sorts the
combined list by score — treats every full-text/BM25 match as a flat `0`
regardless of how relevant it actually was. In practice, a document that
only the keyword search finds (e.g. an exact identifier with little
semantic overlap to the query) gets outranked by unrelated vector hits and
silently dropped before reaching `top_k`, especially in knowledge bases
with many similar documents. Standalone "Full-text search" mode is
unaffected since it never needs to compare its scores against anything
else, which is why this was easy to miss.

Fix: request `return_metadata=MetadataQuery(score=True)` on the BM25 query
and copy `obj.metadata.score` into `properties["score"]`, mirroring what
`search_by_vector()` already does for vector hits.

Related: #32421, #13426, #17065 describe symptoms (fewer/wrong results in
hybrid + weighted-score mode) consistent with this root cause.

## Screenshots

Not applicable — backend retrieval scoring change, no UI difference.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code
