### PR TITLE
fix: align duplicate agent name behavior with agent forms

### DIFF
--- a/web/features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx
+++ b/web/features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx
@@ -255,7 +255,7 @@ describe('AgentRosterList', () => {
       name: 'agentV2.roster.duplicateDialog.title',
     })
     const nameInput = within(dialog).getByRole('textbox', {
-      name: /agentV2\.roster\.createForm\.nameLabel.*common\.label\.optional/,
+      name: 'agentV2.roster.createForm.nameLabel',
     })
     const roleInput = within(dialog).getByRole('textbox', {
       name: /agentV2\.roster\.createForm\.roleLabel.*common\.label\.optional/,
@@ -263,8 +263,8 @@ describe('AgentRosterList', () => {
     const descriptionInput = within(dialog).getByRole('textbox', {
       name: /agentV2\.roster\.createForm\.descriptionLabel.*common\.label\.optional/,
     })
-    expect(nameInput).toHaveValue('')
-    expect(nameInput).toHaveAttribute('placeholder', 'Research Agent copy')
+    expect(nameInput).toHaveValue('Research Agent copy')
+    expect(nameInput).toBeRequired()
     expect(roleInput).toHaveValue('Research Assistant')
     expect(roleInput).not.toBeRequired()
     expect(descriptionInput).toHaveValue('Find and summarize market materials.')
@@ -321,10 +321,7 @@ describe('AgentRosterList', () => {
     })
     expect(
       within(dialog).getByRole('textbox', { name: /agentV2\.roster\.createForm\.nameLabel/ }),
-    ).toHaveValue('')
-    expect(
-      within(dialog).getByRole('textbox', { name: /agentV2\.roster\.createForm\.nameLabel/ }),
-    ).toHaveAttribute('placeholder', 'Research Agent copy')
+    ).toHaveValue('Research Agent copy')
     expect(
       within(dialog).getByRole('textbox', {
         name: /agentV2\.roster\.createForm\.descriptionLabel/,
@@ -335,7 +332,7 @@ describe('AgentRosterList', () => {
     ).toHaveValue('Market Researcher')
   })
 
-  it('duplicates an agent with backend-generated naming when the dialog name is empty', async () => {
+  it('duplicates an agent with the generated copy name by default', async () => {
     const user = userEvent.setup()
     renderList([createAgent()])
 
@@ -353,6 +350,7 @@ describe('AgentRosterList', () => {
           agent_id: 'agent-1',
         },
         body: {
+          name: 'Research Agent copy',
           description: 'Find and summarize market materials.',
           role: 'Research Assistant',
           icon: '🧸',
@@ -364,7 +362,6 @@ describe('AgentRosterList', () => {
         client: expect.any(QueryClient),
       }),
     )
-    expect(duplicateAgentMutationFn.mock.calls[0]?.[0].body).not.toHaveProperty('name')
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('agentV2.roster.duplicateSuccess')
     })
@@ -441,6 +438,7 @@ describe('AgentRosterList', () => {
           agent_id: 'agent-1',
         },
         body: {
+          name: 'Research Agent copy',
           description: 'Find and summarize market materials.',
           role: '',
           icon: '🧸',

--- a/web/features/agent-v2/roster/components/duplicate-agent-dialog.tsx
+++ b/web/features/agent-v2/roster/components/duplicate-agent-dialog.tsx
@@ -12,7 +12,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from '@langgenius/dify-ui/dialog'
-import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Field, FieldError, FieldLabel } from '@langgenius/dify-ui/field'
 import { Form } from '@langgenius/dify-ui/form'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Input } from '@langgenius/dify-ui/input'
@@ -58,7 +58,7 @@ export function DuplicateAgentDialog({
       }),
     ) ?? agent
   const [renderedFormKey, setRenderedFormKey] = useState(formKey)
-  const [name, setName] = useState('')
+  const [name, setName] = useState(() => getDefaultCopyName(latestAgent.name))
   const [description, setDescription] = useState(latestAgent.description ?? '')
   const [role, setRole] = useState(latestAgent.role ?? '')
   const [iconPickerOpen, setIconPickerOpen] = useState(false)
@@ -68,11 +68,9 @@ export function DuplicateAgentDialog({
   const duplicateAgentMutation = useMutation(
     consoleQuery.agent.byAgentId.copy.post.mutationOptions(),
   )
-  const defaultCopyName = getDefaultCopyName(latestAgent.name)
-
   if (formKey !== renderedFormKey) {
     setRenderedFormKey(formKey)
-    setName('')
+    setName(getDefaultCopyName(latestAgent.name))
     setDescription(latestAgent.description ?? '')
     setRole(latestAgent.role ?? '')
     setIconPickerOpen(false)
@@ -91,7 +89,7 @@ export function DuplicateAgentDialog({
             },
           }),
         ) ?? agent
-      setName('')
+      setName(getDefaultCopyName(currentAgent.name))
       setDescription(currentAgent.description ?? '')
       setRole(currentAgent.role ?? '')
       setAgentIcon(createAgentIconSelection(currentAgent))
@@ -107,12 +105,12 @@ export function DuplicateAgentDialog({
     const trimmedName = formValues.name?.trim() ?? ''
     const trimmedRole = formValues.role?.trim() ?? ''
     const body: AgentAppCopyPayload = {
+      name: trimmedName,
       description: formValues.description?.trim() ?? '',
       role: trimmedRole,
       icon_type: agentIcon.type,
       icon: agentIcon.type === 'image' ? agentIcon.fileId : agentIcon.icon,
       icon_background: agentIcon.type === 'emoji' ? agentIcon.background : undefined,
-      ...(trimmedName ? { name: trimmedName } : {}),
     }
 
     duplicateAgentMutation.mutate(
@@ -180,22 +178,33 @@ export function DuplicateAgentDialog({
                   />
                 </button>
                 <div className="flex min-w-0 flex-1 gap-3 pb-1">
-                  <Field name="name" className="relative min-w-0 flex-1">
-                    <FieldLabel>
-                      {t(($) => $['roster.createForm.nameLabel'])}
-                      <span className="ml-1 system-xs-regular text-text-tertiary">
-                        {tCommon(($) => $['label.optional'])}
-                      </span>
-                    </FieldLabel>
+                  <Field
+                    name="name"
+                    className="relative min-w-0 flex-1"
+                    validate={(value) => {
+                      if (typeof value === 'string' && value.length > 0 && !value.trim())
+                        return t(($) => $['roster.createForm.nameRequired'])
+
+                      return null
+                    }}
+                  >
+                    <FieldLabel>{t(($) => $['roster.createForm.nameLabel'])}</FieldLabel>
                     <Input
                       autoComplete="off"
                       // oxlint-disable-next-line jsx-a11y/no-autofocus -- The duplicate dialog opens from an explicit command, and naming the copy is the primary editable action.
                       autoFocus
                       maxLength={255}
                       onValueChange={setName}
-                      placeholder={defaultCopyName}
+                      placeholder={t(($) => $['roster.createForm.namePlaceholder'])}
+                      required
                       value={name}
                     />
+                    <div className="absolute top-full left-0 mt-1">
+                      <FieldError match="valueMissing">
+                        {t(($) => $['roster.createForm.nameRequired'])}
+                      </FieldError>
+                      <FieldError match="customError" />
+                    </div>
                   </Field>
                   <Field name="role" className="relative min-w-0 flex-1">
                     <FieldLabel>


### PR DESCRIPTION
## Summary

- Prefill the duplicate-agent Name field with the generated `<agent> copy` value and submit it with the request.
- Remove the Optional indicator and validate Name consistently with other agent forms.
- Update roster tests to cover the generated name and submission behavior.

Fixes DIFY-2922

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.