### PR TITLE
fix(api): respect configured model params in prompt generator

### DIFF
--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -945,7 +945,7 @@ class LLMGenerator:
                 )
             ),
         ]
-        model_parameters = {"temperature": 0.4}
+        model_parameters, stop = _normalize_completion_params(model_config.completion_params)
 
         response: LLMResult | None = None
         error: str | None = None
@@ -954,7 +954,10 @@ class LLMGenerator:
         with measure_time() as timer:
             try:
                 response = model_instance.invoke_llm(
-                    prompt_messages=list(prompt_messages), model_parameters=model_parameters, stream=False
+                    prompt_messages=list(prompt_messages),
+                    model_parameters=model_parameters,
+                    stop=stop,
+                    stream=False,
                 )
                 generated_raw = response.message.get_text_content()
                 first_brace = generated_raw.find("{")


### PR DESCRIPTION
## Summary

The prompt generator's instruction-modify path discarded the model configuration it was handed and invoked the model with a hardcoded `temperature: 0.4`.

`__instruction_modify_common` received a `ModelConfig` but read only `.provider` and `.name` from it — `completion_params` was dropped on the floor. Two consequences:

1. Any temperature the user set in model settings was silently ignored.
2. Models whose accepted range excludes `0.4` failed outright. **qwen3.8-max requires `temperature >= 0.6`**, so the prompt generator errored on every request against it, while the same prompt succeeded on qwen3.7-max.

The parameters were already flowing correctly end to end — frontend `model.completion_params` → `InstructionGeneratePayload.model_config_data` → `instruction_modify_legacy` / `instruction_modify_workflow` — and were discarded only at the final invocation. No frontend or schema change is needed.

### Fix

Forward the caller's completion params, reusing the existing `_normalize_completion_params` helper already used elsewhere in this module, so this path also gets `stop` splitting and non-positive token-limit handling.

Notably there is **no `0.4` fallback** when params are empty. An unconfigured model sends `{}` and falls through to provider defaults — the same thing `generate_rule_config` (the from-scratch generator, which works today) already does. A fallback would have left the common case broken: a user who simply picks qwen3.8-max and hits generate without opening model settings sends `completion_params: {}`, and would still have received `0.4` and still errored.

### Verification

Reverting just this change and running the generator suites reproduces the failure as `{'temperature': 0.4} != {'temperature': 0.7}` — the user's value being overridden — and the empty-params case as `{'temperature': 0.4} != {}`, which is the reported qwen3.8-max regression exactly.

With the fix: 132 passing across `tests/unit_tests/core/llm_generator/`, `test_generator_api.py`, and `test_workflow_generator_service.py`. `ruff check` and `ruff format` clean; `mypy` reports no errors in the changed file.

Reported internally (Zendesk #4062); no corresponding public issue to link.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods