### PR TITLE
fix: preserve agent task editor focus when inserting commands

### DIFF
--- a/web/app/components/workflow/nodes/agent-v2/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/__tests__/panel.spec.tsx
@@ -3,6 +3,7 @@ import type { AgentV2NodeType } from '../types'
 import type { PromptEditorProps } from '@/app/components/base/prompt-editor'
 import type { NodePanelProps } from '@/app/components/workflow/types'
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { FlowType } from '@/types/common'
 import { AgentV2Panel } from '../panel'
@@ -1230,7 +1231,8 @@ describe('agent/panel', () => {
     expect(screen.queryByText('Clarification Drafter')).not.toBeInTheDocument()
   })
 
-  it('updates agent task and opens prompt insertion shortcuts', () => {
+  it('updates agent task and opens prompt insertion shortcuts', async () => {
+    const user = userEvent.setup()
     render(
       <AgentV2Panel
         id="agent-node"
@@ -1267,9 +1269,9 @@ describe('agent/panel', () => {
       screen.queryByRole('button', { name: 'workflow.nodes.agent.task.mention' }),
     ).not.toBeInTheDocument()
 
-    fireEvent.focus(editor)
+    await user.click(editor)
 
-    fireEvent.click(screen.getByRole('button', { name: 'workflow.nodes.agent.task.insert' }))
+    await user.click(screen.getByRole('button', { name: 'workflow.nodes.agent.task.insert' }))
     expect(mockEditorFocus).toHaveBeenCalled()
     expect(mockInsertNodes.mock.calls[0]?.[0]?.[0]?.getTextContent()).toBe('/')
     expect(

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-task-field.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-task-field.tsx
@@ -36,6 +36,7 @@ function AgentTaskToolbar({ taskLength, onInsert }: { taskLength: number; onInse
         <button
           type="button"
           className="flex items-center gap-1 system-xs-medium hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
+          onMouseDown={(event) => event.preventDefault()}
           onClick={handleInsert}
         >
           <span aria-hidden className="i-ri-slash-commands-2 size-3.5" />


### PR DESCRIPTION
## Summary

- Preserve the Agent Task editor focus when clicking Insert so the slash command is inserted correctly.
- Add regression coverage using the complete user click event sequence.

Fixes DIFY-2923

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.