### PR TITLE
ci: add HITL IM test environment deployment

### DIFF
--- a/.github/workflows/deploy-hitl-im-dev.yml
+++ b/.github/workflows/deploy-hitl-im-dev.yml
@@ -1,0 +1,25 @@
+name: Deploy HITL IM Dev
+
+on:
+  workflow_run:
+    workflows: ['Build and Push API & Web']
+    branches:
+      - 'build/feat/hitl-im-dev'
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: depot-ubuntu-24.04
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'build/feat/hitl-im-dev'
+    steps:
+      - name: Deploy to server
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.HITL_SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            ${{ vars.SSH_SCRIPT || secrets.SSH_SCRIPT }}


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using gpt-5.6-sol. I have reviewed and edited the final diff, and I am responsible for the content.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Add automatic deployment to the HITL IM test environment after `Build and Push API & Web` succeeds.
- Restrict deployment to the exact `build/feat/hitl-im-dev` branch with both the event filter and runtime guard.
- Use the existing HITL deployment naming and `HITL_SSH_HOST` with the shared SSH credentials and deployment script.

Fixes #41163.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

This workflow-only change does not affect documentation, backend code, or frontend code. It was validated with `actionlint` and YAML structure checks.

From Codex
