### PR TITLE
fix(api): respect configured model params in prompt generator (#41165)

### DIFF
--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -562,7 +562,7 @@ class LLMGenerator:
                 )
             ),
         ]
-        model_parameters = {"temperature": 0.4}
+        model_parameters = model_config.completion_params
 
         try:
             response: LLMResult = model_instance.invoke_llm(


### PR DESCRIPTION
Backport of #41165 to `lts/1.13.x`.

## Summary

The prompt generator's instruction-modify path discarded the model configuration it was handed and invoked the model with a hardcoded `temperature: 0.4`.

`__instruction_modify_common` received a `ModelConfig` but read only `.provider` and `.name` from it — `completion_params` was dropped. Two consequences:

1. Any temperature the user set in model settings was silently ignored.
2. Models whose accepted range excludes `0.4` failed outright. **qwen3.8-max requires `temperature >= 0.6`**, so the prompt generator errored on every request against it, while the same prompt succeeded on qwen3.7-max.

The parameters already flow correctly end to end and were discarded only at the final invocation. No frontend or schema change is needed.

## Not a clean cherry-pick

`git cherry-pick` of the main commit conflicts. On this branch:

- `_normalize_completion_params` does not exist (it is a newer helper on `main`),
- nothing in this module passes `stop` to `invoke_llm`,
- `__instruction_modify_common` lacks the `measure_time` / telemetry-emit refactor.

So the fix is adapted to this branch's own idiom — plain assignment, exactly as `generate_rule_config` and the other generators here already do (three existing sites in this file). The result is a one-line change rather than main's two hunks. Backporting the helper as well would have meant a materially larger diff on a stability branch, which did not seem worth it for this fix.

As on main, there is deliberately **no `0.4` fallback**: an unconfigured model sends `{}` and falls through to provider defaults. A fallback would leave the common case broken — a user who picks qwen3.8-max and hits generate without opening model settings sends `completion_params: {}` and would still receive `0.4` and still error.

## Verification

`tests/unit_tests/core/llm_generator/` — 75 passed on this branch. `ruff check` and `ruff format --check` clean on the changed file.

Note the repo pre-commit hook runs `ruff check --fix ./api` across the whole api tree, which on this branch reports 98 pre-existing errors unrelated to this change (and rewrites ~11 unrelated files). Those were excluded; this PR is the single-line change only.

Reported internally (Zendesk #4062); no corresponding public issue to link.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods