### PR TITLE
fix: keep pagination skeletons in app grid

### DIFF
--- a/web/app/components/apps/app-list-catalog.tsx
+++ b/web/app/components/apps/app-list-catalog.tsx
@@ -15,7 +15,6 @@ import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-qu
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { InfiniteScrollSentinel } from '@/app/components/base/infinite-scroll-sentinel'
-import { MAIN_NAV_APP_CARD_GRID_CLASS_NAME } from '@/app/components/main-nav/app-card-grid'
 import { STEP_BY_STEP_TOUR_TARGETS } from '@/app/components/step-by-step-tour/target-registry'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { consoleQuery } from '@/service/client'
@@ -209,35 +208,34 @@ function AppListCatalogContent({
               />
             )}
             {hasNextPage && (
-              <div className="relative col-span-full">
+              <>
+                <AppCardSkeleton count={3} />
+                {isFetchNextPageError && (
+                  <div
+                    className="absolute inset-x-0 bottom-0 flex h-40 items-center justify-center gap-2 bg-background-body system-xs-regular text-text-tertiary"
+                    role="alert"
+                  >
+                    <span>{t(($) => $['errorBoundary.title'], { ns: 'common' })}</span>
+                    <Button
+                      loading={isFetchingNextPage}
+                      size="small"
+                      variant="secondary"
+                      onClick={() => void onFetchNextPage()}
+                    >
+                      {t(($) => $['operation.retry'], { ns: 'common' })}
+                    </Button>
+                  </div>
+                )}
                 <InfiniteScrollSentinel
                   canLoadMore={!isFetching && !isFetchNextPageError}
+                  className="absolute inset-x-0 bottom-0"
                   onLoadMore={() => {
                     void onFetchNextPage()
                   }}
                   preloadDistance={getPreloadDistance}
                   scrollContainerRef={scrollViewportRef}
                 />
-                <div className={cn('relative gap-2.5', MAIN_NAV_APP_CARD_GRID_CLASS_NAME)}>
-                  <AppCardSkeleton count={3} />
-                  {isFetchNextPageError && (
-                    <div
-                      className="absolute inset-0 flex items-center justify-center gap-2 bg-background-body system-xs-regular text-text-tertiary"
-                      role="alert"
-                    >
-                      <span>{t(($) => $['errorBoundary.title'], { ns: 'common' })}</span>
-                      <Button
-                        loading={isFetchingNextPage}
-                        size="small"
-                        variant="secondary"
-                        onClick={() => void onFetchNextPage()}
-                      >
-                        {t(($) => $['operation.retry'], { ns: 'common' })}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              </div>
+              </>
             )}
           </div>
         </>


### PR DESCRIPTION
## Summary

- keep pagination skeletons as direct children of the Studio app card grid so they continue after the final real card
- keep three skeleton cards mounted whenever another page exists to avoid bottom-of-list layout shifts
- position the infinite-scroll sentinel and retry feedback outside grid flow without changing pagination ownership or query behavior

## UX and accessibility

- preserves the existing responsive CSS Grid behavior at every column count
- preserves the `role="alert"` retry feedback and loading button state
- keeps the sentinel hidden from assistive technology and anchored to the grid bottom

## Validation

- `pnpm --dir web exec vp test app/components/apps/__tests__/list.spec.tsx --project unit` (44 passed)
- `pnpm exec vp check web/app/components/apps/app-list-catalog.tsx`
- `pnpm exec vp lint web/app/components/apps/app-list-catalog.tsx`
- verified on `localhost:3000/apps`: at four columns, cards 29-30 and skeletons 1-2 share the same row; after loading 60 cards, three skeletons remain directly after the last card and the sentinel bottom matches the grid bottom
- full `pnpm --dir web type-check` remains blocked by pre-existing generated `.next/types` route errors (`AppRoutes`, `LayoutRoutes`, and `ParamMap`)

Fixes SNP-702

From Codex
