### PR TITLE
fix(agent): memoize and fail-open LOG provider icon enrichment

### DIFF
--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -45,8 +45,6 @@ class AgentMessageTransformer:
         node_id: str,
         node_execution_id: str,
     ) -> Generator[NodeEventBase, None, None]:
-        from core.plugin.impl.plugin import PluginInstaller
-
         message_stream = ToolFileMessageTransformer.transform_tool_invoke_messages(
             messages=messages,
             user_id=user_id,
@@ -62,6 +60,11 @@ class AgentMessageTransformer:
         agent_execution_metadata: Mapping[WorkflowNodeExecutionMetadataKey, Any] = {}
         llm_usage = LLMUsage.empty_usage()
         variables: dict[str, Any] = {}
+        # Per-execution cache for LOG provider icon enrichment. The AgentNode
+        # factory returns a shared AgentMessageTransformer instance, so a
+        # class-level cache would leak icons across concurrent runs; a
+        # function-local cache scopes the memoization to one transform() call.
+        provider_icon_cache: dict[str, tuple[str | Mapping[str, str], str | Mapping[str, str] | None]] = {}
 
         for message in message_stream:
             if message.type in {
@@ -194,35 +197,24 @@ class AgentMessageTransformer:
             elif message.type == ToolInvokeMessage.MessageType.LOG:
                 assert isinstance(message.message, ToolInvokeMessage.LogMessage)
                 if message.message.metadata:
-                    icon = tool_info.get("icon", "")
                     dict_metadata = dict(message.message.metadata)
-                    if dict_metadata.get("provider"):
-                        manager = PluginInstaller()
-                        plugins = manager.list_plugins(tenant_id)
+                    provider = dict_metadata.get("provider")
+                    if provider:
+                        # Fail open: any lookup failure (slow plugin daemon,
+                        # credential decryption error, schema conversion error)
+                        # must not affect Agent execution. A missing icon is
+                        # purely cosmetic, so we always fall through to the
+                        # seed icon from tool_info.
                         try:
-                            current_plugin = next(
-                                plugin
-                                for plugin in plugins
-                                if f"{plugin.plugin_id}/{plugin.name}" == dict_metadata["provider"]
+                            icon, icon_dark = self._resolve_provider_icons(
+                                provider=provider,
+                                user_id=user_id,
+                                tenant_id=tenant_id,
+                                seed_icon=tool_info.get("icon", ""),
+                                cache=provider_icon_cache,
                             )
-                            icon = current_plugin.declaration.icon
-                        except StopIteration:
-                            pass
-                        icon_dark = None
-                        try:
-                            builtin_tool = next(
-                                provider
-                                for provider in BuiltinToolManageService.list_builtin_tools(
-                                    user_id,
-                                    tenant_id,
-                                )
-                                if provider.name == dict_metadata["provider"]
-                            )
-                            icon = builtin_tool.icon
-                            icon_dark = builtin_tool.icon_dark
-                        except StopIteration:
-                            pass
-
+                        except Exception:
+                            icon, icon_dark = tool_info.get("icon", ""), None
                         dict_metadata["icon"] = icon
                         dict_metadata["icon_dark"] = icon_dark
                         message.message.metadata = dict_metadata
@@ -343,3 +335,54 @@ class AgentMessageTransformer:
                 access_controller=_file_access_controller,
             )
         return None
+
+    @staticmethod
+    def _resolve_provider_icons(
+        *,
+        provider: str,
+        user_id: str,
+        tenant_id: str,
+        seed_icon: str,
+        cache: dict[str, tuple[str | Mapping[str, str], str | Mapping[str, str] | None]],
+    ) -> tuple[str | Mapping[str, str], str | Mapping[str, str] | None]:
+        """Resolve (icon, icon_dark) for a LOG provider with per-execution memoization.
+
+        Fails open: a slow plugin daemon, credential decryption error, or any
+        other lookup failure returns (seed_icon, None) so decorative metadata
+        enrichment never affects Agent execution success.
+
+        Repeated LOG messages for the same provider within one execution reuse
+        the cached result instead of repeating the full plugin and built-in
+        provider scans.
+        """
+        cached = cache.get(provider)
+        if cached is not None:
+            return cached
+
+        icon: str | Mapping[str, str] = seed_icon
+        icon_dark: str | Mapping[str, str] | None = None
+
+        from core.plugin.impl.plugin import PluginInstaller
+
+        try:
+            plugins = PluginInstaller().list_plugins(tenant_id)
+        except Exception:
+            plugins = []
+        for plugin in plugins:
+            if f"{plugin.plugin_id}/{plugin.name}" == provider:
+                icon = plugin.declaration.icon
+                break
+
+        try:
+            providers = BuiltinToolManageService.list_builtin_tools(user_id, tenant_id)
+        except Exception:
+            providers = []
+        for built_in in providers:
+            if built_in.name == provider:
+                icon = built_in.icon
+                icon_dark = built_in.icon_dark
+                break
+
+        result = (icon, icon_dark)
+        cache[provider] = result
+        return result

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -194,3 +194,178 @@ def test_transform_keeps_plain_link_as_text() -> None:
 
     assert text == "Link: https://dify.ai\n"
     assert files.value == []
+
+
+def _log_message(provider: str) -> ToolInvokeMessage:
+    return ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LOG,
+        message=ToolInvokeMessage.LogMessage(
+            id="log-id",
+            label="",
+            parent_id=None,
+            error=None,
+            status=ToolInvokeMessage.LogMessage.LogStatus.START,
+            data={},
+            metadata={"provider": provider},
+        ),
+    )
+
+
+def _collect_log_metadata(messages: list[ToolInvokeMessage]) -> list[dict]:
+    events = list(
+        AgentMessageTransformer().transform(
+            messages=_message_stream(messages),
+            tool_info={"icon": "seed-icon"},
+            parameters_for_log={},
+            user_id="user-id",
+            tenant_id="tenant-id",
+            conversation_id=None,
+            node_type=BuiltinNodeTypes.AGENT,
+            node_id="node-id",
+            node_execution_id="execution-id",
+        )
+    )
+    return [
+        event.metadata
+        for event in events
+        if hasattr(event, "metadata") and getattr(event, "metadata", None) is not None
+    ]
+
+
+def test_log_icon_enrichment_uses_seed_when_provider_unknown() -> None:
+    with (
+        patch("core.plugin.impl.plugin.PluginInstaller") as plugin_installer,
+        patch(
+            "services.tools.builtin_tools_manage_service.BuiltinToolManageService.list_builtin_tools",
+            return_value=[],
+        ),
+    ):
+        result = _collect_log_metadata([_log_message("unknown/plugin")])
+
+    assert result
+    assert result[0]["icon"] == "seed-icon"
+    assert result[0]["icon_dark"] is None
+    # The plugin daemon was queried once (no cache hit) for the unknown provider
+    # and the builtins list was queried once.
+    plugin_installer.return_value.list_plugins.assert_called_once_with("tenant-id")
+
+
+def test_log_icon_enrichment_repeated_provider_uses_cache() -> None:
+    """Repeated LOG messages for the same provider must not re-scan plugins/builtins."""
+    plugin = SimpleNamespace(
+        plugin_id="plug",
+        name="tool",
+        declaration=SimpleNamespace(icon="plug-icon"),
+    )
+    built_in = SimpleNamespace(name="plug/tool", icon="built-in-icon", icon_dark="built-in-dark")
+
+    with (
+        patch("core.plugin.impl.plugin.PluginInstaller") as plugin_installer_cls,
+        patch(
+            "services.tools.builtin_tools_manage_service.BuiltinToolManageService.list_builtin_tools",
+            return_value=[built_in],
+        ) as list_builtin,
+    ):
+        plugin_installer_cls.return_value.list_plugins.return_value = [plugin]
+        result = _collect_log_metadata(
+            [_log_message("plug/tool"), _log_message("plug/tool"), _log_message("plug/tool")]
+        )
+
+    assert len(result) == 3
+    for metadata in result:
+        assert metadata["icon"] == "built-in-icon"
+        assert metadata["icon_dark"] == "built-in-dark"
+
+    # The plugin daemon must have been hit only once even though there were
+    # three LOG messages for the same provider.
+    plugin_installer_cls.return_value.list_plugins.assert_called_once_with("tenant-id")
+    list_builtin.assert_called_once_with("user-id", "tenant-id")
+
+
+def test_log_icon_enrichment_fails_open_when_plugin_daemon_unavailable() -> None:
+    built_in = SimpleNamespace(name="plug/tool", icon="built-in-icon", icon_dark="built-in-dark")
+
+    with (
+        patch("core.plugin.impl.plugin.PluginInstaller") as plugin_installer_cls,
+        patch(
+            "services.tools.builtin_tools_manage_service.BuiltinToolManageService.list_builtin_tools",
+            return_value=[built_in],
+        ),
+    ):
+        plugin_installer_cls.return_value.list_plugins.side_effect = RuntimeError("daemon down")
+        result = _collect_log_metadata([_log_message("plug/tool")])
+
+    assert result[0]["icon"] == "built-in-icon"
+    assert result[0]["icon_dark"] == "built-in-dark"
+
+
+def test_log_icon_enrichment_fails_open_when_builtin_service_unavailable() -> None:
+    plugin = SimpleNamespace(
+        plugin_id="plug",
+        name="tool",
+        declaration=SimpleNamespace(icon="plug-icon"),
+    )
+
+    with (
+        patch("core.plugin.impl.plugin.PluginInstaller") as plugin_installer_cls,
+        patch(
+            "services.tools.builtin_tools_manage_service.BuiltinToolManageService.list_builtin_tools",
+            side_effect=RuntimeError("decrypt boom"),
+        ),
+    ):
+        plugin_installer_cls.return_value.list_plugins.return_value = [plugin]
+        result = _collect_log_metadata([_log_message("plug/tool")])
+
+    assert result[0]["icon"] == "plug-icon"
+    assert result[0]["icon_dark"] is None
+
+
+def test_log_icon_enrichment_fails_open_when_both_lookups_raise() -> None:
+    with (
+        patch("core.plugin.impl.plugin.PluginInstaller") as plugin_installer_cls,
+        patch(
+            "services.tools.builtin_tools_manage_service.BuiltinToolManageService.list_builtin_tools",
+            side_effect=RuntimeError("decrypt boom"),
+        ),
+    ):
+        plugin_installer_cls.return_value.list_plugins.side_effect = RuntimeError("daemon down")
+        result = _collect_log_metadata([_log_message("plug/tool")])
+
+    assert result[0]["icon"] == "seed-icon"
+    assert result[0]["icon_dark"] is None
+
+
+def test_log_icon_enrichment_uses_plugin_icon_when_not_in_builtins() -> None:
+    plugin = SimpleNamespace(
+        plugin_id="plug",
+        name="tool",
+        declaration=SimpleNamespace(icon="plug-icon"),
+    )
+
+    with (
+        patch("core.plugin.impl.plugin.PluginInstaller") as plugin_installer_cls,
+        patch(
+            "services.tools.builtin_tools_manage_service.BuiltinToolManageService.list_builtin_tools",
+            return_value=[],
+        ),
+    ):
+        plugin_installer_cls.return_value.list_plugins.return_value = [plugin]
+        result = _collect_log_metadata([_log_message("plug/tool")])
+
+    assert result[0]["icon"] == "plug-icon"
+    assert result[0]["icon_dark"] is None
+
+
+def test_log_icon_enrichment_handles_uncaught_helper_failure() -> None:
+    """A bug in the helper itself must not break Agent execution."""
+    with patch.object(
+        AgentMessageTransformer,
+        "_resolve_provider_icons",
+        side_effect=RuntimeError("unexpected"),
+    ):
+        result = _collect_log_metadata([_log_message("plug/tool")])
+
+    # The transform should still complete and emit the LOG event; metadata
+    # falls back to the seed icon rather than the original (un-enriched) dict.
+    assert result[0]["icon"] == "seed-icon"
+    assert result[0]["icon_dark"] is None


### PR DESCRIPTION
## Summary

The Agent message transformer synchronously called
`PluginInstaller.list_plugins(tenant_id)` (which fetches page 1 of the
plugin daemon list, up to 256 entries) and
`BuiltinToolManageService.list_builtin_tools(user_id, tenant_id)`
(which enumerates every built-in provider controller, loads default
configurations, decrypts credentials, and converts every tool schema)
for every `LOG` message whose `metadata.provider` was set, only to
populate two presentation fields (`icon` and `icon_dark`).

This affected Agent execution on the hot path in three ways:

1. **Repeated work.** The same provider typically emits multiple `LOG`
   messages during one execution, and each one repeated both full
   scans. There was no per-execution memoization.

2. **Slow / unavailable plugin daemon, credential decryption error, or
   unrelated schema conversion failure in the built-in path all
   surfaced as `PluginDaemonClientSideError` at the AgentNode level,
   which `agent_node.py:_run` converted into a failed execution. A
   decorative icon lookup should never fail an Agent run.

3. **`icon` and `icon_dark` are display metadata only.** Forcing them
   to be resolvable before yielding the log event couples execution
   success to a presentation path.

## Fix

Extract icon resolution into a static helper
`_resolve_provider_icons` on `AgentMessageTransformer` that:

- Uses a **function-local cache** (`provider_icon_cache`) in
  `transform()`, not a class-level one, because the AgentNode factory
  returns a shared `AgentMessageTransformer` instance and a class-level
  cache would leak icons across concurrent runs.

- Catches any exception from `PluginInstaller.list_plugins` and from
  `BuiltinToolManageService.list_builtin_tools`, returning an empty
  list so the lookup degrades to "not found" rather than propagating.

- Caches the final `(icon, icon_dark)` tuple for each provider. Hits
  reuse the cached value without touching the plugin daemon or the
  built-in provider list.

- Is wrapped in an outer try/except in the LOG message branch as
  defense in depth: any uncaught failure in the helper (cache bug,
  unexpected return type, etc.) leaves the metadata with the seed
  icon from `tool_info` and `icon_dark=None` rather than raising.

## Behavior preserved

- When the provider is found in the plugin list, `icon` is set from
  the plugin declaration and `icon_dark` stays `None` (matches the
  pre-fix behavior).
- When the provider is found in the built-in list, both `icon` and
  `icon_dark` are set from the built-in entity.
- When the provider is not found in either list, `icon` keeps the
  agent-strategy seed icon from `tool_info["icon"]` and `icon_dark`
  stays `None`.
- The `LOG` event is still emitted with the resolved metadata; only
  the lookup cost and the failure surface change.

## Measured impact

Per the issue reporter's instrumentation, a single Agent `LOG`
emission for a non-empty `metadata.provider` triggered both
`list_plugins` and `list_builtin_tools` end-to-end. With this fix:

- The first emission for a given provider still pays the full lookup
  cost (same as pre-fix).
- Every subsequent emission for the same provider within one
  execution is a dict lookup, no I/O.
- A slow or unavailable plugin daemon no longer fails the run; the
  built-in path (or the seed icon from `tool_info`) covers it.
- A `decrypt_credentials=True` failure for one built-in provider no
  longer aborts the rest of the built-in list build and the Agent
  execution.

## Test coverage (7 new tests in `test_message_transformer.py`)

- `test_log_icon_enrichment_repeated_provider_uses_cache` - three
  LOG messages for the same provider hit `list_plugins` and
  `list_builtin_tools` only once.
- `test_log_icon_enrichment_fails_open_when_plugin_daemon_unavailable`
  - the built-in path still resolves when `list_plugins` raises.
- `test_log_icon_enrichment_fails_open_when_builtin_service_unavailable`
  - the plugin path still resolves when `list_builtin_tools` raises.
- `test_log_icon_enrichment_fails_open_when_both_lookups_raise` -
  both raise -> metadata falls back to the seed icon, no dark.
- `test_log_icon_enrichment_uses_plugin_icon_when_not_in_builtins`
  - provider in plugin only -> plugin icon, no dark.
- `test_log_icon_enrichment_uses_seed_when_provider_unknown` -
  provider unknown to both -> seed icon, no dark, plugin daemon
  queried once.
- `test_log_icon_enrichment_handles_uncaught_helper_failure` - a
  bug in the helper itself (uncaught exception) -> outer try/except
  recovers with the seed icon, log event still emitted.

## Verification

| step | tool | result |
|---|---|---|
| `ruff format --check` on the 2 touched files | ruff | 2 files already formatted |
| `ruff check` on the 2 touched files | ruff | All checks passed |
| `pytest tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py` | pytest 9 | 15 passed (8 existing + 7 new) |
| `pytest tests/unit_tests/core/workflow/` (regression) | pytest 9 | 1236 passed, 13 warnings, no new failures |
| `pyrefly check core/workflow/nodes/agent/message_transformer.py` | pyrefly 1.2.0 | 0 diagnostics |

## /consult-kiro note

Per repo policy I ran `/consult-kiro` on the diff before opening this
PR. The local OpenCode-Zen panel returned a `meta.degraded: true`
envelope with `ok_count: 0` of 3 models: two failed with
`No payment method` (workspace billing page required) and the third
hung in the model-build phase. I did not block on the missing second
opinion. The implementation is independently reviewed by the seven
new tests above and the existing 1236-workflow-test regression run.

## Out of scope (called out for the reviewer)

- A future hardening could move the icon enrichment into a
  post-execution `AgentLogEvent` transformer that runs in a
  background task. That would require a larger API change to the
  event shape and is a separate concern from the per-execution
  memoization + fail-open covered here.
- The same N+1 pattern may exist for other node types (tool nodes,
  knowledge retrieval nodes). This PR is scoped to the Agent LOG
  path that the issue flagged.

Fixes #41143
