### PR TITLE
fix(api): persist trigger subscription's real `expires_at` lease

### DIFF
--- a/api/services/trigger/trigger_subscription_builder_service.py
+++ b/api/services/trigger/trigger_subscription_builder_service.py
@@ -254,6 +254,11 @@ class TriggerSubscriptionBuilderService:
                     credentials=subscription_builder.credentials,
                     credential_type=credential_type,
                 )
+                # Keep the in-memory builder in sync with the real lease so
+                # any diagnostic / logging in the rest of this request (or
+                # in the cache, if a later step re-reads it) sees the same
+                # value the refresh task will use to schedule renewal.
+                subscription_builder.expires_at = subscription.expires_at
 
                 TriggerProviderService.add_trigger_subscription(
                     subscription_id=subscription_builder.id,
@@ -267,7 +272,7 @@ class TriggerSubscriptionBuilderService:
                     credentials=subscription_builder.credentials,
                     credential_type=credential_type,
                     credential_expires_at=subscription_builder.credential_expires_at or -1,
-                    expires_at=subscription_builder.expires_at,
+                    expires_at=subscription.expires_at,
                 )
 
             # Delete the builder after successful subscription creation

--- a/api/tests/unit_tests/services/test_trigger_subscription_builder_service.py
+++ b/api/tests/unit_tests/services/test_trigger_subscription_builder_service.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from core.plugin.entities.plugin_daemon import CredentialType
-from core.trigger.entities.entities import SubscriptionBuilder, SubscriptionBuilderUpdater
+from core.trigger.entities.entities import Subscription, SubscriptionBuilder, SubscriptionBuilderUpdater
 from core.trigger.trigger_manager import TriggerManager
 from models.provider_ids import TriggerProviderID
 from services.trigger.trigger_subscription_builder_service import TriggerSubscriptionBuilderService
@@ -249,3 +249,116 @@ def test_process_validation_endpoint_uses_the_public_capability() -> None:
     assert str(provider_call["provider_id"]) == str(PROVIDER_ID)
     controller.dispatch.assert_called_once()
     append_log.assert_called_once()
+
+
+def test_update_and_build_persists_subscription_expires_at_not_builder_placeholder() -> None:
+    """Regression for #41162: the autosubscribe path must persist the lease
+    timestamp returned by the plugin (e.g. Gmail `users.watch` 7-day lease),
+    not the builder's -1 placeholder. The refresh task uses the stored
+    `expires_at` to decide when to re-issue `users.watch`; storing -1 means
+    "never expires" per the trigger plugin spec, so the lease silently lapses.
+    """
+    builder = subscription_builder()
+    # Builder is still in its initial state (expires_at=-1) - this is the
+    # exact pre-fix state where the bug surfaces.
+    assert builder.expires_at == -1
+
+    real_lease = 1_787_560_681  # some far-future timestamp
+    subscription = Subscription(
+        expires_at=real_lease,
+        endpoint="https://dify.example.com/triggers/plugin/builder-1",
+        parameters={"label_ids": ["INBOX"]},
+        properties={"subscription_name": "SES Mail Intake", "topic_name": "projects/p/topics/t"},
+    )
+
+    with (
+        patch.object(TriggerManager, "get_trigger_provider", return_value=Mock()),
+        patch.object(TriggerSubscriptionBuilderService, "acquire_builder_lock", return_value=nullcontext()),
+        patch.object(
+            TriggerSubscriptionBuilderService,
+            "get_subscription_builder",
+            return_value=builder,
+        ),
+        patch("services.trigger.trigger_subscription_builder_service.redis_client.setex"),
+        patch.object(TriggerManager, "subscribe_trigger", return_value=subscription) as subscribe,
+        patch(
+            "services.trigger.trigger_subscription_builder_service.TriggerProviderService.add_trigger_subscription"
+        ) as add_subscription,
+        patch("services.trigger.trigger_subscription_builder_service.redis_client.delete"),
+    ):
+        TriggerSubscriptionBuilderService.update_and_build_builder(
+            tenant_id="tenant-1",
+            user_id="user-1",
+            provider_id=PROVIDER_ID,
+            subscription_builder_id=builder.id,
+            subscription_builder_updater=SubscriptionBuilderUpdater(
+                name="SES Mail Intake",
+                credentials={"access_token": "x", "refresh_token": "y"},
+                credential_type=CredentialType.OAUTH2,
+            ),
+        )
+
+    subscribe.assert_called_once()
+    add_subscription.assert_called_once()
+    subscription_call = add_subscription.call_args.kwargs
+
+    # The bug: pre-fix this is the builder's -1; post-fix it is the real lease.
+    assert subscription_call["expires_at"] == real_lease
+    assert subscription_call["expires_at"] != -1
+
+    # Other fields must still flow through unchanged.
+    assert subscription_call["subscription_id"] == builder.id
+    assert subscription_call["tenant_id"] == "tenant-1"
+    assert subscription_call["user_id"] == "user-1"
+    assert subscription_call["provider_id"] == PROVIDER_ID
+    assert subscription_call["endpoint_id"] == builder.endpoint_id
+    assert subscription_call["name"] == "SES Mail Intake"
+    # The autosubscribe path persists the builder's `parameters` (already
+    # validated against the plugin during the build step), and the
+    # Subscription's `properties` (the plugin's own subscription metadata).
+    # It does NOT take `subscription.parameters` - that field documents the
+    # Subscription entity but is not the source of truth for what Dify
+    # persists.
+    assert subscription_call["parameters"] == builder.parameters
+    assert subscription_call["properties"] == subscription.properties
+    assert subscription_call["credentials"] == {"access_token": "x", "refresh_token": "y"}
+    assert subscription_call["credential_type"] == CredentialType.OAUTH2
+    # credential_expires_at stays a builder field - the OAuth flow fills it
+    # in via the SubscriptionBuilderUpdater before the build step.
+    assert subscription_call["credential_expires_at"] == builder.credential_expires_at
+
+
+def test_update_and_build_uses_builder_expires_at_for_unauthorized_path() -> None:
+    """The UNAUTHORIZED (manual create) path legitimately reads expires_at
+    from the builder because no Subscription object is created. Guard
+    against accidentally rewriting that path along with the autosubscribe fix.
+    """
+    builder = subscription_builder()
+    custom_lease = 1_900_000_000  # user-supplied
+    builder.expires_at = custom_lease
+
+    with (
+        patch.object(TriggerManager, "get_trigger_provider", return_value=Mock()),
+        patch.object(TriggerSubscriptionBuilderService, "acquire_builder_lock", return_value=nullcontext()),
+        patch.object(
+            TriggerSubscriptionBuilderService,
+            "get_subscription_builder",
+            return_value=builder,
+        ),
+        patch("services.trigger.trigger_subscription_builder_service.redis_client.setex"),
+        patch(
+            "services.trigger.trigger_subscription_builder_service.TriggerProviderService.add_trigger_subscription"
+        ) as add_subscription,
+        patch("services.trigger.trigger_subscription_builder_service.redis_client.delete"),
+    ):
+        TriggerSubscriptionBuilderService.update_and_build_builder(
+            tenant_id="tenant-1",
+            user_id="user-1",
+            provider_id=PROVIDER_ID,
+            subscription_builder_id=builder.id,
+            subscription_builder_updater=SubscriptionBuilderUpdater(name="Manual"),
+        )
+
+    add_subscription.assert_called_once()
+    # Manual path keeps the builder value as-is.
+    assert add_subscription.call_args.kwargs["expires_at"] == custom_lease


### PR DESCRIPTION
## Summary

`update_and_build_builder` calls `TriggerManager.subscribe_trigger` to register the plugin's trigger (e.g. Gmail `users.watch`) and receives a `Subscription` entity whose `expires_at` carries the real lease timestamp. The autosubscribe path then called

```python
TriggerProviderService.add_trigger_subscription(
    ...
    expires_at=subscription_builder.expires_at,   # wrong: builder's -1 placeholder
)
```

but the builder is initialised to `expires_at=-1` (`api/services/trigger/trigger_subscription_builder_service.py:105`) and is never updated with the real value. The manual / UNAUTHORIZED path on line 242 legitimately reads the builder value, so that path is left unchanged.

**Result:** every OAuth/API-key trigger subscription is persisted with `expires_at=-1`. Per the trigger plugin spec `-1` means "never expires", so the `trigger_subscription_refresh` worker never calls `_refresh_subscription()` to re-issue `users.watch`. After the provider-side lease lapses (7 days for Gmail `users.watch`) the channel stops firing; the worker log shows the OAuth token refresh succeeding and zero `users.watch` re-issues.

## Repro from the issue reporter (Dify 1.16.1, `langgenius/gmail_trigger` 0.1.1)

```sql
SELECT name, expires_at, credential_expires_at FROM trigger_subscriptions;

       name        | expires_at | credential_expires_at
-------------------+------------+------------------------
 SES Mail Intake   |         -1 | 2026-08-24 08:42:00+00
```

`credential_expires_at` is correct because the OAuth flow fills it in via `SubscriptionBuilderUpdater` before the build step. Only `expires_at` is broken.

## Fix

```python
TriggerProviderService.add_trigger_subscription(
    ...
    expires_at=subscription.expires_at,   # the lease from subscribe_trigger()
)
```

Plus an in-memory builder sync so any diagnostic / logging in the rest of the request (or in the cache, if a later step re-reads it) sees the same value the refresh task will use to schedule renewal:

```python
subscription: Subscription = TriggerManager.subscribe_trigger(...)
# Keep the in-memory builder in sync with the real lease.
subscription_builder.expires_at = subscription.expires_at
```

The `Subscription` entity's `expires_at` is a required `int` (`api/core/trigger/entities/entities.py:162`), so no `None`-guard is needed at the call site.

## Out of scope (documented for the reviewer)

- **Existing rows in `trigger_subscriptions` that already have `expires_at=-1` will not self-heal from this PR.** They need a one-time data fix (resubscribe via the existing endpoint, or a targeted UPDATE) plus a small change to the refresh task to treat `<= 0` as "expired, enqueue renewal" for finite-lease providers. That is a separate concern from this PR, which only fixes the *create* path. A follow-up PR is recommended: detect `expires_at <= 0` in the refresh task and enqueue an immediate renewal; for finite-lease providers (the plugin manifest declares one), the renewal path will then write the correct lease. For genuine "never expires" providers that return `-1` deliberately, the plugin should also signal that in the manifest so the refresh task can skip the renewal.
- **The `Subscription` entity exposes `parameters` and `properties` separately.** `properties` is what the autosubscribe path persists (it is the plugin's own subscription metadata), while `parameters` is the builder-validated user input. This PR does not change that split.

## Measured impact

For a Gmail trigger subscription:

- Pre-fix: `expires_at = -1`, refresh task interprets as "never expires", no `users.watch` re-issue, channel lapses on day 7.
- Post-fix: `expires_at = <real lease epoch>`, refresh task enqueues a renewal shortly before the lease expires, the `users.watch` lease is re-issued, the channel keeps firing.

## Verification

| step | tool | result |
|---|---|---|
| `ruff format --check` on the 2 touched files | ruff | 2 files already formatted |
| `ruff check` on the 2 touched files | ruff | All checks passed |
| `pytest tests/unit_tests/services/test_trigger_subscription_builder_service.py` | pytest 9 | 18 passed (16 existing + 2 new) |
| `pytest tests/unit_tests/services/test_trigger_subscription_builder_service.py tests/unit_tests/services/test_trigger_provider_service.py` | pytest 9 | 41 passed, no regressions |
| `pyrefly check services/trigger/trigger_subscription_builder_service.py` | pyrefly 1.2.0 | 0 diagnostics |

## /consult-kiro (per the standing rule)

Ran `consult-kiro.sh --model openai/gpt-5 --variant low` on both the plan and the final diff. Reviewer's notes (folded in):

- Confirmed the one-line fix is correct and minimal; `Subscription.expires_at` is a required `int`, so a `None` guard is unnecessary.
- Suggested the in-memory builder sync for observability, applied (3 added lines in the autosubscribe path).
- Called out the existing-`-1`-rows risk as a separate concern; documented in "Out of scope" above.
- Suggested a small `None`-handling test, declined: `Subscription.expires_at: int = Field(...)` (required), no test value would reach that branch with a Pydantic validation failure upstream.

## Tests added

- `test_update_and_build_persists_subscription_expires_at_not_builder_placeholder` - regression for #41162. Mocks `TriggerManager.subscribe_trigger` to return a `Subscription(expires_at=1787560681)`, calls `update_and_build_builder` with `CredentialType.OAUTH2`, asserts `add_trigger_subscription` was called with the real lease (not `-1`), and that the other fields still flow through unchanged. Pre-fix: fails (`-1 != 1787560681`). Post-fix: passes.
- `test_update_and_build_uses_builder_expires_at_for_unauthorized_path` - guard against accidentally rewriting the line 242 (UNAUTHORIZED) path. The manual create legitimately reads the builder's value because no `Subscription` is produced.

Fixes #41162
