### PR TITLE
fix: avoid copy-sensitive agent file toast assertion

### DIFF
--- a/e2e/features/step-definitions/agent-v2/files.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/files.steps.ts
@@ -62,8 +62,9 @@ Then(
   async function (this: DifyWorld) {
     const page = this.getPage()
     const dialog = page.getByRole('dialog', { name: 'Upload file' })
+    const notifications = page.getByRole('region', { name: 'Notifications' })
 
-    await expect(page.getByText('Upload one file.')).toBeVisible()
+    await expect(notifications.getByRole('dialog')).toBeVisible()
     await expect(dialog.getByRole('button', { name: 'Upload' })).toBeDisabled()
     await expect(
       dialog.getByText(agentBuilderTestMaterials.smallFile, { exact: true }),


### PR DESCRIPTION
## Summary

- Replace the Agent v2 multi-file upload rejection assertion that depended on mutable copy with semantic notification roles.
- Preserve checks that upload stays disabled and rejected filenames are not added.

Fixes DIFY-2943

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.