### PR TITLE
fix: failed e2e test in agent caused by changed copywriting

### DIFF
--- a/e2e/features/step-definitions/agent-v2/build-draft.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/build-draft.steps.ts
@@ -280,10 +280,9 @@ Then('I should see the Agent v2 Build mode confirmation state', async function (
 
   await expect(page.getByText('Build mode', { exact: true })).toBeVisible()
   await expect(
-    page.getByText('Configure can only be updated by the agent in this mode.'),
-  ).toBeVisible()
-  await expect(
-    page.getByText('Shape this setup through the chat on the right, then Apply.'),
+    page.getByText(
+      "You're in Build mode. Shape this setup by chatting with the agent, then Apply.",
+    ),
   ).toBeVisible()
 })
 


### PR DESCRIPTION
## Summary

- Update the Agent v2 Build mode confirmation assertion to match the revised UI copy.
- Preserve E2E coverage for the Build mode badge and guidance message.

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.