### PR TITLE
feat(tools): add Annolux curated bilingual search provider

### DIFF
--- a/api/core/tools/provider/builtin/annolux/_assets/icon.svg
+++ b/api/core/tools/provider/builtin/annolux/_assets/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- Minimalist Pure Dark Canvas -->
+  <rect width="512" height="512" rx="112" fill="#090a0f"/>
+
+  <!-- Anno Orbital Ring with 45-degree Lux Slit (Mathematical Pure Geometry) -->
+  <path d="M 256 64 A 192 192 0 1 1 391.76 120.24 L 340.85 171.15 A 120 120 0 1 0 256 136 A 120 120 0 0 0 171.15 340.85 L 120.24 391.76 A 192 192 0 0 1 256 64 Z" fill="#f8fafc"/>
+
+  <!-- 45-degree Lux Egress Photon Ray -->
+  <path d="M 368 84 L 436 152 L 400 188 L 332 120 Z" fill="#f59e0b"/>
+
+  <!-- Central Lux Singularity Photon -->
+  <circle cx="256" cy="256" r="44" fill="#f8fafc"/>
+</svg>

--- a/api/core/tools/provider/builtin/annolux/annolux.yaml
+++ b/api/core/tools/provider/builtin/annolux/annolux.yaml
@@ -1,0 +1,23 @@
+identity:
+  name: annolux
+  author: Annolux
+  label:
+    en_US: Annolux Search
+    zh_Hans: Annolux 搜索
+  description:
+    en_US: Curated English and Chinese technical search with verified snapshot timestamps for AI Agents.
+    zh_Hans: 面向 AI Agent 与 RAG 的中英双语精选搜索，带显式 fetched_at 快照时间戳。
+  icon: _assets/icon.svg
+credentials_for_provider:
+  api_key:
+    type: secret-input
+    required: true
+    label:
+      en_US: API Key
+      zh_Hans: API 密钥
+    placeholder:
+      en_US: Enter your Annolux API key (starts with ann_live_)
+      zh_Hans: 输入以 ann_live_ 开头的 Annolux API Key
+    help:
+      en_US: Get your API key from https://annolux.com/account
+      zh_Hans: 在 https://annolux.com/account 获取 API Key

--- a/api/core/tools/provider/builtin/annolux/tools/annolux_search.py
+++ b/api/core/tools/provider/builtin/annolux/tools/annolux_search.py
@@ -1,0 +1,83 @@
+from typing import Any, Dict, List, Union
+import requests
+
+try:
+    from core.tools.entities.tool_entities import ToolInvokeMessage
+    from core.tools.tool.builtin_tool import BuiltinTool
+except ImportError:
+    class BuiltinTool:  # type: ignore
+        pass
+
+    class ToolInvokeMessage:  # type: ignore
+        @classmethod
+        def create_text_message(cls, text: str):
+            return {"type": "text", "message": text}
+
+        @classmethod
+        def create_json_message(cls, data: dict):
+            return {"type": "json", "message": data}
+
+
+class AnnoluxSearchTool(BuiltinTool):
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: Dict[str, Any],
+    ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+        """Invoke the Annolux search tool."""
+        api_key = self.runtime.credentials.get("api_key")
+        if not api_key:
+            return self.create_text_message("Error: Annolux API key not configured in provider credentials.")
+
+        query = tool_parameters.get("query")
+        if not query:
+            return self.create_text_message("Error: query parameter is required.")
+
+        limit = tool_parameters.get("limit", 5)
+        domains_str = tool_parameters.get("domains", "")
+
+        payload: Dict[str, Any] = {
+            "query": query,
+            "limit": min(max(1, int(limit)), 10),
+            "deduplicate": True,
+            "ranking": "default",
+        }
+        if domains_str and domains_str.strip():
+            payload["domains"] = [d.strip() for d in domains_str.split(",") if d.strip()]
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "dify-builtin-annolux/0.1.0",
+        }
+
+        try:
+            response = requests.post(
+                "https://api.annolux.com/v1/search",
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException as e:
+            return self.create_text_message(f"Annolux Search API Error: {str(e)}")
+
+        results = data.get("results", [])
+        if not results:
+            return self.create_text_message(f"No results found on Annolux for query: {query}")
+
+        return [
+            self.create_json_message({
+                "results": [
+                    {
+                        "title": r.get("title", ""),
+                        "url": r.get("url", ""),
+                        "snippet": r.get("snippet", ""),
+                        "fetched_at": r.get("fetched_at", ""),
+                        "domain": r.get("domain", ""),
+                    }
+                    for r in results
+                ]
+            })
+        ]

--- a/api/core/tools/provider/builtin/annolux/tools/annolux_search.yaml
+++ b/api/core/tools/provider/builtin/annolux/tools/annolux_search.yaml
@@ -1,0 +1,46 @@
+identity:
+  name: annolux_search
+  author: Annolux
+  label:
+    en_US: Annolux Web Search
+    zh_Hans: Annolux 网页搜索
+description:
+  human:
+    en_US: Search curated English and Chinese technical corpus with explicit snapshot timestamps.
+    zh_Hans: 检索精选中英双语高信噪比网页，返回带快照时间戳的准确知识。
+  llm: A curated web search tool for technical documentation, developer topics, and real-time facts with explicit fetched_at dates.
+parameters:
+  - name: query
+    type: string
+    required: true
+    label:
+      en_US: Query
+      zh_Hans: 搜索词
+    human_description:
+      en_US: Natural language search query
+      zh_Hans: 自然语言检索词
+    llm_description: The search query to look up on the web.
+    form: llm
+  - name: limit
+    type: number
+    required: false
+    default: 5
+    min: 1
+    max: 10
+    label:
+      en_US: Result Limit
+      zh_Hans: 返回条数
+    human_description:
+      en_US: Number of results to return (1-10)
+      zh_Hans: 返回结果最大数量（1至10）
+    form: form
+  - name: domains
+    type: string
+    required: false
+    label:
+      en_US: Domain Filter
+      zh_Hans: 域名过滤
+    human_description:
+      en_US: Comma-separated list of domains to filter (e.g. docs.rs, go.dev)
+      zh_Hans: 逗号分隔的域名白名单过滤（如 docs.rs, go.dev）
+    form: form


### PR DESCRIPTION
## Summary
Adds `annolux` as a built-in search tool provider under `api/core/tools/provider/builtin/annolux/`.

[Annolux](https://annolux.com) is a curated English and Chinese web search engine built specifically for AI Agents and RAG systems. Every search snippet includes an immutable `fetched_at` snapshot date to eliminate temporal hallucinations.

## Key Features
- High-signal curated bilingual (EN/ZH) technical and knowledge index (0 SEO spam).
- Explicit `fetched_at` provenance on all results.
- Zero cost on timeouts or upstream errors.

## Verification
- Verified provider schema and parameters (`query`, `limit`, `domains`).
- Tested with standard tool invocation lifecycle.