### PR TITLE
fix(web): restore model selector popup spacing

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup-layout.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup-layout.tsx
@@ -22,13 +22,14 @@ export function ModelSelectorSearchHeader({
   const { t } = useTranslation()
 
   return (
-    <SearchInput
-      aria-label={t(($) => $['form.searchModel'], { ns: 'datasetSettings' }) || ''}
-      className="mx-2 mt-2 mb-1 shrink-0"
-      placeholder={t(($) => $['form.searchModel'], { ns: 'datasetSettings' }) || ''}
-      value={inputValue}
-      onValueChange={onInputValueChange}
-    />
+    <div className="shrink-0 bg-components-panel-bg px-2 pt-2 pb-1">
+      <SearchInput
+        aria-label={t(($) => $['form.searchModel'], { ns: 'datasetSettings' }) || ''}
+        placeholder={t(($) => $['form.searchModel'], { ns: 'datasetSettings' }) || ''}
+        value={inputValue}
+        onValueChange={onInputValueChange}
+      />
+    </div>
   )
 }
 

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/quota-panel.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/quota-panel.tsx
@@ -52,7 +52,7 @@ const QuotaInfotip: FC<QuotaInfotipProps> = ({ tipText }) => {
         closeDelay={200}
         aria-label={tipText}
         onClick={handleClick}
-        className="ml-0.5 inline-flex size-3 shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 focus-visible:ring-1 focus-visible:ring-components-input-border-hover focus-visible:outline-hidden"
+        className="ml-0.5 inline-flex size-3 shrink-0 cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
       >
         <span
           aria-hidden


### PR DESCRIPTION
## Summary

- restore the model selector search header as the owner of its horizontal padding
- keep the existing Popover placement and anchor-width strategy unchanged
- align the internal search gutter with the 8px spacing in the Figma design
- strengthen the Quota infotip trigger focus-visible indicator without changing its Popover structure

## Root cause

PR #40826 replaced the padded search-header wrapper with a full-width `SearchInput` carrying horizontal margins. Because the underlying `InputGroup` is `w-full`, the margins expanded its used width beyond the popup and were clipped by the popup overflow boundary.