### PR TITLE
fix(web): stop digits rendering in the emoji font

### DIFF
--- a/web/app/styles/tailwind-core.css
+++ b/web/app/styles/tailwind-core.css
@@ -56,8 +56,9 @@
    * Reordering does not help — what matters is that they are named at all.
    * Real emoji still render through per-character fallback.
    */
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', 'Noto Sans', Arial, sans-serif;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', Arial,
+    sans-serif;
 }
 
 /* Background-image / gradient utilities. Values resolve at runtime from

--- a/web/app/styles/tailwind-core.css
+++ b/web/app/styles/tailwind-core.css
@@ -42,6 +42,22 @@
 
   /* Custom animations. */
   --animate-spin-slow: spin 2s linear infinite;
+
+  /* Own --font-sans without the emoji families.
+   *
+   * Digits 0-9 carry the Unicode Emoji=Yes property (they are the base
+   * characters for keycap sequences), so Noto Color Emoji has glyphs for them.
+   * When an emoji font is named explicitly in font-family, Chromium routes
+   * those characters to it even when an earlier family covers them, and on
+   * Linux the digits end up rendered as wide, heavy emoji glyphs.
+   *
+   * Tailwind's default stack (changed in 4.3.3, see
+   * tailwindlabs/tailwindcss#20348) lists the emoji families at the end.
+   * Reordering does not help — what matters is that they are named at all.
+   * Real emoji still render through per-character fallback.
+   */
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', 'Noto Sans', Arial, sans-serif;
 }
 
 /* Background-image / gradient utilities. Values resolve at runtime from


### PR DESCRIPTION
## Summary

On Linux, digits render with heavy, wide glyphs pulled from an emoji font instead of the regular sans font — dates in tables (e.g. `24.08.2026`) show up spaced out, table headers no longer fit their columns, and body text has uneven word spacing.

Digits `0`–`9` carry the Unicode `Emoji=Yes` property (they're the base characters for keycap sequences like 0️⃣–9️⃣), so `Noto Color Emoji` has glyphs for them. When an emoji font is named explicitly anywhere in `font-family`, Chromium routes those characters to it even when an earlier family in the stack already covers them.

Dify inherits Tailwind's default `--font-sans`, which lists emoji families at the end. Tailwind 4.3.3 changed that default in a patch release (tailwindlabs/tailwindcss#20348), and the new stack starts with `-apple-system`, which resolves to nothing on Linux — shifting Chromium's fallback path so the emoji font wins for digits. Dify moved from Tailwind 4.3.1 to 4.3.3 between 1.15.0 and 1.16.1, which is when this became visible.

This PR declares an explicit `--font-sans` in the project's `@theme` block without the emoji families. Reordering them to the end doesn't help since they're already last — what matters is that they're named at all. Real emoji continue to render correctly through per-character fallback (verified in chat for both user input and model output).

Fixes #41200

## Test plan

- [x] Verified the affected `@theme` token block in `web/app/styles/tailwind-core.css` and confirmed the diff touches only that file
- [x] Confirmed real emoji still render via per-character fallback in chat, for both user input and model output
