### PR TITLE
fix(api): reserve the app when starting an annotation reply job

### DIFF
--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -89,6 +89,20 @@ class UpdateAnnotationSettingArgs(TypedDict):
     score_threshold: float
 
 
+# Annotation reply jobs reserve their app for this long. It matches the TTL the
+# workers use for terminal job statuses, so a reservation cannot outlive the job
+# it guards even if a worker dies before releasing it.
+ANNOTATION_JOB_TTL = 600
+
+
+def _running_job_id(reservation_key: str) -> str:
+    """Job id currently holding *reservation_key*, or "" if it just expired."""
+    reserved = redis_client.get(reservation_key)
+    if reserved is None:
+        return ""
+    return reserved.decode() if isinstance(reserved, bytes) else str(reserved)
+
+
 class AppAnnotationService:
     @staticmethod
     def _get_annotation_by_ref(annotation_ref: AnnotationRef, session: Session) -> MessageAnnotation | None:
@@ -177,41 +191,51 @@ class AppAnnotationService:
     @classmethod
     def enable_app_annotation(cls, args: EnableAnnotationArgs, app_id: str) -> AnnotationJobStatusDict:
         enable_app_annotation_key = f"enable_app_annotation_{app_id}"
-        cache_result = redis_client.get(enable_app_annotation_key)
-        if cache_result is not None:
-            return {"job_id": cache_result, "job_status": "processing"}
+        job_id = str(uuid.uuid4())
+        # Reserve the app before enqueueing so a second request reuses the in-flight
+        # job instead of starting a task that rebuilds the same annotation index.
+        if not redis_client.set(enable_app_annotation_key, job_id, nx=True, ex=ANNOTATION_JOB_TTL):
+            return {"job_id": _running_job_id(enable_app_annotation_key), "job_status": "processing"}
 
         # async job
-        job_id = str(uuid.uuid4())
         enable_app_annotation_job_key = f"enable_app_annotation_job_{job_id}"
         # send batch add segments task
-        redis_client.setnx(enable_app_annotation_job_key, "waiting")
+        redis_client.set(enable_app_annotation_job_key, "waiting", ex=ANNOTATION_JOB_TTL)
         current_user, current_tenant_id = current_account_with_tenant()
-        enable_annotation_reply_task.delay(
-            job_id,
-            app_id,
-            current_user.id,
-            current_tenant_id,
-            args["score_threshold"],
-            args["embedding_provider_name"],
-            args["embedding_model_name"],
-        )
+        try:
+            enable_annotation_reply_task.delay(
+                job_id,
+                app_id,
+                current_user.id,
+                current_tenant_id,
+                args["score_threshold"],
+                args["embedding_provider_name"],
+                args["embedding_model_name"],
+            )
+        except Exception:
+            redis_client.delete(enable_app_annotation_key)
+            redis_client.delete(enable_app_annotation_job_key)
+            raise
         return {"job_id": job_id, "job_status": "waiting"}
 
     @classmethod
     def disable_app_annotation(cls, app_id: str) -> AnnotationJobStatusDict:
         _, current_tenant_id = current_account_with_tenant()
         disable_app_annotation_key = f"disable_app_annotation_{app_id}"
-        cache_result = redis_client.get(disable_app_annotation_key)
-        if cache_result is not None:
-            return {"job_id": cache_result, "job_status": "processing"}
+        job_id = str(uuid.uuid4())
+        if not redis_client.set(disable_app_annotation_key, job_id, nx=True, ex=ANNOTATION_JOB_TTL):
+            return {"job_id": _running_job_id(disable_app_annotation_key), "job_status": "processing"}
 
         # async job
-        job_id = str(uuid.uuid4())
         disable_app_annotation_job_key = f"disable_app_annotation_job_{job_id}"
         # send batch add segments task
-        redis_client.setnx(disable_app_annotation_job_key, "waiting")
-        disable_annotation_reply_task.delay(job_id, app_id, current_tenant_id)
+        redis_client.set(disable_app_annotation_job_key, "waiting", ex=ANNOTATION_JOB_TTL)
+        try:
+            disable_annotation_reply_task.delay(job_id, app_id, current_tenant_id)
+        except Exception:
+            redis_client.delete(disable_app_annotation_key)
+            redis_client.delete(disable_app_annotation_job_key)
+            raise
         return {"job_id": job_id, "job_status": "waiting"}
 
     @classmethod

--- a/api/tasks/annotation/disable_annotation_reply_task.py
+++ b/api/tasks/annotation/disable_annotation_reply_task.py
@@ -28,8 +28,18 @@ def disable_annotation_reply_task(job_id: str, app_id: str, tenant_id: str):
             select(App).where(App.id == app_id, App.tenant_id == tenant_id, App.status == "normal").limit(1)
         )
         annotations_exists = session.scalar(select(exists().where(MessageAnnotation.app_id == app_id)))
+        disable_app_annotation_key = f"disable_app_annotation_{str(app_id)}"
+        disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
+
+        def _finish_early(message: str) -> None:
+            """Record a terminal status so the caller stops polling "waiting"."""
+            logger.info(click.style(message, fg="red"))
+            redis_client.setex(disable_app_annotation_job_key, 600, "error")
+            redis_client.setex(f"disable_app_annotation_error_{str(job_id)}", 600, message)
+            redis_client.delete(disable_app_annotation_key)
+
         if not app:
-            logger.info(click.style(f"App not found: {app_id}", fg="red"))
+            _finish_early(f"App not found: {app_id}")
             return
 
         app_annotation_setting = session.scalar(
@@ -37,11 +47,8 @@ def disable_annotation_reply_task(job_id: str, app_id: str, tenant_id: str):
         )
 
         if not app_annotation_setting:
-            logger.info(click.style(f"App annotation setting not found: {app_id}", fg="red"))
+            _finish_early(f"App annotation setting not found: {app_id}")
             return
-
-        disable_app_annotation_key = f"disable_app_annotation_{str(app_id)}"
-        disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
 
         try:
             dataset = Dataset(

--- a/api/tasks/annotation/enable_annotation_reply_task.py
+++ b/api/tasks/annotation/enable_annotation_reply_task.py
@@ -40,13 +40,19 @@ def enable_annotation_reply_task(
             select(App).where(App.id == app_id, App.tenant_id == tenant_id, App.status == "normal").limit(1)
         )
 
+        enable_app_annotation_key = f"enable_app_annotation_{str(app_id)}"
+        enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
+
         if not app:
             logger.info(click.style(f"App not found: {app_id}", fg="red"))
+            # Leave a terminal status behind: the caller polls this key and would
+            # otherwise see "waiting" forever.
+            redis_client.setex(enable_app_annotation_job_key, 600, "error")
+            redis_client.setex(f"enable_app_annotation_error_{str(job_id)}", 600, f"App not found: {app_id}")
+            redis_client.delete(enable_app_annotation_key)
             return
 
         annotations = session.scalars(select(MessageAnnotation).where(MessageAnnotation.app_id == app_id)).all()
-        enable_app_annotation_key = f"enable_app_annotation_{str(app_id)}"
-        enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
 
         try:
             documents = []

--- a/api/tests/test_containers_integration_tests/services/test_annotation_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_annotation_service.py
@@ -728,7 +728,9 @@ class TestAnnotationService:
         result = AppAnnotationService.enable_app_annotation(enable_args, app.id)
 
         # Verify cached result
-        assert cached_job_id == result["job_id"].decode("utf-8")
+        # `AnnotationJobStatusDict` declares `job_id: str`, and the controller feeds this dict
+        # straight into `dump_response(AnnotationJobStatusResponse, ...)`, so it has to be a str.
+        assert cached_job_id == result["job_id"]
         assert result["job_status"] == "processing"
 
         # Verify task was not called again

--- a/api/tests/unit_tests/services/test_annotation_service.py
+++ b/api/tests/unit_tests/services/test_annotation_service.py
@@ -316,56 +316,105 @@ class TestAppAnnotationServiceUpsert:
         task.delay.assert_called_once_with(result.id, "q1", TENANT_ID, app.id, setting.collection_binding_id)
 
 
+class _FakeRedis:
+    """Redis stand-in covering the SET NX / GET / DELETE surface the annotation
+    job reservations rely on."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.ttls: dict[str, int] = {}
+
+    def set(self, key, value, nx: bool = False, ex: int | None = None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = str(value).encode()
+        if ex is not None:
+            self.ttls[key] = ex
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def delete(self, key):
+        self.store.pop(key, None)
+        self.ttls.pop(key, None)
+        return 1
+
+
 class TestAppAnnotationServiceEnableDisable:
-    def test_enable_returns_processing_on_cache_hit(self, current_user: Account) -> None:
-        args = {"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"}
-        with (
-            patch.object(annotation_service_module, "redis_client") as redis,
-            patch.object(annotation_service_module, "enable_annotation_reply_task") as task,
-        ):
-            redis.get.return_value = "job-1"
-            result = AppAnnotationService.enable_app_annotation(args, "app-1")
+    ENABLE_ARGS = {"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"}
 
-        assert result == {"job_id": "job-1", "job_status": "processing"}
-        task.delay.assert_not_called()
+    @pytest.fixture
+    def redis(self, monkeypatch: pytest.MonkeyPatch) -> _FakeRedis:
+        fake = _FakeRedis()
+        monkeypatch.setattr(annotation_service_module, "redis_client", fake)
+        return fake
 
-    def test_enable_enqueues_on_cache_miss(self, current_user: Account) -> None:
-        args = {"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"}
-        with (
-            patch.object(annotation_service_module, "redis_client") as redis,
-            patch.object(annotation_service_module.uuid, "uuid4", return_value="uuid-1"),
-            patch.object(annotation_service_module, "enable_annotation_reply_task") as task,
-        ):
-            redis.get.return_value = None
-            result = AppAnnotationService.enable_app_annotation(args, "app-1")
+    def test_enable_enqueues_and_reserves_the_app(
+        self, redis: _FakeRedis, current_user: Account, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        task = MagicMock()
+        monkeypatch.setattr(annotation_service_module, "enable_annotation_reply_task", task)
+        monkeypatch.setattr(annotation_service_module.uuid, "uuid4", lambda: "uuid-1")
+
+        result = AppAnnotationService.enable_app_annotation(cast(Any, self.ENABLE_ARGS), "app-1")
 
         assert result == {"job_id": "uuid-1", "job_status": "waiting"}
-        redis.setnx.assert_called_once_with("enable_app_annotation_job_uuid-1", "waiting")
         task.delay.assert_called_once_with("uuid-1", "app-1", current_user.id, TENANT_ID, 0.5, "p", "m")
+        # The reservation is what makes the guard above effective; it was never
+        # written before, so every request enqueued another rebuild of the index.
+        assert redis.get("enable_app_annotation_app-1") == b"uuid-1"
+        assert redis.ttls["enable_app_annotation_app-1"] == annotation_service_module.ANNOTATION_JOB_TTL
+        assert redis.ttls["enable_app_annotation_job_uuid-1"] == annotation_service_module.ANNOTATION_JOB_TTL
 
-    def test_disable_returns_processing_on_cache_hit(self, current_user: Account) -> None:
-        with (
-            patch.object(annotation_service_module, "redis_client") as redis,
-            patch.object(annotation_service_module, "disable_annotation_reply_task") as task,
-        ):
-            redis.get.return_value = "job-2"
-            result = AppAnnotationService.disable_app_annotation("app-1")
+    def test_enable_reuses_the_in_flight_job(
+        self, redis: _FakeRedis, current_user: Account, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        task = MagicMock()
+        monkeypatch.setattr(annotation_service_module, "enable_annotation_reply_task", task)
 
-        assert result == {"job_id": "job-2", "job_status": "processing"}
-        task.delay.assert_not_called()
+        first = AppAnnotationService.enable_app_annotation(cast(Any, self.ENABLE_ARGS), "app-1")
+        second = AppAnnotationService.enable_app_annotation(cast(Any, self.ENABLE_ARGS), "app-1")
 
-    def test_disable_enqueues_on_cache_miss(self, current_user: Account) -> None:
-        with (
-            patch.object(annotation_service_module, "redis_client") as redis,
-            patch.object(annotation_service_module.uuid, "uuid4", return_value="uuid-2"),
-            patch.object(annotation_service_module, "disable_annotation_reply_task") as task,
-        ):
-            redis.get.return_value = None
-            result = AppAnnotationService.disable_app_annotation("app-1")
+        assert second == {"job_id": first["job_id"], "job_status": "processing"}
+        assert task.delay.call_count == 1
+
+    def test_enable_releases_the_reservation_when_enqueue_fails(
+        self, redis: _FakeRedis, current_user: Account, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        task = MagicMock()
+        task.delay.side_effect = RuntimeError("broker down")
+        monkeypatch.setattr(annotation_service_module, "enable_annotation_reply_task", task)
+
+        with pytest.raises(RuntimeError):
+            AppAnnotationService.enable_app_annotation(cast(Any, self.ENABLE_ARGS), "app-1")
+
+        assert redis.get("enable_app_annotation_app-1") is None
+
+    def test_disable_enqueues_and_reserves_the_app(
+        self, redis: _FakeRedis, current_user: Account, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        task = MagicMock()
+        monkeypatch.setattr(annotation_service_module, "disable_annotation_reply_task", task)
+        monkeypatch.setattr(annotation_service_module.uuid, "uuid4", lambda: "uuid-2")
+
+        result = AppAnnotationService.disable_app_annotation("app-1")
 
         assert result == {"job_id": "uuid-2", "job_status": "waiting"}
-        redis.setnx.assert_called_once_with("disable_app_annotation_job_uuid-2", "waiting")
         task.delay.assert_called_once_with("uuid-2", "app-1", TENANT_ID)
+        assert redis.get("disable_app_annotation_app-1") == b"uuid-2"
+
+    def test_disable_reuses_the_in_flight_job(
+        self, redis: _FakeRedis, current_user: Account, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        task = MagicMock()
+        monkeypatch.setattr(annotation_service_module, "disable_annotation_reply_task", task)
+
+        first = AppAnnotationService.disable_app_annotation("app-1")
+        second = AppAnnotationService.disable_app_annotation("app-1")
+
+        assert second == {"job_id": first["job_id"], "job_status": "processing"}
+        assert task.delay.call_count == 1
 
 
 class TestAppAnnotationServiceListAndExport:


### PR DESCRIPTION
Closes #40595

## Problem

`AppAnnotationService.enable_app_annotation` reads the app-level key that is supposed to serialize annotation reply jobs, but nothing ever writes it:

```python
enable_app_annotation_key = f"enable_app_annotation_{app_id}"
cache_result = redis_client.get(enable_app_annotation_key)      # read
if cache_result is not None:
    return {"job_id": cache_result, "job_status": "processing"}

job_id = str(uuid.uuid4())
redis_client.setnx(f"enable_app_annotation_job_{job_id}", "waiting")   # only the per-job key
enable_annotation_reply_task.delay(...)                                # app key never written
```

The guard can therefore never fire. Every call mints a new job id and enqueues another task, and those tasks concurrently rebuild or delete the same annotation vector data and mutate the same `AppAnnotationSetting`. The worker's `finally` block then deletes a key that was never acquired. `disable_app_annotation` has the same shape.

Two smaller defects come from the same code:

- The per-job status key is written with `setnx` and no expiry, so it survives forever whenever the task does not reach a terminal path.
- The workers return early when the app or the annotation setting is missing, before any status is written, so a caller polling that job id sees `waiting` indefinitely.

## Change

- Reserve the app with `SET key job_id NX EX` before enqueueing. A second request for the same action gets the in-flight job id back with `processing` instead of starting a competing task.
- Give the per-job status key the same TTL the workers already use for terminal statuses (600s), so nothing outlives the job it describes.
- Release the reservation if `.delay()` raises, so a broker failure does not lock the app for the full TTL.
- Record a terminal `error` status (plus the existing `*_error_*` key) on the worker early-return paths and drop the reservation there.

`_running_job_id()` decodes the reserved value because the client is configured with `decode_responses=False`; the previous code would have returned raw bytes as the job id, which was masked by the guard never firing.

Enable and disable still use separate reservations. The issue also proposes making them mutually exclusive with each other, which changes behaviour beyond the broken guard, so I left it out of this PR — happy to follow up if you want it.

## Tests

`TestAppAnnotationServiceEnableDisable` previously mocked the whole redis client and asserted the exact `setnx` call, so it described the implementation rather than the behaviour and could not observe the missing reservation. It is rewritten against a small fake that implements `SET NX EX` semantics, and covers: the reservation is written with a TTL, a second request reuses the in-flight job without enqueueing, and a failed enqueue releases the reservation.

Against the current `main` sources, all five fail:

```
FAILED ...::test_enable_enqueues_and_reserves_the_app
FAILED ...::test_enable_reuses_the_in_flight_job
FAILED ...::test_enable_releases_the_reservation_when_enqueue_fails
FAILED ...::test_disable_enqueues_and_reserves_the_app
FAILED ...::test_disable_reuses_the_in_flight_job
```

with, for the reuse cases:

```
E  AssertionError: {'job_status': 'waiting'} != {'job_status': 'processing'}
E                  {'job_id': 'eb28b41d-...'} != {'job_id': '1e812dc9-...'}
```

With this change:

```
api/tests/unit_tests/services/test_annotation_service.py   ->  47 passed
api/tests/unit_tests/controllers -k annotation             ->  74 passed
```

`ruff check` and `ruff format --check` are clean on the four touched files.