### PR TITLE
fix(api): enforce edit and RBAC permissions on trigger OAuth authorize GET endpoint (#41204)

### DIFF
--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -557,6 +557,8 @@ class TriggerOAuthAuthorizeApi(Resource):
     )
     @setup_required
     @login_required
+    @edit_permission_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -9,6 +9,7 @@ from controllers.console.datasets.rag_pipeline.datasource_auth import Datasource
 from controllers.console.workspace.model_providers import ModelProviderCredentialApi
 from controllers.console.workspace.models import DefaultModelApi, ModelProviderModelApi, ModelProviderModelCredentialApi
 from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddApi, ToolOAuthCustomClient
+from controllers.console.workspace.trigger_providers import TriggerOAuthAuthorizeApi
 
 
 @pytest.mark.parametrize(
@@ -98,6 +99,21 @@ def test_workspace_model_preferences_get_require_admin_and_rbac(
     the same admin + RBAC gates as their sibling POST/DELETE methods."""
     legacy_wrapper = unwrap(method, stop=lambda wrapper: "is_admin_or_owner_required" in wrapper.__code__.co_qualname)
     assert "is_admin_or_owner_required" in legacy_wrapper.__code__.co_qualname
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
+    assert rbac_config["scene"] == RBACPermission.PLUGIN_PREFERENCES
+    assert rbac_config["resource_required"] is False
+
+
+def test_trigger_oauth_authorize_get_requires_edit_and_rbac() -> None:
+    """GET endpoint that initiates trigger OAuth authorization must enforce
+    the same edit + RBAC gates as sibling trigger subscription methods."""
+    method = TriggerOAuthAuthorizeApi.get
+
+    edit_wrapper = unwrap(method, stop=lambda wrapper: "edit_permission_required" in wrapper.__code__.co_qualname)
+    assert "edit_permission_required" in edit_wrapper.__code__.co_qualname
 
     rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
     rbac_config = getclosurevars(rbac_wrapper).nonlocals


### PR DESCRIPTION
## Summary

Fixes #41204

The `GET /console/api/workspaces/current/trigger-provider/<provider>/subscriptions/oauth/authorize` endpoint in `TriggerOAuthAuthorizeApi` was missing authorization decorators:
- `@edit_permission_required`
- `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)`

This allowed workspace members without edit permissions or plugin preferences RBAC permissions to initiate trigger OAuth flows and generate subscription builders.

Added missing permission decorators to match its sibling trigger subscription creation endpoints and added corresponding unit test assertion.

## Screenshots

N/A (Backend API permission enforcement)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
