### PR TITLE
fix(agent): seal the run event stream at the first terminal event

### DIFF
--- a/dify-agent/src/dify_agent/storage/redis_run_store.py
+++ b/dify-agent/src/dify_agent/storage/redis_run_store.py
@@ -82,6 +82,28 @@ return {1, ARGV[1], event_id}
 """
 
 
+_TERMINAL_RUN_STATUSES = ("succeeded", "failed", "cancelled")
+_LUA_TERMINAL_STATUS_TEST = " or ".join(f'record.status == "{status}"' for status in _TERMINAL_RUN_STATUSES)
+
+_APPEND_EVENT_SCRIPT = f"""
+local record_json = redis.call("GET", KEYS[1])
+if not record_json then
+    return {{0, ""}}
+end
+
+local record = cjson.decode(record_json)
+if {_LUA_TERMINAL_STATUS_TEST} then
+    return {{0, ""}}
+end
+
+local ttl = tonumber(ARGV[2])
+local event_id = redis.call("XADD", KEYS[2], "*", "payload", ARGV[1])
+redis.call("EXPIRE", KEYS[2], ttl)
+redis.call("EXPIRE", KEYS[1], ttl)
+return {{1, event_id}}
+"""
+
+
 _REQUEST_CANCELLATION_SCRIPT = """
 local record_json = redis.call("GET", KEYS[1])
 if not record_json then
@@ -192,19 +214,31 @@ class RedisRunStore(RunEventSink):
         return RunRecord.model_validate_json(value)
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
-        """Append a non-terminal event JSON payload with refreshed TTLs."""
-        events_key = run_events_key(self.prefix, event.run_id)
+        """Append a non-terminal event JSON payload with refreshed TTLs.
+
+        A terminal event seals the run: consumers are allowed to stop reading at
+        the first one, so a write that loses the race against ``finalize_run`` or
+        ``finalize_cancellation`` must not land after the terminal cursor. The
+        status check therefore happens inside the same script as the ``XADD``,
+        the way the terminal writers already do it. Returns an empty string when
+        the run was already sealed and nothing was written.
+        """
         payload = RUN_EVENT_ADAPTER.dump_json(event, exclude={"id"}).decode()
-        async with self.redis.pipeline(transaction=True) as pipeline:
-            _ = pipeline.xadd(
-                events_key,
-                {"payload": payload},
-            )
-            _ = pipeline.expire(events_key, self.run_retention_seconds)
-            _ = pipeline.expire(run_record_key(self.prefix, event.run_id), self.run_retention_seconds)
-            results = cast(list[object], await pipeline.execute())
-        event_id = results[0]
-        return event_id.decode() if isinstance(event_id, bytes) else str(event_id)
+        evaluation = cast(
+            Awaitable[object],
+            self.redis.eval(
+                _APPEND_EVENT_SCRIPT,
+                2,
+                run_record_key(self.prefix, event.run_id),
+                run_events_key(self.prefix, event.run_id),
+                payload,
+                str(self.run_retention_seconds),
+            ),
+        )
+        result = cast(list[object], await evaluation)
+        if int(cast(int | bytes | str, result[0])) != 1:
+            return ""
+        return _decode_redis_text(result[1])
 
     async def finalize_run(self, event: TerminalRunEvent) -> RunFinalizationResult:
         """Atomically append the first success/failure event and update its run record."""

--- a/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
+++ b/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
@@ -24,7 +24,13 @@ from dify_agent.protocol.schemas import (
 )
 from dify_agent.runtime.cancellation import RunCancellationIntent
 from dify_agent.runtime.event_sink import RunFinalizationResult
-from dify_agent.storage.redis_run_store import DEFAULT_RUN_RETENTION_SECONDS, RedisRunStore, RunNotFoundError
+from dify_agent.storage.redis_run_store import (
+    _APPEND_EVENT_SCRIPT,
+    _TERMINAL_RUN_STATUSES,
+    DEFAULT_RUN_RETENTION_SECONDS,
+    RedisRunStore,
+    RunNotFoundError,
+)
 
 
 class FakeRedis:
@@ -103,9 +109,25 @@ class FakeRedis:
 
     async def eval(self, script: str, numkeys: int, *keys_and_args: object) -> list[object]:
         self.commands.append(("eval", script, numkeys, *keys_and_args))
+        if script is _APPEND_EVENT_SCRIPT:
+            return self._eval_append_event(*keys_and_args)
         if self.eval_result is None:
             raise AssertionError("test must configure FakeRedis.eval_result")
         return list(self.eval_result)
+
+    def _eval_append_event(self, *keys_and_args: object) -> list[object]:
+        """Mirror _APPEND_EVENT_SCRIPT so the seal is observable in tests."""
+        record_key, events_key, payload, ttl = (str(value) for value in keys_and_args)
+        record_json = self.values.get(record_key)
+        if record_json is None:
+            return [0, ""]
+        record = cast(dict[str, object], json.loads(str(record_json)))
+        if record.get("status") in _TERMINAL_RUN_STATUSES:
+            return [0, ""]
+        event_id = self._append_stream_entry(events_key, {"payload": payload})
+        self.commands.append(("expire", events_key, int(ttl)))
+        self.commands.append(("expire", record_key, int(ttl)))
+        return [1, event_id]
 
     @staticmethod
     def _is_after_min(event_id: str, min_id: str) -> bool:
@@ -355,25 +377,41 @@ def test_wait_for_cancellation_ignores_public_events() -> None:
 def test_append_event_serializes_typed_event_without_id_and_expires_run_keys() -> None:
     redis = FakeRedis()
     store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+    record = asyncio.run(store.create_run())
 
-    event_id = asyncio.run(store.append_event(RunStartedEvent(id="local", run_id="run-1")))
+    event_id = asyncio.run(store.append_event(RunStartedEvent(id="local", run_id=record.run_id)))
 
     assert event_id == "1-0"
-    pipeline_commands = [command for command in redis.commands if command[0] == "pipeline"]
-    assert len(pipeline_commands) == 1
-    assert pipeline_commands[0][1] is True
-    xadd_commands = [command for command in redis.commands if command[0] == "xadd"]
-    assert len(xadd_commands) == 1
-    fields = xadd_commands[0][2]
-    assert isinstance(fields, dict)
-    assert '"id"' not in str(fields["payload"])
-    assert '"type":"run_started"' in str(fields["payload"])
-    expire_commands = {command for command in redis.commands if command[0] == "expire"}
-    assert expire_commands == {
-        ("expire", "test:runs:run-1:events", 60),
-        ("expire", "test:runs:run-1:record", 60),
+    stream = redis.streams[f"test:runs:{record.run_id}:events"]
+    assert len(stream) == 1
+    payload = str(stream[0][1]["payload"])
+    assert '"id"' not in payload
+    assert '"type":"run_started"' in payload
+    expires = {command for command in redis.commands if command[0] == "expire"}
+    assert expires == {
+        ("expire", f"test:runs:{record.run_id}:events", 60),
+        ("expire", f"test:runs:{record.run_id}:record", 60),
     }
-    assert ("execute",) in redis.commands
+
+
+@pytest.mark.parametrize("status", _TERMINAL_RUN_STATUSES)
+def test_append_event_is_a_no_op_once_the_run_is_sealed(status: str) -> None:
+    """A terminal event seals the stream, so a write that lost the race must not land."""
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+    record = asyncio.run(store.create_run())
+    record_key = f"test:runs:{record.run_id}:record"
+    sealed = cast(dict[str, object], json.loads(str(redis.values[record_key])))
+    sealed["status"] = status
+    redis.values[record_key] = json.dumps(sealed)
+    redis.commands.clear()
+
+    event_id = asyncio.run(store.append_event(RunStartedEvent(id="local", run_id=record.run_id)))
+
+    assert event_id == ""
+    assert redis.streams.get(f"test:runs:{record.run_id}:events") is None
+    # The losing writer must not refresh retention on a run that is already done.
+    assert [command for command in redis.commands if command[0] == "expire"] == []
 
 
 def test_get_events_round_trips_run_succeeded_output_and_session_snapshot() -> None:


### PR DESCRIPTION
Closes #40765

## Problem

`RedisRunStore` uses a Lua compare-and-set to commit a terminal event and its run status together, but `append_event` wrote through a plain pipeline that never looked at the durable run status:

```python
async with self.redis.pipeline(transaction=True) as pipeline:
    _ = pipeline.xadd(events_key, {"payload": payload})
    _ = pipeline.expire(events_key, self.run_retention_seconds)
    _ = pipeline.expire(run_record_key(self.prefix, event.run_id), self.run_retention_seconds)
```

There is no read of the run record anywhere on that path, so the check the caller performs (`is_cancelled()`) and the write are in different processes' hands:

1. Process A passes its local check and prepares a stream event.
2. Process B atomically commits `run_cancelled` and flips the run record.
3. Process A's `XADD` lands after the terminal cursor.

The stream then reads `run_started -> run_cancelled -> pydantic_ai_event`, which breaks the contract that a consumer may stop at the first terminal event: an SSE reader and a later polling reader see different histories. The losing write also refreshes the stream and run-record TTL for a run that is already finished.

## Change

`append_event` now goes through `_APPEND_EVENT_SCRIPT`, so the status check and the `XADD` happen in the same script the same way the terminal writers already do it. A sealed run returns an empty event id and nothing is written — no entry, no cursor, no TTL refresh.

The terminal status list lives in one place (`_TERMINAL_RUN_STATUSES`) and the Lua condition is built from it, so the script and the Python side cannot drift.

A missing run record is treated as sealed rather than raising. `append_event` did not raise before, and a run whose record has expired is long finished, so this keeps the change to the behaviour the issue describes.

## Tests

`FakeRedis.eval` previously required every test to hand it a canned result, which meant nothing could observe what the script actually did. It now interprets `_APPEND_EVENT_SCRIPT` against its own stored record, so the seal is visible in tests and the existing `iter_events` tests can keep using `append_event` to build their fixtures.

- `test_append_event_serializes_typed_event_without_id_and_expires_run_keys` — rewritten against observable state: the entry lands and both keys get their TTL refreshed.
- `test_append_event_is_a_no_op_once_the_run_is_sealed` — parametrized over `succeeded`, `failed` and `cancelled`: no stream entry and no `EXPIRE` after the seal.

```
tests/local/dify_agent/storage/test_redis_run_store.py   ->  19 passed
tests/ (excluding pre-existing collection errors)        ->  748 passed, 32 skipped
```

The five collection errors under `layers/config`, `layers/dify_core_tools` and `protocol/test_working_environment` are present on an unmodified checkout too — missing optional dependencies in my environment, unrelated to this change.

`ruff check` and `ruff format --check` are clean on both files.

## Not included

The issue notes the cancellation observer narrows but cannot close the race; that observer is unchanged here since the seal now holds regardless of how wide the window is.