### PR TITLE
fix(agent): collect the test suite that shares module basenames

### DIFF
--- a/dify-agent/pyproject.toml
+++ b/dify-agent/pyproject.toml
@@ -46,6 +46,10 @@ pythonVersion = "3.12"
 extraPaths = ["src", "examples/agenton", "examples/dify_agent"]
 
 [tool.pytest.ini_options]
+# Several test modules share a basename across directories (test_layer.py,
+# test_client.py, ...). The default prepend import mode derives module names
+# from the basename, so collecting them together is an import file mismatch.
+addopts = ["--import-mode=importlib"]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 markers = ["integration: requires a real external service or exercises multiple concrete adapters"]


### PR DESCRIPTION
`pytest tests/` in `dify-agent` does not run:

```
ERROR tests/local/dify_agent/layers/config/test_layer.py
ERROR tests/local/dify_agent/layers/dify_core_tools/test_client.py
ERROR tests/local/dify_agent/layers/dify_core_tools/test_configs.py
ERROR tests/local/dify_agent/layers/dify_core_tools/test_layer.py
ERROR tests/local/dify_agent/protocol/test_working_environment.py
!!!!!!!!!!!!! Interrupted: 5 errors during collection !!!!!!!!!!!!!
```

each of the form:

```
import file mismatch:
imported module 'test_layer' has this __file__ attribute:
  tests/local/dify_agent/layers/ask_human/test_layer.py
which is not the same as the test file we want to collect:
  tests/local/dify_agent/layers/config/test_layer.py
```

Four basenames are used in more than one directory — `test_layer.py`, `test_client.py`, `test_configs.py`, `test_working_environment.py` — and pytest's default prepend import mode names a module after its basename, so the second one to be collected looks like a redefinition of the first. Collection aborts before any test runs.

`importlib` mode derives the module name from the full path instead, which is what pytest recommends for exactly this layout. Adding `__init__.py` to the nineteen test directories that lack one would also work, but it is a much larger change and leaves the next same-named file to reintroduce the failure.

Before, on `main`:

```
5 errors in 1.95s
```

After:

```
777 passed, 32 skipped in 21.41s
```

The 32 tests in those five files pass — they have simply never been able to run together with the rest of the suite. `autofix.yml` runs only `ruff` against `dify-agent`, so nothing in CI was reporting this.