### PR TITLE
perf(api): batch recommended app catalog lookups

### DIFF
--- a/api/repositories/recommended_app_catalog_repository.py
+++ b/api/repositories/recommended_app_catalog_repository.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from constants.languages import languages
 from extensions.ext_redis import RedisClientWrapper
-from models.model import App, RecommendedApp
+from models.model import App, RecommendedApp, Site
 from services.app_dsl_service import AppDslService
 from services.recommended_app_query_service import (
     RecommendedAppCatalogPage,
@@ -117,14 +117,23 @@ class DatabaseRecommendedAppCatalogRepository(RecommendedAppCatalogQuery):
         *,
         session: Session,
     ) -> tuple[tuple[RecommendedAppRecord, ...], set[str]]:
+        if not recommended_apps:
+            return (), set()
+
+        app_ids = [recommended_app.app_id for recommended_app in recommended_apps]
+        apps_by_id = {app.id: app for app in session.scalars(select(App).where(App.id.in_(app_ids))).all()}
+        sites_by_app_id = {
+            site.app_id: site for site in session.scalars(select(Site).where(Site.app_id.in_(app_ids))).all()
+        }
+
         categories: set[str] = set()
         records: list[RecommendedAppRecord] = []
         for recommended_app in recommended_apps:
-            app = session.get(App, recommended_app.app_id)
+            app = apps_by_id.get(recommended_app.app_id)
             if app is None or not app.is_public:
                 continue
 
-            site = app.site_with_session(session=session)
+            site = sites_by_app_id.get(app.id)
             if site is None:
                 continue
 

--- a/api/tests/unit_tests/repositories/test_recommended_app_catalog_repository.py
+++ b/api/tests/unit_tests/repositories/test_recommended_app_catalog_repository.py
@@ -103,6 +103,30 @@ def test_list_recommended_returns_typed_records_and_falls_back_language(
     assert record.categories == ("Workflow",)
 
 
+def test_list_recommended_batches_app_and_site_lookups(
+    sqlite_engine: Engine,
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with sqlite_session_factory() as session:
+        app_ids = {_add_catalog_app(session).id for _ in range(3)}
+
+    select_count = 0
+
+    def count_selects(_conn, _cursor, statement: str, _parameters, _context, _executemany) -> None:
+        nonlocal select_count
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_count += 1
+
+    event.listen(sqlite_engine, "before_cursor_execute", count_selects)
+    try:
+        page = _repository(sqlite_session_factory).list_recommended("en-US")
+    finally:
+        event.remove(sqlite_engine, "before_cursor_execute", count_selects)
+
+    assert {app.app_id for app in page.recommended_apps} == app_ids
+    assert select_count == 3
+
+
 def test_list_recommended_skips_private_apps_and_apps_without_sites(
     sqlite_session_factory: sessionmaker[Session],
 ) -> None:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. I have read the contribution guidelines.
> 2. Associated issue: #41217 (I authored it; external contributors cannot self-assign issues in this repository).
> 3. This PR uses the requested Fixes syntax below.

## Summary

- Batch-load App and Site rows for recommended-app catalog pages instead of querying both models once per catalog entry.
- Keep the existing behavior that excludes private apps and apps without a Site.
- Return early for empty catalog pages.
- Add a regression test proving that three catalog entries use a fixed three SELECT statements instead of 1 + 2N queries.

Fixes #41217

## Screenshots

| Before | After |
| ------ | ----- |
| N/A (backend query optimization) | N/A (backend query optimization) |

## Validation

- 99 repository unit tests passed.
- Ruff format and check passed for both changed files.
- Pyrefly passed for the changed source and test files.
- Mypy passed for the changed source file with the repository's configured flags.
- git diff --check passed.

## Checklist

- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. (Not applicable: no user-facing or API contract change.)
- [ ] I ran the complete make lint && make type-check suite. (Focused Ruff, Pyrefly, and Mypy checks passed; frontend is untouched.)

From Codex
