### PR TITLE
perf(agent): exponential backoff in polling to prevent forking storm

### DIFF
--- a/dify-agent-runtime/internal/server/config.go
+++ b/dify-agent-runtime/internal/server/config.go
@@ -24,7 +24,7 @@ const (
 	DefaultGCIntervalSeconds             = 60.0
 	DefaultGCFinishedJobRetentionSeconds = 300.0
 	DefaultPollInterval                  = 5 * time.Millisecond
-	DefaultMaxPollInterval               = 200 * time.Millisecond
+	DefaultMaxPollInterval               = 50 * time.Millisecond
 	DefaultPipeMonitorInterval           = 1 * time.Second
 	DefaultPipeReadyTimeout              = 10 * time.Second
 	DefaultSQLiteBusyTimeoutMs           = 5000

--- a/dify-agent-runtime/internal/server/config.go
+++ b/dify-agent-runtime/internal/server/config.go
@@ -24,6 +24,7 @@ const (
 	DefaultGCIntervalSeconds             = 60.0
 	DefaultGCFinishedJobRetentionSeconds = 300.0
 	DefaultPollInterval                  = 5 * time.Millisecond
+	DefaultMaxPollInterval               = 200 * time.Millisecond
 	DefaultPipeMonitorInterval           = 1 * time.Second
 	DefaultPipeReadyTimeout              = 10 * time.Second
 	DefaultSQLiteBusyTimeoutMs           = 5000
@@ -53,6 +54,7 @@ type Config struct {
 	MaxOutputLimitBytes          int
 	DefaultTerminateGraceSeconds float64
 	PollInterval                 time.Duration
+	MaxPollInterval              time.Duration
 	PipeMonitorInterval          time.Duration
 	PipeReadyTimeout             time.Duration
 	SQLiteBusyTimeoutMs          int
@@ -90,6 +92,7 @@ func DefaultConfig() (*Config, error) {
 		MaxOutputLimitBytes:          MaxOutputLimitBytes,
 		DefaultTerminateGraceSeconds: DefaultTerminateGraceSeconds,
 		PollInterval:                 DefaultPollInterval,
+		MaxPollInterval:              DefaultMaxPollInterval,
 		PipeMonitorInterval:          DefaultPipeMonitorInterval,
 		PipeReadyTimeout:             DefaultPipeReadyTimeout,
 		SQLiteBusyTimeoutMs:          DefaultSQLiteBusyTimeoutMs,

--- a/dify-agent-runtime/internal/server/service.go
+++ b/dify-agent-runtime/internal/server/service.go
@@ -349,6 +349,11 @@ func (s *Service) WaitJob(jobID string, req *WaitJobRequest) (*JobResult, error)
 		lastGrowthAt = &now
 	}
 
+	// Poll with exponential backoff: start tight so short jobs return with low
+	// latency, then grow the interval up to MaxPollInterval so long/idle waits
+	// stop spawning a tmux liveness probe (fork) every few milliseconds.
+	pollInterval := s.config.PollInterval
+
 	for {
 		view, err := s.GetJobStatus(jobID)
 		if err != nil {
@@ -411,7 +416,8 @@ func (s *Service) WaitJob(jobID string, req *WaitJobRequest) (*JobResult, error)
 			return s.jobResultFromView(view, row, window), nil
 		}
 
-		time.Sleep(s.config.PollInterval)
+		time.Sleep(pollInterval)
+		pollInterval = min(pollInterval*2, s.config.MaxPollInterval)
 	}
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This is a follow-up of #41221 that partially resolves #39976.
#41221 reduces the latency for short-lived tasks but introduces forking storm for long running tasks.

The cap is set to 50ms which aligns with previous fixed interval.

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
