### PR TITLE
test(cli): tsconfig gap

### DIFF
--- a/cli/scripts/e2e-provision.ts
+++ b/cli/scripts/e2e-provision.ts
@@ -62,9 +62,10 @@ async function consoleLogin(): Promise<{ cookieString: string; csrfToken: string
   if (!res.ok) throw new Error(`console/api/login failed: HTTP ${res.status}`)
 
   const setCookies = res.headers.getSetCookie?.() ?? []
-  const cookieString = setCookies.map((c) => c.split(';')[0]).join('; ')
+  const cookiePairs = setCookies.map((c) => c.split(';')[0] ?? '')
+  const cookieString = cookiePairs.join('; ')
   // cookie names may have __Host- prefix on HTTPS deployments
-  const csrfPair = setCookies.map((c) => c.split(';')[0]).find((p) => p.includes('csrf_token='))
+  const csrfPair = cookiePairs.find((p) => p.includes('csrf_token='))
   const csrfToken = csrfPair
     ? csrfPair.slice(csrfPair.indexOf('csrf_token=') + 'csrf_token='.length)
     : ''

--- a/cli/scripts/release-naming.test.ts
+++ b/cli/scripts/release-naming.test.ts
@@ -1,18 +1,24 @@
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vite-plus/test'
-import { FIXTURE_COMPAT, pkgManifestEnv } from '../test/fixtures/pkg-manifest'
+import {
+  FIXTURE_CHANNEL,
+  FIXTURE_COMPAT,
+  FIXTURE_TAG_PREFIX,
+  FIXTURE_VERSION,
+  FIXTURE_VERSION_CORE,
+  pkgManifestEnv,
+} from '../test/fixtures/pkg-manifest'
 
 const SCRIPT = fileURLToPath(new URL('./release-naming.mjs', import.meta.url))
 
-function run(
-  args: string[],
-  env: Record<string, string> = {},
-): { code: number; stdout: string; stderr: string } {
+const PKG_ENV = pkgManifestEnv()
+
+function run(args: string[]): { code: number; stdout: string; stderr: string } {
   try {
     const stdout = execFileSync('node', [SCRIPT, ...args], {
       encoding: 'utf8',
-      env: { ...process.env, ...env },
+      env: { ...process.env, ...PKG_ENV },
     })
     return { code: 0, stdout, stderr: '' }
   } catch (e) {
@@ -23,9 +29,8 @@ function run(
 
 describe('release-naming compat-check', () => {
   const { minDify, maxDify } = FIXTURE_COMPAT // 2.0.0 .. 2.5.0
-  const pkgEnv = pkgManifestEnv()
   const compatCheck = (difyVersion?: string) =>
-    run(difyVersion === undefined ? ['compat-check'] : ['compat-check', difyVersion], pkgEnv).code
+    run(difyVersion === undefined ? ['compat-check'] : ['compat-check', difyVersion]).code
 
   it('accepts a version inside the window', () => {
     expect(compatCheck('2.3.0')).toBe(0)
@@ -69,23 +74,22 @@ describe('release-naming compat-check', () => {
 })
 
 describe('release-naming github-env', () => {
-  it('emits difyctlTag = tagPrefix + version', () => {
-    const { stdout } = run(['github-env'])
-    expect(stdout).toMatch(/^difyctlTag=difyctl-v0\.2\.0-alpha$/m)
-  })
-
-  it('still emits the existing trace fields', () => {
-    const { stdout } = run(['github-env'])
-    for (const key of ['version', 'channel', 'prerelease', 'minDify', 'maxDify', 'tagPrefix'])
-      expect(stdout).toMatch(new RegExp(`^${key}=`, 'm'))
-  })
-
-  // The only assertion against the live manifest: the window must exist and be
-  // well-formed, whatever release it currently points at.
-  it('emits a well-formed compat window from the real cli/package.json', () => {
-    const { stdout } = run(['github-env'])
-    expect(stdout).toMatch(/^minDify=\d+\.\d+\.\d+$/m)
-    expect(stdout).toMatch(/^maxDify=\d+\.\d+\.\d+$/m)
+  it('emits every manifest field for $GITHUB_ENV, plus a composed difyctlTag', () => {
+    const fields = Object.fromEntries(
+      run(['github-env'])
+        .stdout.split('\n')
+        .filter(Boolean)
+        .map((line) => [line.slice(0, line.indexOf('=')), line.slice(line.indexOf('=') + 1)]),
+    )
+    expect(fields).toEqual({
+      version: FIXTURE_VERSION,
+      channel: FIXTURE_CHANNEL,
+      prerelease: 'true',
+      minDify: FIXTURE_COMPAT.minDify,
+      maxDify: FIXTURE_COMPAT.maxDify,
+      tagPrefix: FIXTURE_TAG_PREFIX,
+      difyctlTag: `${FIXTURE_TAG_PREFIX}${FIXTURE_VERSION}`,
+    })
   })
 })
 
@@ -95,13 +99,14 @@ describe('release-naming edge channel', () => {
   })
 
   it('edge-version derives <pkgcore>-edge.<sha> from the package version', () => {
-    // package.json version is 0.2.0-alpha -> core 0.2.0
-    expect(run(['edge-version', '2fd7b82']).stdout.trim()).toBe('0.2.0-edge.2fd7b82')
+    expect(run(['edge-version', '2fd7b82']).stdout.trim()).toBe(
+      `${FIXTURE_VERSION_CORE}-edge.2fd7b82`,
+    )
   })
 
   it('edge-version accepts a 40-char sha', () => {
     const sha = '2fd7b829e1f0aaaabbbbccccddddeeeeffff0000'
-    expect(run(['edge-version', sha]).stdout.trim()).toBe(`0.2.0-edge.${sha}`)
+    expect(run(['edge-version', sha]).stdout.trim()).toBe(`${FIXTURE_VERSION_CORE}-edge.${sha}`)
   })
 
   it('edge-version rejects a non-hex sha', () => {

--- a/cli/scripts/release-r2-edge.test.ts
+++ b/cli/scripts/release-r2-edge.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vite-plus/test'
-import { FIXTURE_COMPAT, pkgManifestEnv } from '../test/fixtures/pkg-manifest'
+import { FIXTURE_COMPAT, FIXTURE_TARGET_IDS, pkgManifestEnv } from '../test/fixtures/pkg-manifest'
 
 const SCRIPT = fileURLToPath(new URL('./release-r2-edge.mjs', import.meta.url))
 
@@ -30,8 +30,7 @@ function run(args: string[]): { code: number; stdout: string; stderr: string } {
 
 function writeChecksums(version: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'difyctl-manifest-'))
-  const ids = ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64', 'windows-x64']
-  const lines = ids.map((id, i) => {
+  const lines = FIXTURE_TARGET_IDS.map((id, i) => {
     const exe = id === 'windows-x64' ? '.exe' : ''
     const sha = String(i).repeat(64)
     return `${sha}  difyctl-v${version}-${id}${exe}`
@@ -53,7 +52,7 @@ type ManifestJson = {
   buildDate: string
   compat: { minDify: string; maxDify: string }
   baseUrl: string
-  targets: Record<string, { asset: string; sha256: string }>
+  targets: Record<(typeof FIXTURE_TARGET_IDS)[number], { asset: string; sha256: string }>
 }
 
 type IndexBuild = {
@@ -187,7 +186,7 @@ describe('release-r2-edge manifest', () => {
 
 function runIndex(
   currentContent: string | null,
-  build: Record<string, string>,
+  build: Omit<IndexBuild, 'dir'>,
   existingDirs?: string[],
 ) {
   let currentArg = '-'

--- a/cli/test/fixtures/pkg-manifest.ts
+++ b/cli/test/fixtures/pkg-manifest.ts
@@ -16,6 +16,11 @@ const PKG_PATH_ENV = 'DIFYCTL_PKG_PATH'
 // window" is a case distinct from either bound.
 export const FIXTURE_COMPAT = { minDify: '2.0.0', maxDify: '2.5.0' }
 
+export const FIXTURE_VERSION_CORE = '7.7.7'
+export const FIXTURE_VERSION = `${FIXTURE_VERSION_CORE}-alpha`
+export const FIXTURE_CHANNEL = 'alpha'
+export const FIXTURE_TAG_PREFIX = 'difyctl-v'
+
 export const FIXTURE_TARGET_IDS = [
   'linux-x64',
   'linux-arm64',
@@ -25,7 +30,7 @@ export const FIXTURE_TARGET_IDS = [
 ] as const
 
 const FIXTURE_RELEASE = {
-  tagPrefix: 'difyctl-v',
+  tagPrefix: FIXTURE_TAG_PREFIX,
   binName: 'difyctl',
   checksumsSuffix: '-checksums.txt',
   targets: FIXTURE_TARGET_IDS.map((id) => ({
@@ -44,9 +49,9 @@ export type PkgManifestOverrides = {
 // Returns the env additions that point a spawned script at the fixture.
 export function pkgManifestEnv(overrides: PkgManifestOverrides = {}): Record<string, string> {
   const manifest = {
-    version: overrides.version ?? '0.2.0-alpha',
+    version: overrides.version ?? FIXTURE_VERSION,
     difyctl: {
-      channel: overrides.channel ?? 'alpha',
+      channel: overrides.channel ?? FIXTURE_CHANNEL,
       compat: overrides.compat ?? FIXTURE_COMPAT,
       release: FIXTURE_RELEASE,
     },

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -11,6 +11,6 @@
     "outDir": "dist",
     "sourceMap": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"], // tests must be included for typechecking
+  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"], // tests must be included for typechecking
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Closes the tsconfig gap that made `cli/scripts/**` simultaneously unchecked by CI and un-committable. 
Refactor logic of version gating check.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
