### PR TITLE
fix(cli): declare write effect for import and context-switch commands

### DIFF
--- a/cli/src/commands/import/studio-app/index.ts
+++ b/cli/src/commands/import/studio-app/index.ts
@@ -1,3 +1,4 @@
+import type { CommandEffect } from '@/framework/command'
 import { DifyCommand } from '@/commands/_shared/dify-command'
 import { httpRetryFlag } from '@/commands/_shared/global-flags'
 import { Flags } from '@/framework/flags'
@@ -6,6 +7,8 @@ import { pluginDependencyLabel, runImportApp } from './run'
 
 export default class ImportStudioApp extends DifyCommand {
   static override description = 'Import a studio app from a DSL YAML file or URL'
+
+  static override effect: CommandEffect = 'write'
 
   static override examples = [
     '<%= config.bin %> import studio-app --from-file ./app.yaml',

--- a/cli/src/commands/use/account/index.ts
+++ b/cli/src/commands/use/account/index.ts
@@ -1,3 +1,4 @@
+import type { CommandEffect } from '@/framework/command'
 import { DifyCommand } from '@/commands/_shared/dify-command'
 import { Flags } from '@/framework/flags'
 import { realStreams } from '@/sys/io/streams'
@@ -5,6 +6,8 @@ import { runUseAccount } from './use-account'
 
 export default class UseAccount extends DifyCommand {
   static override description = 'Switch the active account on the current host'
+
+  static override effect: CommandEffect = 'write'
 
   static override examples = [
     '<%= config.bin %> use account',

--- a/cli/src/commands/use/host/index.ts
+++ b/cli/src/commands/use/host/index.ts
@@ -1,3 +1,4 @@
+import type { CommandEffect } from '@/framework/command'
 import { DifyCommand } from '@/commands/_shared/dify-command'
 import { Flags } from '@/framework/flags'
 import { realStreams } from '@/sys/io/streams'
@@ -5,6 +6,8 @@ import { runUseHost } from './use-host'
 
 export default class UseHost extends DifyCommand {
   static override description = 'Switch the active Dify host'
+
+  static override effect: CommandEffect = 'write'
 
   static override examples = [
     '<%= config.bin %> use host',

--- a/cli/test/e2e/suites/agent/agent-skill-workflow.e2e.ts
+++ b/cli/test/e2e/suites/agent/agent-skill-workflow.e2e.ts
@@ -583,6 +583,18 @@ describe('E2E / agent skill — effect guard (no auth)', () => {
     expect(JSON.parse(r.stdout).effect).toBe('write')
   })
 
+  it('[P0] state-mutating import and context switches have effect=write', async () => {
+    for (const args of [
+      ['help', 'import', 'studio-app', '-o', 'json'],
+      ['help', 'use', 'account', '-o', 'json'],
+      ['help', 'use', 'host', '-o', 'json'],
+    ]) {
+      const r = await run(args)
+      expect(r.exitCode).toBe(0)
+      expect(JSON.parse(r.stdout).effect).toBe('write')
+    }
+  })
+
   it('[P0] auth devices revoke effect=destructive — agent must confirm before calling', async () => {
     const r = await run(['help', 'auth', 'devices', 'revoke', '-o', 'json'])
     expect(r.exitCode).toBe(0)


### PR DESCRIPTION
## Summary

`difyctl` publishes an `effect` field (`read` / `write` / `destructive`) on every command through `difyctl help -o json`, and the agent skill installed by `difyctl skills install` tells agents to treat that field as the confirmation gate before running a command.

Three commands declared no `effect`, so `describeCommand` fell back to the `read` default and agents following the published contract ran them without asking:

- `import studio-app` creates an app, and with `--app-id` overwrites an existing workflow or advanced-chat app
- `use account` and `use host` rewrite the local active-context registry, which the sibling `use workspace` and `config set` already report as `write`

This declares `effect: write` on all three and adds a `[P0]` e2e assertion next to the existing `effect=destructive` guard so the metadata cannot silently regress.

Fixes #41223

## Screenshots

| Before | After |
| ------ | ----- |
| `difyctl help import studio-app -o json \| jq .effect` → `"read"` | `"write"` |
| `difyctl help use account -o json \| jq .effect` → `"read"` | `"write"` |
| `difyctl help use host -o json \| jq .effect` → `"read"` | `"write"` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Claude Code
