### PR TITLE
fix: keep webapp generation running on conversation switch and label interrupted runs

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -793,6 +793,9 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
             with self._database_session() as session:
                 # Save message
                 self._save_message(session=session, graph_runtime_state=resolved_state)
+                message = self._get_message(session=session)
+                if message is not None:
+                    message.status = MessageStatus.STOPPED
             self._emit_message_trace()
 
             yield workflow_finish_resp

--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -734,8 +734,7 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
         with self._database_session() as session:
             self._save_message(session=session, graph_runtime_state=resolved_state)
             message = self._get_message(session=session)
-            if message is not None:
-                message.status = MessageStatus.PAUSED
+            message.status = MessageStatus.PAUSED
             self._message_saved_on_pause = True
         self._base_task_pipeline.queue_manager.publish(QueueAdvancedChatMessageEndEvent(), PublishFrom.TASK_PIPELINE)
 
@@ -794,8 +793,7 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                 # Save message
                 self._save_message(session=session, graph_runtime_state=resolved_state)
                 message = self._get_message(session=session)
-                if message is not None:
-                    message.status = MessageStatus.STOPPED
+                message.status = MessageStatus.STOPPED
             self._emit_message_trace()
 
             yield workflow_finish_resp

--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -82,7 +82,9 @@ class AppQueueManager(ABC):
                 finally:
                     elapsed_time = time.monotonic() - start_time
                     manually_stopped = self._is_stopped()
-                    if manually_stopped and self._execution_coordinator.request_abort("App task was stopped"):
+                    if manually_stopped and self._execution_coordinator.request_abort(
+                        QueueStopEvent.StopBy.USER_MANUAL
+                    ):
                         # publish two messages to make sure the client can receive the stop signal
                         # and stop listening after the stop signal processed
                         self.publish(

--- a/api/core/app/apps/execution_coordinator.py
+++ b/api/core/app/apps/execution_coordinator.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from enum import Enum, auto
 
 from configs import dify_config
+from core.app.entities.queue_entities import QueueStopEvent
 from extensions.ext_redis import redis_client
 from graphon.graph_engine.command_channels import RedisChannel
 from graphon.graph_engine.manager import GraphEngineManager
@@ -166,7 +167,7 @@ class AppExecutionCoordinator:
             self._attempt_id,
         )
 
-    def request_abort(self, reason: str) -> bool:
+    def request_abort(self, stopped_by: QueueStopEvent.StopBy) -> bool:
         watchdog: threading.Timer | None = None
         with self._lock:
             if self._state is not AppExecutionState.RUNNING or self._abort_sent:
@@ -182,18 +183,17 @@ class AppExecutionCoordinator:
             "Aborting app execution task=%s attempt=%s reason=%s",
             self._task_id,
             self._attempt_id,
-            reason,
+            stopped_by.description,
         )
-        self._abort_execution(reason)
+        self._abort_execution(stopped_by)
         return True
 
     def _handle_timeout(self) -> None:
-        reason = f"App execution exceeded {self._timeout_seconds} seconds"
-        if not self.request_abort(reason):
+        if not self.request_abort(QueueStopEvent.StopBy.TIMEOUT):
             return
 
         try:
-            self._on_timeout(reason)
+            self._on_timeout(f"App execution exceeded {self._timeout_seconds} seconds")
         except Exception:
             logger.exception(
                 "Failed to publish timeout for app execution task=%s attempt=%s",
@@ -201,7 +201,7 @@ class AppExecutionCoordinator:
                 self._attempt_id,
             )
 
-    def _abort_execution(self, reason: str) -> None:
+    def _abort_execution(self, stopped_by: QueueStopEvent.StopBy) -> None:
         try:
             set_app_task_stop_flag(self._task_id)
         except Exception:
@@ -212,7 +212,7 @@ class AppExecutionCoordinator:
             )
 
         try:
-            GraphEngineManager(redis_client).send_stop_command(self._task_id, reason=reason)
+            GraphEngineManager(redis_client).send_stop_command(self._task_id, reason=stopped_by.value)
         except Exception:
             logger.exception(
                 "Failed to send stop command for app execution task=%s attempt=%s",

--- a/api/core/app/apps/workflow_app_runner.py
+++ b/api/core/app/apps/workflow_app_runner.py
@@ -426,10 +426,11 @@ class WorkflowBasedAppRunner:
                     QueueWorkflowFailedEvent(error=event.error, exceptions_count=event.exceptions_count)
                 )
             case GraphRunAbortedEvent():
+                stopped_by = QueueStopEvent.StopBy.from_value(event.reason)
                 self._publish_event(
                     QueueStopEvent(
-                        stopped_by=QueueStopEvent.StopBy.USER_MANUAL,
-                        reason=event.reason or "Workflow execution aborted",
+                        stopped_by=stopped_by,
+                        reason=event.reason if stopped_by is QueueStopEvent.StopBy.UNKNOWN else None,
                     )
                 )
             case GraphRunPausedEvent():

--- a/api/core/app/entities/queue_entities.py
+++ b/api/core/app/entities/queue_entities.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from enum import StrEnum, auto
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -493,10 +493,24 @@ class QueueStopEvent(AppQueueEvent):
         Stop by enum
         """
 
-        USER_MANUAL = auto()
-        ANNOTATION_REPLY = auto()
-        OUTPUT_MODERATION = auto()
-        INPUT_MODERATION = auto()
+        description: str
+
+        def __new__(cls, value: str, description: str):
+            obj = str.__new__(cls, value)
+            obj._value_ = value
+            obj.description = description
+            return obj
+
+        USER_MANUAL = ("user_manual", "Stopped by user.")
+        TIMEOUT = ("timeout", "Stopped by timeout.")
+        ANNOTATION_REPLY = ("annotation_reply", "Stopped by annotation reply.")
+        OUTPUT_MODERATION = ("output_moderation", "Stopped by output moderation.")
+        INPUT_MODERATION = ("input_moderation", "Stopped by input moderation.")
+        UNKNOWN = ("unknown", "Stopped by unknown reason.")
+
+        @classmethod
+        def from_value(cls, value: str | None) -> "QueueStopEvent.StopBy":
+            return next((member for member in cls if member.value == value), cls.UNKNOWN)
 
     event: QueueEvent = QueueEvent.STOP
     stopped_by: StopBy
@@ -506,17 +520,7 @@ class QueueStopEvent(AppQueueEvent):
         """
         To stop reason
         """
-        if self.reason:
-            return self.reason
-
-        reason_mapping = {
-            QueueStopEvent.StopBy.USER_MANUAL: "Stopped by user.",
-            QueueStopEvent.StopBy.ANNOTATION_REPLY: "Stopped by annotation reply.",
-            QueueStopEvent.StopBy.OUTPUT_MODERATION: "Stopped by output moderation.",
-            QueueStopEvent.StopBy.INPUT_MODERATION: "Stopped by input moderation.",
-        }
-
-        return reason_mapping.get(self.stopped_by, "Stopped by unknown reason.")
+        return self.reason or self.stopped_by.description
 
 
 class QueueHumanInputFormFilledEvent(AppQueueEvent):

--- a/api/fields/conversation_fields.py
+++ b/api/fields/conversation_fields.py
@@ -304,6 +304,7 @@ class StatusCount(ResponseModel):
     failed: int
     partial_success: int
     paused: int
+    stopped: int
 
 
 class ModelConfig(ResponseModel):

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -11,6 +11,7 @@ from fields.base import ResponseModel
 from fields.conversation_fields import AgentThought, JSONValue, MessageFile
 from graphon.file import File
 from libs.helper import to_timestamp
+from models.enums import MessageStatus
 
 type JSONValueType = JSONValue
 
@@ -61,7 +62,7 @@ class MessageListItem(ResponseModel):
     provider_response_latency: float = 0
     total_price: Decimal | None = None
     currency: str | None = None
-    status: str
+    status: MessageStatus
     error: str | None = None
     extra_contents: list[ExecutionExtraContentDomainModel]
 

--- a/api/models/enums.py
+++ b/api/models/enums.py
@@ -45,6 +45,7 @@ class MessageStatus(StrEnum):
 
     NORMAL = "normal"
     PAUSED = "paused"
+    STOPPED = "stopped"
     ERROR = "error"
 
 

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1470,6 +1470,7 @@ class Conversation(Base):
             "failed": status_counts[WorkflowExecutionStatus.FAILED],
             "partial_success": status_counts[WorkflowExecutionStatus.PARTIAL_SUCCEEDED],
             "paused": status_counts[WorkflowExecutionStatus.PAUSED],
+            "stopped": status_counts[WorkflowExecutionStatus.STOPPED],
         }
 
     @property

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -18094,7 +18094,7 @@ Built-in tool icons are URL strings; API-based tool icons are provider-defined p
 | provider_response_latency | number |  | No |
 | query | string |  | Yes |
 | retriever_resources | [ [RetrieverResource](#retrieverresource) ] |  | Yes |
-| status | string |  | Yes |
+| status | [MessageStatus](#messagestatus) |  | Yes |
 | total_price | string |  | No |
 | total_tokens | integer |  | Yes |
 
@@ -19250,6 +19250,14 @@ Enum class for large language model mode.
 | conversation_id | string | Conversation ID. | Yes |
 | first_id | string | The ID of the first chat record on the current page. Omit this value to fetch the latest messages; for subsequent pages, use the first message ID from the current list to fetch older messages. | No |
 | limit | integer, <br>**Default:** 20 | Number of chat history messages to return per request. | No |
+
+#### MessageStatus
+
+Message Status Enum
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| MessageStatus | string | Message Status Enum |  |
 
 #### Meta
 
@@ -22446,6 +22454,7 @@ Query parameters for listing snippet published workflows.
 | failed | integer |  | Yes |
 | partial_success | integer |  | Yes |
 | paused | integer |  | Yes |
+| stopped | integer |  | Yes |
 | success | integer |  | Yes |
 
 #### StepByStepTourStatePatchPayload

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -3490,7 +3490,7 @@ Model class for i18n object.
 | provider_response_latency | number |  | No |
 | query | string |  | Yes |
 | retriever_resources | [ [RetrieverResource](#retrieverresource) ] |  | Yes |
-| status | string |  | Yes |
+| status | [MessageStatus](#messagestatus) |  | Yes |
 | total_price | string |  | No |
 | total_tokens | integer |  | Yes |
 
@@ -3501,6 +3501,14 @@ Model class for i18n object.
 | conversation_id | string | Conversation ID. | Yes |
 | first_id | string | The ID of the first chat record on the current page. Omit this value to fetch the latest messages; for subsequent pages, use the first message ID from the current list to fetch older messages. | No |
 | limit | integer, <br>**Default:** 20 | Number of chat history messages to return per request. | No |
+
+#### MessageStatus
+
+Message Status Enum
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| MessageStatus | string | Message Status Enum |  |
 
 #### MetadataArgs
 

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -1358,6 +1358,14 @@ Parsed multipart form fields for HITL uploads.
 | ---- | ---- | ----------- | -------- |
 | response_mode | string, <br>**Available values:** "blocking", "streaming" | Response mode<br>*Enum:* `"blocking"`, `"streaming"` | Yes |
 
+#### MessageStatus
+
+Message Status Enum
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| MessageStatus | string | Message Status Enum |  |
+
 #### ParagraphInputConfig
 
 Form input definition.
@@ -1696,7 +1704,7 @@ in form definition, or a variable while the workflow is running.
 | provider_response_latency | number |  | No |
 | query | string |  | Yes |
 | retriever_resources | [ [RetrieverResource](#retrieverresource) ] |  | Yes |
-| status | string |  | Yes |
+| status | [MessageStatus](#messagestatus) |  | Yes |
 | total_price | string |  | No |
 | total_tokens | integer |  | Yes |
 

--- a/api/services/agent/observability_service.py
+++ b/api/services/agent/observability_service.py
@@ -131,6 +131,8 @@ class AgentObservabilityService:
             return "failed"
         if message.status == MessageStatus.PAUSED:
             return "paused"
+        if message.status == MessageStatus.STOPPED:
+            return "stopped"
         return "success"
 
     @staticmethod
@@ -275,6 +277,7 @@ class AgentObservabilityService:
                 func.sum(
                     sa.case((or_(Message.error.is_not(None), Message.status == MessageStatus.ERROR), 1), else_=0)
                 ).label("failed_count"),
+                func.sum(sa.case((Message.status == MessageStatus.STOPPED, 1), else_=0)).label("stopped_count"),
             )
             .join(Message, Message.conversation_id == Conversation.id)
             .where(Message.app_id == app.id, Conversation.app_id == app.id)
@@ -292,6 +295,7 @@ class AgentObservabilityService:
                 message_count=row.message_count,
                 paused_count=row.paused_count,
                 failed_count=row.failed_count,
+                stopped_count=row.stopped_count,
                 source=self._serialize_webapp_source(app),
                 created_at=row.created_at,
                 updated_at=row.updated_at,
@@ -604,6 +608,8 @@ class AgentObservabilityService:
                 conditions.append(or_(Message.error.is_not(None), Message.status == MessageStatus.ERROR))
             elif normalized == "paused":
                 conditions.append(Message.status == MessageStatus.PAUSED)
+            elif normalized == "stopped":
+                conditions.append(Message.status == MessageStatus.STOPPED)
             else:
                 raise ValueError(f"Unsupported status: {status}")
         if not conditions:
@@ -618,6 +624,7 @@ class AgentObservabilityService:
         message_count: int,
         paused_count: int,
         failed_count: int,
+        stopped_count: int,
         source: dict[str, Any],
         created_at: datetime | None,
         updated_at: datetime | None,
@@ -634,7 +641,9 @@ class AgentObservabilityService:
             "operation_rate": operation_rate,
             "unread": conversation.read_at is None,
             "source": source,
-            "status": cls._conversation_status(paused_count=paused_count, failed_count=failed_count),
+            "status": cls._conversation_status(
+                paused_count=paused_count, failed_count=failed_count, stopped_count=stopped_count
+            ),
             "created_at": to_timestamp(created_at or conversation.created_at),
             "updated_at": to_timestamp(updated_at or conversation.updated_at),
         }
@@ -792,11 +801,13 @@ class AgentObservabilityService:
         return "success"
 
     @staticmethod
-    def _conversation_status(*, paused_count: int, failed_count: int) -> str:
+    def _conversation_status(*, paused_count: int, failed_count: int, stopped_count: int) -> str:
         if paused_count:
             return "paused"
         if failed_count:
             return "failed"
+        if stopped_count:
+            return "stopped"
         return "success"
 
     @staticmethod

--- a/api/services/app_task_service.py
+++ b/api/services/app_task_service.py
@@ -7,6 +7,7 @@ new GraphEngine command channel mechanism.
 
 from core.app.apps.base_app_queue_manager import AppQueueManager
 from core.app.entities.app_invoke_entities import InvokeFrom
+from core.app.entities.queue_entities import QueueStopEvent
 from extensions.ext_redis import redis_client
 from graphon.graph_engine.manager import GraphEngineManager
 from models.model import AppMode
@@ -43,4 +44,4 @@ class AppTaskService:
         # New mechanism: Send stop command via GraphEngine for workflow-based apps
         # This ensures proper workflow status recording in the persistence layer
         if app_mode in (AppMode.ADVANCED_CHAT, AppMode.WORKFLOW):
-            GraphEngineManager(redis_client).send_stop_command(task_id)
+            GraphEngineManager(redis_client).send_stop_command(task_id, reason=QueueStopEvent.StopBy.USER_MANUAL.value)

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
@@ -269,7 +269,7 @@ def test_conversation_response_source_uses_caller_session(sqlite_session: Sessio
     assert source.message_count == 1
     assert source.user_feedback_stats == {"like": 1, "dislike": 1}
     assert source.admin_feedback_stats == {"like": 1, "dislike": 0}
-    assert source.status_count == {"success": 1, "failed": 0, "partial_success": 0, "paused": 0}
+    assert source.status_count == {"success": 1, "failed": 0, "partial_success": 0, "paused": 0, "stopped": 0}
     assert source.first_message is not None
     assert source.from_end_user_session_id == "end-user-session"
     assert source.from_account_name == "Account"

--- a/api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py
@@ -6,7 +6,7 @@ import pytest
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.execution_coordinator import AppExecutionState
 from core.app.entities.app_invoke_entities import InvokeFrom
-from core.app.entities.queue_entities import QueueErrorEvent
+from core.app.entities.queue_entities import QueueErrorEvent, QueueStopEvent
 from models import Tenant
 
 
@@ -91,9 +91,9 @@ class TestBaseAppQueueManager:
             graph_engine_manager.return_value.send_stop_command.side_effect = RuntimeError("redis unavailable")
             manager = DummyQueueManager(task_id="t1", user_id="u1", invoke_from=InvokeFrom.SERVICE_API)
 
-            assert manager._execution_coordinator.request_abort("stream closed") is True
-            assert manager._execution_coordinator.request_abort("duplicate") is False
+            assert manager._execution_coordinator.request_abort(QueueStopEvent.StopBy.USER_MANUAL) is True
+            assert manager._execution_coordinator.request_abort(QueueStopEvent.StopBy.TIMEOUT) is False
 
         execution_redis.setex.assert_called_once_with("generate_task_stopped:t1", 600, 1)
-        graph_engine_manager.return_value.send_stop_command.assert_called_once_with("t1", reason="stream closed")
+        graph_engine_manager.return_value.send_stop_command.assert_called_once_with("t1", reason="user_manual")
         assert "Failed to send stop command for app execution task=t1" in caplog.text

--- a/api/tests/unit_tests/core/app/apps/test_execution_coordinator.py
+++ b/api/tests/unit_tests/core/app/apps/test_execution_coordinator.py
@@ -10,6 +10,7 @@ from core.app.apps.execution_coordinator import (
     clear_app_task_cancellation_signals,
     is_app_task_stop_flag_set,
 )
+from core.app.entities.queue_entities import QueueStopEvent
 
 
 def test_listener_close_does_not_abort_running_attempt() -> None:
@@ -62,7 +63,7 @@ def test_watchdog_aborts_and_notifies_response_pipeline() -> None:
     redis_client.setex.assert_called_once_with("generate_task_stopped:task", 600, 1)
     graph_engine_manager.return_value.send_stop_command.assert_called_once_with(
         "task",
-        reason="App execution exceeded 0 seconds",
+        reason="timeout",
     )
     on_timeout.assert_called_once_with("App execution exceeded 0 seconds")
 
@@ -138,11 +139,11 @@ def test_stop_flag_failure_does_not_block_graph_stop(caplog: pytest.LogCaptureFi
         redis_client.setex.side_effect = RuntimeError("redis write failed")
         coordinator = AppExecutionCoordinator(task_id="task", on_timeout=on_timeout, timeout_seconds=1200)
 
-        coordinator.request_abort("test abort")
+        coordinator.request_abort(QueueStopEvent.StopBy.USER_MANUAL)
 
     graph_engine_manager.return_value.send_stop_command.assert_called_once_with(
         "task",
-        reason="test abort",
+        reason="user_manual",
     )
     assert "Failed to set stop flag for app execution task=task" in caplog.text
 

--- a/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
@@ -101,7 +101,7 @@ class TestWorkflowAppQueueManager:
             execution_redis.setex.assert_called_once_with("generate_task_stopped:task", 600, 1)
             graph_engine_manager.return_value.send_stop_command.assert_called_once_with(
                 "task",
-                reason="App execution exceeded 0 seconds",
+                reason="timeout",
             )
 
     def test_terminal_event_does_not_abort_completed_execution(self):

--- a/api/tests/unit_tests/core/app/entities/test_queue_entities.py
+++ b/api/tests/unit_tests/core/app/entities/test_queue_entities.py
@@ -14,9 +14,13 @@ class TestQueueEntities:
         assert event.get_stop_reason() == "Workflow execution timed out"
 
     def test_get_stop_reason_for_unknown_stop_by(self):
-        event = QueueStopEvent(stopped_by=QueueStopEvent.StopBy.USER_MANUAL)
-        event.stopped_by = "unknown"
+        event = QueueStopEvent(stopped_by=QueueStopEvent.StopBy.UNKNOWN)
         assert event.get_stop_reason() == "Stopped by unknown reason."
+
+    def test_stop_by_from_value_degrades_unrecognized_causes(self):
+        assert QueueStopEvent.StopBy.from_value(QueueStopEvent.StopBy.TIMEOUT.value) is QueueStopEvent.StopBy.TIMEOUT
+        assert QueueStopEvent.StopBy.from_value("stopped_by_a_newer_peer") is QueueStopEvent.StopBy.UNKNOWN
+        assert QueueStopEvent.StopBy.from_value(None) is QueueStopEvent.StopBy.UNKNOWN
 
     def test_reasoning_chunk_event_defaults(self):
         event = QueueReasoningChunkEvent(reasoning="thinking", from_node_id="llm")

--- a/api/tests/unit_tests/services/agent/test_agent_observability_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_observability_service.py
@@ -249,12 +249,19 @@ def test_apply_status_filter_accepts_multiple_statuses() -> None:
 
     stmt = FakeStmt()
 
-    result = AgentObservabilityService._apply_status_filter(stmt, ("success", "failed", "paused"))
+    result = AgentObservabilityService._apply_status_filter(stmt, ("success", "failed", "paused", "stopped"))
 
     assert result is stmt
     assert len(stmt.conditions) == 1
     with pytest.raises(ValueError, match="Unsupported status"):
         AgentObservabilityService._apply_status_filter(FakeStmt(), ("unknown",))
+
+
+def test_interrupted_run_is_not_reported_as_success() -> None:
+    stopped = SimpleNamespace(error=None, status=MessageStatus.STOPPED)
+    assert AgentObservabilityService._message_status(stopped) == "stopped"
+    assert AgentObservabilityService._conversation_status(paused_count=0, failed_count=0, stopped_count=1) == "stopped"
+    assert AgentObservabilityService._conversation_status(paused_count=0, failed_count=1, stopped_count=1) == "failed"
 
 
 def test_list_logs_sorts_by_requested_field(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -322,6 +329,7 @@ def test_list_webapp_conversation_logs_includes_feedback_rates(monkeypatch: pyte
         message_count = 2
         paused_count = 0
         failed_count = 0
+        stopped_count = 0
         created_at = timestamp
         updated_at = timestamp
 

--- a/api/tests/unit_tests/services/test_app_task_service.py
+++ b/api/tests/unit_tests/services/test_app_task_service.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from core.app.entities.app_invoke_entities import InvokeFrom
+from core.app.entities.queue_entities import QueueStopEvent
 from models.model import AppMode
 from services.app_task_service import AppTaskService
 
@@ -46,7 +47,9 @@ class TestAppTaskService:
         mock_app_queue_manager.set_stop_flag.assert_called_once_with(task_id, invoke_from, user_id)
         if should_call_graph_engine:
             mock_graph_engine_manager.assert_called_once()
-            mock_graph_engine_manager.return_value.send_stop_command.assert_called_once_with(task_id)
+            mock_graph_engine_manager.return_value.send_stop_command.assert_called_once_with(
+                task_id, reason=QueueStopEvent.StopBy.USER_MANUAL.value
+            )
         else:
             mock_graph_engine_manager.assert_not_called()
 
@@ -79,7 +82,9 @@ class TestAppTaskService:
         # Assert
         mock_app_queue_manager.set_stop_flag.assert_called_once_with(task_id, invoke_from, user_id)
         mock_graph_engine_manager.assert_called_once()
-        mock_graph_engine_manager.return_value.send_stop_command.assert_called_once_with(task_id)
+        mock_graph_engine_manager.return_value.send_stop_command.assert_called_once_with(
+            task_id, reason=QueueStopEvent.StopBy.USER_MANUAL.value
+        )
 
     @patch("services.app_task_service.GraphEngineManager")
     @patch("services.app_task_service.AppQueueManager")

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -2164,6 +2164,7 @@ export type StatusCount = {
   failed: number
   partial_success: number
   paused: number
+  stopped: number
   success: number
 }
 

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -2332,6 +2332,7 @@ export const zStatusCount = z.object({
   failed: z.int(),
   partial_success: z.int(),
   paused: z.int(),
+  stopped: z.int(),
   success: z.int(),
 })
 

--- a/packages/contracts/generated/api/console/installed-apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/types.gen.ts
@@ -225,7 +225,7 @@ export type ExploreMessageListItem = {
   provider_response_latency?: number
   query: string
   retriever_resources: Array<RetrieverResource>
-  status: string
+  status: MessageStatus
   total_price?: string | null
   readonly total_tokens: number
 }
@@ -326,6 +326,8 @@ export type RetrieverResource = {
   summary?: string | null
   word_count?: number | null
 }
+
+export type MessageStatus = 'error' | 'normal' | 'paused' | 'stopped'
 
 export type HumanInputFormDefinition = {
   actions?: Array<UserActionConfig>
@@ -480,7 +482,7 @@ export type ExploreMessageListItemWritable = {
   provider_response_latency?: number
   query: string
   retriever_resources: Array<RetrieverResource>
-  status: string
+  status: MessageStatus
   total_price?: string | null
 }
 

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -373,6 +373,13 @@ export const zRetrieverResource = z.object({
 })
 
 /**
+ * MessageStatus
+ *
+ * Message Status Enum
+ */
+export const zMessageStatus = z.enum(['error', 'normal', 'paused', 'stopped'])
+
+/**
  * ExecutionContentType
  */
 export const zExecutionContentType = z.enum(['human_input'])
@@ -551,7 +558,7 @@ export const zExploreMessageListItem = z.object({
   provider_response_latency: z.number().optional().default(0),
   query: z.string(),
   retriever_resources: z.array(zRetrieverResource),
-  status: z.string(),
+  status: zMessageStatus,
   total_price: z
     .string()
     .regex(/^(?![-+.]*$)[+-]?0*\d*\.?\d*$/)
@@ -626,7 +633,7 @@ export const zExploreMessageListItemWritable = z.object({
   provider_response_latency: z.number().optional().default(0),
   query: z.string(),
   retriever_resources: z.array(zRetrieverResource),
-  status: z.string(),
+  status: zMessageStatus,
   total_price: z
     .string()
     .regex(/^(?![-+.]*$)[+-]?0*\d*\.?\d*$/)

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -1091,7 +1091,7 @@ export type MessageListItem = {
   provider_response_latency?: number
   query: string
   retriever_resources: Array<RetrieverResource>
-  status: string
+  status: MessageStatus
   total_price?: string | null
   readonly total_tokens: number
 }
@@ -1101,6 +1101,8 @@ export type MessageListQuery = {
   first_id?: string | null
   limit?: number
 }
+
+export type MessageStatus = 'error' | 'normal' | 'paused' | 'stopped'
 
 export type MetadataArgs = {
   name: string
@@ -1726,7 +1728,7 @@ export type MessageListItemWritable = {
   provider_response_latency?: number
   query: string
   retriever_resources: Array<RetrieverResource>
-  status: string
+  status: MessageStatus
   total_price?: string | null
 }
 

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -1255,6 +1255,13 @@ export const zMessageListQuery = z.object({
 })
 
 /**
+ * MessageStatus
+ *
+ * Message Status Enum
+ */
+export const zMessageStatus = z.enum(['error', 'normal', 'paused', 'stopped'])
+
+/**
  * MetadataArgs
  */
 export const zMetadataArgs = z.object({
@@ -1996,7 +2003,7 @@ export const zMessageListItem = z.object({
   provider_response_latency: z.number().optional().default(0),
   query: z.string(),
   retriever_resources: z.array(zRetrieverResource),
-  status: z.string(),
+  status: zMessageStatus,
   total_price: z
     .string()
     .regex(/^(?![-+.]*$)[+-]?0*\d*\.?\d*$/)
@@ -2347,7 +2354,7 @@ export const zMessageListItemWritable = z.object({
   provider_response_latency: z.number().optional().default(0),
   query: z.string(),
   retriever_resources: z.array(zRetrieverResource),
-  status: z.string(),
+  status: zMessageStatus,
   total_price: z
     .string()
     .regex(/^(?![-+.]*$)[+-]?0*\d*\.?\d*$/)

--- a/packages/contracts/generated/api/web/types.gen.ts
+++ b/packages/contracts/generated/api/web/types.gen.ts
@@ -360,6 +360,8 @@ export type MessageMoreLikeThisQuery = {
   response_mode: 'blocking' | 'streaming'
 }
 
+export type MessageStatus = 'error' | 'normal' | 'paused' | 'stopped'
+
 export type ParagraphInputConfig = {
   default?: StringSource | null
   output_variable_name: string
@@ -620,7 +622,7 @@ export type WebMessageListItem = {
   provider_response_latency?: number
   query: string
   retriever_resources: Array<RetrieverResource>
-  status: string
+  status: MessageStatus
   total_price?: string | null
   readonly total_tokens: number
 }
@@ -699,7 +701,7 @@ export type WebMessageListItemWritable = {
   provider_response_latency?: number
   query: string
   retriever_resources: Array<RetrieverResource>
-  status: string
+  status: MessageStatus
   total_price?: string | null
 }
 

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -437,6 +437,13 @@ export const zMessageMoreLikeThisQuery = z.object({
 })
 
 /**
+ * MessageStatus
+ *
+ * Message Status Enum
+ */
+export const zMessageStatus = z.enum(['error', 'normal', 'paused', 'stopped'])
+
+/**
  * PassportAccessTokenResponse
  */
 export const zPassportAccessTokenResponse = z.object({
@@ -835,7 +842,7 @@ export const zWebMessageListItem = z.object({
   provider_response_latency: z.number().optional().default(0),
   query: z.string(),
   retriever_resources: z.array(zRetrieverResource),
-  status: z.string(),
+  status: zMessageStatus,
   total_price: z
     .string()
     .regex(/^(?![-+.]*$)[+-]?0*\d*\.?\d*$/)
@@ -963,7 +970,7 @@ export const zWebMessageListItemWritable = z.object({
   provider_response_latency: z.number().optional().default(0),
   query: z.string(),
   retriever_resources: z.array(zRetrieverResource),
-  status: z.string(),
+  status: zMessageStatus,
   total_price: z
     .string()
     .regex(/^(?![-+.]*$)[+-]?0*\d*\.?\d*$/)

--- a/web/__tests__/base/chat-flow.test.tsx
+++ b/web/__tests__/base/chat-flow.test.tsx
@@ -105,7 +105,7 @@ const defaultHookReturn: HookReturn = {
   newConversationId: '',
   chatShouldReloadKey: 'test-reload-key',
   handleFeedback: vi.fn(),
-  currentChatInstanceRef: { current: { handleStop: vi.fn() } },
+  currentChatInstanceRef: { current: { handleStop: vi.fn(), handleDetach: vi.fn() } },
   sidebarCollapseState: false,
   handleSidebarCollapse: vi.fn(),
   clearChatList: false,

--- a/web/app/components/app/log/__tests__/list.spec.tsx
+++ b/web/app/components/app/log/__tests__/list.spec.tsx
@@ -581,7 +581,7 @@ describe('ConversationList', () => {
             from_account_name: 'user-a',
             read_at: 1710000001,
             message_count: 3,
-            status_count: { paused: 1, success: 0, failed: 0, partial_success: 0 },
+            status_count: { paused: 1, success: 0, failed: 0, partial_success: 0, stopped: 0 },
             user_feedback_stats: { like: 2, dislike: 0 },
             admin_feedback_stats: { like: 0, dislike: 1 },
             updated_at: 1710000000,
@@ -593,7 +593,7 @@ describe('ConversationList', () => {
             from_account_name: 'user-b',
             read_at: 1710000001,
             message_count: 4,
-            status_count: { paused: 0, success: 4, failed: 0, partial_success: 0 },
+            status_count: { paused: 0, success: 4, failed: 0, partial_success: 0, stopped: 0 },
             user_feedback_stats: { like: 0, dislike: 0 },
             admin_feedback_stats: { like: 0, dislike: 0 },
             updated_at: 1710000000,
@@ -605,7 +605,19 @@ describe('ConversationList', () => {
             from_account_name: 'user-c',
             read_at: 1710000001,
             message_count: 5,
-            status_count: { paused: 0, success: 3, failed: 0, partial_success: 1 },
+            status_count: { paused: 0, success: 3, failed: 0, partial_success: 1, stopped: 0 },
+            user_feedback_stats: { like: 0, dislike: 0 },
+            admin_feedback_stats: { like: 0, dislike: 0 },
+            updated_at: 1710000000,
+            created_at: 1710000000,
+          },
+          {
+            id: 'conversation-stopped',
+            name: 'Stopped row',
+            from_account_name: 'user-e',
+            read_at: 1710000001,
+            message_count: 7,
+            status_count: { paused: 0, success: 1, failed: 0, partial_success: 0, stopped: 1 },
             user_feedback_stats: { like: 0, dislike: 0 },
             admin_feedback_stats: { like: 0, dislike: 0 },
             updated_at: 1710000000,
@@ -617,7 +629,7 @@ describe('ConversationList', () => {
             from_account_name: 'user-d',
             read_at: 1710000001,
             message_count: 1,
-            status_count: { paused: 0, success: 0, failed: 2, partial_success: 0 },
+            status_count: { paused: 0, success: 0, failed: 2, partial_success: 0, stopped: 0 },
             user_feedback_stats: { like: 0, dislike: 0 },
             admin_feedback_stats: { like: 0, dislike: 0 },
             updated_at: 1710000000,
@@ -630,6 +642,7 @@ describe('ConversationList', () => {
     expect(screen.getByText('Pending')).toBeInTheDocument()
     expect(screen.getByText('Success')).toBeInTheDocument()
     expect(screen.getByText('Partial Success')).toBeInTheDocument()
+    expect(screen.getByText('Stopped')).toBeInTheDocument()
     expect(screen.getByText('2 Failures')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
     expect(screen.getAllByText('1').length).toBeGreaterThan(0)

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -1,4 +1,5 @@
 'use client'
+import type { StatusCount } from '@dify/contracts/api/console/apps/types.gen'
 import type { FC } from 'react'
 import type { ChatItemInTree } from '../../base/chat/types'
 import type {
@@ -93,13 +94,6 @@ type IConversationList = {
 
 const defaultValue = 'N/A'
 
-type StatusCount = {
-  paused: number
-  success: number
-  failed: number
-  partial_success: number
-}
-
 /**
  * Icon component with numbers
  */
@@ -127,6 +121,13 @@ const statusTdRender = (statusCount: StatusCount) => {
       <div className="inline-flex items-center gap-1 system-xs-semibold-uppercase">
         <StatusDot status="warning" />
         <span className="text-util-colors-warning-warning-600">Pending</span>
+      </div>
+    )
+  } else if (statusCount.partial_success + statusCount.failed === 0 && statusCount.stopped > 0) {
+    return (
+      <div className="inline-flex items-center gap-1 system-xs-semibold-uppercase">
+        <StatusDot status="warning" />
+        <span className="text-util-colors-warning-warning-600">Stopped</span>
       </div>
     )
   } else if (statusCount.partial_success + statusCount.failed === 0) {

--- a/web/app/components/base/chat/__tests__/utils.spec.ts
+++ b/web/app/components/base/chat/__tests__/utils.spec.ts
@@ -1,5 +1,6 @@
 import type { IChatItem } from '../chat/type'
 import type { ChatItem, ChatItemInTree } from '../types'
+import { zMessageStatus } from '@dify/contracts/api/web/zod.gen'
 import { get } from 'es-toolkit/compat'
 import { UUID_NIL } from '../constants'
 import {
@@ -12,6 +13,7 @@ import {
   getRawUserVariablesFromUrlParams,
   getThreadMessages,
   isValidGeneratedAnswer,
+  toMessageStatus,
 } from '../utils'
 import branchedTestMessages from './branchedTestMessages.json'
 import legacyTestMessages from './legacyTestMessages.json'
@@ -688,5 +690,13 @@ describe('chat utils - url params and answer helpers', () => {
       expect(thread.map((t) => t.id)).toEqual(['q1', 'a1', 'q3', 'a3'])
       expect(thread[3]!.prevSibling).toBe('a2')
     })
+  })
+})
+
+describe('toMessageStatus', () => {
+  it('yields undefined for a status this build does not recognise', () => {
+    expect(toMessageStatus('stopped')).toBe(zMessageStatus.enum.stopped)
+    expect(toMessageStatus('cancelled_by_operator')).toBeUndefined()
+    expect(toMessageStatus(undefined)).toBeUndefined()
   })
 })

--- a/web/app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx
@@ -110,7 +110,7 @@ const defaultContextValue: ChatWithHistoryContextValue = {
   inputsForms: [],
   isInstalledApp: false,
   currentChatInstanceRef: {
-    current: { handleStop: vi.fn() },
+    current: { handleStop: vi.fn(), handleDetach: vi.fn() },
   } as ChatWithHistoryContextValue['currentChatInstanceRef'],
   setIsResponding: vi.fn(),
   setClearChatList: vi.fn(),
@@ -1225,7 +1225,7 @@ describe('ChatWrapper', () => {
   it('should set handleStop on currentChatInstanceRef', () => {
     const handleStop = vi.fn()
     const currentChatInstanceRef = {
-      current: { handleStop: vi.fn() },
+      current: { handleStop: vi.fn(), handleDetach: vi.fn() },
     } as ChatWithHistoryContextValue['currentChatInstanceRef']
 
     vi.mocked(useChatWithHistoryContext).mockReturnValue({

--- a/web/app/components/base/chat/chat-with-history/__tests__/header-in-mobile.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/header-in-mobile.spec.tsx
@@ -68,7 +68,7 @@ const defaultContextValue: ChatWithHistoryContextValue = {
   conversationList: [],
   isInstalledApp: false,
   currentChatInstanceRef: {
-    current: { handleStop: vi.fn() },
+    current: { handleStop: vi.fn(), handleDetach: vi.fn() },
   } as ChatWithHistoryContextValue['currentChatInstanceRef'],
   setIsResponding: vi.fn(),
   setClearChatList: vi.fn(),

--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -1,6 +1,6 @@
 import type { InstalledAppResponse } from '@dify/contracts/api/console/installed-apps/types.gen'
 import type { ReactNode } from 'react'
-import type { ChatConfig } from '../../types'
+import type { ChatConfig, ChatInstance } from '../../types'
 import type { AppConversationData, AppData, AppMeta, ConversationItem } from '@/models/share'
 import { ToastHost } from '@langgenius/dify-ui/toast'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -791,6 +791,50 @@ describe('useChatWithHistory', () => {
         expect(result!.current.newConversationId).toBe('')
       })
       expect(result!.current.clearChatList).toBe(false)
+    })
+  })
+
+  describe('Running generation on navigation', () => {
+    const trackChatInstance = (result: {
+      current: { currentChatInstanceRef: { current: ChatInstance } }
+    }) => {
+      const handleStop = vi.fn()
+      const handleDetach = vi.fn()
+      result.current.currentChatInstanceRef.current = { handleStop, handleDetach }
+      return { handleStop, handleDetach }
+    }
+
+    beforeEach(() => {
+      mockFetchConversations.mockResolvedValue(createConversationData())
+      mockFetchChatList.mockResolvedValue({ data: [] })
+    })
+
+    it('should detach without stopping when switching to another conversation', async () => {
+      const { result } = await renderWithClient(() => useChatWithHistory())
+      const { handleStop, handleDetach } = trackChatInstance(result!)
+
+      act(() => {
+        result!.current.handleChangeConversation('conversation-1')
+      })
+
+      expect(handleDetach).toHaveBeenCalledTimes(1)
+      expect(handleStop).not.toHaveBeenCalled()
+    })
+
+    it('should stop the run when deleting the conversation it belongs to', async () => {
+      mockDelConversation.mockResolvedValue(undefined)
+      const { result } = await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        expect(result!.current.currentConversationId).toBe('conversation-1')
+      })
+      const { handleStop } = trackChatInstance(result!)
+
+      await act(async () => {
+        await result!.current.handleDeleteConversation('conversation-1', { onSuccess: vi.fn() })
+      })
+
+      expect(handleStop).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -85,6 +85,7 @@ const ChatWrapper = () => {
     chatList,
     handleSend,
     handleStop,
+    handleDetach,
     handleSwitchSibling,
     prepareHumanInputSubmission,
     isResponding: respondingState,
@@ -151,8 +152,10 @@ const ChatWrapper = () => {
   }, [allInputsHidden, inputsForms, chatList, inputsFormValue])
 
   useEffect(() => {
-    if (currentChatInstanceRef.current) currentChatInstanceRef.current.handleStop = handleStop
-  }, [])
+    if (!currentChatInstanceRef.current) return
+    currentChatInstanceRef.current.handleStop = handleStop
+    currentChatInstanceRef.current.handleDetach = handleDetach
+  }, [currentChatInstanceRef, handleStop, handleDetach])
 
   useEffect(() => {
     setIsResponding(respondingState)

--- a/web/app/components/base/chat/chat-with-history/context.ts
+++ b/web/app/components/base/chat/chat-with-history/context.ts
@@ -3,7 +3,7 @@
 import type { RefObject } from 'react'
 import type { ChatProps } from '../chat'
 import type { Theme } from '../embedded-chatbot/theme/theme'
-import type { Callback, ChatConfig, ChatItemInTree, OnFeedback } from '../types'
+import type { Callback, ChatConfig, ChatInstance, ChatItemInTree, OnFeedback } from '../types'
 import type { AppConversationData, AppData, AppMeta, ConversationItem } from '@/models/share'
 import { noop } from 'es-toolkit/function'
 import { createContext, useContext } from 'use-context-selector'
@@ -36,7 +36,7 @@ export type ChatWithHistoryContextValue = {
   isInstalledApp: boolean
   appId?: string
   handleFeedback: OnFeedback
-  currentChatInstanceRef: RefObject<{ handleStop: () => void }>
+  currentChatInstanceRef: RefObject<ChatInstance>
   theme?: Theme
   sidebarCollapseState?: boolean
   handleSidebarCollapse: (state: boolean) => void
@@ -77,7 +77,7 @@ export const ChatWithHistoryContext = createContext<ChatWithHistoryContextValue>
   isMobile: false,
   isInstalledApp: false,
   handleFeedback: () => Promise.resolve(),
-  currentChatInstanceRef: { current: { handleStop: noop } },
+  currentChatInstanceRef: { current: { handleStop: noop, handleDetach: noop } },
   sidebarCollapseState: false,
   handleSidebarCollapse: noop,
   clearChatList: false,

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -1,6 +1,6 @@
 import type { InstalledAppResponse } from '@dify/contracts/api/console/installed-apps/types.gen'
 import type { ExtraContent } from '../chat/type'
-import type { Callback, ChatConfig, ChatItem, OnFeedback } from '../types'
+import type { Callback, ChatConfig, ChatInstance, ChatItem, OnFeedback } from '../types'
 import type { AppData, ConversationItem } from '@/models/share'
 import type { HumanInputFilledFormData, HumanInputFormData } from '@/types/workflow'
 import { toast } from '@langgenius/dify-ui/toast'
@@ -457,12 +457,10 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
     },
     [setShowNewConversationItemInList, checkInputsRequired],
   )
-  const currentChatInstanceRef = useRef<{
-    handleStop: () => void
-  }>({ handleStop: noop })
+  const currentChatInstanceRef = useRef<ChatInstance>({ handleStop: noop, handleDetach: noop })
   const handleChangeConversation = useCallback(
     (conversationId: string) => {
-      currentChatInstanceRef.current.handleStop()
+      currentChatInstanceRef.current.handleDetach()
       setNewConversationId('')
       handleConversationIdInfoChange(conversationId)
       if (conversationId) setClearChatList(false)
@@ -470,7 +468,6 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
     [handleConversationIdInfoChange, setClearChatList],
   )
   const handleNewConversation = useCallback(async () => {
-    currentChatInstanceRef.current.handleStop()
     setShowNewConversationItemInList(true)
     handleChangeConversation('')
     const conversationInputs: Record<string, any> = {}
@@ -517,7 +514,10 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
       } finally {
         setConversationDeleting(false)
       }
-      if (conversationId === currentConversationId) handleNewConversation()
+      if (conversationId === currentConversationId) {
+        currentChatInstanceRef.current.handleStop()
+        handleNewConversation()
+      }
       handleUpdateConversationList()
     },
     [

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -39,6 +39,7 @@ import {
   getProcessedSystemVariablesFromUrlParams,
   getRawInputsFromUrlParams,
   getRawUserVariablesFromUrlParams,
+  toMessageStatus,
 } from '../utils'
 
 function getFormattedChatList(messages: any[]) {
@@ -123,6 +124,7 @@ function getFormattedChatList(messages: any[]) {
       humanInputFormDataList,
       humanInputFilledFormDataList,
       workflow_run_id: workflowRunId,
+      status: toMessageStatus(item.status),
       more,
     })
   })

--- a/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/content.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/content.spec.tsx
@@ -1,3 +1,4 @@
+import type { ChatInstance } from '../../../types'
 import type { ChatWithHistoryContextValue } from '../../context'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -124,9 +125,9 @@ const createMockContext = (
     isMobile: false,
     isInstalledApp: false,
     handleFeedback: vi.fn(),
-    currentChatInstanceRef: { current: { handleStop: vi.fn() } } as React.RefObject<{
-      handleStop: () => void
-    }>,
+    currentChatInstanceRef: {
+      current: { handleStop: vi.fn(), handleDetach: vi.fn() },
+    } as React.RefObject<ChatInstance>,
     sidebarCollapseState: false,
     handleSidebarCollapse: vi.fn(),
     setClearChatList: vi.fn(),

--- a/web/app/components/base/chat/chat/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/hooks.spec.tsx
@@ -2222,6 +2222,36 @@ describe('useChat', () => {
       expect(result.current.isResponding).toBe(false)
     })
 
+    it('should abort the local stream without calling stopChat when detaching', () => {
+      const stopChat = vi.fn()
+      const workflowAbort = createAbortControllerMock()
+      const { result } = renderHook(() => useChat(undefined, undefined, undefined, stopChat))
+
+      act(() => {
+        result.current.handleSend('url', { query: 'test' }, {})
+      })
+
+      const callbacks = vi.mocked(ssePost).mock.calls[0]![2] as HookCallbacks
+      act(() => {
+        callbacks.onWorkflowStarted({ task_id: 'task-123' })
+        callbacks.getAbortController(workflowAbort)
+      })
+
+      act(() => {
+        result.current.handleDetach()
+      })
+
+      expect(stopChat).not.toHaveBeenCalled()
+      expect(workflowAbort.abort).toHaveBeenCalledTimes(1)
+      expect(result.current.isResponding).toBe(false)
+
+      act(() => {
+        result.current.handleStop()
+      })
+
+      expect(stopChat).not.toHaveBeenCalled()
+    })
+
     it('should clear chat tree and controllers on restart', () => {
       const cb = vi.fn()
       const { result } = renderHook(() => useChat())

--- a/web/app/components/base/chat/chat/answer/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/answer/__tests__/index.spec.tsx
@@ -1,5 +1,6 @@
 import type { ChatItem } from '../../../types'
 import type { AppData } from '@/models/share'
+import { zMessageStatus } from '@dify/contracts/api/web/zod.gen'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import Answer from '../index'
 
@@ -149,6 +150,16 @@ describe('Answer Component', () => {
       )
       expect(screen.getByTestId('citation-title')).toBeInTheDocument()
     })
+  })
+
+  it('should mark an answer whose run was stopped', () => {
+    render(
+      <Answer
+        {...defaultProps}
+        item={{ ...defaultProps.item, status: zMessageStatus.enum.stopped }}
+      />,
+    )
+    expect(screen.getByText('share.chat.answerInterrupted')).toBeInTheDocument()
   })
 
   describe('Human Inputs Layout', () => {

--- a/web/app/components/base/chat/chat/answer/index.tsx
+++ b/web/app/components/base/chat/chat/answer/index.tsx
@@ -20,6 +20,7 @@ import HumanInputFormList from './human-input-form-list'
 import More from './more'
 import Operation from './operation'
 import ReasoningPanel from './reasoning-panel'
+import StoppedNotice from './stopped-notice'
 import SuggestedQuestions from './suggested-questions'
 import WorkflowProcessItem from './workflow-process'
 
@@ -270,6 +271,7 @@ const Answer: FC<AnswerProps> = ({
               )}
               {!contentIsEmpty && !hasAgentContent && <BasicContent item={item} />}
               {hasAgentContent && agentContentNode}
+              {!responding && <StoppedNotice status={item.status} />}
               {!!allFiles?.length && (
                 <FileList
                   className="my-1"
@@ -358,6 +360,7 @@ const Answer: FC<AnswerProps> = ({
               )}
               {!contentIsEmpty && !hasAgentContent && <BasicContent item={item} />}
               {hasAgentContent && agentContentNode}
+              {!responding && <StoppedNotice status={item.status} />}
               {!!allFiles?.length && (
                 <FileList
                   className="my-1"

--- a/web/app/components/base/chat/chat/answer/stopped-notice.tsx
+++ b/web/app/components/base/chat/chat/answer/stopped-notice.tsx
@@ -1,0 +1,25 @@
+import type { MessageStatus } from '@dify/contracts/api/web/types.gen'
+import { zMessageStatus } from '@dify/contracts/api/web/zod.gen'
+import { useTranslation } from 'react-i18next'
+
+type StoppedNoticeProps = {
+  status?: MessageStatus
+}
+
+const StoppedNotice = ({ status }: StoppedNoticeProps) => {
+  const { t } = useTranslation()
+
+  if (status !== zMessageStatus.enum.stopped) return null
+
+  return (
+    <div className="mt-1 flex items-center system-xs-regular text-text-tertiary">
+      <span
+        aria-hidden
+        className="mr-1 i-ri-stop-circle-fill size-3.5 shrink-0 text-text-warning-secondary"
+      />
+      <span>{t(($) => $['chat.answerInterrupted'], { ns: 'share' })}</span>
+    </div>
+  )
+}
+
+export default StoppedNotice

--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -550,13 +550,12 @@ export const useChat = (
   const handleRestart = useCallback(
     (cb?: any) => {
       conversationIdRef.current = initialConversationIdRef.current
-      taskIdRef.current = ''
-      handleStop()
+      handleDetach()
       setChatTree([])
       setSuggestedQuestions([])
       cb?.()
     },
-    [handleStop],
+    [handleDetach],
   )
 
   const createAudioPlayerManager = useCallback(() => {

--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -6,6 +6,7 @@ import type { Annotation } from '@/models/log'
 import type { IOnDataMoreInfo, IOtherOptions } from '@/service/base'
 import type { VisionFile } from '@/types/app'
 import type { FileResponse, ReasoningChunkResponse } from '@/types/workflow'
+import { zMessageStatus } from '@dify/contracts/api/web/zod.gen'
 import { toast } from '@langgenius/dify-ui/toast'
 import { uniqBy } from 'es-toolkit/compat'
 import { noop } from 'es-toolkit/function'
@@ -26,7 +27,7 @@ import useTimestamp from '@/hooks/use-timestamp'
 import { useParams, usePathname } from '@/next/navigation'
 import { sseGet, ssePost } from '@/service/base'
 import { TransferMethod } from '@/types/app'
-import { getThreadMessages } from '../utils'
+import { getThreadMessages, isValidGeneratedAnswer } from '../utils'
 import { getProcessedInputs, processOpeningStatement } from './utils'
 
 type GetAbortController = (abortController: AbortController) => void
@@ -236,6 +237,7 @@ export const useChat = (
 
   const [chatTree, setChatTree] = useState<ChatItemInTree[]>(prevChatTree || [])
   const chatTreeRef = useRef<ChatItemInTree[]>(chatTree)
+  const respondingItemRef = useRef<ChatItemInTree | null>(null)
   const [targetMessageId, setTargetMessageId] = useState<string>()
   const threadMessages = useMemo(
     () => getThreadMessages(chatTree, targetMessageId),
@@ -527,6 +529,7 @@ export const useChat = (
   const handleDetach = useCallback(() => {
     hasStopRespondedRef.current = true
     taskIdRef.current = ''
+    respondingItemRef.current = null
     handleResponding(false)
     if (conversationMessagesAbortControllerRef.current)
       conversationMessagesAbortControllerRef.current.abort()
@@ -538,8 +541,11 @@ export const useChat = (
 
   const handleStop = useCallback(() => {
     if (stopChat && taskIdRef.current && !pausedStateRef.current) stopChat(taskIdRef.current)
+    const respondingItem = respondingItemRef.current
+    if (isRespondingRef.current && respondingItem && isValidGeneratedAnswer(respondingItem))
+      updateChatTreeNode(respondingItem.id, { status: zMessageStatus.enum.stopped })
     handleDetach()
-  }, [stopChat, handleDetach])
+  }, [stopChat, handleDetach, updateChatTreeNode])
 
   const handleRestart = useCallback(
     (cb?: any) => {
@@ -1153,6 +1159,7 @@ export const useChat = (
         parentMessageId: questionItem.id,
         siblingIndex: parentMessage?.children?.length ?? chatTree.length,
       }
+      respondingItemRef.current = responseItem
 
       handleResponding(true)
       hasStopRespondedRef.current = false

--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -524,17 +524,22 @@ export const useChat = (
 
   useEffect(() => resetWorkflowEventsSubscription, [resetWorkflowEventsSubscription])
 
-  const handleStop = useCallback(() => {
+  const handleDetach = useCallback(() => {
     hasStopRespondedRef.current = true
+    taskIdRef.current = ''
     handleResponding(false)
-    if (stopChat && taskIdRef.current && !pausedStateRef.current) stopChat(taskIdRef.current)
     if (conversationMessagesAbortControllerRef.current)
       conversationMessagesAbortControllerRef.current.abort()
     if (suggestedQuestionsAbortControllerRef.current)
       suggestedQuestionsAbortControllerRef.current.abort()
     if (workflowEventsAbortControllerRef.current) workflowEventsAbortControllerRef.current.abort()
     resetWorkflowEventsSubscription()
-  }, [stopChat, handleResponding, resetWorkflowEventsSubscription])
+  }, [handleResponding, resetWorkflowEventsSubscription])
+
+  const handleStop = useCallback(() => {
+    if (stopChat && taskIdRef.current && !pausedStateRef.current) stopChat(taskIdRef.current)
+    handleDetach()
+  }, [stopChat, handleDetach])
 
   const handleRestart = useCallback(
     (cb?: any) => {
@@ -1944,6 +1949,7 @@ export const useChat = (
     suggestedQuestions,
     handleRestart,
     handleStop,
+    handleDetach,
     handleAnnotationEdited,
     handleAnnotationAdded,
     handleAnnotationRemoved,

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/chat-wrapper.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/chat-wrapper.spec.tsx
@@ -1,6 +1,6 @@
 import type { RefObject } from 'react'
 import type { HumanInputFieldValue } from '../../chat/answer/human-input-content/field-renderer'
-import type { ChatConfig, ChatItem, ChatItemInTree } from '../../types'
+import type { ChatConfig, ChatInstance, ChatItem, ChatItemInTree } from '../../types'
 import type { EmbeddedChatbotContextValue } from '../context'
 import type { ConversationItem } from '@/models/share'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -189,7 +189,7 @@ const createContextValue = (
   appId: 'app-1',
   disableFeedback: false,
   handleFeedback: vi.fn(),
-  currentChatInstanceRef: { current: { handleStop: vi.fn() } },
+  currentChatInstanceRef: { current: { handleStop: vi.fn(), handleDetach: vi.fn() } },
   theme: undefined,
   clearChatList: false,
   setClearChatList: vi.fn(),
@@ -209,6 +209,7 @@ const createUseChatReturn = (overrides: Partial<UseChatReturn> = {}): UseChatRet
   handleResume: vi.fn(),
   setIsResponding: vi.fn() as UseChatReturn['setIsResponding'],
   handleStop: vi.fn(),
+  handleDetach: vi.fn(),
   handleSwitchSibling: vi.fn(),
   prepareHumanInputSubmission: vi.fn().mockResolvedValue(true),
   isResponding: false,
@@ -890,9 +891,7 @@ describe('EmbeddedChatbot chat-wrapper', () => {
     it('should handle null/undefined refs and config fallbacks', () => {
       vi.mocked(useEmbeddedChatbotContext).mockReturnValue(
         createContextValue({
-          currentChatInstanceRef: { current: null } as unknown as RefObject<{
-            handleStop: () => void
-          }>,
+          currentChatInstanceRef: { current: null } as unknown as RefObject<ChatInstance>,
           appParams: null,
           appMeta: null,
         }),

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/index.spec.tsx
@@ -109,7 +109,7 @@ const createHookReturn = (
     chatShouldReloadKey: 'reload-key',
     allowResetChat: true,
     handleFeedback: vi.fn(),
-    currentChatInstanceRef: { current: { handleStop: vi.fn() } },
+    currentChatInstanceRef: { current: { handleStop: vi.fn(), handleDetach: vi.fn() } },
     clearChatList: false,
     setClearChatList: vi.fn(),
     isResponding: false,

--- a/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
@@ -87,6 +87,7 @@ const ChatWrapper = () => {
     chatList,
     handleSend,
     handleStop,
+    handleDetach,
     handleSwitchSibling,
     prepareHumanInputSubmission,
     isResponding: respondingState,
@@ -145,8 +146,10 @@ const ChatWrapper = () => {
   }, [inputsFormValue, inputsForms, allInputsHidden])
 
   useEffect(() => {
-    if (currentChatInstanceRef.current) currentChatInstanceRef.current.handleStop = handleStop
-  }, [currentChatInstanceRef, handleStop])
+    if (!currentChatInstanceRef.current) return
+    currentChatInstanceRef.current.handleStop = handleStop
+    currentChatInstanceRef.current.handleDetach = handleDetach
+  }, [currentChatInstanceRef, handleStop, handleDetach])
   useEffect(() => {
     setIsResponding(respondingState)
   }, [respondingState, setIsResponding])

--- a/web/app/components/base/chat/embedded-chatbot/context.ts
+++ b/web/app/components/base/chat/embedded-chatbot/context.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import type { RefObject } from 'react'
-import type { ChatConfig, ChatItem, OnFeedback } from '../types'
+import type { ChatConfig, ChatInstance, ChatItem, OnFeedback } from '../types'
 import type { Theme } from './theme/theme'
 import type { AppConversationData, AppData, AppMeta, ConversationItem } from '@/models/share'
 import { noop } from 'es-toolkit/function'
@@ -34,7 +34,7 @@ export type EmbeddedChatbotContextValue = {
   appId?: string
   disableFeedback?: boolean
   handleFeedback: OnFeedback
-  currentChatInstanceRef: RefObject<{ handleStop: () => void }>
+  currentChatInstanceRef: RefObject<ChatInstance>
   theme?: Theme
   clearChatList?: boolean
   setClearChatList: (state: boolean) => void
@@ -72,7 +72,7 @@ export const EmbeddedChatbotContext = createContext<EmbeddedChatbotContextValue>
   isInstalledApp: false,
   allowResetChat: true,
   handleFeedback: () => Promise.resolve(),
-  currentChatInstanceRef: { current: { handleStop: noop } },
+  currentChatInstanceRef: { current: { handleStop: noop, handleDetach: noop } },
   clearChatList: false,
   setClearChatList: noop,
   isResponding: false,

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -28,6 +28,7 @@ import {
   getProcessedInputsFromUrlParams,
   getProcessedSystemVariablesFromUrlParams,
   getProcessedUserVariablesFromUrlParams,
+  toMessageStatus,
 } from '../utils'
 
 function getFormattedChatList(messages: any[]) {
@@ -62,6 +63,7 @@ function getFormattedChatList(messages: any[]) {
         answerFiles.map((item: any) => ({ ...item, related_id: item.id })),
       ),
       parentMessageId: `question-${item.id}`,
+      status: toMessageStatus(item.status),
     })
   })
   return newChatList

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -1,4 +1,4 @@
-import type { ChatConfig, ChatItem, OnFeedback } from '../types'
+import type { ChatConfig, ChatInstance, ChatItem, OnFeedback } from '../types'
 /* oxlint-disable typescript/no-explicit-any */
 import type { InputValueTypes } from '@/app/components/share/text-generation/types'
 import type { Locale } from '@/i18n-config'
@@ -368,12 +368,10 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     },
     [setShowNewConversationItemInList, checkInputsRequired],
   )
-  const currentChatInstanceRef = useRef<{
-    handleStop: () => void
-  }>({ handleStop: noop })
+  const currentChatInstanceRef = useRef<ChatInstance>({ handleStop: noop, handleDetach: noop })
   const handleChangeConversation = useCallback(
     (conversationId: string) => {
-      currentChatInstanceRef.current.handleStop()
+      currentChatInstanceRef.current.handleDetach()
       setNewConversationId('')
       handleConversationIdInfoChange(conversationId)
       if (conversationId) setClearChatList(false)
@@ -385,7 +383,6 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       setClearChatList(true)
       return
     }
-    currentChatInstanceRef.current.handleStop()
     setShowNewConversationItemInList(true)
     handleChangeConversation('')
     handleNewConversationInputsChange(await getProcessedInputsFromUrlParams())

--- a/web/app/components/base/chat/types.ts
+++ b/web/app/components/base/chat/types.ts
@@ -77,3 +77,8 @@ export type Feedback = {
 }
 
 export type OnFeedback = (messageId: string, feedback: Feedback) => Promise<void>
+
+export type ChatInstance = {
+  handleStop: () => void
+  handleDetach: () => void
+}

--- a/web/app/components/base/chat/types.ts
+++ b/web/app/components/base/chat/types.ts
@@ -1,3 +1,4 @@
+import type { MessageStatus } from '@dify/contracts/api/web/types.gen'
 import type { IChatItem } from '@/app/components/base/chat/chat/type'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import type { WorkflowRunningStatus } from '@/app/components/workflow/types'
@@ -43,6 +44,7 @@ export type WorkflowProcess = {
 
 export type ChatItem = IChatItem & {
   isError?: boolean
+  status?: MessageStatus
   workflowProcess?: WorkflowProcess
   conversationId?: string
   allFiles?: FileEntity[]

--- a/web/app/components/base/chat/utils.ts
+++ b/web/app/components/base/chat/utils.ts
@@ -1,5 +1,7 @@
+import type { MessageStatus } from '@dify/contracts/api/web/types.gen'
 import type { IChatItem } from './chat/type'
 import type { ChatItem, ChatItemInTree } from './types'
+import { zMessageStatus } from '@dify/contracts/api/web/zod.gen'
 import { UUID_NIL } from './constants'
 
 async function decodeBase64AndDecompress(base64String: string) {
@@ -257,6 +259,11 @@ function getThreadMessages(tree: ChatItemInTree[], targetMessageId?: string): Ch
   return ret
 }
 
+function toMessageStatus(value: unknown): MessageStatus | undefined {
+  const parsed = zMessageStatus.safeParse(value)
+  return parsed.success ? parsed.data : undefined
+}
+
 export {
   buildChatItemTree,
   getLastAnswer,
@@ -267,4 +274,5 @@ export {
   getRawUserVariablesFromUrlParams,
   getThreadMessages,
   isValidGeneratedAnswer,
+  toMessageStatus,
 }

--- a/web/i18n/ar-TN/share.json
+++ b/web/i18n/ar-TN/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "تم إيقاف الرد",
   "chat.chatFormTip": "لا يمكن تعديل إعدادات الدردشة بعد بدء الدردشة.",
   "chat.chatSettingsTitle": "إعداد الدردشة الجديدة",
   "chat.collapse": "طي",

--- a/web/i18n/de-DE/share.json
+++ b/web/i18n/de-DE/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Antwort unterbrochen",
   "chat.chatFormTip": "Chat-Einstellungen können nach Beginn des Chats nicht mehr geändert werden.",
   "chat.chatSettingsTitle": "Neues Chat-Setup",
   "chat.collapse": "Reduzieren",

--- a/web/i18n/en-US/share.json
+++ b/web/i18n/en-US/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Response interrupted",
   "chat.chatFormTip": "Chat settings cannot be modified after the chat has started.",
   "chat.chatSettingsTitle": "New chat setup",
   "chat.collapse": "Collapse",

--- a/web/i18n/es-ES/share.json
+++ b/web/i18n/es-ES/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Respuesta interrumpida",
   "chat.chatFormTip": "No se pueden modificar los ajustes del chat después de que el chat ha comenzado.",
   "chat.chatSettingsTitle": "Nueva configuración de chat",
   "chat.collapse": "Contraer",

--- a/web/i18n/fa-IR/share.json
+++ b/web/i18n/fa-IR/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "پاسخ متوقف شد",
   "chat.chatFormTip": "تنظیمات چت پس از شروع چت قابل تغییر نیستند.",
   "chat.chatSettingsTitle": "راه‌اندازی چت جدید",
   "chat.collapse": "بستن",

--- a/web/i18n/fr-FR/share.json
+++ b/web/i18n/fr-FR/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Réponse interrompue",
   "chat.chatFormTip": "Les paramètres de chat ne peuvent pas être modifiés une fois que le chat a commencé.",
   "chat.chatSettingsTitle": "Nouvelle configuration de chat",
   "chat.collapse": "Réduire",

--- a/web/i18n/hi-IN/share.json
+++ b/web/i18n/hi-IN/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "प्रतिक्रिया बाधित हुई",
   "chat.chatFormTip": "चैट शुरू होने के बाद चैट सेटिंग्स को संशोधित नहीं किया जा सकता।",
   "chat.chatSettingsTitle": "नया चैट सेटअप",
   "chat.collapse": "संकुचित करें",

--- a/web/i18n/id-ID/share.json
+++ b/web/i18n/id-ID/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Respons terputus",
   "chat.chatFormTip": "Pengaturan obrolan tidak dapat dimodifikasi setelah obrolan dimulai.",
   "chat.chatSettingsTitle": "Penyiapan obrolan baru",
   "chat.collapse": "Roboh",

--- a/web/i18n/it-IT/share.json
+++ b/web/i18n/it-IT/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Risposta interrotta",
   "chat.chatFormTip": "Le impostazioni della chat non possono essere modificate dopo che la chat è iniziata.",
   "chat.chatSettingsTitle": "Nuova configurazione della chat",
   "chat.collapse": "Riduci",

--- a/web/i18n/ja-JP/share.json
+++ b/web/i18n/ja-JP/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "応答が中断されました",
   "chat.chatFormTip": "チャット開始後は設定を変更できません",
   "chat.chatSettingsTitle": "チャット設定",
   "chat.collapse": "縮小",

--- a/web/i18n/ko-KR/share.json
+++ b/web/i18n/ko-KR/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "응답이 중단되었습니다",
   "chat.chatFormTip": "채팅이 시작된 후에는 채팅 설정을 수정할 수 없습니다.",
   "chat.chatSettingsTitle": "새 채팅 설정",
   "chat.collapse": "축소",

--- a/web/i18n/lo-LA/share.json
+++ b/web/i18n/lo-LA/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "ການຕອບກັບຖືກຂັດຂວາງ",
   "chat.chatFormTip": "ການຕັ້ງຄ່າການສົນທະນາບໍ່ສາມາດແກ້ໄຂໄດ້ຫຼັງຈາກເລີ່ມຕົ້ນການສົນທະນາ.",
   "chat.chatSettingsTitle": "ຕັ້ງຄ່າການສົນທະນາໃໝ່",
   "chat.collapse": "ຫຍໍ້",

--- a/web/i18n/nl-NL/share.json
+++ b/web/i18n/nl-NL/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Antwoord onderbroken",
   "chat.chatFormTip": "Chat settings cannot be modified after the chat has started.",
   "chat.chatSettingsTitle": "New chat setup",
   "chat.collapse": "Collapse",

--- a/web/i18n/pl-PL/share.json
+++ b/web/i18n/pl-PL/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Odpowiedź przerwana",
   "chat.chatFormTip": "Ustawienia czatu nie mogą być modyfikowane po rozpoczęciu czatu.",
   "chat.chatSettingsTitle": "Nowa konfiguracja czatu",
   "chat.collapse": "Zwiń",

--- a/web/i18n/pt-BR/share.json
+++ b/web/i18n/pt-BR/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Resposta interrompida",
   "chat.chatFormTip": "As configurações do chat não podem ser modificadas após o início do chat.",
   "chat.chatSettingsTitle": "Nova configuração de chat",
   "chat.collapse": "Contrair",

--- a/web/i18n/ro-RO/share.json
+++ b/web/i18n/ro-RO/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Răspuns întrerupt",
   "chat.chatFormTip": "Setările chat-ului nu pot fi modificate după ce chat-ul a început.",
   "chat.chatSettingsTitle": "Nouă configurare a chatului",
   "chat.collapse": "Restrânge",

--- a/web/i18n/ru-RU/share.json
+++ b/web/i18n/ru-RU/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Ответ прерван",
   "chat.chatFormTip": "Настройки чата не могут быть изменены после его начала.",
   "chat.chatSettingsTitle": "Новая настройка чата",
   "chat.collapse": "Свернуть",

--- a/web/i18n/sl-SI/share.json
+++ b/web/i18n/sl-SI/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Odgovor prekinjen",
   "chat.chatFormTip": "Nastavitve klepeta ni mogoče spremeniti po začetku klepeta.",
   "chat.chatSettingsTitle": "Nova nastavitev klepeta",
   "chat.collapse": "Skrči",

--- a/web/i18n/th-TH/share.json
+++ b/web/i18n/th-TH/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "การตอบกลับถูกขัดจังหวะ",
   "chat.chatFormTip": "การตั้งค่าแชทไม่สามารถเปลี่ยนแปลงได้หลังจากที่แชทเริ่มต้นขึ้นแล้ว.",
   "chat.chatSettingsTitle": "การตั้งค่าการสนทนาใหม่",
   "chat.collapse": "ย่อ",

--- a/web/i18n/tr-TR/share.json
+++ b/web/i18n/tr-TR/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Yanıt kesildi",
   "chat.chatFormTip": "Sohbet başladıktan sonra sohbet ayarları değiştirilemez.",
   "chat.chatSettingsTitle": "Yeni sohbet kurulumu",
   "chat.collapse": "Kısıtla",

--- a/web/i18n/uk-UA/share.json
+++ b/web/i18n/uk-UA/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Відповідь перервано",
   "chat.chatFormTip": "Налаштування чату не можуть бути змінені після початку чату.",
   "chat.chatSettingsTitle": "Нове налаштування чату",
   "chat.collapse": "Згорнути",

--- a/web/i18n/vi-VN/share.json
+++ b/web/i18n/vi-VN/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "Phản hồi đã bị gián đoạn",
   "chat.chatFormTip": "Cài đặt trò chuyện không thể được thay đổi sau khi cuộc trò chuyện đã bắt đầu.",
   "chat.chatSettingsTitle": "Cài đặt trò chuyện mới",
   "chat.collapse": "Thu gọn",

--- a/web/i18n/zh-Hans/share.json
+++ b/web/i18n/zh-Hans/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "回复已中断",
   "chat.chatFormTip": "对话开始后，对话设置将无法修改。",
   "chat.chatSettingsTitle": "新对话设置",
   "chat.collapse": "折叠",

--- a/web/i18n/zh-Hant/share.json
+++ b/web/i18n/zh-Hant/share.json
@@ -1,4 +1,5 @@
 {
+  "chat.answerInterrupted": "回覆已中斷",
   "chat.chatFormTip": "聊天設定在聊天開始後無法修改。",
   "chat.chatSettingsTitle": "新的聊天設置",
   "chat.collapse": "摺疊",


### PR DESCRIPTION
## Summary

Sending a long message in a WebApp Advanced Chat and then switching to another conversation while it was still streaming truncated the answer. The message was persisted with `status=normal` and `error=None`, so it looked like a complete reply rather than a cancelled one.

Three things sit behind that report, and this PR fixes all three.

### 1. Navigating away no longer cancels the run

Streaming execution runs in a Celery worker and the HTTP request is only one subscriber on the run's Redis topic, so dropping the response cancels nothing — but the explicit `POST /chat-messages/{task_id}/stop` still does. Navigation was wired to the same handler as the stop button, which turned "stop listening" into "stop generating".

`useChat` now exposes two operations:

- **`handleDetach`** — releases this client's subscriptions and clears `taskIdRef`. Used when switching conversations, starting a new one, and restarting.
- **`handleStop`** — cancels the run, then detaches. Reached from the stop button, and from deleting the conversation a run belongs to (destructive intent, so cancelling is correct there).

### 2. An interrupted run is recorded as interrupted

A run the user cancelled and one the watchdog aborted on timeout were both persisted as ordinary, error-free messages, so the logs reported them as successes.

The abort cause was lost twice: `workflow_app_runner` hardcoded `USER_MANUAL` for every `GraphRunAbortedEvent`, and the message row never moved off `normal` on the stop path — only the workflow run picked up `STOPPED`.

`QueueStopEvent.StopBy` now owns its reason text and recovers a member from the free-form reason that crosses the graph engine boundary, degrading to `UNKNOWN` for a value this version has never heard of and passing the engine's own text through untouched. `MessageStatus` gains `STOPPED`, which the advanced chat pipeline persists. The console conversation list gained a stopped count and the agent observability logs report and filter on it; a failure still outranks an interruption in the same conversation.

`MessageListItem.status` and `StatusCount.stopped` are typed on the API rather than left as bare `str`, so the generated contract carries the enum and the web drops its two hand-written mirrors. The webapp narrows the served status at the boundary and renders nothing for a value it cannot recognise.

### 3. The webapp says the answer was interrupted

A stopped answer now carries a "Response interrupted" notice — on reload, and at the moment the user presses stop.

## Known limitations

Documented, not introduced here:

- Returning to a conversation while its run is still going renders the answer bubble empty until the run finishes and the message list is fetched again.
- Deleting a conversation *other than* the current one does not cancel a run detached from it. The client cannot — the task id is gone once the wrapper unmounts — so it would need a server-side stop on conversation delete.
- `STOPPED` is persisted on the advanced chat path only. Basic and agent chat still save `normal` on stop, so the notice does not appear there.
- The two log surfaces count different columns: the console conversation list counts `WorkflowExecutionStatus.STOPPED` on the workflow run, agent observability counts `MessageStatus.STOPPED` on the message. They agree for advanced chat and can diverge elsewhere.
- Input moderation and annotation reply still save with no status. Neither is a truncation, but neither is labelled either.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

### Notes for reviewers

- Tests cover the detach/stop split, the `StopBy` recovery (including a value this version has never heard of), the status persistence, and both log surfaces. The in-flight "mark the answer stopped" behaviour has none — hence the unticked box.
- `make lint` passes clean. `make type-check` fails repo-wide at the pyrefly step (`No Python files matched pattern`) before mypy ever runs; that is pre-existing on `main` and unrelated to this branch. mypy run directly reports nothing attributable to the changed files.
