### PR TITLE
fix: prevent sidebar footer actions from triggering hover preview

### DIFF
--- a/web/app/components/detail-sidebar/__tests__/index.spec.tsx
+++ b/web/app/components/detail-sidebar/__tests__/index.spec.tsx
@@ -111,6 +111,16 @@ describe('DetailSidebarFrame', () => {
     expect(localStorage.getItem(DETAIL_SIDEBAR_STORAGE_KEY)).toBe('collapse')
   })
 
+  it('keeps collapsed bottom actions in place when they are hovered', () => {
+    renderDetailSidebarFrame()
+    fireEvent.click(screen.getByTestId('detail-toggle'))
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'help' }))
+
+    expect(screen.getByTestId('detail-top')).toHaveAttribute('data-expand', 'false')
+    expect(screen.getByRole('button', { name: 'account' })).toHaveTextContent('Compact account')
+    expect(localStorage.getItem(DETAIL_SIDEBAR_STORAGE_KEY)).toBe('collapse')
+  })
+
   it('persists expansion when the hovered preview toggle is clicked', () => {
     renderDetailSidebarFrame()
     fireEvent.click(screen.getByTestId('detail-toggle'))

--- a/web/app/components/detail-sidebar/index.tsx
+++ b/web/app/components/detail-sidebar/index.tsx
@@ -135,10 +135,12 @@ export function DetailSidebarFrame({
             : 'overflow-hidden rounded-lg bg-components-panel-bg',
           detailNavigationVisibleExpanded ? 'w-60' : 'w-14',
         )}
-        onMouseEnter={!detailNavigationExpanded ? openDetailNavigationHoverPreview : undefined}
         onMouseLeave={!detailNavigationExpanded ? closeDetailNavigationHoverPreview : undefined}
       >
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          className="flex min-h-0 flex-1 flex-col"
+          onMouseEnter={!detailNavigationExpanded ? openDetailNavigationHoverPreview : undefined}
+        >
           {renderTop({
             expand: detailNavigationVisibleExpanded,
             onToggle: handleToggleDetailNavigation,


### PR DESCRIPTION
## Summary

- Restrict the collapsed detail sidebar hover preview to the main navigation content so footer actions remain clickable.
- Add regression coverage ensuring the help and account controls stay compact when the help action is hovered.

Fixes DIFY-2925

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.