### PR TITLE
fix(ui): add tabs panel focus treatment

### DIFF
--- a/packages/dify-ui/src/tabs/index.stories.tsx
+++ b/packages/dify-ui/src/tabs/index.stories.tsx
@@ -45,6 +45,11 @@ export const Basic: Story = {
     await userEvent.click(activityTab)
 
     await expect(activityTab).toHaveAttribute('aria-selected', 'true')
-    await expect(canvas.getByRole('tabpanel', { name: 'Activity' })).toBeVisible()
+    const activityPanel = canvas.getByRole('tabpanel', { name: 'Activity' })
+    await expect(activityPanel).toBeVisible()
+
+    await userEvent.tab()
+
+    await expect(activityPanel).toHaveFocus()
   },
 }

--- a/packages/dify-ui/src/tabs/index.tsx
+++ b/packages/dify-ui/src/tabs/index.tsx
@@ -31,8 +31,21 @@ function TabsTab({ className, ...props }: TabsTabProps) {
   )
 }
 
-type TabsPanelProps = BaseTabsNS.Panel.Props
-const TabsPanel = BaseTabs.Panel
+type TabsPanelProps = Omit<BaseTabsNS.Panel.Props, 'className'> & {
+  className?: string
+}
+
+function TabsPanel({ className, ...props }: TabsPanelProps) {
+  return (
+    <BaseTabs.Panel
+      className={cn(
+        'outline-hidden focus-visible:inset-ring-2 focus-visible:inset-ring-state-accent-solid',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
 const TabsIndicator = BaseTabs.Indicator
 type TabsIndicatorProps = BaseTabsNS.Indicator.Props


### PR DESCRIPTION
## Summary

- Give focusable Tabs panels a visible inset focus indicator.
- Keep the TabsPanel className contract aligned with the Dify UI wrapper conventions.
- Exercise the real keyboard focus path in the canonical Storybook example.
- Audit all 8 production Tabs consumers (16 panels); no redundant panel focus styles were present, and intentional tabIndex={-1} overrides remain at their interaction owners.

## Validation

- Dify UI Tabs unit test: 1 passed
- Dify UI Tabs Storybook test: 1 passed
- Dify UI type-check
- Full repository check and Tailwind canonical lint

No layout or resting-state visual changes.

From Codex