### PR TITLE
refactor(web): migrate dataset rename form

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2403,11 +2403,6 @@
       "count": 2
     }
   },
-  "web/app/components/datasets/rename-modal/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/settings/chunk-structure/types.ts": {
     "erasable-syntax-only/enums": {
       "count": 1

--- a/web/app/components/datasets/rename-modal/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/rename-modal/__tests__/index.spec.tsx
@@ -27,13 +27,8 @@ vi.mock('@/service/datasets', () => ({
   updateDatasetSetting: (params: unknown) => mockUpdateDatasetSetting(params),
 }))
 
-// Mock AppIcon - simplified mock to enable testing onClick callback
 vi.mock('../../../base/app-icon', () => ({
-  default: ({ onClick }: { onClick?: () => void }) => (
-    <button data-testid="app-icon" onClick={onClick}>
-      Icon
-    </button>
-  ),
+  default: () => <span data-testid="app-icon">Icon</span>,
 }))
 
 vi.mock('@/app/components/base/app-icon-picker', () => ({
@@ -165,9 +160,9 @@ describe('RenameDatasetModal', () => {
   })
 
   describe('Rendering', () => {
-    it('should render modal when show is true', () => {
+    it('should render a named dialog when show is true', () => {
       render(<RenameDatasetModal {...defaultProps} show={true} />)
-      expect(screen.getByText('datasetSettings.title'))!.toBeInTheDocument()
+      expect(screen.getByRole('dialog', { name: 'datasetSettings.title' })).toBeInTheDocument()
     })
 
     it('should render name input with dataset name', () => {
@@ -325,6 +320,33 @@ describe('RenameDatasetModal', () => {
       expect(handleClose).toHaveBeenCalledTimes(1)
     })
 
+    it('should call onClose when Escape is pressed', async () => {
+      const user = userEvent.setup()
+      const handleClose = vi.fn()
+      render(<RenameDatasetModal {...defaultProps} onClose={handleClose} />)
+
+      await user.keyboard('{Escape}')
+
+      expect(handleClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('should submit the form when Enter is pressed in the name input', async () => {
+      const user = userEvent.setup()
+      render(<RenameDatasetModal {...defaultProps} />)
+
+      await user.type(screen.getByRole('textbox', { name: 'datasetSettings.form.name' }), '{Enter}')
+
+      await waitFor(() => {
+        expect(mockUpdateDatasetSetting).toHaveBeenCalledWith({
+          datasetId: 'dataset-1',
+          body: expect.objectContaining({
+            name: 'Test Dataset',
+            description: 'Test description',
+          }),
+        })
+      })
+    })
+
     it('should call API when save button is clicked with valid name', async () => {
       render(<RenameDatasetModal {...defaultProps} />)
 
@@ -362,7 +384,7 @@ describe('RenameDatasetModal', () => {
       })
 
       await waitFor(() => {
-        expect(saveButton)!.toBeDisabled()
+        expect(saveButton).toHaveAttribute('aria-disabled', 'true')
       })
 
       // Resolve the promise to clean up
@@ -777,12 +799,11 @@ describe('RenameDatasetModal', () => {
   describe('Icon Picker Integration', () => {
     it('should render app icon component', () => {
       render(<RenameDatasetModal {...defaultProps} />)
-      // The modal should render with name label and input
-      // AppIcon is rendered alongside the name input
-      // The modal should render with name label and input
-      // AppIcon is rendered alongside the name input
-      expect(screen.getByText('datasetSettings.form.name'))!.toBeInTheDocument()
-      expect(screen.getByDisplayValue('Test Dataset'))!.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'common.operation.edit datasetSettings.form.nameAndIcon',
+        }),
+      ).toContainElement(screen.getByTestId('app-icon'))
     })
 
     it('should initialize icon state from dataset', () => {
@@ -1145,7 +1166,7 @@ describe('RenameDatasetModal', () => {
 
       // Button should be disabled now
       // Button should be disabled now
-      expect(saveButton)!.toBeDisabled()
+      expect(saveButton).toHaveAttribute('aria-disabled', 'true')
 
       // Second click should not trigger another API call because button is disabled
       await act(async () => {
@@ -1263,7 +1284,7 @@ describe('RenameDatasetModal', () => {
 
       // Button should be disabled during loading
       await waitFor(() => {
-        expect(saveButton)!.toBeDisabled()
+        expect(saveButton).toHaveAttribute('aria-disabled', 'true')
       })
 
       // Resolve promise to complete the test

--- a/web/app/components/datasets/rename-modal/index.tsx
+++ b/web/app/components/datasets/rename-modal/index.tsx
@@ -1,16 +1,15 @@
 'use client'
-import type { MouseEventHandler } from 'react'
 import type { AppIconSelection } from '../../base/app-icon-picker'
 import type { DataSet } from '@/models/datasets'
 import { Button } from '@langgenius/dify-ui/button'
-import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { toast } from '@langgenius/dify-ui/toast'
-import { RiCloseLine } from '@remixicon/react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { updateDatasetSetting } from '@/service/datasets'
 import AppIcon from '../../base/app-icon'
 import AppIconPicker from '../../base/app-icon-picker'
@@ -48,7 +47,7 @@ const RenameDatasetModal = ({ show, dataset, onSuccess, onClose }: RenameDataset
   const handleSelectAppIcon = useCallback((icon: AppIconSelection) => {
     setAppIcon(icon)
   }, [])
-  const onConfirm: MouseEventHandler = useCallback(async () => {
+  const onConfirm = useCallback(async () => {
     if (!name.trim()) {
       toast.error(t(($) => $['form.nameError'], { ns: 'datasetSettings' }))
       return
@@ -96,37 +95,51 @@ const RenameDatasetModal = ({ show, dataset, onSuccess, onClose }: RenameDataset
     t,
   ])
   return (
-    <Dialog open={show}>
+    <Dialog
+      open={show}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
       <DialogContent className="w-full max-w-130 overflow-hidden! rounded-xl border-none px-8 py-6 text-left align-middle">
-        <div className="flex items-center justify-between pb-2">
-          <div className="text-xl leading-7.5 font-medium text-text-primary">
-            {t(($) => $.title, { ns: 'datasetSettings' })}
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            onConfirm()
+          }}
+        >
+          <div className="flex items-center justify-between pb-2">
+            <DialogTitle className="text-xl leading-7.5 font-medium text-text-primary">
+              {t(($) => $.title, { ns: 'datasetSettings' })}
+            </DialogTitle>
+            <IconButton
+              size="lg"
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              onClick={onClose}
+            >
+              <span aria-hidden="true" className="i-ri-close-line size-4" />
+            </IconButton>
           </div>
-          <button
-            type="button"
-            className="cursor-pointer border-none bg-transparent p-2 focus-visible:ring-1 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
-            aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-            onClick={onClose}
-          >
-            <RiCloseLine className="size-4 text-text-tertiary" aria-hidden="true" />
-          </button>
-        </div>
-        <div>
-          <div className={cn('flex flex-col py-4')}>
-            <div className="shrink-0 py-2 text-sm leading-5 font-medium text-text-primary">
+          <Field name="name" className="gap-0 py-4">
+            <FieldLabel className="w-full shrink-0 py-2 text-sm leading-5 font-medium text-text-primary">
               {t(($) => $['form.name'], { ns: 'datasetSettings' })}
-            </div>
+            </FieldLabel>
             <div className="flex items-center gap-x-2">
-              <AppIcon
-                size="medium"
+              <button
+                type="button"
+                aria-label={`${t(($) => $['operation.edit'], { ns: 'common' })} ${t(($) => $['form.nameAndIcon'], { ns: 'datasetSettings' })}`}
+                className="shrink-0 cursor-pointer rounded-[10px] border-0 bg-transparent p-0 focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
                 onClick={handleOpenAppIconPicker}
-                className="cursor-pointer"
-                iconType={appIcon.type}
-                icon={appIcon.type === 'image' ? appIcon.fileId : appIcon.icon}
-                background={appIcon.type === 'image' ? undefined : appIcon.background}
-                imageUrl={appIcon.type === 'image' ? appIcon.url : undefined}
-                showEditIcon
-              />
+              >
+                <AppIcon
+                  size="medium"
+                  iconType={appIcon.type}
+                  icon={appIcon.type === 'image' ? appIcon.fileId : appIcon.icon}
+                  background={appIcon.type === 'image' ? undefined : appIcon.background}
+                  imageUrl={appIcon.type === 'image' ? appIcon.url : undefined}
+                  showEditIcon
+                />
+              </button>
               <Input
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -134,30 +147,27 @@ const RenameDatasetModal = ({ show, dataset, onSuccess, onClose }: RenameDataset
                 placeholder={t(($) => $['form.namePlaceholder'], { ns: 'datasetSettings' }) || ''}
               />
             </div>
-          </div>
-          <div className={cn('flex flex-col py-4')}>
-            <div className="shrink-0 py-2 text-sm leading-5 font-medium text-text-primary">
+          </Field>
+          <Field name="description" className="gap-0 py-4">
+            <FieldLabel className="w-full shrink-0 py-2 text-sm leading-5 font-medium text-text-primary">
               {t(($) => $['form.desc'], { ns: 'datasetSettings' })}
-            </div>
-            <div className="w-full">
-              <Textarea
-                aria-label={t(($) => $['form.desc'], { ns: 'datasetSettings' })}
-                value={description}
-                onValueChange={(value) => setDescription(value)}
-                className="resize-none"
-                placeholder={t(($) => $['form.descPlaceholder'], { ns: 'datasetSettings' }) || ''}
-              />
-            </div>
+            </FieldLabel>
+            <Textarea
+              value={description}
+              onValueChange={(value) => setDescription(value)}
+              className="resize-none"
+              placeholder={t(($) => $['form.descPlaceholder'], { ns: 'datasetSettings' }) || ''}
+            />
+          </Field>
+          <div className="flex justify-end gap-2 pt-6">
+            <Button type="button" onClick={onClose}>
+              {t(($) => $['operation.cancel'], { ns: 'common' })}
+            </Button>
+            <Button type="submit" loading={loading} variant="primary">
+              {t(($) => $['operation.save'], { ns: 'common' })}
+            </Button>
           </div>
-        </div>
-        <div className="flex justify-end pt-6">
-          <Button className="mr-2" onClick={onClose}>
-            {t(($) => $['operation.cancel'], { ns: 'common' })}
-          </Button>
-          <Button disabled={loading} variant="primary" onClick={onConfirm}>
-            {t(($) => $['operation.save'], { ns: 'common' })}
-          </Button>
-        </div>
+        </form>
         {showAppIconPicker && (
           <AppIconPicker
             open={showAppIconPicker}


### PR DESCRIPTION
## Summary

- Migrate the dataset rename modal from the legacy Input to Dify UI Field, Input, Textarea, IconButton, and Button anatomy.
- Give the dialog and both controls explicit accessible names through their semantic owners.
- Make the custom dataset icon surface a real button with a visible focus indicator.
- Use native form submission, preserve focus while loading through the Dify UI Button contract, and support Dialog-owned Escape dismissal.

## Validation

- Depends on #41232
- Focused Web tests: 68 passed
- Target accessibility lint
- Full repository check and Tailwind canonical lint
- Browser-checked at localhost:3000 with unchanged modal layout and spacing

From Codex