### PR TITLE
fix: remove enable for get (#35245)

### DIFF
--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -169,6 +169,7 @@ console_ns.schema_model(
 
 
 class TrialAppWorkflowRunApi(TrialAppResource):
+    @trial_feature_enable
     @console_ns.expect(console_ns.models[WorkflowRunRequest.__name__])
     def post(self, trial_app):
         """
@@ -210,6 +211,7 @@ class TrialAppWorkflowRunApi(TrialAppResource):
 
 
 class TrialAppWorkflowTaskStopApi(TrialAppResource):
+    @trial_feature_enable
     def post(self, trial_app, task_id: str):
         """
         Stop workflow task
@@ -290,7 +292,6 @@ class TrialChatApi(TrialAppResource):
 
 
 class TrialMessageSuggestedQuestionApi(TrialAppResource):
-    @trial_feature_enable
     def get(self, trial_app, message_id):
         app_model = trial_app
         app_mode = AppMode.value_of(app_model.mode)
@@ -470,7 +471,6 @@ class TrialCompletionApi(TrialAppResource):
 class TrialSitApi(Resource):
     """Resource for trial app sites."""
 
-    @trial_feature_enable
     @get_app_model_with_trial(None)
     def get(self, app_model):
         """Retrieve app site info.
@@ -492,7 +492,6 @@ class TrialSitApi(Resource):
 class TrialAppParameterApi(Resource):
     """Resource for app variables."""
 
-    @trial_feature_enable
     @get_app_model_with_trial(None)
     def get(self, app_model):
         """Retrieve app parameters."""
@@ -521,7 +520,6 @@ class TrialAppParameterApi(Resource):
 
 
 class AppApi(Resource):
-    @trial_feature_enable
     @get_app_model_with_trial(None)
     @marshal_with(app_detail_with_site_model)
     def get(self, app_model):
@@ -534,7 +532,6 @@ class AppApi(Resource):
 
 
 class AppWorkflowApi(Resource):
-    @trial_feature_enable
     @get_app_model_with_trial(None)
     @marshal_with(workflow_model)
     def get(self, app_model):
@@ -547,7 +544,6 @@ class AppWorkflowApi(Resource):
 
 
 class DatasetListApi(Resource):
-    @trial_feature_enable
     @get_app_model_with_trial(None)
     def get(self, app_model):
         page = request.args.get("page", default=1, type=int)

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -94,7 +94,7 @@ class TestTrialAppWorkflowRunApi:
 
         with app.test_request_context("/"):
             with pytest.raises(NotWorkflowAppError):
-                method(MagicMock(mode=AppMode.CHAT))
+                method(api, MagicMock(mode=AppMode.CHAT))
 
     def test_success(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowRunApi()
@@ -106,7 +106,7 @@ class TestTrialAppWorkflowRunApi:
             patch.object(module.AppGenerateService, "generate", return_value=MagicMock()),
             patch.object(module.RecommendedAppService, "add_trial_app_record"),
         ):
-            result = method(trial_app_workflow)
+            result = method(api, trial_app_workflow)
 
         assert result is not None
 
@@ -124,7 +124,7 @@ class TestTrialAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(ProviderNotInitializeError):
-                method(trial_app_workflow)
+                method(api, trial_app_workflow)
 
     def test_workflow_quota_exceeded(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowRunApi()
@@ -140,7 +140,7 @@ class TestTrialAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(ProviderQuotaExceededError):
-                method(trial_app_workflow)
+                method(api, trial_app_workflow)
 
     def test_workflow_model_not_support(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowRunApi()
@@ -156,7 +156,7 @@ class TestTrialAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(ProviderModelCurrentlyNotSupportError):
-                method(trial_app_workflow)
+                method(api, trial_app_workflow)
 
     def test_workflow_invoke_error(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowRunApi()
@@ -172,7 +172,7 @@ class TestTrialAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(CompletionRequestError):
-                method(trial_app_workflow)
+                method(api, trial_app_workflow)
 
     def test_workflow_rate_limit_error(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowRunApi()
@@ -188,7 +188,7 @@ class TestTrialAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(InvokeRateLimitHttpError):
-                method(trial_app_workflow)
+                method(api, trial_app_workflow)
 
     def test_workflow_value_error(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowRunApi()
@@ -204,7 +204,7 @@ class TestTrialAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(ValueError):
-                method(trial_app_workflow)
+                method(api, trial_app_workflow)
 
     def test_workflow_generic_exception(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowRunApi()
@@ -220,7 +220,7 @@ class TestTrialAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                method(trial_app_workflow)
+                method(api, trial_app_workflow)
 
 
 class TestTrialChatApi:
@@ -566,7 +566,7 @@ class TestTrialMessageSuggestedQuestionApi:
 
         with app.test_request_context("/"):
             with pytest.raises(NotChatAppError):
-                method(api, MagicMock(mode="completion"), str(uuid4()))
+                method(MagicMock(mode="completion"), str(uuid4()))
 
     def test_success(self, app, trial_app_chat, account):
         api = module.TrialMessageSuggestedQuestionApi()
@@ -581,7 +581,7 @@ class TestTrialMessageSuggestedQuestionApi:
                 return_value=["q1", "q2"],
             ),
         ):
-            result = method(api, trial_app_chat, str(uuid4()))
+            result = method(trial_app_chat, str(uuid4()))
 
         assert result == {"data": ["q1", "q2"]}
 
@@ -599,7 +599,7 @@ class TestTrialMessageSuggestedQuestionApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(api, trial_app_chat, str(uuid4()))
+                method(trial_app_chat, str(uuid4()))
 
 
 class TestTrialAppParameterApi:
@@ -931,7 +931,7 @@ class TestTrialAppWorkflowTaskStopApi:
 
         with app.test_request_context("/"):
             with pytest.raises(NotWorkflowAppError):
-                method(trial_app_chat, str(uuid4()))
+                method(api, trial_app_chat, str(uuid4()))
 
     def test_success(self, app, trial_app_workflow, account):
         api = module.TrialAppWorkflowTaskStopApi()
@@ -944,7 +944,7 @@ class TestTrialAppWorkflowTaskStopApi:
             patch.object(module.AppQueueManager, "set_stop_flag_no_user_check") as mock_set_flag,
             patch.object(module.GraphEngineManager, "send_stop_command") as mock_send_cmd,
         ):
-            result = method(trial_app_workflow, task_id)
+            result = method(api, trial_app_workflow, task_id)
 
         assert result == {"result": "success"}
         mock_set_flag.assert_called_once_with(task_id)

--- a/web/service/try-app.spec.ts
+++ b/web/service/try-app.spec.ts
@@ -1,0 +1,26 @@
+import { get } from './base'
+import { fetchTryAppDatasets } from './try-app'
+
+vi.mock('./base', () => ({
+  get: vi.fn(),
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleClient: {
+    trialApps: {
+      info: vi.fn(),
+      workflows: vi.fn(),
+      parameters: vi.fn(),
+    },
+  },
+}))
+
+describe('fetchTryAppDatasets', () => {
+  it('serializes ids as repeated query params', async () => {
+    vi.mocked(get).mockResolvedValue({ data: [] })
+
+    await fetchTryAppDatasets('app-1', ['id-1', 'id-2'])
+
+    expect(get).toHaveBeenCalledWith('/trial-apps/app-1/datasets?ids=id-1&ids=id-2')
+  })
+})

--- a/web/service/try-app.ts
+++ b/web/service/try-app.ts
@@ -1,17 +1,19 @@
 import type { ChatConfig } from '@/app/components/base/chat/types'
 import type { DataSetListResponse } from '@/models/datasets'
 import type { TryAppFlowPreview, TryAppInfo } from '@/models/try-app'
+import qs from 'qs'
 import { consoleClient } from '@/service/client'
+import { get } from './base'
 
 export const fetchTryAppInfo = (appId: string): Promise<TryAppInfo> => {
   return consoleClient.trialApps.info({ params: { appId } })
 }
 
 export const fetchTryAppDatasets = (appId: string, ids: string[]): Promise<DataSetListResponse> => {
-  return consoleClient.trialApps.datasets({
-    params: { appId },
-    query: { ids },
-  })
+  const queryString = qs.stringify({ ids }, { indices: false })
+  const url = `/trial-apps/${encodeURIComponent(appId)}/datasets${queryString ? `?${queryString}` : ''}`
+
+  return get<DataSetListResponse>(url)
 }
 
 export const fetchTryAppFlowPreview = (appId: string): Promise<TryAppFlowPreview> => {


### PR DESCRIPTION
## Summary

Cherry-pick of #35245 (`fix: remove enable for get`) to `lts/1.13.x`.

Resolves ENG-773

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
