### PR TITLE
fix(skills): align Japanese Skills page title

### DIFF
--- a/web/i18n/ja-JP/skill.json
+++ b/web/i18n/ja-JP/skill.json
@@ -241,5 +241,5 @@
   "skillManagement.searchLabel": "スキルを検索",
   "skillManagement.searchPlaceholder": "名前または説明で検索",
   "skillManagement.tags": "タグ",
-  "skillManagement.title": "スキル"
+  "skillManagement.title": "Skills"
 }


### PR DESCRIPTION
## Summary

- Keep the Japanese Skills page title consistent with the main navigation.
- Change `skillManagement.title` from `スキル` to `Skills`.

## Screenshots

| Before | After |
| --- | --- |
| `スキル` | `Skills` |

## Testing

- `pnpm lint:eslint web/i18n/ja-JP/skill.json`
- `pnpm -C web i18n:check --file skill`

## Checklist

- [x] This copy-only change does not require a documentation update.
- [x] I understand that this PR may be closed if there was no previous discussion or issue. This does not apply to typos.
- [x] The relevant frontend lint and i18n checks pass.

From Codex