### PR TITLE
fix: show a not-allowed cursor for the prompt editor in build mode

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/prompt-editor/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/prompt-editor/index.tsx
@@ -1130,7 +1130,7 @@ export function AgentPromptEditor() {
               aria-labelledby="agent-configure-prompt-label"
               compact
               wrapperClassName="min-h-[104px]"
-              className="min-h-26 text-text-primary"
+              className={cn('min-h-26 text-text-primary', readOnly && 'cursor-not-allowed')}
               placeholder={promptPlaceholder}
               placeholderClassName="top-0!"
               editable={!readOnly}


### PR DESCRIPTION
## Summary

- Show a not-allowed cursor when hovering over the read-only Prompt editor in Build mode.
- Preserve the existing editable cursor behavior outside the read-only state.
- Verify the computed cursor at the reported 1308×873 viewport and pass the targeted Vite+ checks.

Fixes DIFY-2924

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.