### PR TITLE
refactor(controllers/console): dep-inject workflow payloads with @model_validate

### DIFF
--- a/api/controllers/console/app/workflow.py
+++ b/api/controllers/console/app/workflow.py
@@ -44,6 +44,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     edit_permission_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_tenant_id,
@@ -705,12 +706,12 @@ class AdvancedChatDraftWorkflowRunApi(Resource):
     @edit_permission_required
     @with_session
     @get_app_model(mode=[AppMode.ADVANCED_CHAT])
-    def post(self, session: Session, current_user: Account, app_model: App):
+    @model_validate(AdvancedChatWorkflowRunPayload)
+    def post(self, payload: AdvancedChatWorkflowRunPayload, session: Session, current_user: Account, app_model: App):
         """
         Run draft workflow
         """
-        args_model = AdvancedChatWorkflowRunPayload.model_validate(console_ns.payload or {})
-        args = args_model.model_dump(exclude_none=True)
+        args = payload.model_dump(exclude_none=True)
 
         external_trace_id = get_external_trace_id(request)
         if external_trace_id:
@@ -760,11 +761,12 @@ class AdvancedChatDraftRunIterationNodeApi(Resource):
     @get_app_model(mode=[AppMode.ADVANCED_CHAT])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(IterationNodeRunPayload)
+    def post(self, payload: IterationNodeRunPayload, current_user: Account, app_model: App, node_id: str):
         """
         Run draft workflow iteration node
         """
-        args = IterationNodeRunPayload.model_validate(console_ns.payload or {}).model_dump(exclude_none=True)
+        args = payload.model_dump(exclude_none=True)
 
         try:
             response = AppGenerateService.generate_single_iteration(
@@ -808,11 +810,12 @@ class WorkflowDraftRunIterationNodeApi(Resource):
     @get_app_model(mode=[AppMode.WORKFLOW])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(IterationNodeRunPayload)
+    def post(self, payload: IterationNodeRunPayload, current_user: Account, app_model: App, node_id: str):
         """
         Run draft workflow iteration node
         """
-        args = IterationNodeRunPayload.model_validate(console_ns.payload or {}).model_dump(exclude_none=True)
+        args = payload.model_dump(exclude_none=True)
 
         try:
             response = AppGenerateService.generate_single_iteration(
@@ -852,11 +855,11 @@ class AdvancedChatDraftRunLoopNodeApi(Resource):
     @get_app_model(mode=[AppMode.ADVANCED_CHAT])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(LoopNodeRunPayload)
+    def post(self, args: LoopNodeRunPayload, current_user: Account, app_model: App, node_id: str):
         """
         Run draft workflow loop node
         """
-        args = LoopNodeRunPayload.model_validate(console_ns.payload or {})
 
         try:
             response = AppGenerateService.generate_single_loop(
@@ -900,11 +903,11 @@ class WorkflowDraftRunLoopNodeApi(Resource):
     @get_app_model(mode=[AppMode.WORKFLOW])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(LoopNodeRunPayload)
+    def post(self, args: LoopNodeRunPayload, current_user: Account, app_model: App, node_id: str):
         """
         Run draft workflow loop node
         """
-        args = LoopNodeRunPayload.model_validate(console_ns.payload or {})
 
         try:
             response = AppGenerateService.generate_single_loop(
@@ -977,11 +980,11 @@ class AdvancedChatDraftHumanInputFormPreviewApi(Resource):
     @with_current_user
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(HumanInputFormPreviewPayload)
+    def post(self, args: HumanInputFormPreviewPayload, current_user: Account, app_model: App, node_id: str):
         """
         Preview human input form content and placeholders
         """
-        args = HumanInputFormPreviewPayload.model_validate(console_ns.payload or {})
         inputs = args.inputs
 
         workflow_service = WorkflowService()
@@ -1013,11 +1016,11 @@ class AdvancedChatDraftHumanInputFormRunApi(Resource):
     @get_app_model(mode=[AppMode.ADVANCED_CHAT])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(HumanInputFormSubmitPayload)
+    def post(self, args: HumanInputFormSubmitPayload, current_user: Account, app_model: App, node_id: str):
         """
         Submit human input form preview
         """
-        args = HumanInputFormSubmitPayload.model_validate(console_ns.payload or {})
         workflow_service = WorkflowService()
         result = workflow_service.submit_human_input_form_preview(
             app_model=app_model,
@@ -1045,11 +1048,11 @@ class WorkflowDraftHumanInputFormPreviewApi(Resource):
     @with_current_user
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(HumanInputFormPreviewPayload)
+    def post(self, args: HumanInputFormPreviewPayload, current_user: Account, app_model: App, node_id: str):
         """
         Preview human input form content and placeholders
         """
-        args = HumanInputFormPreviewPayload.model_validate(console_ns.payload or {})
         inputs = args.inputs
 
         workflow_service = WorkflowService()
@@ -1081,12 +1084,12 @@ class WorkflowDraftHumanInputFormRunApi(Resource):
     @get_app_model(mode=[AppMode.WORKFLOW])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(HumanInputFormSubmitPayload)
+    def post(self, args: HumanInputFormSubmitPayload, current_user: Account, app_model: App, node_id: str):
         """
         Submit human input form preview
         """
         workflow_service = WorkflowService()
-        args = HumanInputFormSubmitPayload.model_validate(console_ns.payload or {})
         result = workflow_service.submit_human_input_form_preview(
             app_model=app_model,
             account=current_user,
@@ -1113,12 +1116,12 @@ class WorkflowDraftHumanInputDeliveryTestApi(Resource):
     @with_current_user
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_TEST_AND_RUN)
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(HumanInputDeliveryTestPayload)
+    def post(self, args: HumanInputDeliveryTestPayload, current_user: Account, app_model: App, node_id: str):
         """
         Test human input delivery
         """
         workflow_service = WorkflowService()
-        args = HumanInputDeliveryTestPayload.model_validate(console_ns.payload or {})
         workflow_service.test_human_input_delivery(
             app_model=app_model,
             account=current_user,
@@ -1150,11 +1153,12 @@ class DraftWorkflowRunApi(Resource):
     @edit_permission_required
     @with_session
     @get_app_model(mode=[AppMode.WORKFLOW])
-    def post(self, session: Session, current_user: Account, app_model: App):
+    @model_validate(DraftWorkflowRunPayload)
+    def post(self, payload: DraftWorkflowRunPayload, session: Session, current_user: Account, app_model: App):
         """
         Run draft workflow
         """
-        args = DraftWorkflowRunPayload.model_validate(console_ns.payload or {}).model_dump(exclude_none=True)
+        args = payload.model_dump(exclude_none=True)
 
         external_trace_id = get_external_trace_id(request)
         if external_trace_id:
@@ -1223,14 +1227,14 @@ class DraftWorkflowNodeRunApi(Resource):
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App, node_id: str):
+    @model_validate(DraftWorkflowNodeRunPayload)
+    def post(self, payload: DraftWorkflowNodeRunPayload, current_user: Account, app_model: App, node_id: str):
         """
         Run draft workflow node
         """
-        args_model = DraftWorkflowNodeRunPayload.model_validate(console_ns.payload or {})
-        args = args_model.model_dump(exclude_none=True)
+        args = payload.model_dump(exclude_none=True)
 
-        user_inputs = args_model.inputs
+        user_inputs = payload.inputs
         if user_inputs is None:
             raise ValueError("missing inputs")
 
@@ -1296,12 +1300,11 @@ class PublishedWorkflowApi(Resource):
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
     @with_current_user
     @edit_permission_required
-    def post(self, current_user: Account, app_model: App):
+    @model_validate(PublishWorkflowPayload)
+    def post(self, args: PublishWorkflowPayload, current_user: Account, app_model: App):
         """
         Publish workflow
         """
-
-        args = PublishWorkflowPayload.model_validate(console_ns.payload or {})
 
         workflow_service = WorkflowService()
         with sessionmaker(db.engine).begin() as session:
@@ -1371,11 +1374,11 @@ class DefaultBlockConfigApi(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
-    def get(self, app_model: App, block_type: str):
+    @model_validate(DefaultBlockConfigQuery)
+    def get(self, args: DefaultBlockConfigQuery, app_model: App, block_type: str):
         """
         Get default block config
         """
-        args = DefaultBlockConfigQuery.model_validate(request.args.to_dict(flat=True))
 
         filters = None
         if args.q:
@@ -1410,14 +1413,14 @@ class ConvertToWorkflowApi(Resource):
     @with_current_tenant_id
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_EDIT)
-    def post(self, current_tenant_id: str, current_user: Account, app_model: App):
+    @model_validate(ConvertToWorkflowPayload)
+    def post(self, payload: ConvertToWorkflowPayload, current_tenant_id: str, current_user: Account, app_model: App):
         """
         Convert basic mode of chatbot app to workflow mode
         Convert expert mode of chatbot app to workflow mode
         Convert Completion App to Workflow App
         """
-        payload = console_ns.payload or {}
-        args = ConvertToWorkflowPayload.model_validate(payload).model_dump(exclude_none=True)
+        args = payload.model_dump(exclude_none=True)
 
         # convert to workflow mode
         workflow_service = WorkflowService()
@@ -1452,9 +1455,8 @@ class WorkflowFeaturesApi(Resource):
     @with_current_user
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    def post(self, current_user: Account, app_model: App):
-
-        args = WorkflowFeaturesPayload.model_validate(console_ns.payload or {})
+    @model_validate(WorkflowFeaturesPayload)
+    def post(self, args: WorkflowFeaturesPayload, current_user: Account, app_model: App):
         features = args.features.model_dump(mode="json", exclude_unset=True)
 
         workflow_service = WorkflowService()
@@ -1483,12 +1485,12 @@ class PublishedAllWorkflowApi(Resource):
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
     @with_current_user
     @edit_permission_required
-    def get(self, current_user: Account, app_model: App):
+    @model_validate(WorkflowListQuery)
+    def get(self, args: WorkflowListQuery, current_user: Account, app_model: App):
         """
         Get published workflows
         """
 
-        args = WorkflowListQuery.model_validate(request.args.to_dict(flat=True))
         page = args.page
         limit = args.limit
         user_id = args.user_id
@@ -1573,11 +1575,11 @@ class WorkflowByIdApi(Resource):
     @with_current_user
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_EDIT)
-    def patch(self, current_user: Account, app_model: App, workflow_id: str):
+    @model_validate(WorkflowUpdatePayload)
+    def patch(self, args: WorkflowUpdatePayload, current_user: Account, app_model: App, workflow_id: str):
         """
         Update workflow attributes
         """
-        args = WorkflowUpdatePayload.model_validate(console_ns.payload or {})
 
         # Prepare update data
         update_data = {}
@@ -1710,11 +1712,11 @@ class DraftWorkflowTriggerRunApi(Resource):
     @edit_permission_required
     @with_session
     @get_app_model(mode=[AppMode.WORKFLOW])
-    def post(self, session: Session, current_user: Account, app_model: App):
+    @model_validate(DraftWorkflowTriggerRunPayload)
+    def post(self, args: DraftWorkflowTriggerRunPayload, session: Session, current_user: Account, app_model: App):
         """
         Poll for trigger events and execute full workflow when event arrives
         """
-        args = DraftWorkflowTriggerRunPayload.model_validate(console_ns.payload or {})
         node_id = args.node_id
         workflow_service = WorkflowService()
         draft_workflow = workflow_service.get_draft_workflow(app_model, session=session)
@@ -1862,12 +1864,12 @@ class DraftWorkflowTriggerRunAllApi(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_TEST_AND_RUN)
     @with_session
     @get_app_model(mode=[AppMode.WORKFLOW])
-    def post(self, session: Session, current_user: Account, app_model: App):
+    @model_validate(DraftWorkflowTriggerRunAllPayload)
+    def post(self, args: DraftWorkflowTriggerRunAllPayload, session: Session, current_user: Account, app_model: App):
         """
         Full workflow debug when the start node is a trigger
         """
 
-        args = DraftWorkflowTriggerRunAllPayload.model_validate(console_ns.payload or {})
         node_ids = args.node_ids
         workflow_service = WorkflowService()
         draft_workflow = workflow_service.get_draft_workflow(app_model, session=session)
@@ -1929,9 +1931,8 @@ class WorkflowOnlineUsersApi(Resource):
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, current_user: Account):
-        args = WorkflowOnlineUsersPayload.model_validate(console_ns.payload or {})
-
+    @model_validate(WorkflowOnlineUsersPayload)
+    def post(self, args: WorkflowOnlineUsersPayload, current_tenant_id: str, current_user: Account):
         app_ids = args.app_ids
         if len(app_ids) > MAX_WORKFLOW_ONLINE_USERS_REQUEST_IDS:
             raise BadRequest(f"Maximum {MAX_WORKFLOW_ONLINE_USERS_REQUEST_IDS} app_ids are allowed per request.")

--- a/api/tests/unit_tests/controllers/console/app/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow.py
@@ -103,6 +103,7 @@ def test_publish_workflow_returns_success(
     with app.test_request_context("/apps/app-1/workflows/publish", method="POST", json={}):
         response = inspect.unwrap(workflow_module.PublishedWorkflowApi.post)(
             workflow_module.PublishedWorkflowApi(),
+            workflow_module.PublishWorkflowPayload.model_validate({}),
             current_user,
             app_model,
         )
@@ -547,7 +548,10 @@ def test_get_published_workflows_serializes_items_before_session_closes(
         method="GET",
         query_string={"page": 1, "limit": 10, "user_id": "", "named_only": "false"},
     ):
-        response = handler(api, "t1", app_model=SimpleNamespace(id="app", workflow_id="wf-1"))
+        query = workflow_module.WorkflowListQuery.model_validate(
+            {"page": "1", "limit": "10", "user_id": "", "named_only": "false"}
+        )
+        response = handler(api, query, "t1", app_model=SimpleNamespace(id="app", workflow_id="wf-1"))
 
     assert response["items"][0]["id"] == "w1"
     assert response["page"] == 1
@@ -806,15 +810,24 @@ def test_advanced_chat_run_conversation_not_exists(app: Flask, monkeypatch: pyte
         method="POST",
         json={"inputs": {}},
     ):
+        payload = workflow_module.AdvancedChatWorkflowRunPayload.model_validate({"inputs": {}})
         with pytest.raises(NotFound):
-            handler(api, Mock(), "t1", app_model=SimpleNamespace(id="app"))
+            handler(api, payload, Mock(), "t1", app_model=SimpleNamespace(id="app"))
 
 
 @pytest.mark.parametrize(
-    ("resource", "payload"),
+    ("resource", "payload_model", "payload"),
     [
-        (workflow_module.DraftWorkflowTriggerRunApi, {"node_id": "node-1"}),
-        (workflow_module.DraftWorkflowTriggerRunAllApi, {"node_ids": ["node-1"]}),
+        (
+            workflow_module.DraftWorkflowTriggerRunApi,
+            workflow_module.DraftWorkflowTriggerRunPayload,
+            {"node_id": "node-1"},
+        ),
+        (
+            workflow_module.DraftWorkflowTriggerRunAllApi,
+            workflow_module.DraftWorkflowTriggerRunAllPayload,
+            {"node_ids": ["node-1"]},
+        ),
     ],
 )
 def test_trigger_run_loads_draft_with_request_session(
@@ -822,6 +835,7 @@ def test_trigger_run_loads_draft_with_request_session(
     monkeypatch: pytest.MonkeyPatch,
     unbound_session: Session,
     resource: type,
+    payload_model: type,
     payload: dict[str, object],
 ) -> None:
     get_draft_workflow = Mock(return_value=None)
@@ -836,7 +850,13 @@ def test_trigger_run_loads_draft_with_request_session(
 
     with app.test_request_context("/", method="POST", json=payload):
         with pytest.raises(ValueError, match="Workflow not found"):
-            handler(resource(), session, SimpleNamespace(id="account-1"), app_model)
+            handler(
+                resource(),
+                payload_model.model_validate(payload),
+                session,
+                SimpleNamespace(id="account-1"),
+                app_model,
+            )
 
     get_draft_workflow.assert_called_once_with(app_model, session=session)
 
@@ -906,7 +926,8 @@ def test_workflow_online_users_filters_inaccessible_workflow(app: Flask, monkeyp
         method="POST",
         json={"app_ids": [app_id_1, app_id_2]},
     ):
-        response = handler(api, "tenant-1", SimpleNamespace(id="account-1"))
+        args = workflow_module.WorkflowOnlineUsersPayload.model_validate({"app_ids": [app_id_1, app_id_2]})
+        response = handler(api, args, "tenant-1", SimpleNamespace(id="account-1"))
 
     assert response == {
         "data": [
@@ -963,7 +984,8 @@ def test_workflow_online_users_batches_redis_reads(app: Flask, monkeypatch: pyte
         method="POST",
         json={"app_ids": app_ids},
     ):
-        response = handler(api, "tenant-1", SimpleNamespace(id="account-1"))
+        args = workflow_module.WorkflowOnlineUsersPayload.model_validate({"app_ids": app_ids})
+        response = handler(api, args, "tenant-1", SimpleNamespace(id="account-1"))
 
     assert len(response["data"]) == len(app_ids)
     assert redis_pipeline_factory.call_count == 2
@@ -989,8 +1011,9 @@ def test_workflow_online_users_rejects_excessive_workflow_ids(app: Flask, monkey
         method="POST",
         json={"app_ids": excessive_ids},
     ):
+        args = workflow_module.WorkflowOnlineUsersPayload.model_validate({"app_ids": excessive_ids})
         with pytest.raises(HTTPException) as exc:
-            handler(api, "tenant-1", SimpleNamespace(id="account-1"))
+            handler(api, args, "tenant-1", SimpleNamespace(id="account-1"))
 
     assert exc.value.code == 400
     assert exc.value.description is not None

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_convert_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_convert_api.py
@@ -60,6 +60,7 @@ class TestConvertToWorkflowApi:
             current_user.id = "u1"
             response = method(
                 api,
+                workflow_module.ConvertToWorkflowPayload.model_validate({}),
                 current_tenant_id="tenant-1",
                 current_user=current_user,
                 app_model=_app("app-1"),

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_human_input_debug_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_human_input_debug_api.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY, MagicMock
 
 import pytest
 from flask import Flask
-from pydantic import ValidationError
+from werkzeug.exceptions import UnprocessableEntity
 
 from controllers.console import wraps as console_wraps
 from controllers.console.app import workflow as workflow_module
@@ -241,5 +241,5 @@ def test_human_input_preview_rejects_non_mapping(app: Flask, monkeypatch: pytest
         method="POST",
         json={"inputs": ["not-a-dict"]},
     ):
-        with pytest.raises(ValidationError):
+        with pytest.raises(UnprocessableEntity):
             workflow_module.AdvancedChatDraftHumanInputFormPreviewApi().post(app_id=app_model.id, node_id="node-1")


### PR DESCRIPTION
## Summary

Part of #36659 (claimed in the issue comments).

Migrates `controllers/console/app/workflow.py` to the `@model_validate` decorator. This was the largest remaining batch of inline validation calls: 21 handlers doing `Model.model_validate(console_ns.payload or {})` or parsing `request.args` by hand now get the validated model injected instead, same pattern as the earlier controllers/web migrations (#40796, #40856).

Left as-is on purpose:

- the sync-draft endpoint, because it branches on Content-Type and also accepts text/plain, which the decorator doesn't cover
- response-side `model_validate(..., from_attributes=True)` calls, which are serialization rather than request parsing

One behavior change: invalid payloads on these endpoints now return 422 from the decorator instead of surfacing a raw pydantic ValidationError. `test_human_input_preview_rejects_non_mapping` was updated to match.

From GitHub Copilot

## Testing

- Updated unit tests that call handlers directly (`inspect.unwrap`) to pass the explicitly-constructed validated model as the first argument:
  - `api/tests/unit_tests/controllers/console/app/test_workflow.py`
  - `api/tests/unit_tests/controllers/console/app/test_workflow_convert_api.py`
  - `api/tests/unit_tests/controllers/console/app/test_workflow_human_input_debug_api.py`
- Local verification:
  - `uv run --project api --dev pytest tests/unit_tests/controllers` → 3884 passed
  - `make lint` → clean (ruff format/check, response-contract lint, import-linter, dotenv-linter)
  - `make type-check` → clean (pyrefly + mypy, 1719 source files, no issues)

## Screenshots

| Before | After |
| ------ | ----- |
| N/A — backend-only controller refactor, no UI change | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods. No frontend files changed, so `vp staged` (frontend) is not applicable.