### PR TITLE
fix(http): honor content-type charset before encoding detection (graphon #93)

### DIFF
--- a/api/dify_graph/nodes/http_request/entities.py
+++ b/api/dify_graph/nodes/http_request/entities.py
@@ -187,14 +187,27 @@ class Response:
         """
         Get response text with robust encoding detection.
 
-        Uses charset_normalizer for better encoding detection than httpx's default,
-        which helps handle Chinese and other non-ASCII characters properly.
+        Honors the charset declared in the Content-Type response header first,
+        because charset_normalizer auto-detection can misjudge UTF-8 as another
+        encoding. Falls back to charset_normalizer and finally to httpx's
+        built-in detection when the server does not declare a charset.
         """
         # Check cache first
         if hasattr(self, "_cached_text") and self._cached_text is not None:
             return self._cached_text
 
-        # Try charset_normalizer for robust encoding detection first
+        # Honor the charset declared in the Content-Type header before guessing
+        charset = self._extract_charset_from_content_type()
+        if charset:
+            try:
+                text = self.response.content.decode(charset, errors="replace")
+            except (TypeError, LookupError):
+                pass
+            else:
+                self._cached_text = text
+                return text
+
+        # Try charset_normalizer for robust encoding detection next
         detected_encoding = charset_normalizer.from_bytes(self.response.content).best()
         if detected_encoding and detected_encoding.encoding:
             try:
@@ -209,6 +222,15 @@ class Response:
         text = self.response.text
         self._cached_text = text
         return text
+
+    def _extract_charset_from_content_type(self) -> str | None:
+        content_type = self.headers.get("content-type", "")
+        if not content_type:
+            return None
+
+        message = Message()
+        message["content-type"] = content_type
+        return message.get_content_charset(failobj=None)
 
     @property
     def content(self) -> bytes:

--- a/api/tests/unit_tests/core/workflow/nodes/http_request/test_entities.py
+++ b/api/tests/unit_tests/core/workflow/nodes/http_request/test_entities.py
@@ -231,3 +231,46 @@ def test_text_property_with_escaped_unicode(mock_response, json_content, descrip
     # The text should be valid JSON that can be parsed back to proper Unicode
     parsed = json.loads(response.text)
     assert isinstance(parsed, dict), f"Invalid JSON for {description}"
+
+
+# Content-Type charset precedence tests
+def test_text_property_prefers_content_type_charset_over_detection(mock_response):
+    """The charset declared in Content-Type must win over charset_normalizer detection."""
+    mock_response.headers = {"content-type": "application/json; charset=utf-8"}
+    type(mock_response).content = PropertyMock(return_value="你好世界".encode())
+    mock_response.text = "incorrect-fallback-text"
+
+    with patch("dify_graph.nodes.http_request.entities.charset_normalizer.from_bytes") as detected_mock:
+        response = Response(mock_response)
+        assert response.text == "你好世界"
+        detected_mock.assert_not_called()
+
+
+def test_text_property_uses_declared_gbk_charset(mock_response):
+    """GBK-encoded body with a declared charset must not be misdetected/garbled."""
+    mock_response.headers = {"content-type": "text/plain; charset=gbk"}
+    type(mock_response).content = PropertyMock(return_value="中文乱码测试".encode("gbk"))
+    mock_response.text = "garbled"
+
+    response = Response(mock_response)
+    assert response.text == "中文乱码测试"
+
+
+def test_text_property_declared_charset_uses_replacement_on_invalid_bytes(mock_response):
+    """When bytes do not match the declared charset, decode with errors='replace'."""
+    mock_response.headers = {"content-type": "text/plain; charset=utf-8"}
+    type(mock_response).content = PropertyMock(return_value=b"\xffabc")
+    mock_response.text = "garbled"
+
+    response = Response(mock_response)
+    assert response.text == "\ufffdabc"
+
+
+def test_text_property_ignores_charset_inside_quoted_parameters(mock_response):
+    """Only the real charset parameter is honored, not one nested in a quoted value."""
+    mock_response.headers = {"content-type": 'text/plain; foo="a; charset=latin-1"; charset=utf-8'}
+    type(mock_response).content = PropertyMock(return_value="你好世界".encode())
+    mock_response.text = "garbled"
+
+    response = Response(mock_response)
+    assert response.text == "你好世界"


### PR DESCRIPTION
## Summary

Backport of [graphon PR #93](https://github.com/langgenius/graphon/pull/93) ("honor content-type charset before encoding detection") to `lts/1.13.x`.

On `lts/1.13.x` the graph engine is still vendored in-repo (`api/dify_graph/`), so this is applied as a manual port rather than a bumped `graphon` dependency (which is how `main` carries the fix).

**Root cause:** the HTTP request node's `Response.text` ran `charset_normalizer` detection first and ignored the `charset` declared in the response `Content-Type` header. Auto-detection can misjudge UTF-8 as another encoding, producing garbled Chinese output — even though the server declared the correct charset.

**Fix:** honor the declared `Content-Type` charset first (decode with `errors="replace"`), then fall back to `charset_normalizer` and finally httpx's built-in detection when no charset is declared. Added `_extract_charset_from_content_type()` using `email.message.Message.get_content_charset()` so quoted parameters are handled correctly.

Public record: dify #31695.

## Test plan

- [x] New unit tests in `test_entities.py`: declared charset takes precedence over detection, GBK real-world case, `errors="replace"` on invalid bytes, and charset nested in quoted params is ignored.
- [x] Existing `Response.text` tests still pass (40 passed).
- [x] `ruff check` / `ruff format` / `basedpyright` clean on changed files.

Resolves ENG-767