### PR TITLE
fix(web): restore AI credits icon

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
@@ -151,7 +151,7 @@ function PopupItem({
                     <>
                       <span
                         aria-hidden="true"
-                        className="i-custom-vender-line-financeandecommerce-credits-coin size-3"
+                        className="i-custom-vender-line-financeAndECommerce-credits-coin size-3"
                       />
                       <span className="ml-1 truncate">
                         {t(($) => $['modelProvider.selector.aiCredits'], { ns: 'common' })}


### PR DESCRIPTION
## Summary

- correct the AI credits icon class to match the generated custom vendor collection
- restore the missing icon in the model selector provider header

## Validation

- pnpm exec vp check web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
- repository-wide credits-coin scan confirms no invalid lowercase class remains
- git diff --check