### PR TITLE
refactor(ci): trim redundant autofix work

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,8 +5,6 @@ on:
   merge_group:
     branches: ['main']
     types: [checks_requested]
-  push:
-    branches: ['main']
 permissions:
   contents: read
 
@@ -32,30 +30,6 @@ jobs:
             docker/.env.example
             docker/docker-compose-template.yaml
             docker/docker-compose.yaml
-      - name: Check web inputs
-        if: github.event_name != 'merge_group'
-        id: web-changes
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            web/**
-            cli/**
-            e2e/**
-            packages/**
-            sdks/nodejs-client/**
-            package.json
-            pnpm-lock.yaml
-            pnpm-workspace.yaml
-            .nvmrc
-            vite.config.ts
-            lint.config.ts
-            eslint.config.mjs
-            knip.config.ts
-            scripts/check-web-production-unused-after-knip-fix.mjs
-            oxlint-suppressions.json
-            eslint-suppressions.json
-            .vscode/**
-            .github/**
       - name: Check api inputs
         if: github.event_name != 'merge_group'
         id: api-changes
@@ -84,12 +58,12 @@ jobs:
             dify-agent/**/*.py
             dify-agent/pyproject.toml
             dify-agent/uv.lock
-      - if: github.event_name != 'merge_group'
+      - if: github.event_name != 'merge_group' && (steps.docker-compose-changes.outputs.any_changed == 'true' || steps.api-changes.outputs.any_changed == 'true' || steps.frontend-contract-changes.outputs.any_changed == 'true' || steps.dify-agent-changes.outputs.any_changed == 'true')
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 
-      - if: github.event_name != 'merge_group'
+      - if: github.event_name != 'merge_group' && (steps.api-changes.outputs.any_changed == 'true' || steps.frontend-contract-changes.outputs.any_changed == 'true' || steps.dify-agent-changes.outputs.any_changed == 'true')
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Generate Docker Compose
@@ -119,12 +93,6 @@ jobs:
           uv run ruff check --fix .
           # Format code
           uv run ruff format .
-
-      - name: count migration progress
-        if: github.event_name != 'merge_group' && steps.api-changes.outputs.any_changed == 'true'
-        run: |
-          cd api
-          ./cnt_base.sh
 
       - name: ast-grep
         if: github.event_name != 'merge_group' && steps.api-changes.outputs.any_changed == 'true'
@@ -157,7 +125,7 @@ jobs:
           find . -name "*.py.bak" -type f -delete
 
       - name: Setup web environment
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && steps.frontend-contract-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/setup-web
 
       - name: Generate API docs
@@ -169,14 +137,6 @@ jobs:
       - name: Generate frontend contracts
         if: github.event_name != 'merge_group' && steps.frontend-contract-changes.outputs.any_changed == 'true'
         run: pnpm --dir packages/contracts gen-api-contract
-
-      - name: ESLint fallback autofix
-        if: github.event_name != 'merge_group' && steps.web-changes.outputs.any_changed == 'true'
-        run: pnpm lint:eslint:fix --quiet || true
-
-      - name: Vite+ static autofix
-        if: github.event_name != 'merge_group' && (steps.web-changes.outputs.any_changed == 'true' || steps.frontend-contract-changes.outputs.any_changed == 'true')
-        run: vp check --fix || true
 
       - if: github.event_name != 'merge_group'
         uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
## Summary

- rely on `vp staged` and Style CI for frontend lint and formatting fixes
- stop rerunning autofix after changes land on `main`
- remove the unused migration progress log step
- install Python, uv, and web dependencies only for jobs that need them
- keep contracts generation, Ruff fixes, Docker/API docs generation, and the merge queue status intact

## Validation

- `pnpm -w check`
- `vp staged --no-stash --verbose`
- `vp fmt --check .github/workflows/autofix.yml`
- `git diff --check`