### PR TITLE
fix(dataset): delete child chunks the index processor leaves behind

### DIFF
--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -12,6 +12,7 @@ from extensions.ext_storage import storage
 from models import WorkflowType
 from models.dataset import (
     AppDatasetJoin,
+    ChildChunk,
     Dataset,
     DatasetMetadata,
     DatasetMetadataBinding,
@@ -154,6 +155,14 @@ def clean_dataset_task(
                     SegmentAttachmentBinding.id.in_(binding_ids)
                 )
                 session.execute(binding_delete_stmt)
+
+            # The index processor only deletes child chunks for high-quality parent-child
+            # datasets, so economy-indexed datasets -- and datasets whose index cleanup
+            # above failed -- keep theirs forever. Both columns are matched so the delete
+            # can use the compound (tenant_id, dataset_id, ...) index.
+            session.execute(
+                delete(ChildChunk).where(ChildChunk.tenant_id == tenant_id, ChildChunk.dataset_id == dataset_id)
+            )
 
             session.execute(delete(DatasetProcessRule).where(DatasetProcessRule.dataset_id == dataset_id))
             session.execute(delete(DatasetQuery).where(DatasetQuery.dataset_id == dataset_id))

--- a/api/tests/unit_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/unit_tests/tasks/test_clean_dataset_task.py
@@ -26,6 +26,7 @@ from extensions.storage.storage_type import StorageType
 from models.base import TypeBase
 from models.dataset import (
     AppDatasetJoin,
+    ChildChunk,
     DatasetMetadata,
     DatasetMetadataBinding,
     DatasetProcessRule,
@@ -76,6 +77,7 @@ def orm_session_maker(
 ) -> sessionmaker[Session]:
     """Create the cleanup tables and return the suite's real SQLite session factory."""
     models = (
+        ChildChunk,
         Document,
         DocumentSegment,
         SegmentAttachmentBinding,
@@ -216,6 +218,27 @@ def _persist_attachment(
     with session_maker.begin() as session:
         session.add_all([attachment_file, binding])
     return binding, attachment_file
+
+
+def _persist_child_chunk(
+    session_maker: sessionmaker[Session],
+    *,
+    dataset_id: str,
+    tenant_id: str,
+) -> ChildChunk:
+    child_chunk = ChildChunk(
+        tenant_id=tenant_id,
+        dataset_id=dataset_id,
+        document_id=str(uuid.uuid4()),
+        segment_id=str(uuid.uuid4()),
+        position=1,
+        content="child",
+        word_count=1,
+        created_by=str(uuid.uuid4()),
+    )
+    with session_maker.begin() as session:
+        session.add(child_chunk)
+    return child_chunk
 
 
 # ============================================================================
@@ -579,3 +602,62 @@ class TestIndexProcessorParameters:
             )
 
         schedule_refresh.assert_not_called()
+
+
+# ============================================================================
+# Test Child Chunk Cleanup
+# ============================================================================
+
+
+class TestChildChunkCleanup:
+    """Child chunks the index processor does not reach must still be deleted."""
+
+    def test_clean_dataset_task_deletes_child_chunks_left_by_the_index_processor(
+        self,
+        orm_session_maker: sessionmaker[Session],
+        dataset_id: str,
+        tenant_id: str,
+        collection_binding_id: str,
+        mock_storage: MagicMock,
+        mock_index_processor_factory: dict[str, MagicMock],
+        mock_get_image_upload_file_ids: MagicMock,
+    ):
+        """ParentChildIndexProcessor.clean() only deletes child chunks when the dataset's
+        indexing_technique is high quality, and clean_dataset_task deliberately continues
+        when that cleanup raises. In both cases nothing else removes the rows, so the task
+        itself has to. The mocked index processor here stands in for exactly that: a clean()
+        that deletes no child chunks."""
+        child_chunk = _persist_child_chunk(orm_session_maker, dataset_id=dataset_id, tenant_id=tenant_id)
+
+        _run_clean_dataset(
+            dataset_id=dataset_id,
+            tenant_id=tenant_id,
+            collection_binding_id=collection_binding_id,
+        )
+
+        with orm_session_maker() as session:
+            remaining = session.get(ChildChunk, child_chunk.id)
+        assert remaining is None, f"Child chunk {child_chunk.id} outlived its dataset; nothing else ever deletes it"
+
+    def test_clean_dataset_task_leaves_child_chunks_of_other_datasets(
+        self,
+        orm_session_maker: sessionmaker[Session],
+        dataset_id: str,
+        tenant_id: str,
+        collection_binding_id: str,
+        mock_storage: MagicMock,
+        mock_index_processor_factory: dict[str, MagicMock],
+        mock_get_image_upload_file_ids: MagicMock,
+    ):
+        """The delete is scoped by both tenant_id and dataset_id."""
+        other = _persist_child_chunk(orm_session_maker, dataset_id=str(uuid.uuid4()), tenant_id=tenant_id)
+
+        _run_clean_dataset(
+            dataset_id=dataset_id,
+            tenant_id=tenant_id,
+            collection_binding_id=collection_binding_id,
+        )
+
+        with orm_session_maker() as session:
+            survivor = session.get(ChildChunk, other.id)
+        assert survivor is not None, "Deleting one dataset must not touch another dataset's child chunks"


### PR DESCRIPTION
Extracted from #38519 so it can be reviewed independently. Refs #38518.

### The leak

Nothing in `clean_dataset_task` deletes rows from `child_chunks`. The only dataset-wide delete lives in `ParentChildIndexProcessor.clean()`, and the entire block that performs it sits inside:

```python
if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
    ...
    if delete_child_chunks:
        # Use existing compound index: (tenant_id, dataset_id, ...)
        session.execute(
            delete(ChildChunk).where(
                ChildChunk.tenant_id == dataset.tenant_id, ChildChunk.dataset_id == dataset.id
            )
        )
```

A dataset whose `indexing_technique` is anything other than high quality therefore keeps every child chunk after it is deleted. `ParagraphIndexProcessor.clean()` and `QAIndexProcessor.clean()` never touch the table at all.

The same rows are stranded on a second path, one the task tolerates on purpose. `clean_dataset_task` wraps the index cleanup in its own `try`/`except` and continues deliberately:

```python
except Exception:
    logger.exception(...)
    # Continue with document and segment deletion even if vector cleanup fails
```

Documents, segments, attachments and metadata are then deleted, and the child chunks that referenced them are not. So whenever the vector store is unreachable at delete time — the case that `except` exists for — the child chunks are orphaned even for a high-quality parent-child dataset.

Both leaks are silent. The dataset disappears from the UI, the rows stay in the table indefinitely, and because the dataset row is already gone there is nothing left to retry the cleanup.

### The change

One `delete` in the task, after the index processor has had its turn:

```python
session.execute(
    delete(ChildChunk).where(ChildChunk.tenant_id == tenant_id, ChildChunk.dataset_id == dataset_id)
)
```

The predicate matches both columns so it can use the existing compound index `child_chunk_dataset_id_idx` on `(tenant_id, dataset_id, document_id, segment_id, index_node_id)` — the same access path the parent-child processor already relies on for its own delete.

Placing it after the index cleanup makes it a no-op for the high-quality parent-child datasets that are already handled: those rows are gone by the time it runs.

### Tests

Two cases in `TestChildChunkCleanup`, using the suite's existing SQLite session factory and fixtures:

- a child chunk that the index processor did not delete (the mocked processor stands in for both leak paths) is gone after the task runs — this fails on `main`
- another dataset's child chunks survive, covering the scoping of the predicate

`tests/unit_tests/tasks/test_clean_dataset_task.py` passes: 10 tests. `ruff check` and `ruff format --check` are clean.
