### PR TITLE
fix(api): enforce RBAC permission on agent app detail GET endpoint (#41264)

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -632,6 +632,7 @@ class AgentAppApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)
     @enterprise_license_required
     @with_current_user
     @with_current_tenant_id

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -4,6 +4,7 @@ from types import FunctionType
 import pytest
 
 from controllers.common.wraps import RBACPermission, RBACResourceScope
+from controllers.console.agent.roster import AgentAppApi
 from controllers.console.datasets.data_source import DataSourceApi
 from controllers.console.datasets.rag_pipeline.datasource_auth import DatasourceAuth
 from controllers.console.workspace.model_providers import ModelProviderCredentialApi
@@ -103,4 +104,16 @@ def test_workspace_model_preferences_get_require_admin_and_rbac(
     rbac_config = getclosurevars(rbac_wrapper).nonlocals
     assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
     assert rbac_config["scene"] == RBACPermission.PLUGIN_PREFERENCES
+    assert rbac_config["resource_required"] is False
+
+
+def test_agent_app_get_requires_rbac() -> None:
+    """GET endpoint that returns agent app details must enforce
+    the same RBAC gates as its sibling PUT/DELETE methods."""
+    method = AgentAppApi.get
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
+    assert rbac_config["scene"] == RBACPermission.AGENT_MANAGE
     assert rbac_config["resource_required"] is False


### PR DESCRIPTION
## Summary

Fixes #41264

The `GET /console/api/agent/<agent_id>` endpoint in `AgentAppApi` was missing authorization decorator:
- `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)`

This allowed workspace members without `AGENT_MANAGE` RBAC permissions to retrieve detailed agent app configurations.

Added missing permission decorator to match all other agent management endpoints in `api/controllers/console/agent/roster.py` and added corresponding unit test assertion.

## Screenshots

N/A (Backend API permission enforcement)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
