### PR TITLE
fix(api): keep workspace owner consistent on ownership transfer

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -171,15 +171,22 @@ class AccountService:
     EMAIL_REGISTER_MAX_ERROR_LIMITS = 5
 
     @staticmethod
+    def _resolve_role_id_by_tag(tenant_id: str, account_id: str, tag: str) -> str:
+        options = ListOption(page_number=1, results_per_page=100)
+        roles = RBACService.Roles.list(tenant_id, account_id, options=options).data
+        for rbac_role in roles:
+            if rbac_role.is_builtin and rbac_role.category == "global_system_default" and rbac_role.role_tag == tag:
+                return str(rbac_role.id)
+
+        raise ValueError(f"Builtin RBAC role not found for tag {tag!r} in tenant {tenant_id}")
+
+    @staticmethod
     def _resolve_legacy_role_id(tenant_id: str, account_id: str, role: TenantAccountRole) -> str:
         """Resolve a legacy workspace role to the corresponding RBAC role id.
 
         Looks up the builtin RBAC role whose tag matches the legacy role name
         (e.g. ``TenantAccountRole.ADMIN`` → builtin role with tag ``"admin"``).
         """
-        options = ListOption(page_number=1, results_per_page=100)
-        roles = RBACService.Roles.list(tenant_id, account_id, options=options).data
-
         expected_tag = {
             TenantAccountRole.OWNER: "owner",
             TenantAccountRole.ADMIN: "admin",
@@ -187,15 +194,7 @@ class AccountService:
             TenantAccountRole.NORMAL: "normal",
             TenantAccountRole.DATASET_OPERATOR: "dataset_operator",
         }[role]
-        for rbac_role in roles:
-            if (
-                rbac_role.is_builtin
-                and rbac_role.category == "global_system_default"
-                and rbac_role.role_tag == expected_tag
-            ):
-                return str(rbac_role.id)
-
-        raise ValueError(f"Builtin RBAC role not found for {role.value} in tenant {tenant_id}")
+        return AccountService._resolve_role_id_by_tag(tenant_id, account_id, expected_tag)
 
     @staticmethod
     def get_workspace_permission_keys(tenant_id: str, account_id: str, *, session: Session) -> set[str]:
@@ -1857,28 +1856,39 @@ class TenantService:
             raise RoleAlreadyAssignedError("The provided role is already assigned to the member.")
 
         if new_role == "owner":
-            # Find the current owner and change their role to 'admin'
+            if dify_config.RBAC_ENABLED:
+                old_owner_id = AccountService.get_rbac_workspace_owner_account_id(
+                    str(tenant.id), operator.id, session=session
+                )
+                owner_role_id = AccountService._resolve_legacy_role_id(
+                    tenant_id=str(tenant.id),
+                    account_id=operator.id,
+                    role=TenantAccountRole.OWNER,
+                )
+                no_access_role_id = AccountService._resolve_role_id_by_tag(
+                    tenant_id=str(tenant.id),
+                    account_id=operator.id,
+                    tag="no_access",
+                )
+                current_roles = RBACService.MemberRoles.get(
+                    str(tenant.id), operator.id, old_owner_id, session=session
+                ).roles
+                remaining_role_ids = [str(r.id) for r in current_roles if str(r.id) != owner_role_id]
+                RBACService.MemberRoles.replace(
+                    tenant_id=str(tenant.id),
+                    account_id=operator.id,
+                    member_account_id=old_owner_id,
+                    role_ids=remaining_role_ids or [no_access_role_id],
+                    session=session,
+                )
+
             current_owner_join = session.scalar(
                 select(TenantAccountJoin)
                 .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.role == "owner")
                 .limit(1)
             )
-            if not dify_config.RBAC_ENABLED:
-                if current_owner_join:
-                    current_owner_join.role = TenantAccountRole.ADMIN
-            elif current_owner_join:
-                admin_role_id = AccountService._resolve_legacy_role_id(
-                    tenant_id=str(tenant.id),
-                    account_id=operator.id,
-                    role=TenantAccountRole.ADMIN,
-                )
-                RBACService.MemberRoles.replace(
-                    tenant_id=str(tenant.id),
-                    account_id=operator.id,
-                    member_account_id=str(current_owner_join.account_id),
-                    role_ids=[admin_role_id],
-                    session=session,
-                )
+            if current_owner_join:
+                current_owner_join.role = TenantAccountRole.NORMAL
 
         # Update the role of the target member
         if dify_config.RBAC_ENABLED:
@@ -1894,6 +1904,8 @@ class TenantService:
                 role_ids=[resolved_role_id],
                 session=session,
             )
+            if new_tenant_role == TenantAccountRole.OWNER:
+                target_member_join.role = new_tenant_role
         else:
             target_member_join.role = new_tenant_role
         session.commit()

--- a/api/services/enterprise/rbac_service.py
+++ b/api/services/enterprise/rbac_service.py
@@ -1846,7 +1846,7 @@ class RBACService:
                         )
                     )
                     if current_owner_join and current_owner_join.account_id != member_account_id:
-                        current_owner_join.role = TenantAccountRole.ADMIN
+                        current_owner_join.role = TenantAccountRole.NORMAL
 
                 target_member_join.role = tenant_role
                 session.commit()

--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_members.py
@@ -300,7 +300,7 @@ class TestOwnerTransferApiWithContainers:
         )
         assert (
             factory.get_join(db_session_with_containers, tenant=tenant, account=current_user).role
-            == TenantAccountRole.ADMIN
+            == TenantAccountRole.NORMAL
         )
         mock_new_owner_email.assert_called_once()
         mock_old_owner_email.assert_called_once()

--- a/api/tests/test_containers_integration_tests/services/test_account_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_account_service.py
@@ -1671,7 +1671,7 @@ class TestTenantService:
 
     def test_update_member_role_to_owner(self, db_session_with_containers: Session, mock_external_service_dependencies):
         """
-        Test updating member role to owner (should change current owner to admin).
+        Test updating member role to owner (should change current owner to normal).
         """
         fake = Faker()
         tenant_name = fake.company()
@@ -1723,7 +1723,7 @@ class TestTenantService:
             .filter_by(tenant_id=tenant.id, account_id=member_account.id)
             .first()
         )
-        assert owner_join.role == "admin"
+        assert owner_join.role == "normal"
         assert member_join.role == "owner"
 
     def test_update_member_role_already_assigned(

--- a/api/tests/unit_tests/services/enterprise/test_rbac_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_rbac_service.py
@@ -997,7 +997,7 @@ class TestMemberRoles:
         }
         assert persisted_joins == {
             "acct-2": svc.TenantAccountRole.OWNER,
-            "acct-owner": svc.TenantAccountRole.ADMIN,
+            "acct-owner": svc.TenantAccountRole.NORMAL,
         }
         assert out.roles[0].id == "owner"
 

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -27,7 +27,7 @@ from services.account_service import (
     RegisterService,
     TenantService,
 )
-from services.enterprise.rbac_service import MembersInRole, Paginated
+from services.enterprise.rbac_service import MemberRolesResponse, MembersInRole, Paginated, RBACRole
 from services.errors.account import (
     AccountAlreadyInTenantError,
     AccountEmailAlreadyInUseError,
@@ -798,6 +798,14 @@ class TestTenantService:
         sqlite_session.add(tenant_account_join)
         return tenant_account_join
 
+    def _db_role_of(self, sqlite_session: Session, tenant: Tenant, account_id: str) -> str | None:
+        return sqlite_session.scalar(
+            select(TenantAccountJoin.role).where(
+                TenantAccountJoin.tenant_id == tenant.id,
+                TenantAccountJoin.account_id == account_id,
+            )
+        )
+
     def test_iter_member_account_id_batches_uses_offset_limit(self, sqlite_session: Session) -> None:
         tenant_id = "00000000-0000-0000-0000-000000000001"
         account_ids = [
@@ -1331,6 +1339,69 @@ class TestTenantService:
             persisted_target_join = assertion_session.get(TenantAccountJoin, target_join_id)
             assert persisted_target_join is not None
             assert persisted_target_join.role == TenantAccountRole.ADMIN
+
+    @pytest.mark.parametrize(
+        ("outgoing_owner_role_tags", "expected_demoted_role_ids"),
+        [(["owner", "editor"], ["editor-role-id"]), (["owner"], ["no-access-role-id"])],
+    )
+    def test_update_member_role_to_owner_rbac_enabled(
+        self,
+        sqlite_session: Session,
+        outgoing_owner_role_tags: list[str],
+        expected_demoted_role_ids: list[str],
+        config_overrides: Callable[..., None],
+    ) -> None:
+        config_overrides(RBAC_ENABLED=True)
+        tenant = Tenant(name="Test Workspace")
+        sqlite_session.add(tenant)
+        sqlite_session.flush()
+
+        operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-1")
+        candidate = TestAccountAssociatedDataFactory.create_account_mock(account_id="candidate-1")
+        self._add_tenant_account_join(sqlite_session, tenant, operator.id, TenantAccountRole.EDITOR)
+        self._add_tenant_account_join(sqlite_session, tenant, candidate.id, TenantAccountRole.EDITOR)
+        self._add_tenant_account_join(sqlite_session, tenant, "stale-db-owner", TenantAccountRole.OWNER)
+        sqlite_session.commit()
+
+        outgoing_owner_roles = MemberRolesResponse(
+            account_id="real-rbac-owner",
+            roles=[
+                RBACRole(id=f"{tag}-role-id", type="workspace", name=tag, role_tag=tag)
+                for tag in outgoing_owner_role_tags
+            ],
+        )
+
+        with (
+            patch(
+                "services.account_service.AccountService.get_workspace_permission_keys",
+                return_value={"workspace.role.manage"},
+            ),
+            patch(
+                "services.account_service.AccountService.get_rbac_workspace_owner_account_id",
+                return_value="real-rbac-owner",
+            ),
+            patch(
+                "services.account_service.AccountService._resolve_legacy_role_id",
+                side_effect=lambda *, role, **_kwargs: f"{role.value}-role-id",
+            ),
+            patch(
+                "services.account_service.AccountService._resolve_role_id_by_tag",
+                return_value="no-access-role-id",
+            ),
+            patch("services.account_service.RBACService.MemberRoles.get", return_value=outgoing_owner_roles),
+            patch("services.account_service.RBACService.MemberRoles.replace") as mock_replace,
+        ):
+            TenantService.update_member_role(tenant, candidate, "owner", operator, session=sqlite_session)
+
+        mock_replace.assert_any_call(
+            tenant_id=str(tenant.id),
+            account_id=operator.id,
+            member_account_id="real-rbac-owner",
+            role_ids=expected_demoted_role_ids,
+            session=sqlite_session,
+        )
+        assert self._db_role_of(sqlite_session, tenant, "stale-db-owner") == TenantAccountRole.NORMAL
+        assert self._db_role_of(sqlite_session, tenant, candidate.id) == TenantAccountRole.OWNER
 
     def test_create_owner_tenant_rbac_enabled_assigns_owner_role(
         self,

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1394,7 +1394,7 @@ class TestTenantService:
             TenantService.update_member_role(tenant, candidate, "owner", operator, session=sqlite_session)
 
         mock_replace.assert_any_call(
-            tenant_id=str(tenant.id),
+            tenant_id=tenant.id,
             account_id=operator.id,
             member_account_id="real-rbac-owner",
             role_ids=expected_demoted_role_ids,


### PR DESCRIPTION
## Summary

Transferring workspace ownership from the console left the workspace in an inconsistent state, in two ways:

1. The outgoing owner was demoted to **admin**, while the enterprise dashboard's equivalent action demotes them to a restricted member.
2. With `RBAC_ENABLED`, the transfer only rebound the RBAC role and never wrote `tenant_account_joins.role`, so anything reading that column — the enterprise dashboard's workspace list/detail, and `TenantService.is_owner`, which guards the transfer endpoint itself — kept resolving to the previous owner.

### Changes

**Who gets demoted, and to what**

- Legacy (`RBAC_ENABLED=false`): the outgoing owner becomes `normal` instead of `admin`. Same correction applied in `RBACService.MemberRoles.replace`'s legacy branch.
- RBAC mode: the outgoing owner is resolved from RBAC via `get_rbac_workspace_owner_account_id` rather than from the core DB row, which may be stale. Only the owner role is stripped; any other roles they hold are kept, falling back to `no_access` (restricted member) when nothing remains. This mirrors `rbacclient.TransferOwner` in dify-enterprise.

**Core owner column**

`tenant_account_joins.role` now moves in both modes: whoever currently holds `owner` is demoted to `normal`, and the new owner is promoted. Keying the demotion off "whoever holds the column" rather than the RBAC-resolved account means workspaces already left inconsistent by an earlier RBAC-mode transfer are repaired on the next one, with no migration needed.

Extracted `AccountService._resolve_role_id_by_tag` from `_resolve_legacy_role_id` so a builtin role can be resolved by tag (`no_access` has no `TenantAccountRole` equivalent).

### Testing

- New parametrized unit test covering both RBAC demotion outcomes (keeps other roles / falls back to `no_access`) and asserting the core owner column swaps, including from a deliberately stale row.
- Updated the existing legacy-mode unit and container integration tests for the `admin` → `normal` change.
- `tests/unit_tests/services/test_account_service.py`, `tests/unit_tests/services/enterprise/test_rbac_service.py`, `tests/unit_tests/controllers/openapi/test_workspaces_members.py`: 210 passed.
- `tests/test_containers_integration_tests/services/test_account_service.py -k test_update_member_role`: 3 passed.
- `ruff check` and `ruff format --check` clean on all touched files.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
