### PR TITLE
test(e2e): stabilize Agent access toggles

### DIFF
--- a/e2e/features/step-definitions/agent-v2/access-point.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/access-point.steps.ts
@@ -11,6 +11,34 @@ import {
   getWebAppCard,
 } from './access-point-helpers'
 
+const toggleAgentAccess = async (
+  world: DifyWorld,
+  surface: AccessSurfaceName,
+  enabled: boolean,
+) => {
+  const agentId = getCurrentAgentId(world)
+  const client = world.getConsoleClient()
+  const toggle = getAccessSurfaceCard(world, surface).getByLabel(`Toggle ${surface} access`)
+
+  await expect(toggle).toBeEnabled()
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-checked', String(enabled))
+
+  await expect
+    .poll(async () => {
+      if (surface === 'Web app') {
+        const agent = await client.agent.byAgentId.get({ params: { agent_id: agentId } })
+        return agent.enable_site
+      }
+
+      const apiAccess = await client.agent.byAgentId.apiAccess.get({
+        params: { agent_id: agentId },
+      })
+      return apiAccess.enabled
+    })
+    .toBe(enabled)
+}
+
 Given('the Agent v2 draft has been published via API', async function (this: DifyWorld) {
   await publishAgentWithPublishableDraft(this.getConsoleClient(), getCurrentAgentId(this))
 })
@@ -73,14 +101,14 @@ When(
       this.agentBuilder.accessPoint.webAppURL = href
     }
 
-    await accessSurfaceCard.getByLabel(`Toggle ${surface} access`).click()
+    await toggleAgentAccess(this, surface, false)
   },
 )
 
 When(
   /^I enable Agent v2 (Web app|Backend service API) access$/,
   async function (this: DifyWorld, surface: AccessSurfaceName) {
-    await getAccessSurfaceCard(this, surface).getByLabel(`Toggle ${surface} access`).click()
+    await toggleAgentAccess(this, surface, true)
   },
 )
 
@@ -88,8 +116,11 @@ Then(
   /^Agent v2 (Web app|Backend service API) access should be out of service$/,
   async function (this: DifyWorld, surface: AccessSurfaceName) {
     const accessSurfaceCard = getAccessSurfaceCard(this, surface)
+    const toggle = accessSurfaceCard.getByLabel(`Toggle ${surface} access`)
 
     await expect(accessSurfaceCard.getByText('Out of service')).toBeVisible({ timeout: 30_000 })
+    await expect(toggle).toBeEnabled()
+    await expect(toggle).toHaveAttribute('aria-checked', 'false')
     if (surface === 'Web app')
       await expect(accessSurfaceCard.getByRole('button', { name: 'Launch' })).toBeDisabled()
   },
@@ -99,8 +130,11 @@ Then(
   /^Agent v2 (Web app|Backend service API) access should be in service$/,
   async function (this: DifyWorld, surface: AccessSurfaceName) {
     const accessSurfaceCard = getAccessSurfaceCard(this, surface)
+    const toggle = accessSurfaceCard.getByLabel(`Toggle ${surface} access`)
 
     await expect(accessSurfaceCard.getByText('In service')).toBeVisible({ timeout: 30_000 })
+    await expect(toggle).toBeEnabled()
+    await expect(toggle).toHaveAttribute('aria-checked', 'true')
     if (surface === 'Web app')
       await expect(accessSurfaceCard.getByRole('link', { name: 'Launch' })).toBeVisible()
   },


### PR DESCRIPTION
## Problem

The Agent v2 Access Point E2E asserted only visible status text after reload. That text can render while the access toggle is still loading, allowing the next click to race the disabled-to-enabled transition. Toggle steps also passed on optimistic UI without proving persistence.

## Fix

- Wait for the labeled toggle to become enabled before clicking.
- Assert its ARIA checked state after the browser action.
- Poll persisted state through the generated Console client for both Web app and Backend service API access.

This keeps the user action in Playwright and avoids handwritten endpoint matching.