### PR TITLE
fix(workflow): Restore Agent V2 support in Chatflow (#41269)

### DIFF
--- a/web/app/components/workflow-app/hooks/use-available-nodes-meta-data.ts
+++ b/web/app/components/workflow-app/hooks/use-available-nodes-meta-data.ts
@@ -31,7 +31,7 @@ export const useAvailableNodesMetaData = () => {
   const isChatMode = useIsChatMode()
   const docLink = useDocLink()
   const agentV2Enabled = isAgentV2Enabled()
-  const shouldUseAgentV2 = agentV2Enabled && !isChatMode
+  const shouldUseAgentV2 = agentV2Enabled
 
   const startNodeMetaData = useMemo(
     () => ({


### PR DESCRIPTION
### Description
This PR resolves #41269. 

It restores the ability to use Agent V2 inside Chatflow by removing the `!isChatMode` restriction that was previously introduced to intentionally hide Agent V2 from Chatflow. 

Now, Chatflow users can properly utilize the new Agent implementation in conversational, multi-turn flows when `agentV2Enabled` is active.

### Changes
- Updated `useAvailableNodesMetaData` in `web/app/components/workflow-app/hooks/use-available-nodes-meta-data.ts` to assign `const shouldUseAgentV2 = agentV2Enabled` instead of checking for `!isChatMode`.




