### PR TITLE
fix(api): Restore Service API OpenAPI semantics (#41274)

### DIFF
--- a/api/controllers/common/fields.py
+++ b/api/controllers/common/fields.py
@@ -195,7 +195,7 @@ class ChatMessageBlockingResponse(ResponseModel):
     conversation_id: UUIDString
     mode: str
     answer: str
-    metadata: BlockingMetadataResponse
+    metadata: BlockingMetadataResponse = Field(description="Metadata including usage and retriever resources.")
     created_at: Int64
 
 
@@ -237,7 +237,7 @@ class ChatPausedBlockingDataResponse(ResponseModel):
     message_id: UUIDString
     workflow_run_id: UUIDString
     answer: str
-    metadata: BlockingMetadataResponse
+    metadata: BlockingMetadataResponse = Field(description="Metadata including usage and retriever resources.")
     created_at: Int64
     paused_nodes: list[str]
     reasons: list[ChatPauseReasonResponse]
@@ -257,7 +257,7 @@ class ChatPausedBlockingResponse(ResponseModel):
     conversation_id: UUIDString
     mode: str
     answer: str
-    metadata: BlockingMetadataResponse
+    metadata: BlockingMetadataResponse = Field(description="Metadata including usage and retriever resources.")
     created_at: Int64
     workflow_run_id: UUIDString
     data: ChatPausedBlockingDataResponse
@@ -283,7 +283,7 @@ class CompletionBlockingResponse(ResponseModel):
     message_id: UUIDString
     mode: str
     answer: str
-    metadata: BlockingMetadataResponse
+    metadata: BlockingMetadataResponse = Field(description="Metadata including usage and retriever resources.")
     created_at: Int64
 
 
@@ -332,7 +332,7 @@ class WorkflowBlockingResponse(RootModel[WorkflowFinishedBlockingResponse | Work
 
 
 class SimpleResultResponse(ResponseModel):
-    result: str
+    result: str = Field(description="Operation result.")
 
 
 class GeneratedAppResponse(RootModel[JSONValue]):
@@ -478,7 +478,7 @@ class Parameters(BaseModel):
     user_input_form: UserInputFormList
     sensitive_word_avoidance: FeatureToggleObject
     file_upload: FileUploadObject
-    system_parameters: SystemParameters
+    system_parameters: SystemParameters = Field(description="System-level parameter limits.")
 
 
 class Site(BaseModel):

--- a/api/controllers/console/datasets/hit_testing_base.py
+++ b/api/controllers/console/datasets/hit_testing_base.py
@@ -34,7 +34,10 @@ class HitTestingPayload(BaseModel):
     query: str = Field(description="Search query text.", max_length=250)
     retrieval_model: RetrievalModel | None = Field(
         default=None,
-        description="Retrieval model configuration. Controls how chunks are searched and ranked.",
+        description=(
+            "Retrieval model configuration. Controls how chunks are searched and ranked when querying this "
+            "knowledge base."
+        ),
     )
     external_retrieval_model: ExternalRetrievalModel = Field(
         default=None,

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -27,6 +27,7 @@ from controllers.service_api.app.error import (
     WorkflowVersionExecutionNotAllowedError,
 )
 from controllers.service_api.schema import (
+    SCOPED_TASK_STOP_USER_DESCRIPTION,
     InputFileList,
     expect_user_json,
     expect_with_user,
@@ -288,7 +289,11 @@ class CompletionStopApi(Resource):
             400: "`app_unavailable` : App unavailable or misconfigured.",
         },
     )
-    @expect_user_json(service_api_ns)
+    @expect_user_json(
+        service_api_ns,
+        model_name="ScopedTaskStopPayload",
+        user_description=SCOPED_TASK_STOP_USER_DESCRIPTION,
+    )
     @service_api_ns.doc("stop_completion")
     @service_api_ns.doc(description="Stop a running completion task")
     @service_api_ns.doc(
@@ -298,7 +303,6 @@ class CompletionStopApi(Resource):
         responses={
             200: "Task stopped successfully",
             401: "Unauthorized - invalid API token",
-            404: "Task not found",
         }
     )
     @service_api_ns.response(200, "Task stopped successfully", service_api_ns.models[SimpleResultResponse.__name__])
@@ -471,7 +475,11 @@ class ChatStopApi(Resource):
             400: "`not_chat_app` : App mode does not match the API route.",
         },
     )
-    @expect_user_json(service_api_ns)
+    @expect_user_json(
+        service_api_ns,
+        model_name="ScopedTaskStopPayload",
+        user_description=SCOPED_TASK_STOP_USER_DESCRIPTION,
+    )
     @service_api_ns.doc("stop_chat_message")
     @service_api_ns.doc(description="Stop a running chat message generation")
     @service_api_ns.doc(
@@ -481,7 +489,6 @@ class ChatStopApi(Resource):
         responses={
             200: "Task stopped successfully",
             401: "Unauthorized - invalid API token",
-            404: "Task not found",
         }
     )
     @service_api_ns.response(200, "Task stopped successfully", service_api_ns.models[SimpleResultResponse.__name__])

--- a/api/controllers/service_api/app/workflow.py
+++ b/api/controllers/service_api/app/workflow.py
@@ -31,6 +31,7 @@ from controllers.service_api.app.error import (
     WorkflowVersionExecutionNotAllowedError,
 )
 from controllers.service_api.schema import (
+    WORKFLOW_TASK_STOP_USER_DESCRIPTION,
     expect_user_json,
     expect_with_user,
     json_or_event_stream_response,
@@ -522,7 +523,11 @@ class WorkflowTaskStopApi(Resource):
             ),
         },
     )
-    @expect_user_json(service_api_ns)
+    @expect_user_json(
+        service_api_ns,
+        model_name="WorkflowTaskStopPayload",
+        user_description=WORKFLOW_TASK_STOP_USER_DESCRIPTION,
+    )
     @service_api_ns.doc("stop_workflow_task")
     @service_api_ns.doc(description="Stop a running workflow task")
     @service_api_ns.doc(
@@ -532,7 +537,6 @@ class WorkflowTaskStopApi(Resource):
         responses={
             200: "Task stopped successfully",
             401: "Unauthorized - invalid API token",
-            404: "Task not found",
         }
     )
     @service_api_ns.response(200, "Task stopped successfully", service_api_ns.models[SimpleResultResponse.__name__])

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -139,7 +139,10 @@ class DatasetCreatePayload(BaseModel):
     external_knowledge_id: str | None = Field(default=None, description="ID of the external knowledge base.")
     retrieval_model: RetrievalModel | None = Field(
         default=None,
-        description="Retrieval model configuration. Controls how chunks are searched and ranked.",
+        description=(
+            "Retrieval model configuration. Controls how chunks are searched and ranked when querying this "
+            "knowledge base."
+        ),
     )
     embedding_model: str | None = Field(
         default=None,
@@ -192,7 +195,10 @@ class DatasetUpdatePayload(BaseModel):
     )
     retrieval_model: RetrievalModel | None = Field(
         default=None,
-        description="Retrieval model configuration. Controls how chunks are searched and ranked.",
+        description=(
+            "Retrieval model configuration. Controls how chunks are searched and ranked when querying this "
+            "knowledge base."
+        ),
     )
     partial_member_list: PartialMemberList = Field(
         default=None,
@@ -1111,6 +1117,7 @@ class DatasetTagsBindingStatusApi(DatasetApiResource):
         tags=["Tags"],
         responses={
             200: "Tags bound to the knowledge base.",
+            404: "`not_found` : Knowledge base not found.",
         },
     )
     @service_api_ns.doc("get_dataset_tags_binding_status")

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -113,7 +113,7 @@ class DocumentTextCreatePayload(BaseModel):
     )
     retrieval_model: RetrievalModel | None = Field(
         default=None,
-        description="Retrieval model configuration. Controls how chunks are searched and ranked.",
+        description="Controls how chunks are searched and ranked when querying this knowledge base.",
     )
     embedding_model: str | None = Field(
         default=None,
@@ -152,7 +152,7 @@ class DocumentTextUpdate(BaseModel):
     doc_language: str = Field(default="English", description="Language of the document for processing optimization.")
     retrieval_model: RetrievalModel | None = Field(
         default=None,
-        description="Retrieval model configuration. Controls how chunks are searched and ranked.",
+        description="Controls how chunks are searched and ranked when querying this knowledge base.",
     )
 
     @field_validator("doc_form")
@@ -524,6 +524,7 @@ class DocumentAddByTextApi(DatasetApiResource):
                 "- `invalid_param` : Knowledge base does not exist. / indexing_technique is required. / "
                 "Invalid doc_form (must be `text_model`, `hierarchical_model`, or `qa_model`)."
             ),
+            404: "`not_found` : Knowledge base not found.",
         },
     )
     @service_api_ns.expect(service_api_ns.models[DocumentTextCreatePayload.__name__])
@@ -569,6 +570,7 @@ class DeprecatedDocumentAddByTextApi(DatasetApiResource):
             200: "Document created successfully",
             401: "Unauthorized - invalid API token",
             400: "Bad request - invalid parameters",
+            404: "`not_found` : Knowledge base not found.",
         }
     )
     @service_api_ns.response(
@@ -704,6 +706,7 @@ class DocumentAddByFileApi(DatasetApiResource):
                 "(must be `text_model`, `hierarchical_model`, or `qa_model`)."
             ),
             413: "`file_too_large` : File size exceeded.",
+            404: "`not_found` : Knowledge base not found.",
         },
     )
     @service_api_ns.doc("create_document_by_file")

--- a/api/controllers/service_api/dataset/metadata.py
+++ b/api/controllers/service_api/dataset/metadata.py
@@ -219,6 +219,7 @@ class DatasetMetadataBuiltInFieldServiceApi(DatasetApiResource):
         tags=["Metadata"],
         responses={
             200: "Built-in metadata fields.",
+            404: "`not_found` : Knowledge base not found.",
         },
     )
     @service_api_ns.doc("get_built_in_fields")

--- a/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
@@ -119,7 +119,7 @@ class PublishedPipelineRunResponse(ResponseModel):
 
 
 class PipelineRunJsonResponse(RootModel[PublishedPipelineRunResponse | WorkflowBlockingResponse]):
-    """JSON responses returned by published and draft knowledge pipeline runs."""
+    """JSON result for published runs and draft runs using `response_mode: blocking`."""
 
 
 register_schema_model(service_api_ns, DatasourceNodeRunPayload)

--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -77,7 +77,7 @@ class SegmentListQuery(BaseModel):
 
 
 class SegmentUpdatePayload(BaseModel):
-    segment: SegmentUpdateArgs = Field(description="Chunk update payload.")
+    segment: SegmentUpdateArgs = Field(description="Chunk data to update.")
 
 
 class ChildChunkListQuery(BaseModel):

--- a/api/controllers/service_api/schema.py
+++ b/api/controllers/service_api/schema.py
@@ -19,6 +19,16 @@ USER_DESCRIPTION = (
     "User identifier, unique within the application. This identifier scopes data access; resources created with "
     "one `user` value are only visible when queried with the same `user` value."
 )
+SCOPED_TASK_STOP_USER_DESCRIPTION = (
+    "End-user identifier, defined by your app and unique within it. Send the same `user` value used for the original "
+    "generation request. See "
+    "[End User Identity](/api-reference/guides/end-user-identity)."
+)
+WORKFLOW_TASK_STOP_USER_DESCRIPTION = (
+    "End-user identifier, defined by your app and unique within it. It does not need to match the `user` that "
+    "started the run; the stop applies to the task regardless of `user`. See "
+    "[End User Identity](/api-reference/guides/end-user-identity)."
+)
 USER_PROPERTY_SCHEMA: dict[str, object] = {"description": USER_DESCRIPTION, "type": "string"}
 USER_QUERY_PARAM: dict[str, object] = {
     "description": "User identifier, used for end-user context.",
@@ -113,17 +123,24 @@ def expect_with_user(namespace: Namespace, model: type[BaseModel]):
     return decorator
 
 
-def expect_user_json(namespace: Namespace):
+def expect_user_json(
+    namespace: Namespace,
+    *,
+    model_name: str | None = None,
+    user_description: str = USER_DESCRIPTION,
+):
     """Document a JSON request body that only carries the Service API ``user``."""
 
     def decorator(view_func):
         required = _json_user_required(view_func)
         schema: dict[str, object] = {"properties": {}, "title": "ServiceApiUserPayload", "type": "object"}
-        _add_user_property(schema, required=required)
-        model_name = "RequiredServiceApiUserPayload" if required else "OptionalServiceApiUserPayload"
-        if model_name not in namespace.models:
-            namespace.schema_model(model_name, schema)
-        return namespace.expect(namespace.models[model_name], validate=False)(view_func)
+        _add_user_property(schema, required=required, description=user_description)
+        resolved_model_name = model_name or (
+            "RequiredServiceApiUserPayload" if required else "OptionalServiceApiUserPayload"
+        )
+        if resolved_model_name not in namespace.models:
+            namespace.schema_model(resolved_model_name, schema)
+        return namespace.expect(namespace.models[resolved_model_name], validate=False)(view_func)
 
     return decorator
 
@@ -163,7 +180,7 @@ def _json_user_required(view_func) -> bool:
     return bool(getattr(view_func, USER_REQUIRED_ATTR, False))
 
 
-def _add_user_property(schema: dict[str, object], *, required: bool) -> None:
+def _add_user_property(schema: dict[str, object], *, required: bool, description: str = USER_DESCRIPTION) -> None:
     variants: list[dict[str, object]] = []
     for keyword in ("anyOf", "oneOf"):
         candidates = schema.get(keyword)
@@ -172,15 +189,15 @@ def _add_user_property(schema: dict[str, object], *, required: bool) -> None:
 
     if variants:
         for variant in variants:
-            _add_user_property_to_object_schema(variant, required=required)
+            _add_user_property_to_object_schema(variant, required=required, description=description)
 
-    _add_user_property_to_object_schema(schema, required=required)
+    _add_user_property_to_object_schema(schema, required=required, description=description)
 
 
-def _add_user_property_to_object_schema(schema: dict[str, object], *, required: bool) -> None:
+def _add_user_property_to_object_schema(schema: dict[str, object], *, required: bool, description: str) -> None:
     properties = schema.setdefault("properties", {})
     if isinstance(properties, dict):
-        cast(dict[str, object], properties)["user"] = USER_PROPERTY_SCHEMA
+        cast(dict[str, object], properties)["user"] = {"description": description, "type": "string"}
 
     if required:
         required_fields = schema.setdefault("required", [])

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -65,6 +65,12 @@ DATASET_TOKEN_AUTH_RESPONSES = {
     401: "Unauthorized - invalid API token",
     403: "Forbidden - dataset API access or workspace access denied",
 }
+VECTOR_SPACE_UNAVAILABLE_RESPONSE = {
+    503: (
+        "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox "
+        "plan only; retry the request later."
+    ),
+}
 
 
 def _document_app_token_contract(view_func: Callable[..., object], fetch_user_arg: FetchUserArg | None) -> None:
@@ -183,6 +189,7 @@ def cloud_edition_billing_resource_check[**P, R](
     api_token_type: str,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def interceptor(view: Callable[P, R]):
+        @wraps(view)
         def decorated(*args: P.args, **kwargs: P.kwargs):
             api_token = validate_and_get_api_token(api_token_type)
             if resource == "vector_space":
@@ -218,6 +225,11 @@ def cloud_edition_billing_resource_check[**P, R](
 
             return view(*args, **kwargs)
 
+        if resource == "vector_space":
+            cast(_RestxDocumentedView, decorated).__apidoc__ = cast(
+                dict[str, object],
+                merge(decorated.__dict__.get("__apidoc__", {}), {"responses": VECTOR_SPACE_UNAVAILABLE_RESPONSE}),
+            )
         return decorated
 
     return interceptor

--- a/api/core/entities/model_entities.py
+++ b/api/core/entities/model_entities.py
@@ -2,10 +2,10 @@ from collections.abc import Sequence
 from enum import StrEnum, auto
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from graphon.model_runtime.entities.common_entities import I18nObject
-from graphon.model_runtime.entities.model_entities import ModelPropertyKey, ModelType, ProviderModel
+from graphon.model_runtime.entities.model_entities import FetchFrom, ModelPropertyKey, ModelType, ProviderModel
 from graphon.model_runtime.entities.provider_entities import ProviderEntity
 
 
@@ -53,8 +53,16 @@ class ProviderModelWithStatusEntity(ProviderModel):
     Model class for model response.
     """
 
+    label: I18nObject = Field(description="Localized display name of the model.")
+    model_type: ModelType = Field(description="Type of the model, matching the `model_type` path parameter.")
+    fetch_from: FetchFrom = Field(
+        description=(
+            "Where the model definition comes from. `predefined-model` for built-in models, "
+            "`customizable-model` for user-configured models."
+        )
+    )
     model_properties: dict[ModelPropertyKey, Any]
-    status: ModelStatus
+    status: ModelStatus = Field(description="Model availability status. `active` when ready to use.")
     load_balancing_enabled: bool = False
     has_invalid_load_balancing_configs: bool = False
 

--- a/api/core/workflow/nodes/human_input/entities.py
+++ b/api/core/workflow/nodes/human_input/entities.py
@@ -59,13 +59,24 @@ class StringSource(BaseModel):
 
 
 class StringListSource(BaseModel):
-    type: ValueSourceType
+    type: ValueSourceType = Field(
+        description=(
+            "Origin of the options. `constant` means `value` lists the options literally; `variable` means "
+            "`selector` points to an `array[string]` workflow variable that provides them."
+        )
+    )
 
     # The selector of default variable, used when `type` is `VARIABLE`.
-    selector: Sequence[str] = Field(default_factory=tuple)
+    selector: Sequence[str] = Field(
+        default_factory=tuple,
+        description="Variable reference path when `type` is `variable`.",
+    )
 
     # The value of the default, used when `type` is `CONSTANT`.
-    value: list[str] = Field(default_factory=list)
+    value: list[str] = Field(
+        default_factory=list,
+        description="Literal option list when `type` is `constant`.",
+    )
 
 
 class BaseInputConfig(BaseModel):
@@ -95,7 +106,13 @@ class ParagraphInputConfig(BaseInputConfig):
 
     # NOTE: This class is renamed from FormInput.
     type: Literal[FormInputType.PARAGRAPH] = FormInputType.PARAGRAPH
-    default: StringSource | None = None
+    default: StringSource | None = Field(
+        default=None,
+        description=(
+            "Raw default-value configuration for the paragraph input. Runtime-resolved values are exposed in the "
+            "surrounding `resolved_default_values` mapping."
+        ),
+    )
 
     @override
     def extract_variable_selectors(self) -> Sequence[Sequence[str]]:
@@ -120,7 +137,9 @@ class ParagraphInputConfig(BaseInputConfig):
 
 class SelectInputConfig(BaseInputConfig):
     type: Literal[FormInputType.SELECT] = FormInputType.SELECT
-    option_source: StringListSource
+    option_source: StringListSource = Field(
+        description="Source of options for `select` inputs. Present only when `type` is `select`."
+    )
 
     @override
     def extract_variable_selectors(self) -> Sequence[Sequence[NodeType]]:

--- a/api/fields/conversation_fields.py
+++ b/api/fields/conversation_fields.py
@@ -243,7 +243,7 @@ class AgentThought(ResponseModel):
     thought: str | None = None
     answer: str | None = None
     tool: str | None = None
-    tool_labels: JSONValue
+    tool_labels: JSONValue = Field(description="Labels for tools used.")
     tool_input: str | None = None
     created_at: int | None = None
     observation: str | None = None

--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -37,7 +37,7 @@ class DatasetMetadataBuiltInFieldsResponse(ResponseModel):
 
 
 class DatasetMetadataActionResponse(ResponseModel):
-    result: str
+    result: str = Field(description="Operation result.")
 
 
 class DatasetRerankingModelResponse(ResponseModel):
@@ -57,8 +57,14 @@ class DatasetVectorSettingResponse(ResponseModel):
 
 class DatasetWeightedScoreResponse(ResponseModel):
     weight_type: str | None = None
-    keyword_setting: DatasetKeywordSettingResponse = Field(default_factory=DatasetKeywordSettingResponse)
-    vector_setting: DatasetVectorSettingResponse = Field(default_factory=DatasetVectorSettingResponse)
+    keyword_setting: DatasetKeywordSettingResponse = Field(
+        default_factory=DatasetKeywordSettingResponse,
+        description="Keyword search weight settings.",
+    )
+    vector_setting: DatasetVectorSettingResponse = Field(
+        default_factory=DatasetVectorSettingResponse,
+        description="Semantic search weight settings.",
+    )
 
     @field_validator("keyword_setting", "vector_setting", mode="before")
     @classmethod
@@ -70,7 +76,10 @@ class DatasetRetrievalModelResponse(ResponseModel):
     search_method: str
     reranking_enable: bool
     reranking_mode: str | None = None
-    reranking_model: DatasetRerankingModelResponse = Field(default_factory=DatasetRerankingModelResponse)
+    reranking_model: DatasetRerankingModelResponse = Field(
+        default_factory=DatasetRerankingModelResponse,
+        description="Reranking model configuration.",
+    )
     weights: DatasetWeightedScoreResponse | None = None
     top_k: int
     score_threshold_enabled: bool
@@ -140,14 +149,21 @@ class DatasetDetailResponse(ResponseModel):
     embedding_model: str | None
     embedding_model_provider: str | None
     embedding_available: bool | None = None
-    retrieval_model_dict: DatasetRetrievalModelResponse
+    retrieval_model_dict: DatasetRetrievalModelResponse = Field(
+        description="Retrieval configuration for the knowledge base."
+    )
     summary_index_setting: DatasetSummaryIndexSettingResponse = Field(
-        default_factory=DatasetSummaryIndexSettingResponse
+        default_factory=DatasetSummaryIndexSettingResponse,
+        description="Summary index configuration.",
     )
     tags: list[DatasetTagResponse]
     doc_form: str | None
     external_knowledge_info: DatasetExternalKnowledgeInfoResponse = Field(
-        default_factory=DatasetExternalKnowledgeInfoResponse
+        default_factory=DatasetExternalKnowledgeInfoResponse,
+        description=(
+            "Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise "
+            "its properties are `null`."
+        ),
     )
     external_retrieval_model: DatasetExternalRetrievalModelResponse | None
     doc_metadata: list[DatasetDocMetadataResponse]
@@ -155,7 +171,10 @@ class DatasetDetailResponse(ResponseModel):
     pipeline_id: str | None
     runtime_mode: str | None
     chunk_structure: str | None
-    icon_info: DatasetIconInfoResponse = Field(default_factory=DatasetIconInfoResponse)
+    icon_info: DatasetIconInfoResponse = Field(
+        default_factory=DatasetIconInfoResponse,
+        description="Icon display configuration for the knowledge base.",
+    )
     is_published: bool
     total_documents: int
     total_available_documents: int

--- a/api/fields/hit_testing_fields.py
+++ b/api/fields/hit_testing_fields.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from fields.base import ResponseModel
 from libs.helper import to_timestamp
@@ -47,7 +47,7 @@ class HitTestingSegment(ResponseModel):
     completed_at: int | None
     error: str | None
     stopped_at: int | None
-    document: HitTestingDocument
+    document: HitTestingDocument = Field(description="Parent document information for the matched chunk.")
 
     @field_validator("disabled_at", "created_at", "indexing_at", "completed_at", "stopped_at", mode="before")
     @classmethod
@@ -77,7 +77,7 @@ class HitTestingFile(ResponseModel):
 
 
 class HitTestingRecord(ResponseModel):
-    segment: HitTestingSegment
+    segment: HitTestingSegment = Field(description="Matched chunk from the knowledge base.")
     child_chunks: list[HitTestingChildChunk]
     score: float | None
     tsne_position: Any | None
@@ -86,7 +86,7 @@ class HitTestingRecord(ResponseModel):
 
 
 class HitTestingResponse(ResponseModel):
-    query: HitTestingQuery
+    query: HitTestingQuery = Field(description="The original query object.")
     records: list[HitTestingRecord]
 
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -15057,7 +15057,7 @@ Legacy Chat App model config used only for follow-up question generation.
 | thought | string |  | No |
 | tool | string |  | No |
 | tool_input | string |  | No |
-| tool_labels | [JSONValue](#jsonvalue) |  | Yes |
+| tool_labels | [JSONValue](#jsonvalue) | Labels for tools used. | Yes |
 
 #### AgentTokenUsageStatisticResponse
 
@@ -16807,9 +16807,9 @@ Model class for provider custom model configuration.
 | embedding_model | string |  | Yes |
 | embedding_model_provider | string |  | Yes |
 | enable_api | boolean |  | Yes |
-| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) |  | No |
+| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) | Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise its properties are `null`. | No |
 | external_retrieval_model | [DatasetExternalRetrievalModelResponse](#datasetexternalretrievalmodelresponse) |  | Yes |
-| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) |  | No |
+| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) | Icon display configuration for the knowledge base. | No |
 | id | string |  | Yes |
 | indexing_technique | string |  | Yes |
 | is_multimodal | boolean |  | Yes |
@@ -16820,9 +16820,9 @@ Model class for provider custom model configuration.
 | permission_keys | [ string ] |  | No |
 | pipeline_id | string |  | Yes |
 | provider | string |  | Yes |
-| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) |  | Yes |
+| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) | Retrieval configuration for the knowledge base. | Yes |
 | runtime_mode | string |  | Yes |
-| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) |  | No |
+| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) | Summary index configuration. | No |
 | tags | [ [DatasetTagResponse](#datasettagresponse) ] |  | Yes |
 | total_available_documents | integer |  | Yes |
 | total_documents | integer |  | Yes |
@@ -16849,9 +16849,9 @@ Model class for provider custom model configuration.
 | embedding_model | string |  | Yes |
 | embedding_model_provider | string |  | Yes |
 | enable_api | boolean |  | Yes |
-| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) |  | No |
+| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) | Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise its properties are `null`. | No |
 | external_retrieval_model | [DatasetExternalRetrievalModelResponse](#datasetexternalretrievalmodelresponse) |  | Yes |
-| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) |  | No |
+| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) | Icon display configuration for the knowledge base. | No |
 | id | string |  | Yes |
 | indexing_technique | string |  | Yes |
 | is_multimodal | boolean |  | Yes |
@@ -16863,9 +16863,9 @@ Model class for provider custom model configuration.
 | permission_keys | [ string ] |  | No |
 | pipeline_id | string |  | Yes |
 | provider | string |  | Yes |
-| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) |  | Yes |
+| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) | Retrieval configuration for the knowledge base. | Yes |
 | runtime_mode | string |  | Yes |
-| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) |  | No |
+| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) | Summary index configuration. | No |
 | tags | [ [DatasetTagResponse](#datasettagresponse) ] |  | Yes |
 | total_available_documents | integer |  | Yes |
 | total_documents | integer |  | Yes |
@@ -16932,9 +16932,9 @@ Model class for provider custom model configuration.
 | embedding_model | string |  | Yes |
 | embedding_model_provider | string |  | Yes |
 | enable_api | boolean |  | Yes |
-| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) |  | No |
+| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) | Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise its properties are `null`. | No |
 | external_retrieval_model | [DatasetExternalRetrievalModelResponse](#datasetexternalretrievalmodelresponse) |  | Yes |
-| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) |  | No |
+| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) | Icon display configuration for the knowledge base. | No |
 | id | string |  | Yes |
 | indexing_technique | string |  | Yes |
 | is_multimodal | boolean |  | Yes |
@@ -16946,9 +16946,9 @@ Model class for provider custom model configuration.
 | permission_keys | [ string ] |  | No |
 | pipeline_id | string |  | Yes |
 | provider | string |  | Yes |
-| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) |  | Yes |
+| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) | Retrieval configuration for the knowledge base. | Yes |
 | runtime_mode | string |  | Yes |
-| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) |  | No |
+| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) | Summary index configuration. | No |
 | tags | [ [DatasetTagResponse](#datasettagresponse) ] |  | Yes |
 | total_available_documents | integer |  | Yes |
 | total_documents | integer |  | Yes |
@@ -17070,7 +17070,7 @@ Model class for provider custom model configuration.
 | ---- | ---- | ----------- | -------- |
 | reranking_enable | boolean |  | Yes |
 | reranking_mode | string |  | No |
-| reranking_model | [DatasetRerankingModelResponse](#datasetrerankingmodelresponse) |  | No |
+| reranking_model | [DatasetRerankingModelResponse](#datasetrerankingmodelresponse) | Reranking model configuration. | No |
 | score_threshold | number |  | No |
 | score_threshold_enabled | boolean |  | Yes |
 | search_method | string |  | Yes |
@@ -17125,8 +17125,8 @@ Model class for provider custom model configuration.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) |  | No |
-| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) |  | No |
+| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) | Keyword search weight settings. | No |
+| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) | Semantic search weight settings. | No |
 | weight_type | string |  | No |
 
 #### DatasourceCredentialDeletePayload
@@ -18479,7 +18479,7 @@ Enum class for form type.
 | attachment_ids | [ string ] | List of attachment IDs to include in the retrieval context. | No |
 | external_retrieval_model | object | Retrieval settings for external knowledge bases. | No |
 | query | string | Search query text. | Yes |
-| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked. | No |
+| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base. | No |
 
 #### HitTestingQuery
 
@@ -18494,7 +18494,7 @@ Enum class for form type.
 | child_chunks | [ [HitTestingChildChunk](#hittestingchildchunk) ] |  | Yes |
 | files | [ [HitTestingFile](#hittestingfile) ] |  | Yes |
 | score | number |  | Yes |
-| segment | [HitTestingSegment](#hittestingsegment) |  | Yes |
+| segment | [HitTestingSegment](#hittestingsegment) | Matched chunk from the knowledge base. | Yes |
 | summary | string |  | Yes |
 | tsne_position |  |  | Yes |
 
@@ -18502,7 +18502,7 @@ Enum class for form type.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| query | [HitTestingQuery](#hittestingquery) |  | Yes |
+| query | [HitTestingQuery](#hittestingquery) | The original query object. | Yes |
 | records | [ [HitTestingRecord](#hittestingrecord) ] |  | Yes |
 
 #### HitTestingSegment
@@ -18516,7 +18516,7 @@ Enum class for form type.
 | created_by | string |  | Yes |
 | disabled_at | integer |  | Yes |
 | disabled_by | string |  | Yes |
-| document | [HitTestingDocument](#hittestingdocument) |  | Yes |
+| document | [HitTestingDocument](#hittestingdocument) | Parent document information for the matched chunk. | Yes |
 | document_id | string |  | Yes |
 | enabled | boolean |  | Yes |
 | error | string |  | Yes |
@@ -19515,15 +19515,15 @@ Model with provider entity.
 | ---- | ---- | ----------- | -------- |
 | deprecated | boolean |  | No |
 | features | [ [ModelFeature](#modelfeature) ] |  | No |
-| fetch_from | [FetchFrom](#fetchfrom) |  | Yes |
+| fetch_from | [FetchFrom](#fetchfrom) | Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models. | Yes |
 | has_invalid_load_balancing_configs | boolean |  | No |
-| label | [I18nObject](#i18nobject) |  | Yes |
+| label | [I18nObject](#i18nobject) | Localized display name of the model. | Yes |
 | load_balancing_enabled | boolean |  | No |
 | model | string |  | Yes |
 | model_properties | object |  | Yes |
-| model_type | [ModelType](#modeltype) |  | Yes |
+| model_type | [ModelType](#modeltype) | Type of the model, matching the `model_type` path parameter. | Yes |
 | provider | [SimpleProviderEntityResponse](#simpleproviderentityresponse) |  | Yes |
-| status | [ModelStatus](#modelstatus) |  | Yes |
+| status | [ModelStatus](#modelstatus) | Model availability status. `active` when ready to use. | Yes |
 
 #### MoreLikeThisQuery
 
@@ -19891,7 +19891,7 @@ Form input definition.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| default | [StringSource](#stringsource) |  | No |
+| default | [StringSource](#stringsource) | Raw default-value configuration for the paragraph input. Runtime-resolved values are exposed in the surrounding `resolved_default_values` mapping. | No |
 | output_variable_name | string |  | Yes |
 | type | string |  | No |
 
@@ -19934,7 +19934,7 @@ Enum class for parameter type.
 | speech_to_text | { **"enabled"**: boolean } |  | Yes |
 | suggested_questions | [ string ] |  | Yes |
 | suggested_questions_after_answer | { **"enabled"**: boolean } |  | Yes |
-| system_parameters | [SystemParameters](#systemparameters) |  | Yes |
+| system_parameters | [SystemParameters](#systemparameters) | System-level parameter limits. | Yes |
 | text_to_speech | { **"autoPlay"**: string, **"enabled"**: boolean, **"language"**: string, **"voice"**: string } |  | Yes |
 | user_input_form | [ object ] |  | Yes |
 
@@ -20848,7 +20848,7 @@ Serialized pricing info with codegen-safe decimal string patterns.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| mode | [ProcessRuleMode](#processrulemode) | Processing mode. `automatic` uses built-in rules, `custom` allows manual configuration, and `hierarchical` enables parent-child chunk structure for `doc_form: hierarchical_model`. | Yes |
+| mode | [ProcessRuleMode](#processrulemode) | `automatic` uses built-in rules, `custom` allows manual configuration, `hierarchical` enables parent-child chunk structure (use with `doc_form: hierarchical_model`). | Yes |
 | rules | [Rule](#rule) | Custom processing rules. | No |
 
 #### ProcessRuleMode
@@ -20980,14 +20980,14 @@ Model class for model response.
 | ---- | ---- | ----------- | -------- |
 | deprecated | boolean |  | No |
 | features | [ [ModelFeature](#modelfeature) ] |  | No |
-| fetch_from | [FetchFrom](#fetchfrom) |  | Yes |
+| fetch_from | [FetchFrom](#fetchfrom) | Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models. | Yes |
 | has_invalid_load_balancing_configs | boolean |  | No |
-| label | [I18nObject](#i18nobject) |  | Yes |
+| label | [I18nObject](#i18nobject) | Localized display name of the model. | Yes |
 | load_balancing_enabled | boolean |  | No |
 | model | string |  | Yes |
 | model_properties | object |  | Yes |
-| model_type | [ModelType](#modeltype) |  | Yes |
-| status | [ModelStatus](#modelstatus) |  | Yes |
+| model_type | [ModelType](#modeltype) | Type of the model, matching the `model_type` path parameter. | Yes |
+| status | [ModelStatus](#modelstatus) | Model availability status. `active` when ready to use. | Yes |
 
 #### ProviderQuery
 
@@ -21037,10 +21037,10 @@ Model class for provider with models response.
 | ---- | ---- | ----------- | -------- |
 | icon_small | [I18nObject](#i18nobject) |  | No |
 | icon_small_dark | [I18nObject](#i18nobject) |  | No |
-| label | [I18nObject](#i18nobject) |  | Yes |
+| label | [I18nObject](#i18nobject) | Localized display name of the provider. | Yes |
 | models | [ [ProviderModelWithStatusEntity](#providermodelwithstatusentity) ] |  | Yes |
 | provider | string |  | Yes |
-| status | [CustomConfigurationStatus](#customconfigurationstatus) |  | Yes |
+| status | [CustomConfigurationStatus](#customconfigurationstatus) | Provider status. `active` when credentials are configured and valid. | Yes |
 | tenant_id | string |  | Yes |
 
 #### PublishWorkflowPayload
@@ -21693,7 +21693,7 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| option_source | [StringListSource](#stringlistsource) |  | Yes |
+| option_source | [StringListSource](#stringlistsource) | Source of options for `select` inputs. Present only when `type` is `select`. | Yes |
 | output_variable_name | string |  | Yes |
 | type | string |  | No |
 
@@ -21808,7 +21808,7 @@ Simple provider entity response.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| result | string |  | Yes |
+| result | string | Operation result. | Yes |
 
 #### Site
 
@@ -22478,9 +22478,9 @@ Query parameters for listing snippet published workflows.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| selector | [ string ] |  | No |
-| type | [ValueSourceType](#valuesourcetype) |  | Yes |
-| value | [ string ] |  | No |
+| selector | [ string ] | Variable reference path when `type` is `variable`. | No |
+| type | [ValueSourceType](#valuesourcetype) | Origin of the options. `constant` means `value` lists the options literally; `variable` means `selector` points to an `array[string]` workflow variable that provides them. | Yes |
+| value | [ string ] | Literal option list when `type` is `constant`. | No |
 
 #### StringSource
 

--- a/api/openapi/markdown/openapi-openapi.md
+++ b/api/openapi/markdown/openapi-openapi.md
@@ -1020,7 +1020,7 @@ Pagination for GET /account/sessions. Strict (extra='forbid').
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| result | string |  | Yes |
+| result | string | Operation result. | Yes |
 
 #### SupportedAppType
 

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -25,6 +25,8 @@ Service operations
 
 ***DEPRECATED***
 
+**Create document by text through the deprecated underscore alias**
+
 Deprecated legacy alias for creating a new document by providing text content. Use /datasets/{dataset_id}/document/create-by-text instead.
 
 #### Parameters
@@ -47,10 +49,14 @@ Deprecated legacy alias for creating a new document by providing text content. U
 | 400 | Bad request - invalid parameters |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
+| 404 | `not_found` : Knowledge base not found. |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### ~~[POST] /datasets/{dataset_id}/documents/{document_id}/update_by_text~~
 
 ***DEPRECATED***
+
+**Update document by text through the deprecated underscore alias**
 
 Deprecated legacy alias for updating an existing document by providing text content. Use /datasets/{dataset_id}/documents/{document_id}/update-by-text instead.
 
@@ -75,6 +81,7 @@ Deprecated legacy alias for updating an existing document by providing text cont
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Document not found |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ---
 ## default
@@ -350,7 +357,7 @@ Stops a chat message generation task. Only supported in `streaming` mode.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [RequiredServiceApiUserPayload](#requiredserviceapiuserpayload)<br> |
+|  Yes | **application/json**: [ScopedTaskStopPayload](#scopedtaskstoppayload)<br> |
 
 #### Responses
 
@@ -360,7 +367,6 @@ Stops a chat message generation task. Only supported in `streaming` mode.
 | 400 | `not_chat_app` : App mode does not match the API route. |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
-| 404 | Task not found |  |
 
 ### [GET] /messages/{message_id}/suggested
 **Get Next Suggested Questions**
@@ -498,7 +504,7 @@ Stops a chat message generation task. Only supported in `streaming` mode.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [RequiredServiceApiUserPayload](#requiredserviceapiuserpayload)<br> |
+|  Yes | **application/json**: [ScopedTaskStopPayload](#scopedtaskstoppayload)<br> |
 
 #### Responses
 
@@ -508,7 +514,6 @@ Stops a chat message generation task. Only supported in `streaming` mode.
 | 400 | `not_chat_app` : App mode does not match the API route. |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
-| 404 | Task not found |  |
 
 ### [GET] /messages/{message_id}/suggested
 **Get Next Suggested Questions**
@@ -574,7 +579,7 @@ Stops a completion message generation task. Only supported in `streaming` mode.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [RequiredServiceApiUserPayload](#requiredserviceapiuserpayload)<br> |
+|  Yes | **application/json**: [ScopedTaskStopPayload](#scopedtaskstoppayload)<br> |
 
 #### Responses
 
@@ -584,7 +589,6 @@ Stops a completion message generation task. Only supported in `streaming` mode.
 | 400 | `app_unavailable` : App unavailable or misconfigured. |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
-| 404 | Task not found |  |
 
 ---
 ## default
@@ -1156,6 +1160,7 @@ Returns the list of tags bound to a specific knowledge base.
 | 200 | Tags bound to the knowledge base. | **application/json**: [DatasetBoundTagListResponse](#datasetboundtaglistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
+| 404 | `not_found` : Knowledge base not found. |  |
 
 ---
 ## default
@@ -1185,7 +1190,9 @@ Create a document by uploading a file. Supports common document formats (PDF, TX
 | 400 | - `no_file_uploaded` : Please upload your file. - `too_many_files` : Only one file is allowed. - `filename_not_exists_error` : The specified filename does not exist. - `provider_not_initialize` : No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials. - `invalid_param` : Knowledge base does not exist, external datasets not supported, unsupported file type, missing required fields, or invalid doc_form (must be `text_model`, `hierarchical_model`, or `qa_model`). |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
+| 404 | `not_found` : Knowledge base not found. |  |
 | 413 | `file_too_large` : File size exceeded. |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### [POST] /datasets/{dataset_id}/document/create-by-text
 **Create Document by Text**
@@ -1212,6 +1219,8 @@ Create a document from raw text content. The document is processed asynchronousl
 | 400 | - `provider_not_initialize` : No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials. - `invalid_param` : Knowledge base does not exist. / indexing_technique is required. / Invalid doc_form (must be `text_model`, `hierarchical_model`, or `qa_model`). |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
+| 404 | `not_found` : Knowledge base not found. |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### ~~[POST] /datasets/{dataset_id}/document/create_by_file~~
 
@@ -1241,7 +1250,9 @@ Create a document by uploading a file. Supports common document formats (PDF, TX
 | 400 | - `no_file_uploaded` : Please upload your file. - `too_many_files` : Only one file is allowed. - `filename_not_exists_error` : The specified filename does not exist. - `provider_not_initialize` : No valid model provider credentials found. Please go to Settings -> Model Provider to complete your provider credentials. - `invalid_param` : Knowledge base does not exist, external datasets not supported, unsupported file type, missing required fields, or invalid doc_form (must be `text_model`, `hierarchical_model`, or `qa_model`). |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
+| 404 | `not_found` : Knowledge base not found. |  |
 | 413 | `file_too_large` : File size exceeded. |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### [GET] /datasets/{dataset_id}/documents
 **List Documents**
@@ -1416,6 +1427,7 @@ Update an existing document by uploading a new file. Re-triggers indexing — us
 | 404 | Document not found |  |
 | 413 | `file_too_large` : File size exceeded. |  |
 | 415 | Unsupported file type |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### [GET] /datasets/{dataset_id}/documents/{document_id}/download
 **Download Document**
@@ -1470,6 +1482,7 @@ Update an existing document by uploading a new file. Re-triggers indexing — us
 | 404 | Document not found |  |
 | 413 | `file_too_large` : File size exceeded. |  |
 | 415 | Unsupported file type |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### [POST] /datasets/{dataset_id}/documents/{document_id}/update-by-text
 **Update Document by Text**
@@ -1498,6 +1511,7 @@ Update an existing document's text content, name, or processing configuration. R
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Document not found |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### ~~[POST] /datasets/{dataset_id}/documents/{document_id}/update_by_file~~
 
@@ -1531,6 +1545,7 @@ Update an existing document by uploading a new file. Re-triggers indexing — us
 | 404 | Document not found |  |
 | 413 | `file_too_large` : File size exceeded. |  |
 | 415 | Unsupported file type |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ---
 ## default
@@ -1627,6 +1642,7 @@ Returns the list of built-in metadata fields provided by the system (e.g., docum
 | 200 | Built-in metadata fields. | **application/json**: [DatasetMetadataBuiltInFieldsResponse](#datasetmetadatabuiltinfieldsresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
+| 404 | `not_found` : Knowledge base not found. |  |
 
 ### [POST] /datasets/{dataset_id}/metadata/built-in/{action}
 **Update Built-in Metadata Field**
@@ -1754,6 +1770,7 @@ Create one or more chunks within a document. Each chunk can include optional key
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | `not_found` : Document is not completed or is disabled. |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### [DELETE] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}
 **Delete Chunk**
@@ -1829,6 +1846,7 @@ Update a chunk's content, keywords, or answer. Re-triggers indexing for the modi
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, or segment not found |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### [GET] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks
 **List Child Chunks**
@@ -1883,6 +1901,7 @@ Create a child chunk under the specified segment.
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, or segment not found |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ### [DELETE] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}
 **Delete Child Chunk**
@@ -1937,6 +1956,7 @@ Update the content of an existing child chunk.
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, segment, or child chunk not found |  |
+| 503 | `service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox plan only; retry the request later. |  |
 
 ---
 ## default
@@ -2232,7 +2252,7 @@ Stop a running workflow task. Only supported in `streaming` mode.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [RequiredServiceApiUserPayload](#requiredserviceapiuserpayload)<br> |
+|  Yes | **application/json**: [WorkflowTaskStopPayload](#workflowtaskstoppayload)<br> |
 
 #### Responses
 
@@ -2242,7 +2262,6 @@ Stop a running workflow task. Only supported in `streaming` mode.
 | 400 | - `not_workflow_app` : App mode does not match the API route. - `invalid_param` : Required parameter missing or invalid. |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
-| 404 | Task not found |  |
 
 ### [POST] /workflows/{workflow_id}/run
 **Run Workflow by ID**
@@ -2312,7 +2331,7 @@ Retrieve the list of available models by type. Primarily used to query `text-emb
 | thought | string |  | No |
 | tool | string |  | No |
 | tool_input | string |  | No |
-| tool_labels | [JSONValue](#jsonvalue) |  | Yes |
+| tool_labels | [JSONValue](#jsonvalue) | Labels for tools used. | Yes |
 
 #### Annotation
 
@@ -2500,7 +2519,7 @@ Blocking chat response for a completed message or paused Chatflow.
 | event | string |  | Yes |
 | id | string |  | Yes |
 | message_id | string |  | Yes |
-| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) |  | Yes |
+| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) | Metadata including usage and retriever resources. | Yes |
 | mode | string |  | Yes |
 | task_id | string |  | Yes |
 
@@ -2534,7 +2553,7 @@ Public pause reason emitted by a blocking Chatflow execution.
 | elapsed_time | float |  | Yes |
 | id | string (uuid) |  | Yes |
 | message_id | string (uuid) |  | Yes |
-| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) |  | Yes |
+| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) | Metadata including usage and retriever resources. | Yes |
 | mode | string |  | Yes |
 | paused_nodes | [ string ] |  | Yes |
 | reasons | [ [ChatPauseReasonResponse](#chatpausereasonresponse) ] |  | Yes |
@@ -2554,7 +2573,7 @@ Public pause reason emitted by a blocking Chatflow execution.
 | event | string |  | Yes |
 | id | string |  | Yes |
 | message_id | string |  | Yes |
-| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) |  | Yes |
+| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) | Metadata including usage and retriever resources. | Yes |
 | mode | string |  | Yes |
 | task_id | string |  | Yes |
 | workflow_run_id | string |  | Yes |
@@ -2642,7 +2661,7 @@ Public pause reason emitted by a blocking Chatflow execution.
 | event | string |  | Yes |
 | id | string (uuid) |  | Yes |
 | message_id | string (uuid) |  | Yes |
-| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) |  | Yes |
+| metadata | [BlockingMetadataResponse](#blockingmetadataresponse) | Metadata including usage and retriever resources. | Yes |
 | mode | string |  | Yes |
 | task_id | string (uuid) |  | Yes |
 
@@ -2782,7 +2801,7 @@ Enum class for custom configuration status.
 | name | string | Name of the knowledge base. | Yes |
 | permission | [PermissionEnum](#permissionenum) | Controls who can access this knowledge base. `only_me` restricts access to the creator, `all_team_members` grants workspace-wide access, and `partial_members` grants access to specified members. | No |
 | provider | string, <br>**Available values:** "external", "vendor", <br>**Default:** vendor | Knowledge base provider: `vendor` for internal knowledge bases, `external` for external ones.<br>*Enum:* `"external"`, `"vendor"` | No |
-| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked. | No |
+| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base. | No |
 | summary_index_setting | object | Summary index configuration. | No |
 
 #### DatasetDetailResponse
@@ -2804,9 +2823,9 @@ Enum class for custom configuration status.
 | embedding_model | string |  | Yes |
 | embedding_model_provider | string |  | Yes |
 | enable_api | boolean |  | Yes |
-| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) |  | No |
+| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) | Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise its properties are `null`. | No |
 | external_retrieval_model | [DatasetExternalRetrievalModelResponse](#datasetexternalretrievalmodelresponse) |  | Yes |
-| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) |  | No |
+| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) | Icon display configuration for the knowledge base. | No |
 | id | string |  | Yes |
 | indexing_technique | string |  | Yes |
 | is_multimodal | boolean |  | Yes |
@@ -2817,9 +2836,9 @@ Enum class for custom configuration status.
 | permission_keys | [ string ] |  | No |
 | pipeline_id | string |  | Yes |
 | provider | string |  | Yes |
-| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) |  | Yes |
+| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) | Retrieval configuration for the knowledge base. | Yes |
 | runtime_mode | string |  | Yes |
-| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) |  | No |
+| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) | Summary index configuration. | No |
 | tags | [ [DatasetTagResponse](#datasettagresponse) ] |  | Yes |
 | total_available_documents | integer |  | Yes |
 | total_documents | integer |  | Yes |
@@ -2846,9 +2865,9 @@ Enum class for custom configuration status.
 | embedding_model | string |  | Yes |
 | embedding_model_provider | string |  | Yes |
 | enable_api | boolean |  | Yes |
-| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) |  | No |
+| external_knowledge_info | [DatasetExternalKnowledgeInfoResponse](#datasetexternalknowledgeinforesponse) | Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise its properties are `null`. | No |
 | external_retrieval_model | [DatasetExternalRetrievalModelResponse](#datasetexternalretrievalmodelresponse) |  | Yes |
-| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) |  | No |
+| icon_info | [DatasetIconInfoResponse](#dataseticoninforesponse) | Icon display configuration for the knowledge base. | No |
 | id | string |  | Yes |
 | indexing_technique | string |  | Yes |
 | is_multimodal | boolean |  | Yes |
@@ -2860,9 +2879,9 @@ Enum class for custom configuration status.
 | permission_keys | [ string ] |  | No |
 | pipeline_id | string |  | Yes |
 | provider | string |  | Yes |
-| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) |  | Yes |
+| retrieval_model_dict | [DatasetRetrievalModelResponse](#datasetretrievalmodelresponse) | Retrieval configuration for the knowledge base. | Yes |
 | runtime_mode | string |  | Yes |
-| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) |  | No |
+| summary_index_setting | [DatasetSummaryIndexSettingResponse](#datasetsummaryindexsettingresponse) | Summary index configuration. | No |
 | tags | [ [DatasetTagResponse](#datasettagresponse) ] |  | Yes |
 | total_available_documents | integer |  | Yes |
 | total_documents | integer |  | Yes |
@@ -2934,7 +2953,7 @@ Enum class for custom configuration status.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| result | string |  | Yes |
+| result | string | Operation result. | Yes |
 
 #### DatasetMetadataBuiltInFieldResponse
 
@@ -2986,7 +3005,7 @@ Enum class for custom configuration status.
 | ---- | ---- | ----------- | -------- |
 | reranking_enable | boolean |  | Yes |
 | reranking_mode | string |  | No |
-| reranking_model | [DatasetRerankingModelResponse](#datasetrerankingmodelresponse) |  | No |
+| reranking_model | [DatasetRerankingModelResponse](#datasetrerankingmodelresponse) | Reranking model configuration. | No |
 | score_threshold | number |  | No |
 | score_threshold_enabled | boolean |  | Yes |
 | search_method | string |  | Yes |
@@ -3024,7 +3043,7 @@ Enum class for custom configuration status.
 | name | string | Name of the knowledge base. | No |
 | partial_member_list | [ object ] | List of team members with access when `permission` is `partial_members`. | No |
 | permission | [PermissionEnum](#permissionenum) | Controls who can access this knowledge base. `only_me` restricts access to the creator, `all_team_members` grants workspace-wide access, and `partial_members` grants access to specified members. | No |
-| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked. | No |
+| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base. | No |
 
 #### DatasetVectorSettingResponse
 
@@ -3038,8 +3057,8 @@ Enum class for custom configuration status.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) |  | No |
-| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) |  | No |
+| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) | Keyword search weight settings. | No |
+| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) | Semantic search weight settings. | No |
 | weight_type | string |  | No |
 
 #### DatasourceCredentialInfoResponse
@@ -3250,7 +3269,7 @@ Request payload for bulk downloading documents as a zip archive.
 | name | string | Document name. | Yes |
 | original_document_id | string | Original document ID for replacement. | No |
 | process_rule | [ProcessRule](#processrule) | Processing rules for chunking. | No |
-| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked. | No |
+| retrieval_model | [RetrievalModel](#retrievalmodel) | Controls how chunks are searched and ranked when querying this knowledge base. | No |
 | text | string | Document text content. | Yes |
 
 #### DocumentTextUpdate
@@ -3261,7 +3280,7 @@ Request payload for bulk downloading documents as a zip archive.
 | doc_language | string, <br>**Default:** English | Language of the document for processing optimization. | No |
 | name | string | Document name. Required when `text` is provided. | No |
 | process_rule | [ProcessRule](#processrule) | Processing rules for chunking. | No |
-| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked. | No |
+| retrieval_model | [RetrievalModel](#retrievalmodel) | Controls how chunks are searched and ranked when querying this knowledge base. | No |
 | text | string | Document text content. | No |
 
 #### EndUserDetail
@@ -3414,7 +3433,7 @@ Enum class for fetch from.
 | attachment_ids | [ string ] | List of attachment IDs to include in the retrieval context. | No |
 | external_retrieval_model | object | Retrieval settings for external knowledge bases. | No |
 | query | string | Search query text. | Yes |
-| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked. | No |
+| retrieval_model | [RetrievalModel](#retrievalmodel) | Retrieval model configuration. Controls how chunks are searched and ranked when querying this knowledge base. | No |
 
 #### HitTestingQuery
 
@@ -3429,7 +3448,7 @@ Enum class for fetch from.
 | child_chunks | [ [HitTestingChildChunk](#hittestingchildchunk) ] |  | Yes |
 | files | [ [HitTestingFile](#hittestingfile) ] |  | Yes |
 | score | number |  | Yes |
-| segment | [HitTestingSegment](#hittestingsegment) |  | Yes |
+| segment | [HitTestingSegment](#hittestingsegment) | Matched chunk from the knowledge base. | Yes |
 | summary | string |  | Yes |
 | tsne_position |  |  | Yes |
 
@@ -3437,7 +3456,7 @@ Enum class for fetch from.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| query | [HitTestingQuery](#hittestingquery) |  | Yes |
+| query | [HitTestingQuery](#hittestingquery) | The original query object. | Yes |
 | records | [ [HitTestingRecord](#hittestingrecord) ] |  | Yes |
 
 #### HitTestingSegment
@@ -3451,7 +3470,7 @@ Enum class for fetch from.
 | created_by | string |  | Yes |
 | disabled_at | integer |  | Yes |
 | disabled_by | string |  | Yes |
-| document | [HitTestingDocument](#hittestingdocument) |  | Yes |
+| document | [HitTestingDocument](#hittestingdocument) | Parent document information for the matched chunk. | Yes |
 | document_id | string |  | Yes |
 | enabled | boolean |  | Yes |
 | error | string |  | Yes |
@@ -3742,7 +3761,7 @@ Form input definition.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| default | [StringSource](#stringsource) |  | No |
+| default | [StringSource](#stringsource) | Raw default-value configuration for the paragraph input. Runtime-resolved values are exposed in the surrounding `resolved_default_values` mapping. | No |
 | output_variable_name | string |  | Yes |
 | type | string |  | No |
 
@@ -3759,7 +3778,7 @@ Form input definition.
 | speech_to_text | { **"enabled"**: boolean } |  | Yes |
 | suggested_questions | [ string ] |  | Yes |
 | suggested_questions_after_answer | { **"enabled"**: boolean } |  | Yes |
-| system_parameters | [SystemParameters](#systemparameters) |  | Yes |
+| system_parameters | [SystemParameters](#systemparameters) | System-level parameter limits. | Yes |
 | text_to_speech | { **"autoPlay"**: string, **"enabled"**: boolean, **"language"**: string, **"voice"**: string } |  | Yes |
 | user_input_form | [ object ] |  | Yes |
 
@@ -3806,11 +3825,11 @@ Shared permission levels for resources (datasets, credentials, etc.)
 
 #### PipelineRunJsonResponse
 
-JSON responses returned by published and draft knowledge pipeline runs.
+JSON result for published runs and draft runs using `response_mode: blocking`.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| PipelineRunJsonResponse | [PublishedPipelineRunResponse](#publishedpipelinerunresponse)<br>[WorkflowBlockingResponse](#workflowblockingresponse) | JSON responses returned by published and draft knowledge pipeline runs. |  |
+| PipelineRunJsonResponse | [PublishedPipelineRunResponse](#publishedpipelinerunresponse)<br>[WorkflowBlockingResponse](#workflowblockingresponse) | JSON result for published runs and draft runs using `response_mode: blocking`. |  |
 
 #### PipelineUploadFileResponse
 
@@ -3835,7 +3854,7 @@ JSON responses returned by published and draft knowledge pipeline runs.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| mode | [ProcessRuleMode](#processrulemode) | Processing mode. `automatic` uses built-in rules, `custom` allows manual configuration, and `hierarchical` enables parent-child chunk structure for `doc_form: hierarchical_model`. | Yes |
+| mode | [ProcessRuleMode](#processrulemode) | `automatic` uses built-in rules, `custom` allows manual configuration, `hierarchical` enables parent-child chunk structure (use with `doc_form: hierarchical_model`). | Yes |
 | rules | [Rule](#rule) | Custom processing rules. | No |
 
 #### ProcessRuleMode
@@ -3854,14 +3873,14 @@ Model class for model response.
 | ---- | ---- | ----------- | -------- |
 | deprecated | boolean |  | No |
 | features | [ [ModelFeature](#modelfeature) ] |  | No |
-| fetch_from | [FetchFrom](#fetchfrom) |  | Yes |
+| fetch_from | [FetchFrom](#fetchfrom) | Where the model definition comes from. `predefined-model` for built-in models, `customizable-model` for user-configured models. | Yes |
 | has_invalid_load_balancing_configs | boolean |  | No |
-| label | [I18nObject](#i18nobject) |  | Yes |
+| label | [I18nObject](#i18nobject) | Localized display name of the model. | Yes |
 | load_balancing_enabled | boolean |  | No |
 | model | string |  | Yes |
 | model_properties | object |  | Yes |
-| model_type | [ModelType](#modeltype) |  | Yes |
-| status | [ModelStatus](#modelstatus) |  | Yes |
+| model_type | [ModelType](#modeltype) | Type of the model, matching the `model_type` path parameter. | Yes |
+| status | [ModelStatus](#modelstatus) | Model availability status. `active` when ready to use. | Yes |
 
 #### ProviderWithModelsListResponse
 
@@ -3877,10 +3896,10 @@ Model class for provider with models response.
 | ---- | ---- | ----------- | -------- |
 | icon_small | [I18nObject](#i18nobject) |  | No |
 | icon_small_dark | [I18nObject](#i18nobject) |  | No |
-| label | [I18nObject](#i18nobject) |  | Yes |
+| label | [I18nObject](#i18nobject) | Localized display name of the provider. | Yes |
 | models | [ [ProviderModelWithStatusEntity](#providermodelwithstatusentity) ] |  | Yes |
 | provider | string |  | Yes |
-| status | [CustomConfigurationStatus](#customconfigurationstatus) |  | Yes |
+| status | [CustomConfigurationStatus](#customconfigurationstatus) | Provider status. `active` when credentials are configured and valid. | Yes |
 | tenant_id | string |  | Yes |
 
 #### PublishedPipelineRunResponse
@@ -3890,12 +3909,6 @@ Model class for provider with models response.
 | batch | string |  | Yes |
 | dataset | [PipelineDataset](#pipelinedataset) |  | Yes |
 | documents | [ [PipelineDocument](#pipelinedocument) ] |  | Yes |
-
-#### RequiredServiceApiUserPayload
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| user | string | User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value. | Yes |
 
 #### RerankingModel
 
@@ -3960,6 +3973,12 @@ Model class for provider with models response.
 | pre_processing_rules | [ [PreProcessingRule](#preprocessingrule) ] | Pre-processing rules to apply before segmentation. | No |
 | segmentation | [Segmentation](#segmentation) | Parent chunk segmentation settings. | No |
 | subchunk_segmentation | [Segmentation](#segmentation) | Child chunk segmentation settings. | No |
+
+#### ScopedTaskStopPayload
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| user | string | End-user identifier, defined by your app and unique within it. Send the same `user` value used for the original generation request. See [End User Identity](/api-reference/guides/end-user-identity). | Yes |
 
 #### SegmentAttachmentResponse
 
@@ -4069,7 +4088,7 @@ Model class for provider with models response.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| segment | [SegmentUpdateArgs](#segmentupdateargs) | Chunk update payload. | Yes |
+| segment | [SegmentUpdateArgs](#segmentupdateargs) | Chunk data to update. | Yes |
 
 #### Segmentation
 
@@ -4084,7 +4103,7 @@ Model class for provider with models response.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| option_source | [StringListSource](#stringlistsource) |  | Yes |
+| option_source | [StringListSource](#stringlistsource) | Source of options for `select` inputs. Present only when `type` is `select`. | Yes |
 | output_variable_name | string |  | Yes |
 | type | string |  | No |
 
@@ -4127,7 +4146,7 @@ Model class for provider with models response.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| result | string |  | Yes |
+| result | string | Operation result. | Yes |
 
 #### SimpleResultStringListResponse
 
@@ -4160,9 +4179,9 @@ Model class for provider with models response.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| selector | [ string ] |  | No |
-| type | [ValueSourceType](#valuesourcetype) |  | Yes |
-| value | [ string ] |  | No |
+| selector | [ string ] | Variable reference path when `type` is `variable`. | No |
+| type | [ValueSourceType](#valuesourcetype) | Origin of the options. `constant` means `value` lists the options literally; `variable` means `selector` points to an `array[string]` workflow variable that provides them. | Yes |
+| value | [ string ] | Literal option list when `type` is `constant`. | No |
 
 #### StringSource
 
@@ -4459,3 +4478,9 @@ Public pause reason emitted by a blocking Workflow execution.
 | total_steps | integer |  | No |
 | total_tokens | integer |  | No |
 | workflow_id | string (uuid) |  | Yes |
+
+#### WorkflowTaskStopPayload
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| user | string | End-user identifier, defined by your app and unique within it. It does not need to match the `user` that started the run; the stop applies to the task regardless of `user`. See [End User Identity](/api-reference/guides/end-user-identity). | Yes |

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -953,7 +953,7 @@ Returns Server-Sent Events stream.
 | thought | string |  | No |
 | tool | string |  | No |
 | tool_input | string |  | No |
-| tool_labels | [JSONValue](#jsonvalue) |  | Yes |
+| tool_labels | [JSONValue](#jsonvalue) | Labels for tools used. | Yes |
 
 #### AppAccessModeQuery
 
@@ -1358,7 +1358,7 @@ Form input definition.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| default | [StringSource](#stringsource) |  | No |
+| default | [StringSource](#stringsource) | Raw default-value configuration for the paragraph input. Runtime-resolved values are exposed in the surrounding `resolved_default_values` mapping. | No |
 | output_variable_name | string |  | Yes |
 | type | string |  | No |
 
@@ -1375,7 +1375,7 @@ Form input definition.
 | speech_to_text | { **"enabled"**: boolean } |  | Yes |
 | suggested_questions | [ string ] |  | Yes |
 | suggested_questions_after_answer | { **"enabled"**: boolean } |  | Yes |
-| system_parameters | [SystemParameters](#systemparameters) |  | Yes |
+| system_parameters | [SystemParameters](#systemparameters) | System-level parameter limits. | Yes |
 | text_to_speech | { **"autoPlay"**: string, **"enabled"**: boolean, **"language"**: string, **"voice"**: string } |  | Yes |
 | user_input_form | [ object ] |  | Yes |
 
@@ -1488,7 +1488,7 @@ Form input definition.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| option_source | [StringListSource](#stringlistsource) |  | Yes |
+| option_source | [StringListSource](#stringlistsource) | Source of options for `select` inputs. Present only when `type` is `select`. | Yes |
 | output_variable_name | string |  | Yes |
 | type | string |  | No |
 
@@ -1521,15 +1521,15 @@ Form input definition.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| result | string |  | Yes |
+| result | string | Operation result. | Yes |
 
 #### StringListSource
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| selector | [ string ] |  | No |
-| type | [ValueSourceType](#valuesourcetype) |  | Yes |
-| value | [ string ] |  | No |
+| selector | [ string ] | Variable reference path when `type` is `variable`. | No |
+| type | [ValueSourceType](#valuesourcetype) | Origin of the options. `constant` means `value` lists the options literally; `variable` means `selector` points to an `array[string]` workflow variable that provides them. | Yes |
+| value | [ string ] | Literal option list when `type` is `constant`. | No |
 
 #### StringSource
 

--- a/api/services/entities/knowledge_entities/knowledge_entities.py
+++ b/api/services/entities/knowledge_entities/knowledge_entities.py
@@ -128,8 +128,8 @@ class DataSource(BaseModel):
 class ProcessRule(BaseModel):
     mode: ProcessRuleMode = Field(
         description=(
-            "Processing mode. `automatic` uses built-in rules, `custom` allows manual configuration, and "
-            "`hierarchical` enables parent-child chunk structure for `doc_form: hierarchical_model`."
+            "`automatic` uses built-in rules, `custom` allows manual configuration, `hierarchical` enables "
+            "parent-child chunk structure (use with `doc_form: hierarchical_model`)."
         )
     )
     rules: Rule | None = Field(default=None, description="Custom processing rules.")

--- a/api/services/entities/model_provider_entities.py
+++ b/api/services/entities/model_provider_entities.py
@@ -179,10 +179,12 @@ class ProviderWithModelsResponse(BaseModel):
 
     tenant_id: str
     provider: str
-    label: I18nObject
+    label: I18nObject = Field(description="Localized display name of the provider.")
     icon_small: I18nObject | None = None
     icon_small_dark: I18nObject | None = None
-    status: CustomConfigurationStatus
+    status: CustomConfigurationStatus = Field(
+        description="Provider status. `active` when credentials are configured and valid."
+    )
     models: list[ProviderModelWithStatusEntity]
 
     @model_validator(mode="after")

--- a/api/tests/unit_tests/commands/test_generate_swagger_specs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_specs.py
@@ -329,6 +329,55 @@ def test_generate_specs_writes_service_api_reference_descriptions(tmp_path: Path
     assert chat_success_content["text/event-stream"]["schema"] == {"type": "string"}
 
     schemas = payload["components"]["schemas"]
+    expected_property_descriptions = {
+        ("AgentThought", "tool_labels"): "Labels for tools used.",
+        ("CompletionBlockingResponse", "metadata"): "Metadata including usage and retriever resources.",
+        ("DatasetCreatePayload", "retrieval_model"): (
+            "Retrieval model configuration. Controls how chunks are searched and ranked when querying this "
+            "knowledge base."
+        ),
+        ("DatasetDetailResponse", "external_knowledge_info"): (
+            "Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise "
+            "its properties are `null`."
+        ),
+        ("DatasetDetailResponse", "icon_info"): "Icon display configuration for the knowledge base.",
+        ("DatasetDetailResponse", "retrieval_model_dict"): "Retrieval configuration for the knowledge base.",
+        ("DatasetDetailResponse", "summary_index_setting"): "Summary index configuration.",
+        ("DatasetRetrievalModelResponse", "reranking_model"): "Reranking model configuration.",
+        ("DatasetWeightedScoreResponse", "keyword_setting"): "Keyword search weight settings.",
+        ("DatasetWeightedScoreResponse", "vector_setting"): "Semantic search weight settings.",
+        ("HitTestingRecord", "segment"): "Matched chunk from the knowledge base.",
+        ("HitTestingResponse", "query"): "The original query object.",
+        ("HitTestingSegment", "document"): "Parent document information for the matched chunk.",
+        ("Parameters", "system_parameters"): "System-level parameter limits.",
+        ("ParagraphInputConfig", "default"): (
+            "Raw default-value configuration for the paragraph input. Runtime-resolved values are exposed in the "
+            "surrounding `resolved_default_values` mapping."
+        ),
+        ("ProviderModelWithStatusEntity", "fetch_from"): (
+            "Where the model definition comes from. `predefined-model` for built-in models, "
+            "`customizable-model` for user-configured models."
+        ),
+        ("ProviderWithModelsResponse", "status"): (
+            "Provider status. `active` when credentials are configured and valid."
+        ),
+        ("SelectInputConfig", "option_source"): (
+            "Source of options for `select` inputs. Present only when `type` is `select`."
+        ),
+        ("StringListSource", "selector"): "Variable reference path when `type` is `variable`.",
+    }
+    for (schema_name, property_name), description in expected_property_descriptions.items():
+        assert schemas[schema_name]["properties"][property_name]["description"] == description
+
+    assert schemas["PipelineRunJsonResponse"]["description"] == (
+        "JSON result for published runs and draft runs using `response_mode: blocking`."
+    )
+    for schema_name in ("DatasetDetailResponse", "DatasetDetailWithPartialMembersResponse"):
+        assert schemas[schema_name]["properties"]["external_knowledge_info"]["description"] == (
+            "Connection details for external knowledge bases. Populated when `provider` is `external`; otherwise "
+            "its properties are `null`."
+        )
+
     chat_blocking_schema = schemas["ChatBlockingResponse"]
     assert chat_blocking_schema["discriminator"] == {
         "mapping": {
@@ -389,6 +438,69 @@ def test_generate_specs_writes_service_api_reference_descriptions(tmp_path: Path
 
     preview_content = payload["paths"]["/files/{file_id}/preview"]["get"]["responses"]["200"]["content"]
     assert preview_content == {"*/*": {"schema": {"format": "binary", "type": "string"}}}
+
+    scoped_stop_schema = schemas["ScopedTaskStopPayload"]
+    workflow_stop_schema = schemas["WorkflowTaskStopPayload"]
+    assert scoped_stop_schema["required"] == ["user"]
+    assert workflow_stop_schema["required"] == ["user"]
+    assert "Send the same" in scoped_stop_schema["properties"]["user"]["description"]
+    assert "does not need to match" in workflow_stop_schema["properties"]["user"]["description"]
+    for path in ("/chat-messages/{task_id}/stop", "/completion-messages/{task_id}/stop"):
+        assert _request_schema(payload["paths"][path]["post"])["$ref"] == ("#/components/schemas/ScopedTaskStopPayload")
+        assert "404" not in payload["paths"][path]["post"]["responses"]
+    assert _request_schema(payload["paths"]["/workflows/tasks/{task_id}/stop"]["post"])["$ref"] == (
+        "#/components/schemas/WorkflowTaskStopPayload"
+    )
+    assert "404" not in payload["paths"]["/workflows/tasks/{task_id}/stop"]["post"]["responses"]
+
+    vector_space_operations = {
+        (method, path)
+        for path, path_item in payload["paths"].items()
+        for method, operation in path_item.items()
+        if isinstance(operation, dict) and "503" in operation.get("responses", {})
+    }
+    assert vector_space_operations == {
+        ("post", "/datasets/{dataset_id}/document/create-by-file"),
+        ("post", "/datasets/{dataset_id}/document/create-by-text"),
+        ("post", "/datasets/{dataset_id}/document/create_by_file"),
+        ("post", "/datasets/{dataset_id}/document/create_by_text"),
+        ("patch", "/datasets/{dataset_id}/documents/{document_id}"),
+        ("post", "/datasets/{dataset_id}/documents/{document_id}/segments"),
+        ("post", "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}"),
+        ("post", "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks"),
+        (
+            "patch",
+            "/datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}",
+        ),
+        ("post", "/datasets/{dataset_id}/documents/{document_id}/update-by-file"),
+        ("post", "/datasets/{dataset_id}/documents/{document_id}/update-by-text"),
+        ("post", "/datasets/{dataset_id}/documents/{document_id}/update_by_file"),
+        ("post", "/datasets/{dataset_id}/documents/{document_id}/update_by_text"),
+    }
+    vector_space_unavailable_description = (
+        "`service_unavailable` : Vector space usage could not be verified. Returned on the Dify Cloud Sandbox "
+        "plan only; retry the request later."
+    )
+    for method, path in vector_space_operations:
+        assert payload["paths"][path][method]["responses"]["503"]["description"] == (
+            vector_space_unavailable_description
+        )
+
+    for path in (
+        "/datasets/{dataset_id}/document/create-by-file",
+        "/datasets/{dataset_id}/document/create-by-text",
+        "/datasets/{dataset_id}/document/create_by_text",
+        "/datasets/{dataset_id}/metadata/built-in",
+        "/datasets/{dataset_id}/tags",
+    ):
+        operation = next(
+            operation
+            for operation in payload["paths"][path].values()
+            if isinstance(operation, dict) and "responses" in operation
+        )
+        assert operation["responses"]["404"]["description"] == "`not_found` : Knowledge base not found."
+
+    assert "503" not in payload["paths"]["/datasets/{dataset_id}"]["patch"]["responses"]
 
     text_to_audio_content = payload["paths"]["/text-to-audio"]["post"]["responses"]["200"]["content"]
     assert text_to_audio_content == {

--- a/api/tests/unit_tests/controllers/test_swagger.py
+++ b/api/tests/unit_tests/controllers/test_swagger.py
@@ -287,19 +287,27 @@ def test_service_openapi_documents_decorator_user_contracts():
 
     required_json_user_operations = (
         ("/completion-messages", "post"),
-        ("/completion-messages/{task_id}/stop", "post"),
         ("/chat-messages", "post"),
-        ("/chat-messages/{task_id}/stop", "post"),
         ("/messages/{message_id}/feedbacks", "post"),
         ("/form/human_input/{form_token}", "post"),
         ("/workflows/run", "post"),
         ("/workflows/{workflow_id}/run", "post"),
-        ("/workflows/tasks/{task_id}/stop", "post"),
     )
     for path, method in required_json_user_operations:
         schema = _json_body_schema(payload, paths[path][method])
         assert schema["properties"]["user"] == USER_PROPERTY_SCHEMA
         assert "user" in schema["required"]
+
+    task_stop_user_descriptions = {
+        "/completion-messages/{task_id}/stop": "Send the same",
+        "/chat-messages/{task_id}/stop": "Send the same",
+        "/workflows/tasks/{task_id}/stop": "does not need to match",
+    }
+    for path, expected_behavior in task_stop_user_descriptions.items():
+        schema = _json_body_schema(payload, paths[path]["post"])
+        assert expected_behavior in schema["properties"]["user"]["description"]
+        assert "user" in schema["required"]
+        assert "404" not in paths[path]["post"]["responses"]
 
     optional_json_user_operations = (
         ("/text-to-audio", "post"),

--- a/packages/contracts/generated/api/service/orpc.gen.ts
+++ b/packages/contracts/generated/api/service/orpc.gen.ts
@@ -926,6 +926,8 @@ export const post15 = oc
   .output(zPostDatasetsByDatasetIdDocumentCreateByTextResponse)
 
 /**
+ * Create document by text through the deprecated underscore alias
+ *
  * Deprecated legacy alias for creating a new document by providing text content. Use /datasets/{dataset_id}/document/create-by-text instead.
  *
  * @deprecated
@@ -939,6 +941,7 @@ export const post16 = oc
     method: 'POST',
     operationId: 'postDatasetsByDatasetIdDocumentCreateByText',
     path: '/datasets/{dataset_id}/document/create_by_text',
+    summary: 'Create document by text through the deprecated underscore alias',
     tags: ['service_api'],
   })
   .input(
@@ -1414,6 +1417,8 @@ export const post24 = oc
   .output(zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByTextResponse)
 
 /**
+ * Update document by text through the deprecated underscore alias
+ *
  * Deprecated legacy alias for updating an existing document by providing text content. Use /datasets/{dataset_id}/documents/{document_id}/update-by-text instead.
  *
  * @deprecated
@@ -1427,6 +1432,7 @@ export const post25 = oc
     method: 'POST',
     operationId: 'postDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText',
     path: '/datasets/{dataset_id}/documents/{document_id}/update_by_text',
+    summary: 'Update document by text through the deprecated underscore alias',
     tags: ['service_api'],
   })
   .input(

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -1824,10 +1824,6 @@ export type PublishedPipelineRunResponse = {
   documents: Array<PipelineDocument>
 }
 
-export type RequiredServiceApiUserPayload = {
-  user: string
-}
-
 export type RerankingModel = {
   reranking_model_name?: string | null
   reranking_provider_name?: string | null
@@ -1880,6 +1876,10 @@ export type Rule = {
   pre_processing_rules?: Array<PreProcessingRule> | null
   segmentation?: Segmentation | null
   subchunk_segmentation?: Segmentation | null
+}
+
+export type ScopedTaskStopPayload = {
+  user: string
 }
 
 export type SegmentAttachmentResponse = {
@@ -2368,6 +2368,10 @@ export type WorkflowRunResponse = {
   workflow_id: string
 }
 
+export type WorkflowTaskStopPayload = {
+  user: string
+}
+
 export type HumanInputFormSubmitResponseWritable = {
   [key: string]: never
 }
@@ -2632,7 +2636,7 @@ export type PostChatMessagesResponses = {
 export type PostChatMessagesResponse = PostChatMessagesResponses[keyof PostChatMessagesResponses]
 
 export type PostChatMessagesByTaskIdStopData = {
-  body: RequiredServiceApiUserPayload
+  body: ScopedTaskStopPayload
   path: {
     task_id: string
   }
@@ -2644,7 +2648,6 @@ export type PostChatMessagesByTaskIdStopErrors = {
   400: unknown
   401: unknown
   403: unknown
-  404: unknown
 }
 
 export type PostChatMessagesByTaskIdStopResponses = {
@@ -2678,7 +2681,7 @@ export type PostCompletionMessagesResponse =
   PostCompletionMessagesResponses[keyof PostCompletionMessagesResponses]
 
 export type PostCompletionMessagesByTaskIdStopData = {
-  body: RequiredServiceApiUserPayload
+  body: ScopedTaskStopPayload
   path: {
     task_id: string
   }
@@ -2690,7 +2693,6 @@ export type PostCompletionMessagesByTaskIdStopErrors = {
   400: unknown
   401: unknown
   403: unknown
-  404: unknown
 }
 
 export type PostCompletionMessagesByTaskIdStopResponses = {
@@ -3092,7 +3094,9 @@ export type PostDatasetsByDatasetIdDocumentCreateByFileErrors = {
   400: unknown
   401: unknown
   403: unknown
+  404: unknown
   413: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByFileResponses = {
@@ -3115,6 +3119,8 @@ export type PostDatasetsByDatasetIdDocumentCreateByTextErrors = {
   400: unknown
   401: unknown
   403: unknown
+  404: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByTextResponses = {
@@ -3140,7 +3146,9 @@ export type PostDatasetsByDatasetIdDocumentCreateByFile2Errors = {
   400: unknown
   401: unknown
   403: unknown
+  404: unknown
   413: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByFile2Responses = {
@@ -3163,6 +3171,8 @@ export type PostDatasetsByDatasetIdDocumentCreateByText2Errors = {
   400: unknown
   401: unknown
   403: unknown
+  404: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByText2Responses = {
@@ -3361,6 +3371,7 @@ export type PatchDatasetsByDatasetIdDocumentsByDocumentIdErrors = {
   404: unknown
   413: unknown
   415: unknown
+  503: unknown
 }
 
 export type PatchDatasetsByDatasetIdDocumentsByDocumentIdResponses = {
@@ -3437,6 +3448,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsErrors = {
   401: unknown
   403: unknown
   404: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsResponses = {
@@ -3512,6 +3524,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdError
   401: unknown
   403: unknown
   404: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdResponses = {
@@ -3565,6 +3578,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChild
   401: unknown
   403: unknown
   404: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksResponses = {
@@ -3622,6 +3636,7 @@ export type PatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChil
     401: unknown
     403: unknown
     404: unknown
+    503: unknown
   }
 
 export type PatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksByChildChunkIdResponses =
@@ -3652,6 +3667,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFileErrors = {
   404: unknown
   413: unknown
   415: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFileResponses = {
@@ -3676,6 +3692,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByTextErrors = {
   401: unknown
   403: unknown
   404: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByTextResponses = {
@@ -3705,6 +3722,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFile2Errors = {
   404: unknown
   413: unknown
   415: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFile2Responses = {
@@ -3728,6 +3746,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText2Errors = {
   401: unknown
   403: unknown
   404: unknown
+  503: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText2Responses = {
@@ -3818,6 +3837,7 @@ export type GetDatasetsByDatasetIdMetadataBuiltInData = {
 export type GetDatasetsByDatasetIdMetadataBuiltInErrors = {
   401: unknown
   403: unknown
+  404: unknown
 }
 
 export type GetDatasetsByDatasetIdMetadataBuiltInResponses = {
@@ -4006,6 +4026,7 @@ export type GetDatasetsByDatasetIdTagsData = {
 export type GetDatasetsByDatasetIdTagsErrors = {
   401: unknown
   403: unknown
+  404: unknown
 }
 
 export type GetDatasetsByDatasetIdTagsResponses = {
@@ -4404,7 +4425,7 @@ export type GetWorkflowsRunByWorkflowRunIdResponse =
   GetWorkflowsRunByWorkflowRunIdResponses[keyof GetWorkflowsRunByWorkflowRunIdResponses]
 
 export type PostWorkflowsTasksByTaskIdStopData = {
-  body: RequiredServiceApiUserPayload
+  body: WorkflowTaskStopPayload
   path: {
     task_id: string
   }
@@ -4416,7 +4437,6 @@ export type PostWorkflowsTasksByTaskIdStopErrors = {
   400: unknown
   401: unknown
   403: unknown
-  404: unknown
 }
 
 export type PostWorkflowsTasksByTaskIdStopResponses = {

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -1735,13 +1735,6 @@ export const zPublishedPipelineRunResponse = z.object({
 })
 
 /**
- * ServiceApiUserPayload
- */
-export const zRequiredServiceApiUserPayload = z.object({
-  user: z.string(),
-})
-
-/**
  * RerankingModel
  */
 export const zRerankingModel = z.object({
@@ -1787,6 +1780,13 @@ export const zRetrieverResource = z.object({
   segment_position: z.int().nullish(),
   summary: z.string().nullish(),
   word_count: z.int().nullish(),
+})
+
+/**
+ * ServiceApiUserPayload
+ */
+export const zScopedTaskStopPayload = z.object({
+  user: z.string(),
 })
 
 /**
@@ -2884,7 +2884,7 @@ export const zWorkflowBlockingResponse = z.union([
 /**
  * PipelineRunJsonResponse
  *
- * JSON responses returned by published and draft knowledge pipeline runs.
+ * JSON result for published runs and draft runs using `response_mode: blocking`.
  */
 export const zPipelineRunJsonResponse = z.union([
   zPublishedPipelineRunResponse,
@@ -3054,6 +3054,13 @@ export const zWorkflowRunResponse = z.object({
 })
 
 /**
+ * ServiceApiUserPayload
+ */
+export const zWorkflowTaskStopPayload = z.object({
+  user: z.string(),
+})
+
+/**
  * HumanInputFormSubmitResponse
  */
 export const zHumanInputFormSubmitResponseWritable = z.record(z.string(), z.never())
@@ -3210,7 +3217,7 @@ export const zPostChatMessagesBody = zChatRequestPayloadWithUser
  */
 export const zPostChatMessagesResponse = z.union([zChatBlockingResponse, z.string()])
 
-export const zPostChatMessagesByTaskIdStopBody = zRequiredServiceApiUserPayload
+export const zPostChatMessagesByTaskIdStopBody = zScopedTaskStopPayload
 
 export const zPostChatMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -3231,7 +3238,7 @@ export const zPostCompletionMessagesBody = zCompletionRequestPayloadWithUser
  */
 export const zPostCompletionMessagesResponse = z.union([zCompletionBlockingResponse, z.string()])
 
-export const zPostCompletionMessagesByTaskIdStopBody = zRequiredServiceApiUserPayload
+export const zPostCompletionMessagesByTaskIdStopBody = zScopedTaskStopPayload
 
 export const zPostCompletionMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -4069,7 +4076,7 @@ export const zGetWorkflowsRunByWorkflowRunIdPath = z.object({
  */
 export const zGetWorkflowsRunByWorkflowRunIdResponse = zWorkflowRunResponse
 
-export const zPostWorkflowsTasksByTaskIdStopBody = zRequiredServiceApiUserPayload
+export const zPostWorkflowsTasksByTaskIdStopBody = zWorkflowTaskStopPayload
 
 export const zPostWorkflowsTasksByTaskIdStopPath = z.object({
   task_id: z.string(),


### PR DESCRIPTION
### Description
This PR resolves #41273.

It restores the missing semantics (field, request, response, streaming, and errors) back into the Service API OpenAPI contract to ensure it can act as a standalone, fully-descriptive source of truth for runtime API semantics. 
