### PR TITLE
  refactor(api): pass session explicitly in Agent V2 tools builder

### DIFF
--- a/api/core/app/apps/agent_app/runtime_request_builder.py
+++ b/api/core/app/apps/agent_app/runtime_request_builder.py
@@ -20,6 +20,7 @@ from dify_agent.layers.execution_context import (
     DifyExecutionContextUserFrom,
 )
 from dify_agent.protocol import CreateRunRequest, DeferredToolResultsPayload
+from sqlalchemy.orm import Session
 
 from clients.agent_backend import (
     AgentBackendAgentAppRunInput,
@@ -30,6 +31,7 @@ from clients.agent_backend import (
 from configs import dify_config
 from core.app.entities.app_invoke_entities import DifyRunContext, InvokeFrom
 from core.app.llm.model_access import resolve_model_context_window
+from core.db.session_factory import session_factory
 from core.plugin.provider_identity import normalize_plugin_daemon_provider_identity
 from core.workflow.nodes.agent_v2.dify_tools_builder import (
     WorkflowAgentDifyToolLayersBuilder,
@@ -106,13 +108,15 @@ class AgentAppRuntimeRequestBuilder:
 
         metadata = self._build_metadata(context)
         try:
-            tool_layers = self._build_tool_layers(
-                tenant_id=context.dify_context.tenant_id,
-                app_id=context.dify_context.app_id,
-                user_id=context.dify_context.user_id,
-                tools=agent_soul.tools,
-                invoke_from=context.dify_context.invoke_from,
-            )
+            with session_factory.create_session() as session:
+                tool_layers = self._build_tool_layers(
+                    session=session,
+                    tenant_id=context.dify_context.tenant_id,
+                    app_id=context.dify_context.app_id,
+                    user_id=context.dify_context.user_id,
+                    tools=agent_soul.tools,
+                    invoke_from=context.dify_context.invoke_from,
+                )
         except WorkflowAgentDifyToolsBuildError as error:
             raise AgentAppRuntimeRequestBuildError(error.error_code, str(error)) from error
         if tool_layers.plugin_tools is not None or tool_layers.core_tools is not None or agent_soul.tools.cli_tools:
@@ -202,6 +206,7 @@ class AgentAppRuntimeRequestBuilder:
     def _build_tool_layers(
         self,
         *,
+        session: Session,
         tenant_id: str,
         app_id: str,
         user_id: str | None,
@@ -212,6 +217,7 @@ class AgentAppRuntimeRequestBuilder:
         # on the direct `dify.plugin.tools` route. This builder emits plugin
         # tools directly and non-plugin Dify tools through `dify.core.tools`.
         return self._dify_tools_builder.build_layers(
+            session=session,
             tenant_id=tenant_id,
             app_id=app_id,
             user_id=user_id,

--- a/api/core/workflow/nodes/agent_v2/dify_tools_builder.py
+++ b/api/core/workflow/nodes/agent_v2/dify_tools_builder.py
@@ -15,6 +15,7 @@ from dify_agent.layers.dify_plugin import (
     DifyPluginToolsLayerConfig,
 )
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from core.agent.entities import AgentToolEntity
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -24,7 +25,6 @@ from core.tools.entities.tool_entities import ToolProviderType
 from core.tools.errors import ToolProviderCredentialValidationError, ToolProviderNotFoundError
 from core.tools.tool_manager import ToolManager
 from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
-from extensions.ext_database import db
 from models.agent_config_entities import AgentSoulDifyToolConfig, AgentSoulToolsConfig
 from models.provider_ids import ToolProviderID
 from models.tools import WorkflowToolProvider
@@ -64,6 +64,7 @@ class ProviderToolsLister(Protocol):
     def __call__(
         self,
         *,
+        session: Session,
         tenant_id: str,
         provider_type: ToolProviderType,
         provider_id: str,
@@ -71,7 +72,7 @@ class ProviderToolsLister(Protocol):
 
 
 class MCPProviderIDResolver(Protocol):
-    def __call__(self, *, tenant_id: str, provider_id: str) -> str: ...
+    def __call__(self, *, session: Session, tenant_id: str, provider_id: str) -> str: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,6 +93,7 @@ class WorkflowAgentDifyToolLayersBuilder(Protocol):
     def build_layers(
         self,
         *,
+        session: Session,
         tenant_id: str,
         app_id: str,
         user_id: str | None,
@@ -102,6 +104,7 @@ class WorkflowAgentDifyToolLayersBuilder(Protocol):
 
 def _list_provider_tool_names(
     *,
+    session: Session,
     tenant_id: str,
     provider_type: ToolProviderType,
     provider_id: str,
@@ -118,7 +121,7 @@ def _list_provider_tool_names(
             api_provider, _ = ToolManager.get_api_provider_controller(tenant_id, provider_id)
             return [tool.entity.identity.name for tool in api_provider.get_tools(tenant_id) or []]
         case ToolProviderType.WORKFLOW:
-            db_provider = db.session.scalar(
+            db_provider = session.scalar(
                 select(WorkflowToolProvider)
                 .where(
                     WorkflowToolProvider.id == provider_id,
@@ -137,9 +140,9 @@ def _list_provider_tool_names(
             raise ToolProviderNotFoundError(f"provider type {provider_type.value} not found")
 
 
-def _resolve_mcp_provider_id(*, tenant_id: str, provider_id: str) -> str:
+def _resolve_mcp_provider_id(*, session: Session, tenant_id: str, provider_id: str) -> str:
     """Normalize MCP provider ids to the runtime-facing server identifier."""
-    service = MCPToolManageService(session=db.session())
+    service = MCPToolManageService(session=session)
     try:
         return service.get_provider_entity(provider_id, tenant_id, by_server_id=True).provider_id
     except ValueError:
@@ -170,6 +173,7 @@ class WorkflowAgentDifyToolsBuilder:
     def build_layers(
         self,
         *,
+        session: Session,
         tenant_id: str,
         app_id: str,
         user_id: str | None,
@@ -191,8 +195,12 @@ class WorkflowAgentDifyToolsBuilder:
         prepared_core: list[DifyCoreToolConfig] = []
         seen_names: set[str] = set()
 
-        for tool_config in self._expand_provider_entries(tenant_id=tenant_id, enabled_tools=enabled_tools):
-            normalized_tool_config = self._normalized_tool_config(tenant_id=tenant_id, tool_config=tool_config)
+        for tool_config in self._expand_provider_entries(
+            session=session, tenant_id=tenant_id, enabled_tools=enabled_tools
+        ):
+            normalized_tool_config = self._normalized_tool_config(
+                session=session, tenant_id=tenant_id, tool_config=tool_config
+            )
             destination = self._tool_layer_destination(normalized_tool_config)
             exposed_name = self._exposed_tool_name(normalized_tool_config)
             if exposed_name in seen_names:
@@ -229,6 +237,7 @@ class WorkflowAgentDifyToolsBuilder:
     def _expand_provider_entries(
         self,
         *,
+        session: Session,
         tenant_id: str,
         enabled_tools: list[AgentSoulDifyToolConfig],
     ) -> list[AgentSoulDifyToolConfig]:
@@ -247,6 +256,7 @@ class WorkflowAgentDifyToolsBuilder:
             provider_id = self._provider_id(tool_config)
             try:
                 tool_names = self._provider_declared_tool_names(
+                    session=session,
                     tenant_id=tenant_id,
                     provider_type=provider_type,
                     provider_id=provider_id,
@@ -271,11 +281,13 @@ class WorkflowAgentDifyToolsBuilder:
     def _provider_declared_tool_names(
         self,
         *,
+        session: Session,
         tenant_id: str,
         provider_type: ToolProviderType,
         provider_id: str,
     ) -> list[str]:
         return self._provider_tools_lister(
+            session=session,
             tenant_id=tenant_id,
             provider_type=provider_type,
             provider_id=provider_id,
@@ -284,12 +296,15 @@ class WorkflowAgentDifyToolsBuilder:
     def _normalized_tool_config(
         self,
         *,
+        session: Session,
         tenant_id: str,
         tool_config: AgentSoulDifyToolConfig,
     ) -> AgentSoulDifyToolConfig:
         if tool_config.provider_type is not ToolProviderType.MCP:
             return tool_config
-        provider_id = self._mcp_provider_id_resolver(tenant_id=tenant_id, provider_id=self._provider_id(tool_config))
+        provider_id = self._mcp_provider_id_resolver(
+            session=session, tenant_id=tenant_id, provider_id=self._provider_id(tool_config)
+        )
         return tool_config.model_copy(update={"provider_id": provider_id, "plugin_id": None, "provider": None})
 
     def _fetch_tool_runtime(

--- a/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
+++ b/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
@@ -38,6 +38,7 @@ from dify_agent.layers.shell import (
 from dify_agent.protocol import CreateRunRequest, DeferredToolResultsPayload
 from pydantic import BaseModel, ValidationError
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
 
 from clients.agent_backend import (
     AgentBackendModelConfig,
@@ -49,6 +50,7 @@ from clients.agent_backend import (
 from configs import dify_config
 from core.app.entities.app_invoke_entities import DifyRunContext, InvokeFrom
 from core.app.llm.model_access import resolve_model_context_window
+from core.db.session_factory import session_factory
 from core.plugin.provider_identity import normalize_plugin_daemon_provider_identity
 from core.workflow.system_variables import SystemVariableKey, get_system_text, get_system_value
 from graphon.file import File, FileTransferMethod
@@ -184,13 +186,15 @@ class WorkflowAgentRuntimeRequestBuilder:
         workflow_job_prompt = workflow_task_prompt or self._WORKFLOW_JOB_PROMPT_FALLBACK
         user_prompt = workflow_context_prompt or self._WORKFLOW_USER_PROMPT_FALLBACK
         try:
-            tool_layers = self._build_tool_layers(
-                tenant_id=context.dify_context.tenant_id,
-                app_id=context.dify_context.app_id,
-                user_id=context.dify_context.user_id,
-                tools=agent_soul.tools,
-                invoke_from=context.dify_context.invoke_from,
-            )
+            with session_factory.create_session() as session:
+                tool_layers = self._build_tool_layers(
+                    session=session,
+                    tenant_id=context.dify_context.tenant_id,
+                    app_id=context.dify_context.app_id,
+                    user_id=context.dify_context.user_id,
+                    tools=agent_soul.tools,
+                    invoke_from=context.dify_context.invoke_from,
+                )
         except WorkflowAgentDifyToolsBuildError as error:
             raise WorkflowAgentRuntimeRequestBuildError(error.error_code, str(error)) from error
         if tool_layers.plugin_tools is not None or tool_layers.core_tools is not None or agent_soul.tools.cli_tools:
@@ -289,6 +293,7 @@ class WorkflowAgentRuntimeRequestBuilder:
     def _build_tool_layers(
         self,
         *,
+        session: Session,
         tenant_id: str,
         app_id: str,
         user_id: str | None,
@@ -299,6 +304,7 @@ class WorkflowAgentRuntimeRequestBuilder:
         # the direct `dify.plugin.tools` route. This builder emits plugin tools
         # directly and non-plugin Dify tools through `dify.core.tools`.
         return self._dify_tools_builder.build_layers(
+            session=session,
             tenant_id=tenant_id,
             app_id=app_id,
             user_id=user_id,

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_dify_tools_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_dify_tools_builder.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
+from sqlalchemy.orm import Session
 
 from core.agent.entities import AgentToolEntity
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -24,6 +26,8 @@ from core.workflow.nodes.agent_v2.dify_tools_builder import (
     WorkflowAgentDifyToolsBuildError,
 )
 from models.agent_config_entities import AgentSoulToolsConfig
+
+TEST_SESSION = Mock(spec=Session)
 
 
 class FakeRuntimeProvider:
@@ -217,6 +221,7 @@ def _build(
 ):
     """Shorthand for tests that expect ``build_layers(...)`` to return only plugin tools."""
     layers = builder.build_layers(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         app_id="app-1",
         user_id="user-1",
@@ -305,6 +310,7 @@ def test_builds_core_tool_with_file_llm_parameter():
     )
 
     result = builder.build_layers(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         app_id="app-1",
         user_id="user-1",
@@ -399,6 +405,7 @@ def test_builds_builtin_compat_plugin_tool_with_files_llm_parameter_schema():
     )
 
     result = builder.build_layers(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         app_id="app-1",
         user_id="user-1",
@@ -445,6 +452,7 @@ def test_build_layers_routes_plugin_direct_and_builtin_via_core() -> None:
     )
 
     result = builder.build_layers(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         app_id="app-1",
         user_id="user-1",
@@ -483,6 +491,7 @@ def test_build_layers_routes_api_and_workflow_via_core(provider_type: str, provi
     )
 
     result = builder.build_layers(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         app_id="app-1",
         user_id="user-1",
@@ -501,7 +510,7 @@ def test_build_layers_normalizes_mcp_provider_ids_to_server_identifier() -> None
     runtime_provider = FakeRuntimeProvider(_tool())
     builder = WorkflowAgentDifyToolsBuilder(
         tool_runtime_provider=runtime_provider,
-        mcp_provider_id_resolver=lambda *, tenant_id, provider_id: "mcp-server-1",
+        mcp_provider_id_resolver=lambda *, session, tenant_id, provider_id: "mcp-server-1",
     )
     tools = AgentSoulToolsConfig.model_validate(
         {
@@ -517,6 +526,7 @@ def test_build_layers_normalizes_mcp_provider_ids_to_server_identifier() -> None
     )
 
     result = builder.build_layers(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         app_id="app-1",
         user_id="user-1",
@@ -546,6 +556,7 @@ def test_build_layers_rejects_app_provider_type() -> None:
 
     with pytest.raises(WorkflowAgentDifyToolsBuildError, match="not supported"):
         builder.build_layers(
+            session=TEST_SESSION,
             tenant_id="tenant-1",
             app_id="app-1",
             user_id="user-1",
@@ -573,6 +584,7 @@ def test_build_layers_rejects_dataset_retrieval_provider_type() -> None:
 
     with pytest.raises(WorkflowAgentDifyToolsBuildError) as exc_info:
         builder.build_layers(
+            session=TEST_SESSION,
             tenant_id="tenant-1",
             app_id="app-1",
             user_id="user-1",
@@ -601,6 +613,7 @@ def test_builds_core_tool_with_missing_required_select_default():
     )
 
     result = builder.build_layers(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         app_id="app-1",
         user_id="user-1",
@@ -930,7 +943,8 @@ def test_provider_level_entry_expands_to_all_tools():
     runtime_provider = FakeRuntimeProvider(_tool())
     listed: list[tuple[str, str, ToolProviderType]] = []
 
-    def lister(*, tenant_id: str, provider_type: ToolProviderType, provider_id: str) -> list[str]:
+    def lister(*, session: Session, tenant_id: str, provider_type: ToolProviderType, provider_id: str) -> list[str]:
+        del session
         listed.append((tenant_id, provider_id, provider_type))
         return ["search", "image_search"]
 
@@ -957,7 +971,7 @@ def test_provider_level_entry_expands_to_all_tools():
 def test_explicit_tool_entry_wins_over_provider_expansion():
     builder = WorkflowAgentDifyToolsBuilder(
         tool_runtime_provider=FakeRuntimeProvider(_tool()),
-        provider_tools_lister=lambda *, tenant_id, provider_type, provider_id: ["search", "image_search"],
+        provider_tools_lister=lambda *, session, tenant_id, provider_type, provider_id: ["search", "image_search"],
     )
     tools = AgentSoulToolsConfig.model_validate(
         {
@@ -988,7 +1002,7 @@ def test_explicit_tool_entry_wins_over_provider_expansion():
 def test_provider_level_entry_with_no_tools_maps_to_declaration_not_found():
     builder = WorkflowAgentDifyToolsBuilder(
         tool_runtime_provider=FakeRuntimeProvider(_tool()),
-        provider_tools_lister=lambda *, tenant_id, provider_type, provider_id: [],
+        provider_tools_lister=lambda *, session, tenant_id, provider_type, provider_id: [],
     )
     tools = AgentSoulToolsConfig.model_validate(
         {
@@ -1010,7 +1024,8 @@ def test_provider_level_entry_with_no_tools_maps_to_declaration_not_found():
 def test_provider_level_entry_unknown_provider_maps_to_declaration_not_found():
     from core.tools.errors import ToolProviderNotFoundError
 
-    def lister(*, tenant_id: str, provider_type: ToolProviderType, provider_id: str) -> list[str]:
+    def lister(*, session: Session, tenant_id: str, provider_type: ToolProviderType, provider_id: str) -> list[str]:
+        del session
         raise ToolProviderNotFoundError("provider gone")
 
     builder = WorkflowAgentDifyToolsBuilder(
@@ -1056,6 +1071,7 @@ def test_list_provider_tool_names_reads_builtin_provider(monkeypatch: pytest.Mon
     monkeypatch.setattr(module.ToolManager, "get_builtin_provider", staticmethod(fake_get_builtin_provider))
 
     names = module._list_provider_tool_names(
+        session=TEST_SESSION,
         tenant_id="tenant-1",
         provider_type=module.ToolProviderType.BUILT_IN,
         provider_id="langgenius/duckduckgo/duckduckgo",

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
@@ -100,7 +100,8 @@ class CapturingPluginLayerBuilder:
         # hard-coded to a placeholder like ``VALIDATION``.
         self.last_invoke_from: InvokeFrom | None = None
 
-    def build_layers(self, *, tenant_id, app_id, user_id, tools, invoke_from):
+    def build_layers(self, *, session, tenant_id, app_id, user_id, tools, invoke_from):
+        del session
         assert tenant_id == "tenant-1"
         assert app_id == "app-1"
         assert user_id == "user-1"
@@ -130,7 +131,8 @@ class CapturingPluginLayerBuilder:
 
 
 class FakeCoreLayerBuilder:
-    def build_layers(self, *, tenant_id, app_id, user_id, tools, invoke_from):
+    def build_layers(self, *, session, tenant_id, app_id, user_id, tools, invoke_from):
+        del session
         assert tenant_id == "tenant-1"
         assert app_id == "app-1"
         assert user_id == "user-1"


### PR DESCRIPTION
## Summary

This PR refactors the Agent V2 tools builder to receive the SQLAlchemy `Session` explicitly instead of accessing the global `db.session`.

This makes the database dependency visible and improves testability without changing tool behavior.

Fixes #37403

## Screenshots

Not applicable. This is a backend-only refactor with no UI changes.

## Testing

- 94 focused tests passed
- `make lint`
- `make type-check`
- `git diff --check`

From Codex

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

=
