### PR TITLE
fix(api): attribute Skill Builder credit usage

### DIFF
--- a/api/core/credit_usage.py
+++ b/api/core/credit_usage.py
@@ -7,6 +7,7 @@ class CreditUsageCreatedBy(StrEnum):
     APP = "app"
     AGENT_NODE = "agent_node"
     BUILD_DRAFT = "build_draft"
+    SKILL_BUILDER = "skill_builder"
     CONVERSATION_NAME = "conversation_name"
     SUGGESTED_QUESTIONS = "suggested_questions"
     WORKFLOW_GENERATION = "workflow_generation"

--- a/api/services/skill_management_service.py
+++ b/api/services/skill_management_service.py
@@ -39,6 +39,7 @@ from sqlalchemy.orm import Session, object_session
 from yaml.error import MarkedYAMLError
 
 from configs import dify_config
+from core.credit_usage import CreditUsageCreatedBy
 from core.db.session_factory import session_factory
 from core.errors.error import ProviderTokenNotInitError
 from core.model_manager import ModelManager
@@ -849,7 +850,10 @@ class SkillManagementService:
             context = self._build_assistant_context(skill=skill, files=files)
 
         try:
-            model_instance = ModelManager.for_tenant(tenant_id=tenant_id).get_default_model_instance(
+            model_instance = ModelManager.for_tenant(
+                tenant_id=tenant_id,
+                request_metadata={"created_by": CreditUsageCreatedBy.SKILL_BUILDER},
+            ).get_default_model_instance(
                 tenant_id=tenant_id,
                 model_type=ModelType.LLM,
             )
@@ -1398,7 +1402,10 @@ class SkillManagementService:
         tenant_id: str,
         model_payload: SkillAssistModelPayload | None,
     ) -> tuple[Any, dict[str, Any]]:
-        model_manager = ModelManager.for_tenant(tenant_id=tenant_id)
+        model_manager = ModelManager.for_tenant(
+            tenant_id=tenant_id,
+            request_metadata={"created_by": CreditUsageCreatedBy.SKILL_BUILDER},
+        )
         if model_payload is None:
             try:
                 model_instance = model_manager.get_default_model_instance(

--- a/api/tests/unit_tests/services/test_skill_management_service.py
+++ b/api/tests/unit_tests/services/test_skill_management_service.py
@@ -15,6 +15,7 @@ import pytest
 from sqlalchemy import Table, delete, func, select
 from sqlalchemy.exc import IntegrityError
 
+from core.credit_usage import CreditUsageCreatedBy
 from core.db.session_factory import session_factory
 from core.tools.tool_file_manager import ToolFileManager
 from models.account import Account
@@ -387,7 +388,7 @@ def test_create_assistant_stream_uses_default_model_and_keeps_draft_read_only() 
     )
     manager = SimpleNamespace(get_default_model_instance=lambda **_kwargs: model)
 
-    with patch("services.skill_management_service.ModelManager.for_tenant", return_value=manager):
+    with patch("services.skill_management_service.ModelManager.for_tenant", return_value=manager) as for_tenant:
         response = list(
             service.create_assistant_stream(
                 tenant_id=TENANT,
@@ -396,6 +397,10 @@ def test_create_assistant_stream_uses_default_model_and_keeps_draft_read_only() 
             )
         )
 
+    for_tenant.assert_called_once_with(
+        tenant_id=TENANT,
+        request_metadata={"created_by": CreditUsageCreatedBy.SKILL_BUILDER},
+    )
     assert response == ["# Draft"]
     draft = service.get_skill(tenant_id=TENANT, skill_id=created["id"])
     assert draft["files"][0]["content"] == created["files"][0]["content"]
@@ -429,7 +434,7 @@ def test_create_assistant_action_stream_applies_file_operations_and_returns_deta
     )
     manager = SimpleNamespace(get_default_model_instance=lambda **_kwargs: model)
 
-    with patch("services.skill_management_service.ModelManager.for_tenant", return_value=manager):
+    with patch("services.skill_management_service.ModelManager.for_tenant", return_value=manager) as for_tenant:
         response = list(
             service.create_assistant_action_stream(
                 tenant_id=TENANT,
@@ -440,6 +445,10 @@ def test_create_assistant_action_stream_applies_file_operations_and_returns_deta
             )
         )
 
+    for_tenant.assert_called_once_with(
+        tenant_id=TENANT,
+        request_metadata={"created_by": CreditUsageCreatedBy.SKILL_BUILDER},
+    )
     events = [json.loads(chunk.removeprefix("data: ").strip()) for chunk in response]
     assert [event["event"] for event in events] == [
         "skill_assistant_progress",


### PR DESCRIPTION
## Summary

- add `skill_builder` to credit usage origin metadata
- attribute Skill Builder assistant model calls to the new origin
- cover both read-only and action-stream assistant paths

Follow-up to #41181.
