### PR TITLE
fix(workflow): correct loop boolean break condition values (#41185)

### DIFF
--- a/web/app/components/workflow/nodes/loop/components/condition-list/condition-item.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-list/condition-item.tsx
@@ -212,7 +212,7 @@ const ConditionItem = ({
       const newCondition = produce(condition, (draft) => {
         draft.variable_selector = valueSelector
         draft.varType = varItem.type
-        draft.value = ''
+        draft.value = varItem.type === VarType.boolean ? false : ''
         draft.comparison_operator = getOperators(varItem.type)[0]
         delete draft.key
         delete draft.sub_variable_condition

--- a/web/app/components/workflow/nodes/loop/use-config.helpers.ts
+++ b/web/app/components/workflow/nodes/loop/use-config.helpers.ts
@@ -43,7 +43,7 @@ export const addBreakCondition = ({
         variable.type,
         isVarFileAttribute ? { key: valueSelector.slice(-1)[0]! } : undefined,
       )[0],
-      value: variable.type === VarType.boolean ? 'false' : '',
+      value: variable.type === VarType.boolean ? false : '',
     })
   })
 

--- a/web/app/components/workflow/panel/chat-variable-panel/components/bool-value.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/bool-value.tsx
@@ -10,7 +10,7 @@ type Props = Readonly<{
 }>
 
 const BoolValue: FC<Props> = ({ value, onChange }) => {
-  const booleanValue = value
+  const booleanValue = typeof value === 'string' ? value === 'true' : !!value
   const handleChange = useCallback(
     (newValue: boolean) => {
       return () => {


### PR DESCRIPTION
### Description
This PR resolves #41185.

- Changed the initial value for boolean loop break conditions from the string `'false'` to the boolean `false` in `addBreakCondition`.
- Fixed `handleVarChange` to correctly reset boolean variable conditions to `false` instead of an empty string.
- Updated the `BoolValue` component to correctly parse and normalize legacy string values (`"true"`/`"false"`) to actual booleans before setting them as selected.
