### PR TITLE
refactor(api): standardize console workflow run endpoints

### DIFF
--- a/api/controllers/console/app/workflow_run.py
+++ b/api/controllers/console/app/workflow_run.py
@@ -3,26 +3,19 @@ from uuid import UUID
 
 from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy.orm import sessionmaker
 
 from configs import dify_config
 from controllers.common.errors import NotFoundError
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
 from controllers.console.app.wraps import get_app_model
+from controllers.console.flask_admission import console_account_admission
 from controllers.console.wraps import (
     RBACPermission,
     RBACResourceScope,
-    account_initialization_required,
     model_validate,
-    rbac_permission_required,
-    setup_required,
-    with_current_tenant_id,
-    with_current_user,
 )
-from core.workflow.human_input_forms import load_form_tokens_by_form_id as _load_form_tokens_by_form_id
-from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
-from extensions.ext_database import db
+from extensions.ext_application_services import application_services
 from fields.base import ResponseModel
 from fields.workflow_run_fields import (
     AdvancedChatWorkflowRunPaginationResponse,
@@ -32,14 +25,11 @@ from fields.workflow_run_fields import (
     WorkflowRunNodeExecutionResponse,
     WorkflowRunPaginationResponse,
 )
-from graphon.enums import WorkflowExecutionStatus
 from libs.custom_inputs import time_duration
-from libs.helper import uuid_value
-from libs.login import login_required
-from models import Account, App, AppMode, WorkflowRunTriggeredFrom
-from models.workflow import WorkflowRun
-from repositories.factory import DifyAPIRepositoryFactory
-from services.workflow_run_service import WorkflowRunListArgs, WorkflowRunService
+from libs.helper import dump_response, uuid_value
+from machinery.context import RequestContext
+from models import App, AppMode, WorkflowRunTriggeredFrom
+from services.workflow_run_service import WorkflowRunListArgs
 
 
 def _build_backstage_input_url(form_token: str | None) -> str | None:
@@ -49,10 +39,6 @@ def _build_backstage_input_url(form_token: str | None) -> str | None:
     if not base_url:
         return None
     return f"{base_url.rstrip('/')}/form/{form_token}"
-
-
-# Workflow run status choices for filtering
-WORKFLOW_RUN_STATUS_CHOICES = ["running", "succeeded", "failed", "stopped", "partial-succeeded"]
 
 
 class WorkflowRunListQuery(BaseModel):
@@ -94,6 +80,19 @@ class WorkflowRunCountQuery(BaseModel):
         if value is None:
             return value
         return time_duration(value)
+
+
+def _workflow_run_list_args(req_data: WorkflowRunListQuery) -> WorkflowRunListArgs:
+    args: WorkflowRunListArgs = {"limit": req_data.limit}
+    if req_data.last_id is not None:
+        args["last_id"] = req_data.last_id
+    if req_data.status is not None:
+        args["status"] = req_data.status
+    return args
+
+
+def _triggered_from(value: str | None) -> WorkflowRunTriggeredFrom:
+    return WorkflowRunTriggeredFrom(value) if value else WorkflowRunTriggeredFrom.DEBUGGING
 
 
 class HumanInputPauseTypeResponse(ResponseModel):
@@ -143,37 +142,24 @@ class AdvancedChatAppWorkflowRunListApi(Resource):
         "Workflow runs retrieved successfully",
         console_ns.models[AdvancedChatWorkflowRunPaginationResponse.__name__],
     )
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
+    @console_account_admission(
+        rbac_resource_scope=RBACResourceScope.APP,
+        rbac_permission=RBACPermission.APP_CREATE_AND_MANAGEMENT,
+    )
     @get_app_model(mode=[AppMode.ADVANCED_CHAT])
     @model_validate(WorkflowRunListQuery)
-    def get(self, req_data: WorkflowRunListQuery, app_model: App):
+    def get(self, req_data: WorkflowRunListQuery, request_context: RequestContext, app_model: App):
         """
         Get advanced chat app workflow run list
         """
-        args: WorkflowRunListArgs = {"limit": req_data.limit}
-        if req_data.last_id is not None:
-            args["last_id"] = req_data.last_id
-        if req_data.status is not None:
-            args["status"] = req_data.status
-
-        # Default to DEBUGGING if not specified
-        triggered_from = (
-            WorkflowRunTriggeredFrom(req_data.triggered_from)
-            if req_data.triggered_from
-            else WorkflowRunTriggeredFrom.DEBUGGING
+        result = application_services().workflow_runs.get_paginate_advanced_chat_workflow_runs(
+            request_context,
+            app_id=app_model.id,
+            args=_workflow_run_list_args(req_data),
+            triggered_from=_triggered_from(req_data.triggered_from),
         )
 
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_paginate_advanced_chat_workflow_runs(
-            app_model=app_model, args=args, triggered_from=triggered_from
-        )
-
-        return AdvancedChatWorkflowRunPaginationResponse.model_validate(result, from_attributes=True).model_dump(
-            mode="json"
-        )
+        return dump_response(AdvancedChatWorkflowRunPaginationResponse, result)
 
 
 @console_ns.route("/apps/<uuid:app_id>/advanced-chat/workflow-runs/count")
@@ -187,34 +173,25 @@ class AdvancedChatAppWorkflowRunCountApi(Resource):
         "Workflow runs count retrieved successfully",
         console_ns.models[WorkflowRunCountResponse.__name__],
     )
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
+    @console_account_admission(
+        rbac_resource_scope=RBACResourceScope.APP,
+        rbac_permission=RBACPermission.APP_CREATE_AND_MANAGEMENT,
+    )
     @get_app_model(mode=[AppMode.ADVANCED_CHAT])
     @model_validate(WorkflowRunCountQuery)
-    def get(self, req_data: WorkflowRunCountQuery, app_model: App):
+    def get(self, req_data: WorkflowRunCountQuery, request_context: RequestContext, app_model: App):
         """
         Get advanced chat workflow runs count statistics
         """
-        args = req_data.model_dump(exclude_none=True)
-
-        # Default to DEBUGGING if not specified
-        triggered_from = (
-            WorkflowRunTriggeredFrom(req_data.triggered_from)
-            if req_data.triggered_from
-            else WorkflowRunTriggeredFrom.DEBUGGING
+        result = application_services().workflow_runs.get_workflow_runs_count(
+            request_context,
+            app_id=app_model.id,
+            status=req_data.status,
+            time_range=req_data.time_range,
+            triggered_from=_triggered_from(req_data.triggered_from),
         )
 
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_workflow_runs_count(
-            app_model=app_model,
-            status=args.get("status"),
-            time_range=args.get("time_range"),
-            triggered_from=triggered_from,
-        )
-
-        return WorkflowRunCountResponse.model_validate(result).model_dump(mode="json")
+        return dump_response(WorkflowRunCountResponse, result)
 
 
 @console_ns.route("/apps/<uuid:app_id>/workflow-runs")
@@ -228,35 +205,24 @@ class WorkflowRunListApi(Resource):
         "Workflow runs retrieved successfully",
         console_ns.models[WorkflowRunPaginationResponse.__name__],
     )
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
+    @console_account_admission(
+        rbac_resource_scope=RBACResourceScope.APP,
+        rbac_permission=RBACPermission.APP_CREATE_AND_MANAGEMENT,
+    )
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
     @model_validate(WorkflowRunListQuery)
-    def get(self, req_data: WorkflowRunListQuery, app_model: App):
+    def get(self, req_data: WorkflowRunListQuery, request_context: RequestContext, app_model: App):
         """
         Get workflow run list
         """
-        args: WorkflowRunListArgs = {"limit": req_data.limit}
-        if req_data.last_id is not None:
-            args["last_id"] = req_data.last_id
-        if req_data.status is not None:
-            args["status"] = req_data.status
-
-        # Default to DEBUGGING for workflow if not specified (backward compatibility)
-        triggered_from = (
-            WorkflowRunTriggeredFrom(req_data.triggered_from)
-            if req_data.triggered_from
-            else WorkflowRunTriggeredFrom.DEBUGGING
+        result = application_services().workflow_runs.get_paginate_workflow_runs(
+            request_context,
+            app_id=app_model.id,
+            args=_workflow_run_list_args(req_data),
+            triggered_from=_triggered_from(req_data.triggered_from),
         )
 
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_paginate_workflow_runs(
-            app_model=app_model, args=args, triggered_from=triggered_from
-        )
-
-        return WorkflowRunPaginationResponse.model_validate(result, from_attributes=True).model_dump(mode="json")
+        return dump_response(WorkflowRunPaginationResponse, result)
 
 
 @console_ns.route("/apps/<uuid:app_id>/workflow-runs/count")
@@ -270,34 +236,25 @@ class WorkflowRunCountApi(Resource):
         "Workflow runs count retrieved successfully",
         console_ns.models[WorkflowRunCountResponse.__name__],
     )
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
+    @console_account_admission(
+        rbac_resource_scope=RBACResourceScope.APP,
+        rbac_permission=RBACPermission.APP_CREATE_AND_MANAGEMENT,
+    )
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
     @model_validate(WorkflowRunCountQuery)
-    def get(self, req_data: WorkflowRunCountQuery, app_model: App):
+    def get(self, req_data: WorkflowRunCountQuery, request_context: RequestContext, app_model: App):
         """
         Get workflow runs count statistics
         """
-        args = req_data.model_dump(exclude_none=True)
-
-        # Default to DEBUGGING for workflow if not specified (backward compatibility)
-        triggered_from = (
-            WorkflowRunTriggeredFrom(req_data.triggered_from)
-            if req_data.triggered_from
-            else WorkflowRunTriggeredFrom.DEBUGGING
+        result = application_services().workflow_runs.get_workflow_runs_count(
+            request_context,
+            app_id=app_model.id,
+            status=req_data.status,
+            time_range=req_data.time_range,
+            triggered_from=_triggered_from(req_data.triggered_from),
         )
 
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_workflow_runs_count(
-            app_model=app_model,
-            status=args.get("status"),
-            time_range=args.get("time_range"),
-            triggered_from=triggered_from,
-        )
-
-        return WorkflowRunCountResponse.model_validate(result).model_dump(mode="json")
+        return dump_response(WorkflowRunCountResponse, result)
 
 
 @console_ns.route("/apps/<uuid:app_id>/workflow-runs/<uuid:run_id>")
@@ -311,23 +268,24 @@ class WorkflowRunDetailApi(Resource):
         console_ns.models[WorkflowRunDetailResponse.__name__],
     )
     @console_ns.response(404, "Workflow run not found")
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
+    @console_account_admission(
+        rbac_resource_scope=RBACResourceScope.APP,
+        rbac_permission=RBACPermission.APP_CREATE_AND_MANAGEMENT,
+    )
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
-    def get(self, app_model: App, run_id: UUID):
+    def get(self, request_context: RequestContext, app_model: App, run_id: UUID):
         """
         Get workflow run detail
         """
-        run_id_str = str(run_id)
-
-        workflow_run_service = WorkflowRunService()
-        workflow_run = workflow_run_service.get_workflow_run(app_model=app_model, run_id=run_id_str)
+        workflow_run = application_services().workflow_runs.get_workflow_run(
+            request_context,
+            app_id=app_model.id,
+            run_id=str(run_id),
+        )
         if workflow_run is None:
             raise NotFoundError("Workflow run not found")
 
-        return WorkflowRunDetailResponse.model_validate(workflow_run, from_attributes=True).model_dump(mode="json")
+        return dump_response(WorkflowRunDetailResponse, workflow_run)
 
 
 @console_ns.route("/apps/<uuid:app_id>/workflow-runs/<uuid:run_id>/node-executions")
@@ -341,28 +299,22 @@ class WorkflowRunNodeExecutionListApi(Resource):
         console_ns.models[WorkflowRunNodeExecutionListResponse.__name__],
     )
     @console_ns.response(404, "Workflow run not found")
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @with_current_user
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
+    @console_account_admission(
+        rbac_resource_scope=RBACResourceScope.APP,
+        rbac_permission=RBACPermission.APP_CREATE_AND_MANAGEMENT,
+    )
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
-    def get(self, current_user: Account, app_model: App, run_id: UUID):
+    def get(self, request_context: RequestContext, app_model: App, run_id: UUID):
         """
         Get workflow run node execution list
         """
-        run_id_str = str(run_id)
-
-        workflow_run_service = WorkflowRunService()
-        node_executions = workflow_run_service.get_workflow_run_node_executions(
-            app_model=app_model,
-            run_id=run_id_str,
-            user=current_user,
+        node_executions = application_services().workflow_runs.get_workflow_run_node_executions(
+            request_context,
+            app_id=app_model.id,
+            run_id=str(run_id),
         )
 
-        return WorkflowRunNodeExecutionListResponse.model_validate(
-            {"data": node_executions}, from_attributes=True
-        ).model_dump(mode="json")
+        return dump_response(WorkflowRunNodeExecutionListResponse, {"data": node_executions})
 
 
 @console_ns.route("/workflow/<string:workflow_run_id>/pause-details")
@@ -378,11 +330,8 @@ class ConsoleWorkflowPauseDetailsApi(Resource):
         console_ns.models[WorkflowPauseDetailsResponse.__name__],
     )
     @console_ns.response(404, "Workflow run not found")
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @with_current_tenant_id
-    def get(self, current_tenant_id: str, workflow_run_id: str):
+    @console_account_admission()
+    def get(self, request_context: RequestContext, workflow_run_id: str):
         """
         Get workflow pause details.
 
@@ -391,51 +340,31 @@ class ConsoleWorkflowPauseDetailsApi(Resource):
         Returns information about why and where the workflow is paused.
         """
 
-        # Query WorkflowRun to determine if workflow is suspended
-        session_maker = sessionmaker(bind=db.engine)
-        workflow_run_repo = DifyAPIRepositoryFactory.create_api_workflow_run_repository(session_maker=session_maker)
-
-        workflow_run = db.session.get(WorkflowRun, workflow_run_id)
-        if not workflow_run:
+        details = application_services().workflow_runs.get_pause_details(
+            request_context,
+            workflow_run_id=workflow_run_id,
+        )
+        if details is None:
             raise NotFoundError("Workflow run not found")
 
-        if workflow_run.tenant_id != current_tenant_id:
-            raise NotFoundError("Workflow run not found")
-
-        # Check if workflow is suspended
-        is_paused = workflow_run.status == WorkflowExecutionStatus.PAUSED
-        if not is_paused:
-            empty_response = WorkflowPauseDetailsResponse(paused_at=None, paused_nodes=[])
-            return empty_response.model_dump(mode="json"), 200
-
-        pause_entity = workflow_run_repo.get_workflow_pause(workflow_run_id)
-        pause_reasons = pause_entity.get_pause_reasons() if pause_entity else []
-        form_tokens_by_form_id = _load_form_tokens_by_form_id(
-            [reason.form_id for reason in pause_reasons if isinstance(reason, HumanInputRequired)]
+        return (
+            dump_response(
+                WorkflowPauseDetailsResponse,
+                {
+                    "paused_at": details.paused_at.isoformat() + "Z" if details.paused_at else None,
+                    "paused_nodes": [
+                        {
+                            "node_id": node.node_id,
+                            "node_title": node.node_title,
+                            "pause_type": {
+                                "type": "human_input",
+                                "form_id": node.form_id,
+                                "backstage_input_url": _build_backstage_input_url(node.form_token),
+                            },
+                        }
+                        for node in details.paused_nodes
+                    ],
+                },
+            ),
+            200,
         )
-
-        # Build response
-        paused_at = pause_entity.paused_at if pause_entity else None
-        paused_nodes: list[PausedNodeResponse] = []
-
-        for reason in pause_reasons:
-            if isinstance(reason, HumanInputRequired):
-                paused_nodes.append(
-                    PausedNodeResponse(
-                        node_id=reason.node_id,
-                        node_title=reason.node_title,
-                        pause_type=HumanInputPauseTypeResponse(
-                            type="human_input",
-                            form_id=reason.form_id,
-                            backstage_input_url=_build_backstage_input_url(form_tokens_by_form_id.get(reason.form_id)),
-                        ),
-                    )
-                )
-            else:
-                raise AssertionError("unimplemented.")
-
-        response = WorkflowPauseDetailsResponse(
-            paused_at=paused_at.isoformat() + "Z" if paused_at else None,
-            paused_nodes=paused_nodes,
-        )
-        return response.model_dump(mode="json"), 200

--- a/api/controllers/console/app/workflow_run.py
+++ b/api/controllers/console/app/workflow_run.py
@@ -1,10 +1,8 @@
-from datetime import UTC, datetime, timedelta
 from typing import Literal
 from uuid import UUID
 
 from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
 
 from configs import dify_config
@@ -35,14 +33,12 @@ from fields.workflow_run_fields import (
     WorkflowRunPaginationResponse,
 )
 from graphon.enums import WorkflowExecutionStatus
-from libs.archive_storage import ArchiveStorageNotConfiguredError, get_archive_storage
 from libs.custom_inputs import time_duration
-from libs.helper import dump_response, uuid_value
+from libs.helper import uuid_value
 from libs.login import login_required
-from models import Account, App, AppMode, WorkflowArchiveLog, WorkflowRunTriggeredFrom
+from models import Account, App, AppMode, WorkflowRunTriggeredFrom
 from models.workflow import WorkflowRun
 from repositories.factory import DifyAPIRepositoryFactory
-from services.retention.workflow_run.constants import ARCHIVE_BUNDLE_NAME
 from services.workflow_run_service import WorkflowRunListArgs, WorkflowRunService
 
 
@@ -57,7 +53,6 @@ def _build_backstage_input_url(form_token: str | None) -> str | None:
 
 # Workflow run status choices for filtering
 WORKFLOW_RUN_STATUS_CHOICES = ["running", "succeeded", "failed", "stopped", "partial-succeeded"]
-EXPORT_SIGNED_URL_EXPIRE_SECONDS = 3600
 
 
 class WorkflowRunListQuery(BaseModel):
@@ -101,12 +96,6 @@ class WorkflowRunCountQuery(BaseModel):
         return time_duration(value)
 
 
-class WorkflowRunExportResponse(ResponseModel):
-    status: str = Field(description="Export status: success/failed")
-    presigned_url: str | None = Field(default=None, description="Pre-signed URL for download")
-    presigned_url_expires_at: str | None = Field(default=None, description="Pre-signed URL expiration time")
-
-
 class HumanInputPauseTypeResponse(ResponseModel):
     type: Literal["human_input"]
     form_id: str
@@ -137,7 +126,6 @@ register_response_schema_models(
     WorkflowRunDetailResponse,
     WorkflowRunNodeExecutionResponse,
     WorkflowRunNodeExecutionListResponse,
-    WorkflowRunExportResponse,
     HumanInputPauseTypeResponse,
     PausedNodeResponse,
     WorkflowPauseDetailsResponse,
@@ -185,63 +173,6 @@ class AdvancedChatAppWorkflowRunListApi(Resource):
 
         return AdvancedChatWorkflowRunPaginationResponse.model_validate(result, from_attributes=True).model_dump(
             mode="json"
-        )
-
-
-@console_ns.route("/apps/<uuid:app_id>/workflow-runs/<uuid:run_id>/export")
-class WorkflowRunExportApi(Resource):
-    @console_ns.doc("get_workflow_run_export_url")
-    @console_ns.doc(description="Generate a download URL for an archived workflow run.")
-    @console_ns.doc(params={"app_id": "Application ID", "run_id": "Workflow run ID"})
-    @console_ns.response(200, "Export URL generated", console_ns.models[WorkflowRunExportResponse.__name__])
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
-    @get_app_model()
-    def get(self, app_model: App, run_id: UUID):
-        tenant_id = app_model.tenant_id
-        app_id = app_model.id
-        run_id_str = str(run_id)
-
-        run_created_at = db.session.scalar(
-            select(WorkflowArchiveLog.run_created_at)
-            .where(
-                WorkflowArchiveLog.tenant_id == tenant_id,
-                WorkflowArchiveLog.app_id == app_id,
-                WorkflowArchiveLog.workflow_run_id == run_id_str,
-            )
-            .limit(1)
-        )
-        if not run_created_at:
-            return {"code": "archive_log_not_found", "message": "workflow run archive not found"}, 404
-
-        prefix = (
-            f"{tenant_id}/app_id={app_id}/year={run_created_at.strftime('%Y')}/"
-            f"month={run_created_at.strftime('%m')}/workflow_run_id={run_id_str}"
-        )
-        archive_key = f"{prefix}/{ARCHIVE_BUNDLE_NAME}"
-
-        try:
-            archive_storage = get_archive_storage()
-        except ArchiveStorageNotConfiguredError as e:
-            return {"code": "archive_storage_not_configured", "message": str(e)}, 500
-
-        presigned_url = archive_storage.generate_presigned_url(
-            archive_key,
-            expires_in=EXPORT_SIGNED_URL_EXPIRE_SECONDS,
-        )
-        expires_at = datetime.now(UTC) + timedelta(seconds=EXPORT_SIGNED_URL_EXPIRE_SECONDS)
-        return (
-            dump_response(
-                WorkflowRunExportResponse,
-                {
-                    "status": "success",
-                    "presigned_url": presigned_url,
-                    "presigned_url_expires_at": expires_at.isoformat(),
-                },
-            ),
-            200,
         )
 
 

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -103,6 +103,7 @@ from services.webapp_access_query_service import (
     WebAppAccessQueryService,
     WebAppAccessUnavailableError,
 )
+from services.workflow_run_service import WorkflowRunService
 from services.workspace_member_query_service import WorkspaceMemberQueryService
 from services.workspace_member_role_resolver import DeploymentWorkspaceMemberRoleResolver
 from services.workspace_plan_gateway import DeploymentWorkspacePlanGateway
@@ -161,6 +162,7 @@ class ApplicationServices:
     partner_tenant_bindings: PartnerTenantBindingService
     recommended_app_queries: RecommendedAppQueryService
     trial_app_usage: TrialAppUsageRecorder
+    workflow_runs: WorkflowRunService
     workspace_queries: WorkspaceQueryService
     workspace_member_queries: WorkspaceMemberQueryService
     tags: TagApplicationService
@@ -343,6 +345,7 @@ def build_application_services(
             trial_enabled=trial_app_enabled,
         ),
         trial_app_usage=TrialAppUsageRepository(session_factory=database_client),
+        workflow_runs=WorkflowRunService(session_factory=database_client),
         workspace_queries=WorkspaceQueryService(
             workspaces=workspace_query_repository,
             plans=DeploymentWorkspacePlanGateway(),

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -3459,22 +3459,6 @@ Stop running workflow task
 | 200 | Workflow run detail retrieved successfully | **application/json**: [WorkflowRunDetailResponse](#workflowrundetailresponse)<br> |
 | 404 | Workflow run not found |  |
 
-### [GET] /apps/{app_id}/workflow-runs/{run_id}/export
-Generate a download URL for an archived workflow run.
-
-#### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string (uuid) |
-| run_id | path | Workflow run ID | Yes | string (uuid) |
-
-#### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Export URL generated | **application/json**: [WorkflowRunExportResponse](#workflowrunexportresponse)<br> |
-
 ### [GET] /apps/{app_id}/workflow-runs/{run_id}/node-executions
 **Get workflow run node execution list**
 
@@ -24572,14 +24556,6 @@ Lifecycle state for an asynchronous archive download request.
 | total_steps | integer |  | No |
 | total_tokens | integer |  | No |
 | version | string |  | No |
-
-#### WorkflowRunExportResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| presigned_url | string | Pre-signed URL for download | No |
-| presigned_url_expires_at | string | Pre-signed URL expiration time | No |
-| status | string | Export status: success/failed | Yes |
 
 #### WorkflowRunForArchivedLogResponse
 

--- a/api/services/workflow_run_service.py
+++ b/api/services/workflow_run_service.py
@@ -1,16 +1,18 @@
 import threading
+from dataclasses import dataclass
+from datetime import datetime
 from typing import TypedDict
 
 from sqlalchemy import Engine, select
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 import contexts
-from extensions.ext_database import db
+from core.workflow.human_input_forms import load_form_tokens_by_form_id as _load_form_tokens_by_form_id
+from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
+from graphon.enums import WorkflowExecutionStatus
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
+from machinery.context import RequestContext
 from models import (
-    Account,
-    App,
-    EndUser,
     Message,
     WorkflowRun,
     WorkflowRunTriggeredFrom,
@@ -31,17 +33,28 @@ class WorkflowRunListArgs(TypedDict, total=False):
     status: str
 
 
+@dataclass(frozen=True, slots=True)
+class WorkflowRunPausedNode:
+    node_id: str
+    node_title: str
+    form_id: str
+    form_token: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRunPauseDetails:
+    paused_at: datetime | None
+    paused_nodes: tuple[WorkflowRunPausedNode, ...]
+
+
 class WorkflowRunService:
-    _session_factory: sessionmaker
+    _session_factory: sessionmaker[Session]
     _workflow_run_repo: APIWorkflowRunRepository
 
-    def __init__(self, session_factory: Engine | sessionmaker | None = None):
+    def __init__(self, session_factory: Engine | sessionmaker[Session]):
         """Initialize WorkflowRunService with repository dependencies."""
-        match session_factory:
-            case None:
-                session_factory = sessionmaker(bind=db.engine, expire_on_commit=False)
-            case Engine():
-                session_factory = sessionmaker(bind=session_factory, expire_on_commit=False)
+        if isinstance(session_factory, Engine):
+            session_factory = sessionmaker(bind=session_factory, expire_on_commit=False)
 
         self._session_factory = session_factory
         self._node_execution_service_repo = DifyAPIRepositoryFactory.create_api_workflow_node_execution_repository(
@@ -51,14 +64,17 @@ class WorkflowRunService:
 
     def get_paginate_advanced_chat_workflow_runs(
         self,
-        app_model: App,
+        context: RequestContext,
+        *,
+        app_id: str,
         args: WorkflowRunListArgs,
         triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING,
     ) -> InfiniteScrollPagination:
         """
         Get advanced chat app workflow run list
 
-        :param app_model: app model
+        :param context: admitted Console request context
+        :param app_id: app id
         :param args: request args
         :param triggered_from: workflow run triggered from (default: DEBUGGING for preview runs)
         """
@@ -73,7 +89,12 @@ class WorkflowRunService:
             def __getattr__(self, item):
                 return getattr(self._workflow_run, item)
 
-        pagination = self.get_paginate_workflow_runs(app_model, args, triggered_from)
+        pagination = self.get_paginate_workflow_runs(
+            context,
+            app_id=app_id,
+            args=args,
+            triggered_from=triggered_from,
+        )
 
         # Batch-load the associated Message for every run in a single query to avoid
         # an N+1 pattern: the deprecated WorkflowRun.message property issues one query
@@ -85,7 +106,7 @@ class WorkflowRunService:
             with self._session_factory() as session:
                 messages = session.scalars(
                     select(Message).where(
-                        Message.app_id == app_model.id,
+                        Message.app_id == app_id,
                         Message.workflow_run_id.in_(run_ids),
                     )
                 ).all()
@@ -111,14 +132,17 @@ class WorkflowRunService:
 
     def get_paginate_workflow_runs(
         self,
-        app_model: App,
+        context: RequestContext,
+        *,
+        app_id: str,
         args: WorkflowRunListArgs,
         triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING,
     ) -> InfiniteScrollPagination:
         """
         Get workflow run list
 
-        :param app_model: app model
+        :param context: admitted Console request context
+        :param app_id: app id
         :param args: request args
         :param triggered_from: workflow run triggered from (default: DEBUGGING)
         """
@@ -127,30 +151,33 @@ class WorkflowRunService:
         status = args.get("status")
 
         return self._workflow_run_repo.get_paginated_workflow_runs(
-            tenant_id=app_model.tenant_id,
-            app_id=app_model.id,
+            tenant_id=self._workspace_id(context),
+            app_id=app_id,
             triggered_from=triggered_from,
             limit=limit,
             last_id=last_id,
             status=status,
         )
 
-    def get_workflow_run(self, app_model: App, run_id: str) -> WorkflowRun | None:
+    def get_workflow_run(self, context: RequestContext, *, app_id: str, run_id: str) -> WorkflowRun | None:
         """
         Get workflow run detail
 
-        :param app_model: app model
+        :param context: admitted Console request context
+        :param app_id: app id
         :param run_id: workflow run id
         """
         return self._workflow_run_repo.get_workflow_run_by_id(
-            tenant_id=app_model.tenant_id,
-            app_id=app_model.id,
+            tenant_id=self._workspace_id(context),
+            app_id=app_id,
             run_id=run_id,
         )
 
     def get_workflow_runs_count(
         self,
-        app_model: App,
+        context: RequestContext,
+        *,
+        app_id: str,
         status: str | None = None,
         time_range: str | None = None,
         triggered_from: WorkflowRunTriggeredFrom = WorkflowRunTriggeredFrom.DEBUGGING,
@@ -158,15 +185,16 @@ class WorkflowRunService:
         """
         Get workflow runs count statistics
 
-        :param app_model: app model
+        :param context: admitted Console request context
+        :param app_id: app id
         :param status: optional status filter
         :param time_range: optional time range filter (e.g., "7d", "4h", "30m", "30s")
         :param triggered_from: workflow run triggered from (default: DEBUGGING)
         :return: dict with total and status counts
         """
         return self._workflow_run_repo.get_workflow_runs_count(
-            tenant_id=app_model.tenant_id,
-            app_id=app_model.id,
+            tenant_id=self._workspace_id(context),
+            app_id=app_id,
             triggered_from=triggered_from,
             status=status,
             time_range=time_range,
@@ -174,14 +202,15 @@ class WorkflowRunService:
 
     def get_workflow_run_node_executions(
         self,
-        app_model: App,
+        context: RequestContext,
+        *,
+        app_id: str,
         run_id: str,
-        user: Account | EndUser,
     ) -> list[WorkflowNodeExecutionTrace]:
         """
         Get workflow run node execution list
         """
-        workflow_run = self.get_workflow_run(app_model, run_id)
+        workflow_run = self.get_workflow_run(context, app_id=app_id, run_id=run_id)
 
         contexts.plugin_tool_providers.set({})
         contexts.plugin_tool_providers_lock.set(threading.Lock())
@@ -189,14 +218,60 @@ class WorkflowRunService:
         if not workflow_run:
             return []
 
-        # Get tenant_id from user
-        tenant_id = user.tenant_id if isinstance(user, EndUser) else user.current_tenant_id
-        if tenant_id is None:
-            raise ValueError("User tenant_id cannot be None")
-
         node_executions = self._node_execution_service_repo.get_executions_by_workflow_run(
-            tenant_id=tenant_id,
-            app_id=app_model.id,
+            tenant_id=self._workspace_id(context),
+            app_id=app_id,
             workflow_run_id=run_id,
         )
         return assemble_workflow_node_execution_traces(node_executions, self._node_execution_service_repo)
+
+    def get_pause_details(
+        self,
+        context: RequestContext,
+        *,
+        workflow_run_id: str,
+    ) -> WorkflowRunPauseDetails | None:
+        workspace_id = self._workspace_id(context)
+        workflow_run = self._workflow_run_repo.get_workflow_run_by_id_and_tenant_id(
+            tenant_id=workspace_id,
+            run_id=workflow_run_id,
+        )
+        if workflow_run is None:
+            return None
+        if workflow_run.status != WorkflowExecutionStatus.PAUSED:
+            return WorkflowRunPauseDetails(paused_at=None, paused_nodes=())
+
+        pause_entity = self._workflow_run_repo.get_workflow_pause(workflow_run_id)
+        pause_reasons = pause_entity.get_pause_reasons() if pause_entity else []
+        human_input_reasons: list[HumanInputRequired] = []
+        for reason in pause_reasons:
+            if not isinstance(reason, HumanInputRequired):
+                raise AssertionError("unimplemented.")
+            human_input_reasons.append(reason)
+
+        form_tokens_by_form_id: dict[str, str] = {}
+        if human_input_reasons:
+            with self._session_factory() as session:
+                form_tokens_by_form_id = _load_form_tokens_by_form_id(
+                    [reason.form_id for reason in human_input_reasons],
+                    session=session,
+                )
+
+        return WorkflowRunPauseDetails(
+            paused_at=pause_entity.paused_at if pause_entity else None,
+            paused_nodes=tuple(
+                WorkflowRunPausedNode(
+                    node_id=reason.node_id,
+                    node_title=reason.node_title,
+                    form_id=reason.form_id,
+                    form_token=form_tokens_by_form_id.get(reason.form_id),
+                )
+                for reason in human_input_reasons
+            ),
+        )
+
+    @staticmethod
+    def _workspace_id(context: RequestContext) -> str:
+        if context.active_workspace_id is None:
+            raise RuntimeError("Console account admission did not resolve an active workspace")
+        return context.active_workspace_id

--- a/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
+++ b/api/tests/test_containers_integration_tests/core/app/layers/test_pause_state_persist_layer.py
@@ -99,7 +99,7 @@ class TestPauseStatePersistenceLayerTestContainers:
     @pytest.fixture
     def workflow_run_service(self, engine: Engine, file_service: FileService):
         """Create WorkflowRunService instance with TestContainers engine and FileService."""
-        return WorkflowRunService(engine)
+        return WorkflowRunService(session_factory=engine)
 
     @pytest.fixture(autouse=True)
     def setup_test_data(self, db_session_with_containers: Session, file_service, workflow_run_service):

--- a/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_run_service.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 
 import pytest
 from faker import Faker
+from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 
-from models.enums import ConversationFromSource, CreatorUserRole, EndUserType
+from machinery.context import RequestContext
+from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import (
     Message,
 )
@@ -20,6 +22,12 @@ from tests.test_containers_integration_tests.helpers import generate_valid_passw
 
 class TestWorkflowRunService:
     """Integration tests for WorkflowRunService using testcontainers."""
+
+    @pytest.fixture
+    def workflow_run_service(self, db_session_with_containers: Session) -> WorkflowRunService:
+        engine = db_session_with_containers.get_bind()
+        assert isinstance(engine, Engine)
+        return WorkflowRunService(session_factory=engine)
 
     @pytest.fixture
     def mock_external_service_dependencies(self):
@@ -49,6 +57,15 @@ class TestWorkflowRunService:
                 "model_manager": mock_model_manager,
                 "account_feature_service": mock_account_feature_service,
             }
+
+    @staticmethod
+    def _request_context(app, account) -> RequestContext:
+        return RequestContext(
+            request_id="request-1",
+            trace_id="trace-1",
+            account_id=account.id,
+            active_workspace_id=app.tenant_id,
+        )
 
     def _create_test_app_and_account(self, db_session_with_containers: Session, mock_external_service_dependencies):
         """
@@ -198,7 +215,10 @@ class TestWorkflowRunService:
         return message
 
     def test_get_paginate_workflow_runs_success(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
     ):
         """
         Test successful pagination of workflow runs with debugging trigger.
@@ -220,9 +240,12 @@ class TestWorkflowRunService:
             workflow_runs.append(workflow_run)
 
         # Act: Execute the method under test
-        workflow_run_service = WorkflowRunService()
         args = {"limit": 3, "last_id": None}
-        result = workflow_run_service.get_paginate_workflow_runs(app, args)
+        result = workflow_run_service.get_paginate_workflow_runs(
+            self._request_context(app, account),
+            app_id=app.id,
+            args=args,
+        )
 
         # Assert: Verify the expected outcomes
         assert result is not None
@@ -240,7 +263,10 @@ class TestWorkflowRunService:
             assert workflow_run.tenant_id == app.tenant_id
 
     def test_get_paginate_workflow_runs_with_last_id(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
     ):
         """
         Test pagination of workflow runs with last_id parameter.
@@ -263,9 +289,12 @@ class TestWorkflowRunService:
             workflow_runs.append(workflow_run)
 
         # Act: Execute the method under test with last_id
-        workflow_run_service = WorkflowRunService()
         args = {"limit": 2, "last_id": workflow_runs[1].id}
-        result = workflow_run_service.get_paginate_workflow_runs(app, args)
+        result = workflow_run_service.get_paginate_workflow_runs(
+            self._request_context(app, account),
+            app_id=app.id,
+            args=args,
+        )
 
         # Assert: Verify the expected outcomes
         assert result is not None
@@ -283,7 +312,10 @@ class TestWorkflowRunService:
             assert workflow_run.tenant_id == app.tenant_id
 
     def test_get_paginate_workflow_runs_default_limit(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
     ):
         """
         Test pagination of workflow runs with default limit.
@@ -301,9 +333,12 @@ class TestWorkflowRunService:
         workflow_run = self._create_test_workflow_run(db_session_with_containers, app, account, "debugging")
 
         # Act: Execute the method under test without limit
-        workflow_run_service = WorkflowRunService()
         args = {}  # No limit specified
-        result = workflow_run_service.get_paginate_workflow_runs(app, args)
+        result = workflow_run_service.get_paginate_workflow_runs(
+            self._request_context(app, account),
+            app_id=app.id,
+            args=args,
+        )
 
         # Assert: Verify the expected outcomes
         assert result is not None
@@ -321,7 +356,10 @@ class TestWorkflowRunService:
             assert workflow_run_result.tenant_id == app.tenant_id
 
     def test_get_paginate_advanced_chat_workflow_runs_success(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
     ):
         """
         Test successful pagination of advanced chat workflow runs with message information.
@@ -346,9 +384,12 @@ class TestWorkflowRunService:
             workflow_runs.append(workflow_run)
 
         # Act: Execute the method under test
-        workflow_run_service = WorkflowRunService()
         args = {"limit": 2, "last_id": None}
-        result = workflow_run_service.get_paginate_advanced_chat_workflow_runs(app, args)
+        result = workflow_run_service.get_paginate_advanced_chat_workflow_runs(
+            self._request_context(app, account),
+            app_id=app.id,
+            args=args,
+        )
 
         # Assert: Verify the expected outcomes
         assert result is not None
@@ -366,7 +407,12 @@ class TestWorkflowRunService:
             assert workflow_run.app_id == app.id
             assert workflow_run.tenant_id == app.tenant_id
 
-    def test_get_workflow_run_success(self, db_session_with_containers: Session, mock_external_service_dependencies):
+    def test_get_workflow_run_success(
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
+    ):
         """
         Test successful retrieval of workflow run by ID.
 
@@ -383,8 +429,11 @@ class TestWorkflowRunService:
         workflow_run = self._create_test_workflow_run(db_session_with_containers, app, account, "debugging")
 
         # Act: Execute the method under test
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_workflow_run(app, workflow_run.id)
+        result = workflow_run_service.get_workflow_run(
+            self._request_context(app, account),
+            app_id=app.id,
+            run_id=workflow_run.id,
+        )
 
         # Assert: Verify the expected outcomes
         assert result is not None
@@ -396,7 +445,12 @@ class TestWorkflowRunService:
         assert result.type == "chat"
         assert result.version == "1.0.0"
 
-    def test_get_workflow_run_not_found(self, db_session_with_containers: Session, mock_external_service_dependencies):
+    def test_get_workflow_run_not_found(
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
+    ):
         """
         Test workflow run retrieval when run ID does not exist.
 
@@ -413,14 +467,20 @@ class TestWorkflowRunService:
         non_existent_id = str(uuid.uuid4())
 
         # Act: Execute the method under test
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_workflow_run(app, non_existent_id)
+        result = workflow_run_service.get_workflow_run(
+            self._request_context(app, account),
+            app_id=app.id,
+            run_id=non_existent_id,
+        )
 
         # Assert: Verify the expected outcomes
         assert result is None
 
     def test_get_workflow_run_node_executions_success(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
     ):
         """
         Test successful retrieval of workflow run node executions.
@@ -489,8 +549,11 @@ class TestWorkflowRunService:
         db_session_with_containers.commit()
 
         # Act: Execute the method under test
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_workflow_run_node_executions(app, workflow_run.id, account)
+        result = workflow_run_service.get_workflow_run_node_executions(
+            self._request_context(app, account),
+            app_id=app.id,
+            run_id=workflow_run.id,
+        )
 
         # Assert: Verify the expected outcomes
         assert result is not None
@@ -509,7 +572,10 @@ class TestWorkflowRunService:
             assert node_execution.node_id.startswith("node_")
 
     def test_get_workflow_run_node_executions_empty(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
     ):
         """
         Test getting node executions for a workflow run with no executions.
@@ -523,7 +589,6 @@ class TestWorkflowRunService:
         account_service = AccountService()
         tenant_service = TenantService()
         app_service = AppService()
-        workflow_run_service = WorkflowRunService()
 
         # Create account and tenant
         account = account_service.create_account(
@@ -551,9 +616,9 @@ class TestWorkflowRunService:
 
         # Act: Get node executions
         result = workflow_run_service.get_workflow_run_node_executions(
-            app_model=app,
+            self._request_context(app, account),
+            app_id=app.id,
             run_id=workflow_run.id,
-            user=account,
         )
 
         # Assert: Verify empty result
@@ -561,7 +626,10 @@ class TestWorkflowRunService:
         assert len(result) == 0
 
     def test_get_workflow_run_node_executions_invalid_workflow_run_id(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
+        self,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies,
+        workflow_run_service: WorkflowRunService,
     ):
         """
         Test getting node executions with invalid workflow run ID.
@@ -575,7 +643,6 @@ class TestWorkflowRunService:
         account_service = AccountService()
         tenant_service = TenantService()
         app_service = AppService()
-        workflow_run_service = WorkflowRunService()
 
         # Create account and tenant
         account = account_service.create_account(
@@ -603,137 +670,11 @@ class TestWorkflowRunService:
 
         # Act: Get node executions with invalid ID
         result = workflow_run_service.get_workflow_run_node_executions(
-            app_model=app,
+            self._request_context(app, account),
+            app_id=app.id,
             run_id=invalid_workflow_run_id,
-            user=account,
         )
 
         # Assert: Verify empty result
         assert result is not None
         assert len(result) == 0
-
-    def test_get_workflow_run_node_executions_database_error(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
-        """
-        Test getting node executions when database encounters an error.
-
-        This test verifies:
-        - Proper error handling when database operations fail
-        - Graceful degradation in error scenarios
-        - Error propagation to calling code
-        """
-        # Arrange: Setup test data
-        account_service = AccountService()
-        tenant_service = TenantService()
-        app_service = AppService()
-        workflow_run_service = WorkflowRunService()
-
-        # Create account and tenant
-        account = account_service.create_account(
-            email="test@example.com",
-            name="Test User",
-            password="password123",
-            interface_language="en-US",
-            session=db_session_with_containers,
-        )
-        TenantService.create_owner_tenant_if_not_exist(account, name="test_tenant", session=db_session_with_containers)
-        tenant = account.current_tenant
-
-        # Create app
-        app_args = CreateAppParams(
-            name="Test App",
-            mode="chat",
-            icon_type="emoji",
-            icon="🚀",
-            icon_background="#4ECDC4",
-        )
-        app = app_service.create_app(tenant.id, app_args, account, session=db_session_with_containers)
-
-        # Create workflow run
-        workflow_run = self._create_test_workflow_run(db_session_with_containers, app, account, "debugging")
-
-        # Mock database error by closing the session
-        db_session_with_containers.close()
-
-        # Act & Assert: Verify error handling
-        with pytest.raises((Exception, RuntimeError)):
-            workflow_run_service.get_workflow_run_node_executions(
-                app_model=app,
-                run_id=workflow_run.id,
-                user=account,
-            )
-
-    def test_get_workflow_run_node_executions_end_user(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
-        """
-        Test node execution retrieval for end user.
-
-        This test verifies:
-        - Proper handling of end user vs account user
-        - Correct tenant ID extraction for end users
-        - Repository method calls with proper parameters
-        """
-        # Arrange: Create test data
-        fake = Faker()
-        app, account = self._create_test_app_and_account(db_session_with_containers, mock_external_service_dependencies)
-
-        # Create workflow run
-        workflow_run = self._create_test_workflow_run(db_session_with_containers, app, account, "debugging")
-
-        # Create end user
-        from models.model import EndUser
-
-        end_user = EndUser(
-            tenant_id=app.tenant_id,
-            app_id=app.id,
-            type=EndUserType.BROWSER,
-            is_anonymous=False,
-            session_id=str(uuid.uuid4()),
-            external_user_id=str(uuid.uuid4()),
-            name=fake.name(),
-        )
-        db_session_with_containers.add(end_user)
-        db_session_with_containers.commit()
-
-        # Create node execution
-        from models.workflow import WorkflowNodeExecutionModel
-
-        node_execution = WorkflowNodeExecutionModel(
-            tenant_id=app.tenant_id,
-            app_id=app.id,
-            workflow_id=workflow_run.workflow_id,
-            triggered_from="workflow-run",
-            workflow_run_id=workflow_run.id,
-            index=0,
-            node_id="node_0",
-            node_type="llm",
-            title="Node 0",
-            inputs=json.dumps({"input": "test_input"}),
-            process_data=json.dumps({"process": "test_process"}),
-            status="succeeded",
-            elapsed_time=0.5,
-            execution_metadata=json.dumps({"tokens": 50}),
-            created_by_role=CreatorUserRole.END_USER,
-            created_by=end_user.id,
-            created_at=datetime.now(UTC),
-        )
-        db_session_with_containers.add(node_execution)
-        db_session_with_containers.commit()
-
-        # Act: Execute the method under test
-        workflow_run_service = WorkflowRunService()
-        result = workflow_run_service.get_workflow_run_node_executions(app, workflow_run.id, end_user)
-
-        # Assert: Verify the expected outcomes
-        assert result is not None
-        assert len(result) == 1
-
-        # Verify node execution properties
-        node_exec = result[0]
-        assert node_exec.tenant_id == app.tenant_id
-        assert node_exec.app_id == app.id
-        assert node_exec.workflow_run_id == workflow_run.id
-        assert node_exec.created_by == end_user.id
-        assert node_exec.created_by_role == CreatorUserRole.END_USER

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_pause_details_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_pause_details_api.py
@@ -1,192 +1,110 @@
-"""Console workflow pause-detail tests backed by persisted workflow execution state."""
+"""Controller tests for Console workflow pause details."""
 
 from __future__ import annotations
 
-import inspect
-from dataclasses import dataclass
 from datetime import datetime
+from inspect import unwrap
+from types import SimpleNamespace
 from unittest.mock import Mock
-from uuid import uuid4
 
 import pytest
 from flask import Flask
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session
 
 from controllers.common.errors import NotFoundError
 from controllers.console.app import workflow_run as workflow_run_module
-from core.workflow.nodes.human_input.entities import ParagraphInputConfig, UserActionConfig
-from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
-from graphon.enums import WorkflowExecutionStatus
-from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
-from models.workflow import WorkflowPause, WorkflowRun, WorkflowType
+from machinery.context import RequestContext
+from services.workflow_run_service import WorkflowRunPauseDetails, WorkflowRunPausedNode
 
 
-@dataclass(frozen=True)
-class _Database:
-    engine: Engine
-    session: Session
-
-
-def _persist_run(
-    session: Session,
-    *,
-    run_id: str,
-    tenant_id: str,
-    status: WorkflowExecutionStatus,
-    paused: bool = False,
-) -> WorkflowRun:
-    workflow_id = str(uuid4())
-    workflow_run = WorkflowRun(
-        id=run_id,
-        tenant_id=tenant_id,
-        app_id=str(uuid4()),
-        workflow_id=workflow_id,
-        type=WorkflowType.WORKFLOW,
-        triggered_from=WorkflowRunTriggeredFrom.DEBUGGING,
-        version="draft",
-        graph="{}",
-        inputs="{}",
-        status=status,
-        created_by_role=CreatorUserRole.ACCOUNT,
-        created_by=str(uuid4()),
-        created_at=datetime(2024, 1, 1, 12, 0, 0),
+def _request_context(*, workspace_id: str = "tenant-1") -> RequestContext:
+    return RequestContext(
+        request_id="request-1",
+        trace_id="trace-1",
+        account_id="account-1",
+        active_workspace_id=workspace_id,
     )
-    session.add(workflow_run)
-    if paused:
-        session.add(
-            WorkflowPause(
-                workflow_id=workflow_id,
-                workflow_run_id=run_id,
-                state_object_key="workflow-pauses/state.json",
-            )
-        )
-    session.commit()
-    return workflow_run
 
 
-class _PauseEntity:
-    def __init__(self, paused_at: datetime, reasons: list[HumanInputRequired]):
-        self.paused_at = paused_at
-        self._reasons = reasons
-
-    def get_pause_reasons(self):
-        return self._reasons
-
-
-def test_pause_details_returns_backstage_input_url(
-    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-) -> None:
-    monkeypatch.setattr(workflow_run_module.dify_config, "APP_WEB_URL", "https://web.example.com")
-
-    tenant_id = str(uuid4())
-    run_id = str(uuid4())
-    _persist_run(
-        sqlite_session,
-        run_id=run_id,
-        tenant_id=tenant_id,
-        status=WorkflowExecutionStatus.PAUSED,
-        paused=True,
-    )
+def _mock_application_services(monkeypatch: pytest.MonkeyPatch, workflow_runs: Mock) -> None:
     monkeypatch.setattr(
         workflow_run_module,
-        "db",
-        _Database(engine=sqlite_session.get_bind(), session=sqlite_session),
+        "application_services",
+        lambda: SimpleNamespace(workflow_runs=workflow_runs),
     )
 
-    reason = HumanInputRequired(
-        form_id="form-1",
-        form_content="content",
-        inputs=[ParagraphInputConfig(output_variable_name="name")],
-        actions=[UserActionConfig(id="approve", title="Approve")],
-        node_id="node-1",
-        node_title="Ask Name",
-    )
-    pause_entity = _PauseEntity(paused_at=datetime(2024, 1, 1, 12, 0, 0), reasons=[reason])
 
-    repo = Mock()
-    repo.get_workflow_pause.return_value = pause_entity
-    monkeypatch.setattr(
-        workflow_run_module.DifyAPIRepositoryFactory,
-        "create_api_workflow_run_repository",
-        lambda *_, **__: repo,
+def test_pause_details_returns_backstage_input_url(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(workflow_run_module.dify_config, "APP_WEB_URL", "https://web.example.com/")
+    workflow_runs = Mock()
+    workflow_runs.get_pause_details.return_value = WorkflowRunPauseDetails(
+        paused_at=datetime(2024, 1, 1, 12, 0, 0),
+        paused_nodes=(
+            WorkflowRunPausedNode(
+                node_id="node-1",
+                node_title="Ask Name",
+                form_id="form-1",
+                form_token="backstage-token",
+            ),
+        ),
     )
-    monkeypatch.setattr(
-        workflow_run_module,
-        "_load_form_tokens_by_form_id",
-        lambda _form_ids: {"form-1": "backstage-token"},
-    )
+    _mock_application_services(monkeypatch, workflow_runs)
+    request_context = _request_context()
 
-    with app.test_request_context(f"/console/api/workflow/{run_id}/pause-details", method="GET"):
-        handler = inspect.unwrap(workflow_run_module.ConsoleWorkflowPauseDetailsApi.get)
-        response, status = handler(
-            workflow_run_module.ConsoleWorkflowPauseDetailsApi(),
-            tenant_id,
-            workflow_run_id=run_id,
-        )
+    api = workflow_run_module.ConsoleWorkflowPauseDetailsApi()
+    handler = unwrap(api.get)
+    with app.test_request_context("/console/api/workflow/run-1/pause-details", method="GET"):
+        response, status = handler(api, request_context, workflow_run_id="run-1")
 
     assert status == 200
-    assert response["paused_at"] == "2024-01-01T12:00:00Z"
-    assert response["paused_nodes"][0]["node_id"] == "node-1"
-    assert response["paused_nodes"][0]["pause_type"]["type"] == "human_input"
-    assert (
-        response["paused_nodes"][0]["pause_type"]["backstage_input_url"]
-        == "https://web.example.com/form/backstage-token"
-    )
-    assert "pending_human_inputs" not in response
-
-
-def test_pause_details_tenant_isolation(app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
-    monkeypatch.setattr(workflow_run_module.dify_config, "APP_WEB_URL", "https://web.example.com")
-
-    run_id = str(uuid4())
-    _persist_run(
-        sqlite_session,
-        run_id=run_id,
-        tenant_id=str(uuid4()),
-        status=WorkflowExecutionStatus.PAUSED,
-        paused=True,
-    )
-    monkeypatch.setattr(
-        workflow_run_module,
-        "db",
-        _Database(engine=sqlite_session.get_bind(), session=sqlite_session),
+    assert response == {
+        "paused_at": "2024-01-01T12:00:00Z",
+        "paused_nodes": [
+            {
+                "node_id": "node-1",
+                "node_title": "Ask Name",
+                "pause_type": {
+                    "type": "human_input",
+                    "form_id": "form-1",
+                    "backstage_input_url": "https://web.example.com/form/backstage-token",
+                },
+            }
+        ],
+    }
+    workflow_runs.get_pause_details.assert_called_once_with(
+        request_context,
+        workflow_run_id="run-1",
     )
 
-    handler = inspect.unwrap(workflow_run_module.ConsoleWorkflowPauseDetailsApi.get)
-    with app.test_request_context(f"/console/api/workflow/{run_id}/pause-details", method="GET"):
-        with pytest.raises(NotFoundError):
-            handler(
-                workflow_run_module.ConsoleWorkflowPauseDetailsApi(),
-                str(uuid4()),
-                workflow_run_id=run_id,
-            )
 
-
-def test_pause_details_returns_empty_response_for_non_paused_run(
-    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+def test_pause_details_maps_missing_or_inaccessible_run_to_not_found(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    tenant_id = str(uuid4())
-    run_id = str(uuid4())
-    _persist_run(
-        sqlite_session,
-        run_id=run_id,
-        tenant_id=tenant_id,
-        status=WorkflowExecutionStatus.RUNNING,
-    )
-    monkeypatch.setattr(
-        workflow_run_module,
-        "db",
-        _Database(engine=sqlite_session.get_bind(), session=sqlite_session),
+    workflow_runs = Mock()
+    workflow_runs.get_pause_details.return_value = None
+    _mock_application_services(monkeypatch, workflow_runs)
+    request_context = _request_context(workspace_id="other-tenant")
+    api = workflow_run_module.ConsoleWorkflowPauseDetailsApi()
+    handler = unwrap(api.get)
+
+    with app.test_request_context("/console/api/workflow/run-1/pause-details", method="GET"):
+        with pytest.raises(NotFoundError, match="Workflow run not found"):
+            handler(api, request_context, workflow_run_id="run-1")
+
+    workflow_runs.get_pause_details.assert_called_once_with(
+        request_context,
+        workflow_run_id="run-1",
     )
 
-    with app.test_request_context(f"/console/api/workflow/{run_id}/pause-details", method="GET"):
-        handler = inspect.unwrap(workflow_run_module.ConsoleWorkflowPauseDetailsApi.get)
-        response, status = handler(
-            workflow_run_module.ConsoleWorkflowPauseDetailsApi(),
-            tenant_id,
-            workflow_run_id=run_id,
-        )
+
+def test_pause_details_returns_empty_response_for_non_paused_run(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_runs = Mock()
+    workflow_runs.get_pause_details.return_value = WorkflowRunPauseDetails(paused_at=None, paused_nodes=())
+    _mock_application_services(monkeypatch, workflow_runs)
+
+    api = workflow_run_module.ConsoleWorkflowPauseDetailsApi()
+    handler = unwrap(api.get)
+    with app.test_request_context("/console/api/workflow/run-1/pause-details", method="GET"):
+        response, status = handler(api, _request_context(), workflow_run_id="run-1")
 
     assert status == 200
     assert response == {"paused_at": None, "paused_nodes": []}

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_run_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_run_api.py
@@ -3,15 +3,20 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from inspect import unwrap
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from flask import Flask
 from flask_restx import marshal
 from sqlalchemy.orm import Session
 
+from controllers.common.errors import NotFoundError
 from controllers.console.app import workflow_run as workflow_run_module
+from extensions.ext_database import db
 from graphon.enums import WorkflowExecutionStatus, WorkflowNodeExecutionStatus
+from machinery.context import RequestContext
 from models import Account, App, AppMode
 from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
 from models.model import IconType
@@ -55,6 +60,23 @@ def _app() -> App:
         enable_site=True,
         enable_api=True,
         max_active_requests=None,
+    )
+
+
+def _request_context(*, workspace_id: str = "tenant-1") -> RequestContext:
+    return RequestContext(
+        request_id="request-1",
+        trace_id="trace-1",
+        account_id="account-1",
+        active_workspace_id=workspace_id,
+    )
+
+
+def _mock_application_services(monkeypatch: pytest.MonkeyPatch, workflow_runs: Mock) -> None:
+    monkeypatch.setattr(
+        workflow_run_module,
+        "application_services",
+        lambda: SimpleNamespace(workflow_runs=workflow_runs),
     )
 
 
@@ -129,17 +151,15 @@ def test_workflow_run_list_returns_frontend_history_contract(
 ) -> None:
     _account(sqlite_session)
     workflow_run = _workflow_run_summary(sqlite_session)
-
-    class WorkflowRunService:
-        def get_paginate_workflow_runs(self, **_kwargs):
-            return {
-                "limit": 10,
-                "has_more": False,
-                "data": [workflow_run],
-            }
-
-    monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
-    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
+    workflow_runs = Mock()
+    workflow_runs.get_paginate_workflow_runs.return_value = {
+        "limit": 10,
+        "has_more": False,
+        "data": [workflow_run],
+    }
+    _mock_application_services(monkeypatch, workflow_runs)
+    monkeypatch.setattr(db, "session", sqlite_session)
+    request_context = _request_context()
 
     api = workflow_run_module.WorkflowRunListApi()
     handler = unwrap(api.get)
@@ -148,6 +168,7 @@ def test_workflow_run_list_returns_frontend_history_contract(
         payload = handler(
             api,
             workflow_run_module.WorkflowRunListQuery(limit=10),
+            request_context,
             app_model=_app(),
         )
 
@@ -168,6 +189,12 @@ def test_workflow_run_list_returns_frontend_history_contract(
         "exceptions_count": 0,
         "retry_index": 0,
     }
+    workflow_runs.get_paginate_workflow_runs.assert_called_once_with(
+        request_context,
+        app_id="app-1",
+        args={"limit": 10},
+        triggered_from=WorkflowRunTriggeredFrom.DEBUGGING,
+    )
 
 
 def test_advanced_chat_workflow_run_list_keeps_message_fields(
@@ -179,17 +206,15 @@ def test_advanced_chat_workflow_run_list_keeps_message_fields(
         conversation_id="conversation-1",
         message_id="message-1",
     )
-
-    class WorkflowRunService:
-        def get_paginate_advanced_chat_workflow_runs(self, **_kwargs):
-            return {
-                "limit": 1,
-                "has_more": True,
-                "data": [workflow_run],
-            }
-
-    monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
-    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
+    workflow_runs = Mock()
+    workflow_runs.get_paginate_advanced_chat_workflow_runs.return_value = {
+        "limit": 1,
+        "has_more": True,
+        "data": [workflow_run],
+    }
+    _mock_application_services(monkeypatch, workflow_runs)
+    monkeypatch.setattr(db, "session", sqlite_session)
+    request_context = _request_context()
 
     api = workflow_run_module.AdvancedChatAppWorkflowRunListApi()
     handler = unwrap(api.get)
@@ -198,6 +223,7 @@ def test_advanced_chat_workflow_run_list_keeps_message_fields(
         payload = handler(
             api,
             workflow_run_module.WorkflowRunListQuery(limit=1),
+            request_context,
             app_model=_app(),
         )
 
@@ -205,6 +231,52 @@ def test_advanced_chat_workflow_run_list_keeps_message_fields(
 
     assert response["data"][0]["conversation_id"] == "conversation-1"
     assert response["data"][0]["message_id"] == "message-1"
+    workflow_runs.get_paginate_advanced_chat_workflow_runs.assert_called_once_with(
+        request_context,
+        app_id="app-1",
+        args={"limit": 1},
+        triggered_from=WorkflowRunTriggeredFrom.DEBUGGING,
+    )
+
+
+def test_workflow_run_count_passes_filters_to_application_service(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_runs = Mock()
+    workflow_runs.get_workflow_runs_count.return_value = {
+        "total": 2,
+        "running": 0,
+        "succeeded": 2,
+        "failed": 0,
+        "stopped": 0,
+        "partial-succeeded": 0,
+    }
+    _mock_application_services(monkeypatch, workflow_runs)
+    request_context = _request_context()
+    query = workflow_run_module.WorkflowRunCountQuery(
+        status="succeeded",
+        time_range="7d",
+        triggered_from="app-run",
+    )
+
+    api = workflow_run_module.WorkflowRunCountApi()
+    handler = unwrap(api.get)
+    with app.test_request_context("/apps/app-1/workflow-runs/count", method="GET"):
+        payload = handler(api, query, request_context, app_model=_app())
+
+    assert payload == {
+        "total": 2,
+        "running": 0,
+        "succeeded": 2,
+        "failed": 0,
+        "stopped": 0,
+        "partial_succeeded": 0,
+    }
+    workflow_runs.get_workflow_runs_count.assert_called_once_with(
+        request_context,
+        app_id="app-1",
+        status="succeeded",
+        time_range="7d",
+        triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+    )
 
 
 def test_workflow_run_detail_returns_frontend_detail_contract(
@@ -212,19 +284,17 @@ def test_workflow_run_detail_returns_frontend_detail_contract(
 ) -> None:
     _account(sqlite_session)
     workflow_run = _workflow_run_summary(sqlite_session)
-
-    class WorkflowRunService:
-        def get_workflow_run(self, **_kwargs):
-            return workflow_run
-
-    monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
-    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
+    workflow_runs = Mock()
+    workflow_runs.get_workflow_run.return_value = workflow_run
+    _mock_application_services(monkeypatch, workflow_runs)
+    monkeypatch.setattr(db, "session", sqlite_session)
+    request_context = _request_context()
 
     api = workflow_run_module.WorkflowRunDetailApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/apps/app-1/workflow-runs/run-1", method="GET"):
-        payload = handler(api, app_model=_app(), run_id="run-1")
+        payload = handler(api, request_context, app_model=_app(), run_id="run-1")
 
     response = _serialize_200_response(api.get, payload)
 
@@ -246,26 +316,48 @@ def test_workflow_run_detail_returns_frontend_detail_contract(
         "finished_at": 1767323045,
         "exceptions_count": 0,
     }
+    workflow_runs.get_workflow_run.assert_called_once_with(
+        request_context,
+        app_id="app-1",
+        run_id="run-1",
+    )
+
+
+def test_workflow_run_detail_maps_missing_run_to_not_found(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_runs = Mock()
+    workflow_runs.get_workflow_run.return_value = None
+    _mock_application_services(monkeypatch, workflow_runs)
+    request_context = _request_context(workspace_id="tenant-2")
+    api = workflow_run_module.WorkflowRunDetailApi()
+    handler = unwrap(api.get)
+
+    with app.test_request_context("/apps/app-1/workflow-runs/run-1", method="GET"):
+        with pytest.raises(NotFoundError, match="Workflow run not found"):
+            handler(api, request_context, app_model=_app(), run_id="run-1")
+
+    workflow_runs.get_workflow_run.assert_called_once_with(
+        request_context,
+        app_id="app-1",
+        run_id="run-1",
+    )
 
 
 def test_workflow_run_node_executions_return_frontend_trace_contract(
     app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
 ) -> None:
-    account = _account(sqlite_session)
+    _account(sqlite_session)
     execution = _workflow_run_node_execution(sqlite_session)
-
-    class WorkflowRunService:
-        def get_workflow_run_node_executions(self, **_kwargs):
-            return [execution]
-
-    monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
-    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
+    workflow_runs = Mock()
+    workflow_runs.get_workflow_run_node_executions.return_value = [execution]
+    _mock_application_services(monkeypatch, workflow_runs)
+    monkeypatch.setattr(db, "session", sqlite_session)
+    request_context = _request_context()
 
     api = workflow_run_module.WorkflowRunNodeExecutionListApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/apps/app-1/workflow-runs/run-1/node-executions", method="GET"):
-        payload = handler(api, account, app_model=_app(), run_id="run-1")
+        payload = handler(api, request_context, app_model=_app(), run_id="run-1")
 
     response = _serialize_200_response(api.get, payload)
 
@@ -297,3 +389,8 @@ def test_workflow_run_node_executions_return_frontend_trace_contract(
             }
         ]
     }
+    workflow_runs.get_workflow_run_node_executions.assert_called_once_with(
+        request_context,
+        app_id="app-1",
+        run_id="run-1",
+    )

--- a/api/tests/unit_tests/extensions/test_ext_application_services.py
+++ b/api/tests/unit_tests/extensions/test_ext_application_services.py
@@ -41,6 +41,7 @@ from services.init_validation_service import InvalidInitializationPasswordError
 from services.partner_tenant_binding_service import PartnerTenantBindingService
 from services.tag_application_service import TagApplicationService
 from services.webapp_access_query_service import WebAppAccessUnavailableError
+from services.workflow_run_service import WorkflowRunService
 
 
 @pytest.mark.parametrize(
@@ -192,6 +193,20 @@ def test_build_application_services_wires_app_site_boundary(
     assert isinstance(services.app_sites, AppSiteService)
     assert isinstance(services.app_sites._sites, AppSiteCommandRepository)
     assert services.app_sites._sites._session_factory is sqlite_session_factory
+
+
+def test_build_application_services_wires_workflow_run_service(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    services = ext_application_services.build_application_services(
+        database_client=sqlite_session_factory,
+        deployment_edition=DeploymentEdition.COMMUNITY,
+        initialization_password="",
+        redis=MagicMock(spec=RedisClientWrapper),
+    )
+
+    assert isinstance(services.workflow_runs, WorkflowRunService)
+    assert services.workflow_runs._session_factory is sqlite_session_factory
 
 
 def test_build_application_services_wires_billing_service(

--- a/api/tests/unit_tests/services/test_workflow_run_service.py
+++ b/api/tests/unit_tests/services/test_workflow_run_service.py
@@ -10,10 +10,9 @@ from sqlalchemy import Engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
 from graphon.enums import WorkflowExecutionStatus
-from models import Account, App, EndUser, Message, WorkflowRun, WorkflowRunTriggeredFrom, WorkflowType
-from models.account import Tenant
-from models.enums import ConversationFromSource, CreatorUserRole, EndUserType
-from models.model import AppMode
+from machinery.context import RequestContext
+from models import Message, WorkflowRun, WorkflowRunTriggeredFrom, WorkflowType
+from models.enums import ConversationFromSource, CreatorUserRole
 from services import workflow_run_service as service_module
 from services.workflow_run_service import WorkflowRunService
 
@@ -30,33 +29,12 @@ def repository_factory_mocks(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock
     return node_repo, workflow_run_repo, factory
 
 
-def _app_model(*, app_id: str = "app-1", tenant_id: str = "tenant-1") -> App:
-    return App(
-        id=app_id,
-        tenant_id=tenant_id,
-        name="Workflow App",
-        mode=AppMode.ADVANCED_CHAT,
-        enable_site=False,
-        enable_api=False,
-    )
-
-
-def _account(*, account_id: str = "account-1", current_tenant_id: str | None = "tenant-1") -> Account:
-    account = Account(name="Workflow User", email=f"{account_id}@example.com")
-    account.id = account_id
-    if current_tenant_id is not None:
-        tenant = Tenant(name="Workflow Tenant")
-        tenant.id = current_tenant_id
-        account._current_tenant = tenant
-    return account
-
-
-def _end_user(*, end_user_id: str = "end-user-1", tenant_id: str = "tenant-1") -> EndUser:
-    return EndUser(
-        id=end_user_id,
-        tenant_id=tenant_id,
-        type=EndUserType.SERVICE_API,
-        session_id=f"session-{end_user_id}",
+def _request_context(*, workspace_id: str | None = "tenant-1") -> RequestContext:
+    return RequestContext(
+        request_id="request-1",
+        trace_id="trace-1",
+        account_id="account-1",
+        active_workspace_id=workspace_id,
     )
 
 
@@ -98,31 +76,6 @@ def _message(*, message_id: str, workflow_run_id: str, conversation_id: str) -> 
 
 
 class TestWorkflowRunServiceInitialization:
-    def test___init___should_create_sessionmaker_from_db_engine_when_session_factory_missing(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        sqlite_engine: Engine,
-    ) -> None:
-        monkeypatch.setattr(service_module, "db", SimpleNamespace(engine=sqlite_engine))
-
-        service = WorkflowRunService()
-
-        assert isinstance(service._session_factory, sessionmaker)
-        assert service._session_factory.kw["bind"] is sqlite_engine
-        assert service._session_factory.kw["expire_on_commit"] is False
-
-    def test___init___should_create_sessionmaker_when_engine_is_provided(
-        self,
-        repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        sqlite_engine: Engine,
-    ) -> None:
-        service = WorkflowRunService(session_factory=sqlite_engine)
-
-        assert isinstance(service._session_factory, sessionmaker)
-        assert service._session_factory.kw["bind"] is sqlite_engine
-        assert service._session_factory.kw["expire_on_commit"] is False
-
     def test___init___should_keep_provided_sessionmaker_and_create_repositories(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
@@ -138,6 +91,22 @@ class TestWorkflowRunServiceInitialization:
         factory.create_api_workflow_node_execution_repository.assert_called_once_with(sqlite_session_factory)
         factory.create_api_workflow_run_repository.assert_called_once_with(sqlite_session_factory)
 
+    def test___init___should_normalize_provided_engine_to_sessionmaker(
+        self,
+        repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
+        sqlite_session_factory: sessionmaker[Session],
+    ) -> None:
+        _, _, factory = repository_factory_mocks
+        engine = sqlite_session_factory.kw["bind"]
+        assert isinstance(engine, Engine)
+
+        service = WorkflowRunService(session_factory=engine)
+
+        assert service._session_factory.kw["bind"] is engine
+        assert service._session_factory.kw["expire_on_commit"] is False
+        factory.create_api_workflow_node_execution_repository.assert_called_once_with(service._session_factory)
+        factory.create_api_workflow_run_repository.assert_called_once_with(service._session_factory)
+
 
 class TestWorkflowRunServiceQueries:
     def test_get_paginate_workflow_runs_should_forward_filters_and_parse_limit(
@@ -147,13 +116,13 @@ class TestWorkflowRunServiceQueries:
     ) -> None:
         _, workflow_run_repo, _ = repository_factory_mocks
         service = WorkflowRunService(session_factory=sqlite_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
         expected = MagicMock(name="pagination")
         workflow_run_repo.get_paginated_workflow_runs.return_value = expected
         args = {"limit": "7", "last_id": "last-1", "status": "succeeded"}
 
         result = service.get_paginate_workflow_runs(
-            app_model=app_model,
+            _request_context(workspace_id="tenant-1"),
+            app_id="app-1",
             args=args,
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
@@ -177,7 +146,6 @@ class TestWorkflowRunServiceQueries:
         sqlite_session: Session,
     ) -> None:
         service = WorkflowRunService(session_factory=sqlite_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
         run_with_message = _workflow_run(status=WorkflowExecutionStatus.RUNNING)
         run_without_message = _workflow_run(run_id="run-2")
         pagination = SimpleNamespace(data=[run_with_message, run_without_message])
@@ -186,7 +154,11 @@ class TestWorkflowRunServiceQueries:
         sqlite_session.add(_message(message_id="msg-1", conversation_id="conv-1", workflow_run_id="run-1"))
         sqlite_session.commit()
 
-        result = service.get_paginate_advanced_chat_workflow_runs(app_model=app_model, args={"limit": "2"})
+        result = service.get_paginate_advanced_chat_workflow_runs(
+            _request_context(),
+            app_id="app-1",
+            args={"limit": "2"},
+        )
 
         assert result is pagination
         assert len(result.data) == 2
@@ -210,7 +182,6 @@ class TestWorkflowRunServiceQueries:
         run (N+1); they are now batch-loaded in a single query.
         """
         service = WorkflowRunService(session_factory=sqlite_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
         runs = [_workflow_run(run_id=f"run-{i}") for i in range(5)]
         pagination = SimpleNamespace(data=runs)
         monkeypatch.setattr(service, "get_paginate_workflow_runs", MagicMock(return_value=pagination))
@@ -224,7 +195,11 @@ class TestWorkflowRunServiceQueries:
         engine = sqlite_session.get_bind()
         event.listen(engine, "before_cursor_execute", count_message_query)
         try:
-            service.get_paginate_advanced_chat_workflow_runs(app_model=app_model, args={})
+            service.get_paginate_advanced_chat_workflow_runs(
+                _request_context(),
+                app_id="app-1",
+                args={},
+            )
         finally:
             event.remove(engine, "before_cursor_execute", count_message_query)
         assert all(not hasattr(run, "message_id") for run in runs)
@@ -237,11 +212,10 @@ class TestWorkflowRunServiceQueries:
     ) -> None:
         _, workflow_run_repo, _ = repository_factory_mocks
         service = WorkflowRunService(session_factory=sqlite_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
         expected = _workflow_run()
         workflow_run_repo.get_workflow_run_by_id.return_value = expected
 
-        result = service.get_workflow_run(app_model=app_model, run_id="run-1")
+        result = service.get_workflow_run(_request_context(), app_id="app-1", run_id="run-1")
 
         assert result is expected
         workflow_run_repo.get_workflow_run_by_id.assert_called_once_with(
@@ -257,12 +231,12 @@ class TestWorkflowRunServiceQueries:
     ) -> None:
         _, workflow_run_repo, _ = repository_factory_mocks
         service = WorkflowRunService(session_factory=sqlite_session_factory)
-        app_model = _app_model(tenant_id="tenant-1", app_id="app-1")
         expected = {"total": 3, "succeeded": 2}
         workflow_run_repo.get_workflow_runs_count.return_value = expected
 
         result = service.get_workflow_runs_count(
-            app_model=app_model,
+            _request_context(),
+            app_id="app-1",
             status="succeeded",
             time_range="7d",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
@@ -285,14 +259,16 @@ class TestWorkflowRunServiceQueries:
     ) -> None:
         service = WorkflowRunService(session_factory=sqlite_session_factory)
         monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=None))
-        app_model = _app_model(app_id="app-1")
-        user = _account(current_tenant_id="tenant-1")
 
-        result = service.get_workflow_run_node_executions(app_model=app_model, run_id="run-1", user=user)
+        result = service.get_workflow_run_node_executions(
+            _request_context(),
+            app_id="app-1",
+            run_id="run-1",
+        )
 
         assert result == []
 
-    def test_get_workflow_run_node_executions_should_use_end_user_tenant_id(
+    def test_get_workflow_run_node_executions_should_use_request_workspace(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
         monkeypatch: pytest.MonkeyPatch,
@@ -301,61 +277,32 @@ class TestWorkflowRunServiceQueries:
         node_repo, _, _ = repository_factory_mocks
         service = WorkflowRunService(session_factory=sqlite_session_factory)
         monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=_workflow_run()))
-        user = _end_user(tenant_id="tenant-end-user")
-        app_model = _app_model(app_id="app-1")
-        expected_executions = [SimpleNamespace(id="exec-1")]
-        expected_traces = [SimpleNamespace(id="exec-1:retry:1")]
-        node_repo.get_executions_by_workflow_run.return_value = expected_executions
-        mock_assemble = MagicMock(return_value=expected_traces)
-        monkeypatch.setattr(service_module, "assemble_workflow_node_execution_traces", mock_assemble)
-
-        result = service.get_workflow_run_node_executions(app_model=app_model, run_id="run-1", user=user)
-
-        assert result == expected_traces
-        node_repo.get_executions_by_workflow_run.assert_called_once_with(
-            tenant_id="tenant-end-user",
-            app_id="app-1",
-            workflow_run_id="run-1",
-        )
-        mock_assemble.assert_called_once_with(expected_executions, node_repo)
-
-    def test_get_workflow_run_node_executions_should_use_account_current_tenant_id(
-        self,
-        repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        monkeypatch: pytest.MonkeyPatch,
-        sqlite_session_factory: sessionmaker[Session],
-    ) -> None:
-        node_repo, _, _ = repository_factory_mocks
-        service = WorkflowRunService(session_factory=sqlite_session_factory)
-        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=_workflow_run()))
-        app_model = _app_model(app_id="app-1")
-        user = _account(current_tenant_id="tenant-account")
         expected_executions = [SimpleNamespace(id="exec-1"), SimpleNamespace(id="exec-2")]
         expected_traces = [SimpleNamespace(id="exec-1:retry:1"), SimpleNamespace(id="exec-1")]
         node_repo.get_executions_by_workflow_run.return_value = expected_executions
         mock_assemble = MagicMock(return_value=expected_traces)
         monkeypatch.setattr(service_module, "assemble_workflow_node_execution_traces", mock_assemble)
 
-        result = service.get_workflow_run_node_executions(app_model=app_model, run_id="run-1", user=user)
+        result = service.get_workflow_run_node_executions(
+            _request_context(workspace_id="tenant-context"),
+            app_id="app-1",
+            run_id="run-1",
+        )
 
         assert result == expected_traces
         node_repo.get_executions_by_workflow_run.assert_called_once_with(
-            tenant_id="tenant-account",
+            tenant_id="tenant-context",
             app_id="app-1",
             workflow_run_id="run-1",
         )
         mock_assemble.assert_called_once_with(expected_executions, node_repo)
 
-    def test_get_workflow_run_node_executions_should_raise_when_resolved_tenant_id_is_none(
+    def test_query_requires_active_workspace(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
-        monkeypatch: pytest.MonkeyPatch,
         sqlite_session_factory: sessionmaker[Session],
     ) -> None:
         service = WorkflowRunService(session_factory=sqlite_session_factory)
-        monkeypatch.setattr(service, "get_workflow_run", MagicMock(return_value=_workflow_run()))
-        app_model = _app_model(app_id="app-1")
-        user = _account(current_tenant_id=None)
 
-        with pytest.raises(ValueError, match="tenant_id cannot be None"):
-            service.get_workflow_run_node_executions(app_model=app_model, run_id="run-1", user=user)
+        with pytest.raises(RuntimeError, match="did not resolve an active workspace"):
+            service.get_workflow_run(_request_context(workspace_id=None), app_id="app-1", run_id="run-1")

--- a/api/tests/unit_tests/services/test_workflow_run_service_pause.py
+++ b/api/tests/unit_tests/services/test_workflow_run_service_pause.py
@@ -1,57 +1,140 @@
-"""Tests for the session lifecycle owned by ``WorkflowRunService``."""
+"""Tests for Console workflow pause details."""
 
-from unittest.mock import create_autospec, patch
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import Engine, text
 from sqlalchemy.orm import Session, sessionmaker
 
-from repositories.api_workflow_run_repository import APIWorkflowRunRepository
-from services.workflow_run_service import WorkflowRunService
+from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
+from graphon.enums import WorkflowExecutionStatus
+from machinery.context import RequestContext
+from services import workflow_run_service as service_module
+from services.workflow_run_service import WorkflowRunPauseDetails, WorkflowRunPausedNode, WorkflowRunService
 
 
 @pytest.fixture
-def sqlite_session_factory(sqlite_engine: Engine) -> sessionmaker[Session]:
-    """Return a real factory whose sessions are bound to the isolated SQLite engine."""
-    return sessionmaker(bind=sqlite_engine, expire_on_commit=False)
+def repository_factory_mocks(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MagicMock]:
+    node_repo = MagicMock()
+    workflow_run_repo = MagicMock()
+    factory = SimpleNamespace(
+        create_api_workflow_node_execution_repository=MagicMock(return_value=node_repo),
+        create_api_workflow_run_repository=MagicMock(return_value=workflow_run_repo),
+    )
+    monkeypatch.setattr(service_module, "DifyAPIRepositoryFactory", factory)
+    return node_repo, workflow_run_repo
 
 
-@pytest.fixture
-def workflow_run_repository():
-    """Keep the repository boundary mocked while exercising real session construction."""
-    return create_autospec(APIWorkflowRunRepository)
+def _request_context(*, workspace_id: str = "tenant-1") -> RequestContext:
+    return RequestContext(
+        request_id="request-1",
+        trace_id="trace-1",
+        account_id="account-1",
+        active_workspace_id=workspace_id,
+    )
 
 
-def test_init_with_session_factory(
-    sqlite_session_factory: sessionmaker[Session], workflow_run_repository: APIWorkflowRunRepository
+def test_get_pause_details_returns_none_when_run_is_not_found(
+    repository_factory_mocks: tuple[MagicMock, MagicMock],
+    sqlite_session_factory: sessionmaker[Session],
 ) -> None:
-    with patch("services.workflow_run_service.DifyAPIRepositoryFactory", autospec=True) as repository_factory:
-        repository_factory.create_api_workflow_run_repository.return_value = workflow_run_repository
+    _, workflow_run_repo = repository_factory_mocks
+    workflow_run_repo.get_workflow_run_by_id_and_tenant_id.return_value = None
+    service = WorkflowRunService(session_factory=sqlite_session_factory)
 
-        service = WorkflowRunService(sqlite_session_factory)
+    result = service.get_pause_details(_request_context(), workflow_run_id="run-1")
 
-    assert service._session_factory is sqlite_session_factory
-    repository_factory.create_api_workflow_run_repository.assert_called_once_with(sqlite_session_factory)
-    with service._session_factory() as session:
-        assert session.scalar(text("SELECT 1")) == 1
+    assert result is None
+    workflow_run_repo.get_workflow_run_by_id_and_tenant_id.assert_called_once_with(
+        tenant_id="tenant-1",
+        run_id="run-1",
+    )
+    workflow_run_repo.get_workflow_pause.assert_not_called()
 
 
-def test_init_with_engine_creates_bound_session_factory(
-    sqlite_engine: Engine, workflow_run_repository: APIWorkflowRunRepository
+def test_get_pause_details_returns_empty_details_for_non_paused_run(
+    repository_factory_mocks: tuple[MagicMock, MagicMock],
+    sqlite_session_factory: sessionmaker[Session],
 ) -> None:
-    with patch("services.workflow_run_service.DifyAPIRepositoryFactory", autospec=True) as repository_factory:
-        repository_factory.create_api_workflow_run_repository.return_value = workflow_run_repository
+    _, workflow_run_repo = repository_factory_mocks
+    workflow_run_repo.get_workflow_run_by_id_and_tenant_id.return_value = SimpleNamespace(
+        status=WorkflowExecutionStatus.SUCCEEDED
+    )
+    service = WorkflowRunService(session_factory=sqlite_session_factory)
 
-        service = WorkflowRunService(sqlite_engine)
+    result = service.get_pause_details(_request_context(), workflow_run_id="run-1")
 
-    assert service._session_factory.kw["bind"] is sqlite_engine
-    assert service._session_factory.kw["expire_on_commit"] is False
-    repository_factory.create_api_workflow_run_repository.assert_called_once_with(service._session_factory)
-    with service._session_factory() as session:
-        assert session.scalar(text("SELECT 1")) == 1
+    assert result == WorkflowRunPauseDetails(paused_at=None, paused_nodes=())
+    workflow_run_repo.get_workflow_pause.assert_not_called()
 
 
-def test_init_with_default_repository_dependencies(sqlite_session_factory: sessionmaker[Session]) -> None:
-    service = WorkflowRunService(sqlite_session_factory)
+def test_get_pause_details_maps_human_input_and_loads_token_with_explicit_session(
+    monkeypatch: pytest.MonkeyPatch,
+    repository_factory_mocks: tuple[MagicMock, MagicMock],
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _, workflow_run_repo = repository_factory_mocks
+    workflow_run_repo.get_workflow_run_by_id_and_tenant_id.return_value = SimpleNamespace(
+        status=WorkflowExecutionStatus.PAUSED
+    )
+    reason = HumanInputRequired(
+        form_id="form-1",
+        form_content="Approve?",
+        node_id="node-1",
+        node_title="Approval",
+    )
+    paused_at = datetime(2026, 1, 2, 3, 4, 5)
+    pause_entity = MagicMock()
+    pause_entity.paused_at = paused_at
+    pause_entity.get_pause_reasons.return_value = [reason]
+    workflow_run_repo.get_workflow_pause.return_value = pause_entity
+    token_loader_sessions: list[Session] = []
 
-    assert service._session_factory is sqlite_session_factory
+    def load_form_tokens(form_ids: list[str], *, session: Session) -> dict[str, str]:
+        assert form_ids == ["form-1"]
+        token_loader_sessions.append(session)
+        return {"form-1": "form-token"}
+
+    monkeypatch.setattr(service_module, "_load_form_tokens_by_form_id", load_form_tokens)
+    service = WorkflowRunService(session_factory=sqlite_session_factory)
+
+    result = service.get_pause_details(
+        _request_context(workspace_id="tenant-context"),
+        workflow_run_id="run-1",
+    )
+
+    assert result == WorkflowRunPauseDetails(
+        paused_at=paused_at,
+        paused_nodes=(
+            WorkflowRunPausedNode(
+                node_id="node-1",
+                node_title="Approval",
+                form_id="form-1",
+                form_token="form-token",
+            ),
+        ),
+    )
+    workflow_run_repo.get_workflow_run_by_id_and_tenant_id.assert_called_once_with(
+        tenant_id="tenant-context",
+        run_id="run-1",
+    )
+    assert len(token_loader_sessions) == 1
+    assert token_loader_sessions[0].get_bind() is sqlite_session_factory.kw["bind"]
+
+
+def test_get_pause_details_rejects_unknown_pause_reason(
+    repository_factory_mocks: tuple[MagicMock, MagicMock],
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _, workflow_run_repo = repository_factory_mocks
+    workflow_run_repo.get_workflow_run_by_id_and_tenant_id.return_value = SimpleNamespace(
+        status=WorkflowExecutionStatus.PAUSED
+    )
+    pause_entity = MagicMock()
+    pause_entity.get_pause_reasons.return_value = [object()]
+    workflow_run_repo.get_workflow_pause.return_value = pause_entity
+    service = WorkflowRunService(session_factory=sqlite_session_factory)
+
+    with pytest.raises(AssertionError, match="unimplemented"):
+        service.get_pause_details(_request_context(), workflow_run_id="run-1")

--- a/packages/contracts/generated/api/console/apps/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/apps/orpc.gen.ts
@@ -168,8 +168,6 @@ import {
   zGetAppsByAppIdWorkflowCommentsMentionUsersResponse,
   zGetAppsByAppIdWorkflowCommentsPath,
   zGetAppsByAppIdWorkflowCommentsResponse,
-  zGetAppsByAppIdWorkflowRunsByRunIdExportPath,
-  zGetAppsByAppIdWorkflowRunsByRunIdExportResponse,
   zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsPath,
   zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsResponse,
   zGetAppsByAppIdWorkflowRunsByRunIdPath,
@@ -2680,30 +2678,11 @@ export const tasks = {
 }
 
 /**
- * Generate a download URL for an archived workflow run.
- */
-export const get50 = oc
-  .route({
-    description: 'Generate a download URL for an archived workflow run.',
-    inputStructure: 'detailed',
-    method: 'GET',
-    operationId: 'getAppsByAppIdWorkflowRunsByRunIdExport',
-    path: '/apps/{app_id}/workflow-runs/{run_id}/export',
-    tags: ['console'],
-  })
-  .input(z.object({ params: zGetAppsByAppIdWorkflowRunsByRunIdExportPath }))
-  .output(zGetAppsByAppIdWorkflowRunsByRunIdExportResponse)
-
-export const export4 = {
-  get: get50,
-}
-
-/**
  * Get workflow run node execution list
  *
  * Get workflow run node execution list
  */
-export const get51 = oc
+export const get50 = oc
   .route({
     description: 'Get workflow run node execution list',
     inputStructure: 'detailed',
@@ -2717,7 +2696,7 @@ export const get51 = oc
   .output(zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsResponse)
 
 export const nodeExecutions = {
-  get: get51,
+  get: get50,
 }
 
 /**
@@ -2725,7 +2704,7 @@ export const nodeExecutions = {
  *
  * Get workflow run detail
  */
-export const get52 = oc
+export const get51 = oc
   .route({
     description: 'Get workflow run detail',
     inputStructure: 'detailed',
@@ -2739,8 +2718,7 @@ export const get52 = oc
   .output(zGetAppsByAppIdWorkflowRunsByRunIdResponse)
 
 export const byRunId = {
-  get: get52,
-  export: export4,
+  get: get51,
   nodeExecutions,
 }
 
@@ -2772,7 +2750,7 @@ export const download4 = {
 /**
  * Read a text/binary preview file in a workflow Agent node sandbox
  */
-export const get53 = oc
+export const get52 = oc
   .route({
     description: 'Read a text/binary preview file in a workflow Agent node sandbox',
     inputStructure: 'detailed',
@@ -2790,13 +2768,13 @@ export const get53 = oc
   .output(zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesReadResponse)
 
 export const read = {
-  get: get53,
+  get: get52,
 }
 
 /**
  * List a directory in a workflow Agent node sandbox
  */
-export const get54 = oc
+export const get53 = oc
   .route({
     description: 'List a directory in a workflow Agent node sandbox',
     inputStructure: 'detailed',
@@ -2814,7 +2792,7 @@ export const get54 = oc
   .output(zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesResponse)
 
 export const files3 = {
-  get: get54,
+  get: get53,
   download: download4,
   read,
 }
@@ -2840,7 +2818,7 @@ export const byWorkflowRunId = {
  *
  * Get workflow run list
  */
-export const get55 = oc
+export const get54 = oc
   .route({
     description: 'Get workflow run list',
     inputStructure: 'detailed',
@@ -2859,7 +2837,7 @@ export const get55 = oc
   .output(zGetAppsByAppIdWorkflowRunsResponse)
 
 export const workflowRuns2 = {
-  get: get55,
+  get: get54,
   count: count3,
   tasks,
   byRunId,
@@ -2871,7 +2849,7 @@ export const workflowRuns2 = {
  *
  * Get all users in current tenant for mentions
  */
-export const get56 = oc
+export const get55 = oc
   .route({
     description: 'Get all users in current tenant for mentions',
     inputStructure: 'detailed',
@@ -2885,7 +2863,7 @@ export const get56 = oc
   .output(zGetAppsByAppIdWorkflowCommentsMentionUsersResponse)
 
 export const mentionUsers = {
-  get: get56,
+  get: get55,
 }
 
 /**
@@ -3010,7 +2988,7 @@ export const delete10 = oc
  *
  * Get a specific workflow comment
  */
-export const get57 = oc
+export const get56 = oc
   .route({
     description: 'Get a specific workflow comment',
     inputStructure: 'detailed',
@@ -3048,7 +3026,7 @@ export const put3 = oc
 
 export const byCommentId = {
   delete: delete10,
-  get: get57,
+  get: get56,
   put: put3,
   replies,
   resolve,
@@ -3059,7 +3037,7 @@ export const byCommentId = {
  *
  * Get all comments for a workflow
  */
-export const get58 = oc
+export const get57 = oc
   .route({
     description: 'Get all comments for a workflow',
     inputStructure: 'detailed',
@@ -3097,7 +3075,7 @@ export const post42 = oc
   .output(zPostAppsByAppIdWorkflowCommentsResponse)
 
 export const comments = {
-  get: get58,
+  get: get57,
   post: post42,
   mentionUsers,
   byCommentId,
@@ -3106,7 +3084,7 @@ export const comments = {
 /**
  * Get workflow average app interaction statistics
  */
-export const get59 = oc
+export const get58 = oc
   .route({
     description: 'Get workflow average app interaction statistics',
     inputStructure: 'detailed',
@@ -3124,13 +3102,13 @@ export const get59 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsAverageAppInteractionsResponse)
 
 export const averageAppInteractions = {
-  get: get59,
+  get: get58,
 }
 
 /**
  * Get workflow daily runs statistics
  */
-export const get60 = oc
+export const get59 = oc
   .route({
     description: 'Get workflow daily runs statistics',
     inputStructure: 'detailed',
@@ -3148,13 +3126,13 @@ export const get60 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsDailyConversationsResponse)
 
 export const dailyConversations2 = {
-  get: get60,
+  get: get59,
 }
 
 /**
  * Get workflow daily terminals statistics
  */
-export const get61 = oc
+export const get60 = oc
   .route({
     description: 'Get workflow daily terminals statistics',
     inputStructure: 'detailed',
@@ -3172,13 +3150,13 @@ export const get61 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsDailyTerminalsResponse)
 
 export const dailyTerminals = {
-  get: get61,
+  get: get60,
 }
 
 /**
  * Get workflow daily token cost statistics
  */
-export const get62 = oc
+export const get61 = oc
   .route({
     description: 'Get workflow daily token cost statistics',
     inputStructure: 'detailed',
@@ -3196,7 +3174,7 @@ export const get62 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsTokenCostsResponse)
 
 export const tokenCosts2 = {
-  get: get62,
+  get: get61,
 }
 
 export const statistics2 = {
@@ -3216,7 +3194,7 @@ export const workflow = {
  *
  * Get default block configuration by type
  */
-export const get63 = oc
+export const get62 = oc
   .route({
     description: 'Get default block configuration by type',
     inputStructure: 'detailed',
@@ -3235,7 +3213,7 @@ export const get63 = oc
   .output(zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsByBlockTypeResponse)
 
 export const byBlockType = {
-  get: get63,
+  get: get62,
 }
 
 /**
@@ -3243,7 +3221,7 @@ export const byBlockType = {
  *
  * Get default block configurations for workflow
  */
-export const get64 = oc
+export const get63 = oc
   .route({
     description: 'Get default block configurations for workflow',
     inputStructure: 'detailed',
@@ -3257,14 +3235,14 @@ export const get64 = oc
   .output(zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsResponse)
 
 export const defaultWorkflowBlockConfigs = {
-  get: get64,
+  get: get63,
   byBlockType,
 }
 
 /**
  * Get conversation variables for workflow
  */
-export const get65 = oc
+export const get64 = oc
   .route({
     description: 'Get conversation variables for workflow',
     inputStructure: 'detailed',
@@ -3297,7 +3275,7 @@ export const post43 = oc
   .output(zPostAppsByAppIdWorkflowsDraftConversationVariablesResponse)
 
 export const conversationVariables2 = {
-  get: get65,
+  get: get64,
   post: post43,
 }
 
@@ -3306,7 +3284,7 @@ export const conversationVariables2 = {
  *
  * Get environment variables for workflow
  */
-export const get66 = oc
+export const get65 = oc
   .route({
     description: 'Get environment variables for workflow',
     inputStructure: 'detailed',
@@ -3340,7 +3318,7 @@ export const post44 = oc
   .output(zPostAppsByAppIdWorkflowsDraftEnvironmentVariablesResponse)
 
 export const environmentVariables = {
-  get: get66,
+  get: get65,
   post: post44,
 }
 
@@ -3545,7 +3523,7 @@ export const loop2 = {
   nodes: nodes6,
 }
 
-export const get67 = oc
+export const get66 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -3559,7 +3537,7 @@ export const get67 = oc
   .output(zGetAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerCandidatesResponse)
 
 export const candidates = {
-  get: get67,
+  get: get66,
 }
 
 export const post51 = oc
@@ -3642,7 +3620,7 @@ export const validate = {
   post: post54,
 }
 
-export const get68 = oc
+export const get67 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -3675,7 +3653,7 @@ export const put4 = oc
   .output(zPutAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerResponse)
 
 export const agentComposer = {
-  get: get68,
+  get: get67,
   put: put4,
   candidates,
   copyFromRoster,
@@ -3687,7 +3665,7 @@ export const agentComposer = {
 /**
  * Get last run result for draft workflow node
  */
-export const get69 = oc
+export const get68 = oc
   .route({
     description: 'Get last run result for draft workflow node',
     inputStructure: 'detailed',
@@ -3700,7 +3678,7 @@ export const get69 = oc
   .output(zGetAppsByAppIdWorkflowsDraftNodesByNodeIdLastRunResponse)
 
 export const lastRun = {
-  get: get69,
+  get: get68,
 }
 
 /**
@@ -3775,7 +3753,7 @@ export const delete11 = oc
 /**
  * Get variables for a specific node
  */
-export const get70 = oc
+export const get69 = oc
   .route({
     description: 'Get variables for a specific node',
     inputStructure: 'detailed',
@@ -3789,7 +3767,7 @@ export const get70 = oc
 
 export const variables = {
   delete: delete11,
-  get: get70,
+  get: get69,
 }
 
 export const byNodeId8 = {
@@ -3834,7 +3812,7 @@ export const run10 = {
 /**
  * Server-Sent Events stream of inspector deltas for a draft workflow run.
  */
-export const get71 = oc
+export const get70 = oc
   .route({
     description: 'Server-Sent Events stream of inspector deltas for a draft workflow run.',
     inputStructure: 'detailed',
@@ -3847,13 +3825,13 @@ export const get71 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsEventsResponse)
 
 export const events = {
-  get: get71,
+  get: get70,
 }
 
 /**
  * Full value for one declared output, including signed download URL for files.
  */
-export const get72 = oc
+export const get71 = oc
   .route({
     description: 'Full value for one declared output, including signed download URL for files.',
     inputStructure: 'detailed',
@@ -3870,7 +3848,7 @@ export const get72 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdByOutputNamePreviewResponse)
 
 export const preview5 = {
-  get: get72,
+  get: get71,
 }
 
 export const byOutputName = {
@@ -3880,7 +3858,7 @@ export const byOutputName = {
 /**
  * One node's declared outputs for a draft workflow run.
  */
-export const get73 = oc
+export const get72 = oc
   .route({
     description: "One node's declared outputs for a draft workflow run.",
     inputStructure: 'detailed',
@@ -3893,14 +3871,14 @@ export const get73 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdResponse)
 
 export const byNodeId9 = {
-  get: get73,
+  get: get72,
   byOutputName,
 }
 
 /**
  * Snapshot of every node's declared outputs for a draft workflow run.
  */
-export const get74 = oc
+export const get73 = oc
   .route({
     description: "Snapshot of every node's declared outputs for a draft workflow run.",
     inputStructure: 'detailed',
@@ -3913,7 +3891,7 @@ export const get74 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsResponse)
 
 export const nodeOutputs = {
-  get: get74,
+  get: get73,
   events,
   byNodeId: byNodeId9,
 }
@@ -3929,7 +3907,7 @@ export const runs = {
 /**
  * Get system variables for workflow
  */
-export const get75 = oc
+export const get74 = oc
   .route({
     description: 'Get system variables for workflow',
     inputStructure: 'detailed',
@@ -3942,7 +3920,7 @@ export const get75 = oc
   .output(zGetAppsByAppIdWorkflowsDraftSystemVariablesResponse)
 
 export const systemVariables = {
-  get: get75,
+  get: get74,
 }
 
 /**
@@ -4042,7 +4020,7 @@ export const delete12 = oc
 /**
  * Get a specific workflow variable
  */
-export const get76 = oc
+export const get75 = oc
   .route({
     description: 'Get a specific workflow variable',
     inputStructure: 'detailed',
@@ -4076,7 +4054,7 @@ export const patch2 = oc
 
 export const byVariableId = {
   delete: delete12,
-  get: get76,
+  get: get75,
   patch: patch2,
   reset,
 }
@@ -4102,7 +4080,7 @@ export const delete13 = oc
  *
  * Get draft workflow variables
  */
-export const get77 = oc
+export const get76 = oc
   .route({
     description: 'Get draft workflow variables',
     inputStructure: 'detailed',
@@ -4122,7 +4100,7 @@ export const get77 = oc
 
 export const variables2 = {
   delete: delete13,
-  get: get77,
+  get: get76,
   byVariableId,
 }
 
@@ -4131,7 +4109,7 @@ export const variables2 = {
  *
  * Get draft workflow for an application
  */
-export const get78 = oc
+export const get77 = oc
   .route({
     description: 'Get draft workflow for an application',
     inputStructure: 'detailed',
@@ -4168,7 +4146,7 @@ export const post60 = oc
   .output(zPostAppsByAppIdWorkflowsDraftResponse)
 
 export const draft2 = {
-  get: get78,
+  get: get77,
   post: post60,
   conversationVariables: conversationVariables2,
   environmentVariables,
@@ -4189,7 +4167,7 @@ export const draft2 = {
  *
  * Get published workflow for an application
  */
-export const get79 = oc
+export const get78 = oc
   .route({
     description: 'Get published workflow for an application',
     inputStructure: 'detailed',
@@ -4223,14 +4201,14 @@ export const post61 = oc
   .output(zPostAppsByAppIdWorkflowsPublishResponse)
 
 export const publish = {
-  get: get79,
+  get: get78,
   post: post61,
 }
 
 /**
  * Server-Sent Events stream of inspector deltas for a published workflow run.
  */
-export const get80 = oc
+export const get79 = oc
   .route({
     description: 'Server-Sent Events stream of inspector deltas for a published workflow run.',
     inputStructure: 'detailed',
@@ -4243,13 +4221,13 @@ export const get80 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsEventsResponse)
 
 export const events2 = {
-  get: get80,
+  get: get79,
 }
 
 /**
  * Full value for one declared output of a published run.
  */
-export const get81 = oc
+export const get80 = oc
   .route({
     description: 'Full value for one declared output of a published run.',
     inputStructure: 'detailed',
@@ -4270,7 +4248,7 @@ export const get81 = oc
   )
 
 export const preview6 = {
-  get: get81,
+  get: get80,
 }
 
 export const byOutputName2 = {
@@ -4280,7 +4258,7 @@ export const byOutputName2 = {
 /**
  * One node's declared outputs for a published workflow run.
  */
-export const get82 = oc
+export const get81 = oc
   .route({
     description: "One node's declared outputs for a published workflow run.",
     inputStructure: 'detailed',
@@ -4293,14 +4271,14 @@ export const get82 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsByNodeIdResponse)
 
 export const byNodeId10 = {
-  get: get82,
+  get: get81,
   byOutputName: byOutputName2,
 }
 
 /**
  * Snapshot of every node's declared outputs for a published workflow run.
  */
-export const get83 = oc
+export const get82 = oc
   .route({
     description: "Snapshot of every node's declared outputs for a published workflow run.",
     inputStructure: 'detailed',
@@ -4313,7 +4291,7 @@ export const get83 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsResponse)
 
 export const nodeOutputs2 = {
-  get: get83,
+  get: get82,
   events: events2,
   byNodeId: byNodeId10,
 }
@@ -4333,7 +4311,7 @@ export const published = {
 /**
  * Get webhook trigger for a node
  */
-export const get84 = oc
+export const get83 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -4351,7 +4329,7 @@ export const get84 = oc
   .output(zGetAppsByAppIdWorkflowsTriggersWebhookResponse)
 
 export const webhook = {
-  get: get84,
+  get: get83,
 }
 
 export const triggers2 = {
@@ -4427,7 +4405,7 @@ export const byWorkflowId = {
  *
  * Get all published workflows for an application
  */
-export const get85 = oc
+export const get84 = oc
   .route({
     description: 'Get all published workflows for an application',
     inputStructure: 'detailed',
@@ -4446,7 +4424,7 @@ export const get85 = oc
   .output(zGetAppsByAppIdWorkflowsResponse)
 
 export const workflows3 = {
-  get: get85,
+  get: get84,
   defaultWorkflowBlockConfigs,
   draft: draft2,
   publish,
@@ -4479,7 +4457,7 @@ export const delete15 = oc
  *
  * Get application details
  */
-export const get86 = oc
+export const get85 = oc
   .route({
     description: 'Get application details',
     inputStructure: 'detailed',
@@ -4512,7 +4490,7 @@ export const put6 = oc
 
 export const byAppId2 = {
   delete: delete15,
-  get: get86,
+  get: get85,
   put: put6,
   advancedChat,
   agent,
@@ -4581,7 +4559,7 @@ export const byApiKeyId = {
  *
  * Get all API keys for an app
  */
-export const get87 = oc
+export const get86 = oc
   .route({
     description: 'Get all API keys for an app',
     inputStructure: 'detailed',
@@ -4614,7 +4592,7 @@ export const post63 = oc
   .output(zPostAppsByResourceIdApiKeysResponse)
 
 export const apiKeys = {
-  get: get87,
+  get: get86,
   post: post63,
   byApiKeyId,
 }
@@ -4628,7 +4606,7 @@ export const byResourceId = {
  *
  * Get list of applications with pagination and filtering
  */
-export const get88 = oc
+export const get87 = oc
   .route({
     description: 'Get list of applications with pagination and filtering',
     inputStructure: 'detailed',
@@ -4661,7 +4639,7 @@ export const post64 = oc
   .output(zPostAppsResponse)
 
 export const apps = {
-  get: get88,
+  get: get87,
   post: post64,
   imports,
   recent,

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -786,12 +786,6 @@ export type WorkflowRunDetailResponse = {
   version?: string | null
 }
 
-export type WorkflowRunExportResponse = {
-  presigned_url?: string | null
-  presigned_url_expires_at?: string | null
-  status: string
-}
-
 export type WorkflowRunNodeExecutionListResponse = {
   data: Array<WorkflowRunNodeExecutionResponse>
 }
@@ -5287,23 +5281,6 @@ export type GetAppsByAppIdWorkflowRunsByRunIdResponses = {
 
 export type GetAppsByAppIdWorkflowRunsByRunIdResponse =
   GetAppsByAppIdWorkflowRunsByRunIdResponses[keyof GetAppsByAppIdWorkflowRunsByRunIdResponses]
-
-export type GetAppsByAppIdWorkflowRunsByRunIdExportData = {
-  body?: never
-  path: {
-    app_id: string
-    run_id: string
-  }
-  query?: never
-  url: '/apps/{app_id}/workflow-runs/{run_id}/export'
-}
-
-export type GetAppsByAppIdWorkflowRunsByRunIdExportResponses = {
-  200: WorkflowRunExportResponse
-}
-
-export type GetAppsByAppIdWorkflowRunsByRunIdExportResponse =
-  GetAppsByAppIdWorkflowRunsByRunIdExportResponses[keyof GetAppsByAppIdWorkflowRunsByRunIdExportResponses]
 
 export type GetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsData = {
   body?: never

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -504,15 +504,6 @@ export const zWorkflowTriggerListResponse = z.object({
 })
 
 /**
- * WorkflowRunExportResponse
- */
-export const zWorkflowRunExportResponse = z.object({
-  presigned_url: z.string().nullish(),
-  presigned_url_expires_at: z.string().nullish(),
-  status: z.string(),
-})
-
-/**
  * WorkflowAgentSandboxDownloadPayload
  */
 export const zWorkflowAgentSandboxDownloadPayload = z.object({
@@ -5570,16 +5561,6 @@ export const zGetAppsByAppIdWorkflowRunsByRunIdPath = z.object({
  * Workflow run detail retrieved successfully
  */
 export const zGetAppsByAppIdWorkflowRunsByRunIdResponse = zWorkflowRunDetailResponse
-
-export const zGetAppsByAppIdWorkflowRunsByRunIdExportPath = z.object({
-  app_id: z.uuid(),
-  run_id: z.uuid(),
-})
-
-/**
- * Export URL generated
- */
-export const zGetAppsByAppIdWorkflowRunsByRunIdExportResponse = zWorkflowRunExportResponse
 
 export const zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsPath = z.object({
   app_id: z.uuid(),


### PR DESCRIPTION
## Summary

- migrate Console workflow-run routes to console_account_admission and the shared application-services composition root
- require an explicit database session factory for WorkflowRunService while retaining explicit Engine injection compatibility
- move pause-detail repository and form-token orchestration out of the controller
- use RequestContext workspace identity for tenant-scoped workflow-run and node-execution queries
- standardize successful responses with dump_response without changing the HTTP response contract

## Stack

Depends on #41293, which removes the unused per-run export endpoint. The branch is based directly on that PR commit; because its head lives in a fork, GitHub cannot select it as an upstream base branch. This PR therefore targets main and will be refreshed after #41293 lands.

## Testing

- 103 focused controller, service, composition, and Swagger tests passed
- make type-check-core
- import-linter: 20 contracts kept
- response contract lint
- no-new-getattr check
- API contract regeneration produced no diff; contracts type-check passed
- 16 container integration tests collect successfully; execution is left to CI because the local Docker socket is unavailable