### PR TITLE
fix(e2e): wait for Agent access state persistence

### DIFF
--- a/e2e/features/step-definitions/agent-v2/access-point.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/access-point.steps.ts
@@ -11,6 +11,30 @@ import {
   getWebAppCard,
 } from './access-point-helpers'
 
+async function setAccessSurfaceEnabled(
+  world: DifyWorld,
+  surface: AccessSurfaceName,
+  enabled: boolean,
+) {
+  const accessToggle = getAccessSurfaceCard(world, surface).getByLabel(`Toggle ${surface} access`)
+
+  await expect(accessToggle).toBeEnabled({ timeout: 30_000 })
+  await expect(accessToggle).toHaveAttribute('aria-checked', String(!enabled))
+  await accessToggle.click()
+
+  const client = world.getConsoleClient()
+  const agentId = getCurrentAgentId(world)
+  await expect
+    .poll(
+      async () => {
+        const agent = await client.agent.byAgentId.get({ params: { agent_id: agentId } })
+        return surface === 'Web app' ? agent.enable_site : agent.enable_api
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(enabled)
+}
+
 Given('the Agent v2 draft has been published via API', async function (this: DifyWorld) {
   await publishAgentWithPublishableDraft(this.getConsoleClient(), getCurrentAgentId(this))
 })
@@ -73,14 +97,14 @@ When(
       this.agentBuilder.accessPoint.webAppURL = href
     }
 
-    await accessSurfaceCard.getByLabel(`Toggle ${surface} access`).click()
+    await setAccessSurfaceEnabled(this, surface, false)
   },
 )
 
 When(
   /^I enable Agent v2 (Web app|Backend service API) access$/,
   async function (this: DifyWorld, surface: AccessSurfaceName) {
-    await getAccessSurfaceCard(this, surface).getByLabel(`Toggle ${surface} access`).click()
+    await setAccessSurfaceEnabled(this, surface, true)
   },
 )
 


### PR DESCRIPTION
## Summary

- wait for the Agent v2 access switch to finish loading and show the expected pre-click state
- keep the browser click as the tested action, then poll the persisted `enable_site` or `enable_api` value before continuing
- apply the same synchronization to Web app and Backend service API enable/disable steps

## Root cause

The scenario introduced in #40105 reloads the Access Point page and enables Web app access immediately afterward. During reload, the card can briefly render `Out of service` from missing query data before the Agent detail request completes. The existing status assertion could therefore pass too early, and the following click could overlap the loading-to-ready rerender. In the observed failures, the click completed from Playwright's perspective, but no enable request reached the API.

This is timing-dependent, so #40105's own E2E run passing is expected and does not rule out the race. #41254 later made the visible status optimistic, which also means the text alone is no longer a persistence barrier. #41265 only caused the full E2E workflow to run through its `api/**` path filter; its Agent-detail request succeeded and is not the cause.

Fixes #41263.

## Verification

- `pnpm -C e2e exec vp check .`
- `pnpm -C e2e type-check`
- `git diff --check`

