### PR TITLE
fix(api): grant in-run tool files to later workflow nodes

### DIFF
--- a/api/core/app/file_access/__init__.py
+++ b/api/core/app/file_access/__init__.py
@@ -5,6 +5,7 @@ from .scope import (
     bind_file_access_scope,
     get_current_file_access_scope,
     grant_retriever_segment_access,
+    grant_tool_file_access,
     grant_upload_file_access,
     is_retriever_segment_access_granted,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "bind_file_access_scope",
     "get_current_file_access_scope",
     "grant_retriever_segment_access",
+    "grant_tool_file_access",
     "grant_upload_file_access",
     "is_retriever_segment_access_granted",
 ]

--- a/api/core/app/file_access/controller.py
+++ b/api/core/app/file_access/controller.py
@@ -19,8 +19,8 @@ class DatabaseFileAccessController(FileAccessControllerProtocol):
 
     Tenant scoping remains mandatory. When the current execution belongs to an
     end user, the lookup is additionally constrained to that end user's file
-    ownership markers, plus upload files explicitly granted by the current
-    execution context.
+    ownership markers, plus upload and tool files explicitly granted by the
+    current execution context.
     """
 
     _scope_getter: Callable[[], FileAccessScope | None]
@@ -80,7 +80,16 @@ class DatabaseFileAccessController(FileAccessControllerProtocol):
         if not resolved_scope.requires_user_ownership:
             return scoped_stmt
 
-        return scoped_stmt.where(ToolFile.user_id == resolved_scope.user_id)
+        user_owned_filter = ToolFile.user_id == resolved_scope.user_id
+        if not resolved_scope.granted_tool_file_ids:
+            return scoped_stmt.where(user_owned_filter)
+
+        return scoped_stmt.where(
+            or_(
+                user_owned_filter,
+                ToolFile.id.in_(resolved_scope.granted_tool_file_ids),
+            )
+        )
 
     @override
     def get_upload_file(

--- a/api/core/app/file_access/scope.py
+++ b/api/core/app/file_access/scope.py
@@ -21,6 +21,11 @@ class FileAccessScope:
     that were returned by trusted retrieval paths without changing persistent
     ownership markers.
 
+    ``granted_tool_file_ids`` is the same pattern for ToolFile records created
+    during this run (plugin downloads, workflow-as-tool outputs). Those files
+    may be owned by a different user_id than the chatting end user, which is
+    why later LLM nodes otherwise drop them.
+
     ``granted_retriever_segment_ids`` gates lazy attachment loading by segment
     ID, so user-provided context cannot make a later LLM node load arbitrary
     same-tenant knowledge attachments.
@@ -32,6 +37,7 @@ class FileAccessScope:
     invoke_from: InvokeFrom
     granted_upload_file_ids: frozenset[str] = field(default_factory=frozenset)
     granted_retriever_segment_ids: frozenset[str] = field(default_factory=frozenset)
+    granted_tool_file_ids: frozenset[str] = field(default_factory=frozenset)
 
     @property
     def requires_user_ownership(self) -> bool:
@@ -55,6 +61,24 @@ def grant_upload_file_access(upload_file_ids: Iterable[str]) -> None:
         replace(
             scope,
             granted_upload_file_ids=scope.granted_upload_file_ids | granted_upload_file_ids,
+        )
+    )
+
+
+def grant_tool_file_access(tool_file_ids: Iterable[str]) -> None:
+    """Allow this execution to read ToolFile records it just produced."""
+    scope = _current_file_access_scope.get()
+    if scope is None:
+        return
+
+    granted_tool_file_ids = frozenset(str(file_id) for file_id in tool_file_ids if file_id)
+    if not granted_tool_file_ids:
+        return
+
+    _current_file_access_scope.set(
+        replace(
+            scope,
+            granted_tool_file_ids=scope.granted_tool_file_ids | granted_tool_file_ids,
         )
     )
 

--- a/api/core/tools/utils/message_transformer.py
+++ b/api/core/tools/utils/message_transformer.py
@@ -9,6 +9,7 @@ from uuid import UUID
 import numpy as np
 import pytz
 
+from core.app.file_access import grant_tool_file_access
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.tool_file_manager import ToolFileManager, resolve_extension
 from core.workflow.file_reference import parse_file_reference
@@ -214,6 +215,11 @@ class ToolFileMessageTransformer:
         resolved_tool_file_id = tool_file_id or ToolFileMessageTransformer._extract_tool_file_id(url)
         if resolved_tool_file_id and "tool_file_id" not in normalized_meta:
             normalized_meta["tool_file_id"] = resolved_tool_file_id
+        if resolved_tool_file_id:
+            # Plugin/tool files may be owned by a different user than the chatting
+            # end user (workflow-as-tool from an agent). Grant this execution so
+            # later LLM nodes can attach the file instead of dropping it (#41169).
+            grant_tool_file_access([resolved_tool_file_id])
         return normalized_meta
 
     @staticmethod

--- a/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
+++ b/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
@@ -3,6 +3,8 @@ from typing import Any
 import pytest
 
 import core.tools.utils.message_transformer as mt
+from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
+from core.app.file_access import FileAccessScope, bind_file_access_scope, get_current_file_access_scope
 from core.tools.entities.tool_entities import ToolInvokeMessage
 from models.tools import ToolFile
 
@@ -135,3 +137,32 @@ def test_transform_tool_invoke_messages_parses_existing_tool_file_link_meta():
 
     assert len(out) == 1
     assert out[0].meta["tool_file_id"] == "existing-tool-file"
+
+
+def test_transform_tool_invoke_messages_grants_tool_file_to_current_end_user_scope():
+    """Workflow-as-tool LLM nodes need a grant for plugin files (#41169)."""
+    msg = ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.IMAGE_LINK,
+        message=ToolInvokeMessage.TextMessage(text="/files/tools/existing-tool-file.png"),
+        meta={},
+    )
+    scope = FileAccessScope(
+        tenant_id="t1",
+        user_id="end-user-1",
+        user_from=UserFrom.END_USER,
+        invoke_from=InvokeFrom.WEB_APP,
+    )
+
+    with bind_file_access_scope(scope):
+        list(
+            mt.ToolFileMessageTransformer.transform_tool_invoke_messages(
+                messages=_gen([msg]),
+                user_id="u1",
+                tenant_id="t1",
+                conversation_id="c1",
+            )
+        )
+        current_scope = get_current_file_access_scope()
+
+    assert current_scope is not None
+    assert "existing-tool-file" in current_scope.granted_tool_file_ids

--- a/api/tests/unit_tests/factories/test_build_from_mapping.py
+++ b/api/tests/unit_tests/factories/test_build_from_mapping.py
@@ -10,7 +10,12 @@ from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
-from core.app.file_access import DatabaseFileAccessController, FileAccessScope, bind_file_access_scope
+from core.app.file_access import (
+    DatabaseFileAccessController,
+    FileAccessScope,
+    bind_file_access_scope,
+    grant_tool_file_access,
+)
 from core.workflow.file_reference import build_file_reference, parse_file_reference, resolve_file_record_id
 from extensions.storage.storage_type import StorageType
 from factories.file_factory.builders import build_from_mapping as _build_from_mapping
@@ -446,6 +451,26 @@ def test_build_from_mapping_scopes_tool_file_to_end_user():
     with bind_file_access_scope(unauthorized_scope):
         with pytest.raises(ValueError, match=f"ToolFile {TEST_TOOL_FILE_ID} not found"):
             build_from_mapping(mapping=tool_file_mapping(), tenant_id=TEST_TENANT_ID)
+
+
+def test_build_from_mapping_allows_granted_tool_file_for_other_end_user():
+    """Tool files produced in this run must remain readable by later nodes (#41169).
+
+    Workflow-as-tool from an agent binds an EndUser scope. Plugin downloads often
+    store ToolFile.user_id as a different identity, so a grant is required.
+    """
+    unauthorized_scope = FileAccessScope(
+        tenant_id=TEST_TENANT_ID,
+        user_id="different-end-user",
+        user_from=UserFrom.END_USER,
+        invoke_from=InvokeFrom.WEB_APP,
+    )
+    with bind_file_access_scope(unauthorized_scope):
+        grant_tool_file_access([TEST_TOOL_FILE_ID])
+        file = build_from_mapping(mapping=tool_file_mapping(), tenant_id=TEST_TENANT_ID)
+
+    assert resolve_file_record_id(file.reference) == TEST_TOOL_FILE_ID
+    assert file.type == FileType.DOCUMENT
 
 
 def test_disallowed_file_types():


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41169

A workflow that downloads an image in a tool node and passes it to a later LLM vision node works in the orchestration test-run, but fails when the same published workflow is invoked as a tool from an Agent.

Orchestration binds an Account file-access scope, so plugin `ToolFile` rows are readable. Agent chat binds an EndUser scope. Plugin uploads (`/files/upload/for-plugin`) often store `ToolFile.user_id` as a different identity than the chatting end user, so later `build_from_mapping` lookups fail the ownership filter and the LLM prompt has no image (`files: []`).

This change mirrors the existing upload-file grant: `ToolFileMessageTransformer` records produced `tool_file_id`s on the current `FileAccessScope`. Later nodes in the same execution can attach those files. Ungranted tool files still require matching `user_id`.

This is the nested-workflow internal file path. It does not change how the Agent App converts tool results to chat text (#40425 / PR #40455).

## Screenshots

Not applicable (backend file-access grant).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran targeted unit tests for the changed files (`test_build_from_mapping.py`, `test_message_transformer.py`, FileAccessScope-related tests)