### PR TITLE
fix: improve login and signup accessibility

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -5045,11 +5045,6 @@
       "count": 1
     }
   },
-  "web/app/signup/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/signup/layout.tsx": {
     "typescript/no-explicit-any": {
       "count": 1

--- a/web/app/signin/__tests__/_header.spec.tsx
+++ b/web/app/signin/__tests__/_header.spec.tsx
@@ -26,6 +26,44 @@ describe('Signin Header', () => {
     vi.clearAllMocks()
   })
 
+  it('uses the application title as the custom logo accessible name', () => {
+    render(<Header />, {
+      systemFeatures: {
+        branding: {
+          application_title: 'Acme AI',
+          enabled: true,
+          login_page_logo: 'https://example.com/acme-logo.svg',
+        },
+      },
+    })
+
+    expect(screen.getByRole('img', { name: 'Acme AI' })).toHaveAttribute(
+      'src',
+      'https://example.com/acme-logo.svg',
+    )
+  })
+
+  it('treats a custom logo as decorative when the application title is empty', () => {
+    const { container } = render(<Header />, {
+      systemFeatures: {
+        branding: {
+          application_title: '',
+          enabled: true,
+          login_page_logo: 'https://example.com/custom-logo.svg',
+        },
+      },
+    })
+
+    expect(container.querySelector('img')).toHaveAttribute('alt', '')
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  it('keeps the default Dify logo accessible name', () => {
+    render(<Header />)
+
+    expect(screen.getByRole('img', { name: 'Dify' })).toBeInTheDocument()
+  })
+
   it('should switch locale without forcing a full page reload', () => {
     render(<Header />)
 

--- a/web/app/signin/_header.tsx
+++ b/web/app/signin/_header.tsx
@@ -24,7 +24,7 @@ const Header = () => {
         <img
           src={systemFeatures.branding.login_page_logo}
           className="block h-7 w-auto object-contain"
-          alt="logo"
+          alt={systemFeatures.branding.application_title || ''}
         />
       ) : (
         <DifyLogo alt="Dify" size="large" />

--- a/web/app/signin/components/__tests__/social-auth.spec.tsx
+++ b/web/app/signin/components/__tests__/social-auth.spec.tsx
@@ -37,6 +37,7 @@ describe('SocialAuth', () => {
 
       expect(screen.getByRole('link', { name: 'login.withGitHub' })).toBeInTheDocument()
       expect(screen.getByRole('link', { name: 'login.withGoogle' })).toBeInTheDocument()
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
   })
 

--- a/web/app/signin/components/social-auth.tsx
+++ b/web/app/signin/components/social-auth.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@langgenius/dify-ui/button'
+import { buttonVariants } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useTranslation } from 'react-i18next'
 import { API_PREFIX } from '@/config'
@@ -8,11 +8,7 @@ import { getPurifyHref } from '@/utils'
 import { getBrowserTimezone } from '@/utils/timezone'
 import style from '../page.module.css'
 
-type SocialAuthProps = {
-  disabled?: boolean
-}
-
-export default function SocialAuth(props: SocialAuthProps) {
+export default function SocialAuth() {
   const { t } = useTranslation()
   const searchParams = useSearchParams()
   const locale = useLocale()
@@ -31,30 +27,20 @@ export default function SocialAuth(props: SocialAuthProps) {
   }
   return (
     <>
-      <div className="w-full">
-        <a href={getOAuthLink('/oauth/login/github')}>
-          <Button disabled={props.disabled} className="w-full">
-            <>
-              <span className={cn(style.githubIcon, 'size-5')} />
-              <span className="truncate leading-normal">
-                {t(($) => $.withGitHub, { ns: 'login' })}
-              </span>
-            </>
-          </Button>
-        </a>
-      </div>
-      <div className="w-full">
-        <a href={getOAuthLink('/oauth/login/google')}>
-          <Button disabled={props.disabled} className="w-full">
-            <>
-              <span className={cn(style.googleIcon, 'size-5')} />
-              <span className="truncate leading-normal">
-                {t(($) => $.withGoogle, { ns: 'login' })}
-              </span>
-            </>
-          </Button>
-        </a>
-      </div>
+      <a
+        className={buttonVariants({ className: 'w-full' })}
+        href={getOAuthLink('/oauth/login/github')}
+      >
+        <span aria-hidden="true" className={cn(style.githubIcon, 'size-5')} />
+        <span className="truncate leading-normal">{t(($) => $.withGitHub, { ns: 'login' })}</span>
+      </a>
+      <a
+        className={buttonVariants({ className: 'w-full' })}
+        href={getOAuthLink('/oauth/login/google')}
+      >
+        <span aria-hidden="true" className={cn(style.googleIcon, 'size-5')} />
+        <span className="truncate leading-normal">{t(($) => $.withGoogle, { ns: 'login' })}</span>
+      </a>
     </>
   )
 }

--- a/web/app/signup/check-code/__tests__/page.spec.tsx
+++ b/web/app/signup/check-code/__tests__/page.spec.tsx
@@ -1,0 +1,98 @@
+import type { MockedFunction } from 'vite-plus/test'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useLocale } from '@/context/i18n'
+import { useRouter, useSearchParams } from '@/next/navigation'
+import { useMailValidity, useSendMail } from '@/service/use-common'
+import CheckCode from '../page'
+
+const mockBack = vi.fn()
+const mockPush = vi.fn()
+const mockReplace = vi.fn()
+const mockSubmitMail = vi.fn()
+const mockVerifyCode = vi.fn()
+
+vi.mock('@/app/components/signin/countdown', () => ({
+  default: ({ onResend }: { onResend: () => void }) => (
+    <button type="button" onClick={onResend}>
+      resend-code
+    </button>
+  ),
+}))
+
+vi.mock('@/context/i18n', () => ({
+  useLocale: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-document-title', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@/next/navigation', () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}))
+
+vi.mock('@/service/use-common', () => ({
+  useMailValidity: vi.fn(),
+  useSendMail: vi.fn(),
+}))
+
+const mockUseLocale = useLocale as unknown as MockedFunction<typeof useLocale>
+const mockUseRouter = useRouter as unknown as MockedFunction<typeof useRouter>
+const mockUseSearchParams = useSearchParams as unknown as MockedFunction<typeof useSearchParams>
+const mockUseMailValidity = useMailValidity as unknown as MockedFunction<typeof useMailValidity>
+const mockUseSendMail = useSendMail as unknown as MockedFunction<typeof useSendMail>
+
+describe('Signup Check Code Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseLocale.mockReturnValue('en-US')
+    mockUseRouter.mockReturnValue({
+      back: mockBack,
+      push: mockPush,
+      replace: mockReplace,
+    } as unknown as ReturnType<typeof useRouter>)
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams({
+        email: 'user@example.com',
+        token: 'signup-token',
+      }) as unknown as ReturnType<typeof useSearchParams>,
+    )
+    mockUseMailValidity.mockReturnValue({
+      mutateAsync: mockVerifyCode,
+    } as unknown as ReturnType<typeof useMailValidity>)
+    mockUseSendMail.mockReturnValue({
+      mutateAsync: mockSubmitMail,
+    } as unknown as ReturnType<typeof useSendMail>)
+    mockVerifyCode.mockResolvedValue({ is_valid: true, token: 'verified-token' })
+  })
+
+  it('labels the one-time code field and submits it with Enter', async () => {
+    const user = userEvent.setup()
+    render(<CheckCode />)
+
+    const codeInput = screen.getByRole('textbox', {
+      name: 'login.checkCode.verificationCode',
+    })
+    expect(codeInput).toHaveAttribute('id', 'code')
+    expect(codeInput).toHaveAttribute('name', 'code')
+    expect(codeInput).toHaveAttribute('inputmode', 'numeric')
+    expect(codeInput).toHaveAttribute('autocomplete', 'one-time-code')
+    expect(screen.getByRole('button', { name: 'login.checkCode.verify' })).toHaveAttribute(
+      'type',
+      'submit',
+    )
+
+    await user.type(codeInput, '123456{Enter}')
+
+    await waitFor(() => {
+      expect(mockVerifyCode).toHaveBeenCalledWith({
+        code: '123456',
+        email: 'user@example.com',
+        token: 'signup-token',
+      })
+    })
+    expect(mockVerifyCode).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/app/signup/check-code/page.tsx
+++ b/web/app/signup/check-code/page.tsx
@@ -1,11 +1,12 @@
 'use client'
 import type { MailSendResponse, MailValidityResponse } from '@/service/use-common'
 import { Button } from '@langgenius/dify-ui/button'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiArrowLeftLine, RiMailSendFill } from '@remixicon/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 import useDocumentTitle from '@/hooks/use-document-title'
@@ -27,6 +28,7 @@ export default function CheckCode() {
   useDocumentTitle(pageTitle)
 
   const verify = async () => {
+    if (loading) return
     try {
       if (!code.trim()) {
         toast.error(t(($) => $['checkCode.emptyCode'], { ns: 'login' }))
@@ -84,26 +86,31 @@ export default function CheckCode() {
         </p>
       </div>
 
-      <form action="">
-        <label htmlFor="code" className="mb-1 system-md-semibold text-text-secondary">
-          {t(($) => $['checkCode.verificationCode'], { ns: 'login' })}
-        </label>
-        <Input
-          value={code}
-          onChange={(e) => setVerifyCode(e.target.value)}
-          maxLength={6}
-          className="mt-1"
-          placeholder={
-            t(($) => $['checkCode.verificationCodePlaceholder'], { ns: 'login' }) as string
-          }
-        />
-        <Button
-          loading={loading}
-          disabled={loading}
-          className="my-3 w-full"
-          variant="primary"
-          onClick={verify}
-        >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          void verify()
+        }}
+      >
+        <Field name="code">
+          <FieldLabel htmlFor="code" className="mb-1 system-md-semibold text-text-secondary">
+            {t(($) => $['checkCode.verificationCode'], { ns: 'login' })}
+          </FieldLabel>
+          <Input
+            id="code"
+            name="code"
+            value={code}
+            onValueChange={setVerifyCode}
+            maxLength={6}
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            className="mt-1"
+            placeholder={
+              t(($) => $['checkCode.verificationCodePlaceholder'], { ns: 'login' }) as string
+            }
+          />
+        </Field>
+        <Button type="submit" loading={loading} className="my-3 w-full" variant="primary">
           {t(($) => $['checkCode.verify'], { ns: 'login' })}
         </Button>
         <Countdown onResend={resendCode} />


### PR DESCRIPTION
## Summary

- replace nested social sign-in buttons with semantic links that retain the shared button styling
- label the signup verification code input and support native form submission with Enter
- use the configured application title as the accessible name for custom login logos, with decorative and Dify fallbacks

Fixes SNP-634

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.