### PR TITLE
feat(api): make indexing workers and embedding delay configurable

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -584,6 +584,10 @@ LOG_FORMAT=%(asctime)s,%(msecs)d %(levelname)-2s [%(filename)s:%(lineno)d] %(req
 
 # Indexing configuration
 INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH=4000
+# Concurrent embedding threads per document (default 10; lower to 1-2 for strict rate limits)
+INDEXING_MAX_WORKERS_NUMBER=10
+# Seconds to wait between embedding HTTP requests (default 0 disables)
+EMBEDDING_BATCH_DELAY=0
 
 # Workflow runtime configuration
 WORKFLOW_MAX_EXECUTION_STEPS=500

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1326,8 +1326,7 @@ class IndexingConfig(BaseSettings):
     )
 
     EMBEDDING_BATCH_DELAY: float = Field(
-        description="Delay in seconds between embedding HTTP requests to avoid provider rate limits. "
-        "0 disables.",
+        description="Delay in seconds between embedding HTTP requests to avoid provider rate limits. 0 disables.",
         default=0,
         ge=0,
     )

--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -1319,6 +1319,19 @@ class IndexingConfig(BaseSettings):
         default=4000,
     )
 
+    INDEXING_MAX_WORKERS_NUMBER: PositiveInt = Field(
+        description="Concurrent workers for embedding indexing within one document. "
+        "Lower values help avoid embedding provider rate limits.",
+        default=10,
+    )
+
+    EMBEDDING_BATCH_DELAY: float = Field(
+        description="Delay in seconds between embedding HTTP requests to avoid provider rate limits. "
+        "0 disables.",
+        default=0,
+        ge=0,
+    )
+
     CHILD_CHUNKS_PREVIEW_NUMBER: PositiveInt = Field(
         description="Maximum number of child chunks to preview",
         default=50,

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -664,7 +664,7 @@ class IndexingRunner:
             )
             create_keyword_thread.start()
 
-        max_workers = 10
+        max_workers = dify_config.INDEXING_MAX_WORKERS_NUMBER
         if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = []

--- a/api/core/rag/embedding/cached_embedding.py
+++ b/api/core/rag/embedding/cached_embedding.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import pickle
+import time
 from typing import Any, cast, override
 
 import numpy as np
@@ -19,6 +20,12 @@ from libs import helper
 from models.dataset import Embedding
 
 logger = logging.getLogger(__name__)
+
+
+def _pause_between_embedding_batches(batch_offset: int) -> None:
+    delay = dify_config.EMBEDDING_BATCH_DELAY
+    if batch_offset > 0 and delay > 0:
+        time.sleep(delay)
 
 
 class CacheEmbedding(Embeddings):
@@ -63,6 +70,7 @@ class CacheEmbedding(Embeddings):
                     else 1
                 )
                 for i in range(0, len(embedding_queue_texts), max_chunks):
+                    _pause_between_embedding_batches(i)
                     batch_texts = embedding_queue_texts[i : i + max_chunks]
 
                     embedding_result = self._model_instance.invoke_text_embedding(
@@ -145,6 +153,7 @@ class CacheEmbedding(Embeddings):
                     else 1
                 )
                 for i in range(0, len(embedding_queue_multimodel_documents), max_chunks):
+                    _pause_between_embedding_batches(i)
                     batch_multimodel_documents = embedding_queue_multimodel_documents[i : i + max_chunks]
 
                     embedding_result = self._model_instance.invoke_multimodal_embedding(

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -8,8 +8,25 @@ from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 from yarl import URL
 
 from configs.app_config import DifyConfig
-from configs.feature import OpsTraceConfig
+from configs.feature import IndexingConfig, OpsTraceConfig
 from enums import DeploymentEdition
+
+
+def test_indexing_config_defaults_preserve_current_embedding_throughput() -> None:
+    config = IndexingConfig()
+
+    assert config.INDEXING_MAX_WORKERS_NUMBER == 10
+    assert config.EMBEDDING_BATCH_DELAY == 0
+
+
+def test_indexing_config_rejects_non_positive_workers() -> None:
+    with pytest.raises(ValidationError):
+        IndexingConfig(INDEXING_MAX_WORKERS_NUMBER=0)
+
+
+def test_indexing_config_rejects_negative_embedding_delay() -> None:
+    with pytest.raises(ValidationError):
+        IndexingConfig(EMBEDDING_BATCH_DELAY=-0.1)
 
 
 def test_ops_trace_config_rejects_parent_context_ttl_shorter_than_retry_window() -> None:

--- a/api/tests/unit_tests/core/rag/embedding/test_embedding_service.py
+++ b/api/tests/unit_tests/core/rag/embedding/test_embedding_service.py
@@ -152,6 +152,39 @@ class TestDocumentCache:
         ]
         assert len(sqlite_embedding_session.scalars(select(Embedding)).all()) == 25
 
+    def test_embed_documents_pauses_between_batches_when_delay_configured(
+        self, sqlite_embedding_session: Session, model_instance: Mock, config_overrides
+    ) -> None:
+        config_overrides(EMBEDDING_BATCH_DELAY=0.25)
+        model_instance.model_type_instance.get_model_schema.return_value = Mock(
+            model_properties={ModelPropertyKey.MAX_CHUNKS: 1}
+        )
+        model_instance.invoke_text_embedding.side_effect = [_result(_vector()), _result(_vector(offset=10))]
+
+        with patch.object(cached_embedding.time, "sleep") as mock_sleep:
+            result = CacheEmbedding(model_instance).embed_documents(["first", "second"])
+
+        assert len(result) == 2
+        assert model_instance.invoke_text_embedding.call_count == 2
+        mock_sleep.assert_called_once_with(0.25)
+        assert len(sqlite_embedding_session.scalars(select(Embedding)).all()) == 2
+
+    def test_embed_documents_skips_pause_when_delay_disabled(
+        self, sqlite_embedding_session: Session, model_instance: Mock, config_overrides
+    ) -> None:
+        config_overrides(EMBEDDING_BATCH_DELAY=0)
+        model_instance.model_type_instance.get_model_schema.return_value = Mock(
+            model_properties={ModelPropertyKey.MAX_CHUNKS: 1}
+        )
+        model_instance.invoke_text_embedding.side_effect = [_result(_vector()), _result(_vector(offset=10))]
+
+        with patch.object(cached_embedding.time, "sleep") as mock_sleep:
+            result = CacheEmbedding(model_instance).embed_documents(["first", "second"])
+
+        assert len(result) == 2
+        mock_sleep.assert_not_called()
+        assert len(sqlite_embedding_session.scalars(select(Embedding)).all()) == 2
+
     @pytest.mark.parametrize(
         "provider_error",
         [InvokeConnectionError("offline"), InvokeRateLimitError("limited"), InvokeAuthorizationError("denied")],

--- a/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
+++ b/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
@@ -760,6 +760,54 @@ class TestIndexingRunnerLoad:
         mock_future.result.assert_called()
         assert mock_update_status.call_args.kwargs["extra_update_params"][DatasetDocument.tokens] == 300
 
+    def test_load_uses_configured_indexing_max_workers(
+        self, mock_dependencies, sample_dataset, sample_dataset_document, sample_documents, config_overrides
+    ):
+        config_overrides(INDEXING_MAX_WORKERS_NUMBER=2)
+        runner = IndexingRunner()
+        mock_future = MagicMock()
+        mock_future.result.return_value = None
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.__enter__.return_value = mock_executor_instance
+        mock_executor_instance.__exit__.return_value = None
+        mock_executor_instance.submit.return_value = mock_future
+        mock_dependencies["executor"].return_value = mock_executor_instance
+
+        with patch.object(runner, "_update_document_index_status"):
+            runner._load(
+                session=mock_dependencies["session"],
+                dataset=sample_dataset,
+                dataset_document=sample_dataset_document,
+                documents=sample_documents,
+                total_tokens=300,
+            )
+
+        mock_dependencies["executor"].assert_called_once_with(max_workers=2)
+
+    def test_load_defaults_to_ten_indexing_workers(
+        self, mock_dependencies, sample_dataset, sample_dataset_document, sample_documents, config_overrides
+    ):
+        config_overrides(INDEXING_MAX_WORKERS_NUMBER=10)
+        runner = IndexingRunner()
+        mock_future = MagicMock()
+        mock_future.result.return_value = None
+        mock_executor_instance = MagicMock()
+        mock_executor_instance.__enter__.return_value = mock_executor_instance
+        mock_executor_instance.__exit__.return_value = None
+        mock_executor_instance.submit.return_value = mock_future
+        mock_dependencies["executor"].return_value = mock_executor_instance
+
+        with patch.object(runner, "_update_document_index_status"):
+            runner._load(
+                session=mock_dependencies["session"],
+                dataset=sample_dataset,
+                dataset_document=sample_dataset_document,
+                documents=sample_documents,
+                total_tokens=300,
+            )
+
+        mock_dependencies["executor"].assert_called_once_with(max_workers=10)
+
     def test_load_propagates_worker_errors(
         self, mock_dependencies, sample_dataset, sample_dataset_document, sample_documents
     ):

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -144,6 +144,10 @@ ALLOW_EMBED=false
 ALLOW_UNSAFE_DATA_SCHEME=false
 TOP_K_MAX_VALUE=10
 INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH=4000
+# Concurrent embedding threads per document (default 10; lower to 1-2 for strict rate limits)
+INDEXING_MAX_WORKERS_NUMBER=10
+# Seconds to wait between embedding HTTP requests (default 0 disables)
+EMBEDDING_BATCH_DELAY=0
 LOOP_NODE_MAX_COUNT=100
 MAX_TOOLS_NUM=10
 MAX_PARALLEL_LIMIT=10


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41112

High-quality indexing currently always fans out with `ThreadPoolExecutor(max_workers=10)`, and `CacheEmbedding` fires the next HTTP request as soon as the previous batch returns. With OpenAI-compatible providers that default to `max_chunks=1`, that easily exceeds self-hosted or free-tier rate limits (429).

This change keeps the current default throughput and makes both knobs configurable:

- `INDEXING_MAX_WORKERS_NUMBER` (default **10**) — per-document embedding thread pool size in `IndexingRunner._load()`
- `EMBEDDING_BATCH_DELAY` (default **0**) — seconds to wait between embedding HTTP batches (text and multimodal). `0` disables the pause.

Existing installations are unchanged unless these env vars are set. For strict rate limits, a typical self-hosted profile is `INDEXING_MAX_WORKERS_NUMBER=1` and `EMBEDDING_BATCH_DELAY=0.5`.

Out of scope (called out as follow-ups in the issue): 429 retry/backoff, per-credential `max_chunks`, and Celery worker amount.

## Screenshots

Not applicable (backend configuration).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran targeted `ruff`, `dotenv-linter`, `pyrefly`, and unit tests for the changed files