### PR TITLE
fix(api): map legacy model_type values when loading providers

### DIFF
--- a/api/core/provider_manager.py
+++ b/api/core/provider_manager.py
@@ -61,6 +61,7 @@ from models.provider import (
     TenantPreferredModelProvider,
 )
 from models.provider_ids import ModelProviderID
+from models.types import parse_enum_text
 from services.feature_service import FeatureService
 
 if TYPE_CHECKING:
@@ -131,7 +132,7 @@ class _ProviderModelCacheEntry:
             id=row["id"],
             provider_name=row["provider_name"],
             model_name=row["model_name"],
-            model_type=ModelType(row["model_type"]),
+            model_type=parse_enum_text(ModelType, row["model_type"]),
             credential_id=row.get("credential_id"),
             credential_name=row.get("credential_name"),
             encrypted_config=row.get("encrypted_config"),
@@ -192,7 +193,7 @@ class _ProviderModelSettingCacheEntry:
         return cls(
             provider_name=row["provider_name"],
             model_name=row["model_name"],
-            model_type=ModelType(row["model_type"]),
+            model_type=parse_enum_text(ModelType, row["model_type"]),
             enabled=row["enabled"],
             load_balancing_enabled=row["load_balancing_enabled"],
         )
@@ -231,7 +232,7 @@ class _ProviderModelCredentialCacheEntry:
             id=row["id"],
             provider_name=row["provider_name"],
             model_name=row["model_name"],
-            model_type=ModelType(row["model_type"]),
+            model_type=parse_enum_text(ModelType, row["model_type"]),
             credential_name=row["credential_name"],
         )
 
@@ -306,7 +307,7 @@ class _LoadBalancingModelConfigCacheEntry:
             tenant_id=row["tenant_id"],
             provider_name=row["provider_name"],
             model_name=row["model_name"],
-            model_type=ModelType(row["model_type"]),
+            model_type=parse_enum_text(ModelType, row["model_type"]),
             name=row["name"],
             encrypted_config=row.get("encrypted_config"),
             credential_id=row.get("credential_id"),
@@ -1395,7 +1396,7 @@ class ProviderManager:
         return [
             {
                 "model": model_key[0],
-                "model_type": ModelType(model_key[1]),
+                "model_type": parse_enum_text(ModelType, model_key[1]),
                 "available_model_credentials": [
                     CredentialConfiguration(credential_id=cred.id, credential_name=cred.credential_name)
                     for cred in creds

--- a/api/models/types.py
+++ b/api/models/types.py
@@ -12,15 +12,17 @@ from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql.type_api import TypeEngine
 
 from configs import dify_config
+from graphon.model_runtime.entities.model_entities import ModelType
+
+_MODEL_TYPE_BY_ORIGIN = {member.to_origin_model_type(): member for member in ModelType}
 
 
 def parse_enum_text[T: enum.StrEnum](enum_class: type[T], value: str | T) -> T:
     """Parse a ``StrEnum`` from a stored or cached string.
 
-    Canonical values are constructed normally. When the constructor rejects the
-    string, this also accepts ``value_of()`` (if present) and origin aliases
-    exposed by ``to_origin_model_type()`` so pre-1.15 ``ModelType`` rows such as
-    ``text-generation`` can still be loaded.
+    Canonical values are constructed normally. For ``ModelType``, pre-1.15 origin
+    aliases such as ``text-generation`` map to the current enum member. Bind
+    still rejects those aliases so new rows stay canonical.
     """
     if isinstance(value, enum_class):
         return value
@@ -29,17 +31,10 @@ def parse_enum_text[T: enum.StrEnum](enum_class: type[T], value: str | T) -> T:
     try:
         return enum_class(value)
     except ValueError:
-        value_of = getattr(enum_class, "value_of", None)
-        if callable(value_of):
-            return cast(T, value_of(value))
-        to_origin = getattr(enum_class, "to_origin_model_type", None)
-        if callable(to_origin):
-            for member in enum_class:
-                try:
-                    if to_origin(member) == value:
-                        return member
-                except ValueError:
-                    continue
+        if enum_class is ModelType:
+            mapped = _MODEL_TYPE_BY_ORIGIN.get(value)
+            if mapped is not None:
+                return cast(T, mapped)
         raise
 
 

--- a/api/models/types.py
+++ b/api/models/types.py
@@ -14,6 +14,35 @@ from sqlalchemy.sql.type_api import TypeEngine
 from configs import dify_config
 
 
+def parse_enum_text[T: enum.StrEnum](enum_class: type[T], value: str | T) -> T:
+    """Parse a ``StrEnum`` from a stored or cached string.
+
+    Canonical values are constructed normally. When the constructor rejects the
+    string, this also accepts ``value_of()`` (if present) and origin aliases
+    exposed by ``to_origin_model_type()`` so pre-1.15 ``ModelType`` rows such as
+    ``text-generation`` can still be loaded.
+    """
+    if isinstance(value, enum_class):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"'{value}' is not a valid {enum_class.__name__}")
+    try:
+        return enum_class(value)
+    except ValueError:
+        value_of = getattr(enum_class, "value_of", None)
+        if callable(value_of):
+            return cast(T, value_of(value))
+        to_origin = getattr(enum_class, "to_origin_model_type", None)
+        if callable(to_origin):
+            for member in enum_class:
+                try:
+                    if to_origin(member) == value:
+                        return member
+                except ValueError:
+                    continue
+        raise
+
+
 class StringUUID(TypeDecorator[uuid.UUID | str | None]):
     impl = CHAR
     cache_ok = True
@@ -207,14 +236,7 @@ class EnumText[T: enum.StrEnum](TypeDecorator[T | None]):
     def process_result_value(self, value: str | None, dialect: Dialect) -> T | None:
         if value is None or value == "":
             return None
-        try:
-            # Type annotation guarantees value is str at this point
-            return self._enum_class(value)
-        except ValueError:
-            value_of = getattr(self._enum_class, "value_of", None)
-            if callable(value_of):
-                return cast(T, value_of(value))
-            raise
+        return parse_enum_text(self._enum_class, value)
 
     @override
     def compare_values(self, x: T | None, y: T | None) -> bool:

--- a/api/tests/test_containers_integration_tests/models/test_types_enum_text.py
+++ b/api/tests/test_containers_integration_tests/models/test_types_enum_text.py
@@ -210,7 +210,7 @@ class TestEnumText:
 
         assert str(exc.value) == "'invalid' is not a valid _UserType"
 
-    def test_select_rejects_legacy_model_type_values(self, engine_with_containers: Engine):
+    def test_select_maps_legacy_model_type_values(self, engine_with_containers: Engine):
         insertion_sql = """
                         INSERT INTO enum_text_legacy_model_type_test (id, model_type) VALUES
                             (1, 'text-generation'),
@@ -221,9 +221,13 @@ class TestEnumText:
             session.execute(sa.text(insertion_sql))
             session.commit()
 
-        for record_id, legacy_value in enumerate(("text-generation", "embeddings", "reranking"), 1):
-            with pytest.raises(ValueError) as exc:
-                with Session(engine_with_containers) as session:
-                    session.scalar(select(_LegacyModelTypeRecord).where(_LegacyModelTypeRecord.id == record_id))
-
-            assert str(exc.value) == f"'{legacy_value}' is not a valid ModelType"
+        expected = {
+            1: ModelType.LLM,
+            2: ModelType.TEXT_EMBEDDING,
+            3: ModelType.RERANK,
+        }
+        with Session(engine_with_containers) as session:
+            for record_id, model_type in expected.items():
+                record = session.scalar(select(_LegacyModelTypeRecord).where(_LegacyModelTypeRecord.id == record_id))
+                assert record is not None
+                assert record.model_type is model_type

--- a/api/tests/unit_tests/core/test_provider_manager.py
+++ b/api/tests/unit_tests/core/test_provider_manager.py
@@ -18,7 +18,7 @@ from core.entities.provider_entities import (
 from core.hosting_configuration import HostingProvider, TrialHostingQuota
 from core.plugin.entities.plugin import PluginInstallationSource
 from core.plugin.entities.plugin_daemon import PluginModelProviderDeclaration
-from core.provider_manager import ProviderConfigurationCacheSource, ProviderManager
+from core.provider_manager import ProviderConfigurationCacheSource, ProviderManager, _ProviderModelCacheEntry
 from enums import DeploymentEdition
 from graphon.model_runtime.entities.common_entities import I18nObject
 from graphon.model_runtime.entities.model_entities import ModelType
@@ -1319,3 +1319,20 @@ def test_get_all_provider_load_balancing_configs_populates_cache_and_groups_conf
     assert [record.provider_name for record in result["openai"]] == ["openai"]
     assert [record.provider_name for record in result["anthropic"]] == ["anthropic"]
     assert "other-provider" not in result
+
+
+def test_provider_model_cache_entry_reads_legacy_model_type_alias() -> None:
+    entry = _ProviderModelCacheEntry.from_cache_row(
+        {
+            "id": "model-1",
+            "provider_name": "openai",
+            "model_name": "gpt-4",
+            "model_type": "text-generation",
+            "credential_id": None,
+            "credential_name": None,
+            "encrypted_config": None,
+        }
+    )
+
+    assert entry.model_type is ModelType.LLM
+    assert entry.to_cache_row()["model_type"] == "llm"

--- a/api/tests/unit_tests/models/test_types.py
+++ b/api/tests/unit_tests/models/test_types.py
@@ -6,7 +6,8 @@ from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.sql.sqltypes import TEXT
 
-from models.types import JSONModelColumn
+from graphon.model_runtime.entities.model_entities import ModelType
+from models.types import EnumText, JSONModelColumn, parse_enum_text
 
 
 class JsonColumnSample(BaseModel):
@@ -63,3 +64,29 @@ def test_json_model_column_uses_long_text_compatible_dialect_types():
 def test_json_model_column_rejects_string_model_paths():
     with pytest.raises(TypeError):
         JSONModelColumn(cast(type[BaseModel], "tests.unit_tests.models.test_types.JsonColumnSample"))
+
+
+def test_parse_enum_text_maps_pre_1_15_model_type_aliases():
+    assert parse_enum_text(ModelType, "text-generation") is ModelType.LLM
+    assert parse_enum_text(ModelType, "embeddings") is ModelType.TEXT_EMBEDDING
+    assert parse_enum_text(ModelType, "reranking") is ModelType.RERANK
+    assert parse_enum_text(ModelType, "llm") is ModelType.LLM
+    assert parse_enum_text(ModelType, ModelType.LLM) is ModelType.LLM
+
+
+def test_parse_enum_text_rejects_unknown_values():
+    with pytest.raises(ValueError, match="not a valid ModelType"):
+        parse_enum_text(ModelType, "not-a-type")
+
+
+def test_enum_text_reads_legacy_model_type_aliases_but_does_not_bind_them():
+    column = EnumText(ModelType)
+    dialect = sqlite.dialect()
+
+    assert column.process_result_value("text-generation", dialect) is ModelType.LLM
+    assert column.process_result_value("embeddings", dialect) is ModelType.TEXT_EMBEDDING
+    assert column.process_result_value("reranking", dialect) is ModelType.RERANK
+    assert column.process_bind_param(ModelType.LLM, dialect) == "llm"
+
+    with pytest.raises(ValueError, match="not a valid ModelType"):
+        column.process_bind_param("text-generation", dialect)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41294

After upgrading to 1.17.0, the model provider page 500s with `ValueError: 'text-generation' is not a valid ModelType`. Pre-1.15 rows still store provider-native spellings (`text-generation`, `embeddings`, `reranking`). Lookups already match those aliases (`_model_type_db_values`), but hydrating the ORM/cache still constructed `ModelType` directly.

`EnumText.process_result_value` used to fall back to `ModelType.value_of()`. Graphon no longer ships that helper, so every unmigrated row crashes the request handler.

This change:

- Parses origin aliases via `ModelType.to_origin_model_type()` when loading `EnumText` columns
- Uses the same helper for Redis cache hydration in `ProviderManager`
- Still **rejects** legacy spellings on bind, so new writes stay canonical (`llm`, `text-embedding`, `rerank`)

The existing `flask data-migrate legacy-model-types` command remains the way to rewrite rows. This only stops the UI from being unusable until that command is run.

## Screenshots

Not applicable (backend enum mapping).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran targeted `ruff` and unit tests for the changed files