### PR TITLE
fix(web): raise the Docker build heap limit to 6144MB

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=packages /app/ .
 COPY . .
 
 WORKDIR /app/web
-ENV NODE_OPTIONS="--max-old-space-size=4096"
+ENV NODE_OPTIONS="--max-old-space-size=6144"
 ENV pnpm_config_verify_deps_before_run=false
 RUN pnpm build && pnpm build:vinext
 


### PR DESCRIPTION
## Summary

Building the web image on a standard 7.75 GB CI runner dies partway through `next build`:

```
#21 [builder 5/5] RUN pnpm build && pnpm build:vinext
#21 4.071   Creating an optimized production build ...
##[error]The runner has received a shutdown signal.
```

No compiler error, no type error, no dependency failure — the runner itself is terminated about five minutes in. That is the shape of an OOM kill rather than a build failure.

The same Dockerfile built fine before the bump to Next.js 16.3.3 (#41262), so the trigger looks like the newer Next/Turbopack memory profile rather than the image setup. `--max-old-space-size=4096` no longer leaves enough headroom on a 7.75 GB machine.

## Change

One line: raise the build-stage Node heap from 4096MB to 6144MB, which still leaves roughly 1.6 GB for the OS and Turbopack's native allocations.

## Notes

Turbopack's native memory is not bounded by `NODE_OPTIONS`, so this widens the margin rather than capping usage outright. If you would rather cap total usage, splitting `RUN pnpm build && pnpm build:vinext` into two layers is an alternative (or complementary) fix — the two builds currently stack their peaks in a single layer. Happy to switch to that if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)