### PR TITLE
fix(web): improve a11y of dataset clickable divs with native buttons

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1870,14 +1870,6 @@
       "count": 1
     }
   },
-  "web/app/components/datasets/create-from-pipeline/list/template-card/operations.tsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 3
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 3
-    }
-  },
   "web/app/components/datasets/create/file-preview/index.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
@@ -2252,12 +2244,6 @@
   "web/app/components/datasets/external-knowledge-base/create/ExternalApiSelect.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
-    },
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 3
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 3
     }
   },
   "web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx": {

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/operations.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/operations.tsx
@@ -12,21 +12,21 @@ type OperationsProps = {
 const Operations = ({ openEditModal, onDelete, onExport, onClose }: OperationsProps) => {
   const { t } = useTranslation()
 
-  const onClickEdit = (e: React.MouseEvent<HTMLDivElement>) => {
+  const onClickEdit = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     e.preventDefault()
     onClose?.()
     openEditModal()
   }
 
-  const onClickExport = (e: React.MouseEvent<HTMLDivElement>) => {
+  const onClickExport = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     e.preventDefault()
     onClose?.()
     onExport()
   }
 
-  const onClickDelete = (e: React.MouseEvent<HTMLDivElement>) => {
+  const onClickDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     e.preventDefault()
     onClose?.()
@@ -36,33 +36,36 @@ const Operations = ({ openEditModal, onDelete, onExport, onClose }: OperationsPr
   return (
     <div className="relative flex w-full flex-col rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg shadow-shadow-shadow-5">
       <div className="flex flex-col p-1">
-        <div
-          className="flex cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-base-hover"
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 text-left hover:bg-state-base-hover"
           onClick={onClickEdit}
         >
           <span className="px-1 system-md-regular text-text-secondary">
             {t(($) => $['operations.editInfo'], { ns: 'datasetPipeline' })}
           </span>
-        </div>
-        <div
-          className="flex cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-base-hover"
+        </button>
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 text-left hover:bg-state-base-hover"
           onClick={onClickExport}
         >
           <span className="px-1 system-md-regular text-text-secondary">
             {t(($) => $['operations.exportPipeline'], { ns: 'datasetPipeline' })}
           </span>
-        </div>
+        </button>
       </div>
       <Divider type="horizontal" className="my-0 bg-divider-subtle" />
       <div className="flex flex-col p-1">
-        <div
-          className="group flex cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-destructive-hover"
+        <button
+          type="button"
+          className="group flex w-full cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 text-left hover:bg-state-destructive-hover"
           onClick={onClickDelete}
         >
           <span className="px-1 system-md-regular text-text-secondary group-hover:text-text-destructive">
             {t(($) => $['operation.delete'], { ns: 'common' })}
           </span>
-        </div>
+        </button>
       </div>
     </div>
   )

--- a/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelect.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelect.tsx
@@ -57,8 +57,11 @@ const ExternalApiSelect: React.FC<ExternalApiSelectProps> = ({ items, value, onS
 
   return (
     <div className="relative w-full">
-      <div
-        className={`flex cursor-pointer items-center justify-between gap-0.5 self-stretch rounded-lg bg-components-input-bg-normal px-2 py-1 hover:bg-state-base-hover-alt ${isOpen && 'bg-state-base-hover-alt'}`}
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        className={`flex cursor-pointer items-center justify-between gap-0.5 self-stretch rounded-lg bg-components-input-bg-normal px-2 py-1 text-left hover:bg-state-base-hover-alt ${isOpen && 'bg-state-base-hover-alt'}`}
         onClick={() => setIsOpen(!isOpen)}
       >
         {selectedItem ? (
@@ -76,15 +79,16 @@ const ExternalApiSelect: React.FC<ExternalApiSelectProps> = ({ items, value, onS
           </span>
         )}
         <RiArrowDownSLine
-          className={`size-4 text-text-quaternary transition-transform ${isOpen ? 'text-text-secondary' : ''}`}
+          className={`size-4 shrink-0 text-text-quaternary transition-transform ${isOpen ? 'text-text-secondary' : ''}`}
         />
-      </div>
+      </button>
       {isOpen && (
         <div className="absolute z-10 mt-1 w-full rounded-xl border border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           {items.map((item) => (
-            <div
+            <button
+              type="button"
               key={item.value}
-              className="flex cursor-pointer items-center p-1"
+              className="block w-full cursor-pointer p-1 text-left"
               onClick={() => handleSelect(item)}
             >
               <div className="flex w-full items-center gap-2 self-stretch rounded-lg p-2 hover:bg-state-base-hover">
@@ -96,18 +100,19 @@ const ExternalApiSelect: React.FC<ExternalApiSelectProps> = ({ items, value, onS
                   {item.url}
                 </span>
               </div>
-            </div>
+            </button>
           ))}
           <div className="flex flex-col items-start self-stretch p-1">
-            <div
-              className="flex cursor-pointer items-center gap-2 self-stretch rounded-lg p-2 hover:bg-state-base-hover"
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-center gap-2 self-stretch rounded-lg p-2 text-left hover:bg-state-base-hover"
               onClick={handleAddNewAPI}
             >
               <RiAddLine className="size-4 text-text-secondary" />
               <span className="grow overflow-hidden system-sm-medium text-ellipsis text-text-secondary">
                 {t(($) => $.createNewExternalAPI, { ns: 'dataset' })}
               </span>
-            </div>
+            </button>
           </div>
         </div>
       )}

--- a/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelect.spec.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelect.spec.tsx
@@ -131,28 +131,38 @@ describe('ExternalApiSelect', () => {
   describe('accessibility', () => {
     it('should render the trigger as a button with listbox semantics', () => {
       render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      const trigger = screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' })
+      const trigger = screen.getByRole('button', {
+        name: 'dataset.selectExternalKnowledgeAPI.placeholder',
+      })
       expect(trigger).toHaveAttribute('aria-haspopup', 'listbox')
       expect(trigger).toHaveAttribute('aria-expanded', 'false')
     })
 
     it('should reflect the expanded state on the trigger', () => {
       render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      const trigger = screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' })
+      const trigger = screen.getByRole('button', {
+        name: 'dataset.selectExternalKnowledgeAPI.placeholder',
+      })
       fireEvent.click(trigger)
       expect(trigger).toHaveAttribute('aria-expanded', 'true')
     })
 
     it('should render dropdown items and the add action as buttons', () => {
       render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      fireEvent.click(screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }))
+      fireEvent.click(
+        screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }),
+      )
       expect(screen.getByRole('button', { name: /API Two/ })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'dataset.createNewExternalAPI' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'dataset.createNewExternalAPI' }),
+      ).toBeInTheDocument()
     })
 
     it('should select an item when its button is clicked', () => {
       render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      fireEvent.click(screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }))
+      fireEvent.click(
+        screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }),
+      )
       fireEvent.click(screen.getByRole('button', { name: /API Two/ }))
       expect(onSelect).toHaveBeenCalledWith(items[1])
     })

--- a/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelect.spec.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelect.spec.tsx
@@ -127,4 +127,34 @@ describe('ExternalApiSelect', () => {
       expect(screen.getByText('https://api2.com')).toBeInTheDocument()
     })
   })
+
+  describe('accessibility', () => {
+    it('should render the trigger as a button with listbox semantics', () => {
+      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
+      const trigger = screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' })
+      expect(trigger).toHaveAttribute('aria-haspopup', 'listbox')
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('should reflect the expanded state on the trigger', () => {
+      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
+      const trigger = screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' })
+      fireEvent.click(trigger)
+      expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('should render dropdown items and the add action as buttons', () => {
+      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
+      fireEvent.click(screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }))
+      expect(screen.getByRole('button', { name: /API Two/ })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'dataset.createNewExternalAPI' })).toBeInTheDocument()
+    })
+
+    it('should select an item when its button is clicked', () => {
+      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
+      fireEvent.click(screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }))
+      fireEvent.click(screen.getByRole('button', { name: /API Two/ }))
+      expect(onSelect).toHaveBeenCalledWith(items[1])
+    })
+  })
 })


### PR DESCRIPTION
Replace clickable `<div>` elements with native `<button>` elements in two dataset components to fix suppressed jsx-a11y violations (`no-static-element-interactions`, `click-events-have-key-events`), following the same approach as #41301.

## Changes

- `ExternalApiSelect.tsx`: convert the select trigger, dropdown options, and the add-new-API row to `<button type="button">`; add `aria-haspopup="listbox"` and `aria-expanded` on the trigger
- `template-card/operations.tsx`: convert the edit / export / delete menu items to `<button type="button">`
- Remove the corresponding entries from `oxlint-suppressions.json`
- Add accessibility tests to `ExternalApiSelect.spec.tsx` (trigger semantics, expanded state, button roles)

## Verification

- `pnpm lint:a11y` on both files: 0 warnings, 0 errors
- `pnpm test ExternalApiSelect.spec`: 12/12 passed
- `pnpm type-check`: 0 errors