### PR TITLE
fix(web): use native buttons for variable inspect triggers

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4946,12 +4946,6 @@
     }
   },
   "web/app/components/workflow/variable-inspect/trigger.tsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 5
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 5
-    },
     "typescript/no-explicit-any": {
       "count": 1
     }

--- a/web/app/components/workflow/variable-inspect/__tests__/trigger.spec.tsx
+++ b/web/app/components/workflow/variable-inspect/__tests__/trigger.spec.tsx
@@ -159,4 +159,53 @@ describe('VariableInspectTrigger', () => {
     ).not.toBeInTheDocument()
     expect(store.getState().showVariableInspectPanel).toBe(true)
   })
+
+  it('should render the normal trigger as a native button', () => {
+    renderTrigger()
+
+    expect(
+      screen.getByRole('button', { name: 'workflow.debug.variableInspect.trigger.normal' }),
+    ).toBeInTheDocument()
+  })
+
+  it('should render the cached and clear triggers as native buttons', () => {
+    inspectVarsState = {
+      conversationVars: [createVariable()],
+      systemVars: [],
+      nodesWithInspectVars: [],
+    }
+
+    renderTrigger()
+
+    expect(
+      screen.getByRole('button', { name: 'workflow.debug.variableInspect.trigger.cached' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'workflow.debug.variableInspect.trigger.clear' }),
+    ).toBeInTheDocument()
+  })
+
+  it('should expose an accessible name on the stop trigger', () => {
+    renderTrigger({
+      nodes: [
+        createNode({
+          data: {
+            type: BlockEnum.Code,
+            title: 'Code',
+            desc: '',
+            _singleRunningStatus: NodeRunningStatus.Running,
+          },
+        }),
+      ],
+      initialStoreState: {
+        workflowRunningData: baseRunningData({
+          result: { status: WorkflowRunningStatus.Running },
+        }),
+      },
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'workflow.debug.variableInspect.trigger.stop' }),
+    ).toBeInTheDocument()
+  })
 })

--- a/web/app/components/workflow/variable-inspect/trigger.tsx
+++ b/web/app/components/workflow/variable-inspect/trigger.tsx
@@ -65,7 +65,8 @@ const VariableInspectTrigger: FC = () => {
   return (
     <div className={cn('flex shrink-0 flex-nowrap items-center gap-1 whitespace-nowrap')}>
       {!isRunning && !currentVars.length && (
-        <div
+        <button
+          type="button"
           className={cn(
             'flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-2 system-2xs-semibold-uppercase text-text-tertiary shadow-lg backdrop-blur-xs hover:bg-background-default-hover',
             nodesReadOnly &&
@@ -77,11 +78,12 @@ const VariableInspectTrigger: FC = () => {
           }}
         >
           {t(($) => $['debug.variableInspect.trigger.normal'], { ns: 'workflow' })}
-        </div>
+        </button>
       )}
       {!isRunning && currentVars.length > 0 && (
         <>
-          <div
+          <button
+            type="button"
             className={cn(
               'flex h-6 shrink-0 cursor-pointer items-center gap-1 rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-2 system-xs-medium text-text-accent shadow-lg backdrop-blur-xs hover:bg-components-actionbar-bg-accent',
               nodesReadOnly &&
@@ -93,8 +95,9 @@ const VariableInspectTrigger: FC = () => {
             }}
           >
             {t(($) => $['debug.variableInspect.trigger.cached'], { ns: 'workflow' })}
-          </div>
-          <div
+          </button>
+          <button
+            type="button"
             className={cn(
               'flex h-6 shrink-0 cursor-pointer items-center rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-1 system-xs-medium text-text-tertiary shadow-lg backdrop-blur-xs hover:bg-components-actionbar-bg-accent hover:text-text-accent',
               nodesReadOnly &&
@@ -106,12 +109,13 @@ const VariableInspectTrigger: FC = () => {
             }}
           >
             {t(($) => $['debug.variableInspect.trigger.clear'], { ns: 'workflow' })}
-          </div>
+          </button>
         </>
       )}
       {isRunning && (
         <>
-          <div
+          <button
+            type="button"
             className="flex h-6 shrink-0 cursor-pointer items-center gap-1 rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-2 system-xs-medium text-text-accent shadow-lg backdrop-blur-xs hover:bg-components-actionbar-bg-accent"
             onClick={() => setShowVariableInspectPanel(true)}
           >
@@ -119,17 +123,19 @@ const VariableInspectTrigger: FC = () => {
             <span className="text-text-accent">
               {t(($) => $['debug.variableInspect.trigger.running'], { ns: 'workflow' })}
             </span>
-          </div>
+          </button>
           {isPreviewRunning && (
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <div
+                  <button
+                    type="button"
+                    aria-label={t(($) => $['debug.variableInspect.trigger.stop'], { ns: 'workflow' })}
                     className="flex h-6 shrink-0 cursor-pointer items-center rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-1 shadow-lg backdrop-blur-xs hover:bg-components-actionbar-bg-accent"
                     onClick={handleStop}
                   >
                     <RiStopCircleFill className="size-4 shrink-0 text-text-accent" />
-                  </div>
+                  </button>
                 }
               />
               <TooltipContent>


### PR DESCRIPTION
Convert the clickable `<div>` elements in `variable-inspect/trigger.tsx` to native `<button>` elements to fix suppressed jsx-a11y violations (`no-static-element-interactions`, `click-events-have-key-events`), following the same approach as #41301.

## Changes

- Convert the normal / cached / clear / running triggers to `<button type="button">`
- Convert the icon-only stop trigger to a button and give it an `aria-label` (it previously had no accessible name)
- Remove the corresponding entries from `oxlint-suppressions.json`
- Add tests asserting the button roles and the stop trigger's accessible name

## Verification

- `pnpm lint:a11y` on the file: 0 warnings, 0 errors
- `pnpm test variable-inspect/__tests__/trigger.spec`: 8/8 passed
- `pnpm type-check`: 0 errors