### PR TITLE
fix(api): enforce RBAC permission on agent composer GET endpoint (#41324)

### DIFF
--- a/api/controllers/console/agent/composer.py
+++ b/api/controllers/console/agent/composer.py
@@ -512,6 +512,7 @@ class AgentComposerApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)
     @with_current_tenant_id
     @with_session
     def get(self, session: Session, tenant_id: str, agent_id: UUID):

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -4,6 +4,7 @@ from types import FunctionType
 import pytest
 
 from controllers.common.wraps import RBACPermission, RBACResourceScope
+from controllers.console.agent.composer import AgentComposerApi
 from controllers.console.agent.roster import AgentAppApi
 from controllers.console.datasets.data_source import DataSourceApi
 from controllers.console.datasets.rag_pipeline.datasource_auth import DatasourceAuth
@@ -107,11 +108,16 @@ def test_workspace_model_preferences_get_require_admin_and_rbac(
     assert rbac_config["resource_required"] is False
 
 
-def test_agent_app_get_requires_rbac() -> None:
-    """GET endpoint that returns agent app details must enforce
-    the same RBAC gates as its sibling PUT/DELETE methods."""
-    method = AgentAppApi.get
-
+@pytest.mark.parametrize(
+    "method",
+    [
+        AgentAppApi.get,
+        AgentComposerApi.get,
+    ],
+)
+def test_agent_app_get_requires_rbac(method: FunctionType) -> None:
+    """GET endpoints that return agent app details or composer state must enforce
+    the same RBAC gates as their sibling PUT/DELETE methods."""
     rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
     rbac_config = getclosurevars(rbac_wrapper).nonlocals
     assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE


### PR DESCRIPTION
## Summary

Fixes #41324

The `GET /console/api/agent/<agent_id>/composer` endpoint in `AgentComposerApi` was missing authorization decorator:
- `@rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)`

This allowed workspace members without `AGENT_MANAGE` RBAC permissions to retrieve detailed agent app composer configurations (system prompts, tools, agent soul, models, etc.).

Added missing permission decorator to match its sibling method `AgentComposerApi.put` and other agent management endpoints in `api/controllers/console/agent/composer.py`, and added corresponding unit test assertion.

## Screenshots

N/A (Backend API permission enforcement)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
