### PR TITLE
ci: run the dify-agent test suite

### DIFF
--- a/.github/workflows/dify-agent-tests.yml
+++ b/.github/workflows/dify-agent-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv lock --check
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --extra server --dev
 
       - name: Run unit tests
-        run: uv run pytest --timeout "${PYTEST_TIMEOUT:-20}"
+        run: uv run pytest

--- a/.github/workflows/dify-agent-tests.yml
+++ b/.github/workflows/dify-agent-tests.yml
@@ -1,0 +1,47 @@
+name: Dify Agent Tests
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dify-agent-tests-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  dify-agent-unit:
+    name: Dify Agent Unit Tests
+    runs-on: depot-ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: dify-agent
+    strategy:
+      matrix:
+        python-version:
+          - '3.12'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup UV and Python
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+          cache-dependency-glob: dify-agent/uv.lock
+
+      - name: Check UV lockfile
+        run: uv lock --check
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run unit tests
+        run: uv run pytest --timeout "${PYTEST_TIMEOUT:-20}"

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -48,6 +48,7 @@ jobs:
       vdb-changed: ${{ steps.changes.outputs.vdb }}
       migration-changed: ${{ steps.changes.outputs.migration }}
       sandbox-runtime-changed: ${{ steps.changes.outputs.sandbox-runtime }}
+      dify-agent-changed: ${{ steps.changes.outputs.dify-agent }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -138,6 +139,9 @@ jobs:
             sandbox-runtime:
               - 'dify-agent-runtime/**'
               - '.github/workflows/sandbox-runtime-tests.yml'
+            dify-agent:
+              - 'dify-agent/**'
+              - '.github/workflows/dify-agent-tests.yml'
             migration:
               - 'api/migrations/**'
               - 'api/.env.example'
@@ -577,4 +581,64 @@ jobs:
           fi
 
           echo "Sandbox runtime tests were not required, but the skip job finished with result: $SKIP_RESULT" >&2
+          exit 1
+
+  dify-agent-tests-run:
+    name: Run Dify Agent Tests
+    needs:
+      - pre_job
+      - check-changes
+    if: needs.pre_job.outputs.should_skip != 'true' && needs.check-changes.outputs.dify-agent-changed == 'true'
+    uses: ./.github/workflows/dify-agent-tests.yml
+    secrets: inherit
+
+  dify-agent-tests-skip:
+    name: Skip Dify Agent Tests
+    needs:
+      - pre_job
+      - check-changes
+    if: needs.pre_job.outputs.should_skip != 'true' && needs.check-changes.outputs.dify-agent-changed != 'true'
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - name: Report skipped dify agent tests
+        run: echo "No dify-agent-related changes detected; skipping dify agent tests."
+
+  dify-agent-tests:
+    name: Dify Agent Tests
+    if: ${{ always() }}
+    needs:
+      - pre_job
+      - check-changes
+      - dify-agent-tests-run
+      - dify-agent-tests-skip
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - name: Finalize Dify Agent Tests status
+        env:
+          SHOULD_SKIP_WORKFLOW: ${{ needs.pre_job.outputs.should_skip }}
+          TESTS_CHANGED: ${{ needs.check-changes.outputs.dify-agent-changed }}
+          RUN_RESULT: ${{ needs.dify-agent-tests-run.result }}
+          SKIP_RESULT: ${{ needs.dify-agent-tests-skip.result }}
+        run: |
+          if [[ "$SHOULD_SKIP_WORKFLOW" == 'true' ]]; then
+            echo "Dify agent tests were skipped because this workflow run duplicated a successful or newer run."
+            exit 0
+          fi
+
+          if [[ "$TESTS_CHANGED" == 'true' ]]; then
+            if [[ "$RUN_RESULT" == 'success' ]]; then
+              echo "Dify agent tests ran successfully."
+              exit 0
+            fi
+
+            echo "Dify agent tests were required but finished with result: $RUN_RESULT" >&2
+            exit 1
+          fi
+
+          if [[ "$SKIP_RESULT" == 'success' ]]; then
+            echo "Dify agent tests were skipped because no dify-agent-related files changed."
+            exit 0
+          fi
+
+          echo "Dify agent tests were not required, but the skip job finished with result: $SKIP_RESULT" >&2
           exit 1

--- a/dify-agent/pyproject.toml
+++ b/dify-agent/pyproject.toml
@@ -46,6 +46,10 @@ pythonVersion = "3.12"
 extraPaths = ["src", "examples/agenton", "examples/dify_agent"]
 
 [tool.pytest.ini_options]
+# Several test modules share a basename across directories (test_layer.py,
+# test_client.py, ...). The default prepend import mode derives module names
+# from the basename, so collecting them together is an import file mismatch.
+addopts = ["--import-mode=importlib"]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 markers = ["integration: requires a real external service or exercises multiple concrete adapters"]


### PR DESCRIPTION
## Summary

`dify-agent` has 78 test files and 777 tests. Nothing in `.github/workflows` runs pytest against them — `autofix.yml` is the only workflow that looks at the directory, and it only runs ruff.

The sibling component `dify-agent-runtime` already has its own paths filter and its own `sandbox-runtime-tests.yml`. This PR gives `dify-agent` the same arrangement.

## Why it matters right now

The suite does not collect on `main`:

```
$ cd dify-agent && uv run pytest -q
Interrupted: 5 errors during collection
5 errors in 1.94s
```

That is what #41208 fixes, and the absent CI job is why it went unnoticed. This branch is stacked on #41208, so with both:

```
777 passed, 32 skipped in 22.37s
```

Both numbers are from `origin/main` as of `0d05eae5`.

If you would rather land them as one change, I am happy to close #41208 and fold its four lines in here.

## What it does

- `.github/workflows/dify-agent-tests.yml` — mirrors `sandbox-runtime-tests.yml`, with the uv/Python setup taken from `api-tests.yml` since this component is Python rather than Go.
- `main-ci.yml` — a `dify-agent` paths filter next to `sandbox-runtime`, plus the run / skip / finalize trio, so the required check stays stable when no `dify-agent` file changed.

The workflow is `workflow_call`-only, like the other component workflows, and the filter includes the workflow file itself so a change to it re-runs the job.
