### PR TITLE
refactor: remove unused workflow run export endpoint

### DIFF
--- a/api/controllers/console/app/workflow_run.py
+++ b/api/controllers/console/app/workflow_run.py
@@ -1,10 +1,8 @@
-from datetime import UTC, datetime, timedelta
 from typing import Literal
 from uuid import UUID
 
 from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
 
 from configs import dify_config
@@ -35,14 +33,12 @@ from fields.workflow_run_fields import (
     WorkflowRunPaginationResponse,
 )
 from graphon.enums import WorkflowExecutionStatus
-from libs.archive_storage import ArchiveStorageNotConfiguredError, get_archive_storage
 from libs.custom_inputs import time_duration
-from libs.helper import dump_response, uuid_value
+from libs.helper import uuid_value
 from libs.login import login_required
-from models import Account, App, AppMode, WorkflowArchiveLog, WorkflowRunTriggeredFrom
+from models import Account, App, AppMode, WorkflowRunTriggeredFrom
 from models.workflow import WorkflowRun
 from repositories.factory import DifyAPIRepositoryFactory
-from services.retention.workflow_run.constants import ARCHIVE_BUNDLE_NAME
 from services.workflow_run_service import WorkflowRunListArgs, WorkflowRunService
 
 
@@ -57,7 +53,6 @@ def _build_backstage_input_url(form_token: str | None) -> str | None:
 
 # Workflow run status choices for filtering
 WORKFLOW_RUN_STATUS_CHOICES = ["running", "succeeded", "failed", "stopped", "partial-succeeded"]
-EXPORT_SIGNED_URL_EXPIRE_SECONDS = 3600
 
 
 class WorkflowRunListQuery(BaseModel):
@@ -101,12 +96,6 @@ class WorkflowRunCountQuery(BaseModel):
         return time_duration(value)
 
 
-class WorkflowRunExportResponse(ResponseModel):
-    status: str = Field(description="Export status: success/failed")
-    presigned_url: str | None = Field(default=None, description="Pre-signed URL for download")
-    presigned_url_expires_at: str | None = Field(default=None, description="Pre-signed URL expiration time")
-
-
 class HumanInputPauseTypeResponse(ResponseModel):
     type: Literal["human_input"]
     form_id: str
@@ -137,7 +126,6 @@ register_response_schema_models(
     WorkflowRunDetailResponse,
     WorkflowRunNodeExecutionResponse,
     WorkflowRunNodeExecutionListResponse,
-    WorkflowRunExportResponse,
     HumanInputPauseTypeResponse,
     PausedNodeResponse,
     WorkflowPauseDetailsResponse,
@@ -185,63 +173,6 @@ class AdvancedChatAppWorkflowRunListApi(Resource):
 
         return AdvancedChatWorkflowRunPaginationResponse.model_validate(result, from_attributes=True).model_dump(
             mode="json"
-        )
-
-
-@console_ns.route("/apps/<uuid:app_id>/workflow-runs/<uuid:run_id>/export")
-class WorkflowRunExportApi(Resource):
-    @console_ns.doc("get_workflow_run_export_url")
-    @console_ns.doc(description="Generate a download URL for an archived workflow run.")
-    @console_ns.doc(params={"app_id": "Application ID", "run_id": "Workflow run ID"})
-    @console_ns.response(200, "Export URL generated", console_ns.models[WorkflowRunExportResponse.__name__])
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_CREATE_AND_MANAGEMENT)
-    @get_app_model()
-    def get(self, app_model: App, run_id: UUID):
-        tenant_id = app_model.tenant_id
-        app_id = app_model.id
-        run_id_str = str(run_id)
-
-        run_created_at = db.session.scalar(
-            select(WorkflowArchiveLog.run_created_at)
-            .where(
-                WorkflowArchiveLog.tenant_id == tenant_id,
-                WorkflowArchiveLog.app_id == app_id,
-                WorkflowArchiveLog.workflow_run_id == run_id_str,
-            )
-            .limit(1)
-        )
-        if not run_created_at:
-            return {"code": "archive_log_not_found", "message": "workflow run archive not found"}, 404
-
-        prefix = (
-            f"{tenant_id}/app_id={app_id}/year={run_created_at.strftime('%Y')}/"
-            f"month={run_created_at.strftime('%m')}/workflow_run_id={run_id_str}"
-        )
-        archive_key = f"{prefix}/{ARCHIVE_BUNDLE_NAME}"
-
-        try:
-            archive_storage = get_archive_storage()
-        except ArchiveStorageNotConfiguredError as e:
-            return {"code": "archive_storage_not_configured", "message": str(e)}, 500
-
-        presigned_url = archive_storage.generate_presigned_url(
-            archive_key,
-            expires_in=EXPORT_SIGNED_URL_EXPIRE_SECONDS,
-        )
-        expires_at = datetime.now(UTC) + timedelta(seconds=EXPORT_SIGNED_URL_EXPIRE_SECONDS)
-        return (
-            dump_response(
-                WorkflowRunExportResponse,
-                {
-                    "status": "success",
-                    "presigned_url": presigned_url,
-                    "presigned_url_expires_at": expires_at.isoformat(),
-                },
-            ),
-            200,
         )
 
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -3459,22 +3459,6 @@ Stop running workflow task
 | 200 | Workflow run detail retrieved successfully | **application/json**: [WorkflowRunDetailResponse](#workflowrundetailresponse)<br> |
 | 404 | Workflow run not found |  |
 
-### [GET] /apps/{app_id}/workflow-runs/{run_id}/export
-Generate a download URL for an archived workflow run.
-
-#### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string (uuid) |
-| run_id | path | Workflow run ID | Yes | string (uuid) |
-
-#### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Export URL generated | **application/json**: [WorkflowRunExportResponse](#workflowrunexportresponse)<br> |
-
 ### [GET] /apps/{app_id}/workflow-runs/{run_id}/node-executions
 **Get workflow run node execution list**
 
@@ -24572,14 +24556,6 @@ Lifecycle state for an asynchronous archive download request.
 | total_steps | integer |  | No |
 | total_tokens | integer |  | No |
 | version | string |  | No |
-
-#### WorkflowRunExportResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| presigned_url | string | Pre-signed URL for download | No |
-| presigned_url_expires_at | string | Pre-signed URL expiration time | No |
-| status | string | Export status: success/failed | Yes |
 
 #### WorkflowRunForArchivedLogResponse
 

--- a/packages/contracts/generated/api/console/apps/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/apps/orpc.gen.ts
@@ -168,8 +168,6 @@ import {
   zGetAppsByAppIdWorkflowCommentsMentionUsersResponse,
   zGetAppsByAppIdWorkflowCommentsPath,
   zGetAppsByAppIdWorkflowCommentsResponse,
-  zGetAppsByAppIdWorkflowRunsByRunIdExportPath,
-  zGetAppsByAppIdWorkflowRunsByRunIdExportResponse,
   zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsPath,
   zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsResponse,
   zGetAppsByAppIdWorkflowRunsByRunIdPath,
@@ -2680,30 +2678,11 @@ export const tasks = {
 }
 
 /**
- * Generate a download URL for an archived workflow run.
- */
-export const get50 = oc
-  .route({
-    description: 'Generate a download URL for an archived workflow run.',
-    inputStructure: 'detailed',
-    method: 'GET',
-    operationId: 'getAppsByAppIdWorkflowRunsByRunIdExport',
-    path: '/apps/{app_id}/workflow-runs/{run_id}/export',
-    tags: ['console'],
-  })
-  .input(z.object({ params: zGetAppsByAppIdWorkflowRunsByRunIdExportPath }))
-  .output(zGetAppsByAppIdWorkflowRunsByRunIdExportResponse)
-
-export const export4 = {
-  get: get50,
-}
-
-/**
  * Get workflow run node execution list
  *
  * Get workflow run node execution list
  */
-export const get51 = oc
+export const get50 = oc
   .route({
     description: 'Get workflow run node execution list',
     inputStructure: 'detailed',
@@ -2717,7 +2696,7 @@ export const get51 = oc
   .output(zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsResponse)
 
 export const nodeExecutions = {
-  get: get51,
+  get: get50,
 }
 
 /**
@@ -2725,7 +2704,7 @@ export const nodeExecutions = {
  *
  * Get workflow run detail
  */
-export const get52 = oc
+export const get51 = oc
   .route({
     description: 'Get workflow run detail',
     inputStructure: 'detailed',
@@ -2739,8 +2718,7 @@ export const get52 = oc
   .output(zGetAppsByAppIdWorkflowRunsByRunIdResponse)
 
 export const byRunId = {
-  get: get52,
-  export: export4,
+  get: get51,
   nodeExecutions,
 }
 
@@ -2772,7 +2750,7 @@ export const download4 = {
 /**
  * Read a text/binary preview file in a workflow Agent node sandbox
  */
-export const get53 = oc
+export const get52 = oc
   .route({
     description: 'Read a text/binary preview file in a workflow Agent node sandbox',
     inputStructure: 'detailed',
@@ -2790,13 +2768,13 @@ export const get53 = oc
   .output(zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesReadResponse)
 
 export const read = {
-  get: get53,
+  get: get52,
 }
 
 /**
  * List a directory in a workflow Agent node sandbox
  */
-export const get54 = oc
+export const get53 = oc
   .route({
     description: 'List a directory in a workflow Agent node sandbox',
     inputStructure: 'detailed',
@@ -2814,7 +2792,7 @@ export const get54 = oc
   .output(zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesResponse)
 
 export const files3 = {
-  get: get54,
+  get: get53,
   download: download4,
   read,
 }
@@ -2840,7 +2818,7 @@ export const byWorkflowRunId = {
  *
  * Get workflow run list
  */
-export const get55 = oc
+export const get54 = oc
   .route({
     description: 'Get workflow run list',
     inputStructure: 'detailed',
@@ -2859,7 +2837,7 @@ export const get55 = oc
   .output(zGetAppsByAppIdWorkflowRunsResponse)
 
 export const workflowRuns2 = {
-  get: get55,
+  get: get54,
   count: count3,
   tasks,
   byRunId,
@@ -2871,7 +2849,7 @@ export const workflowRuns2 = {
  *
  * Get all users in current tenant for mentions
  */
-export const get56 = oc
+export const get55 = oc
   .route({
     description: 'Get all users in current tenant for mentions',
     inputStructure: 'detailed',
@@ -2885,7 +2863,7 @@ export const get56 = oc
   .output(zGetAppsByAppIdWorkflowCommentsMentionUsersResponse)
 
 export const mentionUsers = {
-  get: get56,
+  get: get55,
 }
 
 /**
@@ -3010,7 +2988,7 @@ export const delete10 = oc
  *
  * Get a specific workflow comment
  */
-export const get57 = oc
+export const get56 = oc
   .route({
     description: 'Get a specific workflow comment',
     inputStructure: 'detailed',
@@ -3048,7 +3026,7 @@ export const put3 = oc
 
 export const byCommentId = {
   delete: delete10,
-  get: get57,
+  get: get56,
   put: put3,
   replies,
   resolve,
@@ -3059,7 +3037,7 @@ export const byCommentId = {
  *
  * Get all comments for a workflow
  */
-export const get58 = oc
+export const get57 = oc
   .route({
     description: 'Get all comments for a workflow',
     inputStructure: 'detailed',
@@ -3097,7 +3075,7 @@ export const post42 = oc
   .output(zPostAppsByAppIdWorkflowCommentsResponse)
 
 export const comments = {
-  get: get58,
+  get: get57,
   post: post42,
   mentionUsers,
   byCommentId,
@@ -3106,7 +3084,7 @@ export const comments = {
 /**
  * Get workflow average app interaction statistics
  */
-export const get59 = oc
+export const get58 = oc
   .route({
     description: 'Get workflow average app interaction statistics',
     inputStructure: 'detailed',
@@ -3124,13 +3102,13 @@ export const get59 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsAverageAppInteractionsResponse)
 
 export const averageAppInteractions = {
-  get: get59,
+  get: get58,
 }
 
 /**
  * Get workflow daily runs statistics
  */
-export const get60 = oc
+export const get59 = oc
   .route({
     description: 'Get workflow daily runs statistics',
     inputStructure: 'detailed',
@@ -3148,13 +3126,13 @@ export const get60 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsDailyConversationsResponse)
 
 export const dailyConversations2 = {
-  get: get60,
+  get: get59,
 }
 
 /**
  * Get workflow daily terminals statistics
  */
-export const get61 = oc
+export const get60 = oc
   .route({
     description: 'Get workflow daily terminals statistics',
     inputStructure: 'detailed',
@@ -3172,13 +3150,13 @@ export const get61 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsDailyTerminalsResponse)
 
 export const dailyTerminals = {
-  get: get61,
+  get: get60,
 }
 
 /**
  * Get workflow daily token cost statistics
  */
-export const get62 = oc
+export const get61 = oc
   .route({
     description: 'Get workflow daily token cost statistics',
     inputStructure: 'detailed',
@@ -3196,7 +3174,7 @@ export const get62 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsTokenCostsResponse)
 
 export const tokenCosts2 = {
-  get: get62,
+  get: get61,
 }
 
 export const statistics2 = {
@@ -3216,7 +3194,7 @@ export const workflow = {
  *
  * Get default block configuration by type
  */
-export const get63 = oc
+export const get62 = oc
   .route({
     description: 'Get default block configuration by type',
     inputStructure: 'detailed',
@@ -3235,7 +3213,7 @@ export const get63 = oc
   .output(zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsByBlockTypeResponse)
 
 export const byBlockType = {
-  get: get63,
+  get: get62,
 }
 
 /**
@@ -3243,7 +3221,7 @@ export const byBlockType = {
  *
  * Get default block configurations for workflow
  */
-export const get64 = oc
+export const get63 = oc
   .route({
     description: 'Get default block configurations for workflow',
     inputStructure: 'detailed',
@@ -3257,14 +3235,14 @@ export const get64 = oc
   .output(zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsResponse)
 
 export const defaultWorkflowBlockConfigs = {
-  get: get64,
+  get: get63,
   byBlockType,
 }
 
 /**
  * Get conversation variables for workflow
  */
-export const get65 = oc
+export const get64 = oc
   .route({
     description: 'Get conversation variables for workflow',
     inputStructure: 'detailed',
@@ -3297,7 +3275,7 @@ export const post43 = oc
   .output(zPostAppsByAppIdWorkflowsDraftConversationVariablesResponse)
 
 export const conversationVariables2 = {
-  get: get65,
+  get: get64,
   post: post43,
 }
 
@@ -3306,7 +3284,7 @@ export const conversationVariables2 = {
  *
  * Get environment variables for workflow
  */
-export const get66 = oc
+export const get65 = oc
   .route({
     description: 'Get environment variables for workflow',
     inputStructure: 'detailed',
@@ -3340,7 +3318,7 @@ export const post44 = oc
   .output(zPostAppsByAppIdWorkflowsDraftEnvironmentVariablesResponse)
 
 export const environmentVariables = {
-  get: get66,
+  get: get65,
   post: post44,
 }
 
@@ -3545,7 +3523,7 @@ export const loop2 = {
   nodes: nodes6,
 }
 
-export const get67 = oc
+export const get66 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -3559,7 +3537,7 @@ export const get67 = oc
   .output(zGetAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerCandidatesResponse)
 
 export const candidates = {
-  get: get67,
+  get: get66,
 }
 
 export const post51 = oc
@@ -3642,7 +3620,7 @@ export const validate = {
   post: post54,
 }
 
-export const get68 = oc
+export const get67 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -3675,7 +3653,7 @@ export const put4 = oc
   .output(zPutAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerResponse)
 
 export const agentComposer = {
-  get: get68,
+  get: get67,
   put: put4,
   candidates,
   copyFromRoster,
@@ -3687,7 +3665,7 @@ export const agentComposer = {
 /**
  * Get last run result for draft workflow node
  */
-export const get69 = oc
+export const get68 = oc
   .route({
     description: 'Get last run result for draft workflow node',
     inputStructure: 'detailed',
@@ -3700,7 +3678,7 @@ export const get69 = oc
   .output(zGetAppsByAppIdWorkflowsDraftNodesByNodeIdLastRunResponse)
 
 export const lastRun = {
-  get: get69,
+  get: get68,
 }
 
 /**
@@ -3775,7 +3753,7 @@ export const delete11 = oc
 /**
  * Get variables for a specific node
  */
-export const get70 = oc
+export const get69 = oc
   .route({
     description: 'Get variables for a specific node',
     inputStructure: 'detailed',
@@ -3789,7 +3767,7 @@ export const get70 = oc
 
 export const variables = {
   delete: delete11,
-  get: get70,
+  get: get69,
 }
 
 export const byNodeId8 = {
@@ -3834,7 +3812,7 @@ export const run10 = {
 /**
  * Server-Sent Events stream of inspector deltas for a draft workflow run.
  */
-export const get71 = oc
+export const get70 = oc
   .route({
     description: 'Server-Sent Events stream of inspector deltas for a draft workflow run.',
     inputStructure: 'detailed',
@@ -3847,13 +3825,13 @@ export const get71 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsEventsResponse)
 
 export const events = {
-  get: get71,
+  get: get70,
 }
 
 /**
  * Full value for one declared output, including signed download URL for files.
  */
-export const get72 = oc
+export const get71 = oc
   .route({
     description: 'Full value for one declared output, including signed download URL for files.',
     inputStructure: 'detailed',
@@ -3870,7 +3848,7 @@ export const get72 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdByOutputNamePreviewResponse)
 
 export const preview5 = {
-  get: get72,
+  get: get71,
 }
 
 export const byOutputName = {
@@ -3880,7 +3858,7 @@ export const byOutputName = {
 /**
  * One node's declared outputs for a draft workflow run.
  */
-export const get73 = oc
+export const get72 = oc
   .route({
     description: "One node's declared outputs for a draft workflow run.",
     inputStructure: 'detailed',
@@ -3893,14 +3871,14 @@ export const get73 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdResponse)
 
 export const byNodeId9 = {
-  get: get73,
+  get: get72,
   byOutputName,
 }
 
 /**
  * Snapshot of every node's declared outputs for a draft workflow run.
  */
-export const get74 = oc
+export const get73 = oc
   .route({
     description: "Snapshot of every node's declared outputs for a draft workflow run.",
     inputStructure: 'detailed',
@@ -3913,7 +3891,7 @@ export const get74 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsResponse)
 
 export const nodeOutputs = {
-  get: get74,
+  get: get73,
   events,
   byNodeId: byNodeId9,
 }
@@ -3929,7 +3907,7 @@ export const runs = {
 /**
  * Get system variables for workflow
  */
-export const get75 = oc
+export const get74 = oc
   .route({
     description: 'Get system variables for workflow',
     inputStructure: 'detailed',
@@ -3942,7 +3920,7 @@ export const get75 = oc
   .output(zGetAppsByAppIdWorkflowsDraftSystemVariablesResponse)
 
 export const systemVariables = {
-  get: get75,
+  get: get74,
 }
 
 /**
@@ -4042,7 +4020,7 @@ export const delete12 = oc
 /**
  * Get a specific workflow variable
  */
-export const get76 = oc
+export const get75 = oc
   .route({
     description: 'Get a specific workflow variable',
     inputStructure: 'detailed',
@@ -4076,7 +4054,7 @@ export const patch2 = oc
 
 export const byVariableId = {
   delete: delete12,
-  get: get76,
+  get: get75,
   patch: patch2,
   reset,
 }
@@ -4102,7 +4080,7 @@ export const delete13 = oc
  *
  * Get draft workflow variables
  */
-export const get77 = oc
+export const get76 = oc
   .route({
     description: 'Get draft workflow variables',
     inputStructure: 'detailed',
@@ -4122,7 +4100,7 @@ export const get77 = oc
 
 export const variables2 = {
   delete: delete13,
-  get: get77,
+  get: get76,
   byVariableId,
 }
 
@@ -4131,7 +4109,7 @@ export const variables2 = {
  *
  * Get draft workflow for an application
  */
-export const get78 = oc
+export const get77 = oc
   .route({
     description: 'Get draft workflow for an application',
     inputStructure: 'detailed',
@@ -4168,7 +4146,7 @@ export const post60 = oc
   .output(zPostAppsByAppIdWorkflowsDraftResponse)
 
 export const draft2 = {
-  get: get78,
+  get: get77,
   post: post60,
   conversationVariables: conversationVariables2,
   environmentVariables,
@@ -4189,7 +4167,7 @@ export const draft2 = {
  *
  * Get published workflow for an application
  */
-export const get79 = oc
+export const get78 = oc
   .route({
     description: 'Get published workflow for an application',
     inputStructure: 'detailed',
@@ -4223,14 +4201,14 @@ export const post61 = oc
   .output(zPostAppsByAppIdWorkflowsPublishResponse)
 
 export const publish = {
-  get: get79,
+  get: get78,
   post: post61,
 }
 
 /**
  * Server-Sent Events stream of inspector deltas for a published workflow run.
  */
-export const get80 = oc
+export const get79 = oc
   .route({
     description: 'Server-Sent Events stream of inspector deltas for a published workflow run.',
     inputStructure: 'detailed',
@@ -4243,13 +4221,13 @@ export const get80 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsEventsResponse)
 
 export const events2 = {
-  get: get80,
+  get: get79,
 }
 
 /**
  * Full value for one declared output of a published run.
  */
-export const get81 = oc
+export const get80 = oc
   .route({
     description: 'Full value for one declared output of a published run.',
     inputStructure: 'detailed',
@@ -4270,7 +4248,7 @@ export const get81 = oc
   )
 
 export const preview6 = {
-  get: get81,
+  get: get80,
 }
 
 export const byOutputName2 = {
@@ -4280,7 +4258,7 @@ export const byOutputName2 = {
 /**
  * One node's declared outputs for a published workflow run.
  */
-export const get82 = oc
+export const get81 = oc
   .route({
     description: "One node's declared outputs for a published workflow run.",
     inputStructure: 'detailed',
@@ -4293,14 +4271,14 @@ export const get82 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsByNodeIdResponse)
 
 export const byNodeId10 = {
-  get: get82,
+  get: get81,
   byOutputName: byOutputName2,
 }
 
 /**
  * Snapshot of every node's declared outputs for a published workflow run.
  */
-export const get83 = oc
+export const get82 = oc
   .route({
     description: "Snapshot of every node's declared outputs for a published workflow run.",
     inputStructure: 'detailed',
@@ -4313,7 +4291,7 @@ export const get83 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsResponse)
 
 export const nodeOutputs2 = {
-  get: get83,
+  get: get82,
   events: events2,
   byNodeId: byNodeId10,
 }
@@ -4333,7 +4311,7 @@ export const published = {
 /**
  * Get webhook trigger for a node
  */
-export const get84 = oc
+export const get83 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -4351,7 +4329,7 @@ export const get84 = oc
   .output(zGetAppsByAppIdWorkflowsTriggersWebhookResponse)
 
 export const webhook = {
-  get: get84,
+  get: get83,
 }
 
 export const triggers2 = {
@@ -4427,7 +4405,7 @@ export const byWorkflowId = {
  *
  * Get all published workflows for an application
  */
-export const get85 = oc
+export const get84 = oc
   .route({
     description: 'Get all published workflows for an application',
     inputStructure: 'detailed',
@@ -4446,7 +4424,7 @@ export const get85 = oc
   .output(zGetAppsByAppIdWorkflowsResponse)
 
 export const workflows3 = {
-  get: get85,
+  get: get84,
   defaultWorkflowBlockConfigs,
   draft: draft2,
   publish,
@@ -4479,7 +4457,7 @@ export const delete15 = oc
  *
  * Get application details
  */
-export const get86 = oc
+export const get85 = oc
   .route({
     description: 'Get application details',
     inputStructure: 'detailed',
@@ -4512,7 +4490,7 @@ export const put6 = oc
 
 export const byAppId2 = {
   delete: delete15,
-  get: get86,
+  get: get85,
   put: put6,
   advancedChat,
   agent,
@@ -4581,7 +4559,7 @@ export const byApiKeyId = {
  *
  * Get all API keys for an app
  */
-export const get87 = oc
+export const get86 = oc
   .route({
     description: 'Get all API keys for an app',
     inputStructure: 'detailed',
@@ -4614,7 +4592,7 @@ export const post63 = oc
   .output(zPostAppsByResourceIdApiKeysResponse)
 
 export const apiKeys = {
-  get: get87,
+  get: get86,
   post: post63,
   byApiKeyId,
 }
@@ -4628,7 +4606,7 @@ export const byResourceId = {
  *
  * Get list of applications with pagination and filtering
  */
-export const get88 = oc
+export const get87 = oc
   .route({
     description: 'Get list of applications with pagination and filtering',
     inputStructure: 'detailed',
@@ -4661,7 +4639,7 @@ export const post64 = oc
   .output(zPostAppsResponse)
 
 export const apps = {
-  get: get88,
+  get: get87,
   post: post64,
   imports,
   recent,

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -786,12 +786,6 @@ export type WorkflowRunDetailResponse = {
   version?: string | null
 }
 
-export type WorkflowRunExportResponse = {
-  presigned_url?: string | null
-  presigned_url_expires_at?: string | null
-  status: string
-}
-
 export type WorkflowRunNodeExecutionListResponse = {
   data: Array<WorkflowRunNodeExecutionResponse>
 }
@@ -5287,23 +5281,6 @@ export type GetAppsByAppIdWorkflowRunsByRunIdResponses = {
 
 export type GetAppsByAppIdWorkflowRunsByRunIdResponse =
   GetAppsByAppIdWorkflowRunsByRunIdResponses[keyof GetAppsByAppIdWorkflowRunsByRunIdResponses]
-
-export type GetAppsByAppIdWorkflowRunsByRunIdExportData = {
-  body?: never
-  path: {
-    app_id: string
-    run_id: string
-  }
-  query?: never
-  url: '/apps/{app_id}/workflow-runs/{run_id}/export'
-}
-
-export type GetAppsByAppIdWorkflowRunsByRunIdExportResponses = {
-  200: WorkflowRunExportResponse
-}
-
-export type GetAppsByAppIdWorkflowRunsByRunIdExportResponse =
-  GetAppsByAppIdWorkflowRunsByRunIdExportResponses[keyof GetAppsByAppIdWorkflowRunsByRunIdExportResponses]
 
 export type GetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsData = {
   body?: never

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -504,15 +504,6 @@ export const zWorkflowTriggerListResponse = z.object({
 })
 
 /**
- * WorkflowRunExportResponse
- */
-export const zWorkflowRunExportResponse = z.object({
-  presigned_url: z.string().nullish(),
-  presigned_url_expires_at: z.string().nullish(),
-  status: z.string(),
-})
-
-/**
  * WorkflowAgentSandboxDownloadPayload
  */
 export const zWorkflowAgentSandboxDownloadPayload = z.object({
@@ -5570,16 +5561,6 @@ export const zGetAppsByAppIdWorkflowRunsByRunIdPath = z.object({
  * Workflow run detail retrieved successfully
  */
 export const zGetAppsByAppIdWorkflowRunsByRunIdResponse = zWorkflowRunDetailResponse
-
-export const zGetAppsByAppIdWorkflowRunsByRunIdExportPath = z.object({
-  app_id: z.uuid(),
-  run_id: z.uuid(),
-})
-
-/**
- * Export URL generated
- */
-export const zGetAppsByAppIdWorkflowRunsByRunIdExportResponse = zWorkflowRunExportResponse
 
 export const zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsPath = z.object({
   app_id: z.uuid(),


### PR DESCRIPTION
## Summary

- remove the unused per-run workflow archive export endpoint
- remove its endpoint-specific response model and storage/database dependencies
- regenerate Console OpenAPI and TypeScript/Zod/ORPC contracts

The current Console archive download UI uses the workspace-level workflow-run-archives download flow. The removed endpoint has no caller in the current web or e2e code.

## Breaking change

This removes an undocumented Console endpoint: `GET /apps/{app_id}/workflow-runs/{run_id}/export`. Repository code has no active consumer.

## Stack

This is the bottom layer of the Console workflow-run refactor stack.

From Codex