### PR TITLE
refactor(web): migrate metadata inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2373,16 +2373,6 @@
       "count": 2
     }
   },
-  "web/app/components/datasets/metadata/metadata-dataset/create-content.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/metadata/metadata-document/info-group.tsx": {
     "no-restricted-globals": {
       "count": 1

--- a/web/app/components/datasets/metadata/metadata-dataset/__tests__/create-content.spec.tsx
+++ b/web/app/components/datasets/metadata/metadata-dataset/__tests__/create-content.spec.tsx
@@ -32,7 +32,9 @@ describe('CreateContent', () => {
     it('should render name input field', () => {
       const handleSave = vi.fn()
       renderCreateContent({ onSave: handleSave })
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(
+        screen.getByRole('textbox', { name: 'dataset.metadata.createMetadata.name' }),
+      ).toBeInTheDocument()
     })
 
     it('should render confirm button', () => {
@@ -107,7 +109,9 @@ describe('CreateContent', () => {
       const handleSave = vi.fn()
       renderCreateContent({ onSave: handleSave })
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('textbox', {
+        name: 'dataset.metadata.createMetadata.name',
+      })
       fireEvent.change(input, { target: { value: 'new_field' } })
 
       expect(input).toHaveValue('new_field')
@@ -117,7 +121,9 @@ describe('CreateContent', () => {
       const handleSave = vi.fn()
       renderCreateContent({ onSave: handleSave })
 
-      expect(screen.getByRole('textbox')).toHaveValue('')
+      expect(
+        screen.getByRole('textbox', { name: 'dataset.metadata.createMetadata.name' }),
+      ).toHaveValue('')
     })
   })
 
@@ -126,7 +132,9 @@ describe('CreateContent', () => {
       const handleSave = vi.fn()
       renderCreateContent({ onSave: handleSave })
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('textbox', {
+        name: 'dataset.metadata.createMetadata.name',
+      })
       fireEvent.change(input, { target: { value: 'test_field' } })
       fireEvent.click(screen.getByRole('button', { name: 'common.operation.save' }))
 
@@ -141,7 +149,9 @@ describe('CreateContent', () => {
       renderCreateContent({ onSave: handleSave })
 
       fireEvent.click(screen.getByText('Number'))
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('textbox', {
+        name: 'dataset.metadata.createMetadata.name',
+      })
       fireEvent.change(input, { target: { value: 'num_field' } })
       fireEvent.click(screen.getByRole('button', { name: 'common.operation.save' }))
 
@@ -227,7 +237,9 @@ describe('CreateContent', () => {
       const handleSave = vi.fn()
       renderCreateContent({ onSave: handleSave })
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('textbox', {
+        name: 'dataset.metadata.createMetadata.name',
+      })
       fireEvent.change(input, { target: { value: 'test_field_123' } })
 
       expect(input).toHaveValue('test_field_123')

--- a/web/app/components/datasets/metadata/metadata-dataset/create-content.tsx
+++ b/web/app/components/datasets/metadata/metadata-dataset/create-content.tsx
@@ -1,10 +1,10 @@
 'use client'
 import type { BuiltInMetadataItem } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
 import { noop } from 'es-toolkit/function'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import OptionCard from '../../../workflow/nodes/_base/components/option-card'
 import { DataType } from '../types'
 import Field from './field'
@@ -29,12 +29,6 @@ export function CreateContent({ onClose = noop, hasBack, onBack, onSave }: Props
     [setType],
   )
   const [name, setName] = useState('')
-  const handleNameChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setName(e.target.value)
-    },
-    [setName],
-  )
 
   const handleSave = useCallback(() => {
     onSave({
@@ -97,7 +91,7 @@ export function CreateContent({ onClose = noop, hasBack, onBack, onSave }: Props
             <Input
               aria-label={t(($) => $[`${i18nPrefix}.name`], { ns: 'dataset' })}
               value={name}
-              onChange={handleNameChange}
+              onValueChange={setName}
               placeholder={t(($) => $[`${i18nPrefix}.namePlaceholder`], { ns: 'dataset' })}
             />
           </Field>

--- a/web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx
+++ b/web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx
@@ -23,6 +23,7 @@ import {
   DrawerTitle,
   DrawerViewport,
 } from '@langgenius/dify-ui/drawer'
+import { Input } from '@langgenius/dify-ui/input'
 import { Switch } from '@langgenius/dify-ui/switch'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiAddLine, RiDeleteBinLine, RiEditLine } from '@remixicon/react'
@@ -31,7 +32,6 @@ import * as React from 'react'
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Infotip } from '@/app/components/base/infotip'
-import Input from '@/app/components/base/input'
 import { CreateMetadataModal } from '@/app/components/datasets/metadata/metadata-dataset/create-metadata-modal'
 import { getIconClassName } from '../utils/get-icon'
 import Field from './field'
@@ -303,7 +303,7 @@ const DatasetMetadataDrawer: FC<Props> = ({
                         <Input
                           aria-label={t(($) => $[`${i18nPrefix}.name`], { ns: 'dataset' })}
                           value={templeName}
-                          onChange={(e) => setTempleName(e.target.value)}
+                          onValueChange={setTempleName}
                           placeholder={t(($) => $[`${i18nPrefix}.namePlaceholder`], {
                             ns: 'dataset',
                           })}


### PR DESCRIPTION
## Summary

- migrate dataset metadata create and rename fields from the legacy Web Input to the Dify UI Input primitive
- preserve existing input geometry, placeholders, and accessible names
- remove the obsolete legacy-input lint suppressions

## Validation

- `vp test run --project unit` for the metadata create and drawer suites
- targeted accessibility lint
- `pnpm check`
- `next typegen && pnpm -C web type-check`

From Codex