### PR TITLE
refactor(web): migrate workflow variable inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4202,9 +4202,6 @@
     }
   },
   "web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx": {
-    "jsx-a11y/no-autofocus": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 4
     }

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3597,11 +3597,6 @@
       "count": 31
     }
   },
-  "web/app/components/workflow/nodes/_base/components/variable/var-list.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.trigger.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 3
@@ -4210,9 +4205,6 @@
     "jsx-a11y/no-autofocus": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 4
     }
@@ -4252,9 +4244,6 @@
     }
   },
   "web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/update.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 1
     }

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-list.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-list.spec.tsx
@@ -1,0 +1,40 @@
+import type { PropsWithChildren } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { VarType } from '@/app/components/workflow/types'
+import VarList from '../var-list'
+
+vi.mock('react-sortablejs', () => ({
+  ReactSortable: ({ children }: PropsWithChildren) => <div>{children}</div>,
+}))
+
+vi.mock('../var-reference-picker', () => ({
+  default: () => <button type="button">Variable value</button>,
+}))
+
+describe('VarList', () => {
+  it('normalizes a variable name through its labeled input', () => {
+    const onChange = vi.fn()
+
+    render(
+      <VarList
+        nodeId="node-id"
+        readonly={false}
+        list={[
+          {
+            variable: 'input',
+            value_selector: ['node-id', 'value'],
+            value_type: VarType.string,
+          },
+        ]}
+        onChange={onChange}
+      />,
+    )
+
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'workflow.common.variableNamePlaceholder' }),
+      { target: { value: 'renamed input' } },
+    )
+
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ variable: 'renamed_input' })])
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/variable/var-list.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-list.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react'
 import type { ValueSelector, Var, Variable } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiDraggable } from '@remixicon/react'
 import { useDebounceFn } from 'ahooks'
@@ -11,7 +12,6 @@ import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ReactSortable } from 'react-sortablejs'
 import { v4 as uuid4 } from 'uuid'
-import Input from '@/app/components/base/input'
 import { VarType as VarKindType } from '@/app/components/workflow/nodes/tool/types'
 import { checkKeys, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 import RemoveButton from '../remove-button'
@@ -41,6 +41,7 @@ const VarList: FC<Props> = ({
   isSupportFileVar = true,
 }) => {
   const { t } = useTranslation()
+  const variableNameLabel = t(($) => $['common.variableNamePlaceholder'], { ns: 'workflow' })
 
   const listWithIds = useMemo(
     () =>
@@ -159,11 +160,12 @@ const VarList: FC<Props> = ({
         return (
           <div className={cn('flex items-center space-x-1', 'group relative')} key={index}>
             <Input
-              wrapperClassName="w-[120px]"
+              aria-label={variableNameLabel}
+              className="w-[120px]"
               disabled={readonly}
               value={variable.variable}
               onChange={handleVarNameChange(index)}
-              placeholder={t(($) => $['common.variableNamePlaceholder'], { ns: 'workflow' })!}
+              placeholder={variableNameLabel}
             />
             <VarReferencePicker
               nodeId={nodeId}

--- a/web/app/components/workflow/nodes/loop/components/loop-variables/__tests__/item.spec.tsx
+++ b/web/app/components/workflow/nodes/loop/components/loop-variables/__tests__/item.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ValueType, VarType } from '@/app/components/workflow/types'
 import Item from '../item'
@@ -16,6 +16,31 @@ vi.mock('../variable-type-select', () => ({
 }))
 
 describe('Loop variable item', () => {
+  it('normalizes the variable name through its labeled input', () => {
+    const handleUpdateLoopVariable = vi.fn()
+
+    render(
+      <Item
+        nodeId="loop-node"
+        item={{
+          id: 'loop-variable',
+          label: 'item',
+          var_type: VarType.string,
+          value_type: ValueType.constant,
+          value: '',
+        }}
+        handleRemoveLoopVariable={vi.fn()}
+        handleUpdateLoopVariable={handleUpdateLoopVariable}
+      />,
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'workflow.nodes.loop.variableName' }), {
+      target: { value: 'new name' },
+    })
+
+    expect(handleUpdateLoopVariable).toHaveBeenCalledWith('loop-variable', { label: 'new_name' })
+  })
+
   it('removes the current variable from its named icon command', async () => {
     const user = userEvent.setup()
     const handleRemoveLoopVariable = vi.fn()

--- a/web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx
+++ b/web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx
@@ -3,11 +3,11 @@ import type {
   LoopVariablesComponentShape,
 } from '@/app/components/workflow/nodes/loop/types'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiDeleteBinLine } from '@remixicon/react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { ValueType, VarType } from '@/app/components/workflow/types'
 import { checkKeys, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 import FormItem from './form-item'
@@ -19,6 +19,7 @@ type ItemProps = {
 } & LoopVariablesComponentShape
 const Item = ({ nodeId, item, handleRemoveLoopVariable, handleUpdateLoopVariable }: ItemProps) => {
   const { t } = useTranslation()
+  const variableNameLabel = t(($) => $['nodes.loop.variableName'], { ns: 'workflow' })
 
   const checkVariableName = (value: string) => {
     const { isValid, errorMessageKey } = checkKeys([value], false)
@@ -86,11 +87,13 @@ const Item = ({ nodeId, item, handleRemoveLoopVariable, handleUpdateLoopVariable
       <div className="w-0 grow">
         <div className="mb-1 grid grid-cols-3 gap-1">
           <Input
+            aria-label={variableNameLabel}
             value={item.label}
             onChange={handleUpdateItemLabel}
             onBlur={(e) => checkVariableName(e.target.value)}
+            // oxlint-disable-next-line jsx-a11y/no-autofocus -- An empty item is mounted after the user adds a loop variable, and its name is the primary editing target.
             autoFocus={!item.label}
-            placeholder={t(($) => $['nodes.loop.variableName'], { ns: 'workflow' })}
+            placeholder={variableNameLabel}
           />
           <VariableTypeSelect value={item.var_type} onChange={handleUpdateItemVarType} />
           <InputModeSelect value={item.value_type} onChange={handleUpdateItemValueType} />

--- a/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/__tests__/update.spec.tsx
+++ b/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/__tests__/update.spec.tsx
@@ -45,9 +45,9 @@ describe('parameter-extractor/extract-parameter/update', () => {
       return nextDialogs
     })
     const dialog = dialogs.at(-1)!
-    const nameInput = within(dialog).getByPlaceholderText(
-      'workflow.nodes.parameterExtractor.addExtractParameterContent.namePlaceholder',
-    )
+    const nameInput = within(dialog).getByRole('textbox', {
+      name: 'workflow.nodes.parameterExtractor.addExtractParameterContent.name',
+    })
     const descriptionInput = within(dialog).getByPlaceholderText(
       'workflow.nodes.parameterExtractor.addExtractParameterContent.descriptionPlaceholder',
     )
@@ -98,9 +98,9 @@ describe('parameter-extractor/extract-parameter/update', () => {
     const dialog = dialogs.at(-1)!
 
     fireEvent.change(
-      within(dialog).getByPlaceholderText(
-        'workflow.nodes.parameterExtractor.addExtractParameterContent.namePlaceholder',
-      ),
+      within(dialog).getByRole('textbox', {
+        name: 'workflow.nodes.parameterExtractor.addExtractParameterContent.name',
+      }),
       {
         target: { value: '1bad' },
       },
@@ -109,9 +109,9 @@ describe('parameter-extractor/extract-parameter/update', () => {
     expect(handleSave).not.toHaveBeenCalled()
     expect(mockToast.error).toHaveBeenCalled()
     expect(
-      within(dialog).getByPlaceholderText(
-        'workflow.nodes.parameterExtractor.addExtractParameterContent.namePlaceholder',
-      ),
+      within(dialog).getByRole('textbox', {
+        name: 'workflow.nodes.parameterExtractor.addExtractParameterContent.name',
+      }),
     ).toHaveValue('')
   })
 

--- a/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/update.tsx
+++ b/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/update.tsx
@@ -4,6 +4,7 @@ import type { Param } from '../../types'
 import type { MoreInfo } from '@/app/components/workflow/types'
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Input } from '@langgenius/dify-ui/input'
 import {
   Select,
   SelectContent,
@@ -21,7 +22,6 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Field from '@/app/components/app/configuration/config-var/config-modal/field'
 import ConfigSelect from '@/app/components/app/configuration/config-var/config-select'
-import Input from '@/app/components/base/input'
 import { ChangeType } from '@/app/components/workflow/types'
 import { checkKeys } from '@/utils/var'
 import { ParamType } from '../../types'
@@ -55,6 +55,9 @@ const TYPES = [
 
 const AddExtractParameter: FC<Props> = ({ type, payload, onSave, onCancel }) => {
   const { t } = useTranslation()
+  const nameLabel = t(($) => $[`${i18nPrefix}.addExtractParameterContent.name`], {
+    ns: 'workflow',
+  })
   const isAdd = type === 'add'
   const [param, setParam] = useState<Param>(isAdd ? DEFAULT_PARAM : (payload as Param))
   const [renameInfo, setRenameInfo] = useState<MoreInfo | undefined>(undefined)
@@ -169,14 +172,11 @@ const AddExtractParameter: FC<Props> = ({ type, payload, onSave, onCancel }) => 
 
             <div>
               <div className="space-y-2">
-                <Field
-                  title={t(($) => $[`${i18nPrefix}.addExtractParameterContent.name`], {
-                    ns: 'workflow',
-                  })}
-                >
+                <Field title={nameLabel}>
                   <Input
+                    aria-label={nameLabel}
                     value={param.name}
-                    onChange={(e) => handleParamChange('name')(e.target.value)}
+                    onValueChange={(value) => handleParamChange('name')(value)}
                     placeholder={t(
                       ($) => $[`${i18nPrefix}.addExtractParameterContent.namePlaceholder`],
                       {


### PR DESCRIPTION
## Summary

- migrate workflow variable-name fields to the Dify UI Input primitive without changing their grid geometry
- preserve the native change-event contract used to normalize spaces while keeping the cursor stable
- expose the final inputs through their actual accessible names and cover normalized edits through public DOM behavior
- remove the obsolete legacy-input lint suppressions

Depends on #41339.

## Validation

- `vp test run --project unit` for the variable list, loop variable, and parameter extractor suites
- targeted accessibility lint
- `pnpm check`
- `next typegen && pnpm -C web type-check`

From Codex