### PR TITLE
refactor(web): migrate tracing inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4202,9 +4202,6 @@
     }
   },
   "web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx": {
-    "jsx-a11y/no-autofocus": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 4
     }

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3597,11 +3597,6 @@
       "count": 31
     }
   },
-  "web/app/components/workflow/nodes/_base/components/variable/var-list.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/_base/components/variable/var-reference-picker.trigger.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 3
@@ -4210,9 +4205,6 @@
     "jsx-a11y/no-autofocus": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 4
     }
@@ -4252,9 +4244,6 @@
     }
   },
   "web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/update.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 1
     }

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -59,11 +59,6 @@
       "count": 3
     }
   },
-  "web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/field.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/provider-panel.tsx": {
     "eslint-react/static-components": {
       "count": 2

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/provider-config-modal.spec.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/provider-config-modal.spec.tsx
@@ -355,7 +355,7 @@ describe('ProviderConfigModal', () => {
           screen.getByText(`app.tracing.configProvider.titleapp.tracing.${provider}.title`),
         ).toBeInTheDocument()
         expectedLabels.forEach((label) => {
-          expect(screen.getByText(label)).toBeInTheDocument()
+          expect(screen.getByRole('textbox', { name: label })).toBeInTheDocument()
         })
         expect(
           screen.getByRole('button', { name: 'common.operation.saveAndEnable' }),
@@ -368,11 +368,16 @@ describe('ProviderConfigModal', () => {
     it('should add and choose the provider when saving a new config', async () => {
       const user = userEvent.setup()
       const callbacks = renderProviderConfigModal({ type: TracingProvider.langfuse })
-      const textboxes = screen.getAllByRole('textbox')
 
-      await user.type(textboxes[0]!, 'secret-key')
-      await user.type(textboxes[1]!, 'public-key')
-      await user.type(textboxes[2]!, 'https://cloud.langfuse.com')
+      await user.type(
+        screen.getByRole('textbox', { name: 'app.tracing.configProvider.secretKey' }),
+        'secret-key',
+      )
+      await user.type(
+        screen.getByRole('textbox', { name: 'app.tracing.configProvider.publicKey' }),
+        'public-key',
+      )
+      await user.type(screen.getByRole('textbox', { name: 'Host' }), 'https://cloud.langfuse.com')
       await user.click(screen.getByRole('button', { name: 'common.operation.saveAndEnable' }))
 
       await waitFor(() => {

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/field.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/field.tsx
@@ -1,8 +1,8 @@
 'use client'
 import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Input } from '@langgenius/dify-ui/input'
 import * as React from 'react'
-import Input from '@/app/components/base/input'
 
 type Props = Readonly<{
   className?: string
@@ -23,22 +23,26 @@ const Field: FC<Props> = ({
   isRequired = false,
   placeholder = '',
 }) => {
+  const inputId = React.useId()
+
   return (
     <div className={cn(className)}>
       <div className="flex py-1.75">
-        <div
+        <label
+          htmlFor={inputId}
           className={cn(
             labelClassName,
             'flex h-4.5 items-center text-[13px] font-medium text-text-primary',
           )}
         >
           {label}{' '}
-        </div>
+        </label>
         {isRequired && <span className="ml-0.5 text-xs font-semibold text-[#D92D20]">*</span>}
       </div>
       <Input
+        id={inputId}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onValueChange={(nextValue) => onChange(nextValue)}
         className="h-9"
         placeholder={placeholder}
       />

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-list.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/var-list.spec.tsx
@@ -1,0 +1,40 @@
+import type { PropsWithChildren } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { VarType } from '@/app/components/workflow/types'
+import VarList from '../var-list'
+
+vi.mock('react-sortablejs', () => ({
+  ReactSortable: ({ children }: PropsWithChildren) => <div>{children}</div>,
+}))
+
+vi.mock('../var-reference-picker', () => ({
+  default: () => <button type="button">Variable value</button>,
+}))
+
+describe('VarList', () => {
+  it('normalizes a variable name through its labeled input', () => {
+    const onChange = vi.fn()
+
+    render(
+      <VarList
+        nodeId="node-id"
+        readonly={false}
+        list={[
+          {
+            variable: 'input',
+            value_selector: ['node-id', 'value'],
+            value_type: VarType.string,
+          },
+        ]}
+        onChange={onChange}
+      />,
+    )
+
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'workflow.common.variableNamePlaceholder' }),
+      { target: { value: 'renamed input' } },
+    )
+
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ variable: 'renamed_input' })])
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/variable/var-list.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-list.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react'
 import type { ValueSelector, Var, Variable } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiDraggable } from '@remixicon/react'
 import { useDebounceFn } from 'ahooks'
@@ -11,7 +12,6 @@ import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ReactSortable } from 'react-sortablejs'
 import { v4 as uuid4 } from 'uuid'
-import Input from '@/app/components/base/input'
 import { VarType as VarKindType } from '@/app/components/workflow/nodes/tool/types'
 import { checkKeys, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 import RemoveButton from '../remove-button'
@@ -41,6 +41,7 @@ const VarList: FC<Props> = ({
   isSupportFileVar = true,
 }) => {
   const { t } = useTranslation()
+  const variableNameLabel = t(($) => $['common.variableNamePlaceholder'], { ns: 'workflow' })
 
   const listWithIds = useMemo(
     () =>
@@ -159,11 +160,12 @@ const VarList: FC<Props> = ({
         return (
           <div className={cn('flex items-center space-x-1', 'group relative')} key={index}>
             <Input
-              wrapperClassName="w-[120px]"
+              aria-label={variableNameLabel}
+              className="w-[120px]"
               disabled={readonly}
               value={variable.variable}
               onChange={handleVarNameChange(index)}
-              placeholder={t(($) => $['common.variableNamePlaceholder'], { ns: 'workflow' })!}
+              placeholder={variableNameLabel}
             />
             <VarReferencePicker
               nodeId={nodeId}

--- a/web/app/components/workflow/nodes/loop/components/loop-variables/__tests__/item.spec.tsx
+++ b/web/app/components/workflow/nodes/loop/components/loop-variables/__tests__/item.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ValueType, VarType } from '@/app/components/workflow/types'
 import Item from '../item'
@@ -16,6 +16,31 @@ vi.mock('../variable-type-select', () => ({
 }))
 
 describe('Loop variable item', () => {
+  it('normalizes the variable name through its labeled input', () => {
+    const handleUpdateLoopVariable = vi.fn()
+
+    render(
+      <Item
+        nodeId="loop-node"
+        item={{
+          id: 'loop-variable',
+          label: 'item',
+          var_type: VarType.string,
+          value_type: ValueType.constant,
+          value: '',
+        }}
+        handleRemoveLoopVariable={vi.fn()}
+        handleUpdateLoopVariable={handleUpdateLoopVariable}
+      />,
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'workflow.nodes.loop.variableName' }), {
+      target: { value: 'new name' },
+    })
+
+    expect(handleUpdateLoopVariable).toHaveBeenCalledWith('loop-variable', { label: 'new_name' })
+  })
+
   it('removes the current variable from its named icon command', async () => {
     const user = userEvent.setup()
     const handleRemoveLoopVariable = vi.fn()

--- a/web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx
+++ b/web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx
@@ -3,11 +3,11 @@ import type {
   LoopVariablesComponentShape,
 } from '@/app/components/workflow/nodes/loop/types'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiDeleteBinLine } from '@remixicon/react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { ValueType, VarType } from '@/app/components/workflow/types'
 import { checkKeys, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 import FormItem from './form-item'
@@ -19,6 +19,7 @@ type ItemProps = {
 } & LoopVariablesComponentShape
 const Item = ({ nodeId, item, handleRemoveLoopVariable, handleUpdateLoopVariable }: ItemProps) => {
   const { t } = useTranslation()
+  const variableNameLabel = t(($) => $['nodes.loop.variableName'], { ns: 'workflow' })
 
   const checkVariableName = (value: string) => {
     const { isValid, errorMessageKey } = checkKeys([value], false)
@@ -86,11 +87,13 @@ const Item = ({ nodeId, item, handleRemoveLoopVariable, handleUpdateLoopVariable
       <div className="w-0 grow">
         <div className="mb-1 grid grid-cols-3 gap-1">
           <Input
+            aria-label={variableNameLabel}
             value={item.label}
             onChange={handleUpdateItemLabel}
             onBlur={(e) => checkVariableName(e.target.value)}
+            // oxlint-disable-next-line jsx-a11y/no-autofocus -- An empty item is mounted after the user adds a loop variable, and its name is the primary editing target.
             autoFocus={!item.label}
-            placeholder={t(($) => $['nodes.loop.variableName'], { ns: 'workflow' })}
+            placeholder={variableNameLabel}
           />
           <VariableTypeSelect value={item.var_type} onChange={handleUpdateItemVarType} />
           <InputModeSelect value={item.value_type} onChange={handleUpdateItemValueType} />

--- a/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/__tests__/update.spec.tsx
+++ b/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/__tests__/update.spec.tsx
@@ -45,9 +45,9 @@ describe('parameter-extractor/extract-parameter/update', () => {
       return nextDialogs
     })
     const dialog = dialogs.at(-1)!
-    const nameInput = within(dialog).getByPlaceholderText(
-      'workflow.nodes.parameterExtractor.addExtractParameterContent.namePlaceholder',
-    )
+    const nameInput = within(dialog).getByRole('textbox', {
+      name: 'workflow.nodes.parameterExtractor.addExtractParameterContent.name',
+    })
     const descriptionInput = within(dialog).getByPlaceholderText(
       'workflow.nodes.parameterExtractor.addExtractParameterContent.descriptionPlaceholder',
     )
@@ -98,9 +98,9 @@ describe('parameter-extractor/extract-parameter/update', () => {
     const dialog = dialogs.at(-1)!
 
     fireEvent.change(
-      within(dialog).getByPlaceholderText(
-        'workflow.nodes.parameterExtractor.addExtractParameterContent.namePlaceholder',
-      ),
+      within(dialog).getByRole('textbox', {
+        name: 'workflow.nodes.parameterExtractor.addExtractParameterContent.name',
+      }),
       {
         target: { value: '1bad' },
       },
@@ -109,9 +109,9 @@ describe('parameter-extractor/extract-parameter/update', () => {
     expect(handleSave).not.toHaveBeenCalled()
     expect(mockToast.error).toHaveBeenCalled()
     expect(
-      within(dialog).getByPlaceholderText(
-        'workflow.nodes.parameterExtractor.addExtractParameterContent.namePlaceholder',
-      ),
+      within(dialog).getByRole('textbox', {
+        name: 'workflow.nodes.parameterExtractor.addExtractParameterContent.name',
+      }),
     ).toHaveValue('')
   })
 

--- a/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/update.tsx
+++ b/web/app/components/workflow/nodes/parameter-extractor/components/extract-parameter/update.tsx
@@ -4,6 +4,7 @@ import type { Param } from '../../types'
 import type { MoreInfo } from '@/app/components/workflow/types'
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
+import { Input } from '@langgenius/dify-ui/input'
 import {
   Select,
   SelectContent,
@@ -21,7 +22,6 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Field from '@/app/components/app/configuration/config-var/config-modal/field'
 import ConfigSelect from '@/app/components/app/configuration/config-var/config-select'
-import Input from '@/app/components/base/input'
 import { ChangeType } from '@/app/components/workflow/types'
 import { checkKeys } from '@/utils/var'
 import { ParamType } from '../../types'
@@ -55,6 +55,9 @@ const TYPES = [
 
 const AddExtractParameter: FC<Props> = ({ type, payload, onSave, onCancel }) => {
   const { t } = useTranslation()
+  const nameLabel = t(($) => $[`${i18nPrefix}.addExtractParameterContent.name`], {
+    ns: 'workflow',
+  })
   const isAdd = type === 'add'
   const [param, setParam] = useState<Param>(isAdd ? DEFAULT_PARAM : (payload as Param))
   const [renameInfo, setRenameInfo] = useState<MoreInfo | undefined>(undefined)
@@ -169,14 +172,11 @@ const AddExtractParameter: FC<Props> = ({ type, payload, onSave, onCancel }) => 
 
             <div>
               <div className="space-y-2">
-                <Field
-                  title={t(($) => $[`${i18nPrefix}.addExtractParameterContent.name`], {
-                    ns: 'workflow',
-                  })}
-                >
+                <Field title={nameLabel}>
                   <Input
+                    aria-label={nameLabel}
                     value={param.name}
-                    onChange={(e) => handleParamChange('name')(e.target.value)}
+                    onValueChange={(value) => handleParamChange('name')(value)}
                     placeholder={t(
                       ($) => $[`${i18nPrefix}.addExtractParameterContent.namePlaceholder`],
                       {


### PR DESCRIPTION
## Summary

- migrate the shared tracing configuration field to the Dify UI Input primitive
- associate the existing visual label with the final input through native `label` / `htmlFor` semantics
- preserve the existing 36px control height and modal spacing
- replace index-based test queries with field-name queries and remove the obsolete lint suppression

Depends on #41340.

## Validation

- `vp test run --project unit` for the tracing provider modal and panel suites
- targeted accessibility lint
- `pnpm check`
- `next typegen && pnpm -C web type-check`

From Codex