### PR TITLE
fix(api): skip invalid markdown image URLs

### DIFF
--- a/api/core/rag/index_processor/index_processor_base.py
+++ b/api/core/rag/index_processor/index_processor_base.py
@@ -190,7 +190,16 @@ class BaseIndexProcessor(ABC):
                         upload_file_id_list.append(upload_file_id)
                 continue
             if current_user:
-                upload_file_id = self._download_image(image.split(" ")[0], current_user)
+                image_url = image.split(" ")[0]
+                try:
+                    parsed_url = urlparse(image_url)
+                except ValueError:
+                    logging.debug("Skipping malformed image reference: %s", image_url)
+                    continue
+                if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+                    logging.debug("Skipping non-HTTP image reference: %s", image_url)
+                    continue
+                upload_file_id = self._download_image(image_url, current_user)
                 if upload_file_id:
                     upload_file_id_list.append(upload_file_id)
 

--- a/api/tests/unit_tests/core/rag/indexing/test_index_processor_base.py
+++ b/api/tests/unit_tests/core/rag/indexing/test_index_processor_base.py
@@ -207,6 +207,27 @@ class TestBaseIndexProcessor:
 
         assert files == []
 
+    def test_get_content_files_skips_invalid_remote_image_references(
+        self, processor: _ForwardingBaseIndexProcessor, unbound_session: Session
+    ) -> None:
+        document = Document(page_content="ignored", metadata={"document_id": "doc-1", "dataset_id": "ds-1"})
+        images = [
+            "document_images/image.png",
+            "//example.com/image.png",
+            "data:image/png;base64,AAAA",
+            "ftp://example.com/image.png",
+            "http://[invalid",
+        ]
+
+        with (
+            patch.object(processor, "_extract_markdown_images", return_value=images),
+            patch.object(processor, "_download_image") as mock_image_download,
+        ):
+            files = processor._get_content_files(document, current_user=Mock(), session=unbound_session)
+
+        assert files == []
+        mock_image_download.assert_not_called()
+
     def test_get_content_files_ignores_missing_upload_records(
         self, processor: _ForwardingBaseIndexProcessor, sqlite_session: Session
     ) -> None:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41332.

Knowledge indexing currently sends every Markdown image target that is not a recognized Dify file URL to the remote fetcher. Relative, scheme-less, unsupported, and malformed image references therefore enter the SSRF retry loop even though they cannot be fetched as remote images. A document with many invalid references can occupy an indexing worker long enough to leave subsequent documents queued.

This change:

- validates fallback Markdown image targets before remote fetching;
- skips malformed URLs and URLs without an absolute HTTP(S) scheme and host;
- keeps existing Dify `/files/...` and tool-file handling unchanged;
- keeps valid HTTP(S) image download and attachment occurrence behavior unchanged;
- adds regression coverage for relative, protocol-relative, `data:`, `ftp:`, and malformed image references.

Skipped references are logged at `DEBUG` level to avoid replacing the retry storm with production warning noise. This is intentionally a minimal fix and does not change duplicate handling for valid remote image URLs.

Validation:

- `uv run --project api pytest api/tests/unit_tests/core/rag/indexing/test_index_processor_base.py -q` (`16 passed`)
- `uv run --project api ruff check api/core/rag/index_processor/index_processor_base.py api/tests/unit_tests/core/rag/indexing/test_index_processor_base.py`
- `uv run --project api ruff format --check api/core/rag/index_processor/index_processor_base.py api/tests/unit_tests/core/rag/indexing/test_index_processor_base.py`
- `git diff --check`

No new dependencies are required.

## Screenshots

| Before | After |
| ------ | ----- |
| Invalid Markdown image references enter the remote fetch retry loop. | Invalid or unsupported remote image references are skipped before network I/O. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Codex
