### PR TITLE
refactor(api): remove unused workflow archived logs endpoint

### DIFF
--- a/api/controllers/console/app/workflow_app_log.py
+++ b/api/controllers/console/app/workflow_app_log.py
@@ -92,43 +92,12 @@ class WorkflowRunForLogResponse(ResponseModel):
         return to_timestamp(value)
 
 
-class WorkflowRunForArchivedLogResponse(ResponseModel):
-    id: str
-    status: str | None = None
-    triggered_from: str | None = None
-    elapsed_time: float | None = None
-    total_tokens: int | None = None
-
-    @field_validator("status", mode="before")
-    @classmethod
-    def _normalize_status(cls, value: Any) -> str | None:
-        if value is None:
-            return None
-        if isinstance(value, str):
-            return value
-        return str(getattr(value, "value", value))
-
-
 class WorkflowAppLogPartialResponse(ResponseModel):
     id: str
     workflow_run: WorkflowRunForLogResponse | None = None
     details: Any = None
     created_from: str | None = None
     created_by_role: str | None = None
-    created_by_account: SimpleAccount | None = None
-    created_by_end_user: SimpleEndUser | None = None
-    created_at: int | None = None
-
-    @field_validator("created_at", mode="before")
-    @classmethod
-    def _normalize_timestamp(cls, value: datetime | int | None) -> int | None:
-        return to_timestamp(value)
-
-
-class WorkflowArchivedLogPartialResponse(ResponseModel):
-    id: str
-    workflow_run: WorkflowRunForArchivedLogResponse | None = None
-    trigger_metadata: Any = None
     created_by_account: SimpleAccount | None = None
     created_by_end_user: SimpleEndUser | None = None
     created_at: int | None = None
@@ -147,23 +116,12 @@ class WorkflowAppLogPaginationResponse(ResponseModel):
     data: list[WorkflowAppLogPartialResponse]
 
 
-class WorkflowArchivedLogPaginationResponse(ResponseModel):
-    page: int
-    limit: int
-    total: int
-    has_more: bool
-    data: list[WorkflowArchivedLogPartialResponse]
-
-
 register_schema_models(
     console_ns,
     WorkflowAppLogQuery,
     WorkflowRunForLogResponse,
-    WorkflowRunForArchivedLogResponse,
     WorkflowAppLogPartialResponse,
-    WorkflowArchivedLogPartialResponse,
     WorkflowAppLogPaginationResponse,
-    WorkflowArchivedLogPaginationResponse,
 )
 
 
@@ -207,41 +165,5 @@ class WorkflowAppLogApi(Resource):
             )
 
             return WorkflowAppLogPaginationResponse.model_validate(
-                workflow_app_log_pagination, from_attributes=True
-            ).model_dump(mode="json")
-
-
-@console_ns.route("/apps/<uuid:app_id>/workflow-archived-logs")
-class WorkflowArchivedLogApi(Resource):
-    @console_ns.doc("get_workflow_archived_logs")
-    @console_ns.doc(description="Get workflow archived execution logs")
-    @console_ns.doc(params={"app_id": "Application ID"})
-    @console_ns.doc(params=query_params_from_model(WorkflowAppLogQuery))
-    @console_ns.response(
-        200,
-        "Workflow archived logs retrieved successfully",
-        console_ns.models[WorkflowArchivedLogPaginationResponse.__name__],
-    )
-    @setup_required
-    @login_required
-    @account_initialization_required
-    @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_LOG_AND_ANNOTATION)
-    @get_app_model(mode=[AppMode.WORKFLOW])
-    @model_validate(WorkflowAppLogQuery)
-    def get(self, req_data: WorkflowAppLogQuery, app_model: App):
-        """
-        Get workflow archived logs
-        """
-
-        workflow_app_service = WorkflowAppService()
-        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
-            workflow_app_log_pagination = workflow_app_service.get_paginate_workflow_archive_logs(
-                session=session,
-                app_model=app_model,
-                page=req_data.page,
-                limit=req_data.limit,
-            )
-
-            return WorkflowArchivedLogPaginationResponse.model_validate(
                 workflow_app_log_pagination, from_attributes=True
             ).model_dump(mode="json")

--- a/api/fields/workflow_run_fields.py
+++ b/api/fields/workflow_run_fields.py
@@ -37,19 +37,6 @@ def build_workflow_run_for_log_model(api_or_ns: Namespace):
     return api_or_ns.model("WorkflowRunForLog", workflow_run_for_log_fields)
 
 
-workflow_run_for_archived_log_fields = {
-    "id": fields.String,
-    "status": fields.String,
-    "triggered_from": fields.String,
-    "elapsed_time": fields.Float,
-    "total_tokens": fields.Integer,
-}
-
-
-def build_workflow_run_for_archived_log_model(api_or_ns: Namespace):
-    return api_or_ns.model("WorkflowRunForArchivedLog", workflow_run_for_archived_log_fields)
-
-
 class WorkflowRunForLogResponse(ResponseModel):
     id: str
     version: str | None = None
@@ -74,21 +61,6 @@ class WorkflowRunForLogResponse(ResponseModel):
     @classmethod
     def _normalize_timestamp(cls, value: datetime | int | None) -> int | None:
         return to_timestamp(value)
-
-
-class WorkflowRunForArchivedLogResponse(ResponseModel):
-    id: str
-    status: str | None = None
-    triggered_from: str | None = None
-    elapsed_time: float | None = None
-    total_tokens: int | None = None
-
-    @field_validator("status", mode="before")
-    @classmethod
-    def _normalize_status(cls, value: Any) -> str | None:
-        if value is None or isinstance(value, str):
-            return value
-        return str(getattr(value, "value", value))
 
 
 class WorkflowRunForListResponse(ResponseModel):

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -3359,32 +3359,6 @@ Get workflow application execution logs
 | ---- | ----------- | ------ |
 | 200 | Workflow app logs retrieved successfully | **application/json**: [WorkflowAppLogPaginationResponse](#workflowapplogpaginationresponse)<br> |
 
-### [GET] /apps/{app_id}/workflow-archived-logs
-**Get workflow archived logs**
-
-Get workflow archived execution logs
-
-#### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string (uuid) |
-| created_at__after | query | Filter logs created after this timestamp | No | dateTime |
-| created_at__before | query | Filter logs created before this timestamp | No | dateTime |
-| created_by_account | query | Filter by account | No | string |
-| created_by_end_user_session_id | query | Filter by end user session ID | No | string |
-| detail | query | Whether to return detailed logs | No | boolean |
-| keyword | query | Search keyword for filtering logs | No | string |
-| limit | query | Number of items per page (1-100) | No | integer, <br>**Default:** 20 |
-| page | query | Page number (1-99999) | No | integer, <br>**Default:** 1 |
-| status | query | Execution status filter (succeeded, failed, stopped, partial-succeeded) | No | string, <br>**Available values:** "failed", "partial-succeeded", "paused", "running", "scheduled", "stopped", "succeeded" |
-
-#### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow archived logs retrieved successfully | **application/json**: [WorkflowArchivedLogPaginationResponse](#workflowarchivedlogpaginationresponse)<br> |
-
 ### [GET] /apps/{app_id}/workflow-runs
 **Get workflow run list**
 
@@ -23789,27 +23763,6 @@ How a workflow node is bound to an Agent.
 | page | integer, <br>**Default:** 1 | Page number (1-99999) | No |
 | status | [WorkflowExecutionStatus](#workflowexecutionstatus) | Execution status filter (succeeded, failed, stopped, partial-succeeded) | No |
 
-#### WorkflowArchivedLogPaginationResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| data | [ [WorkflowArchivedLogPartialResponse](#workflowarchivedlogpartialresponse) ] |  | Yes |
-| has_more | boolean |  | Yes |
-| limit | integer |  | Yes |
-| page | integer |  | Yes |
-| total | integer |  | Yes |
-
-#### WorkflowArchivedLogPartialResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| created_at | integer |  | No |
-| created_by_account | [SimpleAccountResponse](#simpleaccountresponse) |  | No |
-| created_by_end_user | [SimpleEndUser](#simpleenduser) |  | No |
-| id | string |  | Yes |
-| trigger_metadata |  |  | No |
-| workflow_run | [WorkflowRunForArchivedLogResponse](#workflowrunforarchivedlogresponse) |  | No |
-
 #### WorkflowAverageAppInteractionStatisticItem
 
 | Name | Type | Description | Required |
@@ -24586,16 +24539,6 @@ Lifecycle state for an asynchronous archive download request.
 | total_steps | integer |  | No |
 | total_tokens | integer |  | No |
 | version | string |  | No |
-
-#### WorkflowRunForArchivedLogResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| elapsed_time | number |  | No |
-| id | string |  | Yes |
-| status | string |  | No |
-| total_tokens | integer |  | No |
-| triggered_from | string |  | No |
 
 #### WorkflowRunForListResponse
 

--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from core.plugin.plugin_service import PluginService
 from graphon.enums import WorkflowExecutionStatus
-from models import Account, App, EndUser, TenantAccountJoin, WorkflowAppLog, WorkflowArchiveLog, WorkflowRun
+from models import Account, App, EndUser, TenantAccountJoin, WorkflowAppLog, WorkflowRun
 from models.enums import AppTriggerType, CreatorUserRole
 from models.trigger import WorkflowTriggerLog
 from services.workflow.entities import TriggerMetadata
@@ -176,79 +176,6 @@ class WorkflowAppService:
             ]
         else:
             items = [LogView(log, None) for log in session.scalars(offset_stmt).all()]
-        return {
-            "page": page,
-            "limit": limit,
-            "total": total,
-            "has_more": total > page * limit,
-            "data": items,
-        }
-
-    def get_paginate_workflow_archive_logs(
-        self,
-        *,
-        session: Session,
-        app_model: App,
-        page: int = 1,
-        limit: int = 20,
-    ):
-        """
-        Get paginate workflow archive logs using SQLAlchemy 2.0 style.
-        """
-        stmt = select(WorkflowArchiveLog).where(
-            WorkflowArchiveLog.tenant_id == app_model.tenant_id,
-            WorkflowArchiveLog.app_id == app_model.id,
-            WorkflowArchiveLog.log_id.isnot(None),
-        )
-
-        stmt = stmt.order_by(WorkflowArchiveLog.run_created_at.desc())
-
-        count_stmt = select(func.count()).select_from(stmt.subquery())
-        total = session.scalar(count_stmt) or 0
-
-        offset_stmt = stmt.offset((page - 1) * limit).limit(limit)
-
-        logs = list(session.scalars(offset_stmt).all())
-        account_ids = {log.created_by for log in logs if log.created_by_role == CreatorUserRole.ACCOUNT}
-        end_user_ids = {log.created_by for log in logs if log.created_by_role == CreatorUserRole.END_USER}
-
-        accounts_by_id = {}
-        if account_ids:
-            accounts_by_id = {
-                account.id: account
-                for account in session.scalars(select(Account).where(Account.id.in_(account_ids))).all()
-            }
-
-        end_users_by_id = {}
-        if end_user_ids:
-            end_users_by_id = {
-                end_user.id: end_user
-                for end_user in session.scalars(select(EndUser).where(EndUser.id.in_(end_user_ids))).all()
-            }
-
-        items = []
-        for log in logs:
-            if log.created_by_role == CreatorUserRole.ACCOUNT:
-                created_by_account = accounts_by_id.get(log.created_by)
-                created_by_end_user = None
-            elif log.created_by_role == CreatorUserRole.END_USER:
-                created_by_account = None
-                created_by_end_user = end_users_by_id.get(log.created_by)
-            else:
-                created_by_account = None
-                created_by_end_user = None
-
-            items.append(
-                {
-                    "id": log.id,
-                    "workflow_run": log.workflow_run_summary,
-                    "trigger_metadata": self.handle_trigger_metadata(app_model.tenant_id, log.trigger_metadata),
-                    "created_by_account": created_by_account,
-                    "created_by_end_user": created_by_end_user,
-                    "created_at": log.log_created_at,
-                }
-            )
-
         return {
             "page": page,
             "limit": limit,

--- a/api/tests/test_containers_integration_tests/services/test_workflow_app_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workflow_app_service.py
@@ -10,8 +10,8 @@ from faker import Faker
 from sqlalchemy.orm import Session
 
 from graphon.enums import WorkflowExecutionStatus
-from models import EndUser, Workflow, WorkflowAppLog, WorkflowArchiveLog, WorkflowRun
-from models.enums import CreatorUserRole, EndUserType, WorkflowRunTriggeredFrom
+from models import EndUser, Workflow, WorkflowAppLog, WorkflowRun
+from models.enums import CreatorUserRole, EndUserType
 from models.workflow import WorkflowAppLogCreatedFrom
 from services.account_service import AccountService, TenantService
 
@@ -1558,71 +1558,3 @@ class TestWorkflowAppService:
 
         assert result["total"] >= 0
         assert isinstance(result["data"], list)
-
-    def test_get_paginate_workflow_archive_logs(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
-        app, account = self._create_test_app_and_account(db_session_with_containers, mock_external_service_dependencies)
-        service = WorkflowAppService()
-
-        end_user = EndUser(
-            tenant_id=app.tenant_id,
-            app_id=app.id,
-            type=EndUserType.BROWSER,
-            is_anonymous=False,
-            session_id="session-1",
-        )
-        db_session_with_containers.add(end_user)
-        db_session_with_containers.commit()
-
-        now = datetime.now(UTC)
-        archive_defaults = {
-            "workflow_id": str(uuid.uuid4()),
-            "run_version": "1.0.0",
-            "run_status": WorkflowExecutionStatus.SUCCEEDED,
-            "run_triggered_from": WorkflowRunTriggeredFrom.APP_RUN,
-            "run_error": None,
-            "run_elapsed_time": 1.0,
-            "run_total_tokens": 0,
-            "run_total_steps": 0,
-            "run_created_at": now,
-            "run_finished_at": now,
-            "run_exceptions_count": 0,
-            "trigger_metadata": '{"type":"trigger-webhook"}',
-            "log_created_at": now,
-            "log_created_from": WorkflowAppLogCreatedFrom.SERVICE_API,
-        }
-        archive_account = WorkflowArchiveLog(
-            tenant_id=app.tenant_id,
-            app_id=app.id,
-            workflow_run_id=str(uuid.uuid4()),
-            log_id=str(uuid.uuid4()),
-            created_by=account.id,
-            created_by_role=CreatorUserRole.ACCOUNT,
-            **archive_defaults,
-        )
-        archive_end_user = WorkflowArchiveLog(
-            tenant_id=app.tenant_id,
-            app_id=app.id,
-            workflow_run_id=str(uuid.uuid4()),
-            log_id=str(uuid.uuid4()),
-            created_by=end_user.id,
-            created_by_role=CreatorUserRole.END_USER,
-            **archive_defaults,
-        )
-        db_session_with_containers.add_all([archive_account, archive_end_user])
-        db_session_with_containers.commit()
-
-        result = service.get_paginate_workflow_archive_logs(
-            session=db_session_with_containers,
-            app_model=app,
-            page=1,
-            limit=20,
-        )
-
-        assert result["total"] == 2
-        assert len(result["data"]) == 2
-        account_item = next(d for d in result["data"] if d["created_by_account"] is not None)
-        end_user_item = next(d for d in result["data"] if d["created_by_end_user"] is not None)
-        assert account_item["created_by_account"].id == account.id
-        assert end_user_item["created_by_end_user"].id == end_user.id

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_app_log_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_app_log_api.py
@@ -50,35 +50,3 @@ def test_workflow_app_log_pagination_response_normalizes_nested_fields():
     assert response["data"][0]["workflow_run"]["status"] == "succeeded"
     assert response["data"][0]["workflow_run"]["created_at"] == int(created_at.timestamp())
     assert response["data"][0]["created_at"] == int(created_at.timestamp())
-
-
-def test_workflow_archived_log_pagination_response_normalizes_nested_fields():
-    created_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
-    response = workflow_app_log_module.WorkflowArchivedLogPaginationResponse.model_validate(
-        {
-            "page": 1,
-            "limit": 20,
-            "total": 1,
-            "has_more": False,
-            "data": [
-                {
-                    "id": "archived-1",
-                    "workflow_run": {
-                        "id": "run-1",
-                        "status": WorkflowExecutionStatus.FAILED,
-                    },
-                    "trigger_metadata": {"type": "trigger-plugin"},
-                    "created_by_end_user": {
-                        "id": "eu-1",
-                        "type": "anonymous",
-                        "is_anonymous": True,
-                        "session_id": "session-1",
-                    },
-                    "created_at": created_at,
-                }
-            ],
-        }
-    ).model_dump(mode="json")
-
-    assert response["data"][0]["workflow_run"]["status"] == "failed"
-    assert response["data"][0]["created_at"] == int(created_at.timestamp())

--- a/packages/contracts/generated/api/console/apps/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/apps/orpc.gen.ts
@@ -159,9 +159,6 @@ import {
   zGetAppsByAppIdWorkflowAppLogsPath,
   zGetAppsByAppIdWorkflowAppLogsQuery,
   zGetAppsByAppIdWorkflowAppLogsResponse,
-  zGetAppsByAppIdWorkflowArchivedLogsPath,
-  zGetAppsByAppIdWorkflowArchivedLogsQuery,
-  zGetAppsByAppIdWorkflowArchivedLogsResponse,
   zGetAppsByAppIdWorkflowCommentsByCommentIdPath,
   zGetAppsByAppIdWorkflowCommentsByCommentIdResponse,
   zGetAppsByAppIdWorkflowCommentsMentionUsersPath,
@@ -2594,38 +2591,11 @@ export const workflowAppLogs = {
 }
 
 /**
- * Get workflow archived logs
+ * Get workflow runs count statistics
  *
- * Get workflow archived execution logs
+ * Get workflow runs count statistics
  */
 export const get48 = oc
-  .route({
-    description: 'Get workflow archived execution logs',
-    inputStructure: 'detailed',
-    method: 'GET',
-    operationId: 'getAppsByAppIdWorkflowArchivedLogs',
-    path: '/apps/{app_id}/workflow-archived-logs',
-    summary: 'Get workflow archived logs',
-    tags: ['console'],
-  })
-  .input(
-    z.object({
-      params: zGetAppsByAppIdWorkflowArchivedLogsPath,
-      query: zGetAppsByAppIdWorkflowArchivedLogsQuery.optional(),
-    }),
-  )
-  .output(zGetAppsByAppIdWorkflowArchivedLogsResponse)
-
-export const workflowArchivedLogs = {
-  get: get48,
-}
-
-/**
- * Get workflow runs count statistics
- *
- * Get workflow runs count statistics
- */
-export const get49 = oc
   .route({
     description: 'Get workflow runs count statistics',
     inputStructure: 'detailed',
@@ -2644,7 +2614,7 @@ export const get49 = oc
   .output(zGetAppsByAppIdWorkflowRunsCountResponse)
 
 export const count3 = {
-  get: get49,
+  get: get48,
 }
 
 /**
@@ -2682,7 +2652,7 @@ export const tasks = {
  *
  * Get workflow run node execution list
  */
-export const get50 = oc
+export const get49 = oc
   .route({
     description: 'Get workflow run node execution list',
     inputStructure: 'detailed',
@@ -2696,7 +2666,7 @@ export const get50 = oc
   .output(zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsResponse)
 
 export const nodeExecutions = {
-  get: get50,
+  get: get49,
 }
 
 /**
@@ -2704,7 +2674,7 @@ export const nodeExecutions = {
  *
  * Get workflow run detail
  */
-export const get51 = oc
+export const get50 = oc
   .route({
     description: 'Get workflow run detail',
     inputStructure: 'detailed',
@@ -2718,7 +2688,7 @@ export const get51 = oc
   .output(zGetAppsByAppIdWorkflowRunsByRunIdResponse)
 
 export const byRunId = {
-  get: get51,
+  get: get50,
   nodeExecutions,
 }
 
@@ -2750,7 +2720,7 @@ export const download4 = {
 /**
  * Read a text/binary preview file in a workflow Agent node sandbox
  */
-export const get52 = oc
+export const get51 = oc
   .route({
     description: 'Read a text/binary preview file in a workflow Agent node sandbox',
     inputStructure: 'detailed',
@@ -2768,13 +2738,13 @@ export const get52 = oc
   .output(zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesReadResponse)
 
 export const read = {
-  get: get52,
+  get: get51,
 }
 
 /**
  * List a directory in a workflow Agent node sandbox
  */
-export const get53 = oc
+export const get52 = oc
   .route({
     description: 'List a directory in a workflow Agent node sandbox',
     inputStructure: 'detailed',
@@ -2792,7 +2762,7 @@ export const get53 = oc
   .output(zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesResponse)
 
 export const files3 = {
-  get: get53,
+  get: get52,
   download: download4,
   read,
 }
@@ -2818,7 +2788,7 @@ export const byWorkflowRunId = {
  *
  * Get workflow run list
  */
-export const get54 = oc
+export const get53 = oc
   .route({
     description: 'Get workflow run list',
     inputStructure: 'detailed',
@@ -2837,7 +2807,7 @@ export const get54 = oc
   .output(zGetAppsByAppIdWorkflowRunsResponse)
 
 export const workflowRuns2 = {
-  get: get54,
+  get: get53,
   count: count3,
   tasks,
   byRunId,
@@ -2849,7 +2819,7 @@ export const workflowRuns2 = {
  *
  * Get all users in current tenant for mentions
  */
-export const get55 = oc
+export const get54 = oc
   .route({
     description: 'Get all users in current tenant for mentions',
     inputStructure: 'detailed',
@@ -2863,7 +2833,7 @@ export const get55 = oc
   .output(zGetAppsByAppIdWorkflowCommentsMentionUsersResponse)
 
 export const mentionUsers = {
-  get: get55,
+  get: get54,
 }
 
 /**
@@ -2988,7 +2958,7 @@ export const delete10 = oc
  *
  * Get a specific workflow comment
  */
-export const get56 = oc
+export const get55 = oc
   .route({
     description: 'Get a specific workflow comment',
     inputStructure: 'detailed',
@@ -3026,7 +2996,7 @@ export const put3 = oc
 
 export const byCommentId = {
   delete: delete10,
-  get: get56,
+  get: get55,
   put: put3,
   replies,
   resolve,
@@ -3037,7 +3007,7 @@ export const byCommentId = {
  *
  * Get all comments for a workflow
  */
-export const get57 = oc
+export const get56 = oc
   .route({
     description: 'Get all comments for a workflow',
     inputStructure: 'detailed',
@@ -3075,7 +3045,7 @@ export const post42 = oc
   .output(zPostAppsByAppIdWorkflowCommentsResponse)
 
 export const comments = {
-  get: get57,
+  get: get56,
   post: post42,
   mentionUsers,
   byCommentId,
@@ -3084,7 +3054,7 @@ export const comments = {
 /**
  * Get workflow average app interaction statistics
  */
-export const get58 = oc
+export const get57 = oc
   .route({
     description: 'Get workflow average app interaction statistics',
     inputStructure: 'detailed',
@@ -3102,13 +3072,13 @@ export const get58 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsAverageAppInteractionsResponse)
 
 export const averageAppInteractions = {
-  get: get58,
+  get: get57,
 }
 
 /**
  * Get workflow daily runs statistics
  */
-export const get59 = oc
+export const get58 = oc
   .route({
     description: 'Get workflow daily runs statistics',
     inputStructure: 'detailed',
@@ -3126,13 +3096,13 @@ export const get59 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsDailyConversationsResponse)
 
 export const dailyConversations2 = {
-  get: get59,
+  get: get58,
 }
 
 /**
  * Get workflow daily terminals statistics
  */
-export const get60 = oc
+export const get59 = oc
   .route({
     description: 'Get workflow daily terminals statistics',
     inputStructure: 'detailed',
@@ -3150,13 +3120,13 @@ export const get60 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsDailyTerminalsResponse)
 
 export const dailyTerminals = {
-  get: get60,
+  get: get59,
 }
 
 /**
  * Get workflow daily token cost statistics
  */
-export const get61 = oc
+export const get60 = oc
   .route({
     description: 'Get workflow daily token cost statistics',
     inputStructure: 'detailed',
@@ -3174,7 +3144,7 @@ export const get61 = oc
   .output(zGetAppsByAppIdWorkflowStatisticsTokenCostsResponse)
 
 export const tokenCosts2 = {
-  get: get61,
+  get: get60,
 }
 
 export const statistics2 = {
@@ -3194,7 +3164,7 @@ export const workflow = {
  *
  * Get default block configuration by type
  */
-export const get62 = oc
+export const get61 = oc
   .route({
     description: 'Get default block configuration by type',
     inputStructure: 'detailed',
@@ -3213,7 +3183,7 @@ export const get62 = oc
   .output(zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsByBlockTypeResponse)
 
 export const byBlockType = {
-  get: get62,
+  get: get61,
 }
 
 /**
@@ -3221,7 +3191,7 @@ export const byBlockType = {
  *
  * Get default block configurations for workflow
  */
-export const get63 = oc
+export const get62 = oc
   .route({
     description: 'Get default block configurations for workflow',
     inputStructure: 'detailed',
@@ -3235,14 +3205,14 @@ export const get63 = oc
   .output(zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsResponse)
 
 export const defaultWorkflowBlockConfigs = {
-  get: get63,
+  get: get62,
   byBlockType,
 }
 
 /**
  * Get conversation variables for workflow
  */
-export const get64 = oc
+export const get63 = oc
   .route({
     description: 'Get conversation variables for workflow',
     inputStructure: 'detailed',
@@ -3275,7 +3245,7 @@ export const post43 = oc
   .output(zPostAppsByAppIdWorkflowsDraftConversationVariablesResponse)
 
 export const conversationVariables2 = {
-  get: get64,
+  get: get63,
   post: post43,
 }
 
@@ -3284,7 +3254,7 @@ export const conversationVariables2 = {
  *
  * Get environment variables for workflow
  */
-export const get65 = oc
+export const get64 = oc
   .route({
     description: 'Get environment variables for workflow',
     inputStructure: 'detailed',
@@ -3318,7 +3288,7 @@ export const post44 = oc
   .output(zPostAppsByAppIdWorkflowsDraftEnvironmentVariablesResponse)
 
 export const environmentVariables = {
-  get: get65,
+  get: get64,
   post: post44,
 }
 
@@ -3523,7 +3493,7 @@ export const loop2 = {
   nodes: nodes6,
 }
 
-export const get66 = oc
+export const get65 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -3537,7 +3507,7 @@ export const get66 = oc
   .output(zGetAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerCandidatesResponse)
 
 export const candidates = {
-  get: get66,
+  get: get65,
 }
 
 export const post51 = oc
@@ -3620,7 +3590,7 @@ export const validate = {
   post: post54,
 }
 
-export const get67 = oc
+export const get66 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -3653,7 +3623,7 @@ export const put4 = oc
   .output(zPutAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerResponse)
 
 export const agentComposer = {
-  get: get67,
+  get: get66,
   put: put4,
   candidates,
   copyFromRoster,
@@ -3665,7 +3635,7 @@ export const agentComposer = {
 /**
  * Get last run result for draft workflow node
  */
-export const get68 = oc
+export const get67 = oc
   .route({
     description: 'Get last run result for draft workflow node',
     inputStructure: 'detailed',
@@ -3678,7 +3648,7 @@ export const get68 = oc
   .output(zGetAppsByAppIdWorkflowsDraftNodesByNodeIdLastRunResponse)
 
 export const lastRun = {
-  get: get68,
+  get: get67,
 }
 
 /**
@@ -3753,7 +3723,7 @@ export const delete11 = oc
 /**
  * Get variables for a specific node
  */
-export const get69 = oc
+export const get68 = oc
   .route({
     description: 'Get variables for a specific node',
     inputStructure: 'detailed',
@@ -3767,7 +3737,7 @@ export const get69 = oc
 
 export const variables = {
   delete: delete11,
-  get: get69,
+  get: get68,
 }
 
 export const byNodeId8 = {
@@ -3812,7 +3782,7 @@ export const run10 = {
 /**
  * Server-Sent Events stream of inspector deltas for a draft workflow run.
  */
-export const get70 = oc
+export const get69 = oc
   .route({
     description: 'Server-Sent Events stream of inspector deltas for a draft workflow run.',
     inputStructure: 'detailed',
@@ -3825,13 +3795,13 @@ export const get70 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsEventsResponse)
 
 export const events = {
-  get: get70,
+  get: get69,
 }
 
 /**
  * Full value for one declared output, including signed download URL for files.
  */
-export const get71 = oc
+export const get70 = oc
   .route({
     description: 'Full value for one declared output, including signed download URL for files.',
     inputStructure: 'detailed',
@@ -3848,7 +3818,7 @@ export const get71 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdByOutputNamePreviewResponse)
 
 export const preview5 = {
-  get: get71,
+  get: get70,
 }
 
 export const byOutputName = {
@@ -3858,7 +3828,7 @@ export const byOutputName = {
 /**
  * One node's declared outputs for a draft workflow run.
  */
-export const get72 = oc
+export const get71 = oc
   .route({
     description: "One node's declared outputs for a draft workflow run.",
     inputStructure: 'detailed',
@@ -3871,14 +3841,14 @@ export const get72 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdResponse)
 
 export const byNodeId9 = {
-  get: get72,
+  get: get71,
   byOutputName,
 }
 
 /**
  * Snapshot of every node's declared outputs for a draft workflow run.
  */
-export const get73 = oc
+export const get72 = oc
   .route({
     description: "Snapshot of every node's declared outputs for a draft workflow run.",
     inputStructure: 'detailed',
@@ -3891,7 +3861,7 @@ export const get73 = oc
   .output(zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsResponse)
 
 export const nodeOutputs = {
-  get: get73,
+  get: get72,
   events,
   byNodeId: byNodeId9,
 }
@@ -3907,7 +3877,7 @@ export const runs = {
 /**
  * Get system variables for workflow
  */
-export const get74 = oc
+export const get73 = oc
   .route({
     description: 'Get system variables for workflow',
     inputStructure: 'detailed',
@@ -3920,7 +3890,7 @@ export const get74 = oc
   .output(zGetAppsByAppIdWorkflowsDraftSystemVariablesResponse)
 
 export const systemVariables = {
-  get: get74,
+  get: get73,
 }
 
 /**
@@ -4020,7 +3990,7 @@ export const delete12 = oc
 /**
  * Get a specific workflow variable
  */
-export const get75 = oc
+export const get74 = oc
   .route({
     description: 'Get a specific workflow variable',
     inputStructure: 'detailed',
@@ -4054,7 +4024,7 @@ export const patch2 = oc
 
 export const byVariableId = {
   delete: delete12,
-  get: get75,
+  get: get74,
   patch: patch2,
   reset,
 }
@@ -4080,7 +4050,7 @@ export const delete13 = oc
  *
  * Get draft workflow variables
  */
-export const get76 = oc
+export const get75 = oc
   .route({
     description: 'Get draft workflow variables',
     inputStructure: 'detailed',
@@ -4100,7 +4070,7 @@ export const get76 = oc
 
 export const variables2 = {
   delete: delete13,
-  get: get76,
+  get: get75,
   byVariableId,
 }
 
@@ -4109,7 +4079,7 @@ export const variables2 = {
  *
  * Get draft workflow for an application
  */
-export const get77 = oc
+export const get76 = oc
   .route({
     description: 'Get draft workflow for an application',
     inputStructure: 'detailed',
@@ -4146,7 +4116,7 @@ export const post60 = oc
   .output(zPostAppsByAppIdWorkflowsDraftResponse)
 
 export const draft2 = {
-  get: get77,
+  get: get76,
   post: post60,
   conversationVariables: conversationVariables2,
   environmentVariables,
@@ -4167,7 +4137,7 @@ export const draft2 = {
  *
  * Get published workflow for an application
  */
-export const get78 = oc
+export const get77 = oc
   .route({
     description: 'Get published workflow for an application',
     inputStructure: 'detailed',
@@ -4201,14 +4171,14 @@ export const post61 = oc
   .output(zPostAppsByAppIdWorkflowsPublishResponse)
 
 export const publish = {
-  get: get78,
+  get: get77,
   post: post61,
 }
 
 /**
  * Server-Sent Events stream of inspector deltas for a published workflow run.
  */
-export const get79 = oc
+export const get78 = oc
   .route({
     description: 'Server-Sent Events stream of inspector deltas for a published workflow run.',
     inputStructure: 'detailed',
@@ -4221,13 +4191,13 @@ export const get79 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsEventsResponse)
 
 export const events2 = {
-  get: get79,
+  get: get78,
 }
 
 /**
  * Full value for one declared output of a published run.
  */
-export const get80 = oc
+export const get79 = oc
   .route({
     description: 'Full value for one declared output of a published run.',
     inputStructure: 'detailed',
@@ -4248,7 +4218,7 @@ export const get80 = oc
   )
 
 export const preview6 = {
-  get: get80,
+  get: get79,
 }
 
 export const byOutputName2 = {
@@ -4258,7 +4228,7 @@ export const byOutputName2 = {
 /**
  * One node's declared outputs for a published workflow run.
  */
-export const get81 = oc
+export const get80 = oc
   .route({
     description: "One node's declared outputs for a published workflow run.",
     inputStructure: 'detailed',
@@ -4271,14 +4241,14 @@ export const get81 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsByNodeIdResponse)
 
 export const byNodeId10 = {
-  get: get81,
+  get: get80,
   byOutputName: byOutputName2,
 }
 
 /**
  * Snapshot of every node's declared outputs for a published workflow run.
  */
-export const get82 = oc
+export const get81 = oc
   .route({
     description: "Snapshot of every node's declared outputs for a published workflow run.",
     inputStructure: 'detailed',
@@ -4291,7 +4261,7 @@ export const get82 = oc
   .output(zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsResponse)
 
 export const nodeOutputs2 = {
-  get: get82,
+  get: get81,
   events: events2,
   byNodeId: byNodeId10,
 }
@@ -4311,7 +4281,7 @@ export const published = {
 /**
  * Get webhook trigger for a node
  */
-export const get83 = oc
+export const get82 = oc
   .route({
     inputStructure: 'detailed',
     method: 'GET',
@@ -4329,7 +4299,7 @@ export const get83 = oc
   .output(zGetAppsByAppIdWorkflowsTriggersWebhookResponse)
 
 export const webhook = {
-  get: get83,
+  get: get82,
 }
 
 export const triggers2 = {
@@ -4405,7 +4375,7 @@ export const byWorkflowId = {
  *
  * Get all published workflows for an application
  */
-export const get84 = oc
+export const get83 = oc
   .route({
     description: 'Get all published workflows for an application',
     inputStructure: 'detailed',
@@ -4424,7 +4394,7 @@ export const get84 = oc
   .output(zGetAppsByAppIdWorkflowsResponse)
 
 export const workflows3 = {
-  get: get84,
+  get: get83,
   defaultWorkflowBlockConfigs,
   draft: draft2,
   publish,
@@ -4457,7 +4427,7 @@ export const delete15 = oc
  *
  * Get application details
  */
-export const get85 = oc
+export const get84 = oc
   .route({
     description: 'Get application details',
     inputStructure: 'detailed',
@@ -4490,7 +4460,7 @@ export const put6 = oc
 
 export const byAppId2 = {
   delete: delete15,
-  get: get85,
+  get: get84,
   put: put6,
   advancedChat,
   agent,
@@ -4525,7 +4495,6 @@ export const byAppId2 = {
   triggerEnable,
   triggers,
   workflowAppLogs,
-  workflowArchivedLogs,
   workflowRuns: workflowRuns2,
   workflow,
   workflows: workflows3,
@@ -4559,7 +4528,7 @@ export const byApiKeyId = {
  *
  * Get all API keys for an app
  */
-export const get86 = oc
+export const get85 = oc
   .route({
     description: 'Get all API keys for an app',
     inputStructure: 'detailed',
@@ -4592,7 +4561,7 @@ export const post63 = oc
   .output(zPostAppsByResourceIdApiKeysResponse)
 
 export const apiKeys = {
-  get: get86,
+  get: get85,
   post: post63,
   byApiKeyId,
 }
@@ -4606,7 +4575,7 @@ export const byResourceId = {
  *
  * Get list of applications with pagination and filtering
  */
-export const get87 = oc
+export const get86 = oc
   .route({
     description: 'Get list of applications with pagination and filtering',
     inputStructure: 'detailed',
@@ -4639,7 +4608,7 @@ export const post64 = oc
   .output(zPostAppsResponse)
 
 export const apps = {
-  get: get87,
+  get: get86,
   post: post64,
   imports,
   recent,

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -753,14 +753,6 @@ export type WorkflowAppLogPaginationResponse = {
   total: number
 }
 
-export type WorkflowArchivedLogPaginationResponse = {
-  data: Array<WorkflowArchivedLogPartialResponse>
-  has_more: boolean
-  limit: number
-  page: number
-  total: number
-}
-
 export type WorkflowRunPaginationResponse = {
   data: Array<WorkflowRunForListResponse>
   has_more: boolean
@@ -1685,15 +1677,6 @@ export type WorkflowAppLogPartialResponse = {
   workflow_run?: WorkflowRunForLogResponse | null
 }
 
-export type WorkflowArchivedLogPartialResponse = {
-  created_at?: number | null
-  created_by_account?: SimpleAccountResponse | null
-  created_by_end_user?: SimpleEndUser | null
-  id: string
-  trigger_metadata?: unknown
-  workflow_run?: WorkflowRunForArchivedLogResponse | null
-}
-
 export type WorkflowRunForListResponse = {
   created_at?: number | null
   created_by_account?: SimpleAccountResponse | null
@@ -2218,14 +2201,6 @@ export type WorkflowRunForLogResponse = {
   total_tokens?: number | null
   triggered_from?: string | null
   version?: string | null
-}
-
-export type WorkflowRunForArchivedLogResponse = {
-  elapsed_time?: number | null
-  id: string
-  status?: string | null
-  total_tokens?: number | null
-  triggered_from?: string | null
 }
 
 export type WorkflowFileUploadPayload = {
@@ -5164,39 +5139,6 @@ export type GetAppsByAppIdWorkflowAppLogsResponses = {
 
 export type GetAppsByAppIdWorkflowAppLogsResponse =
   GetAppsByAppIdWorkflowAppLogsResponses[keyof GetAppsByAppIdWorkflowAppLogsResponses]
-
-export type GetAppsByAppIdWorkflowArchivedLogsData = {
-  body?: never
-  path: {
-    app_id: string
-  }
-  query?: {
-    created_at__after?: string
-    created_at__before?: string
-    created_by_account?: string
-    created_by_end_user_session_id?: string
-    detail?: boolean
-    keyword?: string
-    limit?: number
-    page?: number
-    status?:
-      | 'failed'
-      | 'partial-succeeded'
-      | 'paused'
-      | 'running'
-      | 'scheduled'
-      | 'stopped'
-      | 'succeeded'
-  }
-  url: '/apps/{app_id}/workflow-archived-logs'
-}
-
-export type GetAppsByAppIdWorkflowArchivedLogsResponses = {
-  200: WorkflowArchivedLogPaginationResponse
-}
-
-export type GetAppsByAppIdWorkflowArchivedLogsResponse =
-  GetAppsByAppIdWorkflowArchivedLogsResponses[keyof GetAppsByAppIdWorkflowArchivedLogsResponses]
 
 export type GetAppsByAppIdWorkflowRunsData = {
   body?: never

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -2570,40 +2570,6 @@ export const zWorkflowAppLogPaginationResponse = z.object({
 })
 
 /**
- * WorkflowRunForArchivedLogResponse
- */
-export const zWorkflowRunForArchivedLogResponse = z.object({
-  elapsed_time: z.number().nullish(),
-  id: z.string(),
-  status: z.string().nullish(),
-  total_tokens: z.int().nullish(),
-  triggered_from: z.string().nullish(),
-})
-
-/**
- * WorkflowArchivedLogPartialResponse
- */
-export const zWorkflowArchivedLogPartialResponse = z.object({
-  created_at: z.int().nullish(),
-  created_by_account: zSimpleAccountResponse.nullish(),
-  created_by_end_user: zSimpleEndUser.nullish(),
-  id: z.string(),
-  trigger_metadata: z.unknown().optional(),
-  workflow_run: zWorkflowRunForArchivedLogResponse.nullish(),
-})
-
-/**
- * WorkflowArchivedLogPaginationResponse
- */
-export const zWorkflowArchivedLogPaginationResponse = z.object({
-  data: z.array(zWorkflowArchivedLogPartialResponse),
-  has_more: z.boolean(),
-  limit: z.int(),
-  page: z.int(),
-  total: z.int(),
-})
-
-/**
  * WorkflowFeatureTogglePayload
  */
 export const zWorkflowFeatureTogglePayload = z.object({
@@ -5487,29 +5453,6 @@ export const zGetAppsByAppIdWorkflowAppLogsQuery = z.object({
  * Workflow app logs retrieved successfully
  */
 export const zGetAppsByAppIdWorkflowAppLogsResponse = zWorkflowAppLogPaginationResponse
-
-export const zGetAppsByAppIdWorkflowArchivedLogsPath = z.object({
-  app_id: z.uuid(),
-})
-
-export const zGetAppsByAppIdWorkflowArchivedLogsQuery = z.object({
-  created_at__after: z.iso.datetime().optional(),
-  created_at__before: z.iso.datetime().optional(),
-  created_by_account: z.string().optional(),
-  created_by_end_user_session_id: z.string().optional(),
-  detail: z.boolean().optional().default(false),
-  keyword: z.string().optional(),
-  limit: z.int().gte(1).lte(100).optional().default(20),
-  page: z.int().gte(1).lte(99999).optional().default(1),
-  status: z
-    .enum(['failed', 'partial-succeeded', 'paused', 'running', 'scheduled', 'stopped', 'succeeded'])
-    .optional(),
-})
-
-/**
- * Workflow archived logs retrieved successfully
- */
-export const zGetAppsByAppIdWorkflowArchivedLogsResponse = zWorkflowArchivedLogPaginationResponse
 
 export const zGetAppsByAppIdWorkflowRunsPath = z.object({
   app_id: z.uuid(),


### PR DESCRIPTION
## Summary

- remove the unused Console `GET /apps/{app_id}/workflow-archived-logs` endpoint
- remove its endpoint-only response models and dead `WorkflowAppService` query
- regenerate Console OpenAPI and TypeScript/Zod/ORPC contracts

The frontend implementation that called this endpoint never landed on `main`. Current workflow logs use `/workflow-app-logs`, while archived runs use the workspace-level `/workflow-run-archives` flow.

## Breaking change

This removes the legacy Console workflow archived-logs endpoint. No caller exists in the current repository.

## Stack

This is the bottom layer. A follow-up layer will refactor the remaining workflow app-log endpoint after review.
