### PR TITLE
fix(api): backport broken pipe handling to lts/1.13.x 🤖🤖🤖

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import queue
 import threading
@@ -24,6 +25,17 @@ from dify_graph.runtime import GraphRuntimeState
 from extensions.ext_redis import redis_client
 
 logger = logging.getLogger(__name__)
+
+
+def _is_broken_pipe_error(error: BaseException) -> bool:
+    current_error: BaseException | None = error
+    while current_error is not None:
+        if isinstance(current_error, BrokenPipeError):
+            return True
+        if isinstance(current_error, OSError) and current_error.errno == errno.EPIPE:
+            return True
+        current_error = current_error.__cause__ or current_error.__context__
+    return False
 
 
 class PublishFrom(IntEnum):
@@ -176,12 +188,26 @@ class AppQueueManager(ABC):
 
     @cachedmethod(lambda self: self._stopped_cache, lock=lambda self: self._cache_lock)
     def _is_stopped(self) -> bool:
-        """
-        Check if task is stopped
-        :return:
+        """Return whether the task has a stop flag.
+
+        A broken Redis connection cannot establish that a stop was requested,
+        so this check fails open to avoid interrupting the workflow generator.
+        Other Redis errors retain their existing propagation behavior.
         """
         stopped_cache_key = AppQueueManager._generate_stopped_cache_key(self._task_id)
-        result = redis_client.get(stopped_cache_key)
+        try:
+            result = redis_client.get(stopped_cache_key)
+        except (BrokenPipeError, RedisError) as exc:
+            if not _is_broken_pipe_error(exc):
+                raise
+            logger.warning(
+                "Ignoring broken pipe while checking task stop flag; task=%s key=%s",
+                self._task_id,
+                stopped_cache_key,
+                exc_info=True,
+            )
+            return False
+
         if result is not None:
             return True
 

--- a/api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py
@@ -1,7 +1,10 @@
+import errno
+import logging
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -15,6 +18,12 @@ class DummyQueueManager(AppQueueManager):
 
     def _publish(self, event, pub_from):
         self.published.append((event, pub_from))
+
+
+def _redis_broken_pipe_error() -> RedisConnectionError:
+    error = RedisConnectionError("Error 32 while writing to socket. Broken pipe.")
+    error.__context__ = BrokenPipeError(errno.EPIPE, "Broken pipe")
+    return error
 
 
 class TestBaseAppQueueManager:
@@ -50,6 +59,35 @@ class TestBaseAppQueueManager:
             manager = DummyQueueManager(task_id="t1", user_id="u1", invoke_from=InvokeFrom.SERVICE_API)
 
             assert manager._is_stopped() is True
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(BrokenPipeError(errno.EPIPE, "Broken pipe"), id="direct"),
+            pytest.param(_redis_broken_pipe_error(), id="redis-connection-error"),
+        ],
+    )
+    def test_is_stopped_ignores_broken_pipe(self, error: BaseException, caplog: pytest.LogCaptureFixture):
+        with patch("core.app.apps.base_app_queue_manager.redis_client") as mock_redis:
+            mock_redis.setex.return_value = True
+            mock_redis.get.side_effect = error
+            manager = DummyQueueManager(task_id="t1", user_id="u1", invoke_from=InvokeFrom.SERVICE_API)
+
+            with caplog.at_level(logging.WARNING, logger="core.app.apps.base_app_queue_manager"):
+                assert manager._is_stopped() is False
+
+        assert "Ignoring broken pipe while checking task stop flag" in caplog.text
+        assert "task=t1" in caplog.text
+        assert "key=generate_task_stopped:t1" in caplog.text
+
+    def test_is_stopped_propagates_other_redis_connection_errors(self):
+        with patch("core.app.apps.base_app_queue_manager.redis_client") as mock_redis:
+            mock_redis.setex.return_value = True
+            mock_redis.get.side_effect = RedisConnectionError("Connection refused")
+            manager = DummyQueueManager(task_id="t1", user_id="u1", invoke_from=InvokeFrom.SERVICE_API)
+
+            with pytest.raises(RedisConnectionError, match="Connection refused"):
+                manager._is_stopped()
 
     def test_check_for_sqlalchemy_models_raises(self):
         with patch("core.app.apps.base_app_queue_manager.redis_client") as mock_redis:


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex. I have reviewed and edited the final diff, and I am responsible for the content.

> [!IMPORTANT]
>
> 1. I have read the [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 2. The associated issue is assigned to me.
> 3. This PR uses the required issue-closing syntax below.

## Summary

Backport #41356 to `lts/1.13.x`.

- treat direct and redis-py-wrapped `EPIPE` failures as an unavailable app-task stop signal
- log the ignored broken pipe with the task ID and Redis stop-flag key
- preserve existing propagation behavior for all other Redis failures
- include the regression coverage merged on main

The backport was created with `git cherry-pick -x` from main commit `3e12f0b9fb01cd3e64301c4e2de8e8816cad1b56`. On this LTS branch, the guard also prevents the legacy workflow producer stop check from unwinding the suspended GraphEngine generator and leaving workflow records in `running`.

Fixes #41351

Source PR: #41356

Linear: [ENG-787](https://linear.app/dify/issue/ENG-787/bugee-v3910redis-瞬断后-workflow-永久-running但-celery-task-显示-succeeded)

## Screenshots

Not applicable; this is a backend error-handling backport.

## Verification

Targeted verification commands:

```bash
uv run --project api --group dev pytest -q -o addopts='' \
  api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py \
  api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py

uv run --project api --group dev ruff check \
  api/core/app/apps/base_app_queue_manager.py \
  api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py

./dev/basedpyright-check core/app/apps/base_app_queue_manager.py
```

The LTS cherry-pick provenance checker verifies the single backport commit against the main source commit.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed if there was no previous discussion or associated issue.
- [x] The source change includes regression coverage and the backport remains atomic.
- [x] The affected behavioral docstring is included in the backport.
- [ ] I ran the complete repository-wide `make lint` and `make type-check` suites.
