### PR TITLE
fix(web): use management provider list for MCP integrations

### DIFF
--- a/web/app/components/integrations/__tests__/tool-provider-list.spec.tsx
+++ b/web/app/components/integrations/__tests__/tool-provider-list.spec.tsx
@@ -95,12 +95,10 @@ let mockIsLoadingToolProviders = false
 const mockRefetch = vi.fn()
 const mockUseAllToolProviders = vi.hoisted(() => vi.fn())
 const mockUseAllCustomTools = vi.hoisted(() => vi.fn())
-const mockUseAllMCPTools = vi.hoisted(() => vi.fn())
 const mockUseAllWorkflowTools = vi.hoisted(() => vi.fn())
 vi.mock('@/service/use-tools', () => ({
-  useAllToolProviders: (enabled?: boolean) => mockUseAllToolProviders(enabled),
+  useAllToolProviders: (enabled?: boolean, type?: string) => mockUseAllToolProviders(enabled, type),
   useAllCustomTools: (enabled?: boolean) => mockUseAllCustomTools(enabled),
-  useAllMCPTools: (enabled?: boolean) => mockUseAllMCPTools(enabled),
   useAllWorkflowTools: (enabled?: boolean) => mockUseAllWorkflowTools(enabled),
 }))
 
@@ -314,10 +312,12 @@ vi.mock('@/app/components/tools/marketplace/hooks', () => ({
 
 vi.mock('@/app/components/tools/mcp', () => ({
   default: ({
+    providers,
     searchText,
     contentInset,
     showCreateCard,
   }: {
+    providers?: Array<{ id: string }>
     searchText: string
     contentInset?: string
     showCreateCard?: boolean
@@ -325,6 +325,7 @@ vi.mock('@/app/components/tools/mcp', () => ({
     <div
       data-testid="mcp-list"
       data-content-inset={contentInset}
+      data-provider-ids={providers?.map((provider) => provider.id).join(',')}
       data-show-create-card={String(showCreateCard)}
     >
       MCP List:
@@ -397,11 +398,6 @@ describe('ProviderList', () => {
       isLoading: enabled ? mockIsLoadingToolProviders : false,
       refetch: mockRefetch,
     }))
-    mockUseAllMCPTools.mockImplementation((enabled = true) => ({
-      data: enabled ? mockCollectionData.filter((collection) => collection.type === 'mcp') : [],
-      isLoading: enabled ? mockIsLoadingToolProviders : false,
-      refetch: mockRefetch,
-    }))
     mockUseAllWorkflowTools.mockImplementation((enabled = true) => ({
       data: enabled
         ? mockCollectionData.filter((collection) => collection.type === 'workflow')
@@ -470,10 +466,9 @@ describe('ProviderList', () => {
 
       renderProviderList({ category })
 
-      expect(mockUseAllToolProviders).toHaveBeenCalledWith(false)
+      expect(mockUseAllToolProviders).toHaveBeenCalledWith(false, undefined)
       expect(mockUseAllCustomTools).toHaveBeenCalledWith(category === 'api')
       expect(mockUseAllWorkflowTools).toHaveBeenCalledWith(category === 'workflow')
-      expect(mockUseAllMCPTools).toHaveBeenCalledWith(false)
       expect(screen.getByTestId(cardTestId)).toBeInTheDocument()
       expect(screen.queryByTestId('custom-create-card')).not.toBeInTheDocument()
       expect(screen.queryByTestId('toolbar-add-custom-tool')).not.toBeInTheDocument()
@@ -956,6 +951,30 @@ describe('ProviderList', () => {
   })
 
   describe('MCP Tab', () => {
+    it('uses database provider IDs from the management list', () => {
+      const provider = {
+        id: '019d3f85-d61c-765e-9615-8f469d02689f',
+        name: 'mcp-server',
+        author: 'User',
+        description: { en_US: 'MCP Server', zh_Hans: 'MCP 服务' },
+        icon: { background: '#fff', content: 'M' },
+        label: { en_US: 'MCP Server', zh_Hans: 'MCP 服务' },
+        type: 'mcp' as const,
+        team_credentials: {},
+        is_team_authorization: false,
+        allow_delete: true,
+        labels: [],
+      }
+      mockCollectionData = [...createDefaultCollections(), provider]
+
+      renderProviderList({ category: 'mcp' })
+
+      expect(screen.getByTestId('mcp-list')).toHaveAttribute(
+        'data-provider-ids',
+        '019d3f85-d61c-765e-9615-8f469d02689f',
+      )
+    })
+
     it('renders MCPList component', () => {
       renderProviderList({ category: 'mcp' })
       expect(screen.getByTestId('mcp-list')).toBeInTheDocument()
@@ -966,10 +985,9 @@ describe('ProviderList', () => {
 
       renderProviderList({ category: 'mcp' })
 
-      expect(mockUseAllToolProviders).toHaveBeenCalledWith(false)
+      expect(mockUseAllToolProviders).toHaveBeenCalledWith(true, 'mcp')
       expect(mockUseAllCustomTools).toHaveBeenCalledWith(false)
       expect(mockUseAllWorkflowTools).toHaveBeenCalledWith(false)
-      expect(mockUseAllMCPTools).toHaveBeenCalledWith(true)
       expect(screen.getByTestId('mcp-list')).toBeInTheDocument()
       expect(screen.getByTestId('mcp-list')).toHaveAttribute('data-show-create-card', 'false')
       expect(screen.queryByTestId('toolbar-add-mcp')).not.toBeInTheDocument()

--- a/web/app/components/integrations/tool-provider-list.tsx
+++ b/web/app/components/integrations/tool-provider-list.tsx
@@ -34,12 +34,7 @@ import ProviderDetail from '@/app/components/tools/provider/detail'
 import { ToolProviderGrid } from '@/app/components/tools/tool-provider-grid'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useCheckInstalled, useInvalidateInstalledPluginList } from '@/service/use-plugins'
-import {
-  useAllCustomTools,
-  useAllMCPTools,
-  useAllToolProviders,
-  useAllWorkflowTools,
-} from '@/service/use-tools'
+import { useAllCustomTools, useAllToolProviders, useAllWorkflowTools } from '@/service/use-tools'
 import { useToolProviderCategory } from './hooks/use-tool-provider-category'
 import ToolProviderCreateAction from './tool-provider-create-action'
 import { ToolProviderToolbar } from './tool-provider-toolbar'
@@ -90,19 +85,19 @@ const ProviderList = ({ category, contentInset = 'default', layout }: ProviderLi
   const handleCreatedMCPProviderHandled = useCallback(() => {
     setCreatedMCPProviderId(undefined)
   }, [])
-  const allToolProvidersQuery = useAllToolProviders(activeTab === 'builtin')
+  const allToolProvidersQuery = useAllToolProviders(
+    activeTab === 'builtin' || activeTab === 'mcp',
+    activeTab === 'mcp' ? 'mcp' : undefined,
+  )
   const customToolsQuery = useAllCustomTools(activeTab === 'api')
   const workflowToolsQuery = useAllWorkflowTools(activeTab === 'workflow')
-  const mcpToolsQuery = useAllMCPTools(activeTab === 'mcp')
-  const { refetch: refetchMcpTools } = mcpToolsQuery
+  const { refetch: refetchMcpTools } = allToolProvidersQuery
   const activeToolsQuery =
     activeTab === 'api'
       ? customToolsQuery
       : activeTab === 'workflow'
         ? workflowToolsQuery
-        : activeTab === 'mcp'
-          ? mcpToolsQuery
-          : allToolProvidersQuery
+        : allToolProvidersQuery
   const collectionList = activeToolsQuery.data ?? EMPTY_COLLECTIONS
   const isCollectionListLoading = activeToolsQuery.isLoading
   const refetch = activeToolsQuery.refetch
@@ -235,8 +230,8 @@ const ProviderList = ({ category, contentInset = 'default', layout }: ProviderLi
               )}
               {activeTab === 'mcp' && (
                 <MCPList
-                  providers={mcpToolsQuery.data ?? []}
-                  isLoading={mcpToolsQuery.isLoading}
+                  providers={activeTabCollectionList}
+                  isLoading={allToolProvidersQuery.isLoading}
                   searchText={keywords}
                   contentInset={contentInset}
                   createdProviderId={createdMCPProviderId}

--- a/web/app/components/tools/mcp/index.tsx
+++ b/web/app/components/tools/mcp/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import type { ComponentProps } from 'react'
 import type { ToolsContentInset } from '../content-inset'
+import type { Collection } from '@/app/components/tools/types'
 import type { ToolWithProvider } from '@/app/components/workflow/types'
 import {
   AlertDialog,
@@ -25,7 +26,7 @@ import MCPModal from './modal'
 import MCPCard from './provider-card'
 
 type Props = Readonly<{
-  providers?: ToolWithProvider[]
+  providers?: Collection[]
   isLoading?: boolean
   searchText: string
   contentInset?: ToolsContentInset

--- a/web/service/__tests__/use-tools.spec.tsx
+++ b/web/service/__tests__/use-tools.spec.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { act } from '@testing-library/react'
+import { act, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { renderHook } from '@/test/console/render'
-import { useRefreshMCPServerCode } from '../use-tools'
+import { useAllToolProviders, useRefreshMCPServerCode } from '../use-tools'
 
 const { mockGet, mockPost } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -66,5 +66,28 @@ describe('useRefreshMCPServerCode', () => {
       },
     })
     expect(mockGet).not.toHaveBeenCalled()
+  })
+})
+
+describe('useAllToolProviders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockResolvedValue([])
+  })
+
+  it('keeps filtered MCP providers in a separate query', async () => {
+    renderHook(
+      () => {
+        useAllToolProviders()
+        useAllToolProviders(true, 'mcp')
+      },
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+    expect(mockGet).toHaveBeenCalledWith('/workspaces/current/tool-providers')
+    expect(mockGet).toHaveBeenCalledWith('/workspaces/current/tool-providers', {
+      params: { type: 'mcp' },
+    })
   })
 })

--- a/web/service/use-tools.ts
+++ b/web/service/use-tools.ts
@@ -17,10 +17,15 @@ import { useInvalid } from './use-base'
 const NAME_SPACE = 'tools'
 
 const useAllToolProvidersKey = [NAME_SPACE, 'allToolProviders']
-export const useAllToolProviders = (enabled = true) => {
+type ToolProviderListType = 'builtin' | 'model' | 'api' | 'workflow' | 'mcp'
+
+export const useAllToolProviders = (enabled = true, type?: ToolProviderListType) => {
   return useQuery<Collection[]>({
-    queryKey: useAllToolProvidersKey,
-    queryFn: () => get<Collection[]>('/workspaces/current/tool-providers'),
+    queryKey: type ? [...useAllToolProvidersKey, type] : useAllToolProvidersKey,
+    queryFn: () =>
+      type
+        ? get<Collection[]>('/workspaces/current/tool-providers', { params: { type } })
+        : get<Collection[]>('/workspaces/current/tool-providers'),
     enabled,
   })
 }


### PR DESCRIPTION
## Summary

Cherry-picks `735d814dc073e48721d3ca464aaa9a5610e91a4f` onto `hotfix/1.17.0-fix.4`.

Use the management provider list for MCP integration cards so edit, authorize, refresh, and delete actions receive database provider IDs, while runtime MCP consumers continue using server identifiers.

## Validation

- Hotfix provenance check -> verified 1 PR commit includes cherry-pick provenance from main.
- `git diff --check myori/hotfix/1.17.0-fix.4...HEAD` -> passed.
- Local tests were not run as requested; relying on PR CI. The source main PR #41360 passed its Web tests and checks.