### PR TITLE
refactor(service_api): dep-inject payloads with @model_validate

### DIFF
--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.common.session import with_session
-from controllers.console.wraps import edit_permission_required
+from controllers.console.wraps import edit_permission_required, model_validate
 from controllers.service_api import service_api_ns
 from controllers.service_api.wraps import validate_app_token
 from extensions.ext_redis import redis_client
@@ -106,9 +106,9 @@ class AnnotationReplyActionApi(Resource):
         service_api_ns.models[AnnotationJobStatusResponse.__name__],
     )
     @validate_app_token
-    def post(self, app_model: App, action: Literal["enable", "disable"]):
+    @model_validate(AnnotationReplyActionPayload)
+    def post(self, payload: AnnotationReplyActionPayload, app_model: App, action: Literal["enable", "disable"]):
         """Enable or disable annotation reply feature."""
-        payload = AnnotationReplyActionPayload.model_validate(service_api_ns.payload or {})
         match action:
             case "enable":
                 enable_args: EnableAnnotationArgs = {
@@ -250,9 +250,9 @@ class AnnotationListApi(Resource):
     )
     @validate_app_token
     @with_session
-    def post(self, session: Session, app_model: App):
+    @model_validate(AnnotationCreatePayload)
+    def post(self, payload: AnnotationCreatePayload, session: Session, app_model: App):
         """Create a new annotation."""
-        payload = AnnotationCreatePayload.model_validate(service_api_ns.payload or {})
         insert_args: InsertAnnotationArgs = {"question": payload.question, "answer": payload.answer}
         annotation = AppAnnotationService.insert_app_annotation_directly(insert_args, app_model.id, session)
         return dump_response(Annotation, annotation), HTTPStatus.CREATED
@@ -290,9 +290,9 @@ class AnnotationUpdateDeleteApi(Resource):
     @validate_app_token
     @with_session
     @edit_permission_required
-    def put(self, session: Session, app_model: App, annotation_id: UUID):
+    @model_validate(AnnotationCreatePayload)
+    def put(self, payload: AnnotationCreatePayload, session: Session, app_model: App, annotation_id: UUID):
         """Update an existing annotation."""
-        payload = AnnotationCreatePayload.model_validate(service_api_ns.payload or {})
         update_args: UpdateAnnotationArgs = {"question": payload.question, "answer": payload.answer}
         app_ref = AppRefService.create_app_ref(app_model)
         annotation_ref = AppRefService.create_annotation_ref(app_ref, str(annotation_id))

--- a/api/controllers/service_api/app/human_input_form.py
+++ b/api/controllers/service_api/app/human_input_form.py
@@ -17,6 +17,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from controllers.common.human_input import HumanInputFormSubmitPayload, stringify_form_default_values
 from controllers.common.schema import register_response_schema_models, register_schema_models
+from controllers.console.wraps import model_validate
 from controllers.service_api import service_api_ns
 from controllers.service_api.schema import expect_with_user
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
@@ -163,9 +164,8 @@ class WorkflowHumanInputFormApi(Resource):
         service_api_ns.models[HumanInputFormSubmitResponse.__name__],
     )
     @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.JSON, required=True))
-    def post(self, app_model: App, end_user: EndUser, form_token: str):
-        payload = HumanInputFormSubmitPayload.model_validate(service_api_ns.payload or {})
-
+    @model_validate(HumanInputFormSubmitPayload)
+    def post(self, payload: HumanInputFormSubmitPayload, app_model: App, end_user: EndUser, form_token: str):
         service = HumanInputService(db.engine)
         form = service.get_form_by_token(form_token)
         if form is None:

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -11,6 +11,7 @@ import services
 from controllers.common.controller_schemas import MessageFeedbackPayload, MessageListQuery
 from controllers.common.fields import SimpleResultStringListResponse
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
+from controllers.console.wraps import model_validate
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import NotChatAppError
 from controllers.service_api.schema import expect_with_user
@@ -160,14 +161,13 @@ class MessageFeedbackApi(Resource):
         }
     )
     @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.JSON, required=True))
-    def post(self, app_model: App, end_user: EndUser, message_id: UUID):
+    @model_validate(MessageFeedbackPayload)
+    def post(self, payload: MessageFeedbackPayload, app_model: App, end_user: EndUser, message_id: UUID):
         """Submit feedback for a message.
 
         Allows users to rate messages as like/dislike and provide optional feedback content.
         """
         message_id_str = str(message_id)
-
-        payload = MessageFeedbackPayload.model_validate(service_api_ns.payload or {})
 
         try:
             MessageService.create_feedback(

--- a/api/controllers/service_api/dataset/metadata.py
+++ b/api/controllers/service_api/dataset/metadata.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import NotFound
 from controllers.common.controller_schemas import MetadataUpdatePayload
 from controllers.common.schema import register_response_schema_models, register_schema_model, register_schema_models
 from controllers.common.session import with_session
+from controllers.console.wraps import model_validate
 from controllers.service_api import service_api_ns
 from controllers.service_api.wraps import DatasetApiResource, cloud_edition_billing_rate_limit_check
 from fields.dataset_fields import (
@@ -81,9 +82,9 @@ class DatasetMetadataCreateServiceApi(DatasetApiResource):
     )
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
     @with_session
-    def post(self, session: Session, tenant_id, dataset_id: UUID):
+    @model_validate(MetadataArgs)
+    def post(self, metadata_args: MetadataArgs, session: Session, tenant_id, dataset_id: UUID):
         """Create metadata for a dataset."""
-        metadata_args = MetadataArgs.model_validate(service_api_ns.payload or {})
 
         dataset_id_str = str(dataset_id)
         dataset = DatasetService.get_dataset(dataset_id_str, session)
@@ -156,9 +157,9 @@ class DatasetMetadataServiceApi(DatasetApiResource):
     )
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
     @with_session
-    def patch(self, session: Session, tenant_id, dataset_id: UUID, metadata_id: UUID):
+    @model_validate(MetadataUpdatePayload)
+    def patch(self, payload: MetadataUpdatePayload, session: Session, tenant_id, dataset_id: UUID, metadata_id: UUID):
         """Update metadata name."""
-        payload = MetadataUpdatePayload.model_validate(service_api_ns.payload or {})
 
         dataset_id_str = str(dataset_id)
         metadata_id_str = str(metadata_id)

--- a/api/tests/unit_tests/controllers/service_api/app/test_annotation.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_annotation.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
 import pytest
-from flask import Flask
+from flask import Flask, request
 from flask_restx.api import HTTPStatus
 from pydantic import ValidationError
 
@@ -170,7 +170,8 @@ class TestAnnotationReplyActionApi:
             method="POST",
             json={"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"},
         ):
-            response, status = handler(api, app_model=app_model, action="enable")
+            payload = AnnotationReplyActionPayload.model_validate(request.get_json() or {})
+            response, status = handler(api, payload, app_model=app_model, action="enable")
         assert status == 200
         assert response == {"job_id": "job-1", "job_status": "waiting"}
         enable_mock.assert_called_once()
@@ -186,7 +187,8 @@ class TestAnnotationReplyActionApi:
             method="POST",
             json={"score_threshold": 0.5, "embedding_provider_name": "p", "embedding_model_name": "m"},
         ):
-            response, status = handler(api, app_model=app_model, action="disable")
+            payload = AnnotationReplyActionPayload.model_validate(request.get_json() or {})
+            response, status = handler(api, payload, app_model=app_model, action="disable")
         assert status == 200
         assert response == {"job_id": "job-1", "job_status": "waiting"}
         disable_mock.assert_called_once()
@@ -273,7 +275,8 @@ class TestAnnotationListApi:
         handler = unwrap(api.post)
         app_model = SimpleNamespace(id="app")
         with app.test_request_context("/apps/annotations", method="POST", json={"question": "q", "answer": "a"}):
-            response, status = handler(api, MagicMock(), app_model=app_model)
+            payload = AnnotationCreatePayload.model_validate(request.get_json() or {})
+            response, status = handler(api, payload, MagicMock(), app_model=app_model)
         assert status == HTTPStatus.CREATED
         assert response["question"] == "q"
 
@@ -291,7 +294,8 @@ class TestAnnotationUpdateDeleteApi:
         delete_handler = unwrap(api.delete)
         app_model = SimpleNamespace(id="app", tenant_id="tenant")
         with app.test_request_context("/apps/annotations/1", method="PUT", json={"question": "q", "answer": "a"}):
-            response = put_handler(api, MagicMock(), app_model=app_model, annotation_id="1")
+            payload = AnnotationCreatePayload.model_validate(request.get_json() or {})
+            response = put_handler(api, payload, MagicMock(), app_model=app_model, annotation_id="1")
         assert response["answer"] == "a"
         with app.test_request_context("/apps/annotations/1", method="DELETE"):
             response, status = delete_handler(api, MagicMock(), app_model=app_model, annotation_id="1")

--- a/api/tests/unit_tests/controllers/service_api/app/test_human_input_form.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_human_input_form.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
-from flask import Flask
+from flask import Flask, request
 from werkzeug.exceptions import NotFound
 
 from controllers.common.human_input import HumanInputFormSubmitPayload
@@ -184,7 +184,8 @@ class TestWorkflowHumanInputFormApi:
             method="POST",
             json={"inputs": {"name": "Alice"}, "action": "approve", "user": "external-1"},
         ):
-            response, status = handler(api, app_model=app_model, end_user=end_user, form_token="token-1")
+            payload = HumanInputFormSubmitPayload.model_validate(request.get_json() or {})
+            response, status = handler(api, payload, app_model=app_model, end_user=end_user, form_token="token-1")
 
         assert response == {}
         assert status == 200
@@ -238,7 +239,8 @@ class TestWorkflowHumanInputFormApi:
             method="POST",
             json={"inputs": inputs, "action": "approve", "user": "external-1"},
         ):
-            response, status = handler(api, app_model=app_model, end_user=end_user, form_token="token-1")
+            payload = HumanInputFormSubmitPayload.model_validate(request.get_json() or {})
+            response, status = handler(api, payload, app_model=app_model, end_user=end_user, form_token="token-1")
 
         assert response == {}
         assert status == 200
@@ -294,7 +296,8 @@ class TestWorkflowHumanInputFormApi:
             method="POST",
             json={"inputs": {"name": "Alice"}, "action": "approve", "user": "external-1"},
         ):
+            payload = HumanInputFormSubmitPayload.model_validate(request.get_json() or {})
             with pytest.raises(NotFound):
-                handler(api, app_model=app_model, end_user=end_user, form_token="token-1")
+                handler(api, payload, app_model=app_model, end_user=end_user, form_token="token-1")
 
         service_mock.submit_form_by_token.assert_not_called()

--- a/api/tests/unit_tests/controllers/service_api/app/test_message.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_message.py
@@ -21,7 +21,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
-from flask import Flask
+from flask import Flask, request
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
@@ -476,8 +476,9 @@ class TestMessageFeedbackApi:
             method="POST",
             json={"rating": "like", "content": "ok"},
         ):
+            payload = MessageFeedbackPayload.model_validate(request.get_json() or {})
             with pytest.raises(NotFound):
-                handler(api, app_model=app_model, end_user=end_user, message_id="m1")
+                handler(api, payload, app_model=app_model, end_user=end_user, message_id="m1")
 
 
 class TestAppGetFeedbacksApi:

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py
@@ -13,6 +13,8 @@ Decorator strategy:
   via ``functools.wraps`` → call the unwrapped method directly.
 - Methods without billing decorators → call directly; only patch ``db``,
   services, and ``current_user``.
+- ``@model_validate`` injects the parsed payload as the first argument after
+  ``self``, so unwrapped calls must pass the validated model explicitly.
 """
 
 import uuid
@@ -20,10 +22,11 @@ from inspect import unwrap
 from unittest.mock import ANY, patch
 
 import pytest
-from flask import Flask
+from flask import Flask, request
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
+from controllers.common.controller_schemas import MetadataUpdatePayload
 from controllers.service_api.dataset import metadata as metadata_module
 from controllers.service_api.dataset.metadata import (
     DatasetMetadataBuiltInFieldActionServiceApi,
@@ -35,6 +38,7 @@ from controllers.service_api.dataset.metadata import (
 from models.account import Account, Tenant
 from models.dataset import Dataset
 from models.enums import PermissionEnum
+from services.entities.knowledge_entities.knowledge_entities import MetadataArgs
 from services.errors.metadata import MetadataResourceNotFoundError
 
 
@@ -98,7 +102,10 @@ class TestDatasetMetadataCreatePost(_UsesSQLiteSession):
 
     @staticmethod
     def _call_post(api, session: Session, **kwargs):
-        return unwrap(api.post)(api, session, **kwargs)
+        # `post` is wrapped in @model_validate, so the unwrapped view expects the
+        # validated model where the decorator would have injected it.
+        metadata_args = MetadataArgs.model_validate(request.get_json() or {})
+        return unwrap(api.post)(api, metadata_args, session, **kwargs)
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
@@ -230,7 +237,8 @@ class TestDatasetMetadataServiceApiPatch(_UsesSQLiteSession):
 
     @staticmethod
     def _call_patch(api, session: Session, **kwargs):
-        return unwrap(api.patch)(api, session, **kwargs)
+        payload = MetadataUpdatePayload.model_validate(request.get_json() or {})
+        return unwrap(api.patch)(api, payload, session, **kwargs)
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")


### PR DESCRIPTION
## Summary

part of #36659

Moves the inline `Payload.model_validate(service_api_ns.payload or {})` calls in four `service_api` handlers onto the existing `@model_validate` decorator, so the payload is validated before the handler body runs and arrives as an argument. Claimed in [this comment](https://github.com/langgenius/dify/issues/36659#issuecomment-5435152938).

Seven call sites across four files:

- `service_api/app/annotation.py` — 3 sites
- `service_api/dataset/metadata.py` — 2 of its 3 sites
- `service_api/app/human_input_form.py` — 1 site
- `service_api/app/message.py` — 1 site

`@model_validate` goes innermost in each decorator stack, so the model is injected as the first argument after `self` and the outer decorators still supply `session` / `app_model` / path params — matching how `console/agent/composer.py` and the other 73 converted console handlers already stack it. `service_api/app/annotation.py` already imported from `controllers.console.wraps`, and the recently merged web-layer conversions (#40796, #40856) import `model_validate` from the same place.

## Why only seven of the twenty-four remaining sites

I went through every remaining inline call before picking the slice. The other seventeen are not mechanical, because hoisting the parse changes which error a bad request gets back:

- **Inside a `try`** — `service_api/app/audio.py:190`, `web/audio.py:137`. The `try` maps `AppModelConfigBrokenError` / `NoAudioUploadedServiceError` onto API errors; a decorator parse runs outside it.
- **After a `raise` guard** — `web/completion.py:119`, `web/workflow.py:66`. Both sit behind `raise NotCompletionAppError()` / `NotWorkflowAppError()`, so converting them makes a malformed payload return a validation error where the API currently returns the app-mode error.
- **Parse is deep in the handler** — `segment.py` (4 sites, 23-27 statements before the parse), `conversation.py` (2), `rag_pipeline_workflow.py` (2), `metadata.py:326`, `web/remote_files.py:111`, `web/conversation.py:163`. Each runs permission, embedding or DB work first.
- **Not a handler** — `console/remote_files.py:54` is a plain helper, so there is no route to decorate.

Happy to take any of those on separately if maintainers would rather they were converted with the behaviour change made explicit.

## Screenshots

N/A — backend refactor, no UI.

## How this was verified

- `mypy --check-untyped-defs` on the four changed files: `Success: no issues found in 4 source files`. This is what catches a decorator/signature mismatch, since `@model_validate` is typed with `Concatenate` and rejects a handler whose first parameter is not the model.
- Cross-checked all seven sites programmatically: each `@model_validate(X)` is followed by a signature whose first parameter after `self` is annotated `X`.
- `ruff check` and `ruff format --check` clean across `api/controllers/service_api/`.
- The `service_api` unit test suite does not run to completion on my Windows box (it aborts with a fatal access violation on an unrelated collection), so I am relying on CI for the runtime pass.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code
