### PR TITLE
fix(plugin): make uninstall credential cleanup failure-safe

### DIFF
--- a/api/core/plugin/plugin_service.py
+++ b/api/core/plugin/plugin_service.py
@@ -1243,6 +1243,72 @@ class PluginService:
         return result
 
     @staticmethod
+    def _cleanup_plugin_credentials(tenant_id: str, plugin_id: str) -> None:
+        """Delete plugin-owned credentials and invalidate their provider caches."""
+        provider_name_pattern = f"{plugin_id}/%"
+
+        with Session(db.engine) as session, session.begin():
+            session.execute(
+                delete(TenantPreferredModelProvider).where(
+                    TenantPreferredModelProvider.tenant_id == tenant_id,
+                    TenantPreferredModelProvider.provider_name.like(provider_name_pattern),
+                )
+            )
+
+            provider_ids = session.scalars(
+                select(Provider.id).where(
+                    Provider.tenant_id == tenant_id,
+                    Provider.provider_name.like(provider_name_pattern),
+                )
+            ).all()
+            credential_ids = session.scalars(
+                select(ProviderCredential.id).where(
+                    ProviderCredential.tenant_id == tenant_id,
+                    ProviderCredential.provider_name.like(provider_name_pattern),
+                )
+            ).all()
+
+            if not credential_ids:
+                logger.info("No credentials found for plugin: %s", plugin_id)
+            else:
+                session.execute(
+                    update(Provider)
+                    .where(
+                        Provider.tenant_id == tenant_id,
+                        Provider.provider_name.like(provider_name_pattern),
+                        Provider.credential_id.in_(credential_ids),
+                    )
+                    .values(credential_id=None)
+                )
+                session.execute(
+                    delete(ProviderCredential).where(
+                        ProviderCredential.tenant_id == tenant_id,
+                        ProviderCredential.id.in_(credential_ids),
+                    )
+                )
+                logger.info(
+                    "Completed deleting credentials and cleaning provider associations for plugin: %s",
+                    plugin_id,
+                )
+
+        for provider_id in provider_ids:
+            ProviderCredentialsCache(
+                tenant_id=tenant_id,
+                identity_id=provider_id,
+                cache_type=ProviderCredentialsCacheType.PROVIDER,
+            ).delete()
+
+        from core.provider_manager import ProviderConfigurationCacheSource, ProviderManager
+
+        ProviderManager.invalidate_configurations_cache(
+            tenant_id,
+            sources=(
+                ProviderConfigurationCacheSource.PREFERRED_MODEL_PROVIDERS,
+                ProviderConfigurationCacheSource.PROVIDER_CREDENTIALS,
+            ),
+        )
+
+    @staticmethod
     def uninstall(tenant_id: str, plugin_installation_id: str, *, preserve_credentials: bool = False) -> bool:
         """Uninstall a plugin and optionally retain model-provider credentials for replacement."""
         manager = PluginInstaller()
@@ -1274,62 +1340,24 @@ class PluginService:
         else:
             plugin_id = plugin.plugin_id
             logger.info("Deleting credentials after uninstalling plugin: %s", plugin_id)
-            provider_ids: Sequence[str] = []
-
-            with Session(db.engine) as session, session.begin():
-                session.execute(
-                    delete(TenantPreferredModelProvider).where(
-                        TenantPreferredModelProvider.tenant_id == tenant_id,
-                        TenantPreferredModelProvider.provider_name.like(f"{plugin_id}/%"),
-                    )
+            try:
+                PluginService._cleanup_plugin_credentials(tenant_id, plugin_id)
+            except Exception:
+                logger.exception(
+                    "Plugin credential cleanup failed after uninstall: tenant_id=%s plugin_id=%s",
+                    tenant_id,
+                    plugin_id,
                 )
+                try:
+                    from tasks.plugin_credential_cleanup_task import cleanup_plugin_credentials_task
 
-                credential_ids = session.scalars(
-                    select(ProviderCredential.id).where(
-                        ProviderCredential.tenant_id == tenant_id,
-                        ProviderCredential.provider_name.like(f"{plugin_id}/%"),
-                    )
-                ).all()
-
-                if not credential_ids:
-                    logger.info("No credentials found for plugin: %s", plugin_id)
-                else:
-                    provider_ids = session.scalars(
-                        select(Provider.id).where(
-                            Provider.tenant_id == tenant_id,
-                            Provider.provider_name.like(f"{plugin_id}/%"),
-                            Provider.credential_id.in_(credential_ids),
-                        )
-                    ).all()
-
-                    session.execute(update(Provider).where(Provider.id.in_(provider_ids)).values(credential_id=None))
-                    session.execute(
-                        delete(ProviderCredential).where(
-                            ProviderCredential.id.in_(credential_ids),
-                        )
-                    )
-
-                    logger.info(
-                        "Completed deleting credentials and cleaning provider associations for plugin: %s",
+                    cleanup_plugin_credentials_task.delay(tenant_id, plugin_id)
+                except Exception:
+                    logger.exception(
+                        "Failed to schedule plugin credential cleanup retry: tenant_id=%s plugin_id=%s",
+                        tenant_id,
                         plugin_id,
                     )
-
-            for provider_id in provider_ids:
-                ProviderCredentialsCache(
-                    tenant_id=tenant_id,
-                    identity_id=provider_id,
-                    cache_type=ProviderCredentialsCacheType.PROVIDER,
-                ).delete()
-
-            from core.provider_manager import ProviderConfigurationCacheSource, ProviderManager
-
-            ProviderManager.invalidate_configurations_cache(
-                tenant_id,
-                sources=(
-                    ProviderConfigurationCacheSource.PREFERRED_MODEL_PROVIDERS,
-                    ProviderConfigurationCacheSource.PROVIDER_CREDENTIALS,
-                ),
-            )
 
         PluginService.invalidate_plugin_model_providers_cache(tenant_id)
         return result

--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -174,6 +174,7 @@ def init_app(app: DifyApp) -> Celery:
         "tasks.initialize_created_app_rbac_access_task",  # app access initialization
         "tasks.install_default_plugins_task",  # tenant default plugin installation
         "tasks.new_agent_beta_task",  # New Agent Beta eligibility checks
+        "tasks.plugin_credential_cleanup_task",  # plugin credential cleanup retry
         "tasks.refresh_billing_vector_space_task",  # billing vector-space cache refresh
         "tasks.app_generate.resume_agent_app_task",  # ENG-635: Agent v2 chat ask_human resume
         "tasks.workflow_run_archive_download_tasks",  # workflow-run archive download preparation

--- a/api/tasks/plugin_credential_cleanup_task.py
+++ b/api/tasks/plugin_credential_cleanup_task.py
@@ -1,0 +1,31 @@
+"""Retry plugin credential cleanup after a successful daemon uninstall."""
+
+import logging
+
+from celery import shared_task
+
+from core.plugin.plugin_service import PluginService
+
+logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 5
+_RETRY_DELAY_SECONDS = 60
+
+
+@shared_task(
+    queue="plugin",
+    bind=True,
+    max_retries=_MAX_RETRIES,
+    default_retry_delay=_RETRY_DELAY_SECONDS,
+)
+def cleanup_plugin_credentials_task(self, tenant_id: str, plugin_id: str) -> None:
+    """Retry deleting credentials left after a plugin daemon uninstall."""
+    try:
+        PluginService._cleanup_plugin_credentials(tenant_id, plugin_id)
+    except Exception as exc:
+        logger.exception(
+            "Plugin credential cleanup retry failed: tenant_id=%s plugin_id=%s",
+            tenant_id,
+            plugin_id,
+        )
+        raise self.retry(exc=exc, countdown=_RETRY_DELAY_SECONDS)

--- a/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
 
 import pytest
@@ -17,9 +17,11 @@ from flask import Flask
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from core.helper.model_provider_cache import ProviderCredentialsCacheType
 from core.plugin.entities.plugin import PluginInstallationSource
 from core.plugin.entities.plugin_daemon import PluginVerification
 from core.plugin.plugin_service import PluginService
+from core.provider_manager import ProviderConfigurationCacheSource
 from enums import DeploymentEdition
 from models import ProviderType
 from models.engine import db
@@ -499,10 +501,20 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = True
 
-        result = PluginService.uninstall(tenant_id, "install-1")
+        with (
+            patch("core.plugin.plugin_service.ProviderCredentialsCache") as credentials_cache,
+            patch("core.provider_manager.ProviderManager.invalidate_configurations_cache"),
+        ):
+            result = PluginService.uninstall(tenant_id, "install-1")
 
         assert result is True
         installer.uninstall.assert_called_once()
+        credentials_cache.assert_called_once_with(
+            tenant_id=tenant_id,
+            identity_id=provider_id,
+            cache_type=ProviderCredentialsCacheType.PROVIDER,
+        )
+        credentials_cache.return_value.delete.assert_called_once_with()
 
         plugin_db.expire_all()
 
@@ -560,9 +572,11 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = True
 
-        result = PluginService.uninstall(tenant_id, "install-1", preserve_credentials=True)
+        with patch("tasks.plugin_credential_cleanup_task.cleanup_plugin_credentials_task.delay") as cleanup_retry:
+            result = PluginService.uninstall(tenant_id, "install-1", preserve_credentials=True)
 
         assert result is True
+        cleanup_retry.assert_not_called()
         plugin_db.expire_all()
         assert plugin_db.get(ProviderCredential, credential.id) is not None
         assert plugin_db.get(Provider, provider.id).credential_id == credential.id
@@ -588,8 +602,128 @@ class TestUninstall:
         installer.list_plugins.return_value = [plugin]
         installer.uninstall.return_value = False
 
-        result = PluginService.uninstall(tenant_id, "install-1")
+        with patch("tasks.plugin_credential_cleanup_task.cleanup_plugin_credentials_task.delay") as cleanup_retry:
+            result = PluginService.uninstall(tenant_id, "install-1")
 
         assert result is False
+        cleanup_retry.assert_not_called()
         plugin_db.expire_all()
         assert plugin_db.get(ProviderCredential, credential.id) is not None
+
+    @patch("core.plugin.plugin_service.PluginInstaller")
+    def test_returns_success_and_queues_cleanup_retry_when_cleanup_fails(self, mock_installer_cls: MagicMock) -> None:
+        tenant_id = str(uuid4())
+        plugin_id = "org/myplugin"
+        cleanup_error = RuntimeError("cache unavailable")
+        plugin = MagicMock(installation_id="install-1", plugin_id=plugin_id)
+        installer = mock_installer_cls.return_value
+        installer.list_plugins.return_value = [plugin]
+        installer.uninstall.return_value = True
+
+        with (
+            patch.object(PluginService, "_cleanup_plugin_credentials", side_effect=cleanup_error) as cleanup,
+            patch("tasks.plugin_credential_cleanup_task.cleanup_plugin_credentials_task.delay") as cleanup_retry,
+            patch.object(PluginService, "invalidate_plugin_model_providers_cache") as invalidate_cache,
+        ):
+            result = PluginService.uninstall(tenant_id, "install-1")
+
+        assert result is True
+        installer.uninstall.assert_called_once_with(tenant_id, "install-1")
+        cleanup.assert_called_once_with(tenant_id, plugin_id)
+        cleanup_retry.assert_called_once_with(tenant_id, plugin_id)
+        invalidate_cache.assert_called_once_with(tenant_id)
+
+    @patch("core.plugin.plugin_service.PluginInstaller")
+    def test_cleanup_retry_dispatch_failure_does_not_fail_uninstall(
+        self, mock_installer_cls: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        tenant_id = str(uuid4())
+        plugin_id = "org/myplugin"
+        plugin = MagicMock(installation_id="install-1", plugin_id=plugin_id)
+        installer = mock_installer_cls.return_value
+        installer.list_plugins.return_value = [plugin]
+        installer.uninstall.return_value = True
+
+        with (
+            patch.object(PluginService, "_cleanup_plugin_credentials", side_effect=RuntimeError("cleanup failed")),
+            patch(
+                "tasks.plugin_credential_cleanup_task.cleanup_plugin_credentials_task.delay",
+                side_effect=RuntimeError("broker unavailable"),
+            ),
+            patch.object(PluginService, "invalidate_plugin_model_providers_cache") as invalidate_cache,
+            caplog.at_level("ERROR", logger="core.plugin.plugin_service"),
+        ):
+            result = PluginService.uninstall(tenant_id, "install-1")
+
+        assert result is True
+        invalidate_cache.assert_called_once_with(tenant_id)
+        assert f"tenant_id={tenant_id}" in caplog.text
+        assert f"plugin_id={plugin_id}" in caplog.text
+        assert "Failed to schedule plugin credential cleanup retry" in caplog.text
+
+    def test_cleanup_retry_is_idempotent_after_database_cleanup(self, plugin_db: Session) -> None:
+        tenant_id = str(uuid4())
+        plugin_id = "org/myplugin"
+        provider_name = f"{plugin_id}/model-provider"
+
+        credential = ProviderCredential(
+            tenant_id=tenant_id,
+            provider_name=provider_name,
+            credential_name="default",
+            encrypted_config="{}",
+        )
+        plugin_db.add(credential)
+        plugin_db.flush()
+        credential_id = credential.id
+        provider = Provider(
+            tenant_id=tenant_id,
+            provider_name=provider_name,
+            credential_id=credential_id,
+        )
+        preferred_provider = TenantPreferredModelProvider(
+            tenant_id=tenant_id,
+            provider_name=provider_name,
+            preferred_provider_type=ProviderType.CUSTOM,
+        )
+        plugin_db.add_all([provider, preferred_provider])
+        plugin_db.commit()
+        provider_id = provider.id
+        preferred_provider_id = preferred_provider.id
+
+        with (
+            patch("core.plugin.plugin_service.ProviderCredentialsCache") as credentials_cache,
+            patch("core.provider_manager.ProviderManager.invalidate_configurations_cache") as invalidate_configurations,
+        ):
+            credentials_cache.return_value.delete.side_effect = [RuntimeError("cache unavailable"), None]
+
+            with pytest.raises(RuntimeError, match="cache unavailable"):
+                PluginService._cleanup_plugin_credentials(tenant_id, plugin_id)
+
+            plugin_db.expire_all()
+            assert plugin_db.get(ProviderCredential, credential_id) is None
+            persisted_provider = plugin_db.get(Provider, provider_id)
+            assert persisted_provider is not None
+            assert persisted_provider.credential_id is None
+            assert plugin_db.get(TenantPreferredModelProvider, preferred_provider_id) is None
+
+            PluginService._cleanup_plugin_credentials(tenant_id, plugin_id)
+
+        assert credentials_cache.call_args_list == [
+            call(
+                tenant_id=tenant_id,
+                identity_id=provider_id,
+                cache_type=ProviderCredentialsCacheType.PROVIDER,
+            ),
+            call(
+                tenant_id=tenant_id,
+                identity_id=provider_id,
+                cache_type=ProviderCredentialsCacheType.PROVIDER,
+            ),
+        ]
+        invalidate_configurations.assert_called_once_with(
+            tenant_id,
+            sources=(
+                ProviderConfigurationCacheSource.PREFERRED_MODEL_PROVIDERS,
+                ProviderConfigurationCacheSource.PROVIDER_CREDENTIALS,
+            ),
+        )

--- a/api/tests/unit_tests/tasks/test_plugin_credential_cleanup_task.py
+++ b/api/tests/unit_tests/tasks/test_plugin_credential_cleanup_task.py
@@ -3,10 +3,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def test_cleanup_plugin_credentials_task_uses_plugin_queue() -> None:
+def test_cleanup_plugin_credentials_task_has_bounded_retries() -> None:
     from tasks.plugin_credential_cleanup_task import cleanup_plugin_credentials_task
 
-    assert cleanup_plugin_credentials_task.queue == "plugin"
     assert cleanup_plugin_credentials_task.max_retries == 5
 
 

--- a/api/tests/unit_tests/tasks/test_plugin_credential_cleanup_task.py
+++ b/api/tests/unit_tests/tasks/test_plugin_credential_cleanup_task.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_cleanup_plugin_credentials_task_uses_plugin_queue() -> None:
+    from tasks.plugin_credential_cleanup_task import cleanup_plugin_credentials_task
+
+    assert cleanup_plugin_credentials_task.queue == "plugin"
+    assert cleanup_plugin_credentials_task.max_retries == 5
+
+
+def test_cleanup_plugin_credentials_task_calls_shared_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    import tasks.plugin_credential_cleanup_task as task_module
+    from tasks.plugin_credential_cleanup_task import cleanup_plugin_credentials_task
+
+    cleanup = MagicMock()
+    monkeypatch.setattr(task_module.PluginService, "_cleanup_plugin_credentials", cleanup)
+
+    cleanup_plugin_credentials_task.run("tenant-1", "org/myplugin")
+
+    cleanup.assert_called_once_with("tenant-1", "org/myplugin")
+
+
+def test_cleanup_plugin_credentials_task_retries_cleanup_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import tasks.plugin_credential_cleanup_task as task_module
+    from tasks.plugin_credential_cleanup_task import cleanup_plugin_credentials_task
+
+    error = RuntimeError("cleanup unavailable")
+    monkeypatch.setattr(task_module.PluginService, "_cleanup_plugin_credentials", MagicMock(side_effect=error))
+    retry = MagicMock(side_effect=RuntimeError("retry scheduled"))
+    monkeypatch.setattr(cleanup_plugin_credentials_task, "retry", retry)
+
+    with pytest.raises(RuntimeError, match="retry scheduled"):
+        cleanup_plugin_credentials_task.run("tenant-1", "org/myplugin")
+
+    retry.assert_called_once_with(exc=error, countdown=60)
+
+
+def test_cleanup_plugin_credentials_task_does_not_uninstall_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    import tasks.plugin_credential_cleanup_task as task_module
+    from tasks.plugin_credential_cleanup_task import cleanup_plugin_credentials_task
+
+    monkeypatch.setattr(task_module.PluginService, "_cleanup_plugin_credentials", MagicMock())
+
+    with patch("core.plugin.plugin_service.PluginInstaller") as installer:
+        cleanup_plugin_credentials_task.run("tenant-1", "org/myplugin")
+
+    installer.assert_not_called()


### PR DESCRIPTION
## Summary

- keep plugin-daemon uninstall as the authoritative first step
- make post-uninstall credential cleanup retryable after transient failures
- keep credential cleanup idempotent across partial DB/cache completion
- preserve existing `preserve_credentials=True` replacement behavior

## Details

After the plugin daemon successfully uninstalls a plugin, credential cleanup can
still fail because of a transient database or cache error. In that case the
plugin is already gone, but the uninstall request currently fails and may leave
orphaned credentials or stale provider caches.

This change keeps the existing daemon-first ordering, performs cleanup
synchronously when possible, and schedules a bounded Celery retry on cleanup
failure.

Provider IDs are discovered independently from surviving credential rows so a
retry can still invalidate provider caches when the database cleanup completed
before a cache failure.

The retry task only performs credential/cache cleanup and never retries the
plugin daemon uninstall.

## Tests

- daemon uninstall failure preserves credentials and does not schedule cleanup
- `preserve_credentials=True` skips cleanup and retry scheduling
- cleanup failure after daemon success returns the successful uninstall result
- retry dispatch failure does not change the successful uninstall result
- partial DB-success/cache-failure cleanup is idempotent on retry
- Celery task uses the plugin queue, bounded retries, shared cleanup logic, and
  never calls daemon uninstall

Fixes #39893