### PR TITLE
fix(web): backport Agent V2 configure section states

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/__tests__/index.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/__tests__/index.spec.tsx
@@ -14,13 +14,13 @@ describe('AgentAdvancedSettings', () => {
     render(<AgentAdvancedSettings />)
 
     const label = 'agentV2.agentDetail.configure.advancedSettings.label'
-    const triggers = screen.getAllByRole('button', { name: label })
+    const trigger = screen.getByRole('button', { name: label })
 
-    expect(triggers[0]).not.toHaveAttribute('data-panel-open')
+    expect(trigger).not.toHaveAttribute('data-panel-open')
     expect(screen.queryByText('advanced-env-editor')).not.toBeInTheDocument()
     expect(screen.queryByText('advanced-content-moderation')).not.toBeInTheDocument()
 
-    fireEvent.click(triggers[0]!)
+    fireEvent.click(trigger)
 
     expect(screen.getByText('advanced-env-editor')).toBeInTheDocument()
     expect(screen.queryByText('advanced-content-moderation')).not.toBeInTheDocument()

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/env.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/env.tsx
@@ -540,9 +540,9 @@ export function AgentEnvEditor() {
       panelId={envEditorTableId}
       tip={<AgentConfigureTipContent type="env" />}
       tipAriaLabel={envEditorTip}
-      rootClassName="gap-1 pt-3"
+      rootClassName="gap-1 py-3"
       headerClassName="mb-0 gap-1 px-3"
-      panelContentClassName="px-3 pb-3"
+      panelContentClassName="px-3"
       actions={
         !readOnly ? (
           <>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/section.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/section.tsx
@@ -67,7 +67,7 @@ export function ConfigureSection({
     >
       <div className={cn('mb-2 flex min-h-6 items-center gap-2', headerClassName)}>
         <div className="min-w-0 flex-1">
-          <div className={cn('flex min-w-0 items-center', titleRowClassName)}>
+          <div className={cn('group/collapse-title flex min-w-0 items-center', titleRowClassName)}>
             <Heading id={labelId} className="relative min-w-0 shrink-0">
               {isBuildDraftChanged && <AgentBuildDraftChangeDot />}
               <CollapsibleTrigger className="h-6 min-h-0 w-auto max-w-full justify-start gap-0 rounded-sm px-0 text-text-secondary hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-secondary data-panel-open:text-text-secondary">
@@ -83,15 +83,10 @@ export function ConfigureSection({
                 {tip}
               </Infotip>
             )}
-            <CollapsibleTrigger
-              aria-labelledby={labelId}
-              className="group/collapse-icon size-3.5 min-h-0 shrink-0 justify-center rounded-sm p-0 text-text-quaternary hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-secondary data-panel-open:text-text-quaternary"
-            >
-              <span
-                aria-hidden="true"
-                className="i-custom-vender-solid-general-arrow-down-round-fill size-3.5 rotate-270 transition-transform group-data-panel-open/collapse-icon:rotate-0 motion-reduce:transition-none"
-              />
-            </CollapsibleTrigger>
+            <span
+              aria-hidden="true"
+              className="i-custom-vender-solid-general-arrow-down-round-fill size-3.5 shrink-0 rotate-270 text-text-quaternary transition-transform group-has-data-panel-open/collapse-title:rotate-0 motion-reduce:transition-none"
+            />
           </div>
           {hasDescription && <p className="system-xs-regular text-text-tertiary">{description}</p>}
         </div>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/index.tsx
@@ -333,7 +333,10 @@ function AddToolMenu({
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger
         render={
-          <ConfigureSectionAddButton ariaLabel={t(($) => $['agentDetail.configure.tools.add'])} />
+          <ConfigureSectionAddButton
+            ariaLabel={t(($) => $['agentDetail.configure.tools.add'])}
+            className="data-popup-open:bg-state-base-hover"
+          />
         }
       />
       <PopoverContent


### PR DESCRIPTION
## Summary

- preserve the open-state styling on the Agent V2 Tools add popover trigger
- use a single disclosure trigger per configure section and keep the chevron decorative
- preserve the Env editor section bottom spacing while collapsed

## Backport provenance

Backports #41371 from `main` with `git cherry-pick -x`.

## Verification

- `vp test run --project unit` for the Agent V2 advanced settings, Env editor, and Tools suites (27 tests)
- `pnpm --dir web lint:a11y` for the three changed component files
- `pnpm check`
- `git diff --check origin/hotfix/1.17.0-fix.4...HEAD`

From Codex