### PR TITLE
fix: align documentation links with stable anchors

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -715,7 +715,7 @@ services:
 
   # ssrf_proxy server
   # for more information, please refer to
-  # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
+  # https://docs.dify.ai/en/self-host/deploy/troubleshooting/docker-issues#why-is-ssrf-proxy-needed
   ssrf_proxy:
     image: ubuntu/squid:latest
     restart: always

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -193,7 +193,7 @@ services:
 
   # ssrf_proxy server
   # for more information, please refer to
-  # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
+  # https://docs.dify.ai/en/self-host/deploy/troubleshooting/docker-issues#why-is-ssrf-proxy-needed
   ssrf_proxy:
     image: ubuntu/squid:latest
     restart: always

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -721,7 +721,7 @@ services:
 
   # ssrf_proxy server
   # for more information, please refer to
-  # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
+  # https://docs.dify.ai/en/self-host/deploy/troubleshooting/docker-issues#why-is-ssrf-proxy-needed
   ssrf_proxy:
     image: ubuntu/squid:latest
     restart: always

--- a/web/app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts
@@ -99,7 +99,7 @@ describe('useAvailableNodesMetaData', () => {
     expect(result.current.nodesMap?.[BlockEnum.AgentV2]?.checkValid).toEqual(expect.any(Function))
     expect(result.current.nodesMap?.[BlockEnum.Agent]?.checkValid).toEqual(expect.any(Function))
     expect(result.current.nodesMap?.[BlockEnum.AgentV2]?.metaData.helpLinkUri).toBe(
-      '/docs/use-dify/nodes/agent#choose-an-agent',
+      '/docs/use-dify/nodes/agent#new-agent',
     )
   })
 
@@ -115,7 +115,7 @@ describe('useAvailableNodesMetaData', () => {
     expect(result.current.nodesMap?.[BlockEnum.Agent]).toBeDefined()
     expect(result.current.nodesMap?.[BlockEnum.AgentV2]).toBeDefined()
     expect(result.current.nodesMap?.[BlockEnum.Agent]?.metaData.helpLinkUri).toBe(
-      '/docs/use-dify/nodes/agent',
+      '/docs/use-dify/nodes/agent#classic-agent',
     )
   })
 })

--- a/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
+++ b/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
@@ -113,7 +113,7 @@ describe('agent/default', () => {
   })
 
   it('links directly to the New Agent section of the shared agent node document', () => {
-    expect(nodeDefault.metaData.helpLinkUri).toBe('agent#choose-an-agent')
+    expect(nodeDefault.metaData.helpLinkUri).toBe('agent#new-agent')
   })
 
   it('identifies version 2 agent data as Agent v2', () => {

--- a/web/app/components/workflow/nodes/agent-v2/default.ts
+++ b/web/app/components/workflow/nodes/agent-v2/default.ts
@@ -8,7 +8,7 @@ import { hasValidAgentBinding } from './types'
 const metaData = genNodeMetaData({
   sort: 3,
   type: BlockEnum.AgentV2,
-  helpLinkUri: 'agent#choose-an-agent',
+  helpLinkUri: 'agent#new-agent',
 })
 
 const nodeDefault: NodeDefault<AgentV2NodeType> = {

--- a/web/app/components/workflow/nodes/agent/default.ts
+++ b/web/app/components/workflow/nodes/agent/default.ts
@@ -10,6 +10,7 @@ import { genNodeMetaData } from '../../utils'
 const metaData = genNodeMetaData({
   sort: 3,
   type: BlockEnum.Agent,
+  helpLinkUri: 'agent#classic-agent',
 })
 
 const nodeDefault: NodeDefault<AgentNodeType> = {


### PR DESCRIPTION
## Summary

- point Classic and New Agent node help links at their canonical tab anchors
- keep the contextual Agent Task link on its dedicated section anchor
- replace the retired SSRF FAQ URL in Docker Compose files with the new stable troubleshooting anchor

## Documentation dependencies

- https://github.com/langgenius/dify-docs/pull/1001
- https://github.com/langgenius/dify-docs/pull/1002

## Verification

- `pnpm exec vp test run --project unit app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts app/components/workflow/nodes/agent-v2/__tests__/panel.spec.tsx`
- `pnpm type-check`
- targeted `vp check` on the changed Agent V2 files and specs
- YAML parse check for all three changed Compose files
- `git diff --check`