### PR TITLE
revert(web): restore Agentation devtool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ catalogs:
     abcjs:
       specifier: 6.7.0
       version: 6.7.0
+    agentation:
+      specifier: 3.0.2
+      version: 3.0.2
     ahooks:
       specifier: 3.9.7
       version: 3.9.7
@@ -1562,6 +1565,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
+      agentation:
+        specifier: 'catalog:'
+        version: 3.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       code-inspector-plugin:
         specifier: 'catalog:'
         version: 1.6.6(supports-color@11.0.0)
@@ -5083,6 +5089,17 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentation@3.0.2:
+    resolution: {integrity: sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ahooks@3.9.7:
     resolution: {integrity: sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==}
@@ -12333,6 +12350,11 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agentation@3.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   ahooks@3.9.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -16957,6 +16979,7 @@ time:
   '@vitest/coverage-v8@4.1.11': '2026-08-18T14:22:18.896Z'
   '@voidzero-dev/vite-plus-core@0.3.0': '2026-08-24T04:06:39.867Z'
   abcjs@6.7.0: '2026-08-07T18:50:14.156Z'
+  agentation@3.0.2: '2026-03-25T16:24:19.682Z'
   ahooks@3.9.7: '2026-03-23T15:49:13.605Z'
   c12@4.0.0-beta.5: '2026-05-06T17:28:34.367Z'
   chokidar@5.0.0: '2025-11-25T23:28:06.854Z'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -142,6 +142,7 @@ catalog:
   '@vitest/browser-playwright': 4.1.11
   '@vitest/coverage-v8': 4.1.11
   abcjs: 6.7.0
+  agentation: 3.0.2
   ahooks: 3.9.7
   c12: 4.0.0-beta.5
   chokidar: 5.0.0

--- a/web/.env.example
+++ b/web/.env.example
@@ -39,6 +39,9 @@ NEXT_PUBLIC_SENTRY_DSN=
 # Disable Next.js Telemetry (https://nextjs.org/telemetry)
 NEXT_TELEMETRY_DISABLED=1
 
+# Enable the Agentation visual feedback toolbar in local development.
+NEXT_PUBLIC_ENABLE_AGENTATION=true
+
 # Disable Upload Image as WebApp icon default is false
 NEXT_PUBLIC_UPLOAD_IMAGE_AS_ICON=false
 

--- a/web/app/components/devtools/agentation-loader.tsx
+++ b/web/app/components/devtools/agentation-loader.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { IS_DEV } from '@/config'
+import dynamic from '@/next/dynamic'
+
+const Agentation = dynamic(() => import('agentation').then((module) => module.Agentation), {
+  ssr: false,
+})
+
+const IS_AGENTATION_ENABLED = process.env.NEXT_PUBLIC_ENABLE_AGENTATION !== 'false'
+
+export function AgentationLoader() {
+  if (!IS_DEV || !IS_AGENTATION_ENABLED) return null
+
+  return <Agentation />
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -18,6 +18,7 @@ import { headers } from '@/next/headers'
 import { getApplicationTitle } from '@/utils/document-title'
 import { CloudAnalytics } from './components/base/analytics-consent/cloud-analytics'
 import { PartnerStackCookieRecorder } from './components/billing/partner-stack/cookie-recorder'
+import { AgentationLoader } from './components/devtools/agentation-loader'
 import { ReactScanLoader } from './components/devtools/react-scan/loader'
 import { I18nServerProvider } from './components/provider/i18n-server'
 import { TanStackQueryProvider } from './query-provider'
@@ -86,6 +87,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               </NuqsAdapter>
             </ThemeProvider>
           </JotaiProvider>
+          <AgentationLoader />
         </div>
       </body>
     </html>

--- a/web/package.json
+++ b/web/package.json
@@ -177,6 +177,7 @@
     "@vitejs/plugin-rsc": "catalog:",
     "@vitest/browser-playwright": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "agentation": "catalog:",
     "code-inspector-plugin": "catalog:",
     "happy-dom": "catalog:",
     "playwright": "catalog:",


### PR DESCRIPTION
## Summary

- restore the development-only Agentation toolbar removed in #41372
- add `NEXT_PUBLIC_ENABLE_AGENTATION` to `web/.env.example`, enabled by default
- keep the opt-out owned by `AgentationLoader`; only the literal value `false` disables it

The flag controls rendering only. Agentation remains lazy-loaded, so production does not request its chunk when the development guard is false.

## Verification

- `pnpm install --lockfile-only`
- `git diff --check`