### PR TITLE
chore: remove redundant server_default from Skill model definitions

### DIFF
--- a/api/models/skill.py
+++ b/api/models/skill.py
@@ -66,19 +66,17 @@ class Skill(DefaultFieldsMixin, Base):
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     name: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     display_name: Mapped[str] = mapped_column(sa.String(128), nullable=False)
-    icon: Mapped[str] = mapped_column(sa.String(16), nullable=False, default="📄", server_default="📄")
-    description: Mapped[str] = mapped_column(sa.String(1024), nullable=False, default="", server_default="")
+    icon: Mapped[str] = mapped_column(sa.String(16), nullable=False, default="📄")
+    description: Mapped[str] = mapped_column(sa.String(1024), nullable=False, default="")
     name_manually_edited: Mapped[bool] = mapped_column(
         sa.Boolean,
         nullable=False,
         default=False,
-        server_default=sa.false(),
     )
     visibility: Mapped[str] = mapped_column(
         sa.String(32),
         nullable=False,
         default="workspace",
-        server_default="workspace",
     )
     latest_published_version_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
@@ -123,8 +121,8 @@ class SkillVersion(DefaultFieldsMixin, Base):
 
     skill_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     version_number: Mapped[int] = mapped_column(sa.Integer, nullable=False)
-    version_name: Mapped[str] = mapped_column(sa.String(128), nullable=False, default="", server_default="")
-    publish_note: Mapped[str] = mapped_column(sa.String(1024), nullable=False, default="", server_default="")
+    version_name: Mapped[str] = mapped_column(sa.String(128), nullable=False, default="")
+    publish_note: Mapped[str] = mapped_column(sa.String(1024), nullable=False, default="")
     manifest: Mapped[SkillVersionManifest] = mapped_column(JSONModelColumn(SkillVersionManifest), nullable=False)
     archive_tool_file_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     hash_code: Mapped[str] = mapped_column(sa.String(255), nullable=False)


### PR DESCRIPTION
## Summary

Remove 6 redundant `server_default` entries from `api/models/skill.py` that duplicate their corresponding application-level `default=` values:

- `Skill.icon` - `default="📄"` already set, removed `server_default="📄"`
- `Skill.description` - `default=""` already set, removed `server_default=""`
- `Skill.name_manually_edited` - `default=False` already set, removed `server_default=sa.false()`
- `Skill.visibility` - `default="workspace"` already set, removed `server_default="workspace"`
- `SkillVersion.version_name` - `default=""` already set, removed `server_default=""`
- `SkillVersion.publish_note` - `default=""` already set, removed `server_default=""`

The `server_default` parameter only affects DDL generation (the `DEFAULT` clause in `CREATE TABLE`), not runtime insert behavior. When an equivalent `default=` is already present, keeping `server_default` is redundant and causes confusion for new model authors who reference existing definitions as examples.

This is a scoped slice of #29314, following the same pattern as #39886.

Fixes #29314

## Screenshots

N/A — behavior-preserving model definition cleanup, no UI changes.

## Checklist

- [x] This change requires a documentation update, included: N/A
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. N/A — behavior-preserving cleanup, existing tests cover model schema validity
- [x] I've updated the documentation accordingly. N/A
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

## Verification

- `uv run ruff check models/skill.py` — All checks passed
- `uv run ruff format --check models/skill.py` — 1 file already formatted
- `uv run pytest tests/unit_tests/test_sqlite_fixtures.py -v` — 7 passed
- `uv run pytest tests/unit_tests/migrations/ -v` — 22 passed