### PR TITLE
fix: align documentation links with stable anchors

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -715,7 +715,7 @@ services:
 
   # ssrf_proxy server
   # for more information, please refer to
-  # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
+  # https://docs.dify.ai/en/self-host/deploy/troubleshooting/docker-issues#why-is-ssrf-proxy-needed
   ssrf_proxy:
     image: ubuntu/squid:latest
     restart: always

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -193,7 +193,7 @@ services:
 
   # ssrf_proxy server
   # for more information, please refer to
-  # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
+  # https://docs.dify.ai/en/self-host/deploy/troubleshooting/docker-issues#why-is-ssrf-proxy-needed
   ssrf_proxy:
     image: ubuntu/squid:latest
     restart: always

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -721,7 +721,7 @@ services:
 
   # ssrf_proxy server
   # for more information, please refer to
-  # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
+  # https://docs.dify.ai/en/self-host/deploy/troubleshooting/docker-issues#why-is-ssrf-proxy-needed
   ssrf_proxy:
     image: ubuntu/squid:latest
     restart: always

--- a/web/app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts
@@ -99,7 +99,7 @@ describe('useAvailableNodesMetaData', () => {
     expect(result.current.nodesMap?.[BlockEnum.AgentV2]?.checkValid).toEqual(expect.any(Function))
     expect(result.current.nodesMap?.[BlockEnum.Agent]?.checkValid).toEqual(expect.any(Function))
     expect(result.current.nodesMap?.[BlockEnum.AgentV2]?.metaData.helpLinkUri).toBe(
-      '/docs/use-dify/nodes/agent#choose-an-agent',
+      '/docs/use-dify/nodes/agent#new-agent',
     )
   })
 
@@ -115,7 +115,7 @@ describe('useAvailableNodesMetaData', () => {
     expect(result.current.nodesMap?.[BlockEnum.Agent]).toBeDefined()
     expect(result.current.nodesMap?.[BlockEnum.AgentV2]).toBeDefined()
     expect(result.current.nodesMap?.[BlockEnum.Agent]?.metaData.helpLinkUri).toBe(
-      '/docs/use-dify/nodes/agent',
+      '/docs/use-dify/nodes/agent#classic-agent',
     )
   })
 })

--- a/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
+++ b/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
@@ -113,7 +113,7 @@ describe('agent/default', () => {
   })
 
   it('links directly to the New Agent section of the shared agent node document', () => {
-    expect(nodeDefault.metaData.helpLinkUri).toBe('agent#choose-an-agent')
+    expect(nodeDefault.metaData.helpLinkUri).toBe('agent#new-agent')
   })
 
   it('identifies version 2 agent data as Agent v2', () => {

--- a/web/app/components/workflow/nodes/agent-v2/default.ts
+++ b/web/app/components/workflow/nodes/agent-v2/default.ts
@@ -8,7 +8,7 @@ import { hasValidAgentBinding } from './types'
 const metaData = genNodeMetaData({
   sort: 3,
   type: BlockEnum.AgentV2,
-  helpLinkUri: 'agent#choose-an-agent',
+  helpLinkUri: 'agent#new-agent',
 })
 
 const nodeDefault: NodeDefault<AgentV2NodeType> = {

--- a/web/app/components/workflow/nodes/agent/default.ts
+++ b/web/app/components/workflow/nodes/agent/default.ts
@@ -10,6 +10,7 @@ import { genNodeMetaData } from '../../utils'
 const metaData = genNodeMetaData({
   sort: 3,
   type: BlockEnum.Agent,
+  helpLinkUri: 'agent#classic-agent',
 })
 
 const nodeDefault: NodeDefault<AgentNodeType> = {


### PR DESCRIPTION
## Summary

Cherry-picks `a38ddd9d02fa70e5af38d99edcd9d14d9817ff8e` onto `hotfix/1.17.0-fix.4`.

Align the Classic and Agent V2 help links with their stable documentation anchors, and replace the retired SSRF FAQ URLs in the Docker Compose comments.

## Validation

- Hotfix provenance check -> verified 1 PR commit includes cherry-pick provenance from main.
- `git diff --check myori/hotfix/1.17.0-fix.4...HEAD` -> passed.
- Local tests were not run as requested; relying on PR CI. The source main PR #41384 passed its focused tests, type checks, YAML validation, and main CI.