### PR TITLE
refactor(models): pass session into PipelineCustomizedTemplate.created_user_name

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -1711,9 +1711,8 @@ class PipelineCustomizedTemplate(TypeBase):
         init=False,
     )
 
-    @property
-    def created_user_name(self):
-        account = db.session.scalar(select(Account).where(Account.id == self.created_by))
+    def created_user_name(self, session: Session) -> str:
+        account = session.scalar(select(Account).where(Account.id == self.created_by))
         if account:
             return account.name
         return ""

--- a/api/services/rag_pipeline/pipeline_template/customized/customized_retrieval.py
+++ b/api/services/rag_pipeline/pipeline_template/customized/customized_retrieval.py
@@ -119,5 +119,5 @@ class CustomizedPipelineTemplateRetrieval(PipelineTemplateRetrievalBase):
             "chunk_structure": pipeline_template.chunk_structure,
             "export_data": pipeline_template.yaml_content,
             "graph": graph_data,
-            "created_by": pipeline_template.created_user_name,
+            "created_by": pipeline_template.created_user_name(session=session),
         }

--- a/api/tests/unit_tests/services/rag_pipeline/pipeline_template/test_customized_retrieval.py
+++ b/api/tests/unit_tests/services/rag_pipeline/pipeline_template/test_customized_retrieval.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import pytest
 from sqlalchemy.orm import Session
 
@@ -73,12 +71,11 @@ def test_get_pipeline_templates(sqlite_session: Session) -> None:
 
 
 @pytest.mark.parametrize("sqlite_session", [(Account, PipelineCustomizedTemplate)], indirect=True)
-def test_get_pipeline_template_detail_returns_detail(monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
+def test_get_pipeline_template_detail_returns_detail(sqlite_session: Session) -> None:
     creator = Account(name="creator", email="creator@example.com")
     creator.id = CREATOR_ID
     sqlite_session.add_all([creator, _template()])
     sqlite_session.commit()
-    monkeypatch.setattr("models.dataset.db", SimpleNamespace(session=sqlite_session))
     retrieval = CustomizedPipelineTemplateRetrieval()
 
     detail = retrieval.get_pipeline_template_detail(TEMPLATE_ID, TENANT_ID, session=sqlite_session)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 1. Associated issue: #40372.

## Summary

#40372

Follow-up to #40370/#40797: picks up the slice `PipelineCustomizedTemplate.created_user_name` in `api/models/dataset.py`, which RealJasonHu had claimed and then withdrew (comment thread on #40372).

- `models/dataset.py`: `PipelineCustomizedTemplate.created_user_name` — was `@property` doing `db.session.scalar(select(Account)...)`; now `def created_user_name(self, session: Session) -> str`.

Verified there is exactly one production call site (`CustomizedPipelineTemplateRetrieval.fetch_pipeline_template_detail_from_db` in `services/rag_pipeline/pipeline_template/customized/customized_retrieval.py`), which already owns a `Session`, so this is a self-contained, non-breaking signature change plus one call-site update.

## Testing

- Updated `api/tests/unit_tests/services/rag_pipeline/pipeline_template/test_customized_retrieval.py` to pass the real `sqlite_session` fixture directly instead of monkeypatching `models.dataset.db`.
- Full local verification (see `AGENTS.md`: backend integration tests are CI-only, not run locally):
  - `uv run pytest -o addopts="" tests/unit_tests/models/ tests/unit_tests/services/rag_pipeline/` → **618 passed**, zero regressions
  - `ruff format` / `ruff check --fix` on touched files → clean
  - `./dev/pyrefly-check-local` + `mypy` on touched files → clean

## Screenshots

| Before | After |
| ------ | ----- |
| N/A — backend-only model refactor, no UI change | N/A — backend-only model refactor, no UI change |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods. No frontend files changed, so `vp staged` (frontend) is not applicable.

From Claude Code