### PR TITLE
fix(web): escape prompt editor variable highlight query

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/variable-option.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/variable-option.spec.tsx
@@ -73,6 +73,18 @@ describe('VariableMenuItem', () => {
       const titleContainer = screen.getByTitle('Variable')
       expect(titleContainer.querySelector('.text-text-accent')?.textContent).toBe('')
     })
+
+    it('should treat regex metacharacters in queryString as literal text', () => {
+      render(
+        <VariableMenuItem
+          {...defaultProps}
+          title="source_url})"
+          queryString="source_url})"
+        />,
+      )
+
+      expect(screen.getByText('source_url})')).toHaveClass('text-text-accent')
+    })
   })
 
   describe('Events', () => {

--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/variable-option.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/variable-option.tsx
@@ -26,7 +26,8 @@ export const VariableMenuItem = memo(
     let after = ''
 
     if (queryString) {
-      const regex = new RegExp(queryString, 'i')
+      const escapedQueryString = queryString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const regex = new RegExp(escapedQueryString, 'i')
       const match = regex.exec(title)
 
       if (match) {


### PR DESCRIPTION
Fixes #38384

Related to #38416

## Summary

- Escape the prompt editor's `queryString` before constructing the regular expression used by `VariableMenuItem`.
- Keep case-insensitive highlighting literal, so prompt text such as `source_url})` cannot crash rendering.
- Add a focused regression test for regex metacharacters in the query string.

## Why

Issue #38384 reports that brace-triggered prompt text can be passed to `RegExp` as an invalid pattern, causing the prompt editor to render an unexpected component error. PR #38416 fixes the two filtering call sites in `hooks.tsx`, but the `VariableMenuItem` highlighting call site remained unescaped on the current `main` branch. This patch closes that remaining path.

## Tests

- `git diff --check`
- Added `web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/variable-option.spec.tsx` coverage for `source_url})`.
- The focused Vitest test could not be run locally because dependency installation timed out while fetching `next`/SWC packages; CI should run the repository test suite.
