### PR TITLE
perf(web): virtualize the Web Apps sidebar list again

### DIFF
--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -1373,25 +1373,17 @@ describe('MainNav', () => {
     expect(screen.queryByText('common.mainNav.workspace.inviteMembers')).not.toBeInTheDocument()
   })
 
-  const createInstalledAppList = (count: number) =>
+  const createInstalledAppList = (count: number, pinnedCount = 0) =>
     Array.from({ length: count }, (_, index) =>
       createInstalledApp({
         id: `installed-${index}`,
+        is_pinned: index < pinnedCount,
         app: { ...createInstalledApp().app, id: `app-${index}`, name: `App ${index}` },
       }),
     )
 
-  it('renders the installed web app list in flow layout below the virtualization threshold', async () => {
-    mockInstalledApps = createInstalledAppList(50)
-
-    renderMainNav()
-
-    const firstRow = await screen.findByText('App 0')
-    expect(firstRow.closest('div.absolute')).toBeNull()
-  })
-
-  it('virtualizes the installed web app list above the virtualization threshold', async () => {
-    mockInstalledApps = createInstalledAppList(51)
+  it('virtualizes the installed web app list', async () => {
+    mockInstalledApps = createInstalledAppList(3)
 
     renderMainNav()
 
@@ -1399,10 +1391,21 @@ describe('MainNav', () => {
     const virtualRow = firstRow.closest('div.absolute')
     expect(virtualRow).not.toBeNull()
 
-    // Rows are absolutely positioned inside a container sized to the full list, so
-    // off-screen entries stay out of the layout and paint path.
-    const virtualContainer = virtualRow!.parentElement
-    expect(virtualContainer).toHaveStyle({ height: '1632px' })
+    // Rows are absolutely positioned inside a container sized to the whole list, so
+    // entries outside the viewport stay out of the layout and paint path.
+    expect(virtualRow!.parentElement).toHaveStyle({ height: '96px' })
+  })
+
+  it('measures the pinned separator as its own virtual row', async () => {
+    mockInstalledApps = createInstalledAppList(4, 2)
+
+    renderMainNav()
+
+    const firstRow = await screen.findByText('App 0')
+    expect(screen.getByTestId('divider')).toBeInTheDocument()
+
+    // Four app rows at 32px plus one 17px separator row.
+    expect(firstRow.closest('div.absolute')!.parentElement).toHaveStyle({ height: '145px' })
   })
 
   it('searches installed web apps and renders the matching navigation link', async () => {

--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -1373,41 +1373,6 @@ describe('MainNav', () => {
     expect(screen.queryByText('common.mainNav.workspace.inviteMembers')).not.toBeInTheDocument()
   })
 
-  const createInstalledAppList = (count: number, pinnedCount = 0) =>
-    Array.from({ length: count }, (_, index) =>
-      createInstalledApp({
-        id: `installed-${index}`,
-        is_pinned: index < pinnedCount,
-        app: { ...createInstalledApp().app, id: `app-${index}`, name: `App ${index}` },
-      }),
-    )
-
-  it('virtualizes the installed web app list', async () => {
-    mockInstalledApps = createInstalledAppList(3)
-
-    renderMainNav()
-
-    const firstRow = await screen.findByText('App 0')
-    const virtualRow = firstRow.closest('div.absolute')
-    expect(virtualRow).not.toBeNull()
-
-    // Rows are absolutely positioned inside a container sized to the whole list, so
-    // entries outside the viewport stay out of the layout and paint path.
-    expect(virtualRow!.parentElement).toHaveStyle({ height: '96px' })
-  })
-
-  it('measures the pinned separator as its own virtual row', async () => {
-    mockInstalledApps = createInstalledAppList(4, 2)
-
-    renderMainNav()
-
-    const firstRow = await screen.findByText('App 0')
-    expect(screen.getByTestId('divider')).toBeInTheDocument()
-
-    // Four app rows at 32px plus one 17px separator row.
-    expect(firstRow.closest('div.absolute')!.parentElement).toHaveStyle({ height: '145px' })
-  })
-
   it('searches installed web apps and renders the matching navigation link', async () => {
     const user = userEvent.setup()
     mockInstalledApps = [

--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -174,6 +174,8 @@ const mockProviderContextState = vi.hoisted(() => ({
   } as Partial<ProviderContextState>,
 }))
 
+vi.mock('@tanstack/react-virtual')
+
 vi.mock('@/features/agent-v2/feature-flag', () => ({
   isAgentV2Enabled: () => mockIsAgentV2Enabled(),
 }))
@@ -1369,6 +1371,38 @@ describe('MainNav', () => {
 
     expect(screen.getByText('common.mainNav.workspace.settings')).toBeInTheDocument()
     expect(screen.queryByText('common.mainNav.workspace.inviteMembers')).not.toBeInTheDocument()
+  })
+
+  const createInstalledAppList = (count: number) =>
+    Array.from({ length: count }, (_, index) =>
+      createInstalledApp({
+        id: `installed-${index}`,
+        app: { ...createInstalledApp().app, id: `app-${index}`, name: `App ${index}` },
+      }),
+    )
+
+  it('renders the installed web app list in flow layout below the virtualization threshold', async () => {
+    mockInstalledApps = createInstalledAppList(50)
+
+    renderMainNav()
+
+    const firstRow = await screen.findByText('App 0')
+    expect(firstRow.closest('div.absolute')).toBeNull()
+  })
+
+  it('virtualizes the installed web app list above the virtualization threshold', async () => {
+    mockInstalledApps = createInstalledAppList(51)
+
+    renderMainNav()
+
+    const firstRow = await screen.findByText('App 0')
+    const virtualRow = firstRow.closest('div.absolute')
+    expect(virtualRow).not.toBeNull()
+
+    // Rows are absolutely positioned inside a container sized to the full list, so
+    // off-screen entries stay out of the layout and paint path.
+    const virtualContainer = virtualRow!.parentElement
+    expect(virtualContainer).toHaveStyle({ height: '1632px' })
   })
 
   it('searches installed web apps and renders the matching navigation link', async () => {

--- a/web/app/components/main-nav/components/web-apps-section.tsx
+++ b/web/app/components/main-nav/components/web-apps-section.tsx
@@ -29,7 +29,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { keepPreviousData, useInfiniteQuery, useMutation } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useAtomValue } from 'jotai'
-import { useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
 import { InfiniteScrollSentinel } from '@/app/components/base/infinite-scroll-sentinel'
@@ -46,7 +46,7 @@ const emptyInstalledApps: InstalledAppResponse[] = []
 
 const appNavItemHeight = 32
 const appNavItemGap = 2
-const appNavSeparatorHeight = 17
+const appNavSeparatorHeight = 16.5
 
 const getPreloadDistance = (scrollContainer: Element) =>
   Math.max(160, Math.min(scrollContainer.clientHeight * 0.25, 320))
@@ -111,13 +111,17 @@ const WebAppsSectionContent = () => {
       return rows
     })
   }, [installedApps])
+  const getWebAppRowKey = useCallback(
+    (index: number) => webAppRows[index]?.key ?? index,
+    [webAppRows],
+  )
 
   const rowVirtualizer = useVirtualizer({
     count: webAppRows.length,
     estimateSize: (index) =>
       webAppRows[index]?.kind === 'separator' ? appNavSeparatorHeight : appNavItemHeight,
     gap: appNavItemGap,
-    getItemKey: (index) => webAppRows[index]?.key ?? index,
+    getItemKey: getWebAppRowKey,
     getScrollElement: () => scrollRef.current,
     overscan: 6,
     paddingEnd: 8,
@@ -171,7 +175,6 @@ const WebAppsSectionContent = () => {
 
   const renderAppNavItem = (installedApp: (typeof installedApps)[number]) => (
     <AppNavItem
-      key={installedApp.id}
       app={installedApp}
       ariaLabel={t(($) => $['mainNav.webApps.openApp'], {
         ns: 'common',

--- a/web/app/components/main-nav/components/web-apps-section.tsx
+++ b/web/app/components/main-nav/components/web-apps-section.tsx
@@ -29,7 +29,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { keepPreviousData, useInfiniteQuery, useMutation } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useAtomValue } from 'jotai'
-import { Fragment, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
 import { InfiniteScrollSentinel } from '@/app/components/base/infinite-scroll-sentinel'
@@ -47,9 +47,6 @@ const emptyInstalledApps: InstalledAppResponse[] = []
 const appNavItemHeight = 32
 const appNavItemGap = 2
 const appNavSeparatorHeight = 17
-// Below this many rows the list is cheap enough to render in full, and plain flow
-// layout keeps the markup simpler than absolutely positioned virtual rows.
-const virtualizationThreshold = 50
 
 const getPreloadDistance = (scrollContainer: Element) =>
   Math.max(160, Math.min(scrollContainer.clientHeight * 0.25, 320))
@@ -114,7 +111,6 @@ const WebAppsSectionContent = () => {
       return rows
     })
   }, [installedApps])
-  const shouldVirtualize = webAppRows.length > virtualizationThreshold
 
   const rowVirtualizer = useVirtualizer({
     count: webAppRows.length,
@@ -273,14 +269,7 @@ const WebAppsSectionContent = () => {
                   {t(($) => $['mainNav.webApps.noResults'], { ns: 'common' })}
                 </div>
               )}
-              {webAppRows.length > 0 && !shouldVirtualize && (
-                <div className="space-y-0.5 pb-2">
-                  {webAppRows.map((row) => (
-                    <Fragment key={row.key}>{renderRow(row)}</Fragment>
-                  ))}
-                </div>
-              )}
-              {shouldVirtualize && (
+              {webAppRows.length > 0 && (
                 <div
                   className="relative w-full"
                   style={{ height: `${rowVirtualizer.getTotalSize()}px` }}

--- a/web/app/components/main-nav/components/web-apps-section.tsx
+++ b/web/app/components/main-nav/components/web-apps-section.tsx
@@ -27,8 +27,9 @@ import {
 } from '@langgenius/dify-ui/scroll-area'
 import { toast } from '@langgenius/dify-ui/toast'
 import { keepPreviousData, useInfiniteQuery, useMutation } from '@tanstack/react-query'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { useAtomValue } from 'jotai'
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
 import { InfiniteScrollSentinel } from '@/app/components/base/infinite-scroll-sentinel'
@@ -43,11 +44,29 @@ import { hasPermission } from '@/utils/permission'
 
 const emptyInstalledApps: InstalledAppResponse[] = []
 
+const appNavItemHeight = 32
+const appNavItemGap = 2
+const appNavSeparatorHeight = 17
+// Below this many rows the list is cheap enough to render in full, and plain flow
+// layout keeps the markup simpler than absolutely positioned virtual rows.
+const virtualizationThreshold = 50
+
 const getPreloadDistance = (scrollContainer: Element) =>
   Math.max(160, Math.min(scrollContainer.clientHeight * 0.25, 320))
 
 const selectInstalledApps = (data: InfiniteData<InstalledAppListResponse, string | undefined>) =>
   data.pages.flatMap((page) => page.installed_apps)
+
+type WebAppListRow =
+  | {
+      key: string
+      kind: 'app'
+      app: InstalledAppResponse
+    }
+  | {
+      key: string
+      kind: 'separator'
+    }
 
 const WebAppsSectionContent = () => {
   const { t } = useTranslation()
@@ -83,7 +102,31 @@ const WebAppsSectionContent = () => {
     consoleQuery.installedApps.byInstalledAppId.patch.mutationOptions(),
   )
 
-  const pinnedAppsCount = installedApps.filter(({ is_pinned }) => is_pinned).length
+  const webAppRows = useMemo<WebAppListRow[]>(() => {
+    const pinnedAppsCount = installedApps.filter(({ is_pinned }) => is_pinned).length
+
+    return installedApps.flatMap((app, index) => {
+      const rows: WebAppListRow[] = [{ key: app.id, kind: 'app', app }]
+
+      if (index === pinnedAppsCount - 1 && index !== installedApps.length - 1)
+        rows.push({ key: `${app.id}-separator`, kind: 'separator' })
+
+      return rows
+    })
+  }, [installedApps])
+  const shouldVirtualize = webAppRows.length > virtualizationThreshold
+
+  const rowVirtualizer = useVirtualizer({
+    count: webAppRows.length,
+    estimateSize: (index) =>
+      webAppRows[index]?.kind === 'separator' ? appNavSeparatorHeight : appNavItemHeight,
+    gap: appNavItemGap,
+    getItemKey: (index) => webAppRows[index]?.key ?? index,
+    getScrollElement: () => scrollRef.current,
+    overscan: 6,
+    paddingEnd: 8,
+  })
+
   const canLoadMore = !installedAppsQuery.isFetching && !installedAppsQuery.error
 
   const handleSearchTextChange = (value: string) => {
@@ -143,6 +186,11 @@ const WebAppsSectionContent = () => {
       onDelete={setUninstallDialogAppId}
     />
   )
+  const renderRow = (row: WebAppListRow) => {
+    if (row.kind === 'separator') return <Divider />
+
+    return renderAppNavItem(row.app)
+  }
   return (
     <Collapsible
       open={appsExpanded && searchVisible}
@@ -225,16 +273,34 @@ const WebAppsSectionContent = () => {
                   {t(($) => $['mainNav.webApps.noResults'], { ns: 'common' })}
                 </div>
               )}
-              {installedApps.length > 0 && (
+              {webAppRows.length > 0 && !shouldVirtualize && (
                 <div className="space-y-0.5 pb-2">
-                  {installedApps.map((installedApp, index) => (
-                    <Fragment key={installedApp.id}>
-                      {renderAppNavItem(installedApp)}
-                      {index === pinnedAppsCount - 1 && index !== installedApps.length - 1 && (
-                        <Divider />
-                      )}
-                    </Fragment>
+                  {webAppRows.map((row) => (
+                    <Fragment key={row.key}>{renderRow(row)}</Fragment>
                   ))}
+                </div>
+              )}
+              {shouldVirtualize && (
+                <div
+                  className="relative w-full"
+                  style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+                >
+                  {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                    const row = webAppRows[virtualRow.index]!
+
+                    return (
+                      <div
+                        key={virtualRow.key}
+                        className="absolute top-0 left-0 w-full"
+                        style={{
+                          height: `${virtualRow.size}px`,
+                          transform: `translateY(${virtualRow.start}px)`,
+                        }}
+                      >
+                        {renderRow(row)}
+                      </div>
+                    )
+                  })}
                 </div>
               )}
               {installedAppsQuery.hasNextPage && (


### PR DESCRIPTION
Fixes #41396

## Summary

`web/app/components/main-nav/components/web-apps-section.tsx` rendered the installed-app list through `useVirtualizer` with a `virtualizationThreshold` of 50 rows. #39739 ("chore: paginate installed apps") moved the section to cursor pagination and dropped the virtualizer along the way, so every loaded page now stays in the DOM. The section lives in the main nav, so those rows survive route changes and are repainted on every navigation.

On a workspace with 427 installed apps, a Safari Web Inspector timeline recorded while clicking through the top-level nav entries spends 1067.7ms of 3.06s in `composite` (35%) across 12,112 `paint` records, and renders 23 frames — about 7.5 fps. All script categories together account for only ~830ms, and navigation RSC payloads are 340 B – 3.2 KB, so the cost is in painting and compositing rather than in JavaScript or loading. Controlled A/B/A measurements on that deployment put CSS `mask-image` icons as the largest single paint factor (+42% fps when masks are disabled, with `box-shadow`, `border-radius`, `filter`, `transition` and `content-visibility` all within noise), and every row here carries one. The un-virtualized rows multiply exactly that cost. Full numbers are in the issue.

This change restores the row model and virtualizer that existed before #39739, on top of the current infinite-query data source:

- The pinned/unpinned `Divider` is folded back into a `WebAppListRow` union, so the separator is a virtual row with its own `estimateSize` rather than something rendered inline between rows.
- The list is now always virtualized. The old threshold is not restored, so there is a single render path instead of a branch between flow layout and virtual rows — one fewer branch to lose next time. Worth noting the threshold protected the common case rather than the expensive one: pagination loads 20 rows at a time, so a list only crossed 50 after the user scrolled the sidebar. The reason to drop it is the simpler single path, not the row count.
- `InfiniteScrollSentinel` is untouched. The virtual container is sized to the full list, so the sentinel still sits below it and preloads exactly as before.

### Which icon, precisely

Since it matters for any follow-up: the app icon on each row is an `<em-emoji>` or an `<img>` rendered by `AppIcon`, not a mask icon. The `mask-image` icon on every row is the `ItemOperation` trigger, `i-ri-more-fill`, which is mounted per row and kept at `opacity-0` until the row is hovered. Each un-virtualized row therefore paints a mask icon that is never visible. This PR cuts the row count; not painting a permanently invisible icon per row is a separate improvement and is not attempted here.

On the suggestion of moving these icons from `mask-image` to `background-image`: the generated stylesheet already splits the two, 426 monochrome icons on `mask-image` and 16 multi-color icons on `background-image`. The `mask-image` path is what lets monochrome icons inherit `currentColor` — `i-ri-more-fill` is coloured through `text-*` tokens here — so moving them to `background-image` would lose theming. The alternative that keeps theming is inline `<svg fill="currentColor">`, which runs against `web/CLAUDE.md`'s instruction not to add generated React icons under `app/components/base/icons/src/`. I also have not measured `background-image` to be cheaper to paint than `mask-image`, so I would not want to assume that without a benchmark. Happy to open a separate issue for it.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A | N/A |

This change is visually identical — it only affects how many rows are mounted and painted. I have not attached a capture of the reporting workspace because the sidebar shows internal application names. The measurements above and in the issue stand in for a visual diff.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

Notes on the checklist: this is a frontend-only change, so the backend commands do not apply. Two cases were added to `web/app/components/main-nav/__tests__/index.spec.tsx`, one covering that the list is virtualized and one pinning the separator row's own measurement, and both were verified to fail without the component change. The file needs `vi.mock('@tanstack/react-virtual')` — matching the four existing specs that do the same — because the real virtualizer measures a zero-height scroll element under jsdom and renders no rows. `app/components/main-nav` is green at 5 files / 100 tests. Four spec files unrelated to this change are already failing on `main` (for example `features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx`); I confirmed they fail identically with this change stashed.

From Claude Code
