### PR TITLE
fix(api): harden trial apps access for recommended apps (#38970)

### DIFF
--- a/api/controllers/console/app/wraps.py
+++ b/api/controllers/console/app/wraps.py
@@ -8,6 +8,7 @@ from controllers.console.app.error import AppNotFoundError
 from extensions.ext_database import db
 from libs.login import current_account_with_tenant
 from models import App, AppMode, TrialApp
+from services.recommended_app_service import RecommendedAppService
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -73,6 +74,8 @@ def get_app_model(view: Callable[P, R] | None = None, *, mode: Union[AppMode, li
 
 
 def get_app_model_with_trial(view: Callable[P, R] | None = None, *, mode: Union[AppMode, list[AppMode], None] = None):
+    """Inject an app registered for trial or available from the recommended catalog."""
+
     def decorator(view_func: Callable[P, R]):
         @wraps(view_func)
         def decorated_view(*args: P.args, **kwargs: P.kwargs):
@@ -85,6 +88,8 @@ def get_app_model_with_trial(view: Callable[P, R] | None = None, *, mode: Union[
             del kwargs["app_id"]
 
             app_model = _load_app_model_with_trial(app_id)
+            if app_model is None:
+                app_model = RecommendedAppService.get_app(app_id)
 
             if not app_model:
                 raise AppNotFoundError()

--- a/api/services/recommended_app_service.py
+++ b/api/services/recommended_app_service.py
@@ -1,11 +1,24 @@
+from sqlalchemy import select
+
 from configs import dify_config
 from extensions.ext_database import db
-from models.model import AccountTrialAppRecord, TrialApp
+from models.model import AccountTrialAppRecord, App, TrialApp
 from services.feature_service import FeatureService
 from services.recommend_app.recommend_app_factory import RecommendAppRetrievalFactory
 
 
 class RecommendedAppService:
+    @classmethod
+    def get_app(cls, app_id: str) -> App | None:
+        """Return a normal app only when it belongs to the recommended catalog."""
+        mode = dify_config.HOSTED_FETCH_APP_TEMPLATES_MODE
+        retrieval_instance = RecommendAppRetrievalFactory.get_recommend_app_factory(mode)()
+        recommended_app_detail = retrieval_instance.get_recommend_app_detail(app_id)
+        if recommended_app_detail is None:
+            return None
+
+        return db.session.scalar(select(App).where(App.id == app_id, App.status == "normal").limit(1))
+
     @classmethod
     def get_recommended_apps_and_categories(cls, language: str):
         """

--- a/api/tests/unit_tests/controllers/console/app/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/app/test_wraps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import Select
@@ -44,7 +45,11 @@ def test_get_app_model_with_trial_requires_trial_app_registration(monkeypatch: p
         )
         return None if has_trial_app_join else app_model
 
-    monkeypatch.setattr(wraps_module.db, "session", SimpleNamespace(scalar=scalar))
+    scoped_session = MagicMock()
+    scoped_session.scalar.side_effect = scalar
+    recommended_get_app = MagicMock(return_value=None)
+    monkeypatch.setattr(wraps_module.db, "session", scoped_session)
+    monkeypatch.setattr(wraps_module.RecommendedAppService, "get_app", recommended_get_app)
 
     @wraps_module.get_app_model_with_trial
     def handler(app_model):
@@ -52,6 +57,40 @@ def test_get_app_model_with_trial_requires_trial_app_registration(monkeypatch: p
 
     with pytest.raises(AppNotFoundError):
         handler(app_id="app-1")
+
+    recommended_get_app.assert_called_once_with("app-1")
+
+
+def test_get_app_model_with_trial_falls_back_to_recommended_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_model = SimpleNamespace(id="app-1", mode=AppMode.CHAT.value, status="normal", tenant_id="t1")
+    trial_app_loader = MagicMock(return_value=None)
+    recommended_get_app = MagicMock(return_value=app_model)
+    monkeypatch.setattr(wraps_module, "_load_app_model_with_trial", trial_app_loader)
+    monkeypatch.setattr(wraps_module.RecommendedAppService, "get_app", recommended_get_app)
+
+    @wraps_module.get_app_model_with_trial
+    def handler(app_model):
+        return app_model.id
+
+    assert handler(app_id="app-1") == "app-1"
+    trial_app_loader.assert_called_once_with("app-1")
+    recommended_get_app.assert_called_once_with("app-1")
+
+
+def test_get_app_model_with_trial_prefers_trial_registration(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_model = SimpleNamespace(id="app-1", mode=AppMode.CHAT.value, status="normal", tenant_id="t1")
+    trial_app_loader = MagicMock(return_value=app_model)
+    recommended_get_app = MagicMock()
+    monkeypatch.setattr(wraps_module, "_load_app_model_with_trial", trial_app_loader)
+    monkeypatch.setattr(wraps_module.RecommendedAppService, "get_app", recommended_get_app)
+
+    @wraps_module.get_app_model_with_trial
+    def handler(app_model):
+        return app_model.id
+
+    assert handler(app_id="app-1") == "app-1"
+    trial_app_loader.assert_called_once_with("app-1")
+    recommended_get_app.assert_not_called()
 
 
 def test_get_app_model_requires_app_id() -> None:

--- a/api/tests/unit_tests/services/test_recommended_app_service.py
+++ b/api/tests/unit_tests/services/test_recommended_app_service.py
@@ -438,3 +438,54 @@ class TestRecommendedAppServiceGetDetail:
         assert result["model_config"] == complex_model_config
         assert len(result["workflows"]) == 2
         assert len(result["tools"]) == 3
+
+
+class TestRecommendedAppServiceGetApp:
+    """Test get_app fallback used when an app has no trial registration."""
+
+    @patch("services.recommended_app_service.db")
+    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
+    @patch("services.recommended_app_service.dify_config", autospec=True)
+    def test_returns_normal_recommended_app(self, mock_config, mock_factory_class, mock_db):
+        """A normal app is returned when it belongs to the recommended catalog."""
+        # Arrange
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
+        app_id = "app-1"
+
+        mock_instance = MagicMock()
+        mock_instance.get_recommend_app_detail.return_value = {"id": app_id}
+        mock_factory = MagicMock(return_value=mock_instance)
+        mock_factory_class.get_recommend_app_factory.return_value = mock_factory
+
+        app_model = MagicMock()
+        mock_db.session.scalar.return_value = app_model
+
+        # Act
+        result = RecommendedAppService.get_app(app_id)
+
+        # Assert
+        assert result is app_model
+        mock_instance.get_recommend_app_detail.assert_called_once_with(app_id)
+        mock_db.session.scalar.assert_called_once()
+
+    @patch("services.recommended_app_service.db")
+    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
+    @patch("services.recommended_app_service.dify_config", autospec=True)
+    def test_returns_none_when_app_is_not_recommended(self, mock_config, mock_factory_class, mock_db):
+        """None is returned (and the DB is not touched) when the app is not in the catalog."""
+        # Arrange
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_MODE = "remote"
+        app_id = "not-recommended"
+
+        mock_instance = MagicMock()
+        mock_instance.get_recommend_app_detail.return_value = None
+        mock_factory = MagicMock(return_value=mock_instance)
+        mock_factory_class.get_recommend_app_factory.return_value = mock_factory
+
+        # Act
+        result = RecommendedAppService.get_app(app_id)
+
+        # Assert
+        assert result is None
+        mock_instance.get_recommend_app_detail.assert_called_once_with(app_id)
+        mock_db.session.scalar.assert_not_called()


### PR DESCRIPTION
## Summary

Cherry-pick of #38970 (`fix(api): harden trial apps access for recommended apps`) to `lts/1.13.x`.

### Why

On `lts/1.13.x`, `GET /console/api/trial-apps/<app_id>` (`AppApi.get` via `get_app_model_with_trial`) resolves an app strictly through its **trial registration**:

```sql
SELECT app.* FROM apps app
JOIN trial_apps ta ON ta.app_id = app.id
WHERE app.id = :id AND app.status = 'normal'
```

When a recommended app has **no `trial_apps` row** (e.g. an environment where no trial apps have been registered), this returns `404 App not found` even though the app is a valid recommended app. This surfaced as an "app not found" error when opening the details/try modal for a recommended app (same class of problem as #36096).

### What

`get_app_model_with_trial` now falls back to the recommended catalog when there is no trial registration, via the new `RecommendedAppService.get_app`, which returns a normal app only when it belongs to the recommended catalog:

```python
app_model = _load_app_model_with_trial(app_id)
if app_model is None:
    app_model = RecommendedAppService.get_app(app_id)
if not app_model:
    raise AppNotFoundError()
```

### Backport notes

The original commit depends on a session-injection refactor of the recommend-app retrieval layer that does not exist on `lts/1.13.x` (`get_recommend_app_detail(app_id, session=...)`). The change was adapted to the lts conventions:
- `RecommendedAppService.get_app(app_id)` uses the module-level `db.session` and calls `get_recommend_app_detail(app_id)` (no `session=` kwarg), matching the rest of this file on `lts/1.13.x`.
- The controller wrapper keeps the existing lts-style signature (no PEP 695 generics/overloads).
- Tests were adapted accordingly; the service test suite (which differs structurally from `main`) gets a focused `TestRecommendedAppServiceGetApp` instead of the `main` variant.

## Test plan

- [x] `pytest api/tests/unit_tests/controllers/console/app/test_wraps.py api/tests/unit_tests/services/test_recommended_app_service.py` — 18 passed
- [x] `basedpyright` on the two changed source files — 0 errors
- [x] Pre-existing UP047 lint on `wraps.py` is unchanged from the base branch (no new violations introduced)

Generated with [Devin](https://devin.ai)