### PR TITLE
fix(api): preserve tracing configuration boundaries

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -1573,10 +1573,6 @@ class TraceQueueManager:
         return None
 
     def persist_trace_task(self, task: TraceTask, *, file_id: str | None = None) -> dict[str, str] | None:
-        if not (self._enterprise_telemetry_enabled or self.trace_instance):
-            return None
-
-        task.app_id = self.app_id
         storage_id = self._resolve_storage_id(task)
         if storage_id is None:
             return None

--- a/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
@@ -4,18 +4,18 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import override
 
-from langfuse import Langfuse
+import httpx
+from langfuse import __version__ as langfuse_version
 from langfuse.api import (
     CreateGenerationBody,
     CreateSpanBody,
     IngestionEvent_GenerationCreate,
     IngestionEvent_SpanCreate,
     IngestionEvent_TraceCreate,
+    LangfuseAPI,
     TraceBody,
 )
 from langfuse.api.commons.types.usage import Usage
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
 from sqlalchemy.orm import sessionmaker
 
 from core.ops.base_trace_instance import BaseTraceInstance
@@ -55,36 +55,29 @@ class LangFuseDataTrace(BaseTraceInstance):
         langfuse_config: LangfuseConfig,
     ):
         super().__init__(langfuse_config)
-        # Isolated TracerProvider prevents the langfuse v3 SDK from attaching its
-        # SpanProcessor to the global OpenTelemetry TracerProvider, which would
-        # otherwise siphon every Flask/Celery/SQLAlchemy span in the process into
-        # this tenant's Langfuse project. See langfuse upgrade guide v2 -> v3.
-        self._tracer_provider: TracerProvider | None = TracerProvider(
-            resource=Resource.create({"service.name": "dify-langfuse-app-trace"}),
-        )
-        self.langfuse_client = Langfuse(
-            public_key=langfuse_config.public_key,
-            secret_key=langfuse_config.secret_key,
-            host=langfuse_config.host,
-            tracer_provider=self._tracer_provider,
+        timeout = int(os.environ.get("LANGFUSE_TIMEOUT", 5))
+        self._http_client: httpx.Client | None = httpx.Client(timeout=timeout)
+        self.langfuse_client = LangfuseAPI(
+            base_url=langfuse_config.host,
+            username=langfuse_config.public_key,
+            password=langfuse_config.secret_key,
+            x_langfuse_sdk_name="python",
+            x_langfuse_sdk_version=langfuse_version,
+            x_langfuse_public_key=langfuse_config.public_key,
+            timeout=timeout,
+            httpx_client=self._http_client,
         )
         self.file_base_url = os.getenv("FILES_URL", "http://127.0.0.1:5001")
 
     def close(self) -> None:
-        """Flush and shut down the isolated TracerProvider.
-
-        Called explicitly when the trace instance is evicted from the cache, or
-        implicitly via ``__del__`` on garbage collection. Idempotent.
-        """
-        provider = getattr(self, "_tracer_provider", None)
-        if provider is None:
+        client = getattr(self, "_http_client", None)
+        if client is None:
             return
+        self._http_client = None
         try:
-            provider.shutdown()
+            client.close()
         except Exception:
-            logger.debug("Failed to shut down Langfuse TracerProvider", exc_info=True)
-        finally:
-            self._tracer_provider = None
+            logger.debug("Failed to close Langfuse HTTP client", exc_info=True)
 
     def __del__(self) -> None:
         self.close()
@@ -500,7 +493,7 @@ class LangFuseDataTrace(BaseTraceInstance):
                 id=self._make_event_id(),
                 timestamp=self._now_iso(),
             )
-            self.langfuse_client.api.ingestion.batch(batch=[event])
+            self.langfuse_client.ingestion.batch(batch=[event])
             logger.debug("LangFuse Trace created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create trace: {str(e)}")
@@ -527,7 +520,7 @@ class LangFuseDataTrace(BaseTraceInstance):
                 id=self._make_event_id(),
                 timestamp=self._now_iso(),
             )
-            self.langfuse_client.api.ingestion.batch(batch=[event])
+            self.langfuse_client.ingestion.batch(batch=[event])
             logger.debug("LangFuse Span created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create span: {str(e)}")
@@ -576,7 +569,7 @@ class LangFuseDataTrace(BaseTraceInstance):
                 id=self._make_event_id(),
                 timestamp=self._now_iso(),
             )
-            self.langfuse_client.api.ingestion.batch(batch=[event])
+            self.langfuse_client.ingestion.batch(batch=[event])
             logger.debug("LangFuse Generation created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create generation: {str(e)}")
@@ -590,14 +583,17 @@ class LangFuseDataTrace(BaseTraceInstance):
 
     def api_check(self):
         try:
-            return self.langfuse_client.auth_check()
+            projects = self.langfuse_client.projects.get()
         except Exception as e:
             logger.debug("LangFuse API check failed", exc_info=True)
             raise ValueError(f"LangFuse API check failed: {str(e)}")
+        if not projects.data:
+            raise ValueError("LangFuse API check failed: no project found for the provided credentials")
+        return True
 
     def get_project_key(self):
         try:
-            projects = self.langfuse_client.api.projects.get()
+            projects = self.langfuse_client.projects.get()
             return projects.data[0].id
         except Exception as e:
             logger.debug("LangFuse get project key failed", exc_info=True)

--- a/api/providers/trace/trace-langfuse/tests/unit_tests/langfuse_trace/test_langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/tests/unit_tests/langfuse_trace/test_langfuse_trace.py
@@ -47,97 +47,60 @@ def langfuse_config():
 def trace_instance(langfuse_config, monkeypatch: pytest.MonkeyPatch):
     # Mock Langfuse client to avoid network calls
     mock_client = MagicMock()
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: mock_client)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", lambda **kwargs: mock_client)
 
     instance = LangFuseDataTrace(langfuse_config)
     return instance
 
 
 def test_init(langfuse_config, monkeypatch: pytest.MonkeyPatch):
-    from opentelemetry.sdk.trace import TracerProvider
-
     mock_langfuse = MagicMock()
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", mock_langfuse)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", mock_langfuse)
     monkeypatch.setenv("FILES_URL", "http://test.url")
 
     instance = LangFuseDataTrace(langfuse_config)
 
     mock_langfuse.assert_called_once()
     kwargs = mock_langfuse.call_args.kwargs
-    assert kwargs["public_key"] == langfuse_config.public_key
-    assert kwargs["secret_key"] == langfuse_config.secret_key
-    assert kwargs["host"] == langfuse_config.host
-    assert isinstance(kwargs["tracer_provider"], TracerProvider)
-    assert kwargs["tracer_provider"] is instance._tracer_provider
+    assert kwargs["username"] == langfuse_config.public_key
+    assert kwargs["password"] == langfuse_config.secret_key
+    assert kwargs["base_url"] == langfuse_config.host
     assert instance.file_base_url == "http://test.url"
 
 
-def test_init_passes_isolated_tracer_provider_to_langfuse(langfuse_config, monkeypatch: pytest.MonkeyPatch):
-    """Regression test for langfuse v3 SDK side effect.
+def test_same_public_key_uses_independent_api_clients(monkeypatch: pytest.MonkeyPatch):
+    clients = [MagicMock(), MagicMock()]
+    create_client = MagicMock(side_effect=clients)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", create_client)
 
-    Without an explicit ``tracer_provider=`` kwarg, the Langfuse v3 SDK
-    attaches a ``LangfuseSpanProcessor`` to the *global* OpenTelemetry
-    TracerProvider — siphoning every Flask / Celery / SQLAlchemy span in the
-    process into the tenant's Langfuse project. See langfuse upgrade-path
-    docs (v2 -> v3) and GitHub discussion #9136.
-
-    The fix is to construct an isolated ``TracerProvider`` and pass it via
-    ``tracer_provider=`` so the SDK never touches the global one.
-    """
-    from opentelemetry import trace as otel_trace_api
-    from opentelemetry.sdk.trace import TracerProvider
-
-    captured: dict[str, object] = {}
-
-    def fake_langfuse(**kwargs):
-        captured.update(kwargs)
-        return MagicMock()
-
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", fake_langfuse)
-
-    instance = LangFuseDataTrace(langfuse_config)
-
-    # 1. tracer_provider kwarg must be supplied (drives the no-pollution branch
-    #    in langfuse.LangfuseResourceManager._init_tracer_provider).
-    assert "tracer_provider" in captured, (
-        "Langfuse() must receive an explicit tracer_provider=; without it the "
-        "v3 SDK attaches its SpanProcessor to the global OTEL TracerProvider."
+    first = LangFuseDataTrace(
+        LangfuseConfig(public_key="shared", secret_key="secret-a", host="https://tenant-a.example")
+    )
+    second = LangFuseDataTrace(
+        LangfuseConfig(public_key="shared", secret_key="secret-b", host="https://tenant-b.example")
     )
 
-    passed_provider = captured["tracer_provider"]
-    assert isinstance(passed_provider, TracerProvider)
-    assert passed_provider is instance._tracer_provider
-
-    # 2. The instance's provider must not be the global one.
-    global_provider = otel_trace_api.get_tracer_provider()
-    assert passed_provider is not global_provider
-
-
-def test_close_shuts_down_tracer_provider(langfuse_config, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: MagicMock())
-
-    instance = LangFuseDataTrace(langfuse_config)
-    provider = instance._tracer_provider
-    provider_shutdown = MagicMock()
-    monkeypatch.setattr(provider, "shutdown", provider_shutdown)
-
-    instance.close()
-
-    provider_shutdown.assert_called_once()
-    assert instance._tracer_provider is None
+    assert first.langfuse_client is clients[0]
+    assert second.langfuse_client is clients[1]
+    assert [
+        (call.kwargs["base_url"], call.kwargs["username"], call.kwargs["password"])
+        for call in create_client.call_args_list
+    ] == [
+        ("https://tenant-a.example", "shared", "secret-a"),
+        ("https://tenant-b.example", "shared", "secret-b"),
+    ]
 
 
 def test_close_is_idempotent(langfuse_config, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: MagicMock())
+    http_client = MagicMock()
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.httpx.Client", lambda **kwargs: http_client)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", MagicMock())
 
     instance = LangFuseDataTrace(langfuse_config)
-    provider_shutdown = MagicMock()
-    monkeypatch.setattr(instance._tracer_provider, "shutdown", provider_shutdown)
-
     instance.close()
     instance.close()
 
-    provider_shutdown.assert_called_once()
+    http_client.close.assert_called_once()
 
 
 def test_trace_dispatch(trace_instance, monkeypatch: pytest.MonkeyPatch):
@@ -623,11 +586,11 @@ def test_generate_name_trace(trace_instance):
 def test_add_trace_success(trace_instance):
     data = LangfuseTrace(id="t1", name="trace")
     trace_instance.add_trace(data)
-    trace_instance.langfuse_client.api.ingestion.batch.assert_called_once()
+    trace_instance.langfuse_client.ingestion.batch.assert_called_once()
 
 
 def test_add_trace_error(trace_instance):
-    trace_instance.langfuse_client.api.ingestion.batch.side_effect = Exception("error")
+    trace_instance.langfuse_client.ingestion.batch.side_effect = Exception("error")
     data = LangfuseTrace(id="t1", name="trace")
     with pytest.raises(ValueError, match="LangFuse Failed to create trace: error"):
         trace_instance.add_trace(data)
@@ -636,11 +599,11 @@ def test_add_trace_error(trace_instance):
 def test_add_span_success(trace_instance):
     data = LangfuseSpan(id="s1", name="span", trace_id="t1")
     trace_instance.add_span(data)
-    trace_instance.langfuse_client.api.ingestion.batch.assert_called_once()
+    trace_instance.langfuse_client.ingestion.batch.assert_called_once()
 
 
 def test_add_span_error(trace_instance):
-    trace_instance.langfuse_client.api.ingestion.batch.side_effect = Exception("error")
+    trace_instance.langfuse_client.ingestion.batch.side_effect = Exception("error")
     data = LangfuseSpan(id="s1", name="span", trace_id="t1")
     with pytest.raises(ValueError, match="LangFuse Failed to create span: error"):
         trace_instance.add_span(data)
@@ -656,11 +619,11 @@ def test_update_span(trace_instance):
 def test_add_generation_success(trace_instance):
     data = LangfuseGeneration(id="g1", name="gen", trace_id="t1")
     trace_instance.add_generation(data)
-    trace_instance.langfuse_client.api.ingestion.batch.assert_called_once()
+    trace_instance.langfuse_client.ingestion.batch.assert_called_once()
 
 
 def test_add_generation_error(trace_instance):
-    trace_instance.langfuse_client.api.ingestion.batch.side_effect = Exception("error")
+    trace_instance.langfuse_client.ingestion.batch.side_effect = Exception("error")
     data = LangfuseGeneration(id="g1", name="gen", trace_id="t1")
     with pytest.raises(ValueError, match="LangFuse Failed to create generation: error"):
         trace_instance.add_generation(data)
@@ -674,12 +637,18 @@ def test_update_generation(trace_instance):
 
 
 def test_api_check_success(trace_instance):
-    trace_instance.langfuse_client.auth_check.return_value = True
+    trace_instance.langfuse_client.projects.get.return_value = MagicMock(data=[MagicMock()])
     assert trace_instance.api_check() is True
 
 
+def test_api_check_rejects_empty_project_list(trace_instance):
+    trace_instance.langfuse_client.projects.get.return_value = MagicMock(data=[])
+    with pytest.raises(ValueError, match="no project found for the provided credentials"):
+        trace_instance.api_check()
+
+
 def test_api_check_error(trace_instance):
-    trace_instance.langfuse_client.auth_check.side_effect = Exception("fail")
+    trace_instance.langfuse_client.projects.get.side_effect = Exception("fail")
     with pytest.raises(ValueError, match="LangFuse API check failed: fail"):
         trace_instance.api_check()
 
@@ -687,12 +656,12 @@ def test_api_check_error(trace_instance):
 def test_get_project_key_success(trace_instance):
     mock_data = MagicMock()
     mock_data.id = "proj-1"
-    trace_instance.langfuse_client.api.projects.get.return_value = MagicMock(data=[mock_data])
+    trace_instance.langfuse_client.projects.get.return_value = MagicMock(data=[mock_data])
     assert trace_instance.get_project_key() == "proj-1"
 
 
 def test_get_project_key_error(trace_instance):
-    trace_instance.langfuse_client.api.projects.get.side_effect = Exception("fail")
+    trace_instance.langfuse_client.projects.get.side_effect = Exception("fail")
     with pytest.raises(ValueError, match="LangFuse get project key failed: fail"):
         trace_instance.get_project_key()
 

--- a/api/providers/trace/trace-langfuse/tests/unit_tests/test_langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/tests/unit_tests/test_langfuse_trace.py
@@ -13,7 +13,7 @@ from graphon.enums import BuiltinNodeTypes
 
 
 def _create_trace_instance() -> LangFuseDataTrace:
-    with patch("dify_trace_langfuse.langfuse_trace.Langfuse", autospec=True):
+    with patch("dify_trace_langfuse.langfuse_trace.LangfuseAPI", autospec=True):
         return LangFuseDataTrace(
             LangfuseConfig(
                 public_key="public-key",

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -681,9 +681,16 @@ def test_trace_helpers_and_streaming_metrics(trace_environment: None) -> None:
     assert generated.message_id == "message-1"
 
 
-def test_trace_queue_collect_run_and_storage_boundary(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
-    monkeypatch.setattr(OpsTraceManager, "get_ops_trace_instance", classmethod(lambda cls, _app_id: True))
-    manager = TraceQueueManager(app_id="app-id", user_id="user-1")
+def test_trace_queue_preserves_source_app_when_another_manager_drains(
+    monkeypatch: pytest.MonkeyPatch, trace_environment: None
+) -> None:
+    monkeypatch.setattr(
+        OpsTraceManager,
+        "get_ops_trace_instance",
+        classmethod(lambda cls, app_id: app_id == "source-app-id"),
+    )
+    draining_manager = TraceQueueManager(app_id="draining-app-id", user_id="user-1")
+    source_manager = TraceQueueManager(app_id="source-app-id", user_id="user-2")
     task = TraceTask(
         trace_type=TraceTaskName.GENERATE_NAME_TRACE,
         conversation_id="conversation-1",
@@ -692,8 +699,8 @@ def test_trace_queue_collect_run_and_storage_boundary(monkeypatch: pytest.Monkey
         generate_conversation_name="name",
         inputs="query",
     )
-    manager.add_trace_task(task)
-    assert manager.collect_tasks() == [task]
+    source_manager.add_trace_task(task)
+    assert draining_manager.collect_tasks() == [task]
 
     recording_storage = RecordingStorage()
     dispatcher = RecordingDispatcher()
@@ -701,14 +708,14 @@ def test_trace_queue_collect_run_and_storage_boundary(monkeypatch: pytest.Monkey
     monkeypatch.setattr(module.process_trace_tasks, "apply_async", dispatcher.apply_async)
     file_id = UUID("00000000-0000-0000-0000-000000000123")
     monkeypatch.setattr(module, "uuid4", lambda: file_id)
-    manager.add_trace_task(task)
-    manager.run()
+    source_manager.add_trace_task(task)
+    draining_manager.run()
 
     assert len(recording_storage.writes) == 1
     path, data = recording_storage.writes[0]
-    assert path.endswith(f"app-id/{file_id.hex}.json")
-    assert json.loads(data)["app_id"] == "app-id"
-    assert dispatcher.payloads == [{"file_id": file_id.hex, "app_id": "app-id"}]
+    assert path.endswith(f"source-app-id/{file_id.hex}.json")
+    assert json.loads(data)["app_id"] == "source-app-id"
+    assert dispatcher.payloads == [{"file_id": file_id.hex, "app_id": "source-app-id"}]
 
 
 def test_trace_queue_persists_with_caller_supplied_file_id(
@@ -724,6 +731,7 @@ def test_trace_queue_persists_with_caller_supplied_file_id(
         generate_conversation_name="name",
         inputs="query",
     )
+    task.app_id = "app-id"
     recording_storage = RecordingStorage()
     monkeypatch.setattr(module.storage, "save", recording_storage.save)
 
@@ -740,6 +748,7 @@ def test_trace_queue_persistence_error_propagates(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(OpsTraceManager, "get_ops_trace_instance", classmethod(lambda cls, _app_id: True))
     manager = TraceQueueManager(app_id="app-id", user_id="user-1")
     task = TraceTask(trace_type=TraceTaskName.GENERATE_NAME_TRACE)
+    task.app_id = "app-id"
 
     def fail_save(_path: str, _data: bytes) -> None:
         raise OSError("storage unavailable")


### PR DESCRIPTION
## Summary

- Preserve the originating application context when queued trace tasks are persisted and dispatched.
- Use an independent Langfuse API client for each configured endpoint and credential set.
- Retain existing configuration validation and client cleanup behavior.