### PR TITLE
feat(web): add a shared virtualized card grid for menu card lists

### DIFF
--- a/web/app/components/apps/__tests__/list.spec.tsx
+++ b/web/app/components/apps/__tests__/list.spec.tsx
@@ -18,6 +18,8 @@ import { renderWithNuqs } from '@/test/nuqs-testing'
 import { AppModeEnum } from '@/types/app'
 import { List } from '../list'
 
+vi.mock('@tanstack/react-virtual')
+
 vi.mock('react-i18next', async () => {
   const { createReactI18nextMock } = await import('@/test/i18n-mock')
   return createReactI18nextMock({
@@ -654,6 +656,16 @@ describe('List', () => {
 
       expect(screen.getByTestId('app-card-app-1'))!.toBeInTheDocument()
       expect(screen.getByTestId('app-card-app-2'))!.toBeInTheDocument()
+    })
+
+    it('should render app cards through the virtualized grid', () => {
+      renderList()
+
+      // Cards sit in absolutely positioned rows inside a container sized to the whole
+      // list, so cards outside the viewport are never mounted.
+      const row = screen.getByTestId('app-card-app-1').closest('div.absolute')
+      expect(row).not.toBeNull()
+      expect(row!.parentElement).toHaveStyle({ height: '332px' })
     })
 
     it('should hide starred section when there are no starred apps', () => {

--- a/web/app/components/apps/app-list-catalog.tsx
+++ b/web/app/components/apps/app-list-catalog.tsx
@@ -15,13 +15,19 @@ import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-qu
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { InfiniteScrollSentinel } from '@/app/components/base/infinite-scroll-sentinel'
+import { VirtualizedCardGrid } from '@/app/components/base/virtualized-card-grid'
 import { STEP_BY_STEP_TOUR_TARGETS } from '@/app/components/step-by-step-tour/target-registry'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { consoleQuery } from '@/service/client'
 import { AppModeEnum } from '@/types/app'
 import { AppCard } from './app-card'
 import { AppCardSkeleton } from './app-card-skeleton'
-import { APP_LIST_GRID_CLASS_NAME } from './constants'
+import {
+  APP_CARD_HEIGHT,
+  APP_LIST_GRID_CLASS_NAME,
+  APP_LIST_GRID_COLUMNS_CLASS_NAME,
+  APP_LIST_GRID_PADDING_CLASS_NAME,
+} from './constants'
 import Empty from './empty'
 import FirstEmptyState from './first-empty-state'
 import { useAppListTour } from './hooks/use-app-list-tour'
@@ -165,41 +171,49 @@ function AppListCatalogContent({
           )}
           <div
             className={cn(
-              `relative grow content-start ${APP_LIST_GRID_CLASS_NAME}`,
+              'relative grow',
+              APP_LIST_GRID_PADDING_CLASS_NAME,
               !hasAnyApp && 'overflow-hidden',
             )}
           >
             {hasAnyApp ? (
-              apps.map((app, index) => (
-                <AppCard
-                  key={app.id}
-                  app={app}
-                  onlineUsers={workflowOnlineUsersMap[app.id]}
-                  onOpenTagManagement={onOpenTagManagement}
-                  stepByStepTourActionMenuOpen={
-                    index === 0 ? shouldOpenFirstAppActionMenu : undefined
-                  }
-                  stepByStepTourCardTarget={
-                    index === 0
-                      ? shouldHighlightAllAppsRow
-                        ? STEP_BY_STEP_TOUR_TARGETS.studioNoCreateFirstAppCard
-                        : canCreateApp
-                          ? STEP_BY_STEP_TOUR_TARGETS.studioWithAppsFirstAppCard
-                          : undefined
-                      : undefined
-                  }
-                  stepByStepTourCardHighlightPart={
-                    index < STEP_BY_STEP_TOUR_APP_ROW_CARD_COUNT && shouldHighlightAllAppsRow
-                      ? STEP_BY_STEP_TOUR_TARGETS.studioNoCreateFirstAppRowCard
-                      : undefined
-                  }
-                  stepByStepTourActionMenuHighlightPart={
-                    index === 0 && shouldOpenFirstAppActionMenu
-                      ? STEP_BY_STEP_TOUR_TARGETS.studioWithAppsFirstAppCardActionsMenu
-                      : undefined
-                  }
-                />
-              ))
+              <VirtualizedCardGrid
+                className={cn('content-start', APP_LIST_GRID_COLUMNS_CLASS_NAME)}
+                getItemKey={(app) => app.id}
+                items={apps}
+                renderItem={(app, index) => (
+                  <AppCard
+                    key={app.id}
+                    app={app}
+                    onlineUsers={workflowOnlineUsersMap[app.id]}
+                    onOpenTagManagement={onOpenTagManagement}
+                    stepByStepTourActionMenuOpen={
+                      index === 0 ? shouldOpenFirstAppActionMenu : undefined
+                    }
+                    stepByStepTourCardTarget={
+                      index === 0
+                        ? shouldHighlightAllAppsRow
+                          ? STEP_BY_STEP_TOUR_TARGETS.studioNoCreateFirstAppCard
+                          : canCreateApp
+                            ? STEP_BY_STEP_TOUR_TARGETS.studioWithAppsFirstAppCard
+                            : undefined
+                        : undefined
+                    }
+                    stepByStepTourCardHighlightPart={
+                      index < STEP_BY_STEP_TOUR_APP_ROW_CARD_COUNT && shouldHighlightAllAppsRow
+                        ? STEP_BY_STEP_TOUR_TARGETS.studioNoCreateFirstAppRowCard
+                        : undefined
+                    }
+                    stepByStepTourActionMenuHighlightPart={
+                      index === 0 && shouldOpenFirstAppActionMenu
+                        ? STEP_BY_STEP_TOUR_TARGETS.studioWithAppsFirstAppCardActionsMenu
+                        : undefined
+                    }
+                  />
+                )}
+                rowHeight={APP_CARD_HEIGHT}
+                scrollContainerRef={scrollViewportRef}
+              />
             ) : (
               <Empty
                 stepByStepTourTarget={
@@ -208,7 +222,7 @@ function AppListCatalogContent({
               />
             )}
             {hasNextPage && (
-              <>
+              <div className={cn('relative', APP_LIST_GRID_COLUMNS_CLASS_NAME)}>
                 <AppCardSkeleton count={3} />
                 {isFetchNextPageError && (
                   <div
@@ -235,7 +249,7 @@ function AppListCatalogContent({
                   preloadDistance={getPreloadDistance}
                   scrollContainerRef={scrollViewportRef}
                 />
-              </>
+              </div>
             )}
           </div>
         </>

--- a/web/app/components/apps/constants.ts
+++ b/web/app/components/apps/constants.ts
@@ -2,4 +2,12 @@ import { cn } from '@langgenius/dify-ui/cn'
 import { MAIN_NAV_APP_CARD_GRID_CLASS_NAME } from '@/app/components/main-nav/app-card-grid'
 
 export const APP_LIST_SEARCH_DEBOUNCE_MS = 500
-export const APP_LIST_GRID_CLASS_NAME = cn('gap-2.5 px-8 pt-2', MAIN_NAV_APP_CARD_GRID_CLASS_NAME)
+export const APP_LIST_GRID_PADDING_CLASS_NAME = 'px-8 pt-2'
+export const APP_LIST_GRID_COLUMNS_CLASS_NAME = cn('gap-2.5', MAIN_NAV_APP_CARD_GRID_CLASS_NAME)
+export const APP_LIST_GRID_CLASS_NAME = cn(
+  APP_LIST_GRID_PADDING_CLASS_NAME,
+  APP_LIST_GRID_COLUMNS_CLASS_NAME,
+)
+
+/** Mirrors the `h-41.5` height AppCard renders at. */
+export const APP_CARD_HEIGHT = 166

--- a/web/app/components/base/virtualized-card-grid/__tests__/index.spec.tsx
+++ b/web/app/components/base/virtualized-card-grid/__tests__/index.spec.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { VirtualizedCardGrid } from '..'
+
+vi.mock('@tanstack/react-virtual')
+
+type Card = { id: string; name: string }
+
+const cards: Card[] = [
+  { id: 'a', name: 'Card A' },
+  { id: 'b', name: 'Card B' },
+  { id: 'c', name: 'Card C' },
+]
+
+const renderGrid = (items: Card[] = cards, renderItem?: (item: Card, index: number) => ReactNode) =>
+  render(
+    <VirtualizedCardGrid
+      className="grid grid-cols-[repeat(auto-fill,minmax(288px,1fr))] gap-2.5"
+      getItemKey={(item) => item.id}
+      items={items}
+      renderItem={
+        renderItem ??
+        ((item) => (
+          <div key={item.id} data-testid={`card-${item.id}`}>
+            {item.name}
+          </div>
+        ))
+      }
+      rowHeight={166}
+      scrollContainerRef={createRef<HTMLDivElement>()}
+    />,
+  )
+
+describe('VirtualizedCardGrid', () => {
+  it('renders each card inside a positioned row', () => {
+    renderGrid()
+
+    const row = screen.getByTestId('card-a').closest('div.absolute')
+    expect(row).not.toBeNull()
+    expect(row).toHaveStyle({ height: '166px' })
+  })
+
+  it('sizes the container to the whole list so rows outside the viewport can be skipped', () => {
+    renderGrid()
+
+    // No stylesheet resolves the grid tracks here, so each card occupies its own row.
+    const container = screen.getByTestId('card-a').closest('div.absolute')!.parentElement
+    expect(container).toHaveStyle({ height: '498px' })
+  })
+
+  it('passes the position within the whole list to renderItem', () => {
+    const seen: number[] = []
+    renderGrid(cards, (item, index) => {
+      seen.push(index)
+      return <div key={item.id} data-testid={`card-${item.id}`} />
+    })
+
+    expect(seen).toEqual([0, 1, 2])
+  })
+
+  it('renders nothing for an empty list', () => {
+    const { container } = renderGrid([])
+
+    expect(container.querySelector('div.absolute')).toBeNull()
+  })
+})

--- a/web/app/components/base/virtualized-card-grid/index.tsx
+++ b/web/app/components/base/virtualized-card-grid/index.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import type { ReactNode, RefObject } from 'react'
+import { cn } from '@langgenius/dify-ui/cn'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+type GridLayout = {
+  columnCount: number
+  rowGap: number
+}
+
+const initialLayout: GridLayout = { columnCount: 1, rowGap: 0 }
+
+const readGridLayout = (grid: Element): GridLayout => {
+  const style = window.getComputedStyle(grid)
+  const template = style.gridTemplateColumns
+
+  return {
+    columnCount:
+      !template || template === 'none'
+        ? 1
+        : Math.max(1, template.split(' ').filter(Boolean).length),
+    rowGap: Number.parseFloat(style.rowGap) || 0,
+  }
+}
+
+type VirtualizedCardGridProps<TItem> = Readonly<{
+  /**
+   * Grid classes only — column tracks and gap. Keep padding on a wrapper, because
+   * these classes are applied to every rendered row as well as the container.
+   */
+  className?: string
+  getItemKey: (item: TItem, index: number) => string
+  items: readonly TItem[]
+  overscan?: number
+  renderItem: (item: TItem, index: number) => ReactNode
+  /** Height of a single card, mirroring the height class the card renders at. */
+  rowHeight: number
+  scrollContainerRef: RefObject<Element | null>
+}>
+
+/**
+ * Renders a responsive card grid one row at a time, so a list that has grown to
+ * hundreds of cards only mounts and paints the rows near the viewport.
+ *
+ * The column count and row gap are read back from the resolved grid styles rather
+ * than passed in, so callers keep owning their own track sizing in CSS and the two
+ * cannot drift apart.
+ */
+export function VirtualizedCardGrid<TItem>({
+  className,
+  getItemKey,
+  items,
+  overscan = 2,
+  renderItem,
+  rowHeight,
+  scrollContainerRef,
+}: VirtualizedCardGridProps<TItem>) {
+  const gridRef = useRef<HTMLDivElement>(null)
+  const [layout, setLayout] = useState<GridLayout>(initialLayout)
+
+  useEffect(() => {
+    const grid = gridRef.current
+    if (!grid || typeof ResizeObserver === 'undefined') return
+
+    const measure = () => {
+      const next = readGridLayout(grid)
+      setLayout((current) =>
+        current.columnCount === next.columnCount && current.rowGap === next.rowGap ? current : next,
+      )
+    }
+
+    // `observe` already delivers an initial callback, so nothing is measured
+    // synchronously here.
+    const observer = new ResizeObserver(measure)
+    observer.observe(grid)
+    return () => observer.disconnect()
+  }, [])
+
+  const rows = useMemo(() => {
+    const chunked: TItem[][] = []
+    for (let index = 0; index < items.length; index += layout.columnCount)
+      chunked.push(items.slice(index, index + layout.columnCount) as TItem[])
+
+    return chunked
+  }, [items, layout.columnCount])
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    estimateSize: () => rowHeight,
+    gap: layout.rowGap,
+    getItemKey: (index) => {
+      const firstItem = rows[index]?.[0]
+
+      return firstItem === undefined ? index : getItemKey(firstItem, index * layout.columnCount)
+    },
+    getScrollElement: () => scrollContainerRef.current as HTMLElement | null,
+    overscan,
+  })
+
+  return (
+    <div
+      ref={gridRef}
+      className={cn('relative', className)}
+      style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+    >
+      {rowVirtualizer.getVirtualItems().map((virtualRow) => (
+        <div
+          key={virtualRow.key}
+          className={cn('absolute top-0 left-0 w-full', className)}
+          style={{
+            height: `${virtualRow.size}px`,
+            transform: `translateY(${virtualRow.start}px)`,
+          }}
+        >
+          {rows[virtualRow.index]?.map((item, columnIndex) =>
+            renderItem(item, virtualRow.index * layout.columnCount + columnIndex),
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/app/components/datasets/list/__tests__/datasets.spec.tsx
+++ b/web/app/components/datasets/list/__tests__/datasets.spec.tsx
@@ -1,12 +1,15 @@
 import type { DataSet, DataSetListResponse } from '@/models/datasets'
 import type { useDatasetList } from '@/service/knowledge/use-dataset'
 import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { IndexingType } from '@/app/components/datasets/create/step-two'
 import { STEP_BY_STEP_TOUR_TARGETS } from '@/app/components/step-by-step-tour/target-registry'
 import { ChunkingMode, DatasetPermission, DataSourceType } from '@/models/datasets'
 import { RETRIEVE_METHOD } from '@/types/app'
 import Datasets from '../datasets'
+
+vi.mock('@tanstack/react-virtual')
 
 vi.mock('@/next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -180,6 +183,7 @@ describe('Datasets', () => {
     isFetchingNextPage: false,
     isLoading: false,
     isPlaceholderData: false,
+    scrollContainerRef: createRef<HTMLDivElement>(),
   }
 
   beforeEach(() => {
@@ -410,18 +414,20 @@ describe('Datasets', () => {
   })
 
   describe('Styles', () => {
-    it('should have correct grid styling', () => {
+    it('should keep the padding on the nav and the grid tracks on the virtualized rows', () => {
       render(<Datasets {...defaultProps} />)
+
       const nav = screen.getByRole('navigation')
-      expect(nav).toHaveClass(
-        'relative',
+      expect(nav).toHaveClass('relative', 'grow', 'px-8', 'pt-2')
+
+      // The tracks moved onto the virtualized grid so each rendered row can lay its
+      // own cards out; the nav only owns the surrounding padding now.
+      const grid = nav.querySelector('div.grid')
+      expect(grid).toHaveClass(
         'grid',
-        'grow',
         'grid-cols-[repeat(auto-fill,minmax(296px,1fr))]',
         'content-start',
         'gap-3',
-        'px-8',
-        'pt-2',
       )
     })
   })

--- a/web/app/components/datasets/list/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/list/__tests__/index.spec.tsx
@@ -28,6 +28,8 @@ const useInfiniteQueryMock = vi.hoisted(() =>
   })),
 )
 
+vi.mock('@tanstack/react-virtual')
+
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const original = await importOriginal<typeof import('@tanstack/react-query')>()
   return {

--- a/web/app/components/datasets/list/datasets.tsx
+++ b/web/app/components/datasets/list/datasets.tsx
@@ -1,13 +1,20 @@
 'use client'
 
-import type { ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import type { useDatasetList } from '@/service/knowledge/use-dataset'
+import { cn } from '@langgenius/dify-ui/cn'
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
+import { VirtualizedCardGrid } from '@/app/components/base/virtualized-card-grid'
 import { useInvalidDatasetList } from '@/service/knowledge/use-dataset'
 import DatasetCard from './dataset-card'
 import DatasetCardSkeleton from './dataset-card-skeleton'
+
+const DATASET_LIST_GRID_COLUMNS_CLASS_NAME =
+  'grid grid-cols-[repeat(auto-fill,minmax(296px,1fr))] gap-3'
+/** Mirrors the `h-41.5` height DatasetCard renders at. */
+const DATASET_CARD_HEIGHT = 166
 
 type Props = Readonly<{
   datasetList: ReturnType<typeof useDatasetList>['data'] | null
@@ -17,6 +24,7 @@ type Props = Readonly<{
   isFetchingNextPage: ReturnType<typeof useDatasetList>['isFetchingNextPage']
   isLoading: ReturnType<typeof useDatasetList>['isLoading']
   isPlaceholderData: ReturnType<typeof useDatasetList>['isPlaceholderData']
+  scrollContainerRef: RefObject<Element | null>
   emptyElement?: ReactNode
   onOpenTagManagement?: () => void
   stepByStepTourActionMenuHighlightPart?: string
@@ -32,6 +40,7 @@ const Datasets = ({
   isFetchingNextPage,
   isLoading,
   isPlaceholderData,
+  scrollContainerRef,
   emptyElement,
   onOpenTagManagement = () => {},
   stepByStepTourActionMenuHighlightPart,
@@ -69,25 +78,36 @@ const Datasets = ({
 
   return (
     <>
-      <nav className="relative grid grow grid-cols-[repeat(auto-fill,minmax(296px,1fr))] content-start gap-3 px-8 pt-2">
+      <nav className="relative grow px-8 pt-2">
         {showDatasetSkeleton ? (
-          <DatasetCardSkeleton label={t(($) => $.loading, { ns: 'common' })} />
+          <div className={DATASET_LIST_GRID_COLUMNS_CLASS_NAME}>
+            <DatasetCardSkeleton label={t(($) => $.loading, { ns: 'common' })} />
+          </div>
         ) : (
-          datasets.map((dataset, index) => (
-            <DatasetCard
-              key={dataset.id}
-              dataset={dataset}
-              onSuccess={invalidDatasetList}
-              onOpenTagManagement={onOpenTagManagement}
-              stepByStepTourActionMenuHighlightPart={
-                index === 0 && stepByStepTourActionMenuOpen
-                  ? stepByStepTourActionMenuHighlightPart
-                  : undefined
-              }
-              stepByStepTourActionMenuOpen={index === 0 ? stepByStepTourActionMenuOpen : undefined}
-              stepByStepTourCardTarget={index === 0 ? stepByStepTourCardTarget : undefined}
-            />
-          ))
+          <VirtualizedCardGrid
+            className={cn('content-start', DATASET_LIST_GRID_COLUMNS_CLASS_NAME)}
+            getItemKey={(dataset) => dataset.id}
+            items={datasets}
+            renderItem={(dataset, index) => (
+              <DatasetCard
+                key={dataset.id}
+                dataset={dataset}
+                onSuccess={invalidDatasetList}
+                onOpenTagManagement={onOpenTagManagement}
+                stepByStepTourActionMenuHighlightPart={
+                  index === 0 && stepByStepTourActionMenuOpen
+                    ? stepByStepTourActionMenuHighlightPart
+                    : undefined
+                }
+                stepByStepTourActionMenuOpen={
+                  index === 0 ? stepByStepTourActionMenuOpen : undefined
+                }
+                stepByStepTourCardTarget={index === 0 ? stepByStepTourCardTarget : undefined}
+              />
+            )}
+            rowHeight={DATASET_CARD_HEIGHT}
+            scrollContainerRef={scrollContainerRef}
+          />
         )}
         {!showDatasetSkeleton && !hasAnyDataset && emptyElement}
         {isFetchingNextPage && <Loading />}

--- a/web/app/components/datasets/list/index.tsx
+++ b/web/app/components/datasets/list/index.tsx
@@ -7,7 +7,7 @@ import { useBoolean } from 'ahooks'
 import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   activeStepByStepTourGuideGroupAtom,
@@ -49,6 +49,7 @@ function LegacyList({
   const { t } = useTranslation()
   const { push } = useRouter()
   const isCurrentWorkspaceOwner = useAtomValue(isCurrentWorkspaceOwnerAtom)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [showTagManagementModal, setShowTagManagementModal] = useState(false)
   const [showExternalApiPanel, setShowExternalApiPanel] = useState(false)
   const [includeAll, { toggle: toggleIncludeAll }] = useBoolean(false)
@@ -123,7 +124,10 @@ function LegacyList({
   ])
 
   return (
-    <div className="relative flex grow flex-col overflow-y-auto bg-background-body">
+    <div
+      ref={scrollContainerRef}
+      className="relative flex grow flex-col overflow-y-auto bg-background-body"
+    >
       <DatasetListHeader
         apiBaseUrl={apiBaseInfo?.api_base_url ?? ''}
         canConnectExternalDataset={canConnectExternalDataset}
@@ -157,6 +161,7 @@ function LegacyList({
       ) : (
         <Datasets
           datasetList={datasetListQuery.data}
+          scrollContainerRef={scrollContainerRef}
           emptyElement={
             showFilteredEmptyState ? (
               <FilterEmptyState title={t(($) => $['filterEmpty.noKnowledge'], { ns: 'dataset' })} />

--- a/web/app/components/snippet-list/__tests__/index.spec.tsx
+++ b/web/app/components/snippet-list/__tests__/index.spec.tsx
@@ -15,6 +15,8 @@ const mockQueryState = vi.hoisted(() => ({
   creatorIDs: [] as string[],
 }))
 
+vi.mock('@tanstack/react-virtual')
+
 vi.mock('@/service/use-snippets', () => ({
   useCreateSnippetMutation: () => ({
     mutate: vi.fn(),

--- a/web/app/components/snippet-list/index.tsx
+++ b/web/app/components/snippet-list/index.tsx
@@ -8,6 +8,7 @@ import { useAtomValue } from 'jotai'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SearchInput } from '@/app/components/base/search-input'
+import { VirtualizedCardGrid } from '@/app/components/base/virtualized-card-grid'
 import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { currentWorkspaceLoadingAtom } from '@/context/workspace-state'
 import { TagFilter } from '@/features/tag-management/components/tag-filter'
@@ -34,6 +35,10 @@ const TagManagementModal = dynamic(
     ssr: false,
   },
 )
+
+const SNIPPET_GRID_COLUMNS_CLASS_NAME = 'grid grid-cols-[repeat(auto-fill,minmax(296px,1fr))] gap-4'
+/** Mirrors the `h-40` height SnippetCard renders at. */
+const SNIPPET_CARD_HEIGHT = 160
 
 const SNIPPET_CARD_SKELETON_KEYS = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']
 
@@ -194,28 +199,38 @@ const SnippetList = () => {
           <SnippetCreateButton />
         </div>
       </StudioListHeader>
-      <div
-        className={cn(
-          'relative grid grow grid-cols-[repeat(auto-fill,minmax(296px,1fr))] content-start gap-4 px-8 pt-2',
-          !hasAnySnippet && 'overflow-hidden',
-        )}
-      >
+      <div className={cn('relative grow px-8 pt-2', !hasAnySnippet && 'overflow-hidden')}>
         {showSkeleton ? (
-          <SnippetCardSkeleton count={6} />
+          <div className={SNIPPET_GRID_COLUMNS_CLASS_NAME}>
+            <SnippetCardSkeleton count={6} />
+          </div>
         ) : hasAnySnippet ? (
-          snippets.map((snippet) => (
-            <SnippetCard
-              key={snippet.id}
-              snippet={snippet}
-              onOpenTagManagement={() => setShowTagManagementModal(true)}
-              onRefresh={refetch}
-              onTagsChange={refetch}
-            />
-          ))
+          <VirtualizedCardGrid
+            className={cn('content-start', SNIPPET_GRID_COLUMNS_CLASS_NAME)}
+            getItemKey={(snippet) => snippet.id}
+            items={snippets}
+            renderItem={(snippet) => (
+              <SnippetCard
+                key={snippet.id}
+                snippet={snippet}
+                onOpenTagManagement={() => setShowTagManagementModal(true)}
+                onRefresh={refetch}
+                onTagsChange={refetch}
+              />
+            )}
+            rowHeight={SNIPPET_CARD_HEIGHT}
+            scrollContainerRef={containerRef}
+          />
         ) : (
-          <Empty message={t(($) => $['tabs.noSnippetsFound'], { ns: 'workflow' })} />
+          <div className={SNIPPET_GRID_COLUMNS_CLASS_NAME}>
+            <Empty message={t(($) => $['tabs.noSnippetsFound'], { ns: 'workflow' })} />
+          </div>
         )}
-        {isFetchingNextPage && <SnippetCardSkeleton count={3} />}
+        {isFetchingNextPage && (
+          <div className={SNIPPET_GRID_COLUMNS_CLASS_NAME}>
+            <SnippetCardSkeleton count={3} />
+          </div>
+        )}
       </div>
       <div ref={anchorRef} className="h-0">
         {' '}

--- a/web/features/skills/__tests__/page.spec.tsx
+++ b/web/features/skills/__tests__/page.spec.tsx
@@ -45,6 +45,8 @@ const mocks = vi.hoisted(() => ({
   tagsQueryOptions: vi.fn((_options: unknown) => ({})),
 }))
 
+vi.mock('@tanstack/react-virtual')
+
 vi.mock('@langgenius/dify-ui/toast', () => ({
   toast: {
     error: vi.fn(),

--- a/web/features/skills/page.tsx
+++ b/web/features/skills/page.tsx
@@ -2,7 +2,7 @@
 
 import type { SkillResponse } from '@dify/contracts/api/console/workspaces/types.gen'
 import type { QueryClient } from '@tanstack/react-query'
-import type { UIEvent } from 'react'
+import type { RefObject, UIEvent } from 'react'
 import {
   AlertDialog,
   AlertDialogActions,
@@ -38,6 +38,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { SearchInput } from '@/app/components/base/search-input'
 import { SkeletonRectangle } from '@/app/components/base/skeleton'
+import { VirtualizedCardGrid } from '@/app/components/base/virtualized-card-grid'
 import { SkillCardTags } from '@/features/tag-management/components/skill-card-tags'
 import { TagFilter } from '@/features/tag-management/components/tag-filter'
 import useDocumentTitle from '@/hooks/use-document-title'
@@ -79,6 +80,10 @@ function SkillIcon() {
     </div>
   )
 }
+
+const SKILL_GRID_COLUMNS_CLASS_NAME = 'grid grid-cols-[repeat(auto-fill,minmax(296px,1fr))] gap-2.5'
+/** Mirrors the `h-42` height SkillCard renders at. */
+const SKILL_CARD_HEIGHT = 168
 
 function SkillCardSkeleton() {
   return (
@@ -694,6 +699,7 @@ function SkillGrid({
   onCreate,
   onImport,
   onOpenTagManagement,
+  scrollContainerRef,
   skills,
 }: {
   canDelete: boolean
@@ -708,6 +714,7 @@ function SkillGrid({
   onCreate: () => void
   onImport: () => void
   onOpenTagManagement: () => void
+  scrollContainerRef: RefObject<Element | null>
   skills: SkillResponse[]
 }) {
   const { t } = useTranslation('skill')
@@ -715,40 +722,59 @@ function SkillGrid({
   return (
     <section
       aria-label={t(($) => $['skillManagement.listLabel'])}
-      className="grid grid-cols-[repeat(auto-fill,minmax(296px,1fr))] gap-2.5"
+      className="relative"
       aria-busy={isFetching || undefined}
     >
-      {isPending && <SkillCardSkeleton />}
+      {isPending && (
+        <div className={SKILL_GRID_COLUMNS_CLASS_NAME}>
+          <SkillCardSkeleton />
+        </div>
+      )}
       {!isPending && isError && (
-        <SkillPlaceholderState title={t(($) => $['skillManagement.loadingError'])} />
+        <div className={SKILL_GRID_COLUMNS_CLASS_NAME}>
+          <SkillPlaceholderState title={t(($) => $['skillManagement.loadingError'])} />
+        </div>
       )}
       {!isPending && !isError && skills.length === 0 && (
-        <SkillPlaceholderState
-          canEdit={canEdit}
-          creating={creating}
-          importing={importing}
-          isEmptySearch={isEmptySearch}
-          onCreate={onCreate}
-          onImport={onImport}
-          title={
-            isEmptySearch
-              ? t(($) => $['skillManagement.emptySearch'])
-              : t(($) => $['skillManagement.empty'])
-          }
+        <div className={SKILL_GRID_COLUMNS_CLASS_NAME}>
+          <SkillPlaceholderState
+            canEdit={canEdit}
+            creating={creating}
+            importing={importing}
+            isEmptySearch={isEmptySearch}
+            onCreate={onCreate}
+            onImport={onImport}
+            title={
+              isEmptySearch
+                ? t(($) => $['skillManagement.emptySearch'])
+                : t(($) => $['skillManagement.empty'])
+            }
+          />
+        </div>
+      )}
+      {!isPending && !isError && skills.length > 0 && (
+        <VirtualizedCardGrid
+          className={SKILL_GRID_COLUMNS_CLASS_NAME}
+          getItemKey={(skill) => skill.id}
+          items={skills}
+          renderItem={(skill) => (
+            <SkillCard
+              key={skill.id}
+              canDelete={canDelete}
+              canEdit={canEdit}
+              skill={skill}
+              onOpenTagManagement={onOpenTagManagement}
+            />
+          )}
+          rowHeight={SKILL_CARD_HEIGHT}
+          scrollContainerRef={scrollContainerRef}
         />
       )}
-      {!isPending &&
-        !isError &&
-        skills.map((skill) => (
-          <SkillCard
-            key={skill.id}
-            canDelete={canDelete}
-            canEdit={canEdit}
-            skill={skill}
-            onOpenTagManagement={onOpenTagManagement}
-          />
-        ))}
-      {!isPending && !isError && isFetchingNextPage && <SkillCardSkeleton />}
+      {!isPending && !isError && isFetchingNextPage && (
+        <div className={SKILL_GRID_COLUMNS_CLASS_NAME}>
+          <SkillCardSkeleton />
+        </div>
+      )}
     </section>
   )
 }
@@ -913,6 +939,7 @@ export default function SkillsPage() {
           >
             <ScrollAreaContent className="min-h-full px-8 pt-2 pb-8">
               <SkillGrid
+                scrollContainerRef={listViewportRef}
                 canDelete={canDelete}
                 canEdit={canEdit}
                 creating={createMutation.isPending}


### PR DESCRIPTION
Fixes #41405

## Summary

Studio, Knowledge, Skills and Snippets each render the same shape of list: a responsive `auto-fill` grid of fixed-height cards inside a scroll container, fed by a paginated query that accumulates pages. Each one builds that by hand, so each has to solve column measurement and row positioning again, and none of them stops mounting cards as the list grows.

That last part is what users feel. React Query caches the whole infinite query, so returning to a list re-mounts every accumulated page in a single commit rather than the page-sized batches scrolling adds. On a workspace with 432 apps and 169 datasets, a Safari timeline of clicking through the top-level menus spends 35% of its time compositing and renders about 7.5fps, while all script categories together account for ~830ms of 3.06s and navigation RSC payloads are 340 B – 3.2 KB. Frame pacing tracks item count rather than fetching strategy: Studio (432) and Knowledge (169) stutter, Agents (8) and Skills (4) do not, even though Skills uses the same accumulating infinite query. Full numbers are in the issue.

Related: #41396 is the same class of problem in the Web Apps sidebar, fixed in #41397. That one stays mounted across route changes so its cost is repaint; these page-level grids are re-mounted from scratch, so React reconstructs all N cards in a single commit before anything is painted.

This adds one owner for the behaviour and moves all four lists onto it.

**`app/components/base/virtualized-card-grid`** sits next to `infinite-scroll-sentinel`, the existing shared list utility with the same reach. It owns column measurement, row chunking, virtualizer integration and row positioning — real behaviour rather than a rename-only wrapper.

The column count and row gap are read back from the resolved grid styles rather than taken as props, so callers keep owning their track sizing in CSS and the two cannot drift apart. Card height stays a prop because it belongs to the card, not the grid.

**Only the mechanism is shared, not the values.** Each list keeps its own track sizing and card height:

| List | Track min-width | Gap | Card height |
| --- | --- | --- | --- |
| Studio | 288px | 10px | 166px |
| Knowledge | 296px | 12px | 166px |
| Skills | 296px | 10px | 168px |
| Snippets | 296px | 16px | 160px |

Surrounding padding stays on the existing container and the track classes move onto the virtualized rows, so skeletons, empty states and load-more anchors keep rendering in the grid they did before. Knowledge gains one pass-through prop: `list/index.tsx` now puts a ref on the `overflow-y-auto` container it already had, and hands it to `Datasets`.

Two menus a reviewer will reasonably ask about:

**Integrations** does not qualify. `tool-provider-grid.tsx` renders a one-shot `collections.map(...)` with no paginated query, and the set is bounded — 36 entries in the workspace this was measured on, counting built-in, API and workflow providers.

**Marketplace** does qualify on the data side — `useInfiniteQuery` accumulating pages, same as the four here — but it is left out on purpose. Its cards have no fixed height: the root carries no height class, `CardWrapper` renders two different `Card` variants with different footers depending on install state, and height also varies with `compact`, `descriptionLineRows` and `limitedInstall`. This component takes `rowHeight` as an exact value, so feeding it a guessed constant would mis-position rows rather than merely estimate them. Bringing Marketplace in needs dynamic row measurement first, which changes this component's contract and belongs in its own PR.

Neither of those uses `auto-fill` — Marketplace is `grid-cols-4`, Integrations is breakpoint-based — but that is not why they are excluded. The component reads the resolved `grid-template-columns` rather than deriving columns from container width, so fixed and breakpoint column counts already work as-is.

The eleven other `auto-fill` card grids in the tree are deliberately untouched. They are bounded — template pickers, the ≤100 starred row, home sections — or they are skeletons and decorative placeholder grids rather than lists, so virtualizing them would be churn without a benefit. They keep sharing the grid classes, and adopting the component later is a few lines if any of them starts growing.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A | N/A |

This change is visually identical — it only affects how many cards are mounted and painted. I have not attached a capture of the reporting workspace because the lists show internal application names. The measurements above and in the issue stand in for a visual diff.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

Notes on the checklist: this is a frontend-only change, so the backend commands do not apply. The new component has its own spec, and the Studio list gained a case asserting cards render through the virtualized grid. Specs that mount these lists need `vi.mock('@tanstack/react-virtual')` — matching the four existing specs that already do this — because the real virtualizer measures a zero-height scroll element under happy-dom and renders no rows. One Knowledge spec asserted the grid classes sat on the `<nav>`; it now asserts the padding stays on the `<nav>` and the tracks moved onto the virtualized grid. The five migrated areas are green at 34 files / 539 tests, and the full unit run matches `main` exactly: the same four spec files fail there before and after this change (for example `features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx`), with the pass count moving 23372 → 23377 for the added cases.

From Claude Code

