### PR TITLE
fix(api): align dataset service API visibility

### DIFF
--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -440,6 +440,7 @@ class DatasetListApi(DatasetApiResource):
             query.keyword,
             query.tag_ids,
             query.include_all,
+            visibility_scope="workspace",
         )
         # check embedding setting
         assert isinstance(current_user, Account)

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -257,17 +257,23 @@ class DatasetService:
         include_all=False,
         accessible_dataset_ids: list[str] | None = None,
         include_own_datasets: bool = False,
+        visibility_scope: Literal["account", "workspace"] = "account",
     ):
-        """Return visible datasets for a tenant, using the injected session for auxiliary permission lookups."""
+        """Return datasets for a tenant under either account or workspace visibility.
+
+        Workspace-scoped callers, such as the Dataset Service API, are authorized by
+        the tenant rather than an individual account. They therefore skip account and
+        RBAC resource filters while retaining the tenant boundary.
+        """
         query = select(Dataset).where(Dataset.tenant_id == tenant_id).order_by(Dataset.created_at.desc(), Dataset.id)
 
-        if dify_config.RBAC_ENABLED and accessible_dataset_ids is not None:
+        if visibility_scope == "account" and dify_config.RBAC_ENABLED and accessible_dataset_ids is not None:
             accessible_filter: ColumnElement[bool] = Dataset.id.in_(accessible_dataset_ids)
             if include_own_datasets and user:
                 accessible_filter = sa.or_(Dataset.maintainer == user.id, accessible_filter)
             query = query.where(accessible_filter)
 
-        if user:
+        if visibility_scope == "account" and user:
             # get permitted dataset ids
             dataset_permission = session.scalars(
                 select(DatasetPermission).where(
@@ -322,7 +328,7 @@ class DatasetService:
                                     ),
                                 )
                             )
-        else:
+        elif visibility_scope == "account":
             if dify_config.RBAC_ENABLED:
                 # Without an account we cannot resolve RBAC resource visibility.
                 query = query.where(sa.false())

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
@@ -243,6 +243,7 @@ class TestDatasetListApiGet:
                 mock_dataset_svc.get_datasets.call_args.args
             )
             assert user is account
+            assert mock_dataset_svc.get_datasets.call_args.kwargs == {"visibility_scope": "workspace"}
 
         assert status == 200
         assert response["total"] == 1

--- a/api/tests/unit_tests/services/test_dataset_service_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_dataset.py
@@ -316,6 +316,38 @@ class TestDatasetServiceRetrieval:
         assert total == 1
         assert [dataset.id for dataset in datasets] == [shared.id]
 
+    def test_get_datasets_workspace_scope_returns_all_tenant_rows(self, sqlite_session: Session) -> None:
+        user = _account(role=TenantAccountRole.NORMAL)
+        shared = _dataset(dataset_id="shared", name="Shared", permission=DatasetPermissionEnum.ALL_TEAM)
+        private = _dataset(
+            dataset_id="private",
+            name="Private",
+            maintainer="other",
+            permission=DatasetPermissionEnum.ONLY_ME,
+        )
+        partial = _dataset(
+            dataset_id="partial",
+            name="Partial",
+            maintainer="other",
+            permission=DatasetPermissionEnum.PARTIAL_TEAM,
+        )
+        foreign = _dataset(dataset_id="foreign", tenant_id="tenant-2", name="Foreign")
+        sqlite_session.add_all([shared, private, partial, foreign])
+        sqlite_session.commit()
+
+        with patch("services.dataset_service.dify_config.RBAC_ENABLED", False):
+            datasets, total = DatasetService.get_datasets(
+                page=1,
+                per_page=20,
+                session=sqlite_session,
+                tenant_id="tenant-1",
+                user=user,
+                visibility_scope="workspace",
+            )
+
+        assert total == 3
+        assert {dataset.id for dataset in datasets} == {shared.id, private.id, partial.id}
+
     def test_get_datasets_by_ids_intersects_requested_and_accessible_ids(self, sqlite_session: Session) -> None:
         user = _account(role=TenantAccountRole.NORMAL)
         accessible = _dataset(dataset_id="accessible", name="Accessible", maintainer="other")


### PR DESCRIPTION
## Summary

- Treat Dataset Service API list requests as workspace-scoped, matching the existing direct dataset endpoints.
- Preserve account-scoped visibility behavior for console and other callers.
- Add regression coverage for private and partial-team datasets while retaining tenant isolation.

Fixes #41316

## Testing

- `pytest api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py api/tests/unit_tests/services/test_dataset_service_dataset.py -q` (83 passed)
- Targeted Ruff lint and format checks passed