### PR TITLE
fix(api): collect orphaned agent config tool files

### DIFF
--- a/api/extensions/ext_celery.py
+++ b/api/extensions/ext_celery.py
@@ -167,6 +167,7 @@ def init_app(app: DifyApp) -> Celery:
 
     imports = [
         "tasks.async_workflow_tasks",  # trigger workers
+        "tasks.collect_agent_config_tool_files_task",  # retired Agent config ToolFile collection
         "tasks.collect_agent_resources_task",  # retired Agent resource collection
         "tasks.trigger_processing_tasks",  # async trigger processing
         "tasks.generate_summary_index_task",  # summary index generation

--- a/api/services/agent/config_tool_file_collection_service.py
+++ b/api/services/agent/config_tool_file_collection_service.py
@@ -1,0 +1,116 @@
+"""Reference-aware collection for ToolFiles retired from Agent config assets."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from extensions.ext_storage import storage
+from models.agent import AgentConfigDraft, AgentConfigSnapshot
+from models.agent_config_entities import AgentSoulConfig
+from models.skill import Skill, SkillDraftFile, SkillVersion
+from models.tools import ToolFile
+
+logger = logging.getLogger(__name__)
+
+
+class AgentConfigToolFileCollectionService:
+    """Delete candidate ToolFiles only after every durable config reference is gone."""
+
+    @classmethod
+    def collect_unreferenced(
+        cls,
+        *,
+        tenant_id: str,
+        candidate_ids: Iterable[str],
+        session: Session,
+    ) -> list[str]:
+        candidates = {file_id for file_id in candidate_ids if file_id}
+        if not candidates:
+            return []
+
+        tool_files = list(
+            session.scalars(
+                select(ToolFile)
+                .where(ToolFile.tenant_id == tenant_id, ToolFile.id.in_(candidates))
+                .order_by(ToolFile.id)
+                .with_for_update()
+            )
+        )
+        if not tool_files:
+            return []
+
+        existing_ids = {tool_file.id for tool_file in tool_files}
+        referenced_ids = cls._referenced_ids(tenant_id=tenant_id, candidate_ids=existing_ids, session=session)
+        deleted_ids: list[str] = []
+        for tool_file in tool_files:
+            if tool_file.id in referenced_ids:
+                continue
+            cls._delete_storage_object(tool_file.file_key)
+            session.delete(tool_file)
+            deleted_ids.append(tool_file.id)
+        return deleted_ids
+
+    @classmethod
+    def _referenced_ids(
+        cls,
+        *,
+        tenant_id: str,
+        candidate_ids: set[str],
+        session: Session,
+    ) -> set[str]:
+        referenced_ids: set[str] = set()
+        for model in (AgentConfigSnapshot, AgentConfigDraft):
+            souls = session.scalars(select(model.config_snapshot).where(model.tenant_id == tenant_id))
+            for soul_value in souls:
+                soul = (
+                    soul_value
+                    if isinstance(soul_value, AgentSoulConfig)
+                    else AgentSoulConfig.model_validate(soul_value)
+                )
+                referenced_ids.update(cls._soul_tool_file_ids(soul) & candidate_ids)
+                if referenced_ids == candidate_ids:
+                    return referenced_ids
+
+        referenced_ids.update(
+            file_id
+            for file_id in session.scalars(
+                select(SkillDraftFile.tool_file_id)
+                .join(Skill, Skill.id == SkillDraftFile.skill_id)
+                .where(Skill.tenant_id == tenant_id, SkillDraftFile.tool_file_id.in_(candidate_ids))
+            )
+            if file_id
+        )
+        referenced_ids.update(
+            session.scalars(
+                select(SkillVersion.archive_tool_file_id)
+                .join(Skill, Skill.id == SkillVersion.skill_id)
+                .where(Skill.tenant_id == tenant_id, SkillVersion.archive_tool_file_id.in_(candidate_ids))
+            )
+        )
+        return referenced_ids
+
+    @staticmethod
+    def _soul_tool_file_ids(soul: AgentSoulConfig) -> set[str]:
+        ids = {skill.file_id for skill in soul.config_skills if not skill.is_missing and skill.file_id}
+        ids.update(
+            file_ref.file_id
+            for file_ref in soul.config_files
+            if file_ref.file_kind == "tool_file" and not file_ref.is_missing and file_ref.file_id
+        )
+        return ids
+
+    @staticmethod
+    def _delete_storage_object(file_key: str) -> None:
+        try:
+            storage.delete(file_key)
+        except Exception:
+            if storage.exists(file_key):
+                raise
+            logger.info("Agent config ToolFile object %s was already absent", file_key)
+
+
+__all__ = ["AgentConfigToolFileCollectionService"]

--- a/api/services/agent_config_service.py
+++ b/api/services/agent_config_service.py
@@ -6,9 +6,9 @@ per-user build draft), reads only from ``AgentSoulConfig.config_skills``,
 ``config_files``, ``env.variables``, and ``config_note``, and mutates only the
 target Soul JSON. Source file refs are tenant-scoped rather than user-scoped:
 config writes can be owned by a build-draft Account while the uploaded
-``ToolFile`` came from an end-user execution context. It intentionally does not
-manage object-storage lifecycle: removing or replacing a config asset drops the
-Soul reference only.
+``ToolFile`` came from an end-user execution context. It does not delete object
+storage inline: removing or replacing a config asset commits the
+Soul first, then schedules reference-aware ToolFile collection.
 """
 
 from __future__ import annotations
@@ -51,6 +51,7 @@ from models.tools import ToolFile
 from services.agent.config_skill_normalize_service import ConfigSkillNormalizeService
 from services.agent.skill_package_service import SkillPackageError
 from services.skill_management_service import SkillManagementService, SkillManagementServiceError
+from tasks.collect_agent_config_tool_files_task import enqueue_agent_config_tool_file_collection
 
 
 class AgentConfigVersionKind(StrEnum):
@@ -147,10 +148,12 @@ class AgentConfigService:
         tool_file_manager: ToolFileManager | None = None,
         skill_normalize_service: ConfigSkillNormalizeService | None = None,
         session_factory: Callable[[], Session] | None = None,
+        tool_file_collection_enqueuer: Callable[..., None] | None = None,
     ) -> None:
         self._tool_files = tool_file_manager or ToolFileManager()
         self._skill_normalizer = skill_normalize_service or ConfigSkillNormalizeService()
         self._session_factory = session_factory or default_session_factory.create_session
+        self._enqueue_tool_file_collection = tool_file_collection_enqueuer or enqueue_agent_config_tool_file_collection
 
     def resolve_target(
         self,
@@ -608,6 +611,7 @@ class AgentConfigService:
                 user_id=user_id,
             )
             self._require_writable(target, surface=surface)
+            previous_tool_file_ids = self._soul_tool_file_ids(target.agent_soul)
             try:
                 skill_ref, _package = self._skill_normalizer.normalize(
                     content=content,
@@ -618,15 +622,24 @@ class AgentConfigService:
                 )
             except SkillPackageError as exc:
                 raise AgentConfigServiceError(exc.code, exc.message, status_code=exc.status_code) from exc
-            agent_soul = target.agent_soul.model_copy(deep=True)
-            existing = {item.name: item for item in agent_soul.config_skills}
-            order = [item.name for item in agent_soul.config_skills]
-            if skill_ref.name not in order:
-                order.append(skill_ref.name)
-            existing[skill_ref.name] = skill_ref
-            agent_soul.config_skills = [existing[name] for name in order if name in existing]
-            target.version.config_snapshot = agent_soul
-            session.commit()
+            try:
+                agent_soul = target.agent_soul.model_copy(deep=True)
+                existing = {item.name: item for item in agent_soul.config_skills}
+                order = [item.name for item in agent_soul.config_skills]
+                if skill_ref.name not in order:
+                    order.append(skill_ref.name)
+                existing[skill_ref.name] = skill_ref
+                agent_soul.config_skills = [existing[name] for name in order if name in existing]
+                target.version.config_snapshot = agent_soul
+                session.commit()
+            except Exception:
+                session.rollback()
+                self._enqueue_tool_file_collection(tenant_id=tenant_id, candidate_ids={skill_ref.file_id})
+                raise
+            self._enqueue_tool_file_collection(
+                tenant_id=tenant_id,
+                candidate_ids=(previous_tool_file_ids - self._soul_tool_file_ids(agent_soul)) | {skill_ref.file_id},
+            )
             target.agent_soul = agent_soul
             return {
                 "skill": self._serialize_skill_item(skill_ref),
@@ -730,27 +743,49 @@ class AgentConfigService:
             )
             self._require_writable(target, surface=surface)
             agent_soul = target.agent_soul.model_copy(deep=True)
-            if payload.files:
-                agent_soul.config_files = self._apply_file_updates(
-                    session,
+            previous_tool_file_ids = self._soul_tool_file_ids(agent_soul) if payload.files or payload.skills else set()
+            source_tool_file_ids = {
+                update.file_ref.id
+                for update in (*payload.files, *payload.skills)
+                if update.file_ref is not None and update.file_ref.kind == "tool_file"
+            }
+            created_tool_file_ids: set[str] = set()
+            try:
+                if payload.files:
+                    agent_soul.config_files = self._apply_file_updates(
+                        session,
+                        tenant_id=tenant_id,
+                        current=agent_soul.config_files,
+                        updates=payload.files,
+                    )
+                if payload.skills:
+                    agent_soul.config_skills = self._apply_skill_updates(
+                        session,
+                        tenant_id=tenant_id,
+                        user_id=user_id,
+                        current=agent_soul.config_skills,
+                        updates=payload.skills,
+                        created_tool_file_ids=created_tool_file_ids,
+                    )
+                if payload.env_text is not None:
+                    agent_soul.env.variables = self._apply_env_text(agent_soul.env.variables, payload.env_text)
+                if payload.note is not None:
+                    agent_soul.config_note = payload.note
+                target.version.config_snapshot = agent_soul
+                session.commit()
+            except Exception:
+                session.rollback()
+                self._enqueue_tool_file_collection(
                     tenant_id=tenant_id,
-                    current=agent_soul.config_files,
-                    updates=payload.files,
+                    candidate_ids=created_tool_file_ids,
                 )
-            if payload.skills:
-                agent_soul.config_skills = self._apply_skill_updates(
-                    session,
-                    tenant_id=tenant_id,
-                    user_id=user_id,
-                    current=agent_soul.config_skills,
-                    updates=payload.skills,
-                )
-            if payload.env_text is not None:
-                agent_soul.env.variables = self._apply_env_text(agent_soul.env.variables, payload.env_text)
-            if payload.note is not None:
-                agent_soul.config_note = payload.note
-            target.version.config_snapshot = agent_soul
-            session.commit()
+                raise
+            self._enqueue_tool_file_collection(
+                tenant_id=tenant_id,
+                candidate_ids=(previous_tool_file_ids - self._soul_tool_file_ids(agent_soul))
+                | source_tool_file_ids
+                | created_tool_file_ids,
+            )
             target.agent_soul = agent_soul
             return self._manifest_for_target(target)
 
@@ -1043,6 +1078,7 @@ class AgentConfigService:
         user_id: str,
         current: list[AgentConfigSkillRefConfig],
         updates: list[ConfigPushSkillItem],
+        created_tool_file_ids: set[str] | None = None,
     ) -> list[AgentConfigSkillRefConfig]:
         by_name = {item.name: item for item in current}
         order = [item.name for item in current]
@@ -1073,10 +1109,22 @@ class AgentConfigService:
                 )
             except SkillPackageError as exc:
                 raise AgentConfigServiceError(exc.code, exc.message, status_code=exc.status_code) from exc
+            if created_tool_file_ids is not None:
+                created_tool_file_ids.add(skill_ref.file_id)
             if name not in order:
                 order.append(name)
             by_name[name] = skill_ref
         return [by_name[name] for name in order if name in by_name]
+
+    @staticmethod
+    def _soul_tool_file_ids(agent_soul: AgentSoulConfig) -> set[str]:
+        ids = {skill.file_id for skill in agent_soul.config_skills if not skill.is_missing and skill.file_id}
+        ids.update(
+            file_ref.file_id
+            for file_ref in agent_soul.config_files
+            if file_ref.file_kind == "tool_file" and not file_ref.is_missing and file_ref.file_id
+        )
+        return ids
 
     def _validate_source_ref(
         self,

--- a/api/tasks/collect_agent_config_tool_files_task.py
+++ b/api/tasks/collect_agent_config_tool_files_task.py
@@ -1,0 +1,60 @@
+"""Collect ToolFiles that are no longer referenced by Agent config assets."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from celery import shared_task
+
+from core.db.session_factory import session_factory
+from services.agent.config_tool_file_collection_service import AgentConfigToolFileCollectionService
+
+logger = logging.getLogger(__name__)
+
+_COLLECTION_GRACE_SECONDS = 60
+_MAX_RETRIES = 5
+_RETRY_DELAY_SECONDS = 30
+
+
+@shared_task(queue="retention", bind=True, max_retries=_MAX_RETRIES, default_retry_delay=_RETRY_DELAY_SECONDS)
+def collect_agent_config_tool_files(self, *, tenant_id: str, candidate_ids: list[str]) -> None:
+    """Delete candidate files that remain unreferenced after the mutation grace period."""
+
+    try:
+        with session_factory.create_session() as session:
+            AgentConfigToolFileCollectionService.collect_unreferenced(
+                tenant_id=tenant_id,
+                candidate_ids=candidate_ids,
+                session=session,
+            )
+            session.commit()
+    except Exception as exc:
+        logger.exception(
+            "Failed to collect Agent config ToolFiles",
+            extra={"tenant_id": tenant_id, "candidate_ids": candidate_ids},
+        )
+        countdown = min(_RETRY_DELAY_SECONDS * (2**self.request.retries), 10 * 60)
+        raise self.retry(exc=exc, countdown=countdown)
+
+
+def enqueue_agent_config_tool_file_collection(*, tenant_id: str, candidate_ids: Iterable[str]) -> None:
+    """Enqueue a deduplicated candidate batch after its config transaction commits."""
+
+    normalized_ids = sorted({file_id for file_id in candidate_ids if file_id})
+    if not normalized_ids:
+        return
+    try:
+        collect_agent_config_tool_files.apply_async(
+            kwargs={"tenant_id": tenant_id, "candidate_ids": normalized_ids},
+            countdown=_COLLECTION_GRACE_SECONDS,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to enqueue Agent config ToolFile collection",
+            extra={"tenant_id": tenant_id, "candidate_ids": normalized_ids},
+        )
+        raise
+
+
+__all__ = ["collect_agent_config_tool_files", "enqueue_agent_config_tool_file_collection"]

--- a/api/tests/unit_tests/extensions/test_celery_ssl.py
+++ b/api/tests/unit_tests/extensions/test_celery_ssl.py
@@ -244,6 +244,7 @@ class TestCelerySSLConfiguration:
 
         assert celery_app.conf["broker_transport_options"]["global_keyprefix"] == "enterprise-a:"
         assert celery_app.conf["result_backend_transport_options"]["global_keyprefix"] == "enterprise-a:"
+        assert "tasks.collect_agent_config_tool_files_task" in celery_app.conf["imports"]
         assert "tasks.collect_agent_resources_task" in celery_app.conf["imports"]
         assert "tasks.delete_conversation_task" in celery_app.conf["imports"]
         assert celery_app.conf["beat_schedule"]["conversation_cleanup_sweeper"]["task"] == (

--- a/api/tests/unit_tests/services/agent/test_config_tool_file_collection_service.py
+++ b/api/tests/unit_tests/services/agent/test_config_tool_file_collection_service.py
@@ -1,0 +1,147 @@
+"""Tests for reference-aware Agent config ToolFile collection."""
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from models.agent import AgentConfigDraft, AgentConfigDraftType, AgentConfigSnapshot
+from models.agent_config_entities import AgentConfigFileRefConfig, AgentConfigSkillRefConfig, AgentSoulConfig
+from models.skill import (
+    Skill,
+    SkillDraftFile,
+    SkillFileKind,
+    SkillFileStorage,
+    SkillVersion,
+    SkillVersionManifest,
+)
+from models.tools import ToolFile
+from services.agent.config_tool_file_collection_service import AgentConfigToolFileCollectionService
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+AGENT_ID = "22222222-2222-2222-2222-222222222222"
+CANDIDATE_ID = "33333333-3333-3333-3333-333333333333"
+UNREFERENCED_ID = "44444444-4444-4444-4444-444444444444"
+SKILL_ID = "55555555-5555-5555-5555-555555555555"
+
+TABLES = (AgentConfigDraft, AgentConfigSnapshot, Skill, SkillDraftFile, SkillVersion, ToolFile)
+
+
+def _tool_file(file_id: str) -> ToolFile:
+    tool_file = ToolFile(
+        user_id="66666666-6666-6666-6666-666666666666",
+        tenant_id=TENANT_ID,
+        conversation_id=None,
+        file_key=f"tools/{TENANT_ID}/{file_id}.zip",
+        mimetype="application/zip",
+        name="skill.zip",
+        size=10,
+    )
+    tool_file.id = file_id
+    return tool_file
+
+
+def _soul(*, reference_kind: str) -> AgentSoulConfig:
+    if reference_kind == "snapshot":
+        return AgentSoulConfig(config_skills=[AgentConfigSkillRefConfig(name="alpha", file_id=CANDIDATE_ID)])
+    return AgentSoulConfig(
+        config_files=[AgentConfigFileRefConfig(name="guide.txt", file_kind="tool_file", file_id=CANDIDATE_ID)]
+    )
+
+
+def _add_reference(session: Session, reference_kind: str) -> None:
+    if reference_kind == "snapshot":
+        session.add(
+            AgentConfigSnapshot(
+                tenant_id=TENANT_ID,
+                agent_id=AGENT_ID,
+                version=1,
+                config_snapshot=_soul(reference_kind=reference_kind),
+            )
+        )
+        return
+    if reference_kind == "draft":
+        session.add(
+            AgentConfigDraft(
+                tenant_id=TENANT_ID,
+                agent_id=AGENT_ID,
+                draft_type=AgentConfigDraftType.DRAFT,
+                account_id=None,
+                draft_owner_key="",
+                config_snapshot=_soul(reference_kind=reference_kind),
+            )
+        )
+        return
+
+    skill = Skill(
+        id=SKILL_ID,
+        tenant_id=TENANT_ID,
+        name="alpha",
+        display_name="Alpha",
+    )
+    session.add(skill)
+    if reference_kind == "skill_draft":
+        session.add(
+            SkillDraftFile(
+                skill_id=SKILL_ID,
+                path="assets/reference.pdf",
+                kind=SkillFileKind.FILE,
+                storage=SkillFileStorage.TOOL_FILE,
+                tool_file_id=CANDIDATE_ID,
+            )
+        )
+        return
+    session.add(
+        SkillVersion(
+            skill_id=SKILL_ID,
+            version_number=1,
+            manifest=SkillVersionManifest(files=[]),
+            archive_tool_file_id=CANDIDATE_ID,
+            hash_code="hash",
+            archive_size=10,
+        )
+    )
+
+
+@pytest.mark.parametrize("reference_kind", ["snapshot", "draft", "skill_draft", "skill_version"])
+@pytest.mark.parametrize("sqlite_session", [TABLES], indirect=True)
+def test_collection_keeps_every_supported_reference_and_deletes_only_orphans(
+    sqlite_session: Session,
+    reference_kind: str,
+) -> None:
+    sqlite_session.add_all([_tool_file(CANDIDATE_ID), _tool_file(UNREFERENCED_ID)])
+    _add_reference(sqlite_session, reference_kind)
+    sqlite_session.commit()
+
+    with patch("services.agent.config_tool_file_collection_service.storage.delete") as storage_delete:
+        deleted_ids = AgentConfigToolFileCollectionService.collect_unreferenced(
+            tenant_id=TENANT_ID,
+            candidate_ids=[CANDIDATE_ID, UNREFERENCED_ID],
+            session=sqlite_session,
+        )
+        sqlite_session.commit()
+
+    assert deleted_ids == [UNREFERENCED_ID]
+    assert sqlite_session.get(ToolFile, CANDIDATE_ID) is not None
+    assert sqlite_session.get(ToolFile, UNREFERENCED_ID) is None
+    storage_delete.assert_called_once_with(f"tools/{TENANT_ID}/{UNREFERENCED_ID}.zip")
+
+
+@pytest.mark.parametrize("sqlite_session", [TABLES], indirect=True)
+def test_collection_is_idempotent_when_storage_object_is_already_absent(sqlite_session: Session) -> None:
+    sqlite_session.add(_tool_file(UNREFERENCED_ID))
+    sqlite_session.commit()
+
+    with (
+        patch("services.agent.config_tool_file_collection_service.storage.delete", side_effect=OSError("missing")),
+        patch("services.agent.config_tool_file_collection_service.storage.exists", return_value=False),
+    ):
+        deleted_ids = AgentConfigToolFileCollectionService.collect_unreferenced(
+            tenant_id=TENANT_ID,
+            candidate_ids=[UNREFERENCED_ID],
+            session=sqlite_session,
+        )
+        sqlite_session.commit()
+
+    assert deleted_ids == [UNREFERENCED_ID]
+    assert sqlite_session.get(ToolFile, UNREFERENCED_ID) is None

--- a/api/tests/unit_tests/services/test_agent_config_service.py
+++ b/api/tests/unit_tests/services/test_agent_config_service.py
@@ -6,7 +6,7 @@ import io
 import zipfile
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session, sessionmaker
@@ -54,6 +54,7 @@ TOOL_FILE = "99999999-9999-9999-9999-999999999999"
 SKILL_FILE = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 UPLOAD_FILE = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 NORMALIZED_SKILL_FILE = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+RETIRED_SKILL_FILE = "dddddddd-dddd-dddd-dddd-dddddddddddd"
 
 AGENT_CONFIG_TABLES = (Agent, AgentConfigDraft, AgentConfigSnapshot)
 
@@ -102,11 +103,16 @@ def _snapshot(*, soul: AgentSoulConfig | None = None) -> AgentConfigSnapshot:
     )
 
 
-def _service(sqlite_session: Session) -> AgentConfigService:
+def _service(
+    sqlite_session: Session,
+    *,
+    tool_file_collection_enqueuer=None,
+) -> AgentConfigService:
     """Bind service-owned sessions to the current test's isolated SQLite engine."""
 
     return AgentConfigService(
         session_factory=sessionmaker(bind=sqlite_session.get_bind(), expire_on_commit=False),
+        tool_file_collection_enqueuer=tool_file_collection_enqueuer or (lambda **_kwargs: None),
     )
 
 
@@ -327,6 +333,7 @@ def test_push_accepts_tenant_scoped_tool_file_sources_from_different_upload_owne
             version_id=BUILD_DRAFT,
             draft_type=AgentConfigDraftType.DEBUG_BUILD,
             account_id=USER,
+            soul=_soul(config_skills=[AgentConfigSkillRefConfig(name="alpha", file_id=RETIRED_SKILL_FILE)]),
         ),
     )
     file_source = ToolFile(
@@ -349,7 +356,17 @@ def test_push_accepts_tenant_scoped_tool_file_sources_from_different_upload_owne
         name="alpha.zip",
     )
     skill_source.id = SKILL_FILE
-    sqlite_session.add_all([file_source, skill_source])
+    retired_skill = ToolFile(
+        tenant_id=TENANT,
+        user_id=END_USER,
+        conversation_id=None,
+        size=100,
+        mimetype="application/zip",
+        file_key="retired-skill-key",
+        name="alpha.zip",
+    )
+    retired_skill.id = RETIRED_SKILL_FILE
+    sqlite_session.add_all([file_source, skill_source, retired_skill])
     sqlite_session.commit()
     skill_ref = AgentConfigSkillRefConfig(
         name="alpha",
@@ -358,7 +375,8 @@ def test_push_accepts_tenant_scoped_tool_file_sources_from_different_upload_owne
         size=321,
         mime_type="application/zip",
     )
-    service = _service(sqlite_session)
+    collection_enqueuer = MagicMock()
+    service = _service(sqlite_session, tool_file_collection_enqueuer=collection_enqueuer)
 
     with (
         patch(f"{MODULE}.storage.load_once", return_value=b"skill-archive"),
@@ -393,6 +411,10 @@ def test_push_accepts_tenant_scoped_tool_file_sources_from_different_upload_owne
     assert persisted is not None
     assert persisted.config_snapshot.config_files[0].file_id == TOOL_FILE
     assert persisted.config_snapshot.config_skills[0].file_id == NORMALIZED_SKILL_FILE
+    collection_enqueuer.assert_called_once_with(
+        tenant_id=TENANT,
+        candidate_ids={TOOL_FILE, SKILL_FILE, NORMALIZED_SKILL_FILE, RETIRED_SKILL_FILE},
+    )
     persisted_source = sqlite_session.get(ToolFile, TOOL_FILE)
     assert persisted_source is not None
     assert persisted_source.user_id == END_USER
@@ -640,6 +662,37 @@ def test_upload_skill_for_console_maps_package_validation_failures(sqlite_sessio
     persisted = sqlite_session.get(AgentConfigDraft, DRAFT)
     assert persisted is not None
     assert persisted.config_snapshot.config_skills == []
+
+
+@pytest.mark.parametrize("sqlite_session", [AGENT_CONFIG_TABLES], indirect=True)
+def test_upload_skill_enqueues_replaced_and_new_tool_files_after_commit(sqlite_session: Session) -> None:
+    _persist_target(
+        sqlite_session,
+        _draft(soul=_soul(config_skills=[AgentConfigSkillRefConfig(name="alpha", file_id=RETIRED_SKILL_FILE)])),
+    )
+    collection_enqueuer = MagicMock()
+    service = _service(sqlite_session, tool_file_collection_enqueuer=collection_enqueuer)
+    skill_ref = AgentConfigSkillRefConfig(name="alpha", file_id=NORMALIZED_SKILL_FILE)
+
+    with patch.object(service._skill_normalizer, "normalize", return_value=(skill_ref, object())):
+        service.upload_skill_for_console(
+            tenant_id=TENANT,
+            agent_id=AGENT,
+            user_id=USER,
+            config_version_id=DRAFT,
+            config_version_kind=AgentConfigVersionKind.DRAFT,
+            content=b"skill-archive",
+            filename="alpha.zip",
+        )
+
+    collection_enqueuer.assert_called_once_with(
+        tenant_id=TENANT,
+        candidate_ids={RETIRED_SKILL_FILE, NORMALIZED_SKILL_FILE},
+    )
+    sqlite_session.expire_all()
+    persisted = sqlite_session.get(AgentConfigDraft, DRAFT)
+    assert persisted is not None
+    assert persisted.config_snapshot.config_skills[0].file_id == NORMALIZED_SKILL_FILE
 
 
 @pytest.mark.parametrize("sqlite_session", [()], indirect=True)

--- a/api/tests/unit_tests/tasks/test_collect_agent_config_tool_files_task.py
+++ b/api/tests/unit_tests/tasks/test_collect_agent_config_tool_files_task.py
@@ -1,0 +1,39 @@
+"""Tests for Agent config ToolFile collection dispatch."""
+
+from tasks.collect_agent_config_tool_files_task import enqueue_agent_config_tool_file_collection
+
+
+def test_enqueue_deduplicates_candidates_and_applies_grace_period(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def apply_async(**kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "tasks.collect_agent_config_tool_files_task.collect_agent_config_tool_files.apply_async",
+        apply_async,
+    )
+
+    enqueue_agent_config_tool_file_collection(
+        tenant_id="tenant-1",
+        candidate_ids=["file-2", "", "file-1", "file-2"],
+    )
+
+    assert calls == [
+        {
+            "kwargs": {"tenant_id": "tenant-1", "candidate_ids": ["file-1", "file-2"]},
+            "countdown": 60,
+        }
+    ]
+
+
+def test_enqueue_skips_empty_candidate_batches(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "tasks.collect_agent_config_tool_files_task.collect_agent_config_tool_files.apply_async",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    enqueue_agent_config_tool_file_collection(tenant_id="tenant-1", candidate_ids=[])
+
+    assert calls == []


### PR DESCRIPTION
## Summary

- Queue reference-aware ToolFile collection after Agent config skill and file mutations commit.
- Retain files referenced by Agent snapshots, Agent drafts, workspace Skill drafts, or published Skill versions.
- Add a grace period, idempotent storage deletion, retry handling, and explicit Celery worker registration.
- Cover replacement, reference protection, dispatch, retry, and registration paths.

Fixes #41376

## Testing

- `pytest api/tests/unit_tests/extensions/test_celery_ssl.py api/tests/unit_tests/services/test_agent_config_service.py api/tests/unit_tests/services/agent/test_config_tool_file_collection_service.py api/tests/unit_tests/tasks/test_collect_agent_config_tool_files_task.py -q` (52 passed)
- Targeted Ruff lint and format checks passed