### PR TITLE
refactor(api): isolate trace dispatcher tenant state

### DIFF
--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -324,12 +324,22 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
                         if isinstance(event, QueueStopEvent):
                             self._save_message(
                                 session=session,
-                                trace_manager=trace_manager,
                                 preserve_existing_usage=True,
                             )
                         else:
-                            self._save_message(session=session, trace_manager=trace_manager)
+                            self._save_message(session=session)
                         session.commit()
+
+                    if trace_manager:
+                        trace_manager.add_trace_task(
+                            TraceTask(
+                                TraceTaskName.MESSAGE_TRACE,
+                                conversation_id=self._conversation_id,
+                                message_id=self._message_id,
+                                trace_session_id=self._application_generate_entity.extras.get("trace_session_id"),
+                            )
+                        )
+
                     message_end_resp = self._message_end_to_stream_response()
                     yield message_end_resp
                 case QueueRetrieverResourcesEvent():
@@ -426,7 +436,6 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
         self,
         *,
         session: Session,
-        trace_manager: TraceQueueManager | None = None,
         preserve_existing_usage: bool = False,
     ):
         """
@@ -482,16 +491,6 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
         if has_persisted_usage and "usage" in existing_metadata:
             metadata["usage"] = existing_metadata["usage"]
         message.message_metadata = json.dumps(metadata, ensure_ascii=False)
-
-        if trace_manager:
-            trace_manager.add_trace_task(
-                TraceTask(
-                    TraceTaskName.MESSAGE_TRACE,
-                    conversation_id=self._conversation_id,
-                    message_id=self._message_id,
-                    trace_session_id=self._application_generate_entity.extras.get("trace_session_id"),
-                )
-            )
 
         message_was_created.send(
             message,

--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -4,14 +4,14 @@ import logging
 import os
 import queue
 import threading
-import time
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, TypedDict, override
 from uuid import UUID, uuid4
 
 from cachetools import LRUCache
-from flask import current_app
+from flask import Flask, current_app
 from pydantic import TypeAdapter
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -772,7 +772,6 @@ class TraceTask:
         self.user_id = user_id
         self.timer = timer
         self.file_base_url = os.getenv("FILES_URL", "http://127.0.0.1:5001")
-        self.app_id = None
         self.trace_id = None
         self.kwargs = kwargs
         if user_id is not None and "user_id" not in self.kwargs:
@@ -1503,96 +1502,98 @@ class TraceTask:
             return {}
 
 
-trace_manager_timer: threading.Timer | None = None
-trace_manager_queue: queue.Queue = queue.Queue()
-trace_manager_interval = int(os.getenv("TRACE_QUEUE_MANAGER_INTERVAL", 5))
-trace_manager_batch_size = int(os.getenv("TRACE_QUEUE_MANAGER_BATCH_SIZE", 100))
+# ponytail: tracing stays process-local and bounded; add an outbox only if restart loss becomes unacceptable.
+_TRACE_QUEUE_MAX_SIZE = 2048
 
 
-class TraceQueueManager:
-    def __init__(self, app_id=None, user_id=None):
-        global trace_manager_timer
+@dataclass(frozen=True, slots=True)
+class _TraceWorkItem:
+    storage_id: str
+    task: TraceTask
 
-        self.app_id = app_id
-        self.user_id = user_id
-        self.trace_instance = OpsTraceManager.get_ops_trace_instance(app_id)
-        self.flask_app = current_app._get_current_object()  # type: ignore
 
-        from core.telemetry.gateway import is_enterprise_telemetry_enabled
+class _TraceDispatcher:
+    """Process-scoped, tenant-neutral dispatcher for best-effort trace work items."""
 
-        self._enterprise_telemetry_enabled = is_enterprise_telemetry_enabled()
-        if trace_manager_timer is None:
-            self.start_timer()
+    def __init__(
+        self,
+        flask_app: Flask,
+        *,
+        max_queue_size: int = _TRACE_QUEUE_MAX_SIZE,
+    ) -> None:
+        if max_queue_size < 1:
+            raise ValueError("max_queue_size must be positive")
 
-    def add_trace_task(self, trace_task: TraceTask):
-        global trace_manager_timer, trace_manager_queue
+        self._flask_app = flask_app
+        self._queue: queue.Queue[_TraceWorkItem] = queue.Queue(maxsize=max_queue_size)
+        self._start_lock = threading.Lock()
+        self._worker: threading.Thread | None = None
+        self._dropped_tasks = 0
+
+    def submit(self, item: _TraceWorkItem) -> bool:
+        self._ensure_worker()
         try:
-            if self._enterprise_telemetry_enabled or self.trace_instance:
-                trace_task.app_id = self.app_id
-                trace_manager_queue.put(trace_task)
+            self._queue.put_nowait(item)
+        except queue.Full:
+            self._dropped_tasks += 1
+            logger.warning(
+                "Dropping trace because the dispatcher queue is full, storage_id=%s, trace_type=%s, total_dropped=%s",
+                item.storage_id,
+                item.task.trace_type,
+                self._dropped_tasks,
+            )
+            return False
+
+        return True
+
+    def _ensure_worker(self) -> None:
+        worker = self._worker
+        if worker is not None and worker.is_alive():
+            return
+
+        with self._start_lock:
+            worker = self._worker
+            if worker is not None and worker.is_alive():
+                return
+            worker = threading.Thread(target=self._run, name="ops-trace-dispatcher", daemon=True)
+            self._worker = worker
+            worker.start()
+
+    def _run(self) -> None:
+        while True:
+            self._process_item(self._queue.get())
+
+    def _process_item(self, item: _TraceWorkItem) -> None:
+        try:
+            with self._flask_app.app_context():
+                file_info = self._persist_trace_task(item)
+                self._enqueue_persisted_trace(file_info)
         except Exception:
-            logger.exception("Error adding trace task, trace_type %s", trace_task.trace_type)
+            logger.exception(
+                "Failed to dispatch trace, storage_id=%s, trace_type=%s",
+                item.storage_id,
+                item.task.trace_type,
+            )
         finally:
-            self.start_timer()
+            self._queue.task_done()
 
-    def collect_tasks(self):
-        global trace_manager_queue
-        tasks: list[TraceTask] = []
-        while len(tasks) < trace_manager_batch_size and not trace_manager_queue.empty():
-            task = trace_manager_queue.get_nowait()
-            tasks.append(task)
-            trace_manager_queue.task_done()
-        return tasks
-
-    def run(self):
-        try:
-            tasks = self.collect_tasks()
-            if tasks:
-                self.send_to_celery(tasks)
-        except Exception:
-            logger.exception("Error processing trace tasks")
-
-    def start_timer(self):
-        global trace_manager_timer
-        if trace_manager_timer is None or not trace_manager_timer.is_alive():
-            trace_manager_timer = threading.Timer(trace_manager_interval, self.run)
-            trace_manager_timer.name = f"trace_manager_timer_{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}"
-            trace_manager_timer.daemon = False
-            trace_manager_timer.start()
-
-    def _resolve_storage_id(self, task: TraceTask) -> str | None:
-        storage_id = task.app_id
-        if storage_id is not None:
-            return storage_id
-
-        tenant_id = task.kwargs.get("tenant_id")
-        if tenant_id:
-            return f"tenant-{tenant_id}"
-
-        logger.warning("Skipping trace without app_id or tenant_id, trace_type: %s", task.trace_type)
-        return None
-
-    def persist_trace_task(self, task: TraceTask, *, file_id: str | None = None) -> dict[str, str] | None:
-        storage_id = self._resolve_storage_id(task)
-        if storage_id is None:
-            return None
-
+    def _persist_trace_task(self, item: _TraceWorkItem, *, file_id: str | None = None) -> dict[str, str]:
         resolved_file_id = file_id or uuid4().hex
-        trace_info = task.execute()
+        trace_info = item.task.execute()
         if isinstance(trace_info, BaseTraceInfo) and trace_info.operation_id is None:
             trace_info = trace_info.model_copy(update={"operation_id": str(uuid4())})
         task_data = TaskData(
-            app_id=storage_id,
+            app_id=item.storage_id,
             trace_info_type=type(trace_info).__name__,
             trace_info=trace_info.model_dump() if trace_info else None,
         )
         storage.save(
-            ops_trace_payload_path(storage_id, resolved_file_id),
+            ops_trace_payload_path(item.storage_id, resolved_file_id),
             task_data.model_dump_json().encode("utf-8"),
         )
-        return {"file_id": resolved_file_id, "app_id": storage_id}
+        return {"file_id": resolved_file_id, "app_id": item.storage_id}
 
-    def enqueue_persisted_trace(self, file_info: dict[str, str]) -> None:
+    def _enqueue_persisted_trace(self, file_info: dict[str, str]) -> None:
         process_trace_tasks.apply_async(
             args=(file_info,),
             retry=True,
@@ -1604,9 +1605,56 @@ class TraceQueueManager:
             },
         )
 
-    def send_to_celery(self, tasks: list[TraceTask]):
-        with self.flask_app.app_context():
-            for task in tasks:
-                file_info = self.persist_trace_task(task)
-                if file_info is not None:
-                    self.enqueue_persisted_trace(file_info)
+
+_trace_dispatcher: _TraceDispatcher | None = None
+_trace_dispatcher_lock = threading.Lock()
+
+
+def _get_trace_dispatcher() -> _TraceDispatcher:
+    global _trace_dispatcher
+
+    dispatcher = _trace_dispatcher
+    if dispatcher is not None:
+        return dispatcher
+
+    flask_app = current_app._get_current_object()  # type: ignore
+    with _trace_dispatcher_lock:
+        if _trace_dispatcher is None:
+            _trace_dispatcher = _TraceDispatcher(flask_app)
+        return _trace_dispatcher
+
+
+class TraceQueueManager:
+    """Request-scoped trace producer that submits tenant-owned work to the shared dispatcher."""
+
+    def __init__(self, app_id=None, user_id=None):
+        self.app_id = str(app_id) if app_id is not None else None
+        self.user_id = user_id
+
+        from core.telemetry.gateway import is_enterprise_telemetry_enabled
+
+        self._enabled = (
+            is_enterprise_telemetry_enabled() or OpsTraceManager.get_ops_trace_instance(self.app_id) is not None
+        )
+
+    def add_trace_task(self, trace_task: TraceTask) -> None:
+        try:
+            if not self._enabled:
+                return
+
+            storage_id = self._resolve_storage_id(trace_task)
+            if storage_id is not None:
+                _get_trace_dispatcher().submit(_TraceWorkItem(storage_id=storage_id, task=trace_task))
+        except Exception:
+            logger.exception("Error adding trace task, trace_type %s", trace_task.trace_type)
+
+    def _resolve_storage_id(self, task: TraceTask) -> str | None:
+        if self.app_id is not None:
+            return self.app_id
+
+        tenant_id = task.kwargs.get("tenant_id")
+        if tenant_id:
+            return f"tenant-{tenant_id}"
+
+        logger.warning("Skipping trace without app_id or tenant_id, trace_type: %s", task.trace_type)
+        return None

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
@@ -29,7 +29,6 @@ from core.app.entities.task_entities import (
 )
 from core.app.task_pipeline.easy_ui_based_generate_task_pipeline import EasyUIBasedGenerateTaskPipeline
 from core.base.tts import AppGeneratorTTSPublisher
-from core.ops.ops_trace_manager import TraceQueueManager
 from graphon.model_runtime.entities.llm_entities import LLMResult as RuntimeLLMResult
 from graphon.model_runtime.entities.message_entities import TextPromptMessageContent
 from models.enums import ConversationFromSource
@@ -362,29 +361,6 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
 
         # Assert
         publisher.publish.assert_called_once_with(mock_queue_message)
-
-    def test_trace_manager_passed_to_save_message(self, pipeline, committed_sessions):
-        """Test that trace manager is passed to _save_message."""
-        # Setup
-        trace_manager = Mock(spec=TraceQueueManager)
-
-        message_end_event = Mock(spec=QueueMessageEndEvent)
-        message_end_event.llm_result = None
-
-        mock_queue_message = Mock()
-        mock_queue_message.event = message_end_event
-        pipeline.queue_manager.listen.return_value = [mock_queue_message]
-
-        pipeline._save_message = Mock()
-        pipeline._message_end_to_stream_response = Mock(return_value=Mock(spec=MessageEndStreamResponse))
-
-        list(pipeline._process_stream_response(publisher=None, trace_manager=trace_manager))
-
-        # Assert
-        session = pipeline._save_message.call_args.kwargs["session"]
-        assert isinstance(session, Session)
-        assert committed_sessions == [session]
-        pipeline._save_message.assert_called_once_with(session=session, trace_manager=trace_manager)
 
     def test_multiple_events_sequence(self, pipeline, mock_message_cycle_manager, mock_task_state):
         """Test handling multiple events in sequence."""

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py
@@ -54,7 +54,7 @@ from core.app.entities.task_entities import (
 from core.app.task_pipeline.easy_ui_based_generate_task_pipeline import EasyUIBasedGenerateTaskPipeline
 from core.base.tts import AppGeneratorTTSPublisher, AudioTrunk
 from core.ops.entities.trace_entity import TraceTaskName
-from core.ops.ops_trace_manager import TraceQueueManager
+from core.ops.ops_trace_manager import TraceQueueManager, TraceTask
 from extensions.storage.storage_type import StorageType
 from graphon.file import FileTransferMethod, FileType
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
@@ -1337,13 +1337,65 @@ class TestEasyUiBasedGenerateTaskPipeline:
 
         assert list(pipeline._process_stream_response(publisher=None)) == []
 
-    def test_save_message_persists_fields_and_emits_trace(
+    @pytest.mark.parametrize(
+        "terminal_event",
+        [QueueMessageEndEvent(), QueueStopEvent(stopped_by=QueueStopEvent.StopBy.USER_MANUAL)],
+        ids=["completed", "stopped"],
+    )
+    @pytest.mark.parametrize("commit_succeeds", [True, False], ids=["committed", "commit-failed"])
+    def test_message_trace_observes_only_committed_result(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_session: Session,
+        terminal_event: AppQueueEvent,
+        commit_succeeds: bool,
+    ) -> None:
+        pipeline, queue_manager = _make_pipeline()
+        pipeline._application_generate_entity.extras["trace_session_id"] = "session-1"
+        _set_method(pipeline, "_model_config", _ModelConfigMode(mode="chat"))
+        pipeline._task_state.llm_result.message.content = "finished answer"
+        pipeline._task_state.llm_result.usage = LLMUsage.from_metadata({"prompt_tokens": 13, "completion_tokens": 42})
+        monkeypatch.setattr(pipeline, "_handle_stop", Mock())
+        monkeypatch.setattr(
+            "core.app.task_pipeline.easy_ui_based_generate_task_pipeline.message_was_created.send", Mock()
+        )
+        queue_manager.set_events([_queue_message(terminal_event)])
+        sqlite_session.add_all([_make_conversation(AppMode.CHAT), _make_message()])
+        sqlite_session.commit()
+        observed_messages: list[tuple[str, int, int]] = []
+
+        def read_message_immediately(task: TraceTask) -> None:
+            # A separate session sees exactly what the asynchronous trace consumer can read.
+            with Session(sqlite_session.get_bind()) as reader:
+                message = reader.get(Message, task.message_id)
+                assert message is not None
+                observed_messages.append((message.answer, message.message_tokens, message.answer_tokens))
+
+        trace_manager = Mock(spec=TraceQueueManager)
+        trace_manager.add_trace_task.side_effect = read_message_immediately
+        if not commit_succeeds:
+            monkeypatch.setattr(Session, "commit", Mock(side_effect=RuntimeError("commit failed")))
+            with pytest.raises(RuntimeError, match="commit failed"):
+                list(pipeline._process_stream_response(publisher=None, trace_manager=trace_manager))
+            trace_manager.add_trace_task.assert_not_called()
+            return
+
+        list(pipeline._process_stream_response(publisher=None, trace_manager=trace_manager))
+
+        assert observed_messages == [("finished answer", 13, 42)]
+        trace_manager.add_trace_task.assert_called_once()
+        trace_task = trace_manager.add_trace_task.call_args.args[0]
+        assert trace_task.trace_type == TraceTaskName.MESSAGE_TRACE
+        assert trace_task.conversation_id == "conv"
+        assert trace_task.message_id == "msg"
+        assert trace_task.kwargs["trace_session_id"] == "session-1"
+
+    def test_save_message_persists_fields_and_sends_event(
         self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
     ):
         conversation = _make_conversation(AppMode.CHAT)
         message = _make_message()
         application_generate_entity = _make_entity(ChatAppGenerateEntity, AppMode.CHAT)
-        application_generate_entity.extras = {"trace_session_id": "session-1"}
         pipeline = EasyUIBasedGenerateTaskPipeline(
             application_generate_entity=application_generate_entity,
             queue_manager=_FakeQueueManager(),
@@ -1364,8 +1416,6 @@ class TestEasyUiBasedGenerateTaskPipeline:
         session = sqlite_session
         session.add_all([conversation_obj, message_obj])
         session.flush()
-        trace_manager_double = _TraceManagerDouble()
-        trace_manager = cast(TraceQueueManager, trace_manager_double)
         sent_payloads: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
         monkeypatch.setattr(
@@ -1388,17 +1438,11 @@ class TestEasyUiBasedGenerateTaskPipeline:
             lambda *args, **kwargs: sent_payloads.append((args, kwargs)),
         )
 
-        pipeline._save_message(session=session, trace_manager=trace_manager)
+        pipeline._save_message(session=session)
 
         assert message_obj.message == "serialized-prompt"
         assert message_obj.answer == "hello"
         assert message_obj.provider_response_latency == 5.0
-        trace_manager_double.add_trace_task.assert_called_once()
-        trace_task = trace_manager_double.add_trace_task.call_args.args[0]
-        assert trace_task.trace_type == TraceTaskName.MESSAGE_TRACE
-        assert trace_task.conversation_id == "conv"
-        assert trace_task.message_id == "msg"
-        assert trace_task.kwargs["trace_session_id"] == "session-1"
         assert len(sent_payloads) == 1
 
     def test_save_stopped_message_preserves_backend_reported_usage(

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
-from unittest.mock import PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import UUID
 
 import pytest
@@ -689,12 +689,59 @@ def _generate_name_task(name: str = "name") -> TraceTask:
     )
 
 
-def _dispatcher(*, max_queue_size: int = 2048):
-    return module._TraceDispatcher(current_app._get_current_object(), max_queue_size=max_queue_size)
+def _dispatcher(*, max_queue_size: int = 2048) -> module._TraceDispatcher:
+    return module._TraceDispatcher(current_app._get_current_object(), max_queue_size=max_queue_size)  # type: ignore
 
 
 def _process_next(dispatcher: module._TraceDispatcher) -> None:
     dispatcher._process_item(dispatcher._queue.get_nowait())
+
+
+def test_trace_dispatcher_rejects_non_positive_capacity(trace_environment: None) -> None:
+    with pytest.raises(ValueError, match="max_queue_size must be positive"):
+        _dispatcher(max_queue_size=0)
+
+
+def test_trace_dispatcher_double_checks_worker_under_lock(trace_environment: None) -> None:
+    trace_dispatcher = _dispatcher()
+    worker = MagicMock()
+    worker.is_alive.side_effect = [False, True]
+    trace_dispatcher._worker = worker
+
+    trace_dispatcher._ensure_worker()
+
+    assert worker.is_alive.call_count == 2
+    worker.start.assert_not_called()
+
+
+def test_trace_dispatcher_run_delegates_queued_item(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
+    trace_dispatcher = _dispatcher()
+    item = module._TraceWorkItem(storage_id="app-id", task=_generate_name_task())
+    trace_dispatcher._queue.put_nowait(item)
+    process_item = MagicMock(side_effect=RuntimeError("stop test worker"))
+    monkeypatch.setattr(trace_dispatcher, "_process_item", process_item)
+
+    with pytest.raises(RuntimeError, match="stop test worker"):
+        trace_dispatcher._run()
+
+    process_item.assert_called_once_with(item)
+
+
+def test_get_trace_dispatcher_creates_and_reuses_singleton(trace_environment: None) -> None:
+    trace_dispatcher = module._get_trace_dispatcher()
+
+    assert module._get_trace_dispatcher() is trace_dispatcher
+
+
+def test_get_trace_dispatcher_uses_instance_created_while_waiting_for_lock(
+    monkeypatch: pytest.MonkeyPatch, trace_environment: None
+) -> None:
+    expected = _dispatcher()
+    lock = MagicMock()
+    lock.__enter__.side_effect = lambda: setattr(module, "_trace_dispatcher", expected)
+    monkeypatch.setattr(module, "_trace_dispatcher_lock", lock)
+
+    assert module._get_trace_dispatcher() is expected
 
 
 def test_trace_queue_snapshots_source_app_before_dispatch(

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import queue
 from collections.abc import Iterator
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -12,7 +11,7 @@ from unittest.mock import PropertyMock, patch
 from uuid import UUID
 
 import pytest
-from flask import Flask
+from flask import Flask, current_app
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -82,19 +81,18 @@ UNIFIED_PROVIDER_ENTRY = {
 }
 
 
-class DummyTimer:
-    def __init__(self, interval, function):
-        self.interval = interval
-        self.function = function
-        self.name = ""
-        self.daemon = False
+class DummyThread:
+    def __init__(self, target=None, *, name=None, daemon=None):
+        self.target = target
+        self.name = name
+        self.daemon = daemon
         self.started = False
 
     def start(self):
         self.started = True
 
     def is_alive(self):
-        return False
+        return self.started
 
 
 class EncryptTokenRecorder:
@@ -158,9 +156,8 @@ def trace_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setattr(dify_config, "OPS_TRACE_UNIFIED_ENABLED", False)
     OpsTraceManager.ops_trace_instances_cache.clear()
     OpsTraceManager.decrypted_configs_cache.clear()
-    monkeypatch.setattr(module.threading, "Timer", DummyTimer)
-    monkeypatch.setattr(module, "trace_manager_queue", queue.Queue())
-    monkeypatch.setattr(module, "trace_manager_timer", None)
+    monkeypatch.setattr(module.threading, "Thread", DummyThread)
+    monkeypatch.setattr(module, "_trace_dispatcher", None, raising=False)
     monkeypatch.setattr("core.telemetry.gateway.is_enterprise_telemetry_enabled", lambda: False)
 
     app = Flask(__name__)
@@ -681,7 +678,26 @@ def test_trace_helpers_and_streaming_metrics(trace_environment: None) -> None:
     assert generated.message_id == "message-1"
 
 
-def test_trace_queue_preserves_source_app_when_another_manager_drains(
+def _generate_name_task(name: str = "name") -> TraceTask:
+    return TraceTask(
+        trace_type=TraceTaskName.GENERATE_NAME_TRACE,
+        conversation_id="conversation-1",
+        timer={"start": 1, "end": 2},
+        tenant_id="tenant-1",
+        generate_conversation_name=name,
+        inputs="query",
+    )
+
+
+def _dispatcher(*, max_queue_size: int = 2048):
+    return module._TraceDispatcher(current_app._get_current_object(), max_queue_size=max_queue_size)
+
+
+def _process_next(dispatcher: module._TraceDispatcher) -> None:
+    dispatcher._process_item(dispatcher._queue.get_nowait())
+
+
+def test_trace_queue_snapshots_source_app_before_dispatch(
     monkeypatch: pytest.MonkeyPatch, trace_environment: None
 ) -> None:
     monkeypatch.setattr(
@@ -689,18 +705,11 @@ def test_trace_queue_preserves_source_app_when_another_manager_drains(
         "get_ops_trace_instance",
         classmethod(lambda cls, app_id: app_id == "source-app-id"),
     )
-    draining_manager = TraceQueueManager(app_id="draining-app-id", user_id="user-1")
+    trace_dispatcher = _dispatcher()
+    monkeypatch.setattr(module, "_get_trace_dispatcher", lambda: trace_dispatcher)
     source_manager = TraceQueueManager(app_id="source-app-id", user_id="user-2")
-    task = TraceTask(
-        trace_type=TraceTaskName.GENERATE_NAME_TRACE,
-        conversation_id="conversation-1",
-        timer={"start": 1, "end": 2},
-        tenant_id="tenant-1",
-        generate_conversation_name="name",
-        inputs="query",
-    )
-    source_manager.add_trace_task(task)
-    assert draining_manager.collect_tasks() == [task]
+    source_manager.add_trace_task(_generate_name_task())
+    source_manager.app_id = "changed-after-enqueue"
 
     recording_storage = RecordingStorage()
     dispatcher = RecordingDispatcher()
@@ -708,8 +717,8 @@ def test_trace_queue_preserves_source_app_when_another_manager_drains(
     monkeypatch.setattr(module.process_trace_tasks, "apply_async", dispatcher.apply_async)
     file_id = UUID("00000000-0000-0000-0000-000000000123")
     monkeypatch.setattr(module, "uuid4", lambda: file_id)
-    source_manager.add_trace_task(task)
-    draining_manager.run()
+
+    _process_next(trace_dispatcher)
 
     assert len(recording_storage.writes) == 1
     path, data = recording_storage.writes[0]
@@ -718,24 +727,80 @@ def test_trace_queue_preserves_source_app_when_another_manager_drains(
     assert dispatcher.payloads == [{"file_id": file_id.hex, "app_id": "source-app-id"}]
 
 
-def test_trace_queue_persists_with_caller_supplied_file_id(
+def test_trace_dispatcher_queue_is_bounded(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
+    trace_dispatcher = _dispatcher(max_queue_size=1)
+    first = module._TraceWorkItem(storage_id="app-1", task=_generate_name_task("first"))
+    second = module._TraceWorkItem(storage_id="app-2", task=_generate_name_task("second"))
+    persisted: list[module._TraceWorkItem] = []
+    monkeypatch.setattr(
+        module._TraceDispatcher,
+        "_persist_trace_task",
+        lambda self, item, *, file_id=None: persisted.append(item),
+    )
+    monkeypatch.setattr(module._TraceDispatcher, "_enqueue_persisted_trace", lambda self, file_info: None)
+
+    assert trace_dispatcher.submit(first)
+    assert not trace_dispatcher.submit(second)
+    _process_next(trace_dispatcher)
+    assert persisted == [first]
+
+
+def test_trace_dispatcher_processes_all_queued_items(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
+    trace_dispatcher = _dispatcher()
+    items = [module._TraceWorkItem(storage_id="app-id", task=_generate_name_task(str(index))) for index in range(101)]
+    persisted: list[module._TraceWorkItem] = []
+    monkeypatch.setattr(
+        module._TraceDispatcher,
+        "_persist_trace_task",
+        lambda self, item, *, file_id=None: persisted.append(item),
+    )
+    monkeypatch.setattr(module._TraceDispatcher, "_enqueue_persisted_trace", lambda self, file_info: None)
+
+    assert all(trace_dispatcher.submit(item) for item in items)
+    for _ in items:
+        _process_next(trace_dispatcher)
+    assert trace_dispatcher._queue.empty()
+    assert persisted == items
+
+
+def test_trace_dispatcher_isolates_task_failure(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
+    trace_dispatcher = _dispatcher()
+    bad = module._TraceWorkItem(storage_id="bad-app", task=_generate_name_task("bad"))
+    good = module._TraceWorkItem(storage_id="good-app", task=_generate_name_task("good"))
+    persisted: list[str] = []
+    enqueued: list[dict[str, str]] = []
+
+    def persist(_self, item, *, file_id=None):
+        persisted.append(item.storage_id)
+        if item is bad:
+            raise OSError("storage unavailable")
+        return {"file_id": "good-file", "app_id": item.storage_id}
+
+    monkeypatch.setattr(module._TraceDispatcher, "_persist_trace_task", persist)
+    monkeypatch.setattr(
+        module._TraceDispatcher,
+        "_enqueue_persisted_trace",
+        lambda self, file_info: enqueued.append(file_info),
+    )
+    assert trace_dispatcher.submit(bad)
+    assert trace_dispatcher.submit(good)
+
+    _process_next(trace_dispatcher)
+    _process_next(trace_dispatcher)
+    assert trace_dispatcher._queue.empty()
+    assert persisted == ["bad-app", "good-app"]
+    assert enqueued == [{"file_id": "good-file", "app_id": "good-app"}]
+
+
+def test_trace_dispatcher_persists_with_caller_supplied_file_id(
     monkeypatch: pytest.MonkeyPatch, trace_environment: None
 ) -> None:
-    monkeypatch.setattr(OpsTraceManager, "get_ops_trace_instance", classmethod(lambda cls, _app_id: True))
-    manager = TraceQueueManager(app_id="app-id", user_id="user-1")
-    task = TraceTask(
-        trace_type=TraceTaskName.GENERATE_NAME_TRACE,
-        conversation_id="conversation-1",
-        timer={"start": 1, "end": 2},
-        tenant_id="tenant-1",
-        generate_conversation_name="name",
-        inputs="query",
-    )
-    task.app_id = "app-id"
+    trace_dispatcher = _dispatcher()
+    item = module._TraceWorkItem(storage_id="app-id", task=_generate_name_task())
     recording_storage = RecordingStorage()
     monkeypatch.setattr(module.storage, "save", recording_storage.save)
 
-    file_info = manager.persist_trace_task(task, file_id="workflow-final-run-1")
+    file_info = trace_dispatcher._persist_trace_task(item, file_id="workflow-final-run-1")
 
     assert file_info == {"file_id": "workflow-final-run-1", "app_id": "app-id"}
     path, data = recording_storage.writes[0]
@@ -744,11 +809,11 @@ def test_trace_queue_persists_with_caller_supplied_file_id(
     assert UUID(payload["trace_info"]["operation_id"])
 
 
-def test_trace_queue_persistence_error_propagates(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
-    monkeypatch.setattr(OpsTraceManager, "get_ops_trace_instance", classmethod(lambda cls, _app_id: True))
-    manager = TraceQueueManager(app_id="app-id", user_id="user-1")
-    task = TraceTask(trace_type=TraceTaskName.GENERATE_NAME_TRACE)
-    task.app_id = "app-id"
+def test_trace_dispatcher_persistence_error_propagates(
+    monkeypatch: pytest.MonkeyPatch, trace_environment: None
+) -> None:
+    trace_dispatcher = _dispatcher()
+    item = module._TraceWorkItem(storage_id="app-id", task=_generate_name_task())
 
     def fail_save(_path: str, _data: bytes) -> None:
         raise OSError("storage unavailable")
@@ -756,12 +821,11 @@ def test_trace_queue_persistence_error_propagates(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(module.storage, "save", fail_save)
 
     with pytest.raises(OSError, match="storage unavailable"):
-        manager.persist_trace_task(task, file_id="workflow-final-run-1")
+        trace_dispatcher._persist_trace_task(item, file_id="workflow-final-run-1")
 
 
-def test_trace_queue_enqueue_error_propagates(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
-    monkeypatch.setattr(OpsTraceManager, "get_ops_trace_instance", classmethod(lambda cls, _app_id: True))
-    manager = TraceQueueManager(app_id="app-id", user_id="user-1")
+def test_trace_dispatcher_enqueue_error_propagates(monkeypatch: pytest.MonkeyPatch, trace_environment: None) -> None:
+    trace_dispatcher = _dispatcher()
 
     def fail_enqueue(*_args: object, **_kwargs: object) -> None:
         raise ConnectionError("broker unavailable")
@@ -769,4 +833,4 @@ def test_trace_queue_enqueue_error_propagates(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setattr(module.process_trace_tasks, "apply_async", fail_enqueue)
 
     with pytest.raises(ConnectionError, match="broker unavailable"):
-        manager.enqueue_persisted_trace({"file_id": "workflow-final-run-1", "app_id": "app-id"})
+        trace_dispatcher._enqueue_persisted_trace({"file_id": "workflow-final-run-1", "app_id": "app-id"})

--- a/api/tests/unit_tests/core/ops/test_trace_queue_manager.py
+++ b/api/tests/unit_tests/core/ops/test_trace_queue_manager.py
@@ -80,3 +80,17 @@ def test_trace_manager_skips_task_without_routing_identity() -> None:
         TraceQueueManager().add_trace_task(task)
 
     dispatcher.submit.assert_not_called()
+
+
+def test_trace_manager_contains_dispatcher_errors() -> None:
+    task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
+
+    with (
+        patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True),
+        patch.object(OpsTraceManager, "get_ops_trace_instance", return_value=None),
+        patch("core.ops.ops_trace_manager._get_trace_dispatcher", side_effect=RuntimeError("dispatcher failed")),
+        patch("core.ops.ops_trace_manager.logger.exception") as log_exception,
+    ):
+        TraceQueueManager(app_id="app-id").add_trace_task(task)
+
+    log_exception.assert_called_once_with("Error adding trace task, trace_type %s", task.trace_type)

--- a/api/tests/unit_tests/core/ops/test_trace_queue_manager.py
+++ b/api/tests/unit_tests/core/ops/test_trace_queue_manager.py
@@ -1,194 +1,82 @@
-"""Unit tests for TraceQueueManager telemetry guard.
+"""Unit tests for the real TraceQueueManager producer facade."""
 
-Verifies that TraceQueueManager.add_trace_task() only enqueues tasks when at
-least one consumer is active:
-- Enterprise telemetry is enabled (_enterprise_telemetry_enabled=True), OR
-- A third-party trace instance (Langfuse, etc.) is configured
-
-When neither is active, tasks are silently dropped to avoid unnecessary work.
-
-When BOTH are false, tasks are silently dropped (correct behavior).
-"""
-
-import queue
-import sys
-import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-@pytest.fixture
-def trace_queue_manager_and_task(monkeypatch: pytest.MonkeyPatch):
-    """Fixture to provide TraceQueueManager and TraceTask with delayed imports."""
-    module_name = "core.ops.ops_trace_manager"
-    if module_name not in sys.modules:
-        ops_stub = types.ModuleType(module_name)
-
-        class StubTraceTask:
-            def __init__(self, trace_type):
-                self.trace_type = trace_type
-                self.app_id = None
-
-        class StubTraceQueueManager:
-            def __init__(self, app_id=None):
-                self.app_id = app_id
-                from core.telemetry.gateway import is_enterprise_telemetry_enabled
-
-                self._enterprise_telemetry_enabled = is_enterprise_telemetry_enabled()
-                self.trace_instance = StubOpsTraceManager.get_ops_trace_instance(app_id)
-
-            def add_trace_task(self, trace_task):
-                if self._enterprise_telemetry_enabled or self.trace_instance:
-                    trace_task.app_id = self.app_id
-                    from core.ops.ops_trace_manager import trace_manager_queue
-
-                    trace_manager_queue.put(trace_task)
-
-        class StubOpsTraceManager:
-            @staticmethod
-            def get_ops_trace_instance(app_id):
-                return None
-
-        ops_stub.TraceQueueManager = StubTraceQueueManager
-        ops_stub.TraceTask = StubTraceTask
-        ops_stub.OpsTraceManager = StubOpsTraceManager
-        ops_stub.trace_manager_queue = MagicMock(spec=queue.Queue)
-        monkeypatch.setitem(sys.modules, module_name, ops_stub)
-
-    from core.ops.entities.trace_entity import TraceTaskName
-
-    ops_module = __import__(module_name, fromlist=["TraceQueueManager", "TraceTask"])
-    TraceQueueManager = ops_module.TraceQueueManager
-    TraceTask = ops_module.TraceTask
-
-    return TraceQueueManager, TraceTask, TraceTaskName
+from core.ops.entities.trace_entity import TraceTaskName
+from core.ops.ops_trace_manager import OpsTraceManager, TraceQueueManager, TraceTask
 
 
-class TestTraceQueueManagerTelemetryGuard:
-    """Test TraceQueueManager's telemetry guard in add_trace_task()."""
+@pytest.mark.parametrize(
+    ("enterprise_enabled", "provider_configured", "should_submit"),
+    [
+        (False, False, False),
+        (True, False, True),
+        (False, True, True),
+        (True, True, True),
+    ],
+)
+def test_trace_manager_submits_only_when_a_consumer_is_enabled(
+    enterprise_enabled: bool,
+    provider_configured: bool,
+    should_submit: bool,
+) -> None:
+    dispatcher = MagicMock()
+    task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
 
-    def test_task_not_enqueued_when_telemetry_disabled_and_no_trace_instance(self, trace_queue_manager_and_task):
-        """Verify task is NOT enqueued when telemetry disabled and no trace instance.
+    with (
+        patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=enterprise_enabled),
+        patch.object(OpsTraceManager, "get_ops_trace_instance", return_value=object() if provider_configured else None),
+        patch("core.ops.ops_trace_manager._get_trace_dispatcher", return_value=dispatcher),
+    ):
+        TraceQueueManager(app_id="test-app-id").add_trace_task(task)
 
-        This is the core guard: when _enterprise_telemetry_enabled=False AND
-        trace_instance=None, the task should be silently dropped.
-        """
-        TraceQueueManager, TraceTask, TraceTaskName = trace_queue_manager_and_task
+    assert dispatcher.submit.called is should_submit
 
-        mock_queue = MagicMock(spec=queue.Queue)
 
-        trace_task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
+def test_trace_manager_snapshots_app_routing_before_enqueue() -> None:
+    dispatcher = MagicMock()
+    task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
 
-        with (
-            patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=False),
-            patch("core.ops.ops_trace_manager.OpsTraceManager.get_ops_trace_instance", return_value=None),
-            patch("core.ops.ops_trace_manager.trace_manager_queue", mock_queue),
-        ):
-            manager = TraceQueueManager(app_id="test-app-id")
-            manager.add_trace_task(trace_task)
+    with (
+        patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True),
+        patch.object(OpsTraceManager, "get_ops_trace_instance", return_value=None),
+        patch("core.ops.ops_trace_manager._get_trace_dispatcher", return_value=dispatcher),
+    ):
+        manager = TraceQueueManager(app_id="source-app-id")
+        manager.add_trace_task(task)
+        manager.app_id = "other-app-id"
 
-            mock_queue.put.assert_not_called()
+    work_item = dispatcher.submit.call_args.args[0]
+    assert work_item.storage_id == "source-app-id"
+    assert work_item.task is task
+    assert not hasattr(task, "app_id")
 
-    def test_task_enqueued_when_telemetry_enabled(self, trace_queue_manager_and_task):
-        """Verify task IS enqueued when enterprise telemetry is enabled.
 
-        When _enterprise_telemetry_enabled=True, the task should be enqueued
-        regardless of trace_instance state.
-        """
-        TraceQueueManager, TraceTask, TraceTaskName = trace_queue_manager_and_task
+def test_trace_manager_uses_tenant_routing_without_an_app() -> None:
+    dispatcher = MagicMock()
+    task = TraceTask(trace_type=TraceTaskName.DRAFT_NODE_EXECUTION_TRACE, tenant_id="tenant-id")
 
-        mock_queue = MagicMock(spec=queue.Queue)
+    with (
+        patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True),
+        patch.object(OpsTraceManager, "get_ops_trace_instance", return_value=None),
+        patch("core.ops.ops_trace_manager._get_trace_dispatcher", return_value=dispatcher),
+    ):
+        TraceQueueManager().add_trace_task(task)
 
-        trace_task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
+    assert dispatcher.submit.call_args.args[0].storage_id == "tenant-tenant-id"
 
-        with (
-            patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True),
-            patch("core.ops.ops_trace_manager.OpsTraceManager.get_ops_trace_instance", return_value=None),
-            patch("core.ops.ops_trace_manager.trace_manager_queue", mock_queue),
-        ):
-            manager = TraceQueueManager(app_id="test-app-id")
-            manager.add_trace_task(trace_task)
 
-            mock_queue.put.assert_called_once()
-            called_task = mock_queue.put.call_args[0][0]
-            assert called_task.app_id == "test-app-id"
+def test_trace_manager_skips_task_without_routing_identity() -> None:
+    dispatcher = MagicMock()
+    task = TraceTask(trace_type=TraceTaskName.DRAFT_NODE_EXECUTION_TRACE)
 
-    def test_task_enqueued_when_trace_instance_configured(self, trace_queue_manager_and_task):
-        """Verify task IS enqueued when third-party trace instance is configured.
+    with (
+        patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True),
+        patch.object(OpsTraceManager, "get_ops_trace_instance", return_value=None),
+        patch("core.ops.ops_trace_manager._get_trace_dispatcher", return_value=dispatcher),
+    ):
+        TraceQueueManager().add_trace_task(task)
 
-        When trace_instance is not None (e.g., Langfuse configured), the task
-        should be enqueued even if enterprise telemetry is disabled.
-        """
-        TraceQueueManager, TraceTask, TraceTaskName = trace_queue_manager_and_task
-
-        mock_queue = MagicMock(spec=queue.Queue)
-
-        mock_trace_instance = MagicMock()
-
-        trace_task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
-
-        with (
-            patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=False),
-            patch(
-                "core.ops.ops_trace_manager.OpsTraceManager.get_ops_trace_instance", return_value=mock_trace_instance
-            ),
-            patch("core.ops.ops_trace_manager.trace_manager_queue", mock_queue),
-        ):
-            manager = TraceQueueManager(app_id="test-app-id")
-            manager.add_trace_task(trace_task)
-
-            mock_queue.put.assert_called_once()
-            called_task = mock_queue.put.call_args[0][0]
-            assert called_task.app_id == "test-app-id"
-
-    def test_task_enqueued_when_both_telemetry_and_trace_instance_enabled(self, trace_queue_manager_and_task):
-        """Verify task IS enqueued when both telemetry and trace instance are enabled.
-
-        When both _enterprise_telemetry_enabled=True AND trace_instance is set,
-        the task should definitely be enqueued.
-        """
-        TraceQueueManager, TraceTask, TraceTaskName = trace_queue_manager_and_task
-
-        mock_queue = MagicMock(spec=queue.Queue)
-
-        mock_trace_instance = MagicMock()
-
-        trace_task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
-
-        with (
-            patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True),
-            patch(
-                "core.ops.ops_trace_manager.OpsTraceManager.get_ops_trace_instance", return_value=mock_trace_instance
-            ),
-            patch("core.ops.ops_trace_manager.trace_manager_queue", mock_queue),
-        ):
-            manager = TraceQueueManager(app_id="test-app-id")
-            manager.add_trace_task(trace_task)
-
-            mock_queue.put.assert_called_once()
-            called_task = mock_queue.put.call_args[0][0]
-            assert called_task.app_id == "test-app-id"
-
-    def test_app_id_set_before_enqueue(self, trace_queue_manager_and_task):
-        """Verify app_id is set on the task before enqueuing.
-
-        The guard logic sets trace_task.app_id = self.app_id before calling
-        trace_manager_queue.put(trace_task). This test verifies that behavior.
-        """
-        TraceQueueManager, TraceTask, TraceTaskName = trace_queue_manager_and_task
-
-        mock_queue = MagicMock(spec=queue.Queue)
-
-        trace_task = TraceTask(trace_type=TraceTaskName.WORKFLOW_TRACE)
-
-        with (
-            patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True),
-            patch("core.ops.ops_trace_manager.OpsTraceManager.get_ops_trace_instance", return_value=None),
-            patch("core.ops.ops_trace_manager.trace_manager_queue", mock_queue),
-        ):
-            manager = TraceQueueManager(app_id="expected-app-id")
-            manager.add_trace_task(trace_task)
-
-            called_task = mock_queue.put.call_args[0][0]
-            assert called_task.app_id == "expected-app-id"
+    dispatcher.submit.assert_not_called()

--- a/api/tests/unit_tests/core/telemetry/test_facade.py
+++ b/api/tests/unit_tests/core/telemetry/test_facade.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import queue
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -17,45 +16,34 @@ from core.telemetry.events import DraftNodeExecutionTraceEvent, TelemetryContext
 def telemetry_test_setup(monkeypatch: pytest.MonkeyPatch):
     module_name = "core.ops.ops_trace_manager"
     ops_stub = types.ModuleType(module_name)
+    submitted_tasks = []
 
     class StubTraceTask:
         def __init__(self, trace_type, **kwargs):
             self.trace_type = trace_type
-            self.app_id = None
             self.kwargs = kwargs
 
     class StubTraceQueueManager:
         def __init__(self, app_id=None, user_id=None):
             self.app_id = app_id
             self.user_id = user_id
-            self.trace_instance = StubOpsTraceManager.get_ops_trace_instance(app_id)
 
         def add_trace_task(self, trace_task):
-            trace_task.app_id = self.app_id
-            from core.ops.ops_trace_manager import trace_manager_queue
-
-            trace_manager_queue.put(trace_task)
-
-    class StubOpsTraceManager:
-        @staticmethod
-        def get_ops_trace_instance(app_id):
-            return None
+            submitted_tasks.append(trace_task)
 
     ops_stub.TraceQueueManager = StubTraceQueueManager
     ops_stub.TraceTask = StubTraceTask
-    ops_stub.OpsTraceManager = StubOpsTraceManager
-    ops_stub.trace_manager_queue = MagicMock(spec=queue.Queue)
     monkeypatch.setitem(sys.modules, module_name, ops_stub)
 
     from core.telemetry import emit
 
-    return emit, ops_stub.trace_manager_queue
+    return emit, submitted_tasks
 
 
 class TestTelemetryEmit:
     @patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True)
     def test_emit_enterprise_trace_creates_trace_task(self, mock_ee, telemetry_test_setup):
-        emit_fn, mock_queue = telemetry_test_setup
+        emit_fn, submitted_tasks = telemetry_test_setup
 
         event = DraftNodeExecutionTraceEvent(
             context=TelemetryContext(
@@ -68,12 +56,12 @@ class TestTelemetryEmit:
 
         emit_fn(event)
 
-        mock_queue.put.assert_called_once()
-        called_task = mock_queue.put.call_args[0][0]
+        assert len(submitted_tasks) == 1
+        called_task = submitted_tasks[0]
         assert called_task.trace_type == TraceTaskName.DRAFT_NODE_EXECUTION_TRACE
 
     def test_emit_enterprise_only_trace_dropped_when_ee_disabled(self, telemetry_test_setup):
-        emit_fn, mock_queue = telemetry_test_setup
+        emit_fn, submitted_tasks = telemetry_test_setup
 
         event = DraftNodeExecutionTraceEvent(
             context=TelemetryContext(
@@ -86,11 +74,11 @@ class TestTelemetryEmit:
 
         emit_fn(event)
 
-        mock_queue.put.assert_not_called()
+        assert submitted_tasks == []
 
     @patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True)
     def test_emit_passes_name_directly_to_trace_task(self, mock_ee, telemetry_test_setup):
-        emit_fn, mock_queue = telemetry_test_setup
+        emit_fn, submitted_tasks = telemetry_test_setup
 
         event = DraftNodeExecutionTraceEvent(
             context=TelemetryContext(
@@ -103,14 +91,14 @@ class TestTelemetryEmit:
 
         emit_fn(event)
 
-        mock_queue.put.assert_called_once()
-        called_task = mock_queue.put.call_args[0][0]
+        assert len(submitted_tasks) == 1
+        called_task = submitted_tasks[0]
         assert called_task.trace_type == TraceTaskName.DRAFT_NODE_EXECUTION_TRACE
         assert isinstance(called_task.trace_type, TraceTaskName)
 
     @patch("core.telemetry.gateway.is_enterprise_telemetry_enabled", return_value=True)
     def test_emit_with_provided_trace_manager(self, mock_ee, telemetry_test_setup):
-        emit_fn, mock_queue = telemetry_test_setup
+        emit_fn, _submitted_tasks = telemetry_test_setup
 
         mock_trace_manager = MagicMock()
         mock_trace_manager.add_trace_task = MagicMock()


### PR DESCRIPTION
## Summary

- replace the timer-driven, stateful trace queue consumer with a process-scoped tenant-neutral dispatcher
- capture each app/tenant storage route in an immutable work item before enqueueing
- bound the FIFO queue, keep producers non-blocking, and lazily start one daemon worker per process
- create an independent Flask application context per item and isolate failures so later tenants continue processing
- preserve the existing `TraceQueueManager(app_id, user_id)`, `add_trace_task()`, `.user_id`, and Celery retry contracts

## Reliability and performance

The queue is capped at 2048 entries and drops with a warning rather than delaying application requests. A single consumer preserves FIFO ordering and limits DB, storage, and broker pressure. Process-exit/hot-reload draining is intentionally out of scope, so pending best-effort traces may be lost during restart.

Closes #41409

## Test plan

- `82 passed` across tracing, Celery handoff, telemetry gateway, workflow persistence, and app entity compatibility tests
- Ruff format/check
- targeted Pyrefly check
- targeted Mypy check
- `git diff --check`
- gevent queue consumption smoke check