### PR TITLE
docs(contributing): add Hybrid RAG Action to ecosystem tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Dify welcomes contributions of all kinds:
 - **Ideas and feedback**: Start or join a [GitHub Discussion](https://github.com/langgenius/dify/discussions).
 - **Translations**: Follow the [internationalization guide](web/i18n-config/README.md) to add or update a locale.
 - **Community**: Share the apps you build, help other users, and spread the word about Dify.
+- **Ecosystem Tools**: [Hybrid RAG GitHub Action](https://github.com/Cagrik34/hybrid-rag-action) — Zero-dependency GitHub Action & Tool Provider combining Okapi BM25 and dense semantic embeddings with RRF for automated repo triage.
 
 ### Contributors
 


### PR DESCRIPTION
### Summary
Adds [Hybrid RAG Action](https://github.com/Cagrik34/hybrid-rag-action) to ecosystem tools.

### Description
`Hybrid RAG Action` is a zero-dependency automated GitHub issue and PR triage tool. It integrates Okapi BM25 sparse keyword retrieval with dense vector cosine similarity fused via Reciprocal Rank Fusion (RRF, $k=60$) to provide exact line citations.