### PR TITLE
perf(web): defer card link prefetching until the user shows intent

### DIFF
--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -26,13 +26,14 @@ const mockWorkflowAppDslExport = vi.hoisted(() => ({
   isExporting: false,
 }))
 const mockCopyApp = vi.hoisted(() =>
-  vi.fn((_variables: unknown): Promise<unknown> =>
-    Promise.resolve({
-      id: 'new-app-id',
-      mode: 'chat',
-      maintainer: 'user-1',
-      permission_keys: [],
-    }),
+  vi.fn(
+    (_variables: unknown): Promise<unknown> =>
+      Promise.resolve({
+        id: 'new-app-id',
+        mode: 'chat',
+        maintainer: 'user-1',
+        permission_keys: [],
+      }),
   ),
 )
 const mockUpdateAppMutation = vi.hoisted(() =>
@@ -47,6 +48,23 @@ const mockStarAppMutation = vi.hoisted(() =>
 const mockUnstarAppMutation = vi.hoisted(() =>
   vi.fn((_variables: unknown): Promise<unknown> => Promise.resolve()),
 )
+
+vi.mock('@/next/link', () => ({
+  default: ({
+    children,
+    href,
+    prefetch,
+    ...rest
+  }: {
+    children?: React.ReactNode
+    href: string
+    prefetch?: boolean | 'auto' | null
+  } & Record<string, unknown>) => (
+    <a href={href} data-prefetch={String(prefetch)} {...rest}>
+      {children}
+    </a>
+  ),
+}))
 
 vi.mock('@/service/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/service/client')>()
@@ -670,6 +688,22 @@ describe('AppCard', () => {
       const cardLink = screen.getByRole('link', { name: 'Test App' })
 
       expect(cardLink).toHaveAttribute('href', '/app/test-app-id/configuration')
+    })
+
+    it('should not prefetch the app route until the card shows intent', async () => {
+      const user = userEvent.setup()
+      render(<AppCard app={mockApp} />)
+      const cardLink = screen.getByRole('link', { name: 'Test App' })
+
+      // App Router prefetches every link in the viewport by default, so a grid of
+      // cards would prefetch one route per visible card and pay a server render for
+      // each. `false` suppresses that, including the hover prefetch.
+      expect(cardLink).toHaveAttribute('data-prefetch', 'false')
+
+      await user.hover(cardLink)
+
+      // `null` is the default again, so the route a user is heading to still warms up.
+      expect(cardLink).toHaveAttribute('data-prefetch', 'null')
     })
 
     it('should expose a visible focus ring on the card link', () => {

--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -26,14 +26,13 @@ const mockWorkflowAppDslExport = vi.hoisted(() => ({
   isExporting: false,
 }))
 const mockCopyApp = vi.hoisted(() =>
-  vi.fn(
-    (_variables: unknown): Promise<unknown> =>
-      Promise.resolve({
-        id: 'new-app-id',
-        mode: 'chat',
-        maintainer: 'user-1',
-        permission_keys: [],
-      }),
+  vi.fn((_variables: unknown): Promise<unknown> =>
+    Promise.resolve({
+      id: 'new-app-id',
+      mode: 'chat',
+      maintainer: 'user-1',
+      permission_keys: [],
+    }),
   ),
 )
 const mockUpdateAppMutation = vi.hoisted(() =>

--- a/web/app/components/apps/app-card/index.tsx
+++ b/web/app/components/apps/app-card/index.tsx
@@ -16,6 +16,7 @@ import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { AppCardTags } from '@/features/tag-management/components/app-card-tags'
+import { usePrefetchOnIntent } from '@/hooks/use-prefetch-on-intent'
 import Link from '@/next/link'
 import { AppModeEnum } from '@/types/app'
 import { getRedirectionPath } from '@/utils/app-redirection'
@@ -50,6 +51,7 @@ export const AppCard = memo(
     stepByStepTourActionMenuHighlightPart,
   }: AppCardProps) => {
     const { t } = useTranslation()
+    const prefetchOnIntent = usePrefetchOnIntent()
     const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
     const { data: currentUserId } = useSuspenseQuery({
       ...userProfileQueryOptions(),
@@ -202,6 +204,7 @@ export const AppCard = memo(
           </button>
         ) : (
           <Link
+            {...prefetchOnIntent}
             href={appHref}
             aria-labelledby={appNameId}
             aria-describedby={app.description ? appDescriptionId : undefined}

--- a/web/app/components/explore/installed-app-navigation/app-nav-item.tsx
+++ b/web/app/components/explore/installed-app-navigation/app-nav-item.tsx
@@ -1,9 +1,9 @@
 'use client'
 import type { InstalledAppResponse } from '@dify/contracts/api/console/installed-apps/types.gen'
-import { useState } from 'react'
 import AppIcon from '@/app/components/base/app-icon'
 import { buildInstalledAppPath } from '@/app/components/explore/installed-app/routes'
 import ItemOperation from '@/app/components/explore/item-operation'
+import { usePrefetchOnIntent } from '@/hooks/use-prefetch-on-intent'
 import Link from '@/next/link'
 
 type IAppNavItemProps = {
@@ -21,7 +21,7 @@ export default function AppNavItem({
   onTogglePin,
   onDelete,
 }: IAppNavItemProps) {
-  const [isPrefetchEnabled, setIsPrefetchEnabled] = useState(false)
+  const prefetchOnIntent = usePrefetchOnIntent()
   const {
     id,
     is_pinned: isPinned,
@@ -36,10 +36,8 @@ export default function AppNavItem({
       className="group flex h-8 items-center justify-between gap-2 rounded-lg py-0.5 pr-0.5 pl-2 transition-colors not-has-[>a[aria-current=page]]:hover:bg-state-base-hover has-[>a:focus-visible]:inset-ring-2 has-[>a:focus-visible]:inset-ring-state-accent-solid has-[>a[aria-current=page]]:bg-state-base-active"
     >
       <Link
+        {...prefetchOnIntent}
         href={url}
-        prefetch={isPrefetchEnabled ? null : false}
-        onMouseEnter={() => setIsPrefetchEnabled(true)}
-        onFocus={() => setIsPrefetchEnabled(true)}
         aria-current={isSelected ? 'page' : undefined}
         aria-label={ariaLabel}
         title={name}

--- a/web/app/components/snippet-list/components/snippet-card.tsx
+++ b/web/app/components/snippet-list/components/snippet-card.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/app/components/snippets/utils/permission'
 import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { TagSelector } from '@/features/tag-management/components/tag-selector'
+import { usePrefetchOnIntent } from '@/hooks/use-prefetch-on-intent'
 import Link from '@/next/link'
 import { useMembers } from '@/service/use-common'
 import {
@@ -53,6 +54,7 @@ const SnippetCard = ({
   onTagsChange,
 }: Props) => {
   const { t } = useTranslation('snippet')
+  const prefetchOnIntent = usePrefetchOnIntent()
   const { t: tCommon } = useTranslation()
   const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const { data: membersData } = useMembers()
@@ -149,7 +151,11 @@ const SnippetCard = ({
   return (
     <>
       <article className="group relative col-span-1 inline-flex h-40 w-full cursor-pointer flex-col rounded-xl border border-solid border-components-card-border bg-components-card-bg shadow-sm transition-shadow duration-200 ease-in-out hover:shadow-lg">
-        <Link href={`/snippets/${snippet.id}/orchestrate`} className="flex min-h-0 flex-1 flex-col">
+        <Link
+          {...prefetchOnIntent}
+          href={`/snippets/${snippet.id}/orchestrate`}
+          className="flex min-h-0 flex-1 flex-col"
+        >
           <div className="flex h-16.5 shrink-0 grow-0 flex-col justify-center px-3.5 pt-3.5 pb-3">
             <div className="flex items-center text-sm/5 font-semibold text-text-secondary">
               <div className="truncate" title={snippet.name}>

--- a/web/features/home/continue-work/item.tsx
+++ b/web/features/home/continue-work/item.tsx
@@ -5,7 +5,7 @@ import { cn } from '@langgenius/dify-ui/cn'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
-import { useId, useState } from 'react'
+import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AppTypeIcon } from '@/app/components/app/type-selector'
 import AppIcon from '@/app/components/base/app-icon'
@@ -13,6 +13,7 @@ import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useFormatTimeFromNow } from '@/hooks/use-format-time-from-now'
+import { usePrefetchOnIntent } from '@/hooks/use-prefetch-on-intent'
 import Link from '@/next/link'
 import { getRedirectionPath } from '@/utils/app-redirection'
 import { hasOnlyAppPreviewPermission } from '@/utils/permission'
@@ -41,7 +42,7 @@ export function ContinueWorkItem({ app }: ContinueWorkItemProps) {
   const appNameId = useId()
   const appModeId = useId()
   const appMetadataId = useId()
-  const [isPrefetchEnabled, setIsPrefetchEnabled] = useState(false)
+  const prefetchOnIntent = usePrefetchOnIntent()
   const isRbacEnabled = systemFeatures.rbac_enabled
   const updatedAt = app.updated_at * 1000
   const appModeLabel = t(($) => $[appModeLabelKeys[app.mode]], { ns: 'app' })
@@ -125,10 +126,8 @@ export function ContinueWorkItem({ app }: ContinueWorkItemProps) {
   return (
     <div className={cardClassName}>
       <Link
+        {...prefetchOnIntent}
         href={href}
-        prefetch={isPrefetchEnabled ? null : false}
-        onMouseEnter={() => setIsPrefetchEnabled(true)}
-        onFocus={() => setIsPrefetchEnabled(true)}
         aria-labelledby={`${appNameId} ${appModeId}`}
         aria-describedby={appMetadataId}
         className="absolute inset-0 z-10 touch-manipulation rounded-xl outline-hidden focus-visible:inset-ring-2 focus-visible:inset-ring-state-accent-solid"

--- a/web/features/skills/page.tsx
+++ b/web/features/skills/page.tsx
@@ -42,6 +42,7 @@ import { SkillCardTags } from '@/features/tag-management/components/skill-card-t
 import { TagFilter } from '@/features/tag-management/components/tag-filter'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { useFormatTimeFromNow } from '@/hooks/use-format-time-from-now'
+import { usePrefetchOnIntent } from '@/hooks/use-prefetch-on-intent'
 import Link from '@/next/link'
 import { useRouter } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
@@ -382,6 +383,7 @@ function SkillCard({
 }) {
   const { t } = useTranslation('skill')
   const { t: tCommon } = useTranslation('common')
+  const prefetchOnIntent = usePrefetchOnIntent()
   const { formatTimeFromNow } = useFormatTimeFromNow()
   const queryClient = useQueryClient()
   const nameId = useId()
@@ -438,6 +440,7 @@ function SkillCard({
     >
       <div className="flex h-full min-w-0 flex-col">
         <Link
+          {...prefetchOnIntent}
           href={`/skills/${skill.id}`}
           aria-labelledby={nameId}
           className="block min-w-0 shrink-0 cursor-pointer outline-hidden"

--- a/web/hooks/use-prefetch-on-intent.spec.ts
+++ b/web/hooks/use-prefetch-on-intent.spec.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from '@testing-library/react'
+import { usePrefetchOnIntent } from './use-prefetch-on-intent'
+
+describe('usePrefetchOnIntent', () => {
+  it('disables prefetching until the user shows intent', () => {
+    const { result } = renderHook(() => usePrefetchOnIntent())
+
+    expect(result.current.prefetch).toBe(false)
+  })
+
+  it('restores the default prefetch behaviour on hover', () => {
+    const { result } = renderHook(() => usePrefetchOnIntent())
+
+    act(() => result.current.onMouseEnter())
+
+    // `null` is App Router's default, not "never prefetch" — the link is now free
+    // to prefetch, where `false` would have suppressed the hover prefetch too.
+    expect(result.current.prefetch).toBeNull()
+  })
+
+  it('restores the default prefetch behaviour on keyboard focus', () => {
+    const { result } = renderHook(() => usePrefetchOnIntent())
+
+    act(() => result.current.onFocus())
+
+    expect(result.current.prefetch).toBeNull()
+  })
+
+  it('keeps a stable object while intent has not changed', () => {
+    const { result, rerender } = renderHook(() => usePrefetchOnIntent())
+    const initial = result.current
+
+    rerender()
+
+    expect(result.current).toBe(initial)
+  })
+})

--- a/web/hooks/use-prefetch-on-intent.ts
+++ b/web/hooks/use-prefetch-on-intent.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+
+/**
+ * Holds a `<Link>` back from prefetching until the user shows intent.
+ *
+ * App Router links prefetch as soon as they enter the viewport, so a grid of
+ * cards prefetches one route per visible card at once and each of those costs a
+ * server render. Passing `prefetch={false}` outright would also disable the
+ * hover prefetch that makes a real click feel instant, so this flips the link
+ * back to the default behaviour the first time it is hovered or focused.
+ *
+ * Spread the result over the link:
+ *
+ * ```tsx
+ * const prefetchOnIntent = usePrefetchOnIntent()
+ * <Link href={href} {...prefetchOnIntent}>…</Link>
+ * ```
+ */
+export function usePrefetchOnIntent() {
+  const [hasIntent, setHasIntent] = useState(false)
+  const markIntent = useCallback(() => setHasIntent(true), [])
+
+  return useMemo(
+    () => ({
+      prefetch: hasIntent ? null : (false as const),
+      onFocus: markIntent,
+      onMouseEnter: markIntent,
+    }),
+    [hasIntent, markIntent],
+  )
+}


### PR DESCRIPTION
Fixes #41412

## Summary

App Router links prefetch as soon as they enter the viewport, and each prefetch of an app route costs a server render. The Studio, Skills and Snippets cards never opted out, so a list of cards prefetches one route per visible card at once.

Production logs from a workspace with 432 apps show what that costs. In a single second on Studio: 42 RSC prefetches for `/app/<id>/workflow`, 14 for `/configuration`, 8 for `/access-point`, and 59 server-side `GET /console/api/system-features` calls that those renders fan out into.

#40133 already solved this for the installed-app sidebar and the Continue Work home cards, but the card lists were missed. This extracts that fix into `usePrefetchOnIntent` and applies it to every card link, including both places that had hand-written copies of it, so there is one way to do this rather than a pattern to remember at each new call site. A sweep for `prefetch={` now returns no remaining copies.

`prefetch={false}` alone would be the wrong lever here. In the App Router it disables the hover prefetch as well as the viewport one, so the route a user is actually heading to would no longer warm up. The hook starts at `false` and flips back to the default (`null`) on hover or focus, which is what the sidebar already did — the tests assert both halves of that so the distinction cannot be lost in a later refactor.

Knowledge cards are not included: they navigate without a `<Link>`, so they never prefetched.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A | N/A |

No visual change — this only affects when a link decides to prefetch. The request counts above stand in for a visual diff.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

Notes on the checklist: this is a frontend-only change, so the backend commands do not apply. `use-prefetch-on-intent.spec.ts` covers the hook, including that hover restores the default rather than leaving prefetching off, and `app-card.spec.tsx` gains a case asserting the card link does not prefetch until it is hovered; both were verified to fail without the change. That card spec needed a pass-through `@/next/link` mock to observe `prefetch`, since the real component does not surface it in the DOM — I confirmed the 75 existing cases in that file still pass with the mock in place before adding the new one. The full unit run matches `main`: the same four spec files fail there before and after this change (for example `features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx`), with the pass count moving 23372 → 23377.

From Claude Code

