### PR TITLE
fix(web): stop feature flags reverting to disabled while unknown

### DIFF
--- a/web/context/__tests__/provider-context-provider.spec.tsx
+++ b/web/context/__tests__/provider-context-provider.spec.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react'
+import { useProviderContextSelector } from '../provider-context'
+import { ProviderContextProvider } from '../provider-context-provider'
+
+const mockFeaturesQuery = vi.hoisted(() => vi.fn())
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQuery: (options: { queryKey?: unknown[] }) =>
+      String(options.queryKey?.[0]).includes('features')
+        ? mockFeaturesQuery()
+        : { data: undefined, isLoading: false, isSuccess: false, isFetched: false },
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  }
+})
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    features: {
+      get: { queryOptions: () => ({ queryKey: ['features'] }), key: () => ['features'] },
+    },
+    workspaces: {
+      current: {
+        modelProviders: { summary: { get: { queryOptions: () => ({ queryKey: ['providers'] }) } } },
+      },
+    },
+  },
+}))
+
+vi.mock('@/service/use-common', () => ({
+  commonQueryKeys: { modelList: () => ['model-list'] },
+  useModelListByType: () => ({ data: [] }),
+  useSupportRetrievalMethods: () => ({ data: undefined }),
+}))
+
+vi.mock('@/app/components/base/zendesk/utils', () => ({ setZendeskConversationFields: vi.fn() }))
+
+vi.mock('jotai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('jotai')>()
+  return { ...actual, useAtomValue: () => undefined }
+})
+
+const SkillFlag = () => {
+  const enableSkill = useProviderContextSelector((state) => state.enableSkill)
+
+  return <span data-testid="enable-skill">{String(enableSkill)}</span>
+}
+
+const renderProvider = () =>
+  render(
+    <ProviderContextProvider>
+      <SkillFlag />
+    </ProviderContextProvider>,
+  )
+
+const featuresResult = (data: unknown) => ({
+  data,
+  isLoading: false,
+  isSuccess: !!data,
+  isFetched: !!data,
+})
+
+const enabledFeatures = {
+  billing: { enabled: false },
+  education: { enabled: false },
+  enable_skill: true,
+  can_replace_logo: false,
+  model_load_balancing_enabled: false,
+  webapp_copyright_enabled: false,
+  is_allow_transfer_workspace: false,
+  knowledge_pipeline: { publish_enabled: false },
+  human_input_email_delivery_enabled: false,
+}
+
+describe('ProviderContextProvider', () => {
+  it('reports a feature as disabled before anything is known', () => {
+    mockFeaturesQuery.mockReturnValue(featuresResult(undefined))
+    renderProvider()
+
+    expect(screen.getByTestId('enable-skill')).toHaveTextContent('false')
+  })
+
+  it('keeps the last known feature flags when the query briefly has no data', () => {
+    mockFeaturesQuery.mockReturnValue(featuresResult(enabledFeatures))
+    const { rerender } = renderProvider()
+
+    expect(screen.getByTestId('enable-skill')).toHaveTextContent('true')
+
+    // Anything gated on a flag would otherwise disappear and come back while the
+    // query is without data, because every flag falls back to a disabled default.
+    mockFeaturesQuery.mockReturnValue(featuresResult(undefined))
+    rerender(
+      <ProviderContextProvider>
+        <SkillFlag />
+      </ProviderContextProvider>,
+    )
+
+    expect(screen.getByTestId('enable-skill')).toHaveTextContent('true')
+  })
+})

--- a/web/context/provider-context-provider.tsx
+++ b/web/context/provider-context-provider.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { setZendeskConversationFields } from '@/app/components/base/zendesk/utils'
 import { defaultPlan } from '@/app/components/billing/config'
 import { parseCurrentPlan } from '@/app/components/billing/utils'
@@ -37,7 +37,15 @@ export const ProviderContextProvider = ({ children }: ProviderContextProviderPro
   const { data: textGenerationModelList } = useModelListByType(ModelTypeEnum.textGeneration)
   const { data: supportRetrievalMethods } = useSupportRetrievalMethods()
 
-  const features = featuresQuery.data
+  // Every flag below falls back to a disabled default, so a moment without data
+  // reads as "the feature is off" rather than "not known yet" and anything gated on
+  // one of them disappears until the query resolves again. Hold on to the last
+  // answer instead, so a known feature never silently un-knows itself.
+  const [lastKnownFeatures, setLastKnownFeatures] = useState(featuresQuery.data)
+  if (featuresQuery.data && featuresQuery.data !== lastKnownFeatures)
+    setLastKnownFeatures(featuresQuery.data)
+
+  const features = featuresQuery.data ?? lastKnownFeatures
   const enableBilling = features?.billing.enabled ?? false
   const plan = enableBilling && features ? parseCurrentPlan(features) : defaultPlan
   const isFetchedPlan = featuresQuery.isSuccess && enableBilling


### PR DESCRIPTION
Fixes #41414

## Summary

Every flag the provider context derives falls back to a disabled default:

```ts
const enableSkill = features?.enable_skill ?? false
```

`features` is a client-side `useQuery`, so that fallback collapses "not known yet" into "the feature is off", and anything gated on one of these flags disappears until the query resolves again.

The visible case is the Skills entry in the main nav. It is gated on `enableSkill`, while its neighbours are gated on `system-features` — a suspense query prefetched on the server, so always resolved by the time the nav renders. Skills is the only entry whose flag can be in an unknown state, and it is the only one that flickers. Details and the comparison table are in the issue.

This holds on to the last answer instead, so a feature known to be enabled never silently un-knows itself. It covers every flag derived in that provider rather than only the one that surfaced the problem, and it does not depend on enumerating every way the query can end up without data — which matters, because I was not able to pin down the specific trigger. What I could establish is that the usual suspects are not it: `refreshFeatures` uses `invalidateQueries`, which keeps data; nothing calls `removeQueries` or `resetQueries` against this key; there is a single `ProviderContextProvider` instance, so it is not a second provider mounting empty. The one signal I do have from production logs is a `401` on `/console/api/features` with a `/skills` referer.

Guarding the derivation is the right layer regardless of the trigger: a fallback that cannot distinguish "off" from "unknown" will keep producing this class of bug whatever opens the gap.

Trade-off worth calling out: once a feature set is known, a later gap now shows the previous values rather than defaults. That is the intent, and workspace switches reload the console, so the retained values do not outlive the workspace they belong to.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A | N/A |

The change is a flicker fix — a still frame does not show it, and the reproduction is described in the issue.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

Notes on the checklist: this is a frontend-only change, so the backend commands do not apply. The new `provider-context-provider.spec.tsx` covers both halves — a flag still reads as disabled before anything is known, and a known flag survives the query going empty — and the second case was verified to fail without the change. The full unit run matches `main`: the same four spec files fail there before and after (for example `features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx`), with the pass count moving 23372 → 23374.

From Claude Code
