### PR TITLE
docs: correct UUIDv7 helper docstring

### DIFF
--- a/api/models/base.py
+++ b/api/models/base.py
@@ -103,5 +103,5 @@ def gen_uuidv4_string() -> str:
 
 
 def gen_uuidv7_string() -> str:
-    """gen_uuidv4_string generate a UUIDv4 string."""
+    """Generate a UUIDv7 string."""
     return str(uuidv7())


### PR DESCRIPTION
## Summary

- Correct the copied UUIDv4 description on `gen_uuidv7_string` to describe UUIDv7.
- This is a documentation-only typo correction; no runtime behavior changes.

## Validation

- `git diff --check`
- `python3 -m compileall -q api/models/base.py`

This is a typo correction, so the repository pull-request template typo exception applies; no issue link is required.