### PR TITLE
fix: delete multimodal segment attachment objects from storage

### DIFF
--- a/api/tasks/delete_segment_from_index_task.py
+++ b/api/tasks/delete_segment_from_index_task.py
@@ -7,6 +7,7 @@ from sqlalchemy import delete, select
 
 from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
+from extensions.ext_storage import storage
 from models.dataset import Dataset, Document, SegmentAttachmentBinding
 from models.model import UploadFile
 
@@ -67,6 +68,10 @@ def delete_segment_from_index_task(
                 ).all()
                 if segment_attachment_bindings:
                     attachment_ids = [binding.attachment_id for binding in segment_attachment_bindings]
+                    attachment_files = session.scalars(
+                        select(UploadFile).where(UploadFile.id.in_(attachment_ids))
+                    ).all()
+                    attachment_file_keys = [attachment_file.key for attachment_file in attachment_files]
                     index_processor.clean(
                         session=session, dataset=dataset, node_ids=attachment_ids, with_keywords=False
                     )
@@ -81,6 +86,15 @@ def delete_segment_from_index_task(
                     # delete upload file
                     session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
                     session.commit()
+
+                    for attachment_file_key in attachment_file_keys:
+                        try:
+                            storage.delete(attachment_file_key)
+                        except Exception:
+                            logger.exception(
+                                "Delete attachment_file failed when storage deleted, attachment_file_key: %s",
+                                attachment_file_key,
+                            )
 
             end_at = time.perf_counter()
             logger.info(click.style(f"Segment deleted from index latency: {end_at - start_at}", fg="green"))

--- a/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
+++ b/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
@@ -1,15 +1,18 @@
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy import event
+from sqlalchemy import event, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.rag.index_processor.constant.index_type import IndexStructureType
-from models.dataset import Dataset, Document, DocumentSegment
-from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from extensions.storage.storage_type import StorageType
+from models.dataset import Dataset, Document, DocumentSegment, SegmentAttachmentBinding
+from models.enums import CreatorUserRole, DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from models.model import UploadFile
 from tasks.delete_segment_from_index_task import delete_segment_from_index_task
 from tasks.disable_segment_from_index_task import disable_segment_from_index_task
 from tasks.disable_segments_from_index_task import disable_segments_from_index_task
@@ -58,6 +61,37 @@ def indexed_segment(sqlite_session: Session) -> tuple[Dataset, Document, Documen
     sqlite_session.add_all([dataset, document, segment])
     sqlite_session.commit()
     return dataset, document, segment
+
+
+@pytest.fixture
+def multimodal_indexed_segment(
+    indexed_segment: tuple[Dataset, Document, DocumentSegment], sqlite_session: Session
+) -> tuple[Dataset, Document, DocumentSegment, UploadFile, SegmentAttachmentBinding]:
+    dataset, document, segment = indexed_segment
+    dataset.is_multimodal = True
+    attachment_file = UploadFile(
+        tenant_id=dataset.tenant_id,
+        storage_type=StorageType.LOCAL,
+        key="attachments/segment-image.png",
+        name="segment-image.png",
+        size=10,
+        extension="png",
+        mime_type="image/png",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by=document.created_by,
+        created_at=datetime.now(UTC),
+        used=False,
+    )
+    binding = SegmentAttachmentBinding(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        segment_id=segment.id,
+        attachment_id=attachment_file.id,
+    )
+    sqlite_session.add_all([attachment_file, binding])
+    sqlite_session.commit()
+    return dataset, document, segment, attachment_file, binding
 
 
 @contextmanager
@@ -152,3 +186,65 @@ def test_delete_segment_commits_index_cleanup_without_attachments(
         delete_segment_from_index_task.run(["node-1"], dataset.id, document.id, [segment.id])
 
     assert phase_events == ["clean", "commit"]
+
+
+def test_delete_segment_removes_multimodal_attachment_and_storage_object(
+    multimodal_indexed_segment: tuple[Dataset, Document, DocumentSegment, UploadFile, SegmentAttachmentBinding],
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    dataset, document, segment, attachment_file, binding = multimodal_indexed_segment
+    phase_events: list[str] = []
+    processor = MagicMock()
+    processor.clean.side_effect = lambda *_args, **_kwargs: phase_events.append("clean")
+
+    def delete_storage_object(_key: str) -> None:
+        phase_events.append("storage_delete")
+
+    with (
+        _record_transaction_events(sqlite_session_factory, phase_events),
+        patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+        patch("tasks.delete_segment_from_index_task.storage") as mock_storage,
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        mock_storage.delete.side_effect = delete_storage_object
+        delete_segment_from_index_task.run([segment.index_node_id], dataset.id, document.id, [segment.id])
+
+    assert processor.clean.call_count == 2
+    assert processor.clean.call_args_list[1].kwargs["node_ids"] == [attachment_file.id]
+    mock_storage.delete.assert_called_once_with(attachment_file.key)
+    assert phase_events == ["clean", "commit", "clean", "commit", "storage_delete"]
+
+    with sqlite_session_factory() as verification_session:
+        assert (
+            verification_session.scalar(
+                select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.id == binding.id)
+            )
+            is None
+        )
+        assert verification_session.scalar(select(UploadFile).where(UploadFile.id == attachment_file.id)) is None
+
+
+def test_delete_segment_keeps_database_cleanup_when_storage_delete_fails(
+    multimodal_indexed_segment: tuple[Dataset, Document, DocumentSegment, UploadFile, SegmentAttachmentBinding],
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    dataset, document, segment, attachment_file, binding = multimodal_indexed_segment
+    processor = MagicMock()
+
+    with (
+        patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+        patch("tasks.delete_segment_from_index_task.storage") as mock_storage,
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        mock_storage.delete.side_effect = RuntimeError("storage unavailable")
+        delete_segment_from_index_task.run([segment.index_node_id], dataset.id, document.id, [segment.id])
+
+    mock_storage.delete.assert_called_once_with(attachment_file.key)
+    with sqlite_session_factory() as verification_session:
+        assert (
+            verification_session.scalar(
+                select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.id == binding.id)
+            )
+            is None
+        )
+        assert verification_session.scalar(select(UploadFile).where(UploadFile.id == attachment_file.id)) is None


### PR DESCRIPTION
## Summary

Fixes #41399.

Deleting a single segment from a multimodal knowledge dataset currently removes the attachment binding and `UploadFile` database records, but leaves the physical attachment object in the configured storage backend.

This change:

- preserves attachment storage keys before deleting the `UploadFile` rows
- deletes the physical storage objects after the database cleanup has committed
- treats storage deletion as best-effort so storage failures do not undo database cleanup
- adds regression tests for both successful storage cleanup and storage deletion failure

## Testing

- `pytest api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py -q`
  - 5 passed
- Ruff check passed
- Ruff format check passed
- Pyrefly check passed
- `git diff --check upstream/main...HEAD` passed
