### PR TITLE
feat: hide skill_entry when use has no skill.view permission

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1068,11 +1068,6 @@
       "count": 2
     }
   },
-  "web/app/components/base/icons/src/public/billing/index.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 4
-    }
-  },
   "web/app/components/base/icons/src/public/common/index.ts": {
     "no-barrel-files/no-barrel-files": {
       "count": 5
@@ -1765,11 +1760,6 @@
   "web/app/components/billing/plan/assets/index.tsx": {
     "no-barrel-files/no-barrel-files": {
       "count": 3
-    }
-  },
-  "web/app/components/billing/pricing/assets/index.tsx": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 12
     }
   },
   "web/app/components/datasets/chunk.tsx": {

--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -465,6 +465,7 @@ const ownerWorkspacePermissionKeys = [
   'tool.manage',
   'mcp.manage',
   'agent.manage',
+  'skill.view',
 ]
 
 const datasetOperatorWorkspacePermissionKeys = [
@@ -777,6 +778,17 @@ describe('MainNav', () => {
   it('hides the skills entry when skill is disabled', () => {
     mockProviderContextState.current = {
       enableSkill: false,
+    }
+
+    renderMainNav()
+
+    expect(screen.queryByRole('link', { name: /common.mainNav.skills/ })).not.toBeInTheDocument()
+  })
+
+  it('hides the skills entry when the user lacks skill.view', () => {
+    mockConsoleState.current = {
+      ...consoleState,
+      workspacePermissionKeys: ownerWorkspacePermissionKeys.filter((key) => key !== 'skill.view'),
     }
 
     renderMainNav()

--- a/web/app/components/main-nav/index.tsx
+++ b/web/app/components/main-nav/index.tsx
@@ -15,6 +15,7 @@ import { isCurrentWorkspaceDatasetOperatorAtom } from '@/context/workspace-state
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { isAgentV2Enabled } from '@/features/agent-v2/feature-flag'
 import { useCanManageAgents } from '@/features/agent-v2/permissions'
+import { useCanViewSkills } from '@/features/skills/permissions'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import dynamic from '@/next/dynamic'
 import Link from '@/next/link'
@@ -39,6 +40,7 @@ export function MainNav({ className }: MainNavProps) {
   })
   const agentV2Enabled = isAgentV2Enabled()
   const canManageAgents = useCanManageAgents()
+  const canViewSkills = useCanViewSkills()
   const enableSkill = useProviderContextSelector((state) => state.enableSkill)
   const showEnvTag = currentEnv === 'TESTING' || currentEnv === 'DEVELOPMENT'
   const helpMenuTriggerRef = useRef<HTMLButtonElement>(null)
@@ -49,6 +51,7 @@ export function MainNav({ className }: MainNavProps) {
         isMainNavRouteVisible(route, {
           agentV2Enabled,
           canManageAgents,
+          canViewSkills,
           isCurrentWorkspaceDatasetOperator,
           marketplaceEnabled: systemFeatures.enable_marketplace,
           skillEnabled: enableSkill,
@@ -63,6 +66,7 @@ export function MainNav({ className }: MainNavProps) {
     [
       agentV2Enabled,
       canManageAgents,
+      canViewSkills,
       enableSkill,
       isCurrentWorkspaceDatasetOperator,
       systemFeatures.enable_marketplace,

--- a/web/app/components/main-nav/routes.ts
+++ b/web/app/components/main-nav/routes.ts
@@ -18,6 +18,7 @@ export type MainNavRouteConfig = {
 export type MainNavRouteVisibilityOptions = {
   agentV2Enabled: boolean
   canManageAgents: boolean
+  canViewSkills: boolean
   isCurrentWorkspaceDatasetOperator: boolean
   marketplaceEnabled: boolean
   skillEnabled: boolean
@@ -31,7 +32,7 @@ export type DetailSidebarVisibilityOptions = Pick<
 const VISIBLE_TO_ALL: MainNavRouteVisibility = () => true
 const CAN_MANAGE_AGENTS: MainNavRouteVisibility = (options) => options.canManageAgents
 const SKILL_ENABLED_FOR_WORKSPACE: MainNavRouteVisibility = (options) =>
-  options.skillEnabled && !options.isCurrentWorkspaceDatasetOperator
+  options.skillEnabled && options.canViewSkills && !options.isCurrentWorkspaceDatasetOperator
 
 function isPathUnderRoute(pathname: string, route: string) {
   return pathname === route || pathname.startsWith(`${route}/`)

--- a/web/features/skills/permissions.ts
+++ b/web/features/skills/permissions.ts
@@ -3,15 +3,23 @@ import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { hasPermission } from '@/utils/permission'
 
 const SkillPermission = {
+  View: 'skill.view',
   Edit: 'skill.edit',
   Publish: 'skill.publish',
   Delete: 'skill.delete',
 } as const
 
+export function useCanViewSkills() {
+  const permissionKeys = useAtomValue(workspacePermissionKeysAtom)
+
+  return hasPermission(permissionKeys, SkillPermission.View)
+}
+
 export function useSkillPermissions() {
   const permissionKeys = useAtomValue(workspacePermissionKeysAtom)
 
   return {
+    canView: hasPermission(permissionKeys, SkillPermission.View),
     canEdit: hasPermission(permissionKeys, SkillPermission.Edit),
     canPublish: hasPermission(permissionKeys, SkillPermission.Publish),
     canDelete: hasPermission(permissionKeys, SkillPermission.Delete),


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

#41428

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

after


https://github.com/user-attachments/assets/c16e43ec-a1ee-4774-9059-979944de5a2a



## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
