### PR TITLE
fix(web): remove Explore app details entry

### DIFF
--- a/web/app/components/explore/app-card/__tests__/index.spec.tsx
+++ b/web/app/components/explore/app-card/__tests__/index.spec.tsx
@@ -40,14 +40,12 @@ const createApp = (overrides?: Partial<App>): App => ({
 
 describe('AppCard', () => {
   const onCreate = vi.fn()
-  const onTry = vi.fn()
 
   const renderComponent = (props?: Partial<AppCardProps>) => {
     const mergedProps: AppCardProps = {
       app: createApp(),
       canCreate: false,
       onCreate,
-      onTry,
       isExplore: false,
       ...props,
     }
@@ -95,16 +93,16 @@ describe('AppCard', () => {
         isExplore: true,
       })
 
-      const button = screen.getByText('explore.appCard.addToWorkspace')
+      const button = screen.getByRole('button', { name: 'explore.appCard.addToWorkspace' })
       expect(button).toBeInTheDocument()
       fireEvent.click(button)
       expect(onCreate).toHaveBeenCalledTimes(1)
     })
 
-    it('should render try button in explore mode', () => {
+    it('should not render details button in explore mode', () => {
       renderComponent({ canCreate: true, isExplore: true })
 
-      expect(screen.getByText('explore.appCard.try')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'explore.appCard.try' })).not.toBeInTheDocument()
     })
   })
 
@@ -112,14 +110,13 @@ describe('AppCard', () => {
     it('should hide action buttons when not in explore mode', () => {
       renderComponent({ canCreate: true, isExplore: false })
 
-      expect(screen.queryByText('explore.appCard.addToWorkspace')).not.toBeInTheDocument()
-      expect(screen.queryByText('explore.appCard.try')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'explore.appCard.addToWorkspace' })).not.toBeInTheDocument()
     })
 
     it('should hide create button when canCreate is false', () => {
       renderComponent({ canCreate: false, isExplore: true })
 
-      expect(screen.queryByText('explore.appCard.addToWorkspace')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'explore.appCard.addToWorkspace' })).not.toBeInTheDocument()
     })
   })
 
@@ -137,16 +134,6 @@ describe('AppCard', () => {
       renderComponent({ app: createApp({ description: '' }) })
 
       expect(screen.getByText('Sample App')).toBeInTheDocument()
-    })
-
-    it('should call onTry when try button is clicked', () => {
-      const app = createApp()
-
-      renderComponent({ app, canCreate: true, isExplore: true })
-
-      fireEvent.click(screen.getByText('explore.appCard.try'))
-
-      expect(onTry).toHaveBeenCalledWith({ appId: 'app-id', app })
     })
   })
 })

--- a/web/app/components/explore/app-card/index.tsx
+++ b/web/app/components/explore/app-card/index.tsx
@@ -1,11 +1,8 @@
 'use client'
 import type { App } from '@/models/explore'
-import type { TryAppSelection } from '@/types/try-app'
 import { PlusIcon } from '@heroicons/react/20/solid'
-import { RiInformation2Line } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
-import { useGlobalPublicStore } from '@/context/global-public-context'
 import { AppModeEnum } from '@/types/app'
 import { cn } from '@/utils/classnames'
 import { AppTypeIcon } from '../../app/type-selector'
@@ -15,7 +12,6 @@ export type AppCardProps = {
   app: App
   canCreate: boolean
   onCreate: () => void
-  onTry: (params: TryAppSelection) => void
   isExplore?: boolean
 }
 
@@ -23,16 +19,10 @@ const AppCard = ({
   app,
   canCreate,
   onCreate,
-  onTry,
   isExplore = true,
 }: AppCardProps) => {
   const { t } = useTranslation()
   const { app: appBasicInfo } = app
-  const { systemFeatures } = useGlobalPublicStore()
-  const isTrialApp = app.can_trial && systemFeatures.enable_trial_app
-  const handleTryApp = () => {
-    onTry({ appId: app.app_id, app })
-  }
 
   return (
     <div className={cn('group relative col-span-1 flex cursor-pointer flex-col overflow-hidden rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg pb-2 shadow-sm transition-all duration-200 ease-in-out hover:bg-components-panel-on-panel-item-bg-hover hover:shadow-lg')}>
@@ -69,20 +59,12 @@ const AppCard = ({
           {app.description}
         </div>
       </div>
-      {isExplore && (canCreate || isTrialApp) && (
+      {isExplore && canCreate && (
         <div className={cn('absolute bottom-0 left-0 right-0 hidden bg-gradient-to-t from-components-panel-gradient-2 from-[60.27%] to-transparent p-4 pt-8 group-hover:flex')}>
-          <div className={cn('grid h-8 w-full grid-cols-1 space-x-2', canCreate && 'grid-cols-2')}>
-            {
-              canCreate && (
-                <Button variant="primary" className="h-7" onClick={() => onCreate()}>
-                  <PlusIcon className="mr-1 h-4 w-4" />
-                  <span className="text-xs">{t('appCard.addToWorkspace', { ns: 'explore' })}</span>
-                </Button>
-              )
-            }
-            <Button className="h-7" onClick={handleTryApp}>
-              <RiInformation2Line className="mr-1 size-4" />
-              <span>{t('appCard.try', { ns: 'explore' })}</span>
+          <div className="grid h-8 w-full grid-cols-1">
+            <Button variant="primary" className="h-7" onClick={onCreate}>
+              <PlusIcon className="mr-1 h-4 w-4" />
+              <span className="text-xs">{t('appCard.addToWorkspace', { ns: 'explore' })}</span>
             </Button>
           </div>
         </div>

--- a/web/app/components/explore/app-list/__tests__/index.spec.tsx
+++ b/web/app/components/explore/app-list/__tests__/index.spec.tsx
@@ -70,15 +70,6 @@ vi.mock('@/app/components/explore/create-app-modal', () => ({
   },
 }))
 
-vi.mock('../../try-app', () => ({
-  default: ({ onCreate, onClose }: { onCreate: () => void, onClose: () => void }) => (
-    <div data-testid="try-app-panel">
-      <button data-testid="try-app-create" onClick={onCreate}>create</button>
-      <button data-testid="try-app-close" onClick={onClose}>close</button>
-    </div>
-  ),
-}))
-
 vi.mock('../../banner/banner', () => ({
   default: () => <div data-testid="explore-banner">banner</div>,
 }))
@@ -365,9 +356,8 @@ describe('AppList', () => {
     })
   })
 
-  describe('TryApp Panel', () => {
-    it('should open create modal from try app panel', async () => {
-      vi.useRealTimers()
+  describe('Card Actions', () => {
+    it('should not render details action', () => {
       mockExploreData = {
         categories: ['Writing'],
         allList: [createApp()],
@@ -375,29 +365,7 @@ describe('AppList', () => {
 
       renderAppList(true)
 
-      fireEvent.click(screen.getByText('explore.appCard.try'))
-      expect(screen.getByTestId('try-app-panel')).toBeInTheDocument()
-
-      fireEvent.click(screen.getByTestId('try-app-create'))
-
-      await waitFor(() => {
-        expect(screen.getByTestId('create-app-modal')).toBeInTheDocument()
-      })
-    })
-
-    it('should close try app panel when close is clicked', () => {
-      mockExploreData = {
-        categories: ['Writing'],
-        allList: [createApp()],
-      }
-
-      renderAppList(true)
-
-      fireEvent.click(screen.getByText('explore.appCard.try'))
-      expect(screen.getByTestId('try-app-panel')).toBeInTheDocument()
-
-      fireEvent.click(screen.getByTestId('try-app-close'))
-      expect(screen.queryByTestId('try-app-panel')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'explore.appCard.try' })).not.toBeInTheDocument()
     })
   })
 

--- a/web/app/components/explore/app-list/index.tsx
+++ b/web/app/components/explore/app-list/index.tsx
@@ -2,7 +2,6 @@
 
 import type { CreateAppModalProps } from '@/app/components/explore/create-app-modal'
 import type { App } from '@/models/explore'
-import type { TryAppSelection } from '@/types/try-app'
 import { useDebounceFn } from 'ahooks'
 import { useQueryState } from 'nuqs'
 import * as React from 'react'
@@ -26,7 +25,6 @@ import { fetchAppDetail } from '@/service/explore'
 import { useMembers } from '@/service/use-common'
 import { useExploreAppList } from '@/service/use-explore'
 import { cn } from '@/utils/classnames'
-import TryApp from '../try-app'
 import s from './style.module.css'
 
 type AppsProps = {
@@ -100,19 +98,6 @@ const Apps = ({
   } = useImportDSL()
   const [showDSLConfirmModal, setShowDSLConfirmModal] = useState(false)
 
-  const [currentTryApp, setCurrentTryApp] = useState<TryAppSelection | undefined>(undefined)
-  const isShowTryAppPanel = !!currentTryApp
-  const hideTryAppPanel = useCallback(() => {
-    setCurrentTryApp(undefined)
-  }, [])
-  const handleTryApp = useCallback((params: TryAppSelection) => {
-    setCurrentTryApp(params)
-  }, [])
-  const handleShowFromTryApp = useCallback(() => {
-    setCurrApp(currentTryApp?.app || null)
-    setIsShowCreateModal(true)
-  }, [currentTryApp?.app])
-
   const onCreate: CreateAppModalProps['onConfirm'] = async ({
     name,
     icon_type,
@@ -120,8 +105,6 @@ const Apps = ({
     icon_background,
     description,
   }) => {
-    hideTryAppPanel()
-
     const { export_data } = await fetchAppDetail(
       currApp?.app.id as string,
     )
@@ -228,7 +211,6 @@ const Apps = ({
                   setCurrApp(app)
                   setIsShowCreateModal(true)
                 }}
-                onTry={handleTryApp}
               />
             ))}
           </nav>
@@ -258,16 +240,6 @@ const Apps = ({
           />
         )
       }
-
-      {isShowTryAppPanel && (
-        <TryApp
-          appId={currentTryApp?.appId || ''}
-          app={currentTryApp?.app}
-          category={currentTryApp?.app?.category}
-          onClose={hideTryAppPanel}
-          onCreate={handleShowFromTryApp}
-        />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Related to [ENG-773](https://linear.app/dify/issue/ENG-773/trial-app%E5%AF%BC%E8%87%B4%E6%8E%A2%E7%B4%A2%E6%8A%A5%E9%94%99-lts-cherrypick).

### Background

ENG-773 tracks a 404 from the Explore page on LTS deployments where trial apps are disabled or `trial_apps` metadata is not provisioned. The Explore redesign added a **Details** action to recommended app cards, but that action reuses the TryApp preview flow and its `/trial-apps/:appId` read APIs. As a result, the UI still exposes a preview entry whose data source is unavailable in these deployments.

The backend fallback from #38970 / #41402 hardens recommended-app lookup, but it does not remove this unsupported frontend path. The 404 remained reproducible when validating the LTS setup, while the actual supported action on this page is creating an app from the template.

### Fix

- Remove the **Details** action from Explore app cards and keep **Use template** as the only card action.
- Remove the Explore-specific `onTry` wiring, selected TryApp state, and TryApp panel rendering so card interaction no longer triggers trial-app preview requests.
- Keep the existing template creation and DSL import flow unchanged.
- Keep the shared TryApp implementation intact for other consumers.
- Update the AppCard and AppList tests to cover the removed Details entry and retained template creation flow.

### Validation

- AppCard tests: 13 passed.
- AppList tests: 14 passed.
- Explore app-list integration flow: 7 passed.

## Screenshots

**Before:**

<img width="2072" height="1002" alt="20260828135130_rec_" src="https://github.com/user-attachments/assets/51f8c4e4-edcc-4ff6-a4ee-b5db4eb36152" />

**After:**

<img width="2072" height="1002" alt="20260828134945_rec_" src="https://github.com/user-attachments/assets/4f11bd21-2dfe-4b1e-83cb-72cad76ce59b" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
