### PR TITLE
refactor(models): pass session into WorkflowAppLog accessors

### DIFF
--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -1393,17 +1393,15 @@ class WorkflowAppLog(TypeBase):
 
         return None
 
-    @property
-    def created_by_account(self):
+    def created_by_account(self, session: orm.Session) -> Account | None:
         created_by_role = CreatorUserRole(self.created_by_role)
-        return db.session.get(Account, self.created_by) if created_by_role == CreatorUserRole.ACCOUNT else None
+        return session.get(Account, self.created_by) if created_by_role == CreatorUserRole.ACCOUNT else None
 
-    @property
-    def created_by_end_user(self):
+    def created_by_end_user(self, session: orm.Session):
         from .model import EndUser
 
         created_by_role = CreatorUserRole(self.created_by_role)
-        return db.session.get(EndUser, self.created_by) if created_by_role == CreatorUserRole.END_USER else None
+        return session.get(EndUser, self.created_by) if created_by_role == CreatorUserRole.END_USER else None
 
     def to_dict(self) -> WorkflowAppLogDict:
         result: WorkflowAppLogDict = {

--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -23,16 +23,26 @@ class LogView:
     """Lightweight wrapper for WorkflowAppLog with computed details.
 
     - Exposes `details_` for marshalling to `details` in API response
+    - Resolves the account/end-user accessors through the session it was built with
     - Proxies all other attributes to the underlying `WorkflowAppLog`
     """
 
-    def __init__(self, log: WorkflowAppLog, details: LogViewDetails | None):
+    def __init__(self, log: WorkflowAppLog, details: LogViewDetails | None, session: Session):
         self.log = log
         self.details_ = details
+        self._session = session
 
     @property
     def details(self) -> LogViewDetails | None:
         return self.details_
+
+    @property
+    def created_by_account(self) -> Account | None:
+        return self.log.created_by_account(self._session)
+
+    @property
+    def created_by_end_user(self) -> EndUser | None:
+        return self.log.created_by_end_user(self._session)
 
     def __getattr__(self, name):
         return getattr(self.log, name)
@@ -171,11 +181,11 @@ class WorkflowAppService:
         if detail:
             rows = session.execute(offset_stmt).all()
             items = [
-                LogView(log, {"trigger_metadata": self.handle_trigger_metadata(app_model.tenant_id, meta_val)})
+                LogView(log, {"trigger_metadata": self.handle_trigger_metadata(app_model.tenant_id, meta_val)}, session)
                 for log, meta_val in rows
             ]
         else:
-            items = [LogView(log, None) for log in session.scalars(offset_stmt).all()]
+            items = [LogView(log, None, session) for log in session.scalars(offset_stmt).all()]
         return {
             "page": page,
             "limit": limit,

--- a/api/tests/unit_tests/models/test_workflow_app_log_models.py
+++ b/api/tests/unit_tests/models/test_workflow_app_log_models.py
@@ -1,0 +1,80 @@
+"""Regression coverage for ``models.workflow.WorkflowAppLog`` account accessors.
+
+Ensures the ``@property``→session-parameter refactor preserves the role-based dispatch:
+``created_by_account`` looks up an Account only when role is ACCOUNT; ``created_by_end_user``
+looks up an EndUser only when role is END_USER.
+
+Both accessors are exercised against the real ``sqlite_session`` fixture (a genuine
+SQLAlchemy ``Session`` bound to a pristine full-schema SQLite database) so the assertions
+cover actual query behaviour rather than a mock's recorded call.
+"""
+
+from sqlalchemy.orm import Session
+
+from models.account import Account
+from models.enums import CreatorUserRole, EndUserType
+from models.model import EndUser
+from models.workflow import WorkflowAppLog, WorkflowAppLogCreatedFrom
+
+
+def _log(role: CreatorUserRole, created_by: str) -> WorkflowAppLog:
+    """Construct a WorkflowAppLog without touching the database."""
+    return WorkflowAppLog(
+        tenant_id="00000000-0000-0000-0000-000000000001",
+        app_id="00000000-0000-0000-0000-000000000002",
+        workflow_id="00000000-0000-0000-0000-000000000003",
+        workflow_run_id="00000000-0000-0000-0000-000000000004",
+        created_from=WorkflowAppLogCreatedFrom.WEB_APP,
+        created_by_role=role,
+        created_by=created_by,
+    )
+
+
+class TestCreatedByAccount:
+    def test_returns_account_lookup_when_role_is_account(self, sqlite_session: Session) -> None:
+        account = Account(name="Test Account", email="test@example.com")
+        sqlite_session.add(account)
+        sqlite_session.flush()
+        log = _log(CreatorUserRole.ACCOUNT, created_by=account.id)
+
+        result = log.created_by_account(session=sqlite_session)
+
+        assert result is not None
+        assert result.id == account.id
+
+    def test_returns_none_when_role_is_end_user(self, sqlite_session: Session) -> None:
+        account = Account(name="Test Account", email="test@example.com")
+        sqlite_session.add(account)
+        sqlite_session.flush()
+        log = _log(CreatorUserRole.END_USER, created_by=account.id)
+
+        assert log.created_by_account(session=sqlite_session) is None
+
+
+class TestCreatedByEndUser:
+    def test_returns_end_user_lookup_when_role_is_end_user(self, sqlite_session: Session) -> None:
+        end_user = EndUser(
+            tenant_id="00000000-0000-0000-0000-000000000001",
+            type=EndUserType.BROWSER,
+            session_id="session-1",
+        )
+        sqlite_session.add(end_user)
+        sqlite_session.flush()
+        log = _log(CreatorUserRole.END_USER, created_by=end_user.id)
+
+        result = log.created_by_end_user(session=sqlite_session)
+
+        assert result is not None
+        assert result.id == end_user.id
+
+    def test_returns_none_when_role_is_account(self, sqlite_session: Session) -> None:
+        end_user = EndUser(
+            tenant_id="00000000-0000-0000-0000-000000000001",
+            type=EndUserType.BROWSER,
+            session_id="session-1",
+        )
+        sqlite_session.add(end_user)
+        sqlite_session.flush()
+        log = _log(CreatorUserRole.ACCOUNT, created_by=end_user.id)
+
+        assert log.created_by_end_user(session=sqlite_session) is None

--- a/api/tests/unit_tests/services/test_workflow_app_service_metadata.py
+++ b/api/tests/unit_tests/services/test_workflow_app_service_metadata.py
@@ -2,10 +2,12 @@
 
 import json
 import uuid
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy.orm import Session
 
+from models.account import Account
 from models.enums import AppTriggerType, CreatorUserRole
 from models.workflow import WorkflowAppLog, WorkflowAppLogCreatedFrom
 from services.workflow_app_service import LogView, WorkflowAppService
@@ -24,10 +26,31 @@ class TestLogView:
         )
         log.id = "log-1"
 
-        view = LogView(log=log, details={"trigger_metadata": {"type": "plugin"}})
+        view = LogView(log=log, details={"trigger_metadata": {"type": "plugin"}}, session=MagicMock())
 
         assert view.details == {"trigger_metadata": {"type": "plugin"}}
         assert view.id == "log-1"
+
+    def test_account_accessors_resolve_via_wrapped_session(self, sqlite_session: Session) -> None:
+        account = Account(name="Test Account", email="test@example.com")
+        sqlite_session.add(account)
+        sqlite_session.flush()
+        log = WorkflowAppLog(
+            tenant_id="tenant-1",
+            app_id="app-1",
+            workflow_id="workflow-1",
+            workflow_run_id="run-1",
+            created_from=WorkflowAppLogCreatedFrom.WEB_APP,
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by=account.id,
+        )
+
+        view = LogView(log=log, details=None, session=sqlite_session)
+
+        resolved = view.created_by_account
+        assert resolved is not None
+        assert resolved.id == account.id
+        assert view.created_by_end_user is None
 
 
 class TestHandleTriggerMetadata:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 1. Associated issue: #40372 (claimed the `WorkflowAppLog` slice in [this comment](https://github.com/langgenius/dify/issues/40372#issuecomment-5450086134)).

## Summary

Part of #40372, follow-up to #41370.

Converts the two `WorkflowAppLog` `@property` accessors in `api/models/workflow.py` that reach for the global `db.session` internally into plain methods taking `session: Session` explicitly, per the pattern established in #40370 / #40797:

- `WorkflowAppLog.created_by_account` — now `def created_by_account(self, session) -> Account | None`.
- `WorkflowAppLog.created_by_end_user` — now `def created_by_end_user(self, session)`.

Unlike the zero-call-site slices, these two accessors are read implicitly (`from_attributes=True`) by `WorkflowAppLogPartialResponse` in both the console and service_api workflow-app-log endpoints. Both endpoints already serialize inside an explicit `sessionmaker(...).begin()` block and already wrap each row in the `LogView` view object, so the session is threaded through `LogView` (following the session-carrying wrapper pattern of `SegmentWithSummary` from #36522):

- `LogView` now takes the query `session` and exposes `created_by_account` / `created_by_end_user` as properties that resolve through it; all other attributes keep proxying to the underlying `WorkflowAppLog`.
- No controller changes are needed — both endpoints keep validating the same pagination payload.

Not touching `Workflow.*` (claimed by another contributor on the issue), `WorkflowRun.*`, or `WorkflowNodeExecutionModel.*`.

## Tests

- New `api/tests/unit_tests/models/test_workflow_app_log_models.py`: exercises both accessors against the real `sqlite_session` fixture, covering the role-based dispatch (ACCOUNT vs END_USER) and the None paths, mirroring `test_trigger_models.py` from #40797.
- `test_workflow_app_service_metadata.py`: adapted to the new `LogView` signature and extended with a test asserting the accessors resolve through the session the view was built with.

## Screenshots

N/A (backend-only refactor).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Claude Code