### PR TITLE
fix(web): expose tracing control identifiers

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-button.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-button.tsx
@@ -22,7 +22,10 @@ const ConfigBtn: FC<Props> = ({ className, hasConfigured, children, ...popupProp
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger render={<div className={cn('select-none', className)}>{children}</div>} />
+      <PopoverTrigger
+        data-testid="tracing-config-trigger"
+        render={<div className={cn('select-none', className)}>{children}</div>}
+      />
       <PopoverContent
         placement="bottom-end"
         sideOffset={12}

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-popup.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/config-popup.tsx
@@ -158,6 +158,7 @@ const ConfigPopup: FC<PopupProps> = ({
 
   const switchContent = (
     <Switch
+      aria-label={t(($) => $[`${I18N_PREFIX}.tracing`], { ns: 'app' })}
       className="ml-3"
       checked={enabled}
       onCheckedChange={onStatusChange}

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/provider-panel.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/provider-panel.tsx
@@ -88,6 +88,7 @@ const ProviderPanel: FC<Props> = ({
   )
   return (
     <div
+      data-testid={`tracing-provider-${type}`}
       className={cn(
         'rounded-xl border-[1.5px] bg-background-section-burn px-4 py-3',
         isChosen


### PR DESCRIPTION
## Summary

- Add stable identifiers for the tracing popover and provider cards.
- Give the tracing switch a localized accessible name so tenant-isolation E2E scenarios can operate the controls without DOM or styling selectors.

Supports https://github.com/langgenius/saas-e2e/pull/72.
