### PR TITLE
fix: distinguish Squid denials from forwarded auth errors

### DIFF
--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -160,6 +160,34 @@ def _inject_trace_headers(headers: Headers | None) -> Headers:
     return headers
 
 
+def _is_squid_ssrf_denial(response: httpx.Response) -> bool:
+    """Return whether a 401/403 response is Squid's own access-denied page.
+
+    Squid appends a ``Via`` header to both denied requests and responses it
+    successfully forwards. Requiring the default Squid deny-page markers avoids
+    treating an upstream authentication or authorization response as SSRF.
+    """
+    if response.status_code not in (401, 403):
+        return False
+
+    server_header = response.headers.get("server", "").lower()
+    via_header = response.headers.get("via", "").lower()
+    if "squid" not in server_header and "squid" not in via_header:
+        return False
+
+    try:
+        response_body = response.content.lower()
+    except httpx.ResponseNotRead:
+        # A streaming response cannot be inspected without consuming the stream.
+        # Returning it is safe: Squid has already enforced the network policy.
+        return False
+
+    return (
+        b"error: the requested url could not be retrieved" in response_body
+        and b"access control configuration prevents your request" in response_body
+    )
+
+
 def make_request(
     method: str,
     url: str,
@@ -238,30 +266,26 @@ def make_request(
             else:
                 response = client.send(request, **send_kwargs)
 
-            # Check for SSRF protection by Squid proxy
-            if response.status_code in (401, 403):
-                # Check if this is a Squid SSRF rejection
-                server_header = response.headers.get("server", "").lower()
-                via_header = response.headers.get("via", "").lower()
-
-                # Squid typically identifies itself in Server or Via headers
-                if "squid" in server_header or "squid" in via_header:
-                    # The deny ACL is usually ``to_private_networks`` (RFC1918 +
-                    # loopback / link-local / CGN / IPv6 ULA, etc.). We don't know
-                    # which specific ACL tripped from Squid's response alone, but
-                    # the actionable remediation is the same in every case:
-                    # allowlist the destination in the SSRF proxy. Tell the user
-                    # exactly which env var to set so they don't have to grep the
-                    # squid config. Mention a concrete example CIDR (e.g. the
-                    # 172.21.0.0/16 from the bug report) so they can copy-paste it.
-                    response.close()
-                    raise ToolSSRFError(
-                        f"Access to '{url}' was blocked by SSRF protection "
-                        f"(e.g. SSRF_PROXY_ALLOW_PRIVATE_IPS=172.21.0.0/16 to "
-                        f"allow 172.21.0.0/16). The URL resolves to a private, "
-                        f"loopback, link-local, or otherwise non-public network "
-                        f"address. See https://github.com/langgenius/dify/issues/38443."
-                    )
+            # Squid appends a Via header to every proxied response. Only its
+            # own access-denied page proves that the proxy, rather than the
+            # upstream service, rejected the request.
+            if _is_squid_ssrf_denial(response):
+                # The deny ACL is usually ``to_private_networks`` (RFC1918 +
+                # loopback / link-local / CGN / IPv6 ULA, etc.). We don't know
+                # which specific ACL tripped from Squid's response alone, but
+                # the actionable remediation is the same in every case:
+                # allowlist the destination in the SSRF proxy. Tell the user
+                # exactly which env var to set so they don't have to grep the
+                # squid config. Mention a concrete example CIDR (e.g. the
+                # 172.21.0.0/16 from the bug report) so they can copy-paste it.
+                response.close()
+                raise ToolSSRFError(
+                    f"Access to '{url}' was blocked by SSRF protection "
+                    f"(e.g. SSRF_PROXY_ALLOW_PRIVATE_IPS=172.21.0.0/16 to "
+                    f"allow 172.21.0.0/16). The URL resolves to a private, "
+                    f"loopback, link-local, or otherwise non-public network "
+                    f"address. See https://github.com/langgenius/dify/issues/38443."
+                )
 
             if response.status_code not in STATUS_FORCELIST or max_retries == 0:
                 return response

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -374,10 +374,14 @@ def test_graphon_ssrf_proxy_wraps_module_requests(method_name: str) -> None:
 
 
 def _build_squid_blocked_response(status_code: int = 403) -> MagicMock:
-    """Construct a mock httpx.Response that looks like Squid's ACL deny."""
+    """Construct a mock httpx.Response that looks like Squid's ACL deny page."""
     response = MagicMock()
     response.status_code = status_code
     response.headers = {"server": "squid/4.10", "via": "1.1 squid (squid/4.10)"}
+    response.content = (
+        b"<title>ERROR: The requested URL could not be retrieved</title>"
+        b"Access control configuration prevents your request from being allowed at this time."
+    )
     return response
 
 
@@ -405,14 +409,16 @@ def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
-def test_squid_401_via_header_also_triggers_actionable_error(mock_get_client) -> None:
-    """Squid can return 401 with only the Via header set (no Server header)
-    on some configurations. The detection must work for both."""
+def test_squid_401_deny_page_triggers_actionable_error(mock_get_client) -> None:
+    """A Squid-generated access-denied page must surface as ToolSSRFError."""
     mock_client = MagicMock()
     response = MagicMock()
     response.status_code = 401
-    # Server header absent — only Via identifies Squid.
     response.headers = {"server": "", "via": "1.1 squid (squid/4.10)"}
+    response.content = (
+        b"<title>ERROR: The requested URL could not be retrieved</title>"
+        b"Access control configuration prevents your request from being allowed at this time."
+    )
     mock_client.send.return_value = response
     mock_get_client.return_value = mock_client
 
@@ -420,6 +426,23 @@ def test_squid_401_via_header_also_triggers_actionable_error(mock_get_client) ->
         make_request("GET", "http://10.0.0.1/internal")
 
     assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
+def test_squid_forwarded_auth_error_is_not_treated_as_ssrf_block(mock_get_client, status_code: int) -> None:
+    """Squid adds Via to forwarded upstream auth errors; that alone is not a deny."""
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {"server": "nginx", "via": "1.1 squid (squid/6.13)"}
+    response.content = b'{"message":"invalid API key"}'
+    mock_client.send.return_value = response
+    mock_get_client.return_value = mock_client
+
+    returned = make_request("GET", "https://api.example.com/v1/models")
+
+    assert returned is response
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)


### PR DESCRIPTION
## Summary
- distinguish Squid-generated access-denied pages from 401/403 responses forwarded by Squid
- preserve the actionable `ToolSSRFError` for the default Squid ACL deny page
- add regression coverage for forwarded 401 and 403 authentication/authorization responses

## Validation
- `make test TARGET_TESTS=./api/tests/unit_tests/core/helper/test_ssrf_proxy.py` (38 passed)
- `uv run --project api --dev ruff format --check api/core/helper/ssrf_proxy.py api/tests/unit_tests/core/helper/test_ssrf_proxy.py`
- `uv run --project api --dev ruff check api/core/helper/ssrf_proxy.py api/tests/unit_tests/core/helper/test_ssrf_proxy.py`

Fixes #41434
