### PR TITLE
fix(agent): reject incompatible session snapshots

### DIFF
--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -16,6 +16,7 @@ from controllers.common.schema import register_response_schema_models, register_
 from controllers.console import console_ns
 from controllers.console.agent.app_helpers import resolve_agent_runtime_app_model
 from controllers.console.app.error import (
+    AgentSessionConfigurationChangedError,
     AppUnavailableError,
     CompletionRequestError,
     ConversationCompletedError,
@@ -620,6 +621,10 @@ def _raise_agent_stream_error_before_response(response):
             if isinstance(response, _ClosableStream):
                 response.close()
             message = error_payload.get("message")
+            if error_payload.get("code") == AgentSessionConfigurationChangedError.error_code:
+                raise AgentSessionConfigurationChangedError(
+                    str(message or AgentSessionConfigurationChangedError.description)
+                )
             raise CompletionRequestError(str(message or "Agent App chat failed."))
 
         return _prepend_stream_chunks(buffered, chunk, iterator)

--- a/api/controllers/console/app/error.py
+++ b/api/controllers/console/app/error.py
@@ -1,3 +1,7 @@
+from core.app.apps.agent_app.errors import (
+    AGENT_SESSION_CONFIGURATION_CHANGED_ERROR_CODE,
+    AGENT_SESSION_CONFIGURATION_CHANGED_MESSAGE,
+)
 from libs.exception import BaseHTTPException
 
 
@@ -47,6 +51,12 @@ class CompletionRequestError(BaseHTTPException):
     error_code = "completion_request_error"
     description = "Completion request failed."
     code = 400
+
+
+class AgentSessionConfigurationChangedError(BaseHTTPException):
+    error_code = AGENT_SESSION_CONFIGURATION_CHANGED_ERROR_CODE
+    description = AGENT_SESSION_CONFIGURATION_CHANGED_MESSAGE
+    code = 409
 
 
 class AppMoreLikeThisDisabledError(BaseHTTPException):

--- a/api/core/app/apps/agent_app/app_generator.py
+++ b/api/core/app/apps/agent_app/app_generator.py
@@ -31,7 +31,11 @@ from core.agent.publish_visibility import agent_has_workflow_callable_active_sna
 from core.app.app_config.easy_ui_based_app.model_config.converter import ModelConfigConverter
 from core.app.apps.agent_app.app_config_manager import AgentAppConfigManager
 from core.app.apps.agent_app.app_runner import AgentAppRunner
-from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
+from core.app.apps.agent_app.errors import (
+    AgentAppGeneratorError,
+    AgentAppNotPublishedError,
+    AgentSessionSnapshotIncompatibleError,
+)
 from core.app.apps.agent_app.generate_response_converter import AgentAppGenerateResponseConverter
 from core.app.apps.agent_app.runtime_request_builder import AgentAppRuntimeRequestBuilder
 from core.app.apps.agent_app.session_store import AgentAppWorkspaceStore
@@ -531,6 +535,15 @@ class AgentAppGenerator(MessageBasedAppGenerator):
                 )
             except GenerateTaskStoppedError:
                 pass
+            except AgentSessionSnapshotIncompatibleError as error:
+                logger.info(
+                    "Agent App session snapshot no longer matches the current composition",
+                    extra={
+                        "agent_id": application_generate_entity.agent_id,
+                        "conversation_id": conversation_id,
+                    },
+                )
+                queue_manager.publish_error(error, PublishFrom.APPLICATION_MANAGER)
             except Exception as e:
                 logger.exception("Unknown Error in Agent App generate worker")
                 queue_manager.publish_error(e, PublishFrom.APPLICATION_MANAGER)

--- a/api/core/app/apps/agent_app/errors.py
+++ b/api/core/app/apps/agent_app/errors.py
@@ -1,6 +1,22 @@
+AGENT_SESSION_CONFIGURATION_CHANGED_ERROR_CODE = "agent_session_configuration_changed"
+AGENT_SESSION_CONFIGURATION_CHANGED_MESSAGE = (
+    "The Agent configuration changed after this conversation started. Start a new conversation to continue."
+)
+
+
 class AgentAppGeneratorError(ValueError):
     """Raised when an Agent App turn cannot be set up."""
 
 
 class AgentAppNotPublishedError(AgentAppGeneratorError):
     """Raised when a public Agent App runtime is requested before publish."""
+
+
+class AgentSessionSnapshotIncompatibleError(ValueError):
+    """Raised when a retained session snapshot no longer matches the current composition."""
+
+    error_code = AGENT_SESSION_CONFIGURATION_CHANGED_ERROR_CODE
+    status_code = 409
+
+    def __init__(self) -> None:
+        super().__init__(AGENT_SESSION_CONFIGURATION_CHANGED_MESSAGE)

--- a/api/core/app/apps/agent_app/errors.py
+++ b/api/core/app/apps/agent_app/errors.py
@@ -1,3 +1,5 @@
+from core.app.apps.exc import AppGenerateError
+
 AGENT_SESSION_CONFIGURATION_CHANGED_ERROR_CODE = "agent_session_configuration_changed"
 AGENT_SESSION_CONFIGURATION_CHANGED_MESSAGE = (
     "The Agent configuration changed after this conversation started. Start a new conversation to continue."
@@ -12,7 +14,7 @@ class AgentAppNotPublishedError(AgentAppGeneratorError):
     """Raised when a public Agent App runtime is requested before publish."""
 
 
-class AgentSessionSnapshotIncompatibleError(ValueError):
+class AgentSessionSnapshotIncompatibleError(AppGenerateError):
     """Raised when a retained session snapshot no longer matches the current composition."""
 
     error_code = AGENT_SESSION_CONFIGURATION_CHANGED_ERROR_CODE

--- a/api/core/app/apps/agent_app/runtime_request_builder.py
+++ b/api/core/app/apps/agent_app/runtime_request_builder.py
@@ -50,6 +50,8 @@ from models.agent_config_entities import AgentSoulConfig, AgentSoulToolsConfig
 from models.provider_ids import ModelProviderID
 from services.agent.prompt_mentions import expand_prompt_mentions
 
+from .errors import AgentSessionSnapshotIncompatibleError
+
 
 class AgentAppRuntimeRequestBuildError(ValueError):
     """Raised when Agent App state cannot be mapped to a valid run request."""
@@ -191,6 +193,7 @@ class AgentAppRuntimeRequestBuilder:
                 metadata=metadata,
             )
         )
+        self._validate_session_snapshot_layers(request)
         redacted = cast(dict[str, Any], redact_for_agent_backend_log(request))
         return AgentAppRuntimeRequest(
             request=request,
@@ -198,6 +201,24 @@ class AgentAppRuntimeRequestBuilder:
             metadata=metadata,
             binding_id=context.binding_id,
         )
+
+    @staticmethod
+    def _validate_session_snapshot_layers(request: CreateRunRequest) -> None:
+        """Reject stale snapshots before they reach the Agent backend.
+
+        Draft rows are updated in place, so their IDs cannot prove that a
+        retained snapshot still belongs to the current composition. Agenton
+        requires the ordered layer names to match exactly; enforce the same
+        invariant at the API boundary and return a product-level error.
+        """
+
+        snapshot = request.session_snapshot
+        if snapshot is None:
+            return
+        snapshot_layer_names = tuple(layer.name for layer in snapshot.layers)
+        composition_layer_names = tuple(layer.name for layer in request.composition.layers)
+        if snapshot_layer_names != composition_layer_names:
+            raise AgentSessionSnapshotIncompatibleError()
 
     def _build_tool_layers(
         self,

--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -125,6 +125,15 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
                 "message": str(e),
             }
 
+        error_code = getattr(e, "error_code", None)
+        status_code = getattr(e, "status_code", None)
+        if isinstance(error_code, str) and isinstance(status_code, int):
+            return {
+                "code": error_code,
+                "status": status_code,
+                "message": str(e),
+            }
+
         error_responses: dict[type[Exception], dict[str, JsonValue]] = {
             ValueError: {"code": "invalid_param", "status": 400},
             ProviderTokenNotInitError: {"code": "provider_not_initialize", "status": 400},

--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -7,6 +7,7 @@ from dify_agent.protocol import RunFailureType
 from pydantic import JsonValue
 
 from clients.agent_backend.errors import AgentBackendError, AgentBackendRunFailedError
+from core.app.apps.exc import AppGenerateError
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.task_entities import AppBlockingResponse, AppStreamResponse
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
@@ -125,12 +126,10 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
                 "message": str(e),
             }
 
-        error_code = getattr(e, "error_code", None)
-        status_code = getattr(e, "status_code", None)
-        if isinstance(error_code, str) and isinstance(status_code, int):
+        if isinstance(e, AppGenerateError):
             return {
-                "code": error_code,
-                "status": status_code,
+                "code": e.error_code,
+                "status": e.status_code,
                 "message": str(e),
             }
 

--- a/api/core/app/apps/exc.py
+++ b/api/core/app/apps/exc.py
@@ -1,2 +1,9 @@
+class AppGenerateError(ValueError):
+    """Base class for application-generation errors with a stable response contract."""
+
+    error_code: str
+    status_code: int
+
+
 class GenerateTaskStoppedError(Exception):
     pass

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -55,7 +55,7 @@ from controllers.console.agent.roster import (
 from controllers.console.app import completion as completion_controller
 from controllers.console.app import message as message_controller
 from controllers.console.app.completion import AgentBuildChatFinalizeApi, AgentChatMessageApi, AgentChatMessageStopApi
-from controllers.console.app.error import CompletionRequestError
+from controllers.console.app.error import AgentSessionConfigurationChangedError, CompletionRequestError
 from controllers.console.app.message import (
     AgentChatMessageListApi,
     AgentMessageApi,
@@ -1629,6 +1629,38 @@ def test_agent_chat_stream_preflight_raises_first_error_event() -> None:
     with pytest.raises(CompletionRequestError) as exc_info:
         completion_controller._raise_agent_stream_error_before_response(stream)
     assert "Incorrect API key provided" in exc_info.value.description
+    assert stream.closed is True
+
+
+def test_agent_chat_stream_preflight_preserves_session_configuration_error() -> None:
+    class ClosableStream:
+        def __init__(self) -> None:
+            self.closed = False
+            self._chunks = iter(
+                [
+                    "event: ping\n\n",
+                    (
+                        'data: {"event":"error","message":"Start a new conversation to continue.",'
+                        '"code":"agent_session_configuration_changed","status":409}\n\n'
+                    ),
+                ]
+            )
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> str:
+            return next(self._chunks)
+
+        def close(self) -> None:
+            self.closed = True
+
+    stream = ClosableStream()
+    with pytest.raises(AgentSessionConfigurationChangedError) as exc_info:
+        completion_controller._raise_agent_stream_error_before_response(stream)
+    assert exc_info.value.code == 409
+    assert exc_info.value.error_code == "agent_session_configuration_changed"
+    assert "Start a new conversation" in exc_info.value.description
     assert stream.closed is True
 
 

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_generator.py
@@ -21,6 +21,7 @@ from core.app.apps.agent_app.app_generator import (
     AgentAppGenerator,
     AgentAppGeneratorError,
 )
+from core.app.apps.agent_app.errors import AgentSessionSnapshotIncompatibleError
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
 from core.app.entities.queue_entities import QueueAnnotationReplyEvent
@@ -426,6 +427,23 @@ class TestGenerateWorker:
         queue_manager = mocker.MagicMock()
         self._call(generator, mocker, queue_manager)
         assert queue_manager.publish_error.called
+
+    def test_session_configuration_change_is_published_without_unknown_error_log(
+        self,
+        generator: AgentAppGenerator,
+        mocker: MockerFixture,
+    ) -> None:
+        error = AgentSessionSnapshotIncompatibleError()
+        self._wire(generator, mocker, run_side_effect=error)
+        queue_manager = mocker.MagicMock()
+        info_log = mocker.patch(f"{MODULE}.logger.info")
+        exception_log = mocker.patch(f"{MODULE}.logger.exception")
+
+        self._call(generator, mocker, queue_manager)
+
+        queue_manager.publish_error.assert_called_once_with(error, module.PublishFrom.APPLICATION_MANAGER)
+        info_log.assert_called_once()
+        exception_log.assert_not_called()
 
 
 class TestResumeAfterFormSubmission:

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -12,7 +12,8 @@ from typing import Any, override
 from unittest.mock import MagicMock
 
 import pytest
-from agenton.compositor import CompositorSessionSnapshot
+from agenton.compositor import CompositorSessionSnapshot, LayerSessionSnapshot
+from agenton.layers import LifecycleState
 from dify_agent.layers.ask_human import AskHumanToolResult
 from dify_agent.protocol import (
     AgentRunUsage,
@@ -52,7 +53,8 @@ from clients.agent_backend import (
 )
 from core.app.apps.agent_app import app_runner as app_runner_module
 from core.app.apps.agent_app.app_runner import AgentAppRunner
-from core.app.apps.agent_app.runtime_request_builder import AgentAppRuntimeRequestBuilder
+from core.app.apps.agent_app.errors import AgentSessionSnapshotIncompatibleError
+from core.app.apps.agent_app.runtime_request_builder import AgentAppRuntimeBuildContext, AgentAppRuntimeRequestBuilder
 from core.app.apps.agent_app.session_store import AgentAppSessionScope, StoredAgentAppSession
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import DifyRunContext, InvokeFrom, UserFrom
@@ -625,6 +627,34 @@ def _dify_ctx() -> DifyRunContext:
         user_id="user-1",
         user_from=UserFrom.END_USER,
         invoke_from=InvokeFrom.WEB_APP,
+    )
+
+
+def _compatible_session_snapshot() -> CompositorSessionSnapshot:
+    request = (
+        AgentAppRuntimeRequestBuilder(
+            dify_tools_builder=_NoToolsBuilder(),  # type: ignore[arg-type]
+        )
+        .build(
+            AgentAppRuntimeBuildContext(
+                dify_context=_dify_ctx(),
+                agent_id="agent-1",
+                agent_config_snapshot_id="snap-1",
+                agent_soul=_soul(),
+                conversation_id="conv-1",
+                user_query="hello",
+                idempotency_key="msg-1",
+                binding_id="binding-1",
+                backend_binding_ref="backend-binding-1",
+            )
+        )
+        .request
+    )
+    return CompositorSessionSnapshot(
+        layers=[
+            LayerSessionSnapshot(name=layer.name, lifecycle_state=LifecycleState.SUSPENDED, runtime_state={})
+            for layer in request.composition.layers
+        ]
     )
 
 
@@ -1314,7 +1344,7 @@ def test_repeated_tool_calls_with_placeholder_call_id_and_reused_index_create_di
 
 
 def test_prior_session_snapshot_is_threaded_into_request() -> None:
-    prior = CompositorSessionSnapshot(layers=[])
+    prior = _compatible_session_snapshot()
     client = FakeAgentBackendRunClient()
     store = _FakeSessionStore(loaded=prior)
     qm = _FakeQueueManager()
@@ -1325,8 +1355,23 @@ def test_prior_session_snapshot_is_threaded_into_request() -> None:
     assert client.request.session_snapshot is prior
 
 
+def test_incompatible_session_snapshot_is_rejected_before_backend_invocation() -> None:
+    compatible = _compatible_session_snapshot()
+    stale = CompositorSessionSnapshot(
+        layers=[layer for layer in compatible.layers if layer.name != "agent_soul_prompt"]
+    )
+    client = FakeAgentBackendRunClient()
+    store = _FakeSessionStore(loaded=stale)
+
+    with pytest.raises(AgentSessionSnapshotIncompatibleError, match="Start a new conversation"):
+        _run(_runner(client, store), _FakeQueueManager())
+
+    assert client.request is None
+    assert store.saved == []
+
+
 def test_debug_session_scope_can_reuse_conversation_across_config_snapshots() -> None:
-    prior = CompositorSessionSnapshot(layers=[])
+    prior = _compatible_session_snapshot()
     client = FakeAgentBackendRunClient()
     store = _FakeSessionStore(loaded=prior)
     qm = _FakeQueueManager()
@@ -1599,7 +1644,7 @@ def test_ask_human_pauses_turn_creates_form_and_persists_correlation() -> None:
 def test_submitted_form_resumes_turn_with_deferred_tool_results(monkeypatch: pytest.MonkeyPatch) -> None:
     # ENG-638: a turn that runs while a pending form is answered threads the
     # human's reply into the request as deferred_tool_results.
-    snapshot = CompositorSessionSnapshot(layers=[])
+    snapshot = _compatible_session_snapshot()
     stored = StoredAgentAppSession(
         scope=AgentAppSessionScope(
             tenant_id="tenant-1",

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_runtime_request_builder.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from agenton.compositor import CompositorSessionSnapshot, LayerSessionSnapshot
+from agenton.layers import LifecycleState
 from dify_agent.layers.config import DifyConfigSkillConfig
 from dify_agent.layers.dify_core_tools import DifyCoreToolConfig, DifyCoreToolsLayerConfig
 from dify_agent.layers.dify_plugin import DifyPluginToolConfig, DifyPluginToolsLayerConfig
@@ -20,6 +22,7 @@ from clients.agent_backend import (
     AgentBackendRunRequestBuilder,
 )
 from clients.agent_backend.request_builder import DIFY_SHELL_LAYER_ID
+from core.app.apps.agent_app.errors import AgentSessionSnapshotIncompatibleError
 from core.app.apps.agent_app.runtime_request_builder import (
     AgentAppRuntimeBuildContext,
     AgentAppRuntimeRequestBuilder,
@@ -163,6 +166,7 @@ def _ctx(
     *,
     query: str = "hello",
     agent_config_version_kind: str = "snapshot",
+    session_snapshot: CompositorSessionSnapshot | None = None,
 ) -> AgentAppRuntimeBuildContext:
     dify_context = SimpleNamespace(
         tenant_id="tenant-1",
@@ -182,6 +186,7 @@ def _ctx(
         binding_id="binding-1",
         backend_binding_ref="binding-ref-1",
         agent_config_version_kind=agent_config_version_kind,  # type: ignore[arg-type]
+        session_snapshot=session_snapshot,
     )
 
 
@@ -195,6 +200,15 @@ def _soul_with_model() -> AgentSoulConfig:
             },
             "prompt": {"system_prompt": "You are Iris."},
         }
+    )
+
+
+def _snapshot_for_layer_names(layer_names: list[str]) -> CompositorSessionSnapshot:
+    return CompositorSessionSnapshot(
+        layers=[
+            LayerSessionSnapshot(name=name, lifecycle_state=LifecycleState.SUSPENDED, runtime_state={})
+            for name in layer_names
+        ]
     )
 
 
@@ -235,6 +249,57 @@ class TestAgentAppRuntimeRequestBuilder:
         # LLM credentials are resolved by API and never enter the Agent request.
         assert "credentials" not in result.redacted_request["composition"]["layers"][-1]["config"]
         assert result.metadata["conversation_id"] == "conv-1"
+
+    @pytest.mark.parametrize(
+        ("previous_prompt", "current_prompt"),
+        [("", "You are Iris."), ("You are Iris.", "")],
+    )
+    def test_build_rejects_session_snapshot_after_layer_topology_changes(
+        self,
+        previous_prompt: str,
+        current_prompt: str,
+    ) -> None:
+        builder = AgentAppRuntimeRequestBuilder(
+            dify_tools_builder=_NoToolsBuilder(),  # type: ignore[arg-type]
+        )
+        previous_soul = _soul_with_model()
+        previous_soul.prompt.system_prompt = previous_prompt
+        previous_request = builder.build(_ctx(previous_soul, agent_config_version_kind="draft")).request
+        snapshot = _snapshot_for_layer_names([layer.name for layer in previous_request.composition.layers])
+        current_soul = _soul_with_model()
+        current_soul.prompt.system_prompt = current_prompt
+
+        with pytest.raises(AgentSessionSnapshotIncompatibleError) as exc_info:
+            builder.build(
+                _ctx(
+                    current_soul,
+                    agent_config_version_kind="draft",
+                    session_snapshot=snapshot,
+                )
+            )
+
+        assert exc_info.value.error_code == "agent_session_configuration_changed"
+        assert exc_info.value.status_code == 409
+        assert "Start a new conversation" in str(exc_info.value)
+
+    def test_build_reuses_session_snapshot_when_config_changes_without_changing_layers(self) -> None:
+        builder = AgentAppRuntimeRequestBuilder(
+            dify_tools_builder=_NoToolsBuilder(),  # type: ignore[arg-type]
+        )
+        previous_request = builder.build(_ctx(_soul_with_model(), agent_config_version_kind="draft")).request
+        snapshot = _snapshot_for_layer_names([layer.name for layer in previous_request.composition.layers])
+        current_soul = _soul_with_model()
+        current_soul.prompt.system_prompt = "You are Ada."
+
+        result = builder.build(
+            _ctx(
+                current_soul,
+                agent_config_version_kind="draft",
+                session_snapshot=snapshot,
+            )
+        )
+
+        assert result.request.session_snapshot is snapshot
 
     def test_build_wraps_agent_soul_prompt_for_build_draft(self):
         builder = AgentAppRuntimeRequestBuilder(

--- a/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
@@ -7,6 +7,7 @@ from dify_agent.protocol import RunFailureType
 from sqlalchemy.orm import Session
 
 from clients.agent_backend.errors import AgentBackendRunFailedError
+from core.app.apps.agent_app.errors import AgentSessionSnapshotIncompatibleError
 from core.app.apps.base_app_generate_response_converter import AppGenerateResponseConverter
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.queue_entities import QueueErrorEvent
@@ -166,6 +167,17 @@ class TestBasedGenerateTaskPipeline:
             "code": "agent_run_limit_exceeded",
             "status": 400,
             "message": "run limit reached (agent_run_id=run-1)",
+        }
+
+    def test_stream_converter_preserves_agent_session_configuration_error(self):
+        data = AppGenerateResponseConverter._error_to_stream_response(AgentSessionSnapshotIncompatibleError())
+
+        assert data == {
+            "code": "agent_session_configuration_changed",
+            "status": 409,
+            "message": (
+                "The Agent configuration changed after this conversation started. Start a new conversation to continue."
+            ),
         }
 
     def test_handle_output_moderation_when_flagged(self, pipeline):


### PR DESCRIPTION
## Summary

- Validate the ordered Agent App composition layer names against a retained session snapshot before calling the Agent backend.
- Return HTTP 409 with code agent_session_configuration_changed and a user-facing instruction to start a new conversation when the topology changed.
- Preserve session reuse when configuration values change without adding, removing, or reordering layers.
- Treat this expected conflict as an info event rather than an unknown server error.

## Root cause

Agent Preview updates the shared draft in place, so the draft ID stored on the conversation Binding remains stable while optional runtime layers can change. The old session snapshot was therefore reused even when its ordered layers no longer matched the current composition, and Agenton rejected it with an internal layer mismatch.

## Verification

- 162 related API unit tests passed on the deploy branch.
- 163 related API unit tests passed after applying the change to the latest main.
- Ruff and targeted Pyrefly checks passed.
- Deployed commit 0d13216fe5 to deploy/agent through [Build and Push API & Web](https://github.com/langgenius/dify/actions/runs/33159532073).
- On https://agent.dify.dev:
  - same-topology prompt edits continued the existing conversation with HTTP 200;
  - prompt layer removal and addition both returned HTTP 409 with agent_session_configuration_changed;
  - starting a new conversation succeeded for both layer shapes;
  - rejected requests did not create an Agent backend run;
  - expected conflicts produced one API info log and no unknown-error traceback.

Fixes CUS-1588
