### PR TITLE
fix(e2e): target agent roster list items

### DIFF
--- a/e2e/features/step-definitions/agent-v2/agent-edit.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/agent-edit.steps.ts
@@ -86,7 +86,7 @@ When(
     const copyName = createE2EResourceName('Agent', 'copy')
 
     await page.goto('/agents')
-    const card = page.getByRole('article', { name: agentName, exact: true })
+    const card = page.getByRole('listitem', { name: agentName, exact: true })
 
     await expect(card).toBeVisible({ timeout: 30_000 })
     await card.hover()


### PR DESCRIPTION
## Summary

- update the Agent Roster duplication scenario to locate the renamed card role as a `listitem`
- keep the action scoped to the accessible Agent card name and its More actions control

## Why

PR #41449 migrated the Agent Roster to native list semantics, but this E2E step still queried the removed `article` role. The stale locator caused the post-merge External Runtime E2E job to time out before exercising duplication.

Failed job: https://github.com/langgenius/dify/actions/runs/33171630977/job/98850077879

## Validation

- `git diff --check`
- local E2E not run, as requested

Skill used: [e2e-cucumber-playwright](https://github.com/langgenius/dify/tree/main/.agents/skills/e2e-cucumber-playwright)