### PR TITLE
chore: remove unnecessary type conversions

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -642,13 +642,13 @@ class AppListApi(Resource):
         )
 
         permissions = enterprise_rbac_service.RBACService.MyPermissions.get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user_id,
             session=session,
         )
         if dify_config.RBAC_ENABLED:
             access_filter = resolve_app_access_filter(
-                str(current_tenant_id),
+                current_tenant_id,
                 current_user_id,
                 session=session,
                 permissions=permissions,
@@ -675,7 +675,7 @@ class AppListApi(Resource):
             pagination_model = pagination_model.model_copy(
                 update={
                     "data": [
-                        item.model_copy(update={"permission_keys": permission_keys_map.get(str(item.id), [])})
+                        item.model_copy(update={"permission_keys": permission_keys_map.get(item.id, [])})
                         for item in pagination_model.data
                     ]
                 }
@@ -712,7 +712,7 @@ class AppListApi(Resource):
         app_service = AppService()
         app = app_service.create_app(current_tenant_id, params, current_user, session=session)
         permission_keys_map = enterprise_rbac_service.RBACService.AppPermissions.batch_get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user.id,
             [str(app.id)],
             session=session,
@@ -882,7 +882,7 @@ class AppApi(Resource):
             app_model.access_mode = app_setting.access_mode
 
         permissions = enterprise_rbac_service.RBACService.MyPermissions.get(
-            str(current_tenant_id),
+            current_tenant_id,
             current_user.id,
             app_id=str(app_model.id),
             session=session,
@@ -1020,7 +1020,7 @@ class AppCopyApi(Resource):
                 raise NotFound("App not found")
 
             permission_keys_map = enterprise_rbac_service.RBACService.AppPermissions.batch_get(
-                str(current_tenant_id),
+                current_tenant_id,
                 current_user.id,
                 [str(app.id)],
                 session=session,
@@ -1088,7 +1088,7 @@ class AppPublishToCreatorsPlatformApi(Resource):
         # TODO: Move this configuration and OAuth orchestration into the Creators Platform application service
         # when that domain is refactored. This controller-level integration is a temporary compatibility bridge.
         oauth_code = None
-        client_id = str(dify_config.CREATORS_PLATFORM_OAUTH_CLIENT_ID or "")
+        client_id = dify_config.CREATORS_PLATFORM_OAUTH_CLIENT_ID or ""
         if client_id:
             authorization = application_services().oauth_server.issue_authorization_code(
                 client_id=client_id,

--- a/api/controllers/console/auth/error.py
+++ b/api/controllers/console/auth/error.py
@@ -55,7 +55,7 @@ class PasswordResetRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -65,7 +65,7 @@ class EmailRegisterRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -75,7 +75,7 @@ class EmailChangeRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -85,7 +85,7 @@ class OwnerTransferRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 1):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -137,7 +137,7 @@ class EmailCodeLoginRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 5):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 
@@ -147,7 +147,7 @@ class EmailCodeAccountDeletionRateLimitExceededError(BaseHTTPException):
     code = 429
 
     def __init__(self, minutes: int = 5):
-        description = self.description.format(minutes=int(minutes)) if self.description else None
+        description = self.description.format(minutes=minutes) if self.description else None
         super().__init__(description=description)
 
 

--- a/api/controllers/console/workspace/snippets.py
+++ b/api/controllers/console/workspace/snippets.py
@@ -221,7 +221,7 @@ class CustomizedSnippetDetailApi(Resource):
         """Update customized snippet."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -265,7 +265,7 @@ class CustomizedSnippetDetailApi(Resource):
         """Delete customized snippet."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -304,7 +304,7 @@ class CustomizedSnippetExportApi(Resource):
         """Export snippet as DSL."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -428,7 +428,7 @@ class CustomizedSnippetCheckDependenciesApi(Resource):
         """Check dependencies for a snippet."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 
@@ -458,7 +458,7 @@ class CustomizedSnippetUseCountIncrementApi(Resource):
         """Increment snippet use count when it is inserted into a workflow."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
-            snippet_id=str(snippet_id),
+            snippet_id=snippet_id,
             tenant_id=current_tenant_id,
         )
 

--- a/api/core/workflow/generator/runner.py
+++ b/api/core/workflow/generator/runner.py
@@ -1193,7 +1193,7 @@ class WorkflowGenerator:
             if node.get("node_type") == BuiltinNodeTypes.TOOL and node.get("id")
         }
         for node in graph.get("nodes") or []:
-            planned = planned_by_id.get(str(node.get("id") or ""))
+            planned = planned_by_id.get(node.get("id") or "")
             if planned is None:
                 continue
             data = node.get("data")

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -120,7 +120,7 @@ class AppAnnotationService:
 
         raw_message_id = args.get("message_id")
         if raw_message_id:
-            message_id = str(raw_message_id)
+            message_id = raw_message_id
             message = session.scalar(select(Message).where(Message.id == message_id, Message.app_id == app.id).limit(1))
 
             if not message:
@@ -176,19 +176,19 @@ class AppAnnotationService:
 
     @classmethod
     def enable_app_annotation(cls, args: EnableAnnotationArgs, app_id: str) -> AnnotationJobStatusDict:
-        enable_app_annotation_key = f"enable_app_annotation_{str(app_id)}"
+        enable_app_annotation_key = f"enable_app_annotation_{app_id}"
         cache_result = redis_client.get(enable_app_annotation_key)
         if cache_result is not None:
             return {"job_id": cache_result, "job_status": "processing"}
 
         # async job
         job_id = str(uuid.uuid4())
-        enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
+        enable_app_annotation_job_key = f"enable_app_annotation_job_{job_id}"
         # send batch add segments task
         redis_client.setnx(enable_app_annotation_job_key, "waiting")
         current_user, current_tenant_id = current_account_with_tenant()
         enable_annotation_reply_task.delay(
-            str(job_id),
+            job_id,
             app_id,
             current_user.id,
             current_tenant_id,
@@ -201,17 +201,17 @@ class AppAnnotationService:
     @classmethod
     def disable_app_annotation(cls, app_id: str) -> AnnotationJobStatusDict:
         _, current_tenant_id = current_account_with_tenant()
-        disable_app_annotation_key = f"disable_app_annotation_{str(app_id)}"
+        disable_app_annotation_key = f"disable_app_annotation_{app_id}"
         cache_result = redis_client.get(disable_app_annotation_key)
         if cache_result is not None:
             return {"job_id": cache_result, "job_status": "processing"}
 
         # async job
         job_id = str(uuid.uuid4())
-        disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
+        disable_app_annotation_job_key = f"disable_app_annotation_job_{job_id}"
         # send batch add segments task
         redis_client.setnx(disable_app_annotation_job_key, "waiting")
-        disable_annotation_reply_task.delay(str(job_id), app_id, current_tenant_id)
+        disable_annotation_reply_task.delay(job_id, app_id, current_tenant_id)
         return {"job_id": job_id, "job_status": "waiting"}
 
     @classmethod
@@ -539,7 +539,7 @@ class AppAnnotationService:
                     raise ValueError("The number of annotations exceeds the limit of your subscription.")
             # async job
             job_id = str(uuid.uuid4())
-            indexing_cache_key = f"app_annotation_batch_import_{str(job_id)}"
+            indexing_cache_key = f"app_annotation_batch_import_{job_id}"
 
             # Register job in active tasks list for concurrency tracking
             current_time = int(naive_utc_now().timestamp() * 1000)
@@ -549,7 +549,7 @@ class AppAnnotationService:
 
             # Set job status
             redis_client.setnx(indexing_cache_key, "waiting")
-            batch_import_annotations_task.delay(str(job_id), result, app_id, current_tenant_id, current_user.id)
+            batch_import_annotations_task.delay(job_id, result, app_id, current_tenant_id, current_user.id)
 
         except ValueError as e:
             return {"error_msg": str(e)}

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1832,7 +1832,7 @@ class DocumentService:
         if not upload_file_id:
             raise NotFound(missing_file_message)
 
-        return upload_file_id
+        return str(upload_file_id)
 
     @staticmethod
     def _get_upload_file_for_upload_file_document(document: Document, session: Session) -> UploadFile:
@@ -2798,7 +2798,7 @@ class DocumentService:
         if features.billing.subscription.plan == CloudPlan.SANDBOX and count > 1:
             raise ValueError("Your current plan does not support batch upload, please upgrade your plan.")
 
-        batch_upload_limit = dify_config.BATCH_UPLOAD_LIMIT
+        batch_upload_limit = int(dify_config.BATCH_UPLOAD_LIMIT)
         if count > batch_upload_limit:
             raise ValueError(f"You have reached the batch upload limit of {batch_upload_limit}.")
 

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1664,7 +1664,7 @@ class DocumentService:
         """Fetch documents for a dataset in a single batch query."""
         if not document_ids:
             return []
-        document_id_list: list[str] = [str(document_id) for document_id in document_ids]
+        document_id_list: list[str] = list(document_ids)
         # Fetch all requested documents in one query to avoid N+1 lookups.
         documents: Sequence[Document] = session.scalars(
             select(Document).where(
@@ -1700,7 +1700,7 @@ class DocumentService:
         if not document_ids:
             return 0
 
-        document_id_list: list[str] = [str(document_id) for document_id in document_ids]
+        document_id_list: list[str] = list(document_ids)
 
         result = session.execute(
             update(Document)
@@ -1832,7 +1832,7 @@ class DocumentService:
         if not upload_file_id:
             raise NotFound(missing_file_message)
 
-        return str(upload_file_id)
+        return upload_file_id
 
     @staticmethod
     def _get_upload_file_for_upload_file_document(document: Document, session: Session) -> UploadFile:
@@ -1861,7 +1861,7 @@ class DocumentService:
         """
         Batch load upload files keyed by document id for ZIP downloads.
         """
-        document_id_list: list[str] = [str(document_id) for document_id in document_ids]
+        document_id_list: list[str] = list(document_ids)
 
         documents = DocumentService.get_documents_by_ids(
             DatasetRef(tenant_id=tenant_id, dataset_id=dataset_id), document_id_list, session
@@ -2798,7 +2798,7 @@ class DocumentService:
         if features.billing.subscription.plan == CloudPlan.SANDBOX and count > 1:
             raise ValueError("Your current plan does not support batch upload, please upgrade your plan.")
 
-        batch_upload_limit = int(dify_config.BATCH_UPLOAD_LIMIT)
+        batch_upload_limit = dify_config.BATCH_UPLOAD_LIMIT
         if count > batch_upload_limit:
             raise ValueError(f"You have reached the batch upload limit of {batch_upload_limit}.")
 


### PR DESCRIPTION
> [!NOTE]
> Partial cleanup for #39947 — plenty of remaining flagged sites are left for other contributors; I only touched sites that are provably redundant both statically and at runtime.

## Summary

Removes redundant type conversions flagged by pyrefly's `unnecessary-type-conversion` rule (currently demoted to `info` in `api/pyproject.toml`) across 6 files, where the argument's type is already the target type:

- `api/controllers/console/auth/error.py` — drop `int()` around the `minutes: int` parameter in rate-limit error constructors
- `api/controllers/console/workspace/snippets.py` — drop `str()` around `snippet_id: str` route parameters. Also pass `str(snippet_id)` explicitly in `SnippetDetailApi.get`: its route parameter is typed `UUID` while `SnippetService.get_snippet_by_id` expects `str`, and the previously bare argument surfaced as a `bad-argument-type` error once the redundant casts were removed from the sibling endpoints
- `api/controllers/console/app/app.py` — drop `str()` around `current_tenant_id: str` parameters, one `permission_keys_map.get(str(item.id), ...)` (`App.id` is `Mapped[str]`), and one already-`str` OAuth client id
- `api/services/annotation_service.py` — drop `str()` around `app_id: str`, around `job_id = str(uuid.uuid4())` results (f-string cache keys and `.delay(...)` args), and one truthiness-narrowed `raw_message_id`
- `api/services/dataset_service.py` — drop `str()` around `Sequence[str]` values; `[str(x) for x in seq]` becomes `list(seq)`
- `api/core/workflow/generator/runner.py` — drop one `str()` around a `GraphNodeDict.id` lookup

Deliberately **not** touched (load-bearing at runtime despite the annotations):

- defensive coercions of unvalidated LLM output in `runner.py` (`str(plan.get(...) or "")`, `float(viewport.get(...))` — the planner dict is `cast` from raw LLM JSON, so these guards against non-`str`/non-`float` values are load-bearing)
- the pydantic `mode="before"` validators in `app.py`, whose `str()` casts guard against non-`str` runtime input
- `int(dify_config.BATCH_UPLOAD_LIMIT)` in `DocumentService.check_document_creation_limits` — unit tests patch the attribute with strings, so the runtime value is not guaranteed to be `int` despite the `NonNegativeInt` annotation (initially removed, restored in 7b73afee after CI caught it)
- `str(upload_file_id)` in `DocumentService._get_upload_file_id_for_upload_file_document` — `data_source_info` is unvalidated JSON where `upload_file_id` may be an `int`, and the string-coercion contract is pinned by `test_get_upload_file_id_for_upload_file_document_returns_string_id` (initially removed, restored in 7b73afee after CI caught it)

## Verification

With `unnecessary-type-conversion` temporarily promoted to `error` in `api/pyproject.toml` (not part of this PR — that promotion should land once all sites are clean, as attempted in #41295):

- `pyrefly check .` resolves exactly these 31 diagnostics with **0 new errors** introduced (verified by diffing full-run JSON output before/after; the one newly surfaced `bad-argument-type` in `snippets.py` is fixed by the explicit `str(snippet_id)` noted above)
- `ruff check` and `ruff format --check` pass on all changed files (the identity comprehensions left behind by the `str()` removal are rewritten as `list(...)` to satisfy C416)

## Screenshots

N/A (no UI change)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (pure refactor, no observable behavior change)
- [x] I've updated the documentation accordingly. (not required)
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods (ran `ruff check` / `ruff format --check` / `pyrefly check` directly on the changed files)
