### PR TITLE
fix(api): use portable NULL ordering for installed apps pagination

### DIFF
--- a/api/services/installed_app_service.py
+++ b/api/services/installed_app_service.py
@@ -66,7 +66,8 @@ def _installed_app_cursor_filter(cursor: InstalledAppCursor):
 def _installed_app_order_by():
     return (
         InstalledApp.is_pinned.desc(),
-        InstalledApp.last_used_at.desc().nulls_last(),
+        InstalledApp.last_used_at.is_(None),
+        InstalledApp.last_used_at.desc(),
         InstalledApp.id.asc(),
     )
 


### PR DESCRIPTION
## Summary

- Replaces the PostgreSQL-only `NULLS LAST` construct emitted by
  `.desc().nulls_last()` with a portable boolean sort key
  (`last_used_at.is_(None)`), which orders NULLs last consistently on
  both PostgreSQL and MySQL.
- Fixes a `pymysql.err.ProgrammingError (1064)` SQL syntax error on
  `GET /console/api/installed-apps` for MySQL deployments. The
  regression was introduced by #39739, which added
  `InstalledApp.last_used_at.desc().nulls_last()` to the ordering —
  `NULLS LAST` is not valid syntax in MySQL.
- The new key preserves the exact intended semantics (pinned first,
  recently used first, never-used last, id asc) and stays consistent
  with the keyset/cursor filter in `_installed_app_cursor_filter`,
  which already assumes NULLs sort after non-NULL values. No cursor
  or pagination behavior changes for PostgreSQL users.

## Testing

- `make test TARGET_TESTS=./api/tests/unit_tests/controllers/console/explore/test_installed_app.py`
  (existing ordering/cursor pagination tests pass unchanged)
- Manually verified against MySQL: the ordered query executes without
  error and previously failing `/console/api/installed-apps` returns 200.

## Checklist

- [x] I have searched existing issues and this is not a duplicate
- [x] I have run the relevant unit tests