### PR TITLE
fix(dataset): clean attachments for disabled segment deletion

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3865,26 +3865,26 @@ class SegmentService:
         if cache_result is not None:
             raise ValueError("Segment is deleting.")
 
-        # enabled segment need to delete index
+        # Enabled segments still need the deletion marker while index cleanup is in progress.
         if segment.enabled:
-            # send delete segment index task
             redis_client.setex(indexing_cache_key, 600, 1)
 
-            # Get child chunk IDs before parent segment is deleted
-            child_node_ids = []
-            if segment.index_node_id:
-                child_node_ids = list(
-                    session.scalars(
-                        select(ChildChunk.index_node_id).where(
-                            ChildChunk.segment_id == segment.id,
-                            ChildChunk.dataset_id == dataset.id,
-                        )
-                    ).all()
-                )
-
-            delete_segment_from_index_task.delay(
-                [segment.index_node_id], dataset.id, document.id, [segment.id], child_node_ids
+        # Get child chunk IDs before the parent segment is deleted. Cleanup must also run for
+        # disabled segments because it owns durable resources such as multimodal attachments.
+        child_node_ids = []
+        if segment.index_node_id:
+            child_node_ids = list(
+                session.scalars(
+                    select(ChildChunk.index_node_id).where(
+                        ChildChunk.segment_id == segment.id,
+                        ChildChunk.dataset_id == dataset.id,
+                    )
+                ).all()
             )
+
+        delete_segment_from_index_task.delay(
+            [segment.index_node_id], dataset.id, document.id, [segment.id], child_node_ids
+        )
 
         session.delete(segment)
         # update document word count

--- a/api/tasks/delete_segment_from_index_task.py
+++ b/api/tasks/delete_segment_from_index_task.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 def delete_segment_from_index_task(
     index_node_ids: list, dataset_id: str, document_id: str, segment_ids: list, child_node_ids: list | None = None
 ):
-    """
-    Async Remove segment from index
+    """Remove segment index data and durable attachment records asynchronously.
+
     :param index_node_ids:
     :param dataset_id:
     :param document_id:
@@ -38,48 +38,65 @@ def delete_segment_from_index_task(
             if not dataset_document:
                 return
 
-            if (
-                not dataset_document.enabled
-                or dataset_document.archived
-                or dataset_document.indexing_status != "completed"
-            ):
-                logging.info("Document not in valid state for index operations, skipping")
-                return
-            doc_form = dataset_document.doc_form
-
-            # Proceed with index cleanup using the index_node_ids directly
-            # For actual deletion, we should delete summaries (not just disable them)
-            index_processor = IndexProcessorFactory(doc_form).init_index_processor()
-            index_processor.clean(
-                dataset,
-                index_node_ids,
-                with_keywords=True,
-                delete_child_chunks=True,
-                precomputed_child_node_ids=child_node_ids,
-                delete_summaries=True,  # Actually delete summaries when segment is deleted,
-                session=session,
+            document_allows_index_cleanup = (
+                dataset_document.enabled
+                and not dataset_document.archived
+                and dataset_document.indexing_status == "completed"
             )
-            session.commit()
+            index_processor = None
+            if document_allows_index_cleanup:
+                doc_form = dataset_document.doc_form
+
+                # Proceed with index cleanup using the index_node_ids directly.
+                # For actual deletion, delete summaries instead of only disabling them.
+                index_processor = IndexProcessorFactory(doc_form).init_index_processor()
+                index_processor.clean(
+                    dataset,
+                    index_node_ids,
+                    with_keywords=True,
+                    delete_child_chunks=True,
+                    precomputed_child_node_ids=child_node_ids,
+                    delete_summaries=True,
+                    session=session,
+                )
+                session.commit()
+            else:
+                logging.info("Document not in valid state for index operations, skipping index cleanup")
+
             if dataset.is_multimodal:
                 # delete segment attachment binding
                 segment_attachment_bindings = session.scalars(
-                    select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.segment_id.in_(segment_ids))
+                    select(SegmentAttachmentBinding).where(
+                        SegmentAttachmentBinding.tenant_id == dataset.tenant_id,
+                        SegmentAttachmentBinding.dataset_id == dataset.id,
+                        SegmentAttachmentBinding.document_id == document_id,
+                        SegmentAttachmentBinding.segment_id.in_(segment_ids),
+                    )
                 ).all()
                 if segment_attachment_bindings:
                     attachment_ids = [binding.attachment_id for binding in segment_attachment_bindings]
-                    index_processor.clean(
-                        session=session, dataset=dataset, node_ids=attachment_ids, with_keywords=False
-                    )
+                    if index_processor is not None:
+                        index_processor.clean(
+                            session=session, dataset=dataset, node_ids=attachment_ids, with_keywords=False
+                        )
                     segment_attachment_bind_ids = [i.id for i in segment_attachment_bindings]
 
                     for i in range(0, len(segment_attachment_bind_ids), 1000):
                         segment_attachment_bind_delete_stmt = delete(SegmentAttachmentBinding).where(
-                            SegmentAttachmentBinding.id.in_(segment_attachment_bind_ids[i : i + 1000])
+                            SegmentAttachmentBinding.tenant_id == dataset.tenant_id,
+                            SegmentAttachmentBinding.dataset_id == dataset.id,
+                            SegmentAttachmentBinding.document_id == document_id,
+                            SegmentAttachmentBinding.id.in_(segment_attachment_bind_ids[i : i + 1000]),
                         )
                         session.execute(segment_attachment_bind_delete_stmt)
 
                     # delete upload file
-                    session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
+                    session.execute(
+                        delete(UploadFile).where(
+                            UploadFile.tenant_id == dataset.tenant_id,
+                            UploadFile.id.in_(attachment_ids),
+                        )
+                    )
                     session.commit()
 
             end_at = time.perf_counter()

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -827,6 +827,32 @@ class TestSegmentServiceMutations:
         session.add.assert_called_once_with(document)
         session.commit.assert_called()
 
+    def test_delete_disabled_segment_still_schedules_durable_cleanup(self):
+        session = MagicMock()
+        segment = _make_segment(enabled=False, word_count=4, index_node_id="parent-node")
+        document = _make_document(word_count=10)
+        dataset = _make_dataset()
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.delete_segment_from_index_task") as delete_task,
+        ):
+            mock_redis.get.return_value = None
+            session.scalars.return_value.all.return_value = ["child-1"]
+
+            SegmentService.delete_segment(segment, document, dataset, session)
+
+        mock_redis.setex.assert_not_called()
+        delete_task.delay.assert_called_once_with(
+            ["parent-node"],
+            dataset.id,
+            document.id,
+            [segment.id],
+            ["child-1"],
+        )
+        session.delete.assert_called_once_with(segment)
+        session.commit.assert_called_once()
+
     def test_delete_segment_rejects_when_delete_is_already_in_progress(self):
         segment = _make_segment()
         document = _make_document()

--- a/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
+++ b/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
@@ -1,6 +1,7 @@
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,8 +9,10 @@ from sqlalchemy import event
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.rag.index_processor.constant.index_type import IndexStructureType
-from models.dataset import Dataset, Document, DocumentSegment
-from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from extensions.storage.storage_type import StorageType
+from models.dataset import Dataset, Document, DocumentSegment, SegmentAttachmentBinding
+from models.enums import CreatorUserRole, DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from models.model import UploadFile
 from tasks.delete_segment_from_index_task import delete_segment_from_index_task
 from tasks.disable_segment_from_index_task import disable_segment_from_index_task
 from tasks.disable_segments_from_index_task import disable_segments_from_index_task
@@ -152,3 +155,44 @@ def test_delete_segment_commits_index_cleanup_without_attachments(
         delete_segment_from_index_task.run(["node-1"], dataset.id, document.id, [segment.id])
 
     assert phase_events == ["clean", "commit"]
+
+
+def test_delete_segment_cleans_attachment_records_when_document_is_disabled(
+    indexed_segment: tuple[Dataset, Document, DocumentSegment],
+    sqlite_session: Session,
+) -> None:
+    dataset, document, segment = indexed_segment
+    dataset.is_multimodal = True
+    document.enabled = False
+    attachment = UploadFile(
+        tenant_id=dataset.tenant_id,
+        storage_type=StorageType.LOCAL,
+        key="attachments/disabled-segment.png",
+        name="disabled-segment.png",
+        size=10,
+        extension="png",
+        mime_type="image/png",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by=segment.created_by,
+        created_at=datetime.now(UTC),
+        used=True,
+    )
+    binding = SegmentAttachmentBinding(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        segment_id=segment.id,
+        attachment_id=attachment.id,
+    )
+    sqlite_session.add_all([dataset, document, attachment, binding])
+    sqlite_session.commit()
+    attachment_id = attachment.id
+    binding_id = binding.id
+
+    with patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory:
+        delete_segment_from_index_task.run([segment.index_node_id], dataset.id, document.id, [segment.id])
+
+    processor_factory.assert_not_called()
+    sqlite_session.expire_all()
+    assert sqlite_session.get(SegmentAttachmentBinding, binding_id) is None
+    assert sqlite_session.get(UploadFile, attachment_id) is None


### PR DESCRIPTION
## Summary

- schedule segment cleanup even when the segment is already disabled
- keep index cleanup gated by document state while allowing durable attachment cleanup to continue
- scope attachment reads and deletes to the owning tenant, dataset, and document
- add regression coverage for disabled segments and disabled parent documents

## Problem

`SegmentService.delete_segment()` previously dispatched cleanup only for enabled segments. The cleanup task also returned before attachment cleanup when the parent document was disabled, archived, or not fully indexed. Because segment attachment bindings do not cascade from `DocumentSegment`, deleting the segment left attachment bindings and upload-file metadata orphaned.

This change separates index eligibility from durable resource cleanup. It does not add blob deletion, which is tracked separately by #41399.

Closes #41457

## Tests

- `uv run --project api pytest -q api/tests/unit_tests/services/test_dataset_service_segment.py -k "delete_segment"`
- `uv run --project api pytest -q api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py`
- `uv run --project api ruff check api/services/dataset_service.py api/tasks/delete_segment_from_index_task.py api/tests/unit_tests/services/test_dataset_service_segment.py api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py`
- `uv run --project api --dev pyrefly check api/services/dataset_service.py api/tasks/delete_segment_from_index_task.py`
- `uv run --project api --dev mypy --check-untyped-defs --disable-error-code=import-untyped api/services/dataset_service.py api/tasks/delete_segment_from_index_task.py`