### PR TITLE
fix(api): resolve aliases in remote settings sources

### DIFF
--- a/api/configs/remote_settings_sources/apollo/__init__.py
+++ b/api/configs/remote_settings_sources/apollo/__init__.py
@@ -52,5 +52,4 @@ class ApolloSettingsSource(RemoteSettingsSource):
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         if not isinstance(self.remote_configs, dict):
             raise ValueError(f"remote configs is not dict, but {type(self.remote_configs)}")
-        field_value = self.remote_configs.get(field_name)
-        return field_value, field_name, False
+        return self.resolve_field_value(self.remote_configs, field, field_name)

--- a/api/configs/remote_settings_sources/base.py
+++ b/api/configs/remote_settings_sources/base.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 
+from pydantic import AliasChoices
 from pydantic.fields import FieldInfo
 
 
@@ -10,6 +11,29 @@ class RemoteSettingsSource:
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         raise NotImplementedError
+
+    @staticmethod
+    def resolve_field_value(
+        remote_configs: Mapping[str, Any], field: FieldInfo, field_name: str
+    ) -> tuple[Any, str, bool]:
+        field_value = remote_configs.get(field_name)
+        if field_value is not None:
+            return field_value, field_name, False
+
+        validation_alias = field.validation_alias
+        if isinstance(validation_alias, str):
+            aliases = [validation_alias]
+        elif isinstance(validation_alias, AliasChoices):
+            aliases = [alias for alias in validation_alias.choices if isinstance(alias, str)]
+        else:
+            aliases = []
+
+        for alias in aliases:
+            field_value = remote_configs.get(alias)
+            if field_value is not None:
+                return field_value, alias, False
+
+        return None, field_name, False
 
     def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool):
         return value

--- a/api/configs/remote_settings_sources/nacos/__init__.py
+++ b/api/configs/remote_settings_sources/nacos/__init__.py
@@ -43,8 +43,4 @@ class NacosSettingsSource(RemoteSettingsSource):
 
     @override
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
-        field_value = self.remote_configs.get(field_name)
-        if field_value is None:
-            return None, field_name, False
-
-        return field_value, field_name, False
+        return self.resolve_field_value(self.remote_configs, field, field_name)

--- a/api/tests/unit_tests/configs/test_remote_settings_sources.py
+++ b/api/tests/unit_tests/configs/test_remote_settings_sources.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 from pydantic import AliasChoices
 from pydantic.fields import FieldInfo
@@ -9,7 +7,9 @@ from configs.remote_settings_sources.nacos import NacosSettingsSource
 
 
 @pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
-def test_get_field_value_prefers_field_name(source_cls: type[Any]) -> None:
+def test_get_field_value_prefers_field_name(
+    source_cls: type[NacosSettingsSource] | type[ApolloSettingsSource],
+) -> None:
     source = object.__new__(source_cls)
     source.remote_configs = {"SETTING": "direct", "ALIAS": "aliased"}
     field = FieldInfo(validation_alias="ALIAS")
@@ -18,7 +18,9 @@ def test_get_field_value_prefers_field_name(source_cls: type[Any]) -> None:
 
 
 @pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
-def test_get_field_value_falls_back_to_single_validation_alias(source_cls: type[Any]) -> None:
+def test_get_field_value_falls_back_to_single_validation_alias(
+    source_cls: type[NacosSettingsSource] | type[ApolloSettingsSource],
+) -> None:
     source = object.__new__(source_cls)
     source.remote_configs = {"ALIAS": "aliased"}
     field = FieldInfo(validation_alias="ALIAS")
@@ -27,7 +29,9 @@ def test_get_field_value_falls_back_to_single_validation_alias(source_cls: type[
 
 
 @pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
-def test_get_field_value_falls_back_to_alias_choices_in_order(source_cls: type[Any]) -> None:
+def test_get_field_value_falls_back_to_alias_choices_in_order(
+    source_cls: type[NacosSettingsSource] | type[ApolloSettingsSource],
+) -> None:
     source = object.__new__(source_cls)
     source.remote_configs = {"SECOND_ALIAS": "second"}
     field = FieldInfo(validation_alias=AliasChoices("FIRST_ALIAS", "SECOND_ALIAS"))

--- a/api/tests/unit_tests/configs/test_remote_settings_sources.py
+++ b/api/tests/unit_tests/configs/test_remote_settings_sources.py
@@ -9,7 +9,7 @@ from configs.remote_settings_sources.nacos import NacosSettingsSource
 
 
 @pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
-def test_get_field_value_prefers_field_name(source_cls: type[Any]):
+def test_get_field_value_prefers_field_name(source_cls: type[Any]) -> None:
     source = object.__new__(source_cls)
     source.remote_configs = {"SETTING": "direct", "ALIAS": "aliased"}
     field = FieldInfo(validation_alias="ALIAS")
@@ -18,7 +18,7 @@ def test_get_field_value_prefers_field_name(source_cls: type[Any]):
 
 
 @pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
-def test_get_field_value_falls_back_to_single_validation_alias(source_cls: type[Any]):
+def test_get_field_value_falls_back_to_single_validation_alias(source_cls: type[Any]) -> None:
     source = object.__new__(source_cls)
     source.remote_configs = {"ALIAS": "aliased"}
     field = FieldInfo(validation_alias="ALIAS")
@@ -27,7 +27,7 @@ def test_get_field_value_falls_back_to_single_validation_alias(source_cls: type[
 
 
 @pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
-def test_get_field_value_falls_back_to_alias_choices_in_order(source_cls: type[Any]):
+def test_get_field_value_falls_back_to_alias_choices_in_order(source_cls: type[Any]) -> None:
     source = object.__new__(source_cls)
     source.remote_configs = {"SECOND_ALIAS": "second"}
     field = FieldInfo(validation_alias=AliasChoices("FIRST_ALIAS", "SECOND_ALIAS"))

--- a/api/tests/unit_tests/configs/test_remote_settings_sources.py
+++ b/api/tests/unit_tests/configs/test_remote_settings_sources.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+import pytest
+from pydantic import AliasChoices
+from pydantic.fields import FieldInfo
+
+from configs.remote_settings_sources.apollo import ApolloSettingsSource
+from configs.remote_settings_sources.nacos import NacosSettingsSource
+
+
+@pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
+def test_get_field_value_prefers_field_name(source_cls: type[Any]):
+    source = object.__new__(source_cls)
+    source.remote_configs = {"SETTING": "direct", "ALIAS": "aliased"}
+    field = FieldInfo(validation_alias="ALIAS")
+
+    assert source.get_field_value(field, "SETTING") == ("direct", "SETTING", False)
+
+
+@pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
+def test_get_field_value_falls_back_to_single_validation_alias(source_cls: type[Any]):
+    source = object.__new__(source_cls)
+    source.remote_configs = {"ALIAS": "aliased"}
+    field = FieldInfo(validation_alias="ALIAS")
+
+    assert source.get_field_value(field, "SETTING") == ("aliased", "ALIAS", False)
+
+
+@pytest.mark.parametrize("source_cls", [NacosSettingsSource, ApolloSettingsSource])
+def test_get_field_value_falls_back_to_alias_choices_in_order(source_cls: type[Any]):
+    source = object.__new__(source_cls)
+    source.remote_configs = {"SECOND_ALIAS": "second"}
+    field = FieldInfo(validation_alias=AliasChoices("FIRST_ALIAS", "SECOND_ALIAS"))
+
+    assert source.get_field_value(field, "SETTING") == ("second", "SECOND_ALIAS", False)


### PR DESCRIPTION
Fixes #41786

Original report #41439 was closed during triage because its top-level version field referenced an older release. #41786 revalidates the same issue against current `main`; this PR is the existing implementation for that current-version report.

## Summary

- Preserve exact field-name precedence for remote settings.
- Fall back to `validation_alias` and ordered string entries in `AliasChoices` when the field name is absent.
- Apply the same resolution behavior to both Nacos and Apollo sources, returning the matched alias key so aliased internal fields are populated correctly.
- Keep the implementation scoped to flat remote configuration keys; remove unneeded `AliasPath` handling that was not required by the issue or covered by regression tests.
- Add focused regression tests covering direct precedence, a single validation alias, and multiple alias choices for both sources.

## Screenshots

N/A (backend configuration resolution only).

## Validation

- Focused resolver coverage previously exercised the six direct-name / single-alias / `AliasChoices` cases successfully in an isolated harness.
- On current head `ab210b0f`, Main CI Pipeline, Pyrefly Diff Check, Pyrefly Type Coverage, Semantic Pull Request, and `autofix.ci` have passed.
- `Style Check / Python Style` passed on the current head, including `Run Type Checks`.
- The latest style fix removes the banned `typing.Any` annotation from the parameterized regression tests and uses the precise Nacos/Apollo source class union instead.
- Before the latest code edit, `GYJ99/dify:main` was fast-forward synced to upstream `langgenius/dify:main` at `a233b2f5`.
- Full repository pytest, lint, and type-check have not been run locally.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From ChatGPT