### PR TITLE
fix(config): resolve pydantic validation aliases in remote settings sources

### DIFF
--- a/api/configs/remote_settings_sources/apollo/__init__.py
+++ b/api/configs/remote_settings_sources/apollo/__init__.py
@@ -52,5 +52,5 @@ class ApolloSettingsSource(RemoteSettingsSource):
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         if not isinstance(self.remote_configs, dict):
             raise ValueError(f"remote configs is not dict, but {type(self.remote_configs)}")
-        field_value = self.remote_configs.get(field_name)
-        return field_value, field_name, False
+        field_value, field_key = self._resolve_field_value(self.remote_configs, field, field_name)
+        return field_value, field_key, False

--- a/api/configs/remote_settings_sources/base.py
+++ b/api/configs/remote_settings_sources/base.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 
+from pydantic import AliasChoices
 from pydantic.fields import FieldInfo
 
 
@@ -13,3 +14,32 @@ class RemoteSettingsSource:
 
     def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool):
         return value
+
+    @staticmethod
+    def _resolve_field_value(remote_configs: Mapping[str, Any], field: FieldInfo, field_name: str) -> tuple[Any, str]:
+        """
+        Look up ``field`` in ``remote_configs`` by its field name first, then fall back to its
+        ``validation_alias`` (a plain string or any ``str`` member of an ``AliasChoices``),
+        mirroring how ``EnvSettingsSource`` resolves keys for aliased fields.
+
+        Returns ``(value, key)`` where ``key`` is the name that actually matched, so the caller
+        emits a key that ``DifyConfig`` validation accepts. Returns ``(None, field_name)`` on a miss.
+        """
+        field_value = remote_configs.get(field_name)
+        if field_value is not None:
+            return field_value, field_name
+
+        validation_alias = field.validation_alias
+        if isinstance(validation_alias, str):
+            alias_names = [validation_alias]
+        elif isinstance(validation_alias, AliasChoices):
+            alias_names = [choice for choice in validation_alias.choices if isinstance(choice, str)]
+        else:
+            alias_names = []
+
+        for alias_name in alias_names:
+            alias_value = remote_configs.get(alias_name)
+            if alias_value is not None:
+                return alias_value, alias_name
+
+        return None, field_name

--- a/api/configs/remote_settings_sources/nacos/__init__.py
+++ b/api/configs/remote_settings_sources/nacos/__init__.py
@@ -43,8 +43,5 @@ class NacosSettingsSource(RemoteSettingsSource):
 
     @override
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
-        field_value = self.remote_configs.get(field_name)
-        if field_value is None:
-            return None, field_name, False
-
-        return field_value, field_name, False
+        field_value, field_key = self._resolve_field_value(self.remote_configs, field, field_name)
+        return field_value, field_key, False

--- a/api/tests/unit_tests/configs/test_apollo_settings_source.py
+++ b/api/tests/unit_tests/configs/test_apollo_settings_source.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+import pytest
+from pydantic import AliasChoices, Field
+from pydantic.fields import FieldInfo
+from pydantic_settings import BaseSettings
+
+from configs.remote_settings_sources.apollo import ApolloSettingsSource
+
+
+class _SettingsWithAliases(BaseSettings):
+    PLAIN_KEY: str | None = Field(default=None)
+
+    ALIASED_KEY: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("ALIAS_ONE", "ALIAS_TWO"),
+    )
+
+    STR_ALIASED_KEY: str | None = Field(
+        default=None,
+        validation_alias="STR_ALIAS",
+    )
+
+
+_APOLLO_CONFIGS = {
+    "APOLLO_APP_ID": "app",
+    "APOLLO_CLUSTER": "default",
+    "APOLLO_CONFIG_URL": "http://apollo.invalid",
+    "APOLLO_NAMESPACE": "application",
+}
+
+
+def _field(name: str) -> FieldInfo:
+    return _SettingsWithAliases.model_fields[name]
+
+
+def _make_source(remote_configs: dict[str, object] | None) -> ApolloSettingsSource:
+    with patch("configs.remote_settings_sources.apollo.ApolloClient") as mock_client:
+        mock_client.return_value.get_all_dicts.return_value = remote_configs
+        return ApolloSettingsSource(_APOLLO_CONFIGS)
+
+
+def test_get_field_value_matches_exact_field_name() -> None:
+    source = _make_source({"PLAIN_KEY": "plain-value"})
+
+    assert source.get_field_value(_field("PLAIN_KEY"), "PLAIN_KEY") == ("plain-value", "PLAIN_KEY", False)
+
+
+def test_get_field_value_matches_alias_choices() -> None:
+    source = _make_source({"ALIAS_TWO": "aliased-value"})
+
+    assert source.get_field_value(_field("ALIASED_KEY"), "ALIASED_KEY") == ("aliased-value", "ALIAS_TWO", False)
+
+
+def test_get_field_value_prefers_field_name_over_alias() -> None:
+    source = _make_source({"ALIASED_KEY": "by-name", "ALIAS_ONE": "by-alias"})
+
+    assert source.get_field_value(_field("ALIASED_KEY"), "ALIASED_KEY") == ("by-name", "ALIASED_KEY", False)
+
+
+def test_get_field_value_matches_string_validation_alias() -> None:
+    source = _make_source({"STR_ALIAS": "str-alias-value"})
+
+    assert source.get_field_value(_field("STR_ALIASED_KEY"), "STR_ALIASED_KEY") == (
+        "str-alias-value",
+        "STR_ALIAS",
+        False,
+    )
+
+
+def test_get_field_value_returns_none_when_missing() -> None:
+    source = _make_source({"OTHER_KEY": "other"})
+
+    assert source.get_field_value(_field("ALIASED_KEY"), "ALIASED_KEY") == (None, "ALIASED_KEY", False)
+
+
+def test_get_field_value_raises_when_remote_configs_not_dict() -> None:
+    source = _make_source(None)
+
+    with pytest.raises(ValueError, match="remote configs is not dict"):
+        source.get_field_value(_field("PLAIN_KEY"), "PLAIN_KEY")

--- a/api/tests/unit_tests/configs/test_nacos_settings_source.py
+++ b/api/tests/unit_tests/configs/test_nacos_settings_source.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+from pydantic import AliasChoices, Field
+from pydantic.fields import FieldInfo
+from pydantic_settings import BaseSettings
+
+from configs.remote_settings_sources.nacos import NacosSettingsSource
+
+
+class _SettingsWithAliases(BaseSettings):
+    PLAIN_KEY: str | None = Field(default=None)
+
+    ALIASED_KEY: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("ALIAS_ONE", "ALIAS_TWO"),
+    )
+
+    STR_ALIASED_KEY: str | None = Field(
+        default=None,
+        validation_alias="STR_ALIAS",
+    )
+
+
+def _field(name: str) -> FieldInfo:
+    return _SettingsWithAliases.model_fields[name]
+
+
+def _make_source(content: str) -> NacosSettingsSource:
+    with patch("configs.remote_settings_sources.nacos.NacosHttpClient") as mock_client:
+        mock_client.return_value.http_request.return_value = content
+        return NacosSettingsSource({})
+
+
+def test_get_field_value_matches_exact_field_name() -> None:
+    source = _make_source("PLAIN_KEY=plain-value")
+
+    assert source.get_field_value(_field("PLAIN_KEY"), "PLAIN_KEY") == ("plain-value", "PLAIN_KEY", False)
+
+
+def test_get_field_value_matches_alias_choices() -> None:
+    source = _make_source("ALIAS_TWO=aliased-value")
+
+    assert source.get_field_value(_field("ALIASED_KEY"), "ALIASED_KEY") == ("aliased-value", "ALIAS_TWO", False)
+
+
+def test_get_field_value_prefers_field_name_over_alias() -> None:
+    source = _make_source("ALIASED_KEY=by-name\nALIAS_ONE=by-alias")
+
+    assert source.get_field_value(_field("ALIASED_KEY"), "ALIASED_KEY") == ("by-name", "ALIASED_KEY", False)
+
+
+def test_get_field_value_matches_string_validation_alias() -> None:
+    source = _make_source("STR_ALIAS=str-alias-value")
+
+    assert source.get_field_value(_field("STR_ALIASED_KEY"), "STR_ALIASED_KEY") == (
+        "str-alias-value",
+        "STR_ALIAS",
+        False,
+    )
+
+
+def test_get_field_value_returns_none_when_missing() -> None:
+    source = _make_source("OTHER_KEY=other")
+
+    assert source.get_field_value(_field("ALIASED_KEY"), "ALIASED_KEY") == (None, "ALIASED_KEY", False)


### PR DESCRIPTION
## Summary

Fixes #41439

`NacosSettingsSource.get_field_value` looked up remote config keys only by the exact pydantic field name, never consulting `field.validation_alias` / `AliasChoices`. Any aliased field stored in Nacos under one of its documented alias keys was therefore never found, and silently kept its default — no error, no warning. This is inconsistent with the env/dotenv sources, which do honor aliases, so the same key works via env and fails via Nacos.

`ApolloSettingsSource` had the identical defect, so the resolution now lives on the shared `RemoteSettingsSource` base as a small helper that both sources delegate to. That framing is deliberate: the bug wasn't that one source forgot aliases, it was that every remote source had to remember, and both of the two that exist forgot. A future third source now inherits the correct behavior instead of re-introducing it.

Two details worth review attention:

- **The matched alias is returned as the key, not the field name.** `DifyConfig` does not set `populate_by_name`, so validation only accepts keys present in a field's `AliasChoices`; keying by field name would let a value be silently dropped by `extra="ignore"` for any field whose own name is absent from its choices. `EnvSettingsSource` keys by the alias for the same reason.
- **Field-name lookup keeps priority.** `EnvSettingsSource` ignores the field name entirely when a `validation_alias` is set; keeping the name first is the smaller change and preserves behavior for deployments whose remote keys are already stored by field name.

Non-string alias choices (`AliasPath`) are skipped rather than raising — no config field uses one today, and a flat properties payload has no way to address a path. Apollo's existing `ValueError` guard for a non-dict payload is unchanged and still runs ahead of the lookup.

**Scope.** 12 of 772 `DifyConfig` fields declare a `validation_alias`. Five of them (`inner_UPLOAD_FILE_EXTENSION_BLACKLIST`, `inner_CONSOLE_CORS_ALLOW_ORIGINS`, `inner_WEB_API_CORS_ALLOW_ORIGINS`, `inner_OPENAPI_CORS_ALLOW_ORIGINS`, `inner_OPENAPI_KNOWN_CLIENT_IDS`) do not list their own field name among their choices, so a remote source could never populate them at all. The other seven — including `FILES_URL`, `INTERNAL_FILES_URL` and the `PUBSUB_*` family — worked when set under the primary name but silently ignored the secondary or legacy alias.

**Verification.** `api/tests/unit_tests/configs/` → 88 passed. With both source files reverted to `main` and the tests kept, exactly four tests fail — the alias tests for each source, each returning `None` where the alias-resolved value is expected — and all 88 pass again once the sources are restored. `make lint` and `make type-check` both exit 0, the latter including `mypy: Success: no issues found in 1734 source files`.

These are unit tests against `get_field_value` with a mocked client; they prove the method resolves aliases. They do not exercise end-to-end `DifyConfig` construction against a live Nacos or Apollo server, and I haven't claimed to have tested that.

**Note on scope and coordination.** @GYJ99 offered to take this issue on 2026-08-28 and I don't want to cut across that — I had a tested fix ready and am posting it in case it's useful. Happy to close this if @GYJ99 is proceeding, or to fold in any review feedback.

## Screenshots

| Before | After |
| ------ | ----- |
| n/a — no user-visible surface. The change affects config resolution at startup; the observable difference is an aliased setting resolving from its alias key instead of silently falling back to its default. The revert→fail→restore→pass evidence is in the Summary. | n/a |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Claude Code