### PR TITLE
fix(api): forward configured stop sequences from ModelConfigEntity to runtime

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -57,11 +57,15 @@ class ModelConfigConverter:
             raise QuotaExceededError(f"Model provider {provider_name} quota exceeded.")
 
         # model config
+        # `stop` is already extracted out of `completion_params` by
+        # `ModelConfigManager.convert` and lives on `ModelConfigEntity.stop`. Read
+        # the canonical entity field rather than re-extracting from the dict, so
+        # non-workflow apps actually forward the configured stop sequences to the
+        # model runtime. The defensive `list(...)` copy prevents downstream
+        # consumers (e.g. `CoTAgentRunner` appending "Observation") from leaking
+        # state back into the per-request `ModelConfigEntity`.
         completion_params = model_config.parameters
-        stop = []
-        if "stop" in completion_params:
-            stop = completion_params["stop"]
-            del completion_params["stop"]
+        stop = list(model_config.stop)
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)
 

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
@@ -40,6 +40,7 @@ class TestModelConfigConverter:
         model_config.provider = "openai"
         model_config.model = "gpt-4"
         model_config.parameters = {"temperature": 0.5}
+        model_config.stop = []
         model_config.mode = None
 
         app_config.model = model_config
@@ -93,7 +94,12 @@ class TestModelConfigConverter:
         assert result.stop == []
 
     def test_convert_success_with_stop_parameter(self, mock_app_config, patch_provider_manager):
-        mock_app_config.model.parameters = {"temperature": 0.7, "stop": ["\n"]}
+        # `stop` is owned by `ModelConfigEntity.stop` (extracted upstream by
+        # `ModelConfigManager.convert`). The converter must read it from there,
+        # not from `model_config.parameters["stop"]` (which no longer carries it
+        # by the time the converter runs in the real call flow).
+        mock_app_config.model.parameters = {"temperature": 0.7}
+        mock_app_config.model.stop = ["\n"]
 
         result = ModelConfigConverter.convert(mock_app_config)
 
@@ -218,8 +224,8 @@ class TestModelConfigConverter:
         "parameters",
         [
             {},
-            {"stop": []},
-            {"stop": ["END"], "max_tokens": 100},
+            {"max_tokens": 100},
+            {"temperature": 0.3, "max_tokens": 256},
         ],
     )
     def test_convert_parameter_edge_cases(self, mock_app_config, patch_provider_manager, parameters):
@@ -227,11 +233,72 @@ class TestModelConfigConverter:
 
         result = ModelConfigConverter.convert(mock_app_config)
 
-        if "stop" in parameters:
-            assert result.stop == parameters.get("stop")
-            expected_params = parameters.copy()
-            expected_params.pop("stop", None)
-            assert result.parameters == expected_params
-        else:
-            assert result.stop == []
-            assert result.parameters == parameters
+        # `parameters` is passed through unchanged — the converter no longer
+        # strips `stop` out of it (that extraction happens upstream in
+        # `ModelConfigManager.convert`).
+        assert result.stop == []
+        assert result.parameters == parameters
+
+    @pytest.mark.parametrize(
+        ("entity_stop", "expected_stop"),
+        [
+            ([], []),
+            (["END"], ["END"]),
+            (["###", "Observation"], ["###", "Observation"]),
+        ],
+    )
+    def test_convert_stop_from_entity_field(self, mock_app_config, patch_provider_manager, entity_stop, expected_stop):
+        # Regression for the field that is the actual canonical owner of
+        # `stop` after `ModelConfigManager.convert`. The converter must honour
+        # `model.stop` regardless of what the `parameters` dict contains.
+        mock_app_config.model.parameters = {"temperature": 0.5}
+        mock_app_config.model.stop = list(entity_stop)
+
+        result = ModelConfigConverter.convert(mock_app_config)
+
+        assert result.stop == expected_stop
+        assert result.parameters == {"temperature": 0.5}
+
+    def test_convert_stop_list_is_defensive_copy(self, mock_app_config, patch_provider_manager):
+        # Downstream consumers (e.g. `CoTAgentRunner` appending "Observation")
+        # mutate the converter's output. Without a defensive copy at this
+        # boundary, that mutation would leak back into the per-request
+        # `ModelConfigEntity` and persist into the next call.
+        source_stop = ["###"]
+        mock_app_config.model.parameters = {"temperature": 0.5}
+        mock_app_config.model.stop = source_stop
+
+        result = ModelConfigConverter.convert(mock_app_config)
+
+        result.stop.append("Observation")
+        assert mock_app_config.model.stop == source_stop
+        assert result.stop == ["###", "Observation"]
+
+    def test_convert_end_to_end_stop_preserved_after_manager_extraction(self, mock_app_config, patch_provider_manager):
+        # End-to-end regression for #41460. In the real call flow the
+        # `EasyUIBasedAppConfig.model` is a `ModelConfigEntity` produced by
+        # `ModelConfigManager.convert`, which has already removed `stop` from
+        # `parameters` and moved it onto the entity field. The converter must
+        # still surface it on `ModelConfigWithCredentialsEntity.stop`, so the
+        # value reaches the model runtime at generation time.
+        from core.app.app_config.easy_ui_based_app.model_config.manager import ModelConfigManager
+
+        saved_config = {
+            "model": {
+                "provider": "openai",
+                "name": "gpt-4",
+                "mode": "chat",
+                "completion_params": {"temperature": 0.5, "stop": ["###"]},
+            }
+        }
+
+        model_entity = ModelConfigManager.convert(saved_config)
+        assert model_entity.stop == ["###"]
+        assert "stop" not in model_entity.parameters
+
+        mock_app_config.model = model_entity
+
+        result = ModelConfigConverter.convert(mock_app_config)
+
+        assert result.stop == ["###"]
+        assert result.parameters == {"temperature": 0.5}


### PR DESCRIPTION
## Summary

Fixes #41460 — stop sequences configured on non-workflow apps (chatbot, completion, agent, agent-chat) were silently dropped at runtime. `ModelConfigManager.convert` already extracts `stop` out of `completion_params` and moves it onto `ModelConfigEntity.stop`, but the downstream `ModelConfigConverter.convert` then re-reads `stop` from `model_config.parameters["stop"]` — which is no longer there. `ModelConfigWithCredentialsEntity.stop` was therefore always `[]`, so every advanced-prompt run was invoked with no stop sequences and the model ran past the user's configured cutoff.

## Root cause

- `api/core/app/app_config/easy_ui_based_app/model_config/manager.py:25-29` — manager extracts `stop` from `completion_params` and stores it on the entity.
- `api/core/app/app_config/easy_ui_based_app/model_config/converter.py:60-64` — converter re-extracts `stop` from `model_config.parameters`, where the key no longer exists. The `if "stop" in completion_params` branch is never taken, so `stop` falls back to `[]`.
- Affected consumers all read `model_conf.stop`:
  - `api/core/app/apps/base_app_runner.py:167` (advanced-prompt path)
  - `api/core/agent/cot_agent_runner.py:67-69, 142` (CoT agent)
  - `api/core/agent/fc_agent_runner.py:174` (function-calling agent)

## Reproduction

The original reproducer from #41460:

```python
from core.app.app_config.easy_ui_based_app.model_config.converter import ModelConfigConverter
from core.app.app_config.easy_ui_based_app.model_config.manager import ModelConfigManager

saved = {"model": {"provider": "openai", "name": "gpt-4", "mode": "chat",
                   "completion_params": {"temperature": 0.5, "stop": ["###"]}}}
entity = ModelConfigManager.convert(saved)
# -> entity.stop == ["###"]  ✓ manager did the right thing
runtime = ModelConfigConverter.convert(MagicMock(tenant_id="t", model=entity))
# -> runtime.stop == []       ✗ converter DROPS the value
```

After the fix `runtime.stop == ["###"]` and the model actually stops at the configured sequence.

## Changes

- **`api/core/app/app_config/easy_ui_based_app/model_config/converter.py`** — read the canonical `model_config.stop` field instead of re-extracting from the dict, and take a defensive `list(...)` copy. The defensive copy is required because `CoTAgentRunner` does `app_generate_entity.model_conf.stop.append("Observation")` and we don't want that mutation to leak back into the per-request `ModelConfigEntity`.
- **`api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py`** —
  - `test_convert_success_with_stop_parameter`: was written against the buggy re-extraction path (it put `stop` inside `parameters`). Updated to set `model.stop` directly with a comment explaining the real call flow.
  - `test_convert_parameter_edge_cases`: no longer asserts that the converter strips `stop` from `parameters` (the manager does that now). `parameters` is passed through unchanged.
  - `test_convert_stop_from_entity_field` (new, parametrised over `[]`, `["END"]`, `["###", "Observation"]`) — entity field is the canonical source.
  - `test_convert_stop_list_is_defensive_copy` (new) — mutating the returned `stop` does not mutate `model.stop` on the entity.
  - `test_convert_end_to_end_stop_preserved_after_manager_extraction` (new) — the end-to-end regression for #41460. Runs `ModelConfigManager.convert` then `ModelConfigConverter.convert` and asserts the configured stop value reaches the runtime entity.

## Out of scope (deliberate)

- `ModelConfigManager.convert` still does `del completion_params["stop"]` as a side effect on the caller-owned input dict. Keeping that behaviour is correct (avoid sending `stop` twice to providers that don't accept it in `parameters`) and matches the existing design; changing it would be an unrelated cleanup.
- Other app generators (`workflow`, `advanced_chat`) have separate `WorkflowUIBasedAppConfig` / `AdvancedChatAppConfigEntity` paths that don't go through this converter. Out of scope for this fix.

## Testing

- `uv run python -m pytest --noconftest -q tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py` — 18 passed.
- `uv run python -m pytest --noconftest -q tests/unit_tests/core/app/test_easy_ui_model_config_manager.py tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_manager.py` — 41 passed across all three related test files.
- `uv run ruff check` — All checks passed.
- `uv run ruff format` — applied.
- `pyrefly check` on the test file is not gated (file is in `tests/unit_tests/pyrefly.toml` `project-excludes` per "Existing strict-mode debt"). The production file `converter.py` is also clean.
- `/consult-kiro` (openai/gpt-5 low) confirmed the fix, the defensive copy, and the test coverage.

## Risk

Low. The change is a one-line read-source swap plus a defensive copy. The only call sites are the four non-workflow app generators (`chat`, `completion`, `agent_app`, `agent_chat`), all of which call `ModelConfigConverter.convert` immediately after `ModelConfigManager.convert` populates the entity. The fix aligns the converter with the documented ownership in the manager; call sites that hand-built an `EasyUIBasedAppConfig` with `stop` in `parameters` and not on the entity were already inconsistent with the manager's contract.

## Impact

- **Users**: stop sequences actually take effect for non-workflow apps. The UI already lets users configure `stop`; the bug was that the value never reached the model. Advanced-prompt runs now terminate at the configured sequence instead of running past it.
- **Maintainers**: a 12-line production diff with a clear regression test. No new patterns introduced; the fix removes a stale re-extraction branch that was masking a field-ownership drift.
