### PR TITLE
fix(web): make plugin detail drawer non-modal

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/index.tsx
@@ -4,7 +4,6 @@ import type { PluginDetail } from '@/app/components/plugins/types'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Drawer,
-  DrawerBackdrop,
   DrawerContent,
   DrawerPopup,
   DrawerPortal,
@@ -68,18 +67,18 @@ const PluginDetailPanel: FC<Props> = ({
   return (
     <Drawer
       open={!!detail}
-      modal
+      modal={false}
+      disablePointerDismissal
       swipeDirection="right"
       onOpenChange={(open) => {
         if (!open) onHide()
       }}
     >
       <DrawerPortal>
-        <DrawerBackdrop className="bg-transparent" />
-        <DrawerViewport>
+        <DrawerViewport className="pointer-events-none">
           <DrawerPopup
             className={cn(
-              'justify-start bg-components-panel-bg! p-0! shadow-xl data-[swipe-direction=right]:top-2 data-[swipe-direction=right]:right-2 data-[swipe-direction=right]:bottom-2 data-[swipe-direction=right]:h-[calc(100dvh-16px)] data-[swipe-direction=right]:w-100 data-[swipe-direction=right]:max-w-[calc(100vw-1rem)] data-[swipe-direction=right]:rounded-2xl data-[swipe-direction=right]:border-[0.5px] data-[swipe-direction=right]:border-components-panel-border',
+              'pointer-events-auto touch-auto justify-start bg-components-panel-bg! p-0! shadow-xl data-[swipe-direction=right]:top-2 data-[swipe-direction=right]:right-2 data-[swipe-direction=right]:bottom-2 data-[swipe-direction=right]:h-[calc(100dvh-16px)] data-[swipe-direction=right]:w-100 data-[swipe-direction=right]:max-w-[calc(100vw-1rem)] data-[swipe-direction=right]:rounded-2xl data-[swipe-direction=right]:border-[0.5px] data-[swipe-direction=right]:border-components-panel-border',
             )}
           >
             <DrawerContent className="flex min-h-0 flex-1 flex-col p-0 pb-0">


### PR DESCRIPTION
## Summary

- make the installed plugin detail drawer non-modal
- keep outside card interactions available without dismissing the drawer
- align installed plugin browsing with the existing built-in tool detail behavior

## Testing

- `pnpm --dir web exec vp test run --project unit app/components/plugins/plugin-detail-panel/__tests__/index.spec.tsx app/components/plugins/plugin-page/__tests__/plugins-panel.spec.tsx`
- `pnpm check`
- verified on localhost in Chrome: Audio → GitHub → Code Interpreter → GitHub, with one non-modal detail dialog throughout

## Stack

- depends on #41470
- related Linear issue: [SNP-729](https://linear.app/dify/issue/SNP-729/tool-plugin-页面先点击一个-built-in-工具卡片后再点击一个插件卡片状态异常)

From Codex