### PR TITLE
fix(webhook): resolve missing file body parameter to None, not the files mapping

### DIFF
--- a/api/core/workflow/nodes/trigger_webhook/node.py
+++ b/api/core/workflow/nodes/trigger_webhook/node.py
@@ -160,7 +160,11 @@ class TriggerWebhookNode(Node[WebhookData]):
 
             match param_type:
                 case SegmentType.FILE:
-                    # Get File object (already processed by webhook controller)
+                    # Get File object (already processed by webhook controller).
+                    # Fall through to `None` (not the whole `files` mapping) when the
+                    # configured file param is missing, present-but-malformed, or the
+                    # FileVariable cannot be built — matches the missing-value contract
+                    # used by the query param and regular body branches above.
                     files = webhook_data.get("files", {})
                     if files and isinstance(files, dict):
                         file = files.get(param_name)
@@ -169,11 +173,11 @@ class TriggerWebhookNode(Node[WebhookData]):
                             if file_var:
                                 outputs[param_name] = file_var
                             else:
-                                outputs[param_name] = files
+                                outputs[param_name] = None
                         else:
-                            outputs[param_name] = files
+                            outputs[param_name] = None
                     else:
-                        outputs[param_name] = files
+                        outputs[param_name] = None
                 case _:
                     # Get regular body parameter
                     outputs[param_name] = webhook_data.get("body", {}).get(param_name)

--- a/api/tests/unit_tests/core/workflow/nodes/webhook/test_webhook_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/webhook/test_webhook_node.py
@@ -282,6 +282,168 @@ def test_webhook_node_run_with_file_params():
     assert isinstance(result.outputs["upload"], FileVariable)
     assert isinstance(result.outputs["document"], FileVariable)
     assert result.outputs["upload"].value.filename == "image.jpg"
+    # Regression for #41071: a configured file param that is not present in
+    # the incoming `files` mapping must resolve to None (not the whole mapping).
+    assert result.outputs["missing_file"] is None
+
+
+def test_webhook_node_missing_file_param_resolves_to_none():
+    """Regression for #41071: a configured file param that is not present in
+    the incoming `files` mapping must resolve to None, not the whole `files`
+    mapping. Pre-fix the entire mapping was assigned, so the downstream node
+    received `avatar`'s file dict under `attachment`.
+    """
+    file1 = File(
+        file_type=FileType.IMAGE,
+        transfer_method=FileTransferMethod.LOCAL_FILE,
+        related_id="file1",
+        filename="image.jpg",
+        mime_type="image/jpeg",
+        storage_key="",
+    )
+
+    data = WebhookData(
+        title="Test Webhook",
+        body=[
+            WebhookBodyParameter(name="avatar", type="file", required=False),
+            WebhookBodyParameter(name="attachment", type="file", required=False),
+        ],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": {"avatar": file1.to_dict()},
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+    with patch.object(node._file_reference_factory, "build_from_mapping") as mock_file_factory:
+
+        def _to_file(*, mapping: dict[str, Any]) -> File:
+            return File(
+                file_id=mapping.get("id"),
+                file_type=FileType(mapping["type"]),
+                transfer_method=FileTransferMethod(mapping["transfer_method"]),
+                related_id=mapping.get("related_id"),
+                filename=mapping.get("filename"),
+                extension=mapping.get("extension"),
+                mime_type=mapping.get("mime_type"),
+                size=mapping.get("size", -1),
+                storage_key=mapping.get("storage_key", ""),
+                remote_url=mapping.get("url"),
+            )
+
+        mock_file_factory.side_effect = _to_file
+        result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert isinstance(result.outputs["avatar"], FileVariable)
+    assert result.outputs["avatar"].value.filename == "image.jpg"
+    # The configured-but-absent param must be None, not the whole files mapping.
+    assert result.outputs["attachment"] is None
+
+
+def test_webhook_node_file_entry_not_a_dict_resolves_to_none():
+    """Regression for #41071 (case 2 of the issue): if a file entry exists
+    but is not a dict (e.g. the multipart parser returned a string for a
+    non-file part that collided on name), the configured param resolves to
+    None rather than inheriting the whole `files` mapping."""
+    data = WebhookData(
+        title="Test Webhook",
+        body=[WebhookBodyParameter(name="avatar", type="file", required=False)],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": {"avatar": "not-a-dict"},
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+    result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.outputs["avatar"] is None
+
+
+def test_webhook_node_file_var_build_fails_resolves_to_none():
+    """Regression for #41071 (case 3 of the issue): when the file entry is a
+    valid dict but `build_from_mapping` raises ValueError, the converter logs
+    the failure and returns None. The configured param must be None, not the
+    whole `files` mapping."""
+    file1 = File(
+        file_type=FileType.IMAGE,
+        transfer_method=FileTransferMethod.LOCAL_FILE,
+        related_id="file1",
+        filename="image.jpg",
+        mime_type="image/jpeg",
+        storage_key="",
+    )
+
+    data = WebhookData(
+        title="Test Webhook",
+        body=[WebhookBodyParameter(name="avatar", type="file", required=False)],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": {"avatar": file1.to_dict()},
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+    with patch.object(node._file_reference_factory, "build_from_mapping") as mock_file_factory:
+        mock_file_factory.side_effect = ValueError("simulated build failure")
+        result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.outputs["avatar"] is None
+
+
+def test_webhook_node_files_not_a_dict_resolves_to_none():
+    """Regression for #41071 (outer fallback): if the entire `files` value is
+    not a dict (e.g. None or a list), every configured file param resolves to
+    None rather than inheriting the unexpected value."""
+    data = WebhookData(
+        title="Test Webhook",
+        body=[
+            WebhookBodyParameter(name="avatar", type="file", required=False),
+            WebhookBodyParameter(name="attachment", type="file", required=False),
+        ],
+    )
+
+    variable_pool = build_webhook_variable_pool(
+        {
+            "webhook_data": {
+                "headers": {},
+                "query_params": {},
+                "body": {},
+                "files": None,
+            }
+        }
+    )
+
+    node = create_webhook_node(data, variable_pool)
+    result = node._run()
+
+    assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert result.outputs["avatar"] is None
+    assert result.outputs["attachment"] is None
 
 
 def test_webhook_node_run_mixed_parameters():


### PR DESCRIPTION
## Summary

Fixes #41071 — a configured file body parameter on a webhook trigger that is missing from the incoming `files` mapping (or present but malformed) was being assigned the entire `files` mapping instead of `None`. Downstream nodes ended up receiving an unexpected object shape.

The query-param branch (line 141) and the regular body-param branch (line 179) already fall through to `None` for missing keys; the file-param branch was the inconsistent one.

## Root cause

`api/core/workflow/nodes/trigger_webhook/node.py:162-176`. The `SegmentType.FILE` case had three fallback paths that all assigned `outputs[param_name] = files`:

- configured param is not in `files` (e.g. `avatar` was uploaded but `attachment` was not configured in the request);
- the entry is in `files` but is not a dict (e.g. a multipart field collided on a non-file name);
- `generate_file_var` could not build a `FileVariable` from a valid dict (e.g. `build_from_mapping` raised `ValueError`).

`generate_file_var` already returns `None` on `ValueError` (line 104), so the inner build-failure path was just being normalized to the same value as the outer paths — the wrong value, but the same one.

## Reproduction

1. Create a webhook trigger with two file-type body parameters (`avatar`, `attachment`).
2. Send a multipart/form-data request that only includes `avatar`.
3. In a downstream node, reference the `attachment` output variable.

Expected: `attachment is None`. Actual: `attachment` holds `avatar`'s file dict.

## Changes

- **`api/core/workflow/nodes/trigger_webhook/node.py`** — replace the three `outputs[param_name] = files` assignments with `outputs[param_name] = None`; add a 4-line comment documenting the missing-value contract that query params and body params already follow.
- **`api/tests/unit_tests/core/workflow/nodes/webhook/test_webhook_node.py`** —
  - `test_webhook_node_run_with_file_params`: was already configuring a `missing_file` param that was not in the incoming `files` mapping but never asserted on it. Add `assert result.outputs["missing_file"] is None` to pin the fix.
  - `test_webhook_node_missing_file_param_resolves_to_none` (new): two file params configured, one present and one absent. Asserts `attachment is None` and `avatar` is a `FileVariable`.
  - `test_webhook_node_file_entry_not_a_dict_resolves_to_none` (new): `files = {"avatar": "not-a-dict"}`. Asserts `avatar is None`.
  - `test_webhook_node_file_var_build_fails_resolves_to_none` (new): valid file dict, but `build_from_mapping` is mocked to raise `ValueError`. Asserts `avatar is None`.
  - `test_webhook_node_files_not_a_dict_resolves_to_none` (new): outer fallback — `files: None` (not a dict at all). Asserts all configured file params are `None`.

## Out of scope (deliberate)

- The `BINARY` content-type branch at line 158 still returns `raw_data` on build failure, and the `TEXT` branch at line 150 still returns `""` for an empty body. Both are intentionally different: the `BINARY` branch models a single opaque payload where the raw bytes are a useful fallback for downstream custom handling, and the `TEXT` branch treats the whole body as a single string parameter. Changing those would be a behavior change outside the issue's scope.
- No other call sites read `outputs[param_name]` for a missing file param — the fix is contained to `_extract_configured_outputs`.

## Testing

- `uv run python -m pytest -q tests/unit_tests/core/workflow/nodes/webhook/test_webhook_node.py` — 23/23 pass (19 pre-existing + 4 new; existing `test_webhook_node_run_with_file_params` was extended with one assertion).
- `uv run ruff check` — All checks passed.
- `uv run ruff format --check` — 2 files already formatted.
- `uv run pyrefly check core/workflow/nodes/trigger_webhook/node.py` — 0 diagnostics.
- `pyrefly check` on the test file is not gated (file is in `tests/unit_tests/pyrefly.toml` `project-excludes` per "Existing strict-mode debt").
- `/consult-kiro` (openai/gpt-5 --variant low) confirmed: "Good fix. No further changes required."

## Risk

Low. The change is a 3-line normalization to `None` plus a comment, with 4 new tests pinning each fallback path. The only consumers of the file-param output are downstream workflow nodes that read `outputs[name]`, and they already expect `None` for missing values (the query-param and body-param branches establish that contract). The fix brings the file branch in line with the existing contract; the only sites that could have been relying on the previous behaviour are downstream nodes that were working around the bug by checking the file dict's keys against the configured param name.

## Impact

- **Users**: webhook triggers with multiple file-type body parameters now correctly return `None` for the parameters that were not sent. Downstream nodes that check `outputs["attachment"]` for a value get an unset value, not a file dict from a sibling parameter.
- **Maintainers**: a 12-line production diff with 4 new tests covering each of the 3 bug surfaces plus the outer fallback. No new patterns introduced; the fix removes a drift between the file-param branch and the already-existing missing-value contract used by query and body params.
