### PR TITLE
fix: MCP session crash, agent iteration off-by-one, and request responder memory leak

### DIFF
--- a/api/core/agent/cot_agent_runner.py
+++ b/api/core/agent/cot_agent_runner.py
@@ -79,7 +79,7 @@ class CotAgentRunner(BaseAgentRunner, ABC):
         self._instruction = self._fill_in_inputs_from_external_data_tools(instruction, inputs)
 
         iteration_step = 1
-        max_iteration_steps = min(app_config.agent.max_iteration, 99) + 1
+        max_iteration_steps = min(app_config.agent.max_iteration, 99)
 
         # convert tools into ModelRuntime Tool format
         tool_instances, prompt_messages_tools = self._init_prompt_tools()
@@ -196,7 +196,7 @@ class CotAgentRunner(BaseAgentRunner, ABC):
             # Check if max iteration is reached and model still wants to call tools
             if iteration_step == max_iteration_steps and scratchpad.action:
                 if scratchpad.action.action_name.lower() != "final answer":
-                    raise AgentMaxIterationError(app_config.agent.max_iteration)
+                    raise AgentMaxIterationError(max_iteration_steps)
 
             # get llm usage
             if "usage" in usage_dict:

--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -119,7 +119,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
         assert app_config.agent
 
         iteration_step = 1
-        max_iteration_steps = min(app_config.agent.max_iteration, 99) + 1
+        max_iteration_steps = min(app_config.agent.max_iteration, 99)
 
         # continue to run until there is not any tool call
         function_call_state = True
@@ -308,7 +308,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
 
             # Check if max iteration is reached and model still wants to call tools
             if iteration_step == max_iteration_steps and tool_calls:
-                raise AgentMaxIterationError(app_config.agent.max_iteration)
+                raise AgentMaxIterationError(max_iteration_steps)
 
             # call tools
             tool_responses = []

--- a/api/core/mcp/session/base_session.py
+++ b/api/core/mcp/session/base_session.py
@@ -333,8 +333,8 @@ class BaseSession[
                                     )
                                 )
                         else:
-                            self._handle_incoming(
-                                RuntimeError(f"Received response with an unknown request ID: {message}")
+                            logger.warning(
+                                "Received response with an unknown request ID: %s", message
                             )
                     case Exception():
                         self._handle_incoming(message)
@@ -360,6 +360,8 @@ class BaseSession[
 
                         if not responder.completed:
                             self._handle_incoming(responder)
+                            if not responder.completed:
+                                self._in_flight.pop(responder.request_id, None)
 
                     case SessionMessage(message=JSONRPCMessage(root=JSONRPCNotification())):
                         try:
@@ -382,14 +384,18 @@ class BaseSession[
                     case _:  # Response or error
                         response_root = message.message.root
                         if not isinstance(response_root, (JSONRPCResponse, JSONRPCError)):
-                            self._handle_incoming(RuntimeError(f"Server Error: {message}"))
+                            logger.warning("Unexpected message type in response: %s", message)
                             continue
 
                         response_queue = self._response_streams.get(response_root.id)
                         if response_queue is not None:
                             response_queue.put(response_root)
                         else:
-                            self._handle_incoming(RuntimeError(f"Server Error: {message}"))
+                            logger.warning(
+                                "Received response for unknown request ID %s: %s",
+                                response_root.id,
+                                message,
+                            )
             except queue.Empty:
                 continue
             except Exception:


### PR DESCRIPTION
## Summary

Three fixes in the MCP session layer and agent execution layer.

## Fix 1: MCP session receive-loop crash (High)

**File:** `api/core/mcp/session/base_session.py`

`_receive_loop` called `_handle_incoming(RuntimeError(...))` for unexpected responses (unknown request ID, unexpected message type). The default `_message_handler` propagates `Exception` as `ValueError`, crashing the entire receive loop. This is a session-level DoS — a misbehaving MCP server can crash the client session with a single unexpected response.

**Fix:** Replace 3 `_handle_incoming(RuntimeError(...))` calls with `logger.warning(...)`.

## Fix 2: Agent iteration off-by-one (Medium)

**Files:** `api/core/agent/fc_agent_runner.py`, `api/core/agent/cot_agent_runner.py`

`max_iteration_steps = min(app_config.agent.max_iteration, 99) + 1` added +1 unnecessarily. With config `max_iteration=10`, the agent ran 11 iterations (1 through 11). The error message reported "exceeded the maximum iteration limit of 10" but the agent actually ran 11 rounds.

**Fix:** Remove the `+ 1` and update `AgentMaxIterationError` to use the corrected `max_iteration_steps`.

## Fix 3: MCP request responder memory leak (Medium)

**File:** `api/core/mcp/session/base_session.py`

`RequestResponder` instances that never enter the context manager (`_entered=False`) remain in `_in_flight` dict forever because the `on_complete` callback only fires on `__exit__` when `completed=True`. If a server sends unsupported request types repeatedly, `_in_flight` grows unbounded.

**Fix:** Add cleanup after `_handle_incoming` to pop uncompleted responders.