### PR TITLE
fix: keep multimodal rerank result mapping aligned

### DIFF
--- a/api/core/rag/rerank/rerank_model.py
+++ b/api/core/rag/rerank/rerank_model.py
@@ -142,17 +142,19 @@ class RerankModelRunner(BaseRerankRunner):
                 and document.metadata is not None
                 and document.metadata["doc_id"] not in doc_ids
             ):
+                doc_ids.add(document.metadata["doc_id"])
                 if document.metadata.get("doc_type") == DocType.IMAGE:
                     upload_file = self._session.get(UploadFile, document.metadata["doc_id"])
-                    if upload_file:
-                        blob = storage.load_once(upload_file.key)
-                        document_file_base64 = base64.b64encode(blob).decode()
-                        docs.append(
-                            MultimodalRerankInput(
-                                content=document_file_base64,
-                                content_type=document.metadata["doc_type"],
-                            )
+                    if not upload_file:
+                        continue
+                    blob = storage.load_once(upload_file.key)
+                    document_file_base64 = base64.b64encode(blob).decode()
+                    docs.append(
+                        MultimodalRerankInput(
+                            content=document_file_base64,
+                            content_type=document.metadata["doc_type"],
                         )
+                    )
                 else:
                     docs.append(
                         MultimodalRerankInput(
@@ -160,7 +162,6 @@ class RerankModelRunner(BaseRerankRunner):
                             content_type=document.metadata.get("doc_type") or DocType.TEXT,
                         )
                     )
-                doc_ids.add(document.metadata["doc_id"])
                 unique_documents.append(document)
             elif document.provider == "external":
                 if document not in unique_documents:

--- a/api/tests/unit_tests/core/rag/rerank/test_reranker.py
+++ b/api/tests/unit_tests/core/rag/rerank/test_reranker.py
@@ -535,29 +535,59 @@ class TestRerankModelRunnerMultimodal(_UsesSQLiteSession):
         text_rerank_call_args = mock_text_rerank.call_args.args
         assert len(text_rerank_call_args[1]) == 3
 
-    def test_fetch_multimodal_rerank_skips_missing_image_upload(self, rerank_runner):
-        image_doc = Document(
-            page_content="image-content",
+    def test_run_skips_missing_image_upload_without_shifting_result_mapping(
+        self, rerank_runner: RerankModelRunner, mock_model_instance, sqlite_session: Session
+    ):
+        missing_image_doc = Document(
+            page_content="missing-image-content",
             metadata={"doc_id": "img-missing", "doc_type": DocType.IMAGE},
             provider="dify",
         )
-        rerank_result = RerankResult(model="rerank-model", docs=[])
+        text_doc = Document(
+            page_content="valid-text-content",
+            metadata={"doc_id": "txt-valid", "doc_type": DocType.TEXT},
+            provider="dify",
+        )
+        mock_model_instance.invoke_multimodal_rerank.return_value = RerankResult(
+            model="rerank-model",
+            docs=[RerankDocument(index=0, text="valid-text-content", score=0.91)],
+        )
+        query_upload = UploadFile(
+            tenant_id="00000000-0000-0000-0000-000000000001",
+            storage_type=StorageType.LOCAL,
+            key="query-image-key",
+            name="query.png",
+            size=10,
+            extension="png",
+            mime_type="image/png",
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by="00000000-0000-0000-0000-000000000002",
+            created_at=datetime.now(UTC),
+            used=True,
+        )
+        query_upload.id = "00000000-0000-0000-0000-000000000003"
+        sqlite_session.add(query_upload)
+        sqlite_session.commit()
 
-        with patch.object(
-            rerank_runner,
-            "fetch_text_rerank",
-            return_value=(rerank_result, [image_doc]),
-        ) as mock_text_rerank:
-            result, unique_documents = rerank_runner.fetch_multimodal_rerank(
-                query="python",
-                documents=[image_doc],
-                query_type=QueryType.TEXT_QUERY,
+        with (
+            patch.object(rerank_runner, "_session", sqlite_session),
+            patch("core.rag.rerank.rerank_model.ModelManager.for_tenant") as mock_mm,
+            patch("core.rag.rerank.rerank_model.storage.load_once", return_value=b"query-image-bytes") as mock_load,
+        ):
+            mock_mm.return_value.check_model_support_vision.return_value = True
+            result = rerank_runner.run(
+                query=query_upload.id,
+                documents=[missing_image_doc, text_doc],
+                query_type=QueryType.IMAGE_QUERY,
             )
 
-        assert result == rerank_result
-        assert unique_documents == [image_doc]
-        docs_arg = mock_text_rerank.call_args.args[1]
-        assert len(docs_arg) == 1
+        invoke_kwargs = mock_model_instance.invoke_multimodal_rerank.call_args.kwargs
+        assert len(invoke_kwargs["docs"]) == 1
+        assert invoke_kwargs["docs"][0]["content"] == "valid-text-content"
+        assert len(result) == 1
+        assert result[0].metadata["doc_id"] == "txt-valid"
+        assert result[0].metadata["score"] == 0.91
+        mock_load.assert_called_once_with("query-image-key")
 
     def test_fetch_multimodal_rerank_image_query_invokes_multimodal_model(
         self, rerank_runner: RerankModelRunner, mock_model_instance, sqlite_session: Session


### PR DESCRIPTION
## Summary

- skip image candidates with missing `UploadFile` rows before adding them to the source-document mapping
- replace the misleading text-query test with an image-query regression that verifies the final result metadata

## Why

The multimodal reranker already omitted a missing image from the model input, but retained its source document. Provider result indices were then resolved against a longer, shifted list, assigning valid results to the wrong document metadata.

The fix keeps model inputs and source documents aligned while preserving duplicate suppression and existing storage-error behavior.

## Verification

- new regression fails on the original code with `img-missing != txt-valid`
- `UV_NO_SYNC=1 make test TARGET_TESTS=./api/tests/unit_tests/core/rag/rerank/test_reranker.py` — 45 passed
- Ruff check and format check
- Pyrefly and Mypy
- `git diff --check`

Fixes #41479

AI assistance was used for code-path analysis, regression-test design, and drafting. The final diff and verification results were reviewed manually.
