### PR TITLE
fix: preserve cached embedding input alignment

### DIFF
--- a/api/core/rag/embedding/cached_embedding.py
+++ b/api/core/rag/embedding/cached_embedding.py
@@ -51,7 +51,7 @@ class CacheEmbedding(Embeddings):
 
         if embedding_queue_indices:
             embedding_queue_texts = [texts[i] for i in embedding_queue_indices]
-            embedding_queue_embeddings = []
+            indexed_embeddings: list[tuple[int, list[float]]] = []
             try:
                 model_type_instance = cast(TextEmbeddingModel, self._model_instance.model_type_instance)
                 model_schema = model_type_instance.get_model_schema(
@@ -64,12 +64,13 @@ class CacheEmbedding(Embeddings):
                 )
                 for i in range(0, len(embedding_queue_texts), max_chunks):
                     batch_texts = embedding_queue_texts[i : i + max_chunks]
+                    batch_indices = embedding_queue_indices[i : i + max_chunks]
 
                     embedding_result = self._model_instance.invoke_text_embedding(
                         texts=batch_texts, input_type=EmbeddingInputType.DOCUMENT
                     )
 
-                    for vector in embedding_result.embeddings:
+                    for embedding_index, vector in zip(batch_indices, embedding_result.embeddings):
                         try:
                             # FIXME: type ignore for numpy here
                             normalized_embedding = (vector / np.linalg.norm(vector)).tolist()  # type: ignore
@@ -78,14 +79,14 @@ class CacheEmbedding(Embeddings):
                                 # for issue #11827  float values are not json compliant
                                 logger.warning("Normalized embedding is nan: %s", normalized_embedding)
                                 continue
-                            embedding_queue_embeddings.append(normalized_embedding)
+                            indexed_embeddings.append((embedding_index, normalized_embedding))
                         except IntegrityError:
                             db.session.rollback()
                         except Exception:
                             logger.exception("Failed transform embedding")
                 cache_embeddings = []
                 try:
-                    for i, n_embedding in zip(embedding_queue_indices, embedding_queue_embeddings):
+                    for i, n_embedding in indexed_embeddings:
                         text_embeddings[i] = n_embedding
                         hash = helper.generate_text_hash(texts[i])
                         if hash not in cache_embeddings:
@@ -133,7 +134,7 @@ class CacheEmbedding(Embeddings):
 
         if embedding_queue_indices:
             embedding_queue_multimodel_documents = [multimodel_documents[i] for i in embedding_queue_indices]
-            embedding_queue_embeddings = []
+            indexed_embeddings: list[tuple[int, list[float]]] = []
             try:
                 model_type_instance = cast(TextEmbeddingModel, self._model_instance.model_type_instance)
                 model_schema = model_type_instance.get_model_schema(
@@ -146,13 +147,14 @@ class CacheEmbedding(Embeddings):
                 )
                 for i in range(0, len(embedding_queue_multimodel_documents), max_chunks):
                     batch_multimodel_documents = embedding_queue_multimodel_documents[i : i + max_chunks]
+                    batch_indices = embedding_queue_indices[i : i + max_chunks]
 
                     embedding_result = self._model_instance.invoke_multimodal_embedding(
                         multimodel_documents=batch_multimodel_documents,
                         input_type=EmbeddingInputType.DOCUMENT,
                     )
 
-                    for vector in embedding_result.embeddings:
+                    for embedding_index, vector in zip(batch_indices, embedding_result.embeddings):
                         try:
                             # FIXME: type ignore for numpy here
                             normalized_embedding = (vector / np.linalg.norm(vector)).tolist()  # type: ignore
@@ -161,14 +163,14 @@ class CacheEmbedding(Embeddings):
                                 # for issue #11827  float values are not json compliant
                                 logger.warning("Normalized embedding is nan: %s", normalized_embedding)
                                 continue
-                            embedding_queue_embeddings.append(normalized_embedding)
+                            indexed_embeddings.append((embedding_index, normalized_embedding))
                         except IntegrityError:
                             db.session.rollback()
                         except Exception:
                             logger.exception("Failed transform embedding")
                 cache_embeddings = []
                 try:
-                    for i, n_embedding in zip(embedding_queue_indices, embedding_queue_embeddings):
+                    for i, n_embedding in indexed_embeddings:
                         multimodel_embeddings[i] = n_embedding
                         file_id = multimodel_documents[i]["file_id"]
                         if file_id not in cache_embeddings:

--- a/api/tests/unit_tests/core/rag/embedding/test_embedding_service.py
+++ b/api/tests/unit_tests/core/rag/embedding/test_embedding_service.py
@@ -203,6 +203,36 @@ class TestDocumentCache:
         assert "Normalized embedding is nan" in caplog.text
         assert sqlite_embedding_session.scalar(select(Embedding)) is None
 
+    def test_nan_vector_does_not_shift_following_embedding_across_batches_and_cache_hits(
+        self, sqlite_embedding_session: Session, model_instance: Mock
+    ) -> None:
+        cached_vector = (_vector() / np.linalg.norm(_vector())).tolist()
+        _persist_embedding(sqlite_embedding_session, text="cached", vector=cached_vector)
+        valid_vector = _vector(offset=10)
+        expected = (valid_vector / np.linalg.norm(valid_vector)).tolist()
+        model_instance.model_type_instance.get_model_schema.return_value.model_properties = {
+            ModelPropertyKey.MAX_CHUNKS: 1
+        }
+        model_instance.invoke_text_embedding.side_effect = [
+            _result(np.array([np.nan, 1.0])),
+            _result(valid_vector),
+        ]
+
+        result = CacheEmbedding(model_instance).embed_documents(["cached", "invalid", "valid"])
+
+        assert result == [cached_vector, None, expected]
+        assert [call.kwargs["texts"] for call in model_instance.invoke_text_embedding.call_args_list] == [
+            ["invalid"],
+            ["valid"],
+        ]
+        persisted = sqlite_embedding_session.scalars(select(Embedding)).all()
+        assert len(persisted) == 2
+        persisted_by_hash = {row.hash: row.get_embedding() for row in persisted}
+        assert persisted_by_hash == {
+            helper.generate_text_hash("cached"): cached_vector,
+            helper.generate_text_hash("valid"): expected,
+        }
+
     def test_duplicate_text_is_cached_once(self, sqlite_embedding_session: Session, model_instance: Mock) -> None:
         model_instance.invoke_text_embedding.return_value = _result(_vector(), _vector())
 
@@ -250,6 +280,23 @@ class TestMultimodalDocumentCache:
             multimodel_documents=[document], input_type=EmbeddingInputType.DOCUMENT
         )
         assert sqlite_embedding_session.scalar(select(Embedding).where(Embedding.hash == "file-1")) is not None
+
+    def test_nan_vector_does_not_shift_following_embedding(
+        self, sqlite_embedding_session: Session, model_instance: Mock
+    ) -> None:
+        valid_vector = _vector(offset=10)
+        expected = (valid_vector / np.linalg.norm(valid_vector)).tolist()
+        model_instance.invoke_multimodal_embedding.return_value = _result(np.array([np.nan, 1.0]), valid_vector)
+
+        result = CacheEmbedding(model_instance).embed_multimodal_documents(
+            [{"file_id": "invalid"}, {"file_id": "valid"}]
+        )
+
+        assert result == [None, expected]
+        persisted = sqlite_embedding_session.scalars(select(Embedding)).all()
+        assert len(persisted) == 1
+        assert persisted[0].hash == "valid"
+        assert persisted[0].get_embedding() == expected
 
 
 class TestQueryCache:


### PR DESCRIPTION
## Summary

- keep each successfully normalized document embedding paired with its original input index
- add regression coverage for text and multimodal batches when an earlier vector is skipped as NaN

## Why

`CacheEmbedding` intentionally skips vectors that normalize to NaN, but previously collected the surviving vectors separately and then zipped them with every uncached input index. A later valid vector could therefore be returned in the skipped input's slot and persisted under the wrong text hash or file ID.

This is production-reachable: #11827 reported an embedding provider returning all-zero vectors, which normalize to NaN.

The fix carries the original batch index with every successfully normalized vector. It preserves the existing batching, cache deduplication, transaction handling, logging, and invalid-vector behavior.

## Verification

- the new regressions fail on the original code with the valid vector in the invalid input's slot
- `UV_NO_SYNC=1 make test TARGET_TESTS=./api/tests/unit_tests/core/rag/embedding/test_embedding_service.py` — 20 passed
- vector factory unit module — 51 passed
- Ruff check and format check
- Pyrefly and Mypy
- `git diff --check`

Fixes #41476

AI assistance was used for code-path analysis, regression-test design, review, and drafting. The final diff and verification results were reviewed manually.
