### PR TITLE
fix(mcp): keep receiver alive on orphaned responses

### DIFF
--- a/api/core/mcp/session/base_session.py
+++ b/api/core/mcp/session/base_session.py
@@ -333,9 +333,10 @@ class BaseSession[
                                     )
                                 )
                         else:
-                            self._handle_incoming(
-                                RuntimeError(f"Received response with an unknown request ID: {message}")
-                            )
+                            # No request is waiting on this transport error: the request it belonged to
+                            # has already returned or timed out. Dropping it must not tear down the
+                            # receiver, otherwise every later message on this session is lost too.
+                            logger.warning("Discarding HTTP error with no request awaiting a response: %s", message)
                     case Exception():
                         self._handle_incoming(message)
                     case SessionMessage(message=JSONRPCMessage(root=JSONRPCRequest())):
@@ -389,7 +390,13 @@ class BaseSession[
                         if response_queue is not None:
                             response_queue.put(response_root)
                         else:
-                            self._handle_incoming(RuntimeError(f"Server Error: {message}"))
+                            # Orphaned response: duplicate, late, or for a request that already timed
+                            # out. Log and keep going so one stray message cannot kill the session.
+                            logger.warning(
+                                "Discarding response with an unknown or expired request ID %s: %s",
+                                response_root.id,
+                                message,
+                            )
             except queue.Empty:
                 continue
             except Exception:

--- a/api/tests/unit_tests/core/mcp/session/test_base_session.py
+++ b/api/tests/unit_tests/core/mcp/session/test_base_session.py
@@ -476,39 +476,92 @@ def test_check_receiver_status_fail(streams):
     executor.shutdown()
 
 
-@pytest.mark.timeout(10)
-def test_receive_loop_unknown_request_id(streams):
-    read_stream, write_stream = streams
-    session = MockSession(read_stream, write_stream, ReceiveRequest, ReceiveNotification)
+def _keep_alive_notification():
+    return SessionMessage(
+        message=JSONRPCMessage(
+            JSONRPCNotification(jsonrpc="2.0", method="test/notification", params={"message": "still alive"})
+        )
+    )
 
-    with session:
-        resp = JSONRPCResponse(jsonrpc="2.0", id=999, result={"ok": True})
-        read_stream.put(SessionMessage(message=JSONRPCMessage(resp)))
 
-        for _ in range(30):
-            if any(isinstance(x, RuntimeError) and "Server Error" in str(x) for x in session.handled_incoming):
-                break
-            time.sleep(0.1)
-
-    assert any("Server Error" in str(x) for x in session.handled_incoming)
+def _wait_for_notification(session, timeout=3.0):
+    deadline = time.time() + timeout
+    while not session.received_notifications and time.time() < deadline:
+        time.sleep(0.05)
 
 
 @pytest.mark.timeout(10)
-def test_receive_loop_http_error_unknown_id(streams):
+def test_receive_loop_unknown_request_id(streams, caplog: pytest.LogCaptureFixture):
     read_stream, write_stream = streams
     session = MockSession(read_stream, write_stream, ReceiveRequest, ReceiveNotification)
 
+    with caplog.at_level(logging.WARNING, logger="core.mcp.session.base_session"):
+        with session:
+            resp = JSONRPCResponse(jsonrpc="2.0", id=999, result={"ok": True})
+            read_stream.put(SessionMessage(message=JSONRPCMessage(resp)))
+            # Queued behind the orphan: it only arrives if the receiver survived.
+            read_stream.put(_keep_alive_notification())
+            _wait_for_notification(session)
+
+    assert "unknown or expired request ID 999" in caplog.text
+    # The orphan must not reach the message handler, which raises in ClientSession.
+    assert not any(isinstance(x, Exception) for x in session.handled_incoming)
+    assert len(session.received_notifications) == 1
+    session.check_receiver_status()
+
+
+@pytest.mark.timeout(10)
+def test_receive_loop_http_error_unknown_id(streams, caplog: pytest.LogCaptureFixture):
+    read_stream, write_stream = streams
+    session = MockSession(read_stream, write_stream, ReceiveRequest, ReceiveNotification)
+
+    with caplog.at_level(logging.WARNING, logger="core.mcp.session.base_session"):
+        with session:
+            response = Response(status_code=401, request=Request("GET", "http://test"))
+            error = HTTPStatusError("Unauthorized", request=response.request, response=response)
+            read_stream.put(error)
+            read_stream.put(_keep_alive_notification())
+            _wait_for_notification(session)
+
+    assert "Discarding HTTP error with no request awaiting a response" in caplog.text
+    assert not any(isinstance(x, Exception) for x in session.handled_incoming)
+    assert len(session.received_notifications) == 1
+    session.check_receiver_status()
+
+
+@pytest.mark.timeout(10)
+def test_receive_loop_survives_orphan_when_handler_raises(streams):
+    """Regression test for #41482.
+
+    ClientSession's default message handler re-raises any Exception it is handed. Routing an
+    orphaned response through _handle_incoming therefore escaped _receive_loop and killed the
+    receiver for the rest of the session.
+    """
+    read_stream, write_stream = streams
+
+    class RaisingSession(MockSession):
+        def _handle_incoming(self, item):
+            super()._handle_incoming(item)
+            if isinstance(item, Exception):
+                raise ValueError(str(item))
+
+    session = RaisingSession(read_stream, write_stream, ReceiveRequest, ReceiveNotification)
+
     with session:
-        response = Response(status_code=401, request=Request("GET", "http://test"))
-        error = HTTPStatusError("Unauthorized", request=response.request, response=response)
-        read_stream.put(error)
+        read_stream.put(SessionMessage(message=JSONRPCMessage(JSONRPCResponse(jsonrpc="2.0", id=999, result={}))))
+        read_stream.put(
+            SessionMessage(
+                message=JSONRPCMessage(
+                    JSONRPCError(jsonrpc="2.0", id=998, error=ErrorData(code=-32000, message="late"))
+                )
+            )
+        )
+        read_stream.put(_keep_alive_notification())
+        _wait_for_notification(session)
 
-        for _ in range(30):
-            if any(isinstance(x, RuntimeError) and "unknown request ID" in str(x) for x in session.handled_incoming):
-                break
-            time.sleep(0.1)
-
-    assert any("unknown request ID" in str(x) for x in session.handled_incoming)
+    assert len(session.received_notifications) == 1
+    # Raises whatever killed the receiver, if anything did.
+    session.check_receiver_status()
 
 
 @pytest.mark.timeout(10)


### PR DESCRIPTION
## Summary

Fixes #41482

The MCP client session's background receiver died permanently the first time it saw a response it could not match to an in-flight request.

`BaseSession._receive_loop` routed unmatched messages through `_handle_incoming(RuntimeError(...))`. `ClientSession`'s default message handler re-raises any `Exception` it is handed (`_default_message_handler` in `api/core/mcp/session/client_session.py`), so that `RuntimeError` propagated back out of the loop and hit the `except Exception: logger.exception(...); raise` at the bottom. The receiver thread ended, and every subsequent message on that session — notifications, responses to other in-flight requests — was silently dropped. Callers blocked in `send_request` only unblocked because `check_receiver_status()` re-raised the stored failure, so a single stray message failed the whole session rather than one request.

Two paths reached it:

- a JSON-RPC response/error whose `id` is no longer in `_response_streams` — a duplicate, a late reply, or a request that already timed out
- a bare `HTTPStatusError` arriving when no request is awaiting a response

Both are now logged at `WARNING` and skipped, so one orphaned message can no longer tear down the session.

**Deliberately unchanged:** the `not isinstance(response_root, (JSONRPCResponse, JSONRPCError))` branch still reports through `_handle_incoming`. A malformed message is a protocol failure, not an orphaned response, and it should keep surfacing to the message handler rather than being downgraded to a log line.

**Known follow-up, out of scope here:** `send_request` waits in a `while True` loop with no absolute deadline — its only exit besides a real response is `check_receiver_status()` raising. Now that the receiver survives, a caller whose response was mis-`id`ed waits indefinitely instead of failing fast. That is still strictly better than killing every other request on the session, but the loop needs a bounded deadline. Happy to open a separate issue for it.

Related: #41483 addresses the same issue. This PR keeps the two orphan paths from that change, restores the protocol-error branch that was flagged in review there, and adds a regression test that actually fails on the unpatched code.

## Screenshots

N/A — backend-only change, no user-facing UI.

## Testing

`api/tests/unit_tests/core/mcp/session/test_base_session.py`

- Rewrote `test_receive_loop_unknown_request_id` and `test_receive_loop_http_error_unknown_id`, which asserted the old `RuntimeError` routing. Each now queues the orphan, queues a valid notification behind it, and asserts the notification is still received — i.e. the receiver survived.
- Added `test_receive_loop_survives_orphan_when_handler_raises`. This is the actual regression test: it subclasses `MockSession` with a `_handle_incoming` that re-raises, mirroring `_default_message_handler`, which is the real mechanism that killed the receiver. The stock `MockSession` only records exceptions, so a test built on it passes even against the buggy code.

Results:

- `tests/unit_tests/core/mcp/session/test_base_session.py` — 27 passed
- `tests/unit_tests/core/mcp/session/test_client_session.py` — 29 passed
- `ruff check` and `ruff format --check` clean on both changed files

Red/green verified: reverting only the `base_session.py` change and rerunning the suite gives 3 failed / 24 passed, with `ValueError: Server Error: ...` escaping `_receive_loop`. The new tests fail without the fix and pass with it.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

