### PR TITLE
fix: distinguish zero and disabled score thresholds

### DIFF
--- a/api/core/app/app_config/entities.py
+++ b/api/core/app/app_config/entities.py
@@ -149,7 +149,7 @@ class DatasetRetrieveConfigEntity(BaseModel):
 
     retrieve_strategy: RetrieveStrategy
     top_k: int | None = None
-    score_threshold: float | None = 0.0
+    score_threshold: float | None = None
     rerank_mode: str | None = "reranking_model"
     reranking_model: RerankingModelDict | None = None
     weights: WeightsDict | None = None

--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -100,7 +100,7 @@ class RetrievalService:
         dataset_id: str,
         query: str,
         top_k: int = 4,
-        score_threshold: float | None = 0.0,
+        score_threshold: float | None = None,
         reranking_model: RerankingModelDict | None = None,
         reranking_mode: str = "reranking_model",
         weights: WeightsDict | None = None,
@@ -326,7 +326,9 @@ class RetrievalService:
                 # vector retrieval time uses embedding similarity, which is not comparable to
                 # reranked or fused scores and incorrectly drops high-quality chunks (#35233).
                 embedding_score_threshold = (
-                    0.0 if retrieval_method == RetrievalMethod.HYBRID_SEARCH else score_threshold
+                    0.0
+                    if retrieval_method == RetrievalMethod.HYBRID_SEARCH or score_threshold is None
+                    else score_threshold
                 )
                 with Session(db.engine) as session:
                     vector = Vector(dataset=dataset, session=session)
@@ -787,7 +789,7 @@ class RetrievalService:
         exceptions: list[str],
         query: str | None = None,
         top_k: int = 4,
-        score_threshold: float | None = 0.0,
+        score_threshold: float | None = None,
         reranking_model: RerankingModelDict | None = None,
         reranking_mode: str = "reranking_model",
         weights: WeightsDict | None = None,
@@ -907,7 +909,7 @@ class RetrievalService:
                         top_n=top_k,
                         query_type=query_type,
                     )
-                    if not data_post_processor.rerank_runner and score_threshold:
+                    if not data_post_processor.rerank_runner and score_threshold is not None:
                         all_documents_item = self._filter_documents_by_vector_score_threshold(
                             all_documents_item, score_threshold
                         )

--- a/api/core/rag/rerank/weight_rerank.py
+++ b/api/core/rag/rerank/weight_rerank.py
@@ -67,7 +67,7 @@ class WeightRerankRunner(BaseRerankRunner):
                 self.weights.vector_setting.vector_weight * query_vector_score
                 + self.weights.keyword_setting.keyword_weight * query_score
             )
-            if score_threshold and score < score_threshold:
+            if score_threshold is not None and score < score_threshold:
                 continue
             if document.metadata is not None:
                 document.metadata["score"] = score

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -485,7 +485,7 @@ class DatasetRetrieval:
                 available_datasets,
                 query,
                 retrieve_config.top_k or 0,
-                retrieve_config.score_threshold or 0,
+                retrieve_config.score_threshold,
                 retrieve_config.rerank_mode or "reranking_model",
                 retrieve_config.reranking_model,
                 retrieve_config.weights,
@@ -731,7 +731,7 @@ class DatasetRetrieval:
                         else None
                     )
                     # get score threshold
-                    score_threshold = 0.0
+                    score_threshold = None
                     score_threshold_enabled = retrieval_model_config.get("score_threshold_enabled")
                     if score_threshold_enabled:
                         score_threshold = retrieval_model_config.get("score_threshold", 0.0)
@@ -775,7 +775,7 @@ class DatasetRetrieval:
         available_datasets: list[Dataset],
         query: str | None,
         top_k: int,
-        score_threshold: float,
+        score_threshold: float | None,
         reranking_mode: str,
         reranking_model: RerankingModelDict | None = None,
         weights: WeightsDict | None = None,
@@ -1178,7 +1178,7 @@ class DatasetRetrieval:
                             top_k=retrieval_model.get("top_k") or 4,
                             score_threshold=retrieval_model.get("score_threshold", 0.0)
                             if retrieval_model["score_threshold_enabled"]
-                            else 0.0,
+                            else None,
                             reranking_model=retrieval_model.get("reranking_model", None)
                             if retrieval_model["reranking_enable"]
                             else None,
@@ -1454,7 +1454,7 @@ class DatasetRetrieval:
         return documents[:top_k] if top_k else documents
 
     def calculate_vector_score(
-        self, all_documents: list[Document], top_k: int, score_threshold: float
+        self, all_documents: list[Document], top_k: int, score_threshold: float | None
     ) -> list[Document]:
         filter_documents = []
         for document in all_documents:
@@ -1884,7 +1884,7 @@ class DatasetRetrieval:
         reranking_model: RerankingModelDict | None,
         weights: WeightsDict | None,
         top_k: int,
-        score_threshold: float,
+        score_threshold: float | None,
         query: str | None,
         attachment_id: str | None,
         dataset_count: int,
@@ -1999,7 +1999,7 @@ class DatasetRetrieval:
         reranking_model: RerankingModelDict | None,
         weights: WeightsDict | None,
         top_k: int,
-        score_threshold: float,
+        score_threshold: float | None,
         query: str | None,
         attachment_id: str | None,
         dataset_count: int,

--- a/api/core/tools/utils/dataset_retriever/dataset_multi_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_multi_retriever_tool.py
@@ -192,7 +192,7 @@ class DatasetMultiRetrieverTool(DatasetRetrieverBaseTool):
                         top_k=retrieval_model.get("top_k") or 4,
                         score_threshold=retrieval_model.get("score_threshold", 0.0)
                         if retrieval_model["score_threshold_enabled"]
-                        else 0.0,
+                        else None,
                         reranking_model=retrieval_model.get("reranking_model", None)
                         if retrieval_model["reranking_enable"]
                         else None,

--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -150,7 +150,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                         top_k=self.top_k,
                         score_threshold=retrieval_model.get("score_threshold", 0.0)
                         if retrieval_model["score_threshold_enabled"]
-                        else 0.0,
+                        else None,
                         reranking_model=retrieval_model.get("reranking_model")
                         if retrieval_model["reranking_enable"]
                         else None,

--- a/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
+++ b/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
@@ -732,8 +732,8 @@ def build_knowledge_layer_config(agent_soul: AgentSoulConfig) -> DifyKnowledgeBa
     Agent Soul DTO validation owns malformed set rejection. Runtime mapping is
     intentionally lossless: every configured set is forwarded with its query
     policy, dataset refs, retrieval controls, and metadata-filtering controls.
-    ``score_threshold=None`` means disabled threshold filtering and maps to the
-    inner retrieval request's ``0.0`` default through the Agent backend DTO.
+    ``score_threshold=None`` means disabled threshold filtering and remains
+    disabled in the inner retrieval request.
     """
     if not agent_soul.knowledge.sets:
         return None
@@ -788,7 +788,7 @@ def _knowledge_retrieval_config(retrieval: AgentKnowledgeRetrievalConfig) -> Dif
     return DifyKnowledgeRetrievalConfig(
         mode=retrieval.mode,
         top_k=retrieval.top_k,
-        score_threshold=retrieval.score_threshold or 0.0,
+        score_threshold=retrieval.score_threshold,
         reranking_mode=retrieval.reranking_mode,
         reranking_enable=retrieval.reranking_enable,
         reranking_model=DifyKnowledgeRerankingModelConfig(

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -277,9 +277,7 @@ class KnowledgeRetrievalNode(Node[KnowledgeRetrievalNodeData]):
                     query=query,
                     retrieval_mode=DatasetRetrieveConfigEntity.RetrieveStrategy.MULTIPLE.value,
                     top_k=node_data.multiple_retrieval_config.top_k,
-                    score_threshold=node_data.multiple_retrieval_config.score_threshold
-                    if node_data.multiple_retrieval_config.score_threshold is not None
-                    else 0.0,
+                    score_threshold=node_data.multiple_retrieval_config.score_threshold,
                     reranking_mode=node_data.multiple_retrieval_config.reranking_mode,
                     reranking_model=reranking_model,
                     weights=weights,

--- a/api/core/workflow/nodes/knowledge_retrieval/retrieval.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/retrieval.py
@@ -75,7 +75,7 @@ class KnowledgeRetrievalRequest(BaseModel):
         default="disabled", description="Metadata filtering mode: 'disabled', 'automatic', or 'manual'"
     )
     top_k: int = Field(default=0, description="Number of top results to return")
-    score_threshold: float = Field(default=0.0, description="Minimum relevance score threshold")
+    score_threshold: float | None = Field(default=None, description="Minimum relevance score threshold")
     reranking_mode: str = Field(default="reranking_model", description="Reranking strategy")
     reranking_model: RerankingModelDict | None = Field(default=None, description="Reranking model configuration")
     weights: WeightsDict | None = Field(default=None, description="Weights for weighted score reranking")

--- a/api/services/entities/knowledge_retrieval_inner.py
+++ b/api/services/entities/knowledge_retrieval_inner.py
@@ -66,7 +66,7 @@ class InnerKnowledgeRetrieveRetrievalConfig(BaseModel):
 
     mode: Literal["multiple", "single"]
     top_k: int | None = Field(default=None, ge=1)
-    score_threshold: float = 0.0
+    score_threshold: float | None = None
     reranking_mode: str = "reranking_model"
     reranking_enable: bool = True
     reranking_model: InnerKnowledgeRetrieveRerankingModelConfig | None = None

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -154,7 +154,7 @@ class HitTestingService:
             top_k=resolved_retrieval_model.get("top_k", 4),
             score_threshold=resolved_retrieval_model.get("score_threshold", 0.0)
             if resolved_retrieval_model["score_threshold_enabled"]
-            else 0.0,
+            else None,
             reranking_model=resolved_retrieval_model.get("reranking_model", None)
             if resolved_retrieval_model["reranking_enable"]
             else None,

--- a/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
@@ -404,7 +404,7 @@ class TestHitTestingService:
             query="test query",
             attachment_ids=attachment_ids,
             top_k=4,
-            score_threshold=0.0,
+            score_threshold=None,
             reranking_model=None,
             reranking_mode="reranking_model",
             weights=None,

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_runtime_request_builder.py
@@ -458,7 +458,7 @@ class TestAgentAppRuntimeRequestBuilder:
         assert knowledge_set["query"] == {"mode": "generated_query", "value": None}
         assert knowledge_set["retrieval"]["mode"] == "multiple"
         assert knowledge_set["retrieval"]["top_k"] == 3
-        assert knowledge_set["retrieval"]["score_threshold"] == 0.0
+        assert knowledge_set["retrieval"]["score_threshold"] is None
 
     def test_build_raises_when_model_missing(self):
         builder = AgentAppRuntimeRequestBuilder(

--- a/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
@@ -205,7 +205,7 @@ class TestRetrievalServiceInternals:
                 exceptions,
                 query=None,
                 top_k=4,
-                score_threshold=0.0,
+                score_threshold=None,
                 reranking_model=None,
                 reranking_mode="reranking_model",
                 weights=None,
@@ -226,6 +226,7 @@ class TestRetrievalServiceInternals:
         assert len(results) == 2
         assert {doc.metadata["doc_id"] for doc in results} == {"att-1", "att-2"}
         assert mock_retrieve.call_count == 2
+        assert all(call.kwargs["score_threshold"] is None for call in mock_retrieve.call_args_list)
 
     @patch("core.rag.datasource.retrieval_service.ExternalDatasetService.fetch_external_knowledge_retrieval")
     @patch("core.rag.datasource.retrieval_service.MetadataFilteringCondition.model_validate")
@@ -375,7 +376,7 @@ class TestRetrievalServiceInternals:
             dataset_id=internal_dataset.id,
             query="query",
             top_k=4,
-            score_threshold=0.5,
+            score_threshold=None,
             reranking_model=None,
             all_documents=all_documents,
             retrieval_method=RetrievalMethod.SEMANTIC_SEARCH,
@@ -388,6 +389,7 @@ class TestRetrievalServiceInternals:
         assert exceptions == []
         mock_vector_class.assert_called_once_with(dataset=internal_dataset, session=vector_session)
         vector_instance.search_by_vector.assert_called_once()
+        assert vector_instance.search_by_vector.call_args.kwargs["score_threshold"] == 0.0
 
     @patch("core.rag.datasource.retrieval_service.Vector")
     @patch("core.rag.datasource.retrieval_service.RetrievalService._get_dataset")
@@ -1067,6 +1069,60 @@ class TestRetrievalServiceInternals:
         assert len(all_documents) == 4
         assert any(doc.metadata["doc_id"] == "processed-doc" for doc in all_documents)
         processor_instance.invoke.assert_called_once()
+        assert processor_instance.invoke.call_args.kwargs["score_threshold"] is None
+
+    @pytest.mark.parametrize(
+        ("score_threshold", "expected_ids"),
+        [
+            pytest.param(0.0, ["positive", "zero"], id="zero-threshold"),
+            pytest.param(None, ["positive", "zero", "negative"], id="disabled-threshold"),
+        ],
+    )
+    def test_retrieve_internal_hybrid_fallback_distinguishes_zero_from_disabled_threshold(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        internal_dataset,
+        internal_flask_app,
+        vector_session,
+        score_threshold: float | None,
+        expected_ids: list[str],
+    ) -> None:
+        executor = _ImmediateExecutor()
+        monkeypatch.setattr(retrieval_service_module, "ThreadPoolExecutor", lambda *args, **kwargs: executor)
+        monkeypatch.setattr(
+            retrieval_service_module.concurrent.futures,
+            "as_completed",
+            lambda futures, timeout=None: iter(futures),
+        )
+        documents = [
+            create_mock_document("positive", "positive", 0.5),
+            create_mock_document("zero", "zero", 0.0),
+            create_mock_document("negative", "negative", -0.5),
+        ]
+
+        with (
+            patch("core.rag.datasource.retrieval_service.RetrievalService.embedding_search") as mock_embedding_search,
+            patch("core.rag.datasource.retrieval_service.RetrievalService.full_text_index_search"),
+            patch("core.rag.datasource.retrieval_service.DataPostProcessor") as mock_processor_class,
+        ):
+            mock_embedding_search.side_effect = lambda **kwargs: kwargs["all_documents"].extend(documents)
+            processor_instance = Mock()
+            processor_instance.rerank_runner = None
+            processor_instance.invoke.side_effect = lambda **kwargs: kwargs["documents"]
+            mock_processor_class.return_value = processor_instance
+
+            all_documents: list[Document] = []
+            RetrievalService()._retrieve(
+                flask_app=internal_flask_app,
+                retrieval_method=RetrievalMethod.HYBRID_SEARCH,
+                dataset=internal_dataset,
+                all_documents=all_documents,
+                exceptions=[],
+                query="query",
+                score_threshold=score_threshold,
+            )
+
+        assert [document.metadata["doc_id"] for document in all_documents] == expected_ids
 
     @patch("core.rag.datasource.retrieval_service.sign_upload_file_preview_url", return_value="signed://file")
     def test_get_segment_attachment_info_success(self, mock_sign):

--- a/api/tests/unit_tests/core/rag/rerank/test_reranker.py
+++ b/api/tests/unit_tests/core/rag/rerank/test_reranker.py
@@ -17,6 +17,7 @@ from operator import itemgetter
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy.orm import Session
 
 from core.model_manager import ModelInstance
@@ -879,6 +880,33 @@ class TestWeightRerankRunner:
 
         # Assert: Only documents above threshold are returned
         assert all(doc.metadata["score"] >= 0.5 for doc in result)
+
+    @pytest.mark.parametrize(
+        ("score_threshold", "expected_ids"),
+        [
+            pytest.param(0.0, ["positive", "zero"], id="zero-threshold"),
+            pytest.param(None, ["positive", "zero", "negative"], id="disabled-threshold"),
+        ],
+    )
+    def test_score_threshold_distinguishes_zero_from_disabled(
+        self,
+        mocker: MockerFixture,
+        weights_config: Weights,
+        score_threshold: float | None,
+        expected_ids: list[str],
+    ) -> None:
+        documents = [
+            Document(page_content="Positive", metadata={"doc_id": "positive"}),
+            Document(page_content="Zero", metadata={"doc_id": "zero"}),
+            Document(page_content="Negative", metadata={"doc_id": "negative"}),
+        ]
+        runner = WeightRerankRunner(tenant_id="tenant123", weights=weights_config)
+        mocker.patch.object(runner, "_calculate_keyword_score", return_value=[0.0, 0.0, 0.0])
+        mocker.patch.object(runner, "_calculate_cosine", return_value=[0.5, 0.0, -0.5])
+
+        result = runner.run(query="test", documents=documents, score_threshold=score_threshold)
+
+        assert [document.metadata["doc_id"] for document in result] == expected_ids
 
     def test_top_k_selection_weighted(
         self,

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -4898,6 +4898,46 @@ class TestRetrieveCoverage:
         assert len(files or []) == 1
         hit_callback.return_retriever_resource_info.assert_called_once()
 
+    def test_multiple_strategy_preserves_disabled_score_threshold(self, retrieval: DatasetRetrieval) -> None:
+        config = DatasetEntity(
+            dataset_ids=["d1"],
+            retrieve_config=DatasetRetrieveConfigEntity(
+                retrieve_strategy=DatasetRetrieveConfigEntity.RetrieveStrategy.MULTIPLE,
+                top_k=4,
+                reranking_model={"reranking_provider_name": "cohere", "reranking_model_name": "rerank-v3"},
+                metadata_filtering_mode="disabled",
+            ),
+        )
+        model_config = self._build_model_config()
+
+        with (
+            patch("core.rag.retrieval.dataset_retrieval.ModelManager.for_tenant") as mock_model_manager,
+            patch.object(retrieval, "_get_available_datasets", return_value=[SimpleNamespace(id="d1")]),
+            patch.object(retrieval, "get_metadata_filter_condition", return_value=(None, None)),
+            patch.object(retrieval, "multiple_retrieve", return_value=[]) as mock_multiple_retrieve,
+        ):
+            bound_model_instance = Mock()
+            bound_model_instance.model_name = "gpt-4"
+            bound_model_instance.credentials = {}
+            bound_model_instance.provider_model_bundle = Mock()
+            bound_model_instance.model_type_instance.get_model_schema.return_value = SimpleNamespace(features=[])
+            mock_model_manager.return_value.get_model_instance.return_value = bound_model_instance
+            retrieval.retrieve(
+                MagicMock(),
+                app_id="app-1",
+                user_id="user-1",
+                tenant_id="tenant-1",
+                model_config=model_config,
+                config=config,
+                query="python",
+                invoke_from=InvokeFrom.WEB_APP,
+                show_retrieve_source=False,
+                hit_callback=Mock(),
+                message_id="m1",
+            )
+
+        assert mock_multiple_retrieve.call_args.args[7] is None
+
 
 class TestSingleAndMultipleRetrieveCoverage:
     @pytest.fixture(autouse=True)
@@ -4958,7 +4998,19 @@ class TestSingleAndMultipleRetrieveCoverage:
         mock_end.assert_called_once()
         assert retrieval.llm_usage.total_tokens == 2
 
-    def test_single_retrieve_dify_path_and_filters(self, retrieval: DatasetRetrieval) -> None:
+    @pytest.mark.parametrize(
+        ("score_threshold_enabled", "expected_score_threshold"),
+        [
+            pytest.param(True, 0.0, id="zero-threshold"),
+            pytest.param(False, None, id="disabled-threshold"),
+        ],
+    )
+    def test_single_retrieve_dify_path_and_filters(
+        self,
+        retrieval: DatasetRetrieval,
+        score_threshold_enabled: bool,
+        expected_score_threshold: float | None,
+    ) -> None:
         dataset_id = str(uuid4())
         tenant_id = str(uuid4())
         document_id = str(uuid4())
@@ -4977,8 +5029,8 @@ class TestSingleAndMultipleRetrieveCoverage:
                 "reranking_mode": "reranking_model",
                 "weights": {"vector_setting": {}},
                 "top_k": 3,
-                "score_threshold_enabled": True,
-                "score_threshold": 0.2,
+                "score_threshold_enabled": score_threshold_enabled,
+                "score_threshold": 0.0,
             },
         )
         app = Flask(__name__)
@@ -5014,6 +5066,7 @@ class TestSingleAndMultipleRetrieveCoverage:
 
         assert results == [result_doc]
         assert mock_retrieve.call_args.kwargs["document_ids_filter"] == [document_id]
+        assert mock_retrieve.call_args.kwargs["score_threshold"] == expected_score_threshold
         assert retrieval.llm_usage.total_tokens == 1
 
     def test_single_retrieve_returns_empty_when_no_dataset_selected(self, retrieval: DatasetRetrieval) -> None:
@@ -5538,7 +5591,7 @@ class TestInternalHooksCoverage:
                 "search_method": "semantic_search",
                 "top_k": 4,
                 "score_threshold": 0.3,
-                "score_threshold_enabled": True,
+                "score_threshold_enabled": False,
                 "reranking_enable": True,
                 "reranking_model": {"reranking_provider_name": "x", "reranking_model_name": "y"},
                 "reranking_mode": "reranking_model",
@@ -5585,6 +5638,7 @@ class TestInternalHooksCoverage:
                 attachment_ids=["att-1"],
             )
         assert mock_retrieve.call_count == 2
+        assert mock_retrieve.call_args.kwargs["score_threshold"] is None
         assert len(all_documents) >= 3
 
     def test_to_dataset_retriever_tool_paths(self, retrieval: DatasetRetrieval) -> None:

--- a/api/tests/unit_tests/core/tools/utils/test_misc_utils_extra.py
+++ b/api/tests/unit_tests/core/tools/utils/test_misc_utils_extra.py
@@ -272,12 +272,23 @@ def test_single_dataset_retriever_returns_empty_when_metadata_filter_finds_no_do
     retrieve_mock.assert_not_called()
 
 
-def test_single_dataset_retriever_non_economy_run_sorts_context_and_resources(sqlite_session: Session):
+@pytest.mark.parametrize(
+    ("score_threshold_enabled", "expected_score_threshold"),
+    [
+        pytest.param(True, 0.2, id="enabled-threshold"),
+        pytest.param(False, None, id="disabled-threshold"),
+    ],
+)
+def test_single_dataset_retriever_non_economy_run_sorts_context_and_resources(
+    sqlite_session: Session,
+    score_threshold_enabled: bool,
+    expected_score_threshold: float | None,
+):
     dataset = _persist_dataset(
         sqlite_session,
         retrieval_model={
             "search_method": "semantic_search",
-            "score_threshold_enabled": True,
+            "score_threshold_enabled": score_threshold_enabled,
             "score_threshold": 0.2,
             "reranking_enable": True,
             "reranking_model": {"reranking_provider_name": "provider", "reranking_model_name": "model"},
@@ -357,7 +368,7 @@ def test_single_dataset_retriever_non_economy_run_sorts_context_and_resources(sq
             "get_metadata_filter_condition",
             return_value=(None, None),
         ),
-        patch.object(single_retriever_module.RetrievalService, "retrieve", return_value=documents),
+        patch.object(single_retriever_module.RetrievalService, "retrieve", return_value=documents) as retrieve_mock,
         patch.object(
             single_retriever_module.RetrievalService,
             "format_retrieval_documents",
@@ -370,6 +381,7 @@ def test_single_dataset_retriever_non_economy_run_sorts_context_and_resources(sq
     assert result == "signed high\nsummary low\nquestion:signed low answer:low answer"
     assert callback.documents == documents
     assert callback.resources is not None
+    assert retrieve_mock.call_args.kwargs["score_threshold"] == expected_score_threshold
     resource_info = callback.resources
     assert [item.position for item in resource_info] == [1, 2]
     assert resource_info[0].segment_id == high_segment.id
@@ -425,16 +437,25 @@ def test_multi_dataset_retriever_retriever_returns_early_when_dataset_is_missing
     retrieve_mock.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("score_threshold_enabled", "expected_score_threshold"),
+    [
+        pytest.param(True, 0.4, id="enabled-threshold"),
+        pytest.param(False, None, id="disabled-threshold"),
+    ],
+)
 def test_multi_dataset_retriever_retriever_non_economy_uses_retrieval_model(
     sqlite_session: Session,
     sqlite_session_factory: sessionmaker[Session],
+    score_threshold_enabled: bool,
+    expected_score_threshold: float | None,
 ):
     dataset = _persist_dataset(
         sqlite_session,
         retrieval_model={
             "search_method": "semantic_search",
             "top_k": 6,
-            "score_threshold_enabled": True,
+            "score_threshold_enabled": score_threshold_enabled,
             "score_threshold": 0.4,
             "reranking_enable": False,
             "reranking_mode": None,
@@ -477,7 +498,7 @@ def test_multi_dataset_retriever_retriever_non_economy_uses_retrieval_model(
         dataset_id=dataset.id,
         query="hello",
         top_k=6,
-        score_threshold=0.4,
+        score_threshold=expected_score_threshold,
         reranking_model=None,
         reranking_mode="reranking_model",
         weights={"balanced": True},

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
@@ -856,7 +856,7 @@ def test_build_maps_agent_soul_knowledge_to_knowledge_layer_config():
             "retrieval": {
                 "mode": "single",
                 "top_k": None,
-                "score_threshold": 0.0,
+                "score_threshold": None,
                 "reranking_mode": "reranking_model",
                 "reranking_enable": True,
                 "reranking_model": None,
@@ -884,7 +884,7 @@ def test_build_maps_agent_soul_knowledge_to_knowledge_layer_config():
     assert knowledge_layer["config"]["max_observation_chars"] == 12000
 
 
-def test_build_knowledge_layer_maps_disabled_score_threshold_to_zero():
+def test_build_knowledge_layer_preserves_disabled_score_threshold():
     context = _context()
     snapshot = AgentConfigSnapshot(
         id="snapshot-1",
@@ -923,7 +923,7 @@ def test_build_knowledge_layer_maps_disabled_score_threshold_to_zero():
 
     dumped = result.request.model_dump(mode="json")
     knowledge_layer = next(layer for layer in dumped["composition"]["layers"] if layer["name"] == "knowledge")
-    assert knowledge_layer["config"]["sets"][0]["retrieval"]["score_threshold"] == 0.0
+    assert knowledge_layer["config"]["sets"][0]["retrieval"]["score_threshold"] is None
 
 
 def test_build_skips_knowledge_layer_when_agent_soul_has_no_sets():

--- a/api/tests/unit_tests/core/workflow/nodes/knowledge_retrieval/test_knowledge_retrieval_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/knowledge_retrieval/test_knowledge_retrieval_node.py
@@ -556,7 +556,7 @@ class TestFetchDatasetRetriever:
             retrieval_mode="multiple",
             multiple_retrieval_config=MultipleRetrievalConfig(
                 top_k=5,
-                score_threshold=0.7,
+                score_threshold=None,
                 reranking_enable=False,
                 reranking_mode="reranking_model",
             ),
@@ -590,6 +590,7 @@ class TestFetchDatasetRetriever:
         call_args = mock_rag_retrieval.knowledge_retrieval.call_args
         request = call_args[1]["request"]
         assert request.reranking_enable is False
+        assert request.score_threshold is None
 
     def test_version_method(self):
         """Test version class method."""

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -382,6 +382,7 @@ class TestHitTestingServiceRetrieve:
             call_kwargs = mock_retrieve.call_args[1]
             assert call_kwargs["retrieval_method"] == RetrievalMethod.HYBRID_SEARCH
             assert call_kwargs["top_k"] == 3
+            assert call_kwargs["score_threshold"] is None
 
 
 class TestHitTestingServiceExternalRetrieve:

--- a/api/tests/unit_tests/services/test_knowledge_retrieval_inner_service.py
+++ b/api/tests/unit_tests/services/test_knowledge_retrieval_inner_service.py
@@ -226,6 +226,7 @@ class TestInnerKnowledgeRetrievalService:
 
         rag_request = rag.knowledge_retrieval.call_args.kwargs["request"]
         assert rag_request.retrieval_mode == "single"
+        assert rag_request.score_threshold is None
         assert rag_request.model_provider == "openai"
         assert rag_request.model_name == "gpt-4o-mini"
         assert rag_request.model_mode == "chat"

--- a/dify-agent/src/dify_agent/layers/knowledge/configs.py
+++ b/dify-agent/src/dify_agent/layers/knowledge/configs.py
@@ -103,7 +103,7 @@ class DifyKnowledgeRetrievalConfig(BaseModel):
 
     mode: Literal["multiple", "single"]
     top_k: int | None = Field(default=None, ge=1)
-    score_threshold: float = 0.0
+    score_threshold: float | None = None
     reranking_mode: str = "reranking_model"
     reranking_enable: bool = True
     reranking_model: DifyKnowledgeRerankingModelConfig | None = None

--- a/dify-agent/tests/local/dify_agent/layers/knowledge/test_configs.py
+++ b/dify-agent/tests/local/dify_agent/layers/knowledge/test_configs.py
@@ -26,6 +26,8 @@ def test_knowledge_base_config_accepts_valid_multiple_mode() -> None:
 
     assert config.sets[0].dataset_ids == ["dataset-1"]
     assert config.sets[0].retrieval.top_k == 4
+    assert config.sets[0].retrieval.score_threshold is None
+    assert config.sets[0].retrieval.to_request_payload()["score_threshold"] is None
     assert config.sets[0].metadata_filtering.mode == "disabled"
 
 


### PR DESCRIPTION
## Summary

- preserve `None` as the disabled score-threshold sentinel across app, dataset, tool, hit-test, Workflow, Agent v2, inner-request, and dify-agent paths
- treat `0.0` as an active threshold in weighted reranking so negative combined scores are filtered
- retain the existing vector-database boundary behavior and add regressions for the affected production routes

## Why

`WeightRerankRunner` used a truthiness check before applying the score threshold. An enabled threshold of `0.0` therefore skipped filtering and returned negative-score documents.

Changing only that guard would make existing callers that encode a disabled threshold as `0.0` start filtering unexpectedly. This patch reuses the existing optional representation end to end: `None` remains disabled, while `0.0` is an active boundary. `None` is converted to the existing `0.0` value only when calling vector-database providers, preserving their current contract.

Fixes #41488

## Screenshots

Not applicable; this changes backend retrieval behavior and internal request semantics.

## Verification

- related API unit modules: `391 passed, 14 warnings`
- adjacent caller modules after follow-up review: `168 passed, 5 warnings`
- dify-agent knowledge-layer suite: `34 passed`
- API Ruff format/check over 3,388 files, response-contract lint, and all 23 import contracts: passed
- affected API production files: Pyrefly and Mypy passed
- dify-agent `make check` and targeted BasedPyright: passed
- `git diff --check`: passed

The repository `make lint` command reached its final dotenv step but could not inspect `web/.env.example`, which is absent from this API/dify-agent sparse worktree. Full package typechecks also report pre-existing missing optional provider/server dependencies; all affected production files pass targeted type checks against the current worktree sources.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

AI assistance was used for code-path analysis, regression-test design, review, and drafting. The final diff and verification results were reviewed manually.

From Codex
