### PR TITLE
revert(web): revert dataset button a11y changes

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1829,6 +1829,14 @@
       "count": 1
     }
   },
+  "web/app/components/datasets/create-from-pipeline/list/template-card/operations.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 3
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 3
+    }
+  },
   "web/app/components/datasets/create/file-preview/index.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
@@ -2203,6 +2211,12 @@
   "web/app/components/datasets/external-knowledge-base/create/ExternalApiSelect.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
+    },
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 3
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 3
     }
   },
   "web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx": {

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/operations.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/operations.tsx
@@ -12,21 +12,21 @@ type OperationsProps = {
 const Operations = ({ openEditModal, onDelete, onExport, onClose }: OperationsProps) => {
   const { t } = useTranslation()
 
-  const onClickEdit = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const onClickEdit = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation()
     e.preventDefault()
     onClose?.()
     openEditModal()
   }
 
-  const onClickExport = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const onClickExport = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation()
     e.preventDefault()
     onClose?.()
     onExport()
   }
 
-  const onClickDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const onClickDelete = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation()
     e.preventDefault()
     onClose?.()
@@ -36,36 +36,33 @@ const Operations = ({ openEditModal, onDelete, onExport, onClose }: OperationsPr
   return (
     <div className="relative flex w-full flex-col rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg shadow-shadow-shadow-5">
       <div className="flex flex-col p-1">
-        <button
-          type="button"
-          className="flex w-full cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 text-left hover:bg-state-base-hover"
+        <div
+          className="flex cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-base-hover"
           onClick={onClickEdit}
         >
           <span className="px-1 system-md-regular text-text-secondary">
             {t(($) => $['operations.editInfo'], { ns: 'datasetPipeline' })}
           </span>
-        </button>
-        <button
-          type="button"
-          className="flex w-full cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 text-left hover:bg-state-base-hover"
+        </div>
+        <div
+          className="flex cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-base-hover"
           onClick={onClickExport}
         >
           <span className="px-1 system-md-regular text-text-secondary">
             {t(($) => $['operations.exportPipeline'], { ns: 'datasetPipeline' })}
           </span>
-        </button>
+        </div>
       </div>
       <Divider type="horizontal" className="my-0 bg-divider-subtle" />
       <div className="flex flex-col p-1">
-        <button
-          type="button"
-          className="group flex w-full cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 text-left hover:bg-state-destructive-hover"
+        <div
+          className="group flex cursor-pointer items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-destructive-hover"
           onClick={onClickDelete}
         >
           <span className="px-1 system-md-regular text-text-secondary group-hover:text-text-destructive">
             {t(($) => $['operation.delete'], { ns: 'common' })}
           </span>
-        </button>
+        </div>
       </div>
     </div>
   )

--- a/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelect.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelect.tsx
@@ -57,11 +57,8 @@ const ExternalApiSelect: React.FC<ExternalApiSelectProps> = ({ items, value, onS
 
   return (
     <div className="relative w-full">
-      <button
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        className={`flex cursor-pointer items-center justify-between gap-0.5 self-stretch rounded-lg bg-components-input-bg-normal px-2 py-1 text-left hover:bg-state-base-hover-alt ${isOpen && 'bg-state-base-hover-alt'}`}
+      <div
+        className={`flex cursor-pointer items-center justify-between gap-0.5 self-stretch rounded-lg bg-components-input-bg-normal px-2 py-1 hover:bg-state-base-hover-alt ${isOpen && 'bg-state-base-hover-alt'}`}
         onClick={() => setIsOpen(!isOpen)}
       >
         {selectedItem ? (
@@ -79,16 +76,15 @@ const ExternalApiSelect: React.FC<ExternalApiSelectProps> = ({ items, value, onS
           </span>
         )}
         <RiArrowDownSLine
-          className={`size-4 shrink-0 text-text-quaternary transition-transform ${isOpen ? 'text-text-secondary' : ''}`}
+          className={`size-4 text-text-quaternary transition-transform ${isOpen ? 'text-text-secondary' : ''}`}
         />
-      </button>
+      </div>
       {isOpen && (
         <div className="absolute z-10 mt-1 w-full rounded-xl border border-components-panel-border bg-components-panel-bg-blur shadow-lg">
           {items.map((item) => (
-            <button
-              type="button"
+            <div
               key={item.value}
-              className="block w-full cursor-pointer p-1 text-left"
+              className="flex cursor-pointer items-center p-1"
               onClick={() => handleSelect(item)}
             >
               <div className="flex w-full items-center gap-2 self-stretch rounded-lg p-2 hover:bg-state-base-hover">
@@ -100,19 +96,18 @@ const ExternalApiSelect: React.FC<ExternalApiSelectProps> = ({ items, value, onS
                   {item.url}
                 </span>
               </div>
-            </button>
+            </div>
           ))}
           <div className="flex flex-col items-start self-stretch p-1">
-            <button
-              type="button"
-              className="flex w-full cursor-pointer items-center gap-2 self-stretch rounded-lg p-2 text-left hover:bg-state-base-hover"
+            <div
+              className="flex cursor-pointer items-center gap-2 self-stretch rounded-lg p-2 hover:bg-state-base-hover"
               onClick={handleAddNewAPI}
             >
               <RiAddLine className="size-4 text-text-secondary" />
               <span className="grow overflow-hidden system-sm-medium text-ellipsis text-text-secondary">
                 {t(($) => $.createNewExternalAPI, { ns: 'dataset' })}
               </span>
-            </button>
+            </div>
           </div>
         </div>
       )}

--- a/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelect.spec.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelect.spec.tsx
@@ -127,44 +127,4 @@ describe('ExternalApiSelect', () => {
       expect(screen.getByText('https://api2.com')).toBeInTheDocument()
     })
   })
-
-  describe('accessibility', () => {
-    it('should render the trigger as a button with listbox semantics', () => {
-      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      const trigger = screen.getByRole('button', {
-        name: 'dataset.selectExternalKnowledgeAPI.placeholder',
-      })
-      expect(trigger).toHaveAttribute('aria-haspopup', 'listbox')
-      expect(trigger).toHaveAttribute('aria-expanded', 'false')
-    })
-
-    it('should reflect the expanded state on the trigger', () => {
-      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      const trigger = screen.getByRole('button', {
-        name: 'dataset.selectExternalKnowledgeAPI.placeholder',
-      })
-      fireEvent.click(trigger)
-      expect(trigger).toHaveAttribute('aria-expanded', 'true')
-    })
-
-    it('should render dropdown items and the add action as buttons', () => {
-      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      fireEvent.click(
-        screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }),
-      )
-      expect(screen.getByRole('button', { name: /API Two/ })).toBeInTheDocument()
-      expect(
-        screen.getByRole('button', { name: 'dataset.createNewExternalAPI' }),
-      ).toBeInTheDocument()
-    })
-
-    it('should select an item when its button is clicked', () => {
-      render(<ExternalApiSelect items={items} onSelect={onSelect} />)
-      fireEvent.click(
-        screen.getByRole('button', { name: 'dataset.selectExternalKnowledgeAPI.placeholder' }),
-      )
-      fireEvent.click(screen.getByRole('button', { name: /API Two/ }))
-      expect(onSelect).toHaveBeenCalledWith(items[1])
-    })
-  })
 })


### PR DESCRIPTION
## Summary

- fully revert #41319 and restore the previous dataset interaction implementation
- remove the invalid listbox assertions added by that PR
- restore the corresponding a11y lint suppressions until the controls are fixed through their owning primitives

## Rationale

#41319 changed the DOM and accessibility contracts without verifying the final widgets:

- `ExternalApiSelect` declares `aria-haspopup="listbox"`, but renders no `listbox`, `option`, selected state, or listbox keyboard model
- the template card actions render native buttons inside a Base UI `Menu.Popup` instead of `DropdownMenuItem`, so they are not registered as menu items and do not receive the menu keyboard/focus contract
- the added tests assert ARIA strings and native button roles without testing the actual popup role hierarchy, selection state, focus movement, or keyboard interaction

This revert intentionally restores the previous known behavior. A correct accessibility change should be submitted separately using the Dify UI Select/Menu owners, with label, focus, keyboard, and real product-state verification.

Related review: https://github.com/langgenius/dify/pull/41319#issuecomment-5469044355

## Verification

- `vp test run --project unit app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelect.spec.tsx` (8 passed)
- `git diff HEAD^ HEAD --check`
