### PR TITLE
fix(core): propagate stop sequences from ModelConfigEntity to runtime model config (#41460)

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -57,11 +57,10 @@ class ModelConfigConverter:
             raise QuotaExceededError(f"Model provider {provider_name} quota exceeded.")
 
         # model config
-        completion_params = model_config.parameters
-        stop = []
+        completion_params = model_config.parameters.copy() if model_config.parameters else {}
+        stop = list(getattr(model_config, "stop", None) or [])
         if "stop" in completion_params:
-            stop = completion_params["stop"]
-            del completion_params["stop"]
+            stop = completion_params.pop("stop")
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)
 

--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -58,7 +58,7 @@ class ModelConfigConverter:
 
         # model config
         completion_params = model_config.parameters.copy() if model_config.parameters else {}
-        stop = list(getattr(model_config, "stop", None) or [])
+        stop = list(model_config.stop) if model_config.stop else []
         if "stop" in completion_params:
             stop = completion_params.pop("stop")
 

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
@@ -100,6 +100,15 @@ class TestModelConfigConverter:
         assert result.parameters == {"temperature": 0.7}
         assert result.stop == ["\n"]
 
+    def test_convert_success_with_model_config_stop_attribute(self, mock_app_config, patch_provider_manager):
+        mock_app_config.model.stop = ["###", "END"]
+        mock_app_config.model.parameters = {"temperature": 0.7}
+
+        result = ModelConfigConverter.convert(mock_app_config)
+
+        assert result.parameters == {"temperature": 0.7}
+        assert result.stop == ["###", "END"]
+
     def test_convert_mode_from_schema_valid(self, mock_app_config, mock_provider_bundle, mocker: MockerFixture):
         mock_app_config.model.mode = None
 


### PR DESCRIPTION
### Summary
Fixes an issue where stop sequences configured on non-workflow apps (Chatbot, Agent, Completion) are not passed to `ModelConfigWithCredentialsEntity` during runtime conversion and thus never reach the LLM invocation.

### Details
`ModelConfigManager.convert` extracts `stop` from `completion_params` onto `ModelConfigEntity.stop`. However, `ModelConfigConverter.convert` was previously only checking `model_config.parameters["stop"]`, which was already empty. This change checks `model_config.stop` (as well as `completion_params["stop"]` for fallback compatibility) so stop sequences are preserved and passed to `ModelConfigWithCredentialsEntity`.

Closes #41460

### Testing
- Added unit test `test_convert_success_with_model_config_stop_attribute` in `test_model_config_converter.py`.
- Ran full unit test suite for `test_model_config_converter.py` (14/14 passed).