### PR TITLE
fix(api): preserve QA segment answer when omitted in update

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3612,8 +3612,9 @@ class SegmentService:
             if segment.content == content:
                 segment.word_count = len(content)
                 if document.doc_form == IndexStructureType.QA_INDEX:
-                    segment.answer = args.answer
-                    segment.word_count += len(args.answer) if args.answer else 0
+                    if args.answer is not None:
+                        segment.answer = args.answer
+                    segment.word_count += len(segment.answer) if segment.answer else 0
                 word_count_change = segment.word_count - word_count_change
                 keyword_changed = False
                 if args.keywords:
@@ -3710,8 +3711,11 @@ class SegmentService:
 
                     # calc embedding use tokens
                     if document.doc_form == IndexStructureType.QA_INDEX:
-                        segment.answer = args.answer
-                        tokens = embedding_model.get_text_embedding_num_tokens(texts=[content + segment.answer])[0]  # type: ignore
+                        if args.answer is not None:
+                            segment.answer = args.answer
+                        tokens = embedding_model.get_text_embedding_num_tokens(
+                            texts=[content + (segment.answer or "")]
+                        )[0]  # type: ignore
                     else:
                         tokens = embedding_model.get_text_embedding_num_tokens(texts=[content])[0]
                 segment.content = content
@@ -3727,8 +3731,9 @@ class SegmentService:
                 segment.disabled_at = None
                 segment.disabled_by = None
                 if document.doc_form == IndexStructureType.QA_INDEX:
-                    segment.answer = args.answer
-                    segment.word_count += len(args.answer) if args.answer else 0
+                    if args.answer is not None:
+                        segment.answer = args.answer
+                    segment.word_count += len(segment.answer) if segment.answer else 0
                 word_count_change = segment.word_count - word_count_change
                 # update document word count
                 if word_count_change != 0:

--- a/api/tests/unit_tests/services/dataset_service_test_helpers.py
+++ b/api/tests/unit_tests/services/dataset_service_test_helpers.py
@@ -352,6 +352,7 @@ def _make_segment(
     index_node_id: str = "node-1",
     dataset_id: str = "dataset-1",
     document_id: str = "doc-1",
+    answer: str | None = None,
 ) -> DocumentSegment:
     segment = DocumentSegment(
         tenant_id="tenant-id",
@@ -364,7 +365,7 @@ def _make_segment(
         created_by="account-id",
         enabled=enabled,
         keywords=keywords or [],
-        answer=None,
+        answer=answer,
         index_node_id=index_node_id,
         disabled_at=None,
         disabled_by=None,

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -1014,6 +1014,41 @@ class TestSegmentServiceAdditionalRegenerationBranches:
         vector_service.update_segment_vector.assert_not_called()
         vector_service.update_multimodel_vector.assert_called_once_with(segment, [], dataset, session=session)
 
+    def test_update_segment_same_content_preserves_existing_answer_when_omitted_for_qa_segments(self, account_context):
+        session = MagicMock()
+        existing_answer = "existing answer"
+        segment = _make_segment(
+            content="question",
+            answer=existing_answer,
+            word_count=len("question") + len(existing_answer),
+            keywords=["old-kw"],
+        )
+        document = _make_document(doc_form=IndexStructureType.QA_INDEX, word_count=50)
+        dataset = _make_dataset()
+        refreshed_segment = SimpleNamespace(id=segment.id)
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.VectorService") as vector_service,
+        ):
+            mock_redis.get.return_value = None
+            session.get.return_value = refreshed_segment
+
+            result = SegmentService.update_segment(
+                SegmentUpdateArgs(content="question", keywords=["new-kw"]),
+                segment,
+                document,
+                dataset,
+                session,
+            )
+
+        assert result is refreshed_segment
+        assert segment.answer == existing_answer
+        assert segment.word_count == len("question") + len(existing_answer)
+        assert document.word_count == 50
+        vector_service.update_segment_vector.assert_called_once_with(["new-kw"], segment, dataset, session=session)
+        vector_service.update_multimodel_vector.assert_called_once_with(segment, [], dataset, session=session)
+
     def test_update_segment_content_change_uses_answer_when_counting_tokens_for_qa_segments(self, account_context):
         session = MagicMock()
         segment = _make_segment(content="old", word_count=3)
@@ -1049,6 +1084,84 @@ class TestSegmentServiceAdditionalRegenerationBranches:
         assert segment.tokens == 21
         assert segment.word_count == len("new question") + len("new answer")
         vector_service.update_segment_vector.assert_called_once_with(["kw-1"], segment, dataset, session=session)
+        vector_service.update_multimodel_vector.assert_called_once_with(segment, [], dataset, session=session)
+
+    def test_update_segment_content_change_preserves_answer_in_high_quality_for_qa_segments(self, account_context):
+        session = MagicMock()
+        existing_answer = "existing answer"
+        segment = _make_segment(
+            content="old question",
+            answer=existing_answer,
+            word_count=len("old question") + len(existing_answer),
+        )
+        document = _make_document(doc_form=IndexStructureType.QA_INDEX, word_count=50)
+        dataset = _make_dataset(indexing_technique="high_quality")
+        refreshed_segment = SimpleNamespace(id=segment.id)
+        embedding_model = MagicMock()
+        embedding_model.get_text_embedding_num_tokens.return_value = [30]
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.ModelManager") as model_manager_cls,
+            patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.helper.generate_text_hash", return_value="hash-qa"),
+            patch("services.dataset_service.naive_utc_now", return_value="now"),
+        ):
+            mock_redis.get.return_value = None
+            model_manager_cls.for_tenant.return_value.get_model_instance.return_value = embedding_model
+            session.scalar.return_value = None
+            session.get.return_value = refreshed_segment
+
+            result = SegmentService.update_segment(
+                SegmentUpdateArgs(content="new question"),
+                segment,
+                document,
+                dataset,
+                session,
+            )
+
+        assert result is refreshed_segment
+        embedding_model.get_text_embedding_num_tokens.assert_called_once_with(texts=["new questionexisting answer"])
+        assert segment.answer == existing_answer
+        assert segment.word_count == len("new question") + len(existing_answer)
+        assert document.word_count == 50 + (len("new question") - len("old question"))
+        vector_service.update_segment_vector.assert_called_once_with(None, segment, dataset, session=session)
+        vector_service.update_multimodel_vector.assert_called_once_with(segment, [], dataset, session=session)
+
+    def test_update_segment_content_change_preserves_answer_in_economy_for_qa_segments(self, account_context):
+        session = MagicMock()
+        existing_answer = "existing answer"
+        segment = _make_segment(
+            content="old question",
+            answer=existing_answer,
+            word_count=len("old question") + len(existing_answer),
+        )
+        document = _make_document(doc_form=IndexStructureType.QA_INDEX, word_count=50)
+        dataset = _make_dataset(indexing_technique="economy")
+        refreshed_segment = SimpleNamespace(id=segment.id)
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.helper.generate_text_hash", return_value="hash-qa"),
+            patch("services.dataset_service.naive_utc_now", return_value="now"),
+        ):
+            mock_redis.get.return_value = None
+            session.get.return_value = refreshed_segment
+
+            result = SegmentService.update_segment(
+                SegmentUpdateArgs(content="new question"),
+                segment,
+                document,
+                dataset,
+                session,
+            )
+
+        assert result is refreshed_segment
+        assert segment.answer == existing_answer
+        assert segment.word_count == len("new question") + len(existing_answer)
+        assert document.word_count == 50 + (len("new question") - len("old question"))
+        vector_service.update_segment_vector.assert_called_once_with(None, segment, dataset, session=session)
         vector_service.update_multimodel_vector.assert_called_once_with(segment, [], dataset, session=session)
 
     def test_update_segment_content_change_parent_child_uses_default_embedding_and_ignores_summary_failures(


### PR DESCRIPTION
## Summary
Fixes an issue where updating a QA knowledge base segment (`doc_form == 'qa_model'`) via Service API or `SegmentService.update_segment` without supplying an `answer` field causes `segment.answer = args.answer` to overwrite the existing answer with `None`.

- In economy indexing, the answer was lost silently.
- In high quality indexing, string concatenation with `None` caused a `TypeError: can only concatenate str (not 'NoneType') to str`.

## Changes
- In `api/services/dataset_service.py` (`SegmentService.update_segment`), only update `segment.answer` if `args.answer is not None`.
- Calculate `word_count` using `segment.answer` (preserving the answer if `args.answer` was omitted).
- Use `(segment.answer or '')` safely during text embedding token calculation.
- Added unit tests in `api/tests/unit_tests/services/test_dataset_service_segment.py` covering QA segment partial updates in both High Quality and Economy indexing modes.

Closes #41315