### PR TITLE
fix(api): make Stop button actually cancel the upstream LLM stream

### DIFF
--- a/api/core/agent/cot_agent_runner.py
+++ b/api/core/agent/cot_agent_runner.py
@@ -11,6 +11,7 @@ from core.agent.entities import AgentScratchpadUnit
 from core.agent.errors import AgentMaxIterationError
 from core.agent.output_parser.cot_output_parser import CotAgentOutputParser
 from core.app.apps.base_app_queue_manager import PublishFrom
+from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.queue_entities import QueueAgentThoughtEvent, QueueMessageEndEvent, QueueMessageFileEvent
 from core.credit_usage import CreditUsageAppType, CreditUsageCreatedBy
 from core.model_context import use_credit_usage_metadata
@@ -170,6 +171,17 @@ class CotAgentRunner(BaseAgentRunner, ABC):
                 )
 
             for chunk in react_chunks:
+                # Stop button: check between parsed agent chunks. Without
+                # this, an in-flight LLM stream keeps producing tokens for a
+                # request the user has already abandoned. The outer
+                # base_app_runner.is_stopped() check only fires AFTER this
+                # agent runner yields, which is too late when the parser is
+                # buffering many raw upstream chunks before yielding. Raising
+                # GenerateTaskStoppedError here short-circuits the inner loop;
+                # the except handler in base_app_runner._handle_invoke_result_stream
+                # then calls invoke_result.close() to cancel the upstream stream.
+                if self.queue_manager.is_stopped():
+                    raise GenerateTaskStoppedError()
                 if isinstance(chunk, AgentScratchpadUnit.Action):
                     action = chunk
                     # detect action

--- a/api/core/app/apps/base_app_runner.py
+++ b/api/core/app/apps/base_app_runner.py
@@ -298,6 +298,17 @@ class AppRunner:
         usage = None
         try:
             for result in invoke_result:
+                # Stop button: actually cancel the upstream LLM stream.
+                # Without this, plugin_daemon and the upstream provider keep
+                # generating tokens for a request the user has already abandoned.
+                # The Stop button only paused the SSE output on Dify; MTPLX and
+                # other inference servers continued generating until completion.
+                # Raising GenerateTaskStoppedError here short-circuits the
+                # loop and triggers the explicit `invoke_result.close()` in
+                # the except handler below, which cancels the upstream stream.
+                if queue_manager.is_stopped():
+                    raise GenerateTaskStoppedError()
+
                 if not agent:
                     queue_manager.publish(QueueLLMChunkEvent(chunk=result), PublishFrom.APPLICATION_MANAGER)
                 else:


### PR DESCRIPTION
## Summary

The Stop button on a streaming chat or agent-chat request only paused the SSE output on Dify. The plugin_daemon kept the gRPC stream open, which kept the upstream provider (e.g. MTPLX) generating tokens for a request the user had already abandoned. Long prompts continued to consume GPU time and quota until the LLM finished its full response.

This PR makes the Stop button a real cancel in two places:

1. **`base_app_runner._handle_invoke_result_stream`** — chat and agent-chat share this consumer loop. Check `queue_manager.is_stopped()` at the top of each chunk iteration. Raising `GenerateTaskStoppedError` here short-circuits the loop; the existing `except` handler at the bottom of the method already calls `invoke_result.close()`, which cancels the upstream stream through plugin_daemon and the inference server.

2. **`cot_agent_runner.CotAgentRunner.run`** — agent-chat has an inner `for chunk in react_chunks:` loop that consumes upstream chunks before yielding to the outer chat stream loop. Without an `is_stopped()` check here, agent-chat apps still ignore Stop until the parser yields a parsed chunk (which can be many raw upstream chunks later). The same check raises `GenerateTaskStoppedError`, which propagates up to the existing `except` handler that closes `invoke_result`.

Both fixes use the existing `GenerateTaskStoppedError` control flow and the existing `invoke_result.close()` cleanup path. No new exception handling needed.

## Why two locations

The chat-mode `base_app_runner` patch alone was insufficient for agent-chat apps. The agent runner has its own generator that consumes upstream chunks internally before yielding to the outer consumer. The outer `is_stopped()` check only fires between agent yields, so without the inner check agent-chat continues generating until the parser happens to yield. With both checks, both paths cancel within milliseconds of the user clicking Stop.

## Test plan

End-to-end tested against an MTPLX-backed chat app and agent-chat app:

**chat app (e.g. "Write a 500-word essay about cats")**
- pre-stop: 102 chunks in 2.0s
- STOP sent at t=2.96s
- stream ended at t=4.02s, delta after stop = 1.06s
- `message_end` received — clean termination

**agent-chat app (no tools configured)**
- pre-stop: 3 events, 1 content chunk
- STOP sent
- stream ended in 0.02s — clean termination

Without these patches the agent-chat app kept generating until the LLM finished the full response (~30-90s for a 500-word prompt on MTPLX), wasting GPU time and quota.

## Related issues

Same underlying bug reported across multiple Dify versions and modes:

- #36164 "Stop Response button does not immediately terminate LLM calls and keeps consuming tokens" (open, Dify 1.13.3) — exact wording of this PR's symptom
- #40966 "Stop generating not work" (open, Dify 1.15.0) — chatflow variant
- #6493 "LLM node cannot stopped with ollama" (open since 0.6.14) — workflow variant, hangs for hours
- #13035 "stop response api ineffective for chat assistant" (closed as not planned, Dify 0.15.2)
- #35549 "chatflows remain in running state in log system" (closed via #37129, partial log-only fix)

## Notes

- Uses the existing `GenerateTaskStoppedError` exception, no new exceptions.
- Uses the existing `invoke_result.close()` cleanup in the except handler, no new teardown.
- Compatible with both blocking and streaming response modes.
- Plugin SDK reasoning-fragmentation fix is a separate package and PR (#382).
