### PR TITLE
fix(agent): persist tool model selector and pinned LLM parameters

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -1135,6 +1135,14 @@ class ToolManager:
                             continue
                     value = parameter.init_frontend_parameter(parameter_value)
                     runtime_parameters[parameter.name] = value
+            elif parameter.form == ToolParameter.ToolParameterForm.LLM and not variable_pool:
+                # Agent Soul can pin LLM-form parameters (for example Text to SQL
+                # ``tables``) as constants. Forward those values so the plugin
+                # does not require the model to fill them again.
+                parameter_value = tool_configurations.get(parameter.name)
+                if parameter_value in (None, ""):
+                    continue
+                runtime_parameters[parameter.name] = parameter.init_frontend_parameter(parameter_value)
         return runtime_parameters
 
     @classmethod

--- a/api/core/workflow/nodes/agent_v2/dify_tools_builder.py
+++ b/api/core/workflow/nodes/agent_v2/dify_tools_builder.py
@@ -406,7 +406,9 @@ class WorkflowAgentDifyToolsBuilder:
             credentials=self._normalize_credentials(runtime.credentials, tool_name=exposed_name),
             runtime_parameters=runtime_parameters,
             parameters=parameters,
-            parameters_json_schema=self._plugin_parameters_json_schema(tool_runtime, parameters),
+            parameters_json_schema=self._plugin_parameters_json_schema(
+                tool_runtime, parameters, runtime_parameters
+            ),
         )
 
     def _to_core_backend_tool_config(
@@ -416,6 +418,7 @@ class WorkflowAgentDifyToolsBuilder:
         exposed_name: str,
     ) -> DifyCoreToolConfig:
         parameters = self._prepared_parameters(tool_runtime)
+        runtime_parameters = self._runtime_parameters(tool_runtime, parameters)
         return DifyCoreToolConfig(
             provider_type=_CORE_TOOL_PROVIDER_TYPES[tool_config.provider_type],
             provider_id=self._provider_id(tool_config),
@@ -423,9 +426,12 @@ class WorkflowAgentDifyToolsBuilder:
             credential_id=tool_config.credential_ref.id if tool_config.credential_ref else None,
             name=exposed_name,
             description=self._description(tool_config, tool_runtime),
-            runtime_parameters=self._runtime_parameters(tool_runtime, parameters),
+            runtime_parameters=runtime_parameters,
             parameters=parameters,
-            parameters_json_schema=tool_runtime.get_llm_parameters_json_schema(),
+            parameters_json_schema=self._omit_pinned_llm_parameters(
+                tool_runtime.get_llm_parameters_json_schema(),
+                runtime_parameters,
+            ),
         )
 
     @staticmethod
@@ -452,9 +458,25 @@ class WorkflowAgentDifyToolsBuilder:
         return description
 
     @staticmethod
+    def _omit_pinned_llm_parameters(
+        schema: dict[str, Any],
+        runtime_parameters: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        properties = schema.get("properties")
+        required = schema.get("required")
+        if not isinstance(properties, dict):
+            return schema
+        for name in runtime_parameters:
+            properties.pop(name, None)
+            if isinstance(required, list) and name in required:
+                required.remove(name)
+        return schema
+
+    @staticmethod
     def _plugin_parameters_json_schema(
         tool_runtime: Tool,
         parameters: list[DifyPluginToolParameter],
+        runtime_parameters: Mapping[str, Any],
     ) -> dict[str, Any]:
         schema = tool_runtime.get_llm_parameters_json_schema()
         properties = schema.setdefault("properties", {})
@@ -467,6 +489,8 @@ class WorkflowAgentDifyToolsBuilder:
 
         for parameter in parameters:
             if parameter.form is not DifyPluginToolParameterForm.LLM:
+                continue
+            if parameter.name in runtime_parameters:
                 continue
             if parameter.type is DifyPluginToolParameterType.FILE:
                 properties[parameter.name] = _plugin_file_input_schema(parameter.llm_description or "")
@@ -484,7 +508,7 @@ class WorkflowAgentDifyToolsBuilder:
 
             if parameter.required and parameter.name not in required:
                 required.append(parameter.name)
-        return schema
+        return WorkflowAgentDifyToolsBuilder._omit_pinned_llm_parameters(schema, runtime_parameters)
 
     @staticmethod
     def _runtime_parameters(

--- a/api/core/workflow/nodes/agent_v2/dify_tools_builder.py
+++ b/api/core/workflow/nodes/agent_v2/dify_tools_builder.py
@@ -406,9 +406,7 @@ class WorkflowAgentDifyToolsBuilder:
             credentials=self._normalize_credentials(runtime.credentials, tool_name=exposed_name),
             runtime_parameters=runtime_parameters,
             parameters=parameters,
-            parameters_json_schema=self._plugin_parameters_json_schema(
-                tool_runtime, parameters, runtime_parameters
-            ),
+            parameters_json_schema=self._plugin_parameters_json_schema(tool_runtime, parameters, runtime_parameters),
         )
 
     def _to_core_backend_tool_config(

--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -8,6 +8,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    JsonValue,
     WithJsonSchema,
     field_validator,
     model_validator,
@@ -133,7 +134,9 @@ _OUTPUT_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9
 _CONFIG_SKILL_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 JsonPrimitive = str | int | float | bool | None
-RuntimeParameterValue = JsonPrimitive | list[str] | list[int] | list[float] | list[bool]
+# JSON values, including model-selector / app-selector objects. Those selectors
+# are dictionaries at the plugin boundary (provider + model + model_type).
+RuntimeParameterValue = JsonValue
 
 
 class AgentFlexibleConfig(BaseModel):

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -14110,13 +14110,13 @@ Stable Agent Soul reference to one normalized skill archive.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| default | string<br>integer<br>number<br>boolean<br>[ string ]<br>[ integer ]<br>[ number ]<br>[ boolean ] |  | No |
+| default | [JsonValue](#jsonvalue) |  | No |
 | env_name | string |  | No |
 | key | string |  | No |
 | name | string |  | No |
 | required | boolean |  | No |
 | type | string |  | No |
-| value | string<br>integer<br>number<br>boolean<br>[ string ]<br>[ integer ]<br>[ number ]<br>[ boolean ] |  | No |
+| value | [JsonValue](#jsonvalue) |  | No |
 | variable | string |  | No |
 
 #### AgentFeatureToggleConfig

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_dify_tools_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_dify_tools_builder.py
@@ -670,6 +670,57 @@ def test_rejects_missing_required_runtime_parameter():
     assert exc_info.value.error_code == "agent_tool_runtime_parameter_missing"
 
 
+def test_forwards_model_selector_and_pinned_llm_runtime_parameters():
+    tool = _tool(runtime_parameters={})
+    tool.entity.parameters = [
+        *tool.entity.parameters,
+        ToolParameter(
+            name="model",
+            label=I18nObject(en_US="Model"),
+            type=ToolParameter.ToolParameterType.MODEL_SELECTOR,
+            form=ToolParameter.ToolParameterForm.FORM,
+            required=True,
+        ),
+        ToolParameter(
+            name="tables",
+            label=I18nObject(en_US="Tables"),
+            type=ToolParameter.ToolParameterType.STRING,
+            form=ToolParameter.ToolParameterForm.LLM,
+            required=False,
+            llm_description="Optional table filter",
+        ),
+    ]
+    builder = WorkflowAgentDifyToolsBuilder(tool_runtime_provider=FakeRuntimeProvider(tool))
+    model = {"provider": "openai", "model": "gpt-4.1", "model_type": "llm"}
+    tools = AgentSoulToolsConfig.model_validate(
+        {
+            "dify_tools": [
+                {
+                    "provider_id": "langgenius/search/search",
+                    "provider_type": "plugin",
+                    "tool_name": "search",
+                    "credential_type": "api-key",
+                    "credential_id": "credential-1",
+                    "runtime_parameters": {
+                        "region": "us",
+                        "tables": "orders",
+                        "model": model,
+                    },
+                }
+            ]
+        }
+    )
+
+    result = _build(builder, tools)
+
+    assert result is not None
+    prepared = result.tools[0]
+    assert prepared.runtime_parameters["model"] == model
+    assert prepared.runtime_parameters["tables"] == "orders"
+    assert "tables" not in prepared.parameters_json_schema.get("properties", {})
+    assert "query" in prepared.parameters_json_schema.get("properties", {})
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # invoke_from is threaded through to ToolManager
 # ──────────────────────────────────────────────────────────────────────────────

--- a/api/tests/unit_tests/models/test_agent_config_entities.py
+++ b/api/tests/unit_tests/models/test_agent_config_entities.py
@@ -28,6 +28,35 @@ def test_agent_soul_model_settings_preserves_plugin_declared_parameters() -> Non
     assert dumped["thinking_budget"] == 4096
 
 
+def test_agent_soul_dify_tool_runtime_parameters_accept_model_selector() -> None:
+    from models.agent_config_entities import AgentSoulDifyToolConfig
+
+    config = AgentSoulDifyToolConfig.model_validate(
+        {
+            "provider_id": "hjlarry/database/database",
+            "provider_type": "plugin",
+            "tool_name": "text2sql",
+            "credential_type": "api-key",
+            "credential_ref": {"id": "credential-db", "type": "provider"},
+            "runtime_parameters": {
+                "tables": "orders",
+                "model": {
+                    "provider": "openai",
+                    "model": "gpt-4.1",
+                    "model_type": "llm",
+                },
+            },
+        }
+    )
+
+    assert config.runtime_parameters["tables"] == "orders"
+    assert config.runtime_parameters["model"] == {
+        "provider": "openai",
+        "model": "gpt-4.1",
+        "model_type": "llm",
+    }
+
+
 def test_file_default_value_accepts_canonical_reference_mapping() -> None:
     reference = build_file_reference(record_id="tool-file-1")
 

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -1347,31 +1347,13 @@ export type AgentSecretRefConfig = {
 }
 
 export type AgentEnvVariableConfig = {
-  default?:
-    | string
-    | number
-    | number
-    | boolean
-    | Array<string>
-    | Array<number>
-    | Array<number>
-    | Array<boolean>
-    | null
+  default?: JsonValue2
   env_name?: string | null
   key?: string | null
   name?: string | null
   required?: boolean
   type?: string | null
-  value?:
-    | string
-    | number
-    | number
-    | boolean
-    | Array<string>
-    | Array<number>
-    | Array<number>
-    | Array<boolean>
-    | null
+  value?: JsonValue2
   variable?: string | null
   [key: string]: unknown
 }
@@ -1437,16 +1419,7 @@ export type AgentSoulDifyToolConfig = {
   provider_id?: string | null
   provider_type: ToolProviderType
   runtime_parameters?: {
-    [key: string]:
-      | string
-      | number
-      | number
-      | boolean
-      | Array<string>
-      | Array<number>
-      | Array<number>
-      | Array<boolean>
-      | null
+    [key: string]: JsonValue2
   }
   tool_name?: string | null
 }

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -1386,42 +1386,6 @@ export const zAgentConfigRevisionResponse = z.object({
 })
 
 /**
- * AgentEnvVariableConfig
- */
-export const zAgentEnvVariableConfig = z.object({
-  default: z
-    .union([
-      z.string(),
-      z.int(),
-      z.number(),
-      z.boolean(),
-      z.array(z.string()),
-      z.array(z.int()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-    ])
-    .nullish(),
-  env_name: z.string().max(255).nullish(),
-  key: z.string().max(255).nullish(),
-  name: z.string().max(255).nullish(),
-  required: z.boolean().optional().default(false),
-  type: z.string().max(64).nullish(),
-  value: z
-    .union([
-      z.string(),
-      z.int(),
-      z.number(),
-      z.boolean(),
-      z.array(z.string()),
-      z.array(z.int()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-    ])
-    .nullish(),
-  variable: z.string().max(255).nullish(),
-})
-
-/**
  * AgentHumanToolConfig
  */
 export const zAgentHumanToolConfig = z.object({
@@ -1466,24 +1430,6 @@ export const zAgentSoulModelCredentialRef = z.object({
   id: z.string().max(255).nullish(),
   provider: z.string().max(255).nullish(),
   type: z.string().min(1).max(64),
-})
-
-/**
- * AgentSandboxProviderConfig
- */
-export const zAgentSandboxProviderConfig = z.object({
-  cpu: z.int().gte(1).nullish(),
-  env: z.array(zAgentEnvVariableConfig).optional(),
-  image: z.string().nullish(),
-  working_dir: z.string().nullish(),
-})
-
-/**
- * AgentSoulSandboxConfig
- */
-export const zAgentSoulSandboxConfig = z.object({
-  config: zAgentSandboxProviderConfig.optional(),
-  provider: z.string().nullish(),
 })
 
 /**
@@ -1602,58 +1548,11 @@ export const zAgentSecretRefConfig = z.object({
 })
 
 /**
- * AgentSoulEnvConfig
- */
-export const zAgentSoulEnvConfig = z.object({
-  secret_refs: z.array(zAgentSecretRefConfig).optional(),
-  variables: z.array(zAgentEnvVariableConfig).optional(),
-})
-
-/**
- * AgentCliToolEnvConfig
- */
-export const zAgentCliToolEnvConfig = z.object({
-  secret_refs: z.array(zAgentSecretRefConfig).optional(),
-  variables: z.array(zAgentEnvVariableConfig).optional(),
-})
-
-/**
  * AgentCliToolRiskLevel
  *
  * Risk marker for CLI tool bootstrap commands.
  */
 export const zAgentCliToolRiskLevel = z.enum(['dangerous', 'safe', 'unknown'])
-
-/**
- * AgentCliToolConfig
- */
-export const zAgentCliToolConfig = z.object({
-  approved: z.boolean().optional().default(false),
-  authorization_status: zAgentCliToolAuthorizationStatus.nullish(),
-  command: z.string().nullish(),
-  dangerous: z.boolean().optional().default(false),
-  dangerous_accepted: z.boolean().optional().default(false),
-  dangerous_acknowledged: z.boolean().optional().default(false),
-  dangerous_command: z.boolean().optional().default(false),
-  description: z.string().nullish(),
-  enabled: z.boolean().optional().default(true),
-  env: zAgentCliToolEnvConfig.optional(),
-  id: z.string().max(255).nullish(),
-  inferred_from: z.string().max(255).nullish(),
-  install: z.string().nullish(),
-  install_command: z.string().nullish(),
-  install_commands: z.array(z.string()).optional(),
-  invoke_metadata: z.record(z.string(), z.unknown()).optional(),
-  label: z.string().max(255).nullish(),
-  name: z.string().max(255).nullish(),
-  permission: zAgentPermissionConfig.nullish(),
-  pre_authorized: z.boolean().nullish(),
-  requires_confirmation: z.boolean().optional().default(false),
-  risk_accepted: z.boolean().optional().default(false),
-  risk_level: zAgentCliToolRiskLevel.nullish(),
-  setup_command: z.string().nullish(),
-  tool_name: z.string().max(255).nullish(),
-})
 
 /**
  * AgentComposerKnowledgeDatasetCandidateResponse
@@ -1674,27 +1573,6 @@ export const zAgentComposerKnowledgeSetCandidateResponse = z.object({
   id: z.string(),
   missing_dataset_ids: z.array(z.string()).optional(),
   name: z.string(),
-})
-
-/**
- * AgentComposerSoulCandidatesResponse
- */
-export const zAgentComposerSoulCandidatesResponse = z.object({
-  cli_tools: z.array(zAgentCliToolConfig).optional(),
-  dify_tools: z.array(zAgentComposerDifyToolCandidateResponse).optional(),
-  human_contacts: z.array(zAgentHumanContactConfig).optional(),
-  knowledge_sets: z.array(zAgentComposerKnowledgeSetCandidateResponse).optional(),
-})
-
-/**
- * AgentComposerCandidatesResponse
- */
-export const zAgentComposerCandidatesResponse = z.object({
-  allowed_node_job_candidates: zAgentComposerNodeJobCandidatesResponse.optional(),
-  allowed_soul_candidates: zAgentComposerSoulCandidatesResponse.optional(),
-  capabilities: zComposerCandidateCapabilities.optional(),
-  truncated: z.boolean().optional().default(false),
-  variant: zComposerVariant,
 })
 
 /**
@@ -1754,6 +1632,106 @@ export const zHumanInputFormSubmissionData = z.object({
   node_title: z.string(),
   rendered_content: z.string(),
   submitted_data: z.record(z.string(), zJsonValue2).nullish(),
+})
+
+/**
+ * AgentEnvVariableConfig
+ */
+export const zAgentEnvVariableConfig = z.object({
+  default: zJsonValue2.optional(),
+  env_name: z.string().max(255).nullish(),
+  key: z.string().max(255).nullish(),
+  name: z.string().max(255).nullish(),
+  required: z.boolean().optional().default(false),
+  type: z.string().max(64).nullish(),
+  value: zJsonValue2.optional(),
+  variable: z.string().max(255).nullish(),
+})
+
+/**
+ * AgentSoulEnvConfig
+ */
+export const zAgentSoulEnvConfig = z.object({
+  secret_refs: z.array(zAgentSecretRefConfig).optional(),
+  variables: z.array(zAgentEnvVariableConfig).optional(),
+})
+
+/**
+ * AgentSandboxProviderConfig
+ */
+export const zAgentSandboxProviderConfig = z.object({
+  cpu: z.int().gte(1).nullish(),
+  env: z.array(zAgentEnvVariableConfig).optional(),
+  image: z.string().nullish(),
+  working_dir: z.string().nullish(),
+})
+
+/**
+ * AgentSoulSandboxConfig
+ */
+export const zAgentSoulSandboxConfig = z.object({
+  config: zAgentSandboxProviderConfig.optional(),
+  provider: z.string().nullish(),
+})
+
+/**
+ * AgentCliToolEnvConfig
+ */
+export const zAgentCliToolEnvConfig = z.object({
+  secret_refs: z.array(zAgentSecretRefConfig).optional(),
+  variables: z.array(zAgentEnvVariableConfig).optional(),
+})
+
+/**
+ * AgentCliToolConfig
+ */
+export const zAgentCliToolConfig = z.object({
+  approved: z.boolean().optional().default(false),
+  authorization_status: zAgentCliToolAuthorizationStatus.nullish(),
+  command: z.string().nullish(),
+  dangerous: z.boolean().optional().default(false),
+  dangerous_accepted: z.boolean().optional().default(false),
+  dangerous_acknowledged: z.boolean().optional().default(false),
+  dangerous_command: z.boolean().optional().default(false),
+  description: z.string().nullish(),
+  enabled: z.boolean().optional().default(true),
+  env: zAgentCliToolEnvConfig.optional(),
+  id: z.string().max(255).nullish(),
+  inferred_from: z.string().max(255).nullish(),
+  install: z.string().nullish(),
+  install_command: z.string().nullish(),
+  install_commands: z.array(z.string()).optional(),
+  invoke_metadata: z.record(z.string(), z.unknown()).optional(),
+  label: z.string().max(255).nullish(),
+  name: z.string().max(255).nullish(),
+  permission: zAgentPermissionConfig.nullish(),
+  pre_authorized: z.boolean().nullish(),
+  requires_confirmation: z.boolean().optional().default(false),
+  risk_accepted: z.boolean().optional().default(false),
+  risk_level: zAgentCliToolRiskLevel.nullish(),
+  setup_command: z.string().nullish(),
+  tool_name: z.string().max(255).nullish(),
+})
+
+/**
+ * AgentComposerSoulCandidatesResponse
+ */
+export const zAgentComposerSoulCandidatesResponse = z.object({
+  cli_tools: z.array(zAgentCliToolConfig).optional(),
+  dify_tools: z.array(zAgentComposerDifyToolCandidateResponse).optional(),
+  human_contacts: z.array(zAgentHumanContactConfig).optional(),
+  knowledge_sets: z.array(zAgentComposerKnowledgeSetCandidateResponse).optional(),
+})
+
+/**
+ * AgentComposerCandidatesResponse
+ */
+export const zAgentComposerCandidatesResponse = z.object({
+  allowed_node_job_candidates: zAgentComposerNodeJobCandidatesResponse.optional(),
+  allowed_soul_candidates: zAgentComposerSoulCandidatesResponse.optional(),
+  capabilities: zComposerCandidateCapabilities.optional(),
+  truncated: z.boolean().optional().default(false),
+  variant: zComposerVariant,
 })
 
 /**
@@ -1920,23 +1898,7 @@ export const zAgentSoulDifyToolConfig = z.object({
   provider: z.string().max(255).nullish(),
   provider_id: z.string().max(255).nullish(),
   provider_type: zToolProviderType,
-  runtime_parameters: z
-    .record(
-      z.string(),
-      z
-        .union([
-          z.string(),
-          z.int(),
-          z.number(),
-          z.boolean(),
-          z.array(z.string()),
-          z.array(z.int()),
-          z.array(z.number()),
-          z.array(z.boolean()),
-        ])
-        .nullable(),
-    )
-    .optional(),
+  runtime_parameters: z.record(z.string(), zJsonValue2).optional(),
   tool_name: z.string().min(1).max(255).nullish(),
 })
 

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -2571,31 +2571,13 @@ export type AgentSecretRefConfig = {
 }
 
 export type AgentEnvVariableConfig = {
-  default?:
-    | string
-    | number
-    | number
-    | boolean
-    | Array<string>
-    | Array<number>
-    | Array<number>
-    | Array<boolean>
-    | null
+  default?: JsonValue2
   env_name?: string | null
   key?: string | null
   name?: string | null
   required?: boolean
   type?: string | null
-  value?:
-    | string
-    | number
-    | number
-    | boolean
-    | Array<string>
-    | Array<number>
-    | Array<number>
-    | Array<boolean>
-    | null
+  value?: JsonValue2
   variable?: string | null
   [key: string]: unknown
 }
@@ -2661,16 +2643,7 @@ export type AgentSoulDifyToolConfig = {
   provider_id?: string | null
   provider_type: ToolProviderType
   runtime_parameters?: {
-    [key: string]:
-      | string
-      | number
-      | number
-      | boolean
-      | Array<string>
-      | Array<number>
-      | Array<number>
-      | Array<boolean>
-      | null
+    [key: string]: JsonValue2
   }
   tool_name?: string | null
 }

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -2962,35 +2962,13 @@ export const zAgentTextToSpeechFeatureConfig = z.object({
  * AgentEnvVariableConfig
  */
 export const zAgentEnvVariableConfig = z.object({
-  default: z
-    .union([
-      z.string(),
-      z.int(),
-      z.number(),
-      z.boolean(),
-      z.array(z.string()),
-      z.array(z.int()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-    ])
-    .nullish(),
+  default: zJsonValue2.optional(),
   env_name: z.string().max(255).nullish(),
   key: z.string().max(255).nullish(),
   name: z.string().max(255).nullish(),
   required: z.boolean().optional().default(false),
   type: z.string().max(64).nullish(),
-  value: z
-    .union([
-      z.string(),
-      z.int(),
-      z.number(),
-      z.boolean(),
-      z.array(z.string()),
-      z.array(z.int()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-    ])
-    .nullish(),
+  value: zJsonValue2.optional(),
   variable: z.string().max(255).nullish(),
 })
 
@@ -3531,23 +3509,7 @@ export const zAgentSoulDifyToolConfig = z.object({
   provider: z.string().max(255).nullish(),
   provider_id: z.string().max(255).nullish(),
   provider_type: zToolProviderType,
-  runtime_parameters: z
-    .record(
-      z.string(),
-      z
-        .union([
-          z.string(),
-          z.int(),
-          z.number(),
-          z.boolean(),
-          z.array(z.string()),
-          z.array(z.int()),
-          z.array(z.number()),
-          z.array(z.boolean()),
-        ])
-        .nullable(),
-    )
-    .optional(),
+  runtime_parameters: z.record(z.string(), zJsonValue2).optional(),
   tool_name: z.string().min(1).max(255).nullish(),
 })
 

--- a/packages/contracts/generated/api/console/snippets/types.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/types.gen.ts
@@ -822,31 +822,13 @@ export type AgentSecretRefConfig = {
 }
 
 export type AgentEnvVariableConfig = {
-  default?:
-    | string
-    | number
-    | number
-    | boolean
-    | Array<string>
-    | Array<number>
-    | Array<number>
-    | Array<boolean>
-    | null
+  default?: JsonValue2
   env_name?: string | null
   key?: string | null
   name?: string | null
   required?: boolean
   type?: string | null
-  value?:
-    | string
-    | number
-    | number
-    | boolean
-    | Array<string>
-    | Array<number>
-    | Array<number>
-    | Array<boolean>
-    | null
+  value?: JsonValue2
   variable?: string | null
   [key: string]: unknown
 }
@@ -912,16 +894,7 @@ export type AgentSoulDifyToolConfig = {
   provider_id?: string | null
   provider_type: ToolProviderType
   runtime_parameters?: {
-    [key: string]:
-      | string
-      | number
-      | number
-      | boolean
-      | Array<string>
-      | Array<number>
-      | Array<number>
-      | Array<boolean>
-      | null
+    [key: string]: JsonValue2
   }
   tool_name?: string | null
 }
@@ -1004,6 +977,8 @@ export type AgentSuggestedQuestionsAfterAnswerModelConfig = {
   provider: string
   [key: string]: unknown
 }
+
+export type JsonValue2 = unknown
 
 export type AgentKnowledgeDatasetConfig = {
   description?: string | null

--- a/packages/contracts/generated/api/console/snippets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/zod.gen.ts
@@ -754,42 +754,6 @@ export const zAgentTextToSpeechFeatureConfig = z.object({
 })
 
 /**
- * AgentEnvVariableConfig
- */
-export const zAgentEnvVariableConfig = z.object({
-  default: z
-    .union([
-      z.string(),
-      z.int(),
-      z.number(),
-      z.boolean(),
-      z.array(z.string()),
-      z.array(z.int()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-    ])
-    .nullish(),
-  env_name: z.string().max(255).nullish(),
-  key: z.string().max(255).nullish(),
-  name: z.string().max(255).nullish(),
-  required: z.boolean().optional().default(false),
-  type: z.string().max(64).nullish(),
-  value: z
-    .union([
-      z.string(),
-      z.int(),
-      z.number(),
-      z.boolean(),
-      z.array(z.string()),
-      z.array(z.int()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-    ])
-    .nullish(),
-  variable: z.string().max(255).nullish(),
-})
-
-/**
  * AgentHumanToolConfig
  */
 export const zAgentHumanToolConfig = z.object({
@@ -834,24 +798,6 @@ export const zAgentSoulModelCredentialRef = z.object({
   id: z.string().max(255).nullish(),
   provider: z.string().max(255).nullish(),
   type: z.string().min(1).max(64),
-})
-
-/**
- * AgentSandboxProviderConfig
- */
-export const zAgentSandboxProviderConfig = z.object({
-  cpu: z.int().gte(1).nullish(),
-  env: z.array(zAgentEnvVariableConfig).optional(),
-  image: z.string().nullish(),
-  working_dir: z.string().nullish(),
-})
-
-/**
- * AgentSoulSandboxConfig
- */
-export const zAgentSoulSandboxConfig = z.object({
-  config: zAgentSandboxProviderConfig.optional(),
-  provider: z.string().nullish(),
 })
 
 /**
@@ -963,58 +909,11 @@ export const zAgentSecretRefConfig = z.object({
 })
 
 /**
- * AgentSoulEnvConfig
- */
-export const zAgentSoulEnvConfig = z.object({
-  secret_refs: z.array(zAgentSecretRefConfig).optional(),
-  variables: z.array(zAgentEnvVariableConfig).optional(),
-})
-
-/**
- * AgentCliToolEnvConfig
- */
-export const zAgentCliToolEnvConfig = z.object({
-  secret_refs: z.array(zAgentSecretRefConfig).optional(),
-  variables: z.array(zAgentEnvVariableConfig).optional(),
-})
-
-/**
  * AgentCliToolRiskLevel
  *
  * Risk marker for CLI tool bootstrap commands.
  */
 export const zAgentCliToolRiskLevel = z.enum(['dangerous', 'safe', 'unknown'])
-
-/**
- * AgentCliToolConfig
- */
-export const zAgentCliToolConfig = z.object({
-  approved: z.boolean().optional().default(false),
-  authorization_status: zAgentCliToolAuthorizationStatus.nullish(),
-  command: z.string().nullish(),
-  dangerous: z.boolean().optional().default(false),
-  dangerous_accepted: z.boolean().optional().default(false),
-  dangerous_acknowledged: z.boolean().optional().default(false),
-  dangerous_command: z.boolean().optional().default(false),
-  description: z.string().nullish(),
-  enabled: z.boolean().optional().default(true),
-  env: zAgentCliToolEnvConfig.optional(),
-  id: z.string().max(255).nullish(),
-  inferred_from: z.string().max(255).nullish(),
-  install: z.string().nullish(),
-  install_command: z.string().nullish(),
-  install_commands: z.array(z.string()).optional(),
-  invoke_metadata: z.record(z.string(), z.unknown()).optional(),
-  label: z.string().max(255).nullish(),
-  name: z.string().max(255).nullish(),
-  permission: zAgentPermissionConfig.nullish(),
-  pre_authorized: z.boolean().nullish(),
-  requires_confirmation: z.boolean().optional().default(false),
-  risk_accepted: z.boolean().optional().default(false),
-  risk_level: zAgentCliToolRiskLevel.nullish(),
-  setup_command: z.string().nullish(),
-  tool_name: z.string().max(255).nullish(),
-})
 
 /**
  * AgentComposerKnowledgeDatasetCandidateResponse
@@ -1035,27 +934,6 @@ export const zAgentComposerKnowledgeSetCandidateResponse = z.object({
   id: z.string(),
   missing_dataset_ids: z.array(z.string()).optional(),
   name: z.string(),
-})
-
-/**
- * AgentComposerSoulCandidatesResponse
- */
-export const zAgentComposerSoulCandidatesResponse = z.object({
-  cli_tools: z.array(zAgentCliToolConfig).optional(),
-  dify_tools: z.array(zAgentComposerDifyToolCandidateResponse).optional(),
-  human_contacts: z.array(zAgentHumanContactConfig).optional(),
-  knowledge_sets: z.array(zAgentComposerKnowledgeSetCandidateResponse).optional(),
-})
-
-/**
- * AgentComposerCandidatesResponse
- */
-export const zAgentComposerCandidatesResponse = z.object({
-  allowed_node_job_candidates: zAgentComposerNodeJobCandidatesResponse.optional(),
-  allowed_soul_candidates: zAgentComposerSoulCandidatesResponse.optional(),
-  capabilities: zComposerCandidateCapabilities.optional(),
-  truncated: z.boolean().optional().default(false),
-  variant: zComposerVariant,
 })
 
 /**
@@ -1111,6 +989,108 @@ export const zAgentSuggestedQuestionsAfterAnswerFeatureConfig = z.object({
   enabled: z.boolean().optional().default(false),
   model: zAgentSuggestedQuestionsAfterAnswerModelConfig.nullish(),
   prompt: z.string().nullish(),
+})
+
+export const zJsonValue2 = z.unknown()
+
+/**
+ * AgentEnvVariableConfig
+ */
+export const zAgentEnvVariableConfig = z.object({
+  default: zJsonValue2.optional(),
+  env_name: z.string().max(255).nullish(),
+  key: z.string().max(255).nullish(),
+  name: z.string().max(255).nullish(),
+  required: z.boolean().optional().default(false),
+  type: z.string().max(64).nullish(),
+  value: zJsonValue2.optional(),
+  variable: z.string().max(255).nullish(),
+})
+
+/**
+ * AgentSoulEnvConfig
+ */
+export const zAgentSoulEnvConfig = z.object({
+  secret_refs: z.array(zAgentSecretRefConfig).optional(),
+  variables: z.array(zAgentEnvVariableConfig).optional(),
+})
+
+/**
+ * AgentSandboxProviderConfig
+ */
+export const zAgentSandboxProviderConfig = z.object({
+  cpu: z.int().gte(1).nullish(),
+  env: z.array(zAgentEnvVariableConfig).optional(),
+  image: z.string().nullish(),
+  working_dir: z.string().nullish(),
+})
+
+/**
+ * AgentSoulSandboxConfig
+ */
+export const zAgentSoulSandboxConfig = z.object({
+  config: zAgentSandboxProviderConfig.optional(),
+  provider: z.string().nullish(),
+})
+
+/**
+ * AgentCliToolEnvConfig
+ */
+export const zAgentCliToolEnvConfig = z.object({
+  secret_refs: z.array(zAgentSecretRefConfig).optional(),
+  variables: z.array(zAgentEnvVariableConfig).optional(),
+})
+
+/**
+ * AgentCliToolConfig
+ */
+export const zAgentCliToolConfig = z.object({
+  approved: z.boolean().optional().default(false),
+  authorization_status: zAgentCliToolAuthorizationStatus.nullish(),
+  command: z.string().nullish(),
+  dangerous: z.boolean().optional().default(false),
+  dangerous_accepted: z.boolean().optional().default(false),
+  dangerous_acknowledged: z.boolean().optional().default(false),
+  dangerous_command: z.boolean().optional().default(false),
+  description: z.string().nullish(),
+  enabled: z.boolean().optional().default(true),
+  env: zAgentCliToolEnvConfig.optional(),
+  id: z.string().max(255).nullish(),
+  inferred_from: z.string().max(255).nullish(),
+  install: z.string().nullish(),
+  install_command: z.string().nullish(),
+  install_commands: z.array(z.string()).optional(),
+  invoke_metadata: z.record(z.string(), z.unknown()).optional(),
+  label: z.string().max(255).nullish(),
+  name: z.string().max(255).nullish(),
+  permission: zAgentPermissionConfig.nullish(),
+  pre_authorized: z.boolean().nullish(),
+  requires_confirmation: z.boolean().optional().default(false),
+  risk_accepted: z.boolean().optional().default(false),
+  risk_level: zAgentCliToolRiskLevel.nullish(),
+  setup_command: z.string().nullish(),
+  tool_name: z.string().max(255).nullish(),
+})
+
+/**
+ * AgentComposerSoulCandidatesResponse
+ */
+export const zAgentComposerSoulCandidatesResponse = z.object({
+  cli_tools: z.array(zAgentCliToolConfig).optional(),
+  dify_tools: z.array(zAgentComposerDifyToolCandidateResponse).optional(),
+  human_contacts: z.array(zAgentHumanContactConfig).optional(),
+  knowledge_sets: z.array(zAgentComposerKnowledgeSetCandidateResponse).optional(),
+})
+
+/**
+ * AgentComposerCandidatesResponse
+ */
+export const zAgentComposerCandidatesResponse = z.object({
+  allowed_node_job_candidates: zAgentComposerNodeJobCandidatesResponse.optional(),
+  allowed_soul_candidates: zAgentComposerSoulCandidatesResponse.optional(),
+  capabilities: zComposerCandidateCapabilities.optional(),
+  truncated: z.boolean().optional().default(false),
+  variant: zComposerVariant,
 })
 
 /**
@@ -1282,23 +1262,7 @@ export const zAgentSoulDifyToolConfig = z.object({
   provider: z.string().max(255).nullish(),
   provider_id: z.string().max(255).nullish(),
   provider_type: zToolProviderType,
-  runtime_parameters: z
-    .record(
-      z.string(),
-      z
-        .union([
-          z.string(),
-          z.int(),
-          z.number(),
-          z.boolean(),
-          z.array(z.string()),
-          z.array(z.int()),
-          z.array(z.number()),
-          z.array(z.boolean()),
-        ])
-        .nullable(),
-    )
-    .optional(),
+  runtime_parameters: z.record(z.string(), zJsonValue2).optional(),
   tool_name: z.string().min(1).max(255).nullish(),
 })
 

--- a/web/app/components/app/configuration/config/agent/agent-tools/__tests__/setting-built-in-tool.spec.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/__tests__/setting-built-in-tool.spec.tsx
@@ -180,7 +180,8 @@ describe('SettingBuiltInTool', () => {
     })
 
     await userEvent.click(screen.getByText('tools.setBuiltInTools.parameters'))
-    expect(screen.getByText('Info Param')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-form')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'common.operation.save' })).toBeInTheDocument()
     await userEvent.click(screen.getByText('tools.setBuiltInTools.setting'))
     expect(screen.getByTestId('mock-form')).toBeInTheDocument()
   })
@@ -228,6 +229,18 @@ describe('SettingBuiltInTool', () => {
     await userEvent.click(screen.getByRole('button', { name: 'update-form' }))
     await userEvent.click(screen.getByRole('button', { name: 'common.operation.save' }))
     expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ settingParam: 'updated' }))
+  })
+
+  it('should save llm parameter overrides from the parameters tab', async () => {
+    const { onSave } = renderComponent({ setting: { settingParam: 'value' } })
+    await waitFor(() => expect(screen.getByTestId('mock-form')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('tools.setBuiltInTools.parameters'))
+    nextFormValue = { infoParam: 'orders' }
+    await userEvent.click(screen.getByRole('button', { name: 'update-form' }))
+    await userEvent.click(screen.getByRole('button', { name: 'common.operation.save' }))
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ settingParam: 'value', infoParam: 'orders' }),
+    )
   })
 
   it('should keep save disabled until required field provided', async () => {

--- a/web/app/components/app/configuration/config/agent/agent-tools/setting-built-in-tool.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/setting-built-in-tool.tsx
@@ -150,7 +150,19 @@ const SettingBuiltInTool: FC<Props> = ({
       )}
     </div>
   )
-  const infoUI = renderSchemaDetails(infoSchemas)
+  const infoUI = readonly ? (
+    renderSchemaDetails(infoSchemas)
+  ) : (
+    <Form
+      value={tempSetting}
+      onChange={setTempSetting}
+      formSchemas={infoSchemas}
+      isEditMode={false}
+      showOnVariableMap={{}}
+      validating={false}
+      readonly={readonly}
+    />
+  )
   const settingDetailsUI = renderSchemaDetails(settingSchemas)
 
   const settingUI = (
@@ -268,7 +280,7 @@ const SettingBuiltInTool: FC<Props> = ({
                         {isInfoActive && infoUI}
                         {!isInfoActive && showSettingAsDetails && settingDetailsUI}
                         {!isInfoActive && !showSettingAsDetails && settingUI}
-                        {!readonly && !isInfoActive && (
+                        {!readonly && (hasSetting || infoSchemas.length > 0) && (
                           <div className="flex shrink-0 justify-end space-x-2 rounded-b-[10px] bg-components-panel-bg py-2">
                             <Button
                               className="flex h-8 items-center px-3! text-[13px]! font-medium"

--- a/web/features/agent-v2/agent-composer/__tests__/store.spec.ts
+++ b/web/features/agent-v2/agent-composer/__tests__/store.spec.ts
@@ -481,6 +481,60 @@ describe('agent composer store conversions', () => {
     ])
   })
 
+  it('should persist model-selector tool settings as runtime parameters', () => {
+    const publishConfig = formStateToAgentSoulConfig({
+      formState: {
+        ...defaultAgentSoulConfigFormState,
+        tools: [
+          {
+            id: 'hjlarry/database/database',
+            kind: 'provider',
+            name: 'database',
+            iconClassName: 'i-custom-public-other-default-tool-icon text-text-tertiary',
+            providerType: 'plugin',
+            credentialVariant: 'authorized',
+            credentialId: 'credential-db',
+            credentialType: 'api-key',
+            actions: [
+              {
+                id: 'hjlarry/database/database:text2sql',
+                name: 'Text to SQL',
+                toolName: 'text2sql',
+                description: 'Generate SQL.',
+              },
+            ],
+          },
+        ],
+        toolSettings: {
+          'hjlarry/database/database:text2sql': {
+            tables: 'orders',
+            model: {
+              provider: 'openai',
+              model: 'gpt-4.1',
+              model_type: 'llm',
+              type: 'model-selector',
+            },
+          },
+        },
+      },
+    })
+
+    expect(publishConfig.tools?.dify_tools).toEqual([
+      expect.objectContaining({
+        provider_id: 'hjlarry/database/database',
+        tool_name: 'text2sql',
+        runtime_parameters: {
+          tables: 'orders',
+          model: {
+            provider: 'openai',
+            model: 'gpt-4.1',
+            model_type: 'llm',
+          },
+        },
+      }),
+    ])
+  })
+
   it('should preserve oauth2 credential references when saving tool config', () => {
     const baseConfig = {
       tools: {

--- a/web/features/agent-v2/agent-composer/conversions.ts
+++ b/web/features/agent-v2/agent-composer/conversions.ts
@@ -167,9 +167,9 @@ const toKnowledgeConfig = (
   sets: toKnowledgeSets(knowledgeRetrievals),
 })
 
-const isToolRuntimeParameterValue = (
-  value: unknown,
-): value is AgentSoulToolRuntimeParameterValue => {
+const SELECTOR_UI_TYPES = new Set(['model-selector', 'app-selector'])
+
+const isJsonRuntimeParameterValue = (value: unknown): boolean => {
   if (
     value === null ||
     typeof value === 'string' ||
@@ -178,20 +178,39 @@ const isToolRuntimeParameterValue = (
   )
     return true
 
-  if (!Array.isArray(value)) return false
+  if (Array.isArray(value)) return value.every(isJsonRuntimeParameterValue)
 
-  return (
-    value.every((item) => typeof item === 'string') ||
-    value.every((item) => typeof item === 'number') ||
-    value.every((item) => typeof item === 'boolean')
-  )
+  if (typeof value !== 'object') return false
+
+  return Object.values(value as Record<string, unknown>).every(isJsonRuntimeParameterValue)
+}
+
+const normalizeRuntimeParameterValue = (value: unknown): unknown => {
+  if (value === undefined || value === '') return undefined
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return value
+
+  const record = { ...(value as Record<string, unknown>) }
+  if (typeof record.type === 'string' && SELECTOR_UI_TYPES.has(record.type)) delete record.type
+
+  return Object.keys(record).length === 0 ? undefined : record
+}
+
+const isToolRuntimeParameterValue = (
+  value: unknown,
+): value is AgentSoulToolRuntimeParameterValue => {
+  if (value === undefined) return false
+
+  return isJsonRuntimeParameterValue(value)
 }
 
 const toToolRuntimeParameters = (settings: Record<string, unknown> | undefined) => {
   const runtimeParameters: Record<string, AgentSoulToolRuntimeParameterValue> = {}
 
   Object.entries(settings ?? {}).forEach(([key, value]) => {
-    if (isToolRuntimeParameterValue(value)) runtimeParameters[key] = value
+    const normalized = normalizeRuntimeParameterValue(value)
+    if (isToolRuntimeParameterValue(normalized))
+      runtimeParameters[key] = normalized as AgentSoulToolRuntimeParameterValue
   })
 
   return runtimeParameters


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41348.

Adding a plugin tool such as Text to SQL to an Agent failed in two ways:

1. **Parameters tab was read-only.** LLM-form fields like `tables` could not be set by hand.
2. **Model → Save → Apply did nothing.** The Settings form stores `model-selector` as an object (`provider` / `model` / `model_type`). Soul conversion only kept scalars, so the model was dropped. Preview then failed with `Dify Tool 'text2sql' is missing runtime parameters: model`.

This change:

- Accepts JSON objects (model/app selectors) in Agent Soul `runtime_parameters`.
- Keeps those objects when converting composer tool settings to Soul, and strips the UI-only `type: model-selector` key.
- Forwards pinned LLM-form values into the tool runtime and omits them from the model-visible parameter schema.
- Makes the Parameters tab an editable form and keeps Save available on both tabs.

## Screenshots

| Before | After |
| ------ | ----- |
| Parameters tab showed schema docs only; saving a model did not persist | Parameters can be filled and saved; model selector round-trips into `runtime_parameters` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran backend unit tests for the touched modules and frontend unit tests for the composer/tool dialog.