### PR TITLE
fix(api): resolve MCP provider by UUID or server identifier

### DIFF
--- a/api/services/tools/mcp_tools_manage_service.py
+++ b/api/services/tools/mcp_tools_manage_service.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 from urllib.parse import urlparse
+from uuid import UUID
 
 from pydantic import BaseModel, Field
 from sqlalchemy import or_, select
@@ -32,6 +33,14 @@ UNCHANGED_SERVER_URL_PLACEHOLDER = "[__HIDDEN__]"
 CLIENT_NAME = "Dify"
 EMPTY_TOOLS_JSON = "[]"
 EMPTY_CREDENTIALS_JSON = "{}"
+
+
+def _is_uuid_string(value: str) -> bool:
+    try:
+        UUID(value)
+    except ValueError:
+        return False
+    return True
 
 
 class OAuthDataType(StrEnum):
@@ -90,7 +99,7 @@ class MCPToolManageService:
         Get MCP provider by ID or server identifier.
 
         Args:
-            provider_id: Provider ID (UUID)
+            provider_id: Provider ID (UUID) or server identifier
             server_identifier: Server identifier
             tenant_id: Tenant ID
 
@@ -101,18 +110,45 @@ class MCPToolManageService:
             ValueError: If provider not found
         """
         if server_identifier:
-            stmt = select(MCPToolProvider).where(
-                MCPToolProvider.tenant_id == tenant_id, MCPToolProvider.server_identifier == server_identifier
+            provider = self._session.scalar(
+                select(MCPToolProvider).where(
+                    MCPToolProvider.tenant_id == tenant_id, MCPToolProvider.server_identifier == server_identifier
+                )
             )
         else:
-            stmt = select(MCPToolProvider).where(
-                MCPToolProvider.tenant_id == tenant_id, MCPToolProvider.id == provider_id
-            )
+            provider = self._get_provider_by_id_or_server_identifier(provider_id, tenant_id)
 
-        provider = self._session.scalar(stmt)
         if not provider:
             raise ValueError("MCP tool not found")
         return provider
+
+    def _get_provider_by_id_or_server_identifier(
+        self, identifier: str | None, tenant_id: str
+    ) -> MCPToolProvider | None:
+        """
+        Resolve a provider from an identifier that may be either form.
+
+        Detail responses expose ``server_identifier`` as the entity ``id``, so the frontend
+        round-trips that value back into endpoints that nominally take a provider UUID.
+        Passing it straight to the ``id`` column makes PostgreSQL fail the UUID cast, so
+        only query by ``id`` when the value actually parses as a UUID, and fall back to
+        ``server_identifier`` otherwise.
+        """
+        if not identifier:
+            return None
+
+        if _is_uuid_string(identifier):
+            provider = self._session.scalar(
+                select(MCPToolProvider).where(MCPToolProvider.tenant_id == tenant_id, MCPToolProvider.id == identifier)
+            )
+            if provider:
+                return provider
+
+        return self._session.scalar(
+            select(MCPToolProvider).where(
+                MCPToolProvider.tenant_id == tenant_id, MCPToolProvider.server_identifier == identifier
+            )
+        )
 
     def get_provider_entity(self, provider_id: str, tenant_id: str, by_server_id: bool = False) -> MCPProviderEntity:
         """Get provider entity by ID or server identifier."""
@@ -213,7 +249,7 @@ class MCPToolManageService:
             stmt = select(MCPToolProvider).where(
                 MCPToolProvider.tenant_id == tenant_id,
                 MCPToolProvider.name == name,
-                MCPToolProvider.id != provider_id,
+                MCPToolProvider.id != mcp_provider.id,
             )
             existing_provider = self._session.scalar(stmt)
             if existing_provider:

--- a/api/tests/test_containers_integration_tests/services/tools/test_mcp_tools_manage_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_mcp_tools_manage_service.py
@@ -223,6 +223,95 @@ class TestMCPToolManageService:
         with pytest.raises(ValueError, match="MCP tool not found"):
             service.get_provider(provider_id=mcp_provider1.id, tenant_id=tenant2.id)
 
+    def test_get_mcp_provider_by_provider_id_accepts_server_identifier(
+        self, db_session_with_containers: Session, mock_external_service_dependencies
+    ):
+        """
+        Test that a non-UUID server identifier passed as provider_id resolves instead of failing.
+
+        Detail responses expose ``server_identifier`` as the entity ``id``, so the frontend
+        round-trips that value back into endpoints that take a provider_id. Casting it to the
+        UUID ``id`` column used to raise "invalid input syntax for type uuid" (500).
+
+        This test verifies:
+        - A human-readable server identifier is accepted as provider_id
+        - The correct provider is returned
+        """
+        # Arrange: Create test data
+        account, tenant = self._create_test_account_and_tenant(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+        mcp_provider = self._create_test_mcp_provider(
+            db_session_with_containers, mock_external_service_dependencies, tenant.id, account.id
+        )
+        mcp_provider.server_identifier = "my-mcp-tools"
+        db_session_with_containers.commit()
+
+        # Act: Execute the method under test
+
+        service = MCPToolManageService(db_session_with_containers)
+        result = service.get_provider(provider_id="my-mcp-tools", tenant_id=tenant.id)
+
+        # Assert: Verify the expected outcomes
+        assert result is not None
+        assert result.id == mcp_provider.id
+        assert result.server_identifier == "my-mcp-tools"
+        assert result.tenant_id == tenant.id
+
+    def test_get_mcp_provider_by_provider_id_non_uuid_not_found(
+        self, db_session_with_containers: Session, mock_external_service_dependencies
+    ):
+        """
+        Test that an unknown non-UUID provider_id raises ValueError rather than a database error.
+
+        This test verifies:
+        - Unknown human-readable identifiers surface as "MCP tool not found"
+        - No UUID cast error escapes to the caller
+        """
+        # Arrange: Create test data
+        account, tenant = self._create_test_account_and_tenant(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+        # Act & Assert: Verify proper error handling
+
+        service = MCPToolManageService(db_session_with_containers)
+        with pytest.raises(ValueError, match="MCP tool not found"):
+            service.get_provider(provider_id="no-such-mcp-tools", tenant_id=tenant.id)
+
+    def test_get_mcp_provider_by_provider_id_server_identifier_tenant_isolation(
+        self, db_session_with_containers: Session, mock_external_service_dependencies
+    ):
+        """
+        Test tenant isolation when a server identifier is passed as provider_id.
+
+        This test verifies:
+        - The server identifier fallback stays scoped to the requesting tenant
+        - Security boundaries are maintained
+        """
+        # Arrange: Create test data for two tenants
+        account1, tenant1 = self._create_test_account_and_tenant(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+        account2, tenant2 = self._create_test_account_and_tenant(
+            db_session_with_containers, mock_external_service_dependencies
+        )
+
+        # Create MCP provider in tenant1
+        mcp_provider1 = self._create_test_mcp_provider(
+            db_session_with_containers, mock_external_service_dependencies, tenant1.id, account1.id
+        )
+        mcp_provider1.server_identifier = "tenant1-mcp-tools"
+        db_session_with_containers.commit()
+
+        # Act & Assert: Verify tenant isolation
+
+        service = MCPToolManageService(db_session_with_containers)
+        with pytest.raises(ValueError, match="MCP tool not found"):
+            service.get_provider(provider_id="tenant1-mcp-tools", tenant_id=tenant2.id)
+
     def test_get_mcp_provider_by_server_identifier_success(
         self, db_session_with_containers: Session, mock_external_service_dependencies
     ):


### PR DESCRIPTION
## Summary

Fixes #41512

Opening an MCP tool provider's detail page returns HTTP 500 with `invalid input syntax for type uuid: "my-mcp-tools"`. The frontend sends a human-readable `server_identifier` on a route whose backend casts it to the UUID `id` column.

### Root Cause

`ToolTransformService.mcp_provider_to_user_provider` decides what to expose as the entity `id`:

```python
response["id"] = db_provider.server_identifier if not for_list else db_provider.id
```

`ToolMCPListAllApi` (`GET /workspaces/current/tools/mcp`) calls `list_providers()` without `for_list`, which defaults to `False`. Every provider in the list the UI renders therefore carries `id == server_identifier`. The frontend reuses that value as the path parameter for follow-up calls, and `get_provider()` passed it straight to `MCPToolProvider.id`. PostgreSQL rejects the cast and the request 500s.

Every endpoint reached with a round-tripped identifier hit this:

- `GET /tool-provider/mcp/tools/<path:provider_id>`
- `GET /tool-provider/mcp/update/<path:provider_id>`
- `POST /tool-provider/mcp/auth`
- provider deletion, credential update, and credential clearing

### Fix

`get_provider()` now dispatches on the identifier's form: it queries `id` only when the value parses as a UUID, and falls back to `server_identifier` otherwise. Because every affected route funnels through this one method, fixing it here covers all of them. UUID matches take precedence, so existing UUID callers are unchanged.

This mirrors a guard the codebase already applies to the same ambiguity in `services/data_migration/export_service.py` and `commands/data_migration.py` — the pattern simply had not been applied on this path.

A second instance of the same defect is also fixed: `update_provider()`'s duplicate-name check compared `MCPToolProvider.id != provider_id`, which would still fail the cast when renaming a provider addressed by `server_identifier`. It now compares against the resolved `mcp_provider.id`.

### Note on scope

The `response["id"]` assignment itself is left alone. It is the upstream cause, but changing it alters the public response shape for every MCP consumer — a wider change than this bug warrants, and better handled as its own discussion.

## Screenshots

Backend-only change; no user-visible UI changes.

| Before | After |
| ------ | ----- |
| `GET /tool-provider/mcp/tools/my-mcp-tools` → 500 `invalid input syntax for type uuid` | `GET /tool-provider/mcp/tools/my-mcp-tools` → 200 with the provider payload |

## Testing

Three tests added to `api/tests/test_containers_integration_tests/services/tools/test_mcp_tools_manage_service.py`, all prefixed `test_get_mcp_provider_by_provider_id_`:

| Test | Covers |
| ---- | ------ |
| `..._accepts_server_identifier` | The #41512 repro — a non-UUID `"my-mcp-tools"` as `provider_id` now resolves; raises `DataError` without this fix |
| `..._non_uuid_not_found` | An unknown identifier surfaces as `ValueError("MCP tool not found")`, not a database error |
| `..._server_identifier_tenant_isolation` | The fallback lookup stays scoped to the requesting tenant |

They belong in the testcontainers suite because only a real PostgreSQL exercises the UUID cast that was failing.

**Local validation**

- `pytest .../test_mcp_tools_manage_service.py` — 29 passed (3 new, 26 existing; the 6 pre-existing `get_provider` tests confirm the UUID path is unchanged)
- `ruff format --check ./api` — 3391 files already formatted
- `ruff check ./api` — All checks passed
- `pyrefly check` — 0 diagnostics

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods