### PR TITLE
fix: stabilize node block selectors and restore start tabs

### DIFF
--- a/web/app/components/workflow/__tests__/custom-edge.spec.tsx
+++ b/web/app/components/workflow/__tests__/custom-edge.spec.tsx
@@ -1,9 +1,11 @@
 import type { ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Position } from 'reactflow'
 import { ErrorHandleTypeEnum } from '@/app/components/workflow/nodes/_base/components/error-handle/types'
 import CustomEdge from '../custom-edge'
 import { BlockEnum, NodeRunningStatus } from '../types'
+import { renderWorkflowComponent } from './workflow-test-env'
 
 const mockUseAvailableBlocks = vi.hoisted(() => vi.fn())
 const mockUseNodesInteractions = vi.hoisted(() => vi.fn())
@@ -38,6 +40,9 @@ vi.mock('reactflow', () => ({
     Right: 'right',
     Left: 'left',
   },
+  useStoreApi: () => ({
+    getState: () => ({ getNodes: () => [] }),
+  }),
 }))
 
 vi.mock('../hooks/use-available-blocks', async (importOriginal) => {
@@ -81,8 +86,10 @@ describe('CustomEdge', () => {
     })
   })
 
-  it('should render a gradient edge and its real insert-node trigger', () => {
-    render(
+  it('should render a gradient edge and hide the start tab from its insert-node selector', async () => {
+    const user = userEvent.setup()
+
+    renderWorkflowComponent(
       <CustomEdge
         id="edge-1"
         source="source-node"
@@ -130,10 +137,14 @@ describe('CustomEdge', () => {
       opacity: '0.7',
       zIndex: '1001',
     })
+
+    await user.click(addBlockTrigger)
+
+    expect(screen.queryByRole('tab', { name: 'workflow.tabs.start' })).not.toBeInTheDocument()
   })
 
   it('should prefer the running stroke color when the edge is selected', () => {
-    render(
+    renderWorkflowComponent(
       <CustomEdge
         id="edge-selected"
         source="source-node"
@@ -163,7 +174,7 @@ describe('CustomEdge', () => {
   })
 
   it('should use the fail-branch running color while the connected node is hovering', () => {
-    render(
+    renderWorkflowComponent(
       <CustomEdge
         id="edge-hover"
         source="source-node"
@@ -193,7 +204,7 @@ describe('CustomEdge', () => {
   })
 
   it('should fall back to the default edge color when no highlight state is active', () => {
-    render(
+    renderWorkflowComponent(
       <CustomEdge
         id="edge-default"
         source="source-node"

--- a/web/app/components/workflow/nodes/_base/components/__tests__/node-handle.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/node-handle.spec.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import type { CommonNodeType } from '@/app/components/workflow/types'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { NodeSourceHandle, NodeTargetHandle } from '../node-handle'
 
@@ -210,6 +211,16 @@ describe('node-handle', () => {
 
   // Target-side tests cover selector visibility, connection locking, and status rendering.
   describe('NodeTargetHandle', () => {
+    it('should show the start tab when adding a node before the target node', async () => {
+      const user = userEvent.setup()
+
+      renderTargetHandle()
+
+      await user.click(screen.getByTestId('handle-target-handle'))
+
+      expect(screen.getByRole('tab', { name: 'workflow.tabs.start' })).toBeInTheDocument()
+    })
+
     it('should toggle the target add trigger', () => {
       renderTargetHandle()
 
@@ -260,6 +271,16 @@ describe('node-handle', () => {
 
   // Source-side tests cover selector opening paths, previous-node selection, and status styling.
   describe('NodeSourceHandle', () => {
+    it('should show the start tab when adding a node after the source node', async () => {
+      const user = userEvent.setup()
+
+      renderSourceHandle()
+
+      await user.click(screen.getByTestId('handle-source-handle'))
+
+      expect(screen.getByRole('tab', { name: 'workflow.tabs.start' })).toBeInTheDocument()
+    })
+
     it('should toggle the source add trigger', () => {
       renderSourceHandle()
 

--- a/web/app/components/workflow/nodes/_base/components/node-handle.tsx
+++ b/web/app/components/workflow/nodes/_base/components/node-handle.tsx
@@ -79,6 +79,7 @@ export const NodeTargetHandle = memo(
             'z-1 size-4! rounded-none! border-none! bg-transparent! outline-hidden!',
             'after:absolute after:top-1 after:left-1.5 after:h-2 after:w-0.5 after:bg-workflow-link-line-handle',
             'transition-all hover:scale-125',
+            open && 'scale-125',
             data._runningStatus === NodeRunningStatus.Succeeded &&
               'after:bg-workflow-link-line-success-handle',
             data._runningStatus === NodeRunningStatus.Failed &&
@@ -106,6 +107,7 @@ export const NodeTargetHandle = memo(
                 nextNodeTargetHandle: handleId,
               }}
               placement="left"
+              showStartTab
               triggerClassName={`
                 absolute left-0 top-0 opacity-0 pointer-events-none transition-opacity duration-150
                 ${nodeSelectorClassName}
@@ -206,6 +208,7 @@ export const NodeSourceHandle = memo(
           'group/handle z-1 size-4! rounded-none! border-none! bg-transparent! outline-hidden!',
           'after:absolute after:top-1 after:right-1.5 after:h-2 after:w-0.5 after:bg-workflow-link-line-handle',
           'transition-all hover:scale-125',
+          open && 'scale-125',
           data._runningStatus === NodeRunningStatus.Succeeded &&
             'after:bg-workflow-link-line-success-handle',
           data._runningStatus === NodeRunningStatus.Failed &&
@@ -252,6 +255,7 @@ export const NodeSourceHandle = memo(
               data-popup-open:opacity-100
             `}
             availableBlocksTypes={availableNextBlocks}
+            showStartTab
           />
         )}
       </Handle>


### PR DESCRIPTION
## Summary

- Show the Start tab in block selectors opened from either side of a workflow node.
- Keep the Start tab hidden when inserting a node from the middle of an existing edge.
- Preserve the node handle anchor size while its selector is open to prevent popup repositioning.

Fixes SNP-727

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.

From Codex