### PR TITLE
fix(web): align tool plugin card layout

### DIFF
--- a/web/app/components/plugins/plugin-item/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-item/__tests__/index.spec.tsx
@@ -614,7 +614,9 @@ describe('PluginItem', () => {
 
       // Assert
       const pluginContainer = container.firstChild as HTMLElement
-      expect(pluginContainer).toHaveClass('border-components-option-card-option-selected-border')
+      expect(pluginContainer).toHaveClass(
+        'after:inset-ring-components-option-card-option-selected-border',
+      )
     })
 
     it('should not highlight unselected plugin', () => {
@@ -628,7 +630,7 @@ describe('PluginItem', () => {
       // Assert
       const pluginContainer = container.firstChild as HTMLElement
       expect(pluginContainer).not.toHaveClass(
-        'border-components-option-card-option-selected-border',
+        'after:inset-ring-components-option-card-option-selected-border',
       )
     })
 
@@ -654,9 +656,18 @@ describe('PluginItem', () => {
 
       // Assert
       expect(screen.getByTestId('plugin-action').parentElement).toHaveClass(
+        'absolute',
+        'top-1/2',
+        'right-0',
+        '-translate-y-1/2',
+        'pointer-events-none',
         'opacity-0',
+        'group-hover/plugin-item:pointer-events-auto',
         'group-hover/plugin-item:opacity-100',
-        'focus-within:opacity-100',
+        'group-focus-within/plugin-item:pointer-events-auto',
+        'group-focus-within/plugin-item:opacity-100',
+        '[@media(hover:none)]:pointer-events-auto',
+        '[@media(hover:none)]:opacity-100',
       )
     })
   })

--- a/web/app/components/plugins/plugin-item/index.tsx
+++ b/web/app/components/plugins/plugin-item/index.tsx
@@ -120,8 +120,9 @@ const PluginItem: FC<Props> = ({
   return (
     <div
       className={cn(
-        'group/plugin-item relative overflow-hidden rounded-xl border-[1.5px] border-background-section-burn p-1',
-        selectedPluginID === plugin_id && 'border-components-option-card-option-selected-border',
+        'group/plugin-item relative flex min-w-[min(100%,496px)] flex-1 cursor-pointer flex-col overflow-hidden rounded-xl p-0.75',
+        selectedPluginID === plugin_id &&
+          "after:pointer-events-none after:absolute after:inset-0 after:rounded-xl after:inset-ring-[1.5px] after:inset-ring-components-option-card-option-selected-border after:content-['']",
         source === PluginSource.debugging
           ? 'bg-[repeating-linear-gradient(-45deg,rgba(16,24,40,0.04),rgba(16,24,40,0.04)_5px,rgba(0,0,0,0.02)_5px,rgba(0,0,0,0.02)_10px)]'
           : 'bg-background-section-burn',
@@ -132,7 +133,7 @@ const PluginItem: FC<Props> = ({
     >
       <div
         className={cn(
-          'relative rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs',
+          'relative rounded-[10px] border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-3',
           className,
         )}
       >
@@ -188,10 +189,14 @@ const PluginItem: FC<Props> = ({
                 }
               />
             </div>
-            <div className="flex items-center justify-between">
-              <Description text={descriptionText} descriptionLineRows={1}></Description>
+            <div className="relative flex h-4 min-w-0 items-center">
+              <Description
+                className="min-w-0 flex-1 group-focus-within/plugin-item:pr-20 group-hover/plugin-item:pr-20 [@media(hover:none)]:pr-20"
+                text={descriptionText}
+                descriptionLineRows={1}
+              />
               <div
-                className="opacity-0 transition-opacity group-hover/plugin-item:opacity-100 focus-within:opacity-100"
+                className="pointer-events-none absolute top-1/2 right-0 -translate-y-1/2 opacity-0 transition-opacity group-focus-within/plugin-item:pointer-events-auto group-focus-within/plugin-item:opacity-100 group-hover/plugin-item:pointer-events-auto group-hover/plugin-item:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100"
                 onClick={(e) => e.stopPropagation()}
               >
                 <Action
@@ -212,7 +217,7 @@ const PluginItem: FC<Props> = ({
           </div>
         </div>
       </div>
-      <div className="mt-1.5 mb-1 flex h-4 items-center gap-x-2 px-4">
+      <div className="flex h-6.5 items-center gap-x-2 px-3 pt-1.5 pb-1">
         {/* Organization & Name */}
         <div className="flex grow items-center overflow-hidden">
           <OrgInfo


### PR DESCRIPTION
## Summary

- Align installed tool plugin cards with the shared card height and footer spacing.
- Keep card actions out of the description row's layout flow while preserving hover, keyboard, and touch access.
- Keep selected-card borders from affecting card geometry.

From Codex

## Screenshots

| Before | After |
| ------ | ----- |
| User-reported layout mismatch | Not captured locally; browser UI was not started or downloaded for this visual-only change. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I added focused unit coverage and kept this as one atomic change.
- [ ] I updated documentation accordingly.
- [ ] Full backend lint/type-check and frontend staged-check command were not run; focused frontend verification completed.