### PR TITLE
fix: prevent the exit versions button from shrinking

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
@@ -471,7 +471,7 @@ function AgentVersionRestoreBar({
       <Button
         type="button"
         variant="secondary"
-        className="h-8 rounded-lg px-3 text-text-accent"
+        className="h-8 shrink-0 rounded-lg px-3 text-text-accent"
         onClick={onExitVersions}
       >
         <span aria-hidden className="i-ri-arrow-go-back-line size-4 shrink-0" />


### PR DESCRIPTION
## Summary

- Prevent the Exit versions button from shrinking in the version restore bar.
- Preserve the complete button label and icon when horizontal space is constrained.

Fixes DIFY-2964

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.