### PR TITLE
fix(web): publish workflow before creating tool

### DIFF
--- a/web/app/components/app/app-publisher/__tests__/features-wrapper.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/features-wrapper.spec.tsx
@@ -39,6 +39,12 @@ vi.mock('@/app/components/app/app-publisher', () => ({
         <button type="button" onClick={() => props.onPublish?.({ id: 'model-1' })}>
           publish-through-wrapper
         </button>
+        <button
+          type="button"
+          onClick={() => props.onPublish?.(undefined, { showSuccessToast: false })}
+        >
+          publish-silently-through-wrapper
+        </button>
         <button type="button" onClick={() => props.onRestore?.()}>
           restore-through-wrapper
         </button>
@@ -104,6 +110,23 @@ describe('FeaturesWrappedAppPublisher', () => {
 
     await waitFor(() => {
       expect(mockOnPublish).toHaveBeenCalledWith({ id: 'model-1' }, mockFeatures)
+    })
+  })
+
+  it('should pass publish notification options through to onPublish', async () => {
+    render(
+      <FeaturesWrappedAppPublisher
+        publishedConfig={publishedConfig as any}
+        onPublish={mockOnPublish}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('publish-silently-through-wrapper'))
+
+    await waitFor(() => {
+      expect(mockOnPublish).toHaveBeenCalledWith(undefined, mockFeatures, {
+        showSuccessToast: false,
+      })
     })
   })
 

--- a/web/app/components/app/app-publisher/__tests__/index.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/index.spec.tsx
@@ -95,9 +95,15 @@ vi.mock('@/service/access-control/use-app-access-control', () => ({
 }))
 
 const mockPublishToCreatorsPlatform = vi.fn()
+const mockCreateWorkflowToolProvider = vi.fn()
 
 vi.mock('@/service/apps', () => ({
   publishToCreatorsPlatform: (...args: unknown[]) => mockPublishToCreatorsPlatform(...args),
+}))
+
+vi.mock('@/service/tools', () => ({
+  createWorkflowToolProvider: (...args: unknown[]) => mockCreateWorkflowToolProvider(...args),
+  saveWorkflowToolProvider: vi.fn(),
 }))
 
 vi.mock('@/service/use-workflow', () => ({
@@ -167,9 +173,26 @@ vi.mock('@/app/components/base/amplitude', () => ({
 }))
 
 vi.mock('@/app/components/tools/workflow-tool', () => ({
-  WorkflowToolDrawer: ({ onHide }: { onHide: () => void }) => (
+  WorkflowToolDrawer: ({
+    onCreate,
+    onHide,
+  }: {
+    onCreate?: (payload: Record<string, unknown>) => void
+    onHide: () => void
+  }) => (
     <div role="dialog" aria-label="Workflow tool drawer">
       workflow tool drawer
+      <button
+        type="button"
+        onClick={() =>
+          onCreate?.({
+            workflow_app_id: 'app-1',
+            name: 'workflow_tool',
+          })
+        }
+      >
+        create-workflow-tool
+      </button>
       <button type="button" onClick={onHide}>
         close-workflow-tool-drawer
       </button>
@@ -816,6 +839,28 @@ describe('AppPublisher', () => {
 
     expect(screen.queryByText('publisher-workflow-tool')).not.toBeInTheDocument()
     expect(screen.getByRole('dialog', { name: 'Workflow tool drawer' })).toBeInTheDocument()
+  })
+
+  it('should not create a workflow tool when automatic publishing fails', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    mockAppDetail = {
+      ...mockAppDetail,
+      mode: AppModeEnum.WORKFLOW,
+    }
+    mockOnPublish.mockRejectedValueOnce(new Error('publish failed'))
+
+    render(<AppPublisher publishedAt={Date.now()} onPublish={mockOnPublish} />)
+
+    fireEvent.click(screen.getByText(/(?:^|\.)common\.publish(?=$|:)/))
+    fireEvent.click(screen.getByText('publisher-workflow-tool'))
+    fireEvent.click(screen.getByRole('button', { name: 'create-workflow-tool' }))
+
+    await waitFor(() => {
+      expect(mockOnPublish).toHaveBeenCalledOnce()
+    })
+    expect(mockCreateWorkflowToolProvider).not.toHaveBeenCalled()
+    expect(mockToastError).toHaveBeenCalledWith('publish failed')
+    consoleWarnSpy.mockRestore()
   })
 
   it('should not open workflow tool drawer without tool.manage', () => {

--- a/web/app/components/app/app-publisher/__tests__/index.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/index.spec.tsx
@@ -846,8 +846,8 @@ describe('AppPublisher', () => {
       ...mockAppDetail,
       mode: AppModeEnum.WORKFLOW,
     }
-    mockOnPublish.mockImplementation(async () => {
-      mockToastSuccess('common.api.actionSuccess')
+    mockOnPublish.mockImplementation(async (_params, options?: { showSuccessToast?: boolean }) => {
+      if (options?.showSuccessToast !== false) mockToastSuccess('common.api.actionSuccess')
     })
     mockCreateWorkflowToolProvider.mockResolvedValue({})
 
@@ -860,7 +860,31 @@ describe('AppPublisher', () => {
     await waitFor(() => {
       expect(mockCreateWorkflowToolProvider).toHaveBeenCalledOnce()
     })
+    expect(mockOnPublish).toHaveBeenCalledWith(undefined, { showSuccessToast: false })
     expect(mockToastSuccess).toHaveBeenCalledOnce()
+  })
+
+  it('should not show a success toast when workflow tool creation fails after publishing', async () => {
+    mockAppDetail = {
+      ...mockAppDetail,
+      mode: AppModeEnum.WORKFLOW,
+    }
+    mockOnPublish.mockImplementation(async (_params, options?: { showSuccessToast?: boolean }) => {
+      if (options?.showSuccessToast !== false) mockToastSuccess('common.api.actionSuccess')
+    })
+    mockCreateWorkflowToolProvider.mockRejectedValue(new Error('create failed'))
+
+    render(<AppPublisher publishedAt={Date.now()} onPublish={mockOnPublish} />)
+
+    fireEvent.click(screen.getByText(/(?:^|\.)common\.publish(?=$|:)/))
+    fireEvent.click(screen.getByText('publisher-workflow-tool'))
+    fireEvent.click(screen.getByRole('button', { name: 'create-workflow-tool' }))
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('create failed')
+    })
+    expect(mockOnPublish).toHaveBeenCalledWith(undefined, { showSuccessToast: false })
+    expect(mockToastSuccess).not.toHaveBeenCalled()
   })
 
   it('should not create a workflow tool when automatic publishing fails', async () => {

--- a/web/app/components/app/app-publisher/__tests__/index.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/index.spec.tsx
@@ -841,6 +841,28 @@ describe('AppPublisher', () => {
     expect(screen.getByRole('dialog', { name: 'Workflow tool drawer' })).toBeInTheDocument()
   })
 
+  it('should show one success toast when automatically publishing a workflow tool', async () => {
+    mockAppDetail = {
+      ...mockAppDetail,
+      mode: AppModeEnum.WORKFLOW,
+    }
+    mockOnPublish.mockImplementation(async () => {
+      mockToastSuccess('common.api.actionSuccess')
+    })
+    mockCreateWorkflowToolProvider.mockResolvedValue({})
+
+    render(<AppPublisher publishedAt={Date.now()} onPublish={mockOnPublish} />)
+
+    fireEvent.click(screen.getByText(/(?:^|\.)common\.publish(?=$|:)/))
+    fireEvent.click(screen.getByText('publisher-workflow-tool'))
+    fireEvent.click(screen.getByRole('button', { name: 'create-workflow-tool' }))
+
+    await waitFor(() => {
+      expect(mockCreateWorkflowToolProvider).toHaveBeenCalledOnce()
+    })
+    expect(mockToastSuccess).toHaveBeenCalledOnce()
+  })
+
   it('should not create a workflow tool when automatic publishing fails', async () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     mockAppDetail = {

--- a/web/app/components/app/app-publisher/features-wrapper.tsx
+++ b/web/app/components/app/app-publisher/features-wrapper.tsx
@@ -1,5 +1,6 @@
 import type {
   AppPublisherProps,
+  AppPublisherPublishOptions,
   AppPublisherPublishParams,
 } from '@/app/components/app/app-publisher/types'
 import type { ConfigurationPublishConfig } from '@/app/components/app/configuration/hooks/configuration-lifecycle/types'
@@ -26,6 +27,7 @@ type Props = Omit<AppPublisherProps, 'onPublish'> & {
   onPublish?: (
     params?: AppPublisherPublishParams,
     features?: Features,
+    options?: AppPublisherPublishOptions,
   ) => Promise<unknown> | unknown
   publishedConfig: ConfigurationPublishConfig
   resetAppConfig?: () => void
@@ -88,7 +90,8 @@ const FeaturesWrappedAppPublisher = (props: Props) => {
   }
 
   const handlePublish = useCallback(
-    (params?: AppPublisherPublishParams) => {
+    (params?: AppPublisherPublishParams, options?: AppPublisherPublishOptions) => {
+      if (options) return props.onPublish?.(params, features, options)
       return props.onPublish?.(params, features)
     },
     [features, props],

--- a/web/app/components/app/app-publisher/publisher-content/index.tsx
+++ b/web/app/components/app/app-publisher/publisher-content/index.tsx
@@ -132,7 +132,7 @@ export function PublisherContent({
     hasTriggerNode,
     inputs,
     onClosePublisher: closePublisher,
-    onPublish: publish.handlePublish,
+    onPublish: publish.publishWorkflowTool,
     onRefreshData,
     outputs,
     toolPublished,

--- a/web/app/components/app/app-publisher/publisher-content/use-publish-controller.ts
+++ b/web/app/components/app/app-publisher/publisher-content/use-publish-controller.ts
@@ -1,5 +1,9 @@
 import type { QueryClient } from '@tanstack/react-query'
-import type { AppPublisherProps, AppPublisherPublishParams } from '../types'
+import type {
+  AppPublisherProps,
+  AppPublisherPublishOptions,
+  AppPublisherPublishParams,
+} from '../types'
 import type { CollaborationUpdate } from '@/app/components/workflow/collaboration/types/collaboration'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { useQueryClient } from '@tanstack/react-query'
@@ -81,8 +85,11 @@ export function usePublishController({
       : publishedAt
   const hasPublishedVersion = Boolean(currentPublishedAt)
 
-  async function publishApp(params?: AppPublisherPublishParams) {
-    await onPublish?.(params)
+  async function publishApp(
+    params?: AppPublisherPublishParams,
+    options?: AppPublisherPublishOptions,
+  ) {
+    await onPublish?.(params, options)
     setPublished(true)
 
     const socket = appId ? webSocketClient.getSocket(appId) : null
@@ -120,6 +127,10 @@ export function usePublishController({
       console.warn('[app-publisher] publish failed', error)
       setPublished(false)
     }
+  }
+
+  async function publishWorkflowTool(params?: AppPublisherPublishParams) {
+    await publishApp(params, { showSuccessToast: false })
   }
 
   async function handleRestore() {
@@ -168,7 +179,7 @@ export function usePublishController({
     isWorkflowApp,
     published,
     publishedWorkflow,
-    publishWorkflowTool: publishApp,
+    publishWorkflowTool,
     resetPublished: () => setPublished(false),
   }
 }

--- a/web/app/components/app/app-publisher/publisher-content/use-publish-controller.ts
+++ b/web/app/components/app/app-publisher/publisher-content/use-publish-controller.ts
@@ -81,37 +81,41 @@ export function usePublishController({
       : publishedAt
   const hasPublishedVersion = Boolean(currentPublishedAt)
 
+  async function publishApp(params?: AppPublisherPublishParams) {
+    await onPublish?.(params)
+    setPublished(true)
+
+    const socket = appId ? webSocketClient.getSocket(appId) : null
+    if (appId) {
+      invalidateAppWorkflow(appId)
+      if (supportsMultiEnvironment) refreshAppDeploymentData(queryClient, appId)
+    } else {
+      console.warn('[app-publisher] missing appId, skip workflow invalidate and socket emit')
+    }
+    if (socket) {
+      const timestamp = Date.now()
+      socket.emit('collaboration_event', {
+        type: 'app_publish_update',
+        data: {
+          action: 'published',
+          timestamp,
+        },
+        timestamp,
+      })
+    } else if (appId) {
+      console.warn('[app-publisher] socket not ready, skip collaboration_event emit', { appId })
+    }
+
+    trackEvent('app_published_time', {
+      action_mode: 'app',
+      app_id: appId,
+      app_name: appName,
+    })
+  }
+
   async function handlePublish(params?: AppPublisherPublishParams) {
     try {
-      await onPublish?.(params)
-      setPublished(true)
-
-      const socket = appId ? webSocketClient.getSocket(appId) : null
-      if (appId) {
-        invalidateAppWorkflow(appId)
-        if (supportsMultiEnvironment) refreshAppDeploymentData(queryClient, appId)
-      } else {
-        console.warn('[app-publisher] missing appId, skip workflow invalidate and socket emit')
-      }
-      if (socket) {
-        const timestamp = Date.now()
-        socket.emit('collaboration_event', {
-          type: 'app_publish_update',
-          data: {
-            action: 'published',
-            timestamp,
-          },
-          timestamp,
-        })
-      } else if (appId) {
-        console.warn('[app-publisher] socket not ready, skip collaboration_event emit', { appId })
-      }
-
-      trackEvent('app_published_time', {
-        action_mode: 'app',
-        app_id: appId,
-        app_name: appName,
-      })
+      await publishApp(params)
     } catch (error) {
       console.warn('[app-publisher] publish failed', error)
       setPublished(false)
@@ -164,6 +168,7 @@ export function usePublishController({
     isWorkflowApp,
     published,
     publishedWorkflow,
+    publishWorkflowTool: publishApp,
     resetPublished: () => setPublished(false),
   }
 }

--- a/web/app/components/app/app-publisher/types.ts
+++ b/web/app/components/app/app-publisher/types.ts
@@ -4,9 +4,16 @@ import type { PublishWorkflowParams } from '@/types/workflow'
 
 export type AppPublisherPublishParams = ModelAndParameter | PublishWorkflowParams
 
+export type AppPublisherPublishOptions = {
+  showSuccessToast?: boolean
+}
+
 type AppPublisherPublishHandler =
-  | ((params?: AppPublisherPublishParams) => Promise<unknown> | unknown)
-  | ((params?: unknown) => Promise<unknown> | unknown)
+  | ((
+      params?: AppPublisherPublishParams,
+      options?: AppPublisherPublishOptions,
+    ) => Promise<unknown> | unknown)
+  | ((params?: unknown, options?: AppPublisherPublishOptions) => Promise<unknown> | unknown)
 
 type AppPublisherRestoreHandler = () => Promise<unknown> | unknown
 

--- a/web/app/components/tools/workflow-tool/hooks/__tests__/use-configure-button.spec.ts
+++ b/web/app/components/tools/workflow-tool/hooks/__tests__/use-configure-button.spec.ts
@@ -430,6 +430,7 @@ describe('useConfigureButton', () => {
       expect(mockInvalidateAllWorkflowTools).toHaveBeenCalled()
       expect(onRefreshData).toHaveBeenCalled()
       expect(mockInvalidateWorkflowToolDetailByAppID).toHaveBeenCalledWith('app-123')
+      expect(mockToastNotify).toHaveBeenCalledWith({ type: 'success', message: expect.any(String) })
       expect(onConfigured).toHaveBeenCalled()
     })
 
@@ -478,6 +479,7 @@ describe('useConfigureButton', () => {
       expect(onRefreshData).toHaveBeenCalled()
       expect(mockInvalidateAllWorkflowTools).toHaveBeenCalled()
       expect(mockInvalidateWorkflowToolDetailByAppID).toHaveBeenCalledWith('app-123')
+      expect(mockToastNotify).toHaveBeenCalledWith({ type: 'success', message: expect.any(String) })
       expect(onConfigured).toHaveBeenCalled()
     })
 

--- a/web/app/components/tools/workflow-tool/hooks/__tests__/use-configure-button.spec.ts
+++ b/web/app/components/tools/workflow-tool/hooks/__tests__/use-configure-button.spec.ts
@@ -430,7 +430,6 @@ describe('useConfigureButton', () => {
       expect(mockInvalidateAllWorkflowTools).toHaveBeenCalled()
       expect(onRefreshData).toHaveBeenCalled()
       expect(mockInvalidateWorkflowToolDetailByAppID).toHaveBeenCalledWith('app-123')
-      expect(mockToastNotify).toHaveBeenCalledWith({ type: 'success', message: expect.any(String) })
       expect(onConfigured).toHaveBeenCalled()
     })
 

--- a/web/app/components/tools/workflow-tool/hooks/__tests__/use-configure-button.spec.ts
+++ b/web/app/components/tools/workflow-tool/hooks/__tests__/use-configure-button.spec.ts
@@ -370,6 +370,46 @@ describe('useConfigureButton', () => {
 
   // Mutation handlers
   describe('handleCreate', () => {
+    it('should publish before creating the provider', async () => {
+      mockCreateWorkflowToolProvider.mockResolvedValue({})
+      const handlePublish = vi.fn().mockResolvedValue(undefined)
+      const { result } = renderHook(() =>
+        useConfigureButton(createDefaultOptions({ handlePublish })),
+      )
+
+      await act(async () => {
+        await result.current.handleCreate(
+          createMockRequest({ workflow_app_id: 'app-123' }) as WorkflowToolProviderRequest & {
+            workflow_app_id: string
+          },
+        )
+      })
+
+      expect(handlePublish).toHaveBeenCalledOnce()
+      expect(mockCreateWorkflowToolProvider).toHaveBeenCalledOnce()
+      expect(handlePublish.mock.invocationCallOrder[0]).toBeLessThan(
+        mockCreateWorkflowToolProvider.mock.invocationCallOrder[0]!,
+      )
+    })
+
+    it('should not create the provider when publishing fails', async () => {
+      const handlePublish = vi.fn().mockRejectedValue(new Error('Publish failed'))
+      const { result } = renderHook(() =>
+        useConfigureButton(createDefaultOptions({ handlePublish })),
+      )
+
+      await act(async () => {
+        await result.current.handleCreate(
+          createMockRequest({ workflow_app_id: 'app-123' }) as WorkflowToolProviderRequest & {
+            workflow_app_id: string
+          },
+        )
+      })
+
+      expect(mockCreateWorkflowToolProvider).not.toHaveBeenCalled()
+      expect(mockToastNotify).toHaveBeenCalledWith({ type: 'error', message: 'Publish failed' })
+    })
+
     it('should create provider, invalidate caches, refresh, and notify configured', async () => {
       mockCreateWorkflowToolProvider.mockResolvedValue({})
       const onRefreshData = vi.fn()

--- a/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
@@ -9,6 +9,7 @@ import type { InputVar, Variable } from '@/app/components/workflow/types'
 import type { PublishWorkflowParams } from '@/types/workflow'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useEffect, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { createWorkflowToolProvider, saveWorkflowToolProvider } from '@/service/tools'
 import {
   useInvalidateAllWorkflowTools,
@@ -120,6 +121,7 @@ export function useConfigureButton(options: UseConfigureButtonOptions) {
     onRefreshData,
     onConfigured,
   } = options
+  const { t } = useTranslation()
 
   // Data fetching via React Query
   const { data: detail, isLoading } = useWorkflowToolDetailByAppID(
@@ -182,6 +184,7 @@ export function useConfigureButton(options: UseConfigureButtonOptions) {
       invalidateAllWorkflowTools()
       onRefreshData?.()
       invalidateDetail(workflowAppId)
+      toast.success(t(($) => $['api.actionSuccess'], { ns: 'common' }))
       onConfigured?.()
     } catch (e) {
       toast.error((e as Error).message)
@@ -201,6 +204,7 @@ export function useConfigureButton(options: UseConfigureButtonOptions) {
       onRefreshData?.()
       invalidateAllWorkflowTools()
       invalidateDetail(workflowAppId)
+      toast.success(t(($) => $['api.actionSuccess'], { ns: 'common' }))
       onConfigured?.()
     } catch (e) {
       toast.error((e as Error).message)

--- a/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
@@ -180,6 +180,7 @@ export function useConfigureButton(options: UseConfigureButtonOptions) {
   // Mutation handlers (not memoized — only used in conditionally-rendered modal)
   const handleCreate = async (data: WorkflowToolProviderRequest & { workflow_app_id: string }) => {
     try {
+      await handlePublish()
       await createWorkflowToolProvider(data)
       invalidateAllWorkflowTools()
       onRefreshData?.()

--- a/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
+++ b/web/app/components/tools/workflow-tool/hooks/use-configure-button.ts
@@ -9,7 +9,6 @@ import type { InputVar, Variable } from '@/app/components/workflow/types'
 import type { PublishWorkflowParams } from '@/types/workflow'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useEffect, useMemo, useRef } from 'react'
-import { useTranslation } from 'react-i18next'
 import { createWorkflowToolProvider, saveWorkflowToolProvider } from '@/service/tools'
 import {
   useInvalidateAllWorkflowTools,
@@ -122,8 +121,6 @@ export function useConfigureButton(options: UseConfigureButtonOptions) {
     onConfigured,
   } = options
 
-  const { t } = useTranslation()
-
   // Data fetching via React Query
   const { data: detail, isLoading } = useWorkflowToolDetailByAppID(
     workflowAppId,
@@ -185,7 +182,6 @@ export function useConfigureButton(options: UseConfigureButtonOptions) {
       invalidateAllWorkflowTools()
       onRefreshData?.()
       invalidateDetail(workflowAppId)
-      toast.success(t(($) => $['api.actionSuccess'], { ns: 'common' }))
       onConfigured?.()
     } catch (e) {
       toast.error((e as Error).message)

--- a/web/app/components/workflow-app/components/workflow-header/__tests__/features-trigger.spec.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/__tests__/features-trigger.spec.tsx
@@ -186,6 +186,23 @@ vi.mock('@/app/components/app/app-publisher', () => ({
           type="button"
           onClick={() => {
             Promise.resolve(
+              (
+                props.onPublish as
+                  | ((
+                      params?: unknown,
+                      options?: { showSuccessToast?: boolean },
+                    ) => Promise<unknown> | unknown)
+                  | undefined
+              )?.(undefined, { showSuccessToast: false }),
+            ).catch(() => undefined)
+          }}
+        >
+          publisher-publish-silently
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            Promise.resolve(
               props.onPublish?.({
                 url: '/apps/app-1/workflows/publish',
                 title: 'Test title',
@@ -580,6 +597,21 @@ describe('FeaturesTrigger', () => {
             name: 'Updated App',
           }),
         )
+      })
+    })
+
+    it('should not show a success toast when the publisher requests a silent publish', async () => {
+      const user = userEvent.setup()
+      renderWithToast(<FeaturesTrigger />)
+
+      await user.click(screen.getByRole('button', { name: 'publisher-publish-silently' }))
+
+      await waitFor(() => {
+        expect(mockPublishWorkflow).toHaveBeenCalled()
+      })
+      expect(toastMocks.call).not.toHaveBeenCalledWith({
+        type: 'success',
+        message: 'common.api.actionSuccess',
       })
     })
 

--- a/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
@@ -1,4 +1,7 @@
-import type { AppPublisherPublishParams } from '@/app/components/app/app-publisher/types'
+import type {
+  AppPublisherPublishOptions,
+  AppPublisherPublishParams,
+} from '@/app/components/app/app-publisher/types'
 import type { EndNodeType } from '@/app/components/workflow/nodes/end/types'
 import type { StartNodeType } from '@/app/components/workflow/nodes/start/types'
 import type { CommonEdgeType, Node } from '@/app/components/workflow/types'
@@ -150,7 +153,7 @@ const FeaturesTrigger = () => {
 
   const updatePublishedWorkflow = useInvalidateAppWorkflow()
   const onPublish = useCallback(
-    async (params?: AppPublisherPublishParams) => {
+    async (params?: AppPublisherPublishParams, options?: AppPublisherPublishOptions) => {
       const publishParams = params && 'title' in params ? params : undefined
       // First check if there are any items in the checklist
       // if (!validateBeforeRun())
@@ -172,7 +175,9 @@ const FeaturesTrigger = () => {
           releaseNotes: publishParams?.releaseNotes || '',
         })
         if (res) {
-          toast.success(t(($) => $['api.actionSuccess'], { ns: 'common' }))
+          if (options?.showSuccessToast !== false) {
+            toast.success(t(($) => $['api.actionSuccess'], { ns: 'common' }))
+          }
           updatePublishedWorkflow(appID!)
           updateAppDetail()
           invalidateAppTriggers(appID!)


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using gpt-5.6-terra. I have reviewed and edited the final diff, and I am responsible for the content.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41526

Linear reference: ENG-808.

- Publish the current workflow before creating a Workflow as Tool, matching the existing update path.
- Propagate automatic publish failures so provider creation does not continue against a stale published workflow.
- Silence the intermediate workflow-publish success toast for Tool create/update, then show one success toast only after the provider mutation succeeds.

### Testing

- `pnpm exec vp test run --project unit app/components/app/app-publisher` — 106 tests passed.
- `pnpm exec vp test run --project unit app/components/tools/workflow-tool` — 65 tests passed.
- `pnpm exec vp test run --project unit app/components/workflow-app/components/workflow-header/__tests__/features-trigger.spec.tsx` — 23 tests passed.
- Targeted Vite+ formatting, lint, and TypeScript checks passed for all nine changed files.
- `git diff --check` passed.

## Screenshots

| Before | After |
| ------ | ----- |
| Not applicable; behavior-only change | Not applicable; behavior-only change |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Codex