### PR TITLE
fix: hide chat features drawer while opener dialog is active

### DIFF
--- a/web/app/components/base/features/new-feature-panel/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/index.tsx
@@ -17,6 +17,7 @@ import SpeechToText from '@/app/components/base/features/new-feature-panel/speec
 import TextToSpeech from '@/app/components/base/features/new-feature-panel/text-to-speech'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useDefaultModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
+import { useModalContext } from '@/context/modal-context'
 
 type Props = Readonly<{
   show: boolean
@@ -56,10 +57,11 @@ const NewFeaturePanel = ({
   const { t } = useTranslation()
   const { data: speech2textDefaultModel } = useDefaultModel(ModelTypeEnum.speech2text)
   const { data: text2speechDefaultModel } = useDefaultModel(ModelTypeEnum.tts)
+  const { hasBlockingModalOpen } = useModalContext()
 
   return (
     <FeaturePanelDrawer
-      show={show}
+      show={show && !hasBlockingModalOpen}
       onClose={onClose}
       inWorkflow={inWorkflow}
       className={drawerClassName}


### PR DESCRIPTION
## Summary

- Hide the Chat Features drawer while a nested blocking dialog is active.
- Restore the drawer after the Conversation Opener dialog closes without changing its user-controlled state.

Fixes DIFY-2963

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.