### PR TITLE
refactor(models): pass session into CustomizedSnippet accessors

### DIFF
--- a/api/models/snippet.py
+++ b/api/models/snippet.py
@@ -1,17 +1,17 @@
 import json
+from collections.abc import Sequence
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy import DateTime, String, func
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from libs.uuid_utils import uuidv7
 
 from .account import Account
 from .base import Base
-from .engine import db
 from .model import Tag, TagBinding
 from .types import AdjustedJSON, LongText, StringUUID
 
@@ -65,13 +65,12 @@ class CustomizedSnippet(Base):
         DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
 
-    @property
-    def graph_dict(self) -> dict[str, Any]:
+    def graph_dict(self, session: Session) -> dict[str, Any]:
         """Get graph from associated workflow."""
         if self.workflow_id:
             from .workflow import Workflow
 
-            workflow = db.session.get(Workflow, self.workflow_id)
+            workflow = session.get(Workflow, self.workflow_id)
             if workflow:
                 return json.loads(workflow.graph) if workflow.graph else {}
         return {}
@@ -81,10 +80,9 @@ class CustomizedSnippet(Base):
         """Parse input_fields JSON to list."""
         return json.loads(self.input_fields) if self.input_fields else []
 
-    @property
-    def tags(self):
+    def tags(self, session: Session) -> Sequence[Tag]:
         """Get snippet tags."""
-        tags = db.session.scalars(
+        tags = session.scalars(
             sa.select(Tag)
             .join(TagBinding, Tag.id == TagBinding.tag_id)
             .where(
@@ -97,24 +95,21 @@ class CustomizedSnippet(Base):
 
         return tags or []
 
-    @property
-    def created_by_account(self) -> Account | None:
+    def created_by_account(self, session: Session) -> Account | None:
         """Get the account that created this snippet."""
         if self.created_by:
-            return db.session.get(Account, self.created_by)
+            return session.get(Account, self.created_by)
         return None
 
-    @property
-    def author_name(self) -> str | None:
+    def author_name(self, session: Session) -> str | None:
         """Get the creator account name."""
-        account = self.created_by_account
+        account = self.created_by_account(session)
         return account.name if account else None
 
-    @property
-    def updated_by_account(self) -> Account | None:
+    def updated_by_account(self, session: Session) -> Account | None:
         """Get the account that last updated this snippet."""
         if self.updated_by:
-            return db.session.get(Account, self.updated_by)
+            return session.get(Account, self.updated_by)
         return None
 
     @property

--- a/api/tests/unit_tests/models/test_snippet.py
+++ b/api/tests/unit_tests/models/test_snippet.py
@@ -5,7 +5,6 @@ import json
 import pytest
 from sqlalchemy.orm import Session
 
-from models import snippet as snippet_module
 from models.account import Account
 from models.enums import TagType
 from models.model import Tag, TagBinding
@@ -21,21 +20,14 @@ ACCOUNT_2_ID = "55555555-5555-5555-5555-555555555556"
 SQLITE_MODELS = (Workflow, Tag, TagBinding, Account)
 
 
-@pytest.fixture
-def snippet_session(sqlite_session: Session, monkeypatch: pytest.MonkeyPatch) -> Session:
-    """Expose the shared SQLite session to model properties that use the global Flask session."""
-    monkeypatch.setattr(snippet_module.db, "session", sqlite_session)
-    return sqlite_session
-
-
-def test_graph_dict_returns_empty_without_workflow_id() -> None:
+def test_graph_dict_returns_empty_without_workflow_id(sqlite_session: Session) -> None:
     snippet = CustomizedSnippet(workflow_id=None)
 
-    assert snippet.graph_dict == {}
+    assert snippet.graph_dict(session=sqlite_session) == {}
 
 
 @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
-def test_graph_dict_loads_published_workflow_graph(snippet_session: Session) -> None:
+def test_graph_dict_loads_published_workflow_graph(sqlite_session: Session) -> None:
     workflow = Workflow(
         tenant_id=TENANT_ID,
         app_id=APP_ID,
@@ -46,18 +38,18 @@ def test_graph_dict_loads_published_workflow_graph(snippet_session: Session) -> 
         created_by=ACCOUNT_1_ID,
     )
     workflow.id = WORKFLOW_ID
-    snippet_session.add(workflow)
-    snippet_session.commit()
+    sqlite_session.add(workflow)
+    sqlite_session.commit()
     snippet = CustomizedSnippet(workflow_id=WORKFLOW_ID)
 
-    assert snippet.graph_dict == {"nodes": [{"id": "llm-1"}], "edges": []}
+    assert snippet.graph_dict(session=sqlite_session) == {"nodes": [{"id": "llm-1"}], "edges": []}
 
 
 @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
-def test_graph_dict_returns_empty_when_workflow_missing(snippet_session: Session) -> None:
+def test_graph_dict_returns_empty_when_workflow_missing(sqlite_session: Session) -> None:
     snippet = CustomizedSnippet(workflow_id=WORKFLOW_ID)
 
-    assert snippet.graph_dict == {}
+    assert snippet.graph_dict(session=sqlite_session) == {}
 
 
 def test_input_fields_list_parses_json_or_returns_empty() -> None:
@@ -68,44 +60,70 @@ def test_input_fields_list_parses_json_or_returns_empty() -> None:
 
 
 @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
-def test_tags_returns_query_results_or_empty(snippet_session: Session) -> None:
+def test_tags_returns_query_results_or_empty(sqlite_session: Session) -> None:
     tag = Tag(tenant_id=TENANT_ID, type=TagType.SNIPPET, name="Reusable", created_by=ACCOUNT_1_ID)
     binding = TagBinding(tenant_id=TENANT_ID, tag_id=tag.id, target_id=SNIPPET_ID, created_by=ACCOUNT_1_ID)
-    snippet_session.add_all((tag, binding))
-    snippet_session.commit()
+    sqlite_session.add_all((tag, binding))
+    sqlite_session.commit()
     snippet = CustomizedSnippet(id=SNIPPET_ID, tenant_id=TENANT_ID)
 
-    assert snippet.tags == [tag]
+    assert snippet.tags(session=sqlite_session) == [tag]
 
-    snippet_session.delete(binding)
-    snippet_session.commit()
-    assert snippet.tags == []
+    sqlite_session.delete(binding)
+    sqlite_session.commit()
+    assert snippet.tags(session=sqlite_session) == []
 
 
 @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
-def test_account_properties_and_author_name(snippet_session: Session) -> None:
+def test_account_properties_and_author_name(sqlite_session: Session) -> None:
     account = Account(name="Ada", email="ada@example.com")
     account.id = ACCOUNT_1_ID
     updated_account = Account(name="Grace", email="grace@example.com")
     updated_account.id = ACCOUNT_2_ID
-    snippet_session.add_all((account, updated_account))
-    snippet_session.commit()
+    sqlite_session.add_all((account, updated_account))
+    sqlite_session.commit()
     snippet = CustomizedSnippet(created_by=ACCOUNT_1_ID, updated_by=ACCOUNT_2_ID)
 
-    assert snippet.created_by_account is account
-    assert snippet.author_name == "Ada"
-    assert snippet.updated_by_account is updated_account
+    assert snippet.created_by_account(session=sqlite_session) is account
+    assert snippet.author_name(session=sqlite_session) == "Ada"
+    assert snippet.updated_by_account(session=sqlite_session) is updated_account
 
 
-def test_account_properties_return_none_without_account_ids() -> None:
+def test_account_properties_return_none_without_account_ids(sqlite_session: Session) -> None:
     snippet = CustomizedSnippet(created_by=None, updated_by=None)
 
-    assert snippet.created_by_account is None
-    assert snippet.author_name is None
-    assert snippet.updated_by_account is None
+    assert snippet.created_by_account(session=sqlite_session) is None
+    assert snippet.author_name(session=sqlite_session) is None
+    assert snippet.updated_by_account(session=sqlite_session) is None
 
 
 def test_version_str_returns_string_value() -> None:
     snippet = CustomizedSnippet(version=7)
 
     assert snippet.version_str == "7"
+
+
+class TestCustomizedSnippetSessionAccessors:
+    """Regression coverage for ``CustomizedSnippet`` accessors refactored to take a caller-provided session.
+
+    ``graph_dict`` / ``tags`` / ``created_by_account`` / ``updated_by_account`` were ``@property``
+    accessors reaching for the global ``db.session`` internally; they are now plain methods
+    accepting a ``Session`` explicitly. ``author_name`` threads the session through to
+    ``created_by_account``.
+    """
+
+    def test_accessors_return_none_when_related_rows_are_absent(self, sqlite_session: Session):
+        missing_account_id = "66666666-6666-6666-6666-666666666666"
+        snippet = CustomizedSnippet(
+            id=SNIPPET_ID,
+            tenant_id=TENANT_ID,
+            created_by=missing_account_id,
+            updated_by=missing_account_id,
+            workflow_id=None,
+        )
+
+        assert snippet.created_by_account(session=sqlite_session) is None
+        assert snippet.updated_by_account(session=sqlite_session) is None
+        assert snippet.author_name(session=sqlite_session) is None
+        assert snippet.graph_dict(session=sqlite_session) == {}
+        assert snippet.tags(session=sqlite_session) == []


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 1. Associated issue: #40372 (claimed the `snippet.py` slice in [this comment](https://github.com/langgenius/dify/issues/40372#issuecomment-5474759541)).

## Summary

Part of #40372.

Follow-up to #40370 and #41370: converts the `CustomizedSnippet` accessors in
`api/models/snippet.py` that reach for the global `db.session` internally into plain
methods taking `session: Session` explicitly, per the pattern established in those PRs:

- `CustomizedSnippet.graph_dict` — was `@property` doing `db.session.get(Workflow, ...)`;
  now `def graph_dict(self, session: Session) -> dict[str, Any]`.
- `CustomizedSnippet.tags` — was `@property` doing `db.session.scalars(...)`;
  now `def tags(self, session: Session) -> Sequence[Tag]`.
- `CustomizedSnippet.created_by_account` — same conversion;
  now `def created_by_account(self, session: Session) -> Account | None`.
- `CustomizedSnippet.updated_by_account` — same conversion;
  now `def updated_by_account(self, session: Session) -> Account | None`.
- `CustomizedSnippet.author_name` — delegates to `created_by_account`, so it threads the
  caller's session through; now `def author_name(self, session: Session) -> str | None`.

`input_fields_list` and `version_str` touch no database and remain `@property`.
The now-unused `from .engine import db` import is dropped — `snippet.py` no longer
references the global session at all.

No production callers needed updating: the only references to these accessor names
elsewhere in the codebase belong to other models.

## Tests

`api/tests/unit_tests/models/test_snippet.py` previously needed a `snippet_session`
fixture that monkeypatched `snippet_module.db.session` onto the SQLite session, purely
to work around the accessors reaching for the global session. That fixture is now
obsolete and has been removed; the existing tests take `sqlite_session` directly and
pass it into each accessor.

Adds `TestCustomizedSnippetSessionAccessors::test_accessors_return_none_when_related_rows_are_absent`,
covering the case where `created_by` / `updated_by` hold ids with no matching row — a
distinct path from the existing "no id at all" test, since it exercises `session.get()`
returning `None` rather than the falsy-id short circuit. It also asserts the empty-result
paths for `graph_dict` and `tags`.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Codex