### PR TITLE
refactor(inner_api): dep-inject workspace payloads with @model_validate

### DIFF
--- a/api/controllers/inner_api/workspace/workspace.py
+++ b/api/controllers/inner_api/workspace/workspace.py
@@ -56,7 +56,6 @@ class EnterpriseWorkspace(Resource):
     )
     @model_validate(WorkspaceCreatePayload)
     def post(self, args: WorkspaceCreatePayload):
-
         account = db.session.scalar(select(Account).where(Account.email == args.owner_email).limit(1))
         if account is None:
             return {"message": "owner account not found."}, 404
@@ -99,7 +98,6 @@ class EnterpriseWorkspaceNoOwnerEmail(Resource):
     )
     @model_validate(WorkspaceOwnerlessPayload)
     def post(self, args: WorkspaceOwnerlessPayload):
-
         tenant = TenantService.create_tenant(args.name, is_from_dashboard=True, session=db.session())
 
         tenant_was_created.send(tenant)
@@ -138,7 +136,6 @@ class EnterpriseWorkspaceMember(Resource):
     )
     @model_validate(WorkspaceMemberPayload)
     def post(self, args: WorkspaceMemberPayload):
-
         try:
             role = TenantAccountRole(args.role)
         except ValueError:

--- a/api/controllers/inner_api/workspace/workspace.py
+++ b/api/controllers/inner_api/workspace/workspace.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 
 from controllers.common.schema import register_schema_models
-from controllers.console.wraps import setup_required
+from controllers.console.wraps import model_validate, setup_required
 from controllers.inner_api import inner_api_ns
 from controllers.inner_api.wraps import enterprise_inner_api_only
 from events.tenant_event import tenant_was_created
@@ -54,8 +54,8 @@ class EnterpriseWorkspace(Resource):
             404: "Owner account not found or service not available",
         }
     )
-    def post(self):
-        args = WorkspaceCreatePayload.model_validate(inner_api_ns.payload or {})
+    @model_validate(WorkspaceCreatePayload)
+    def post(self, args: WorkspaceCreatePayload):
 
         account = db.session.scalar(select(Account).where(Account.email == args.owner_email).limit(1))
         if account is None:
@@ -97,8 +97,8 @@ class EnterpriseWorkspaceNoOwnerEmail(Resource):
             404: "Service not available",
         }
     )
-    def post(self):
-        args = WorkspaceOwnerlessPayload.model_validate(inner_api_ns.payload or {})
+    @model_validate(WorkspaceOwnerlessPayload)
+    def post(self, args: WorkspaceOwnerlessPayload):
 
         tenant = TenantService.create_tenant(args.name, is_from_dashboard=True, session=db.session())
 
@@ -136,8 +136,8 @@ class EnterpriseWorkspaceMember(Resource):
             404: "Workspace or account not found",
         }
     )
-    def post(self):
-        args = WorkspaceMemberPayload.model_validate(inner_api_ns.payload or {})
+    @model_validate(WorkspaceMemberPayload)
+    def post(self, args: WorkspaceMemberPayload):
 
         try:
             role = TenantAccountRole(args.role)

--- a/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 from flask import Flask
+from flask_restx import Resource
 from pydantic import ValidationError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.exceptions import UnprocessableEntity
@@ -348,7 +349,9 @@ class TestModelValidateDecorator:
             (EnterpriseWorkspaceMember, "/enterprise/workspace/member"),
         ],
     )
-    def test_invalid_body_is_rejected_before_the_handler_runs(self, app: Flask, api_cls, route: str):
+    def test_invalid_body_is_rejected_before_the_handler_runs(
+        self, app: Flask, api_cls: type[Resource], route: str
+    ) -> None:
         api_instance = api_cls()
 
         with (

--- a/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
@@ -338,14 +338,22 @@ class TestEnterpriseWorkspaceMember:
 
 
 class TestModelValidateDecorator:
-    """The handler tests unwrap the view, so this is what covers the decorator itself."""
+    """The handler tests unwrap the view, so this is what covers the decorators themselves."""
 
-    def test_invalid_body_is_rejected_before_the_handler_runs(self, app: Flask):
-        api_instance = EnterpriseWorkspace()
+    @pytest.mark.parametrize(
+        ("api_cls", "route"),
+        [
+            (EnterpriseWorkspace, "/enterprise/workspace"),
+            (EnterpriseWorkspaceNoOwnerEmail, "/enterprise/workspace/ownerless"),
+            (EnterpriseWorkspaceMember, "/enterprise/workspace/member"),
+        ],
+    )
+    def test_invalid_body_is_rejected_before_the_handler_runs(self, app: Flask, api_cls, route: str):
+        api_instance = api_cls()
 
         with (
             config_overrides_context(INNER_API=True, INNER_API_KEY="inner-key"),
-            app.test_request_context(json={}, headers={"X-Inner-Api-Key": "inner-key"}),
+            app.test_request_context(route, method="POST", json={}, headers={"X-Inner-Api-Key": "inner-key"}),
             patch("controllers.console.wraps._is_setup_completed", return_value=True),
             patch("controllers.inner_api.workspace.workspace.TenantService") as tenant_service,
         ):
@@ -353,4 +361,4 @@ class TestModelValidateDecorator:
                 api_instance.post()
 
         assert exc_info.value.code == 422
-        tenant_service.create_owner_tenant.assert_not_called()
+        tenant_service.assert_not_called()

--- a/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/inner_api/workspace/test_workspace.py
@@ -14,6 +14,7 @@ import pytest
 from flask import Flask
 from pydantic import ValidationError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from werkzeug.exceptions import UnprocessableEntity
 
 from controllers.inner_api.workspace.workspace import (
     EnterpriseWorkspace,
@@ -29,6 +30,7 @@ from services.account_service import (
     EnterpriseWorkspaceMemberAccountNotFoundError,
     EnterpriseWorkspaceMemberWorkspaceNotFoundError,
 )
+from tests.unit_tests.config_override import config_overrides_context
 
 
 @pytest.fixture
@@ -145,10 +147,9 @@ class TestEnterpriseWorkspace:
 
         # Act — unwrap to bypass auth/setup decorators (tested in test_auth_wraps.py)
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {"name": "My Workspace", "owner_email": "owner@example.com"}
-                result = unwrapped_post(api_instance)
+        payload = {"name": "My Workspace", "owner_email": "owner@example.com"}
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceCreatePayload.model_validate(payload))
 
         # Assert
         assert result["message"] == "enterprise workspace created."
@@ -168,10 +169,9 @@ class TestEnterpriseWorkspace:
         """Test that post() returns 404 when the owner account does not exist"""
         # Act
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {"name": "My Workspace", "owner_email": "missing@example.com"}
-                result = unwrapped_post(api_instance)
+        payload = {"name": "My Workspace", "owner_email": "missing@example.com"}
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceCreatePayload.model_validate(payload))
 
         # Assert
         assert result == ({"message": "owner account not found."}, 404)
@@ -214,10 +214,9 @@ class TestEnterpriseWorkspaceNoOwnerEmail:
 
         # Act — unwrap to bypass auth/setup decorators (tested in test_auth_wraps.py)
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {"name": "My Workspace"}
-                result = unwrapped_post(api_instance)
+        payload = {"name": "My Workspace"}
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceOwnerlessPayload.model_validate(payload))
 
         # Assert
         assert result["message"] == "enterprise workspace created."
@@ -251,16 +250,15 @@ class TestEnterpriseWorkspaceMember:
         mock_tenant_svc.join_enterprise_workspace_member.return_value = membership
 
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {
-                    "workspace_id": "workspace-id",
-                    "account_id": "account-id",
-                    "email": "member@example.com",
-                    "role": "normal",
-                    "operator_account_id": "operator-id",
-                }
-                result = unwrapped_post(api_instance)
+        payload = {
+            "workspace_id": "workspace-id",
+            "account_id": "account-id",
+            "email": "member@example.com",
+            "role": "normal",
+            "operator_account_id": "operator-id",
+        }
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceMemberPayload.model_validate(payload))
 
         assert result["message"] == "enterprise workspace member joined."
         assert result["member"] == {
@@ -281,15 +279,14 @@ class TestEnterpriseWorkspaceMember:
         mock_tenant_svc.join_enterprise_workspace_member.side_effect = EnterpriseWorkspaceMemberWorkspaceNotFoundError
 
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {
-                    "workspace_id": "missing-workspace",
-                    "account_id": "account-id",
-                    "email": "member@example.com",
-                    "role": "normal",
-                }
-                result = unwrapped_post(api_instance)
+        payload = {
+            "workspace_id": "missing-workspace",
+            "account_id": "account-id",
+            "email": "member@example.com",
+            "role": "normal",
+        }
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceMemberPayload.model_validate(payload))
 
         assert result == ({"message": "workspace not found."}, 404)
         mock_tenant_svc.join_enterprise_workspace_member.assert_called_once()
@@ -299,15 +296,14 @@ class TestEnterpriseWorkspaceMember:
         mock_tenant_svc.join_enterprise_workspace_member.side_effect = EnterpriseWorkspaceMemberAccountNotFoundError
 
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {
-                    "workspace_id": "workspace-id",
-                    "account_id": "missing-account",
-                    "email": "member@example.com",
-                    "role": "normal",
-                }
-                result = unwrapped_post(api_instance)
+        payload = {
+            "workspace_id": "workspace-id",
+            "account_id": "missing-account",
+            "email": "member@example.com",
+            "role": "normal",
+        }
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceMemberPayload.model_validate(payload))
 
         assert result == ({"message": "account not found."}, 404)
         mock_tenant_svc.join_enterprise_workspace_member.assert_called_once()
@@ -315,29 +311,46 @@ class TestEnterpriseWorkspaceMember:
     @pytest.mark.usefixtures("database_session")
     def test_post_rejects_owner_role(self, api_instance, app: Flask):
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {
-                    "workspace_id": "workspace-id",
-                    "account_id": "account-id",
-                    "email": "member@example.com",
-                    "role": "owner",
-                }
-                result = unwrapped_post(api_instance)
+        payload = {
+            "workspace_id": "workspace-id",
+            "account_id": "account-id",
+            "email": "member@example.com",
+            "role": "owner",
+        }
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceMemberPayload.model_validate(payload))
 
         assert result == ({"message": "cannot join workspace as owner."}, 400)
 
     @pytest.mark.usefixtures("database_session")
     def test_post_rejects_invalid_role(self, api_instance, app: Flask):
         unwrapped_post = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.workspace.workspace.inner_api_ns") as mock_ns:
-                mock_ns.payload = {
-                    "workspace_id": "workspace-id",
-                    "account_id": "account-id",
-                    "email": "member@example.com",
-                    "role": "not-a-role",
-                }
-                result = unwrapped_post(api_instance)
+        payload = {
+            "workspace_id": "workspace-id",
+            "account_id": "account-id",
+            "email": "member@example.com",
+            "role": "not-a-role",
+        }
+        with app.test_request_context(json=payload):
+            result = unwrapped_post(api_instance, WorkspaceMemberPayload.model_validate(payload))
 
         assert result == ({"message": "invalid workspace member role."}, 400)
+
+
+class TestModelValidateDecorator:
+    """The handler tests unwrap the view, so this is what covers the decorator itself."""
+
+    def test_invalid_body_is_rejected_before_the_handler_runs(self, app: Flask):
+        api_instance = EnterpriseWorkspace()
+
+        with (
+            config_overrides_context(INNER_API=True, INNER_API_KEY="inner-key"),
+            app.test_request_context(json={}, headers={"X-Inner-Api-Key": "inner-key"}),
+            patch("controllers.console.wraps._is_setup_completed", return_value=True),
+            patch("controllers.inner_api.workspace.workspace.TenantService") as tenant_service,
+        ):
+            with pytest.raises(UnprocessableEntity) as exc_info:
+                api_instance.post()
+
+        assert exc_info.value.code == 422
+        tenant_service.create_owner_tenant.assert_not_called()


### PR DESCRIPTION
## Summary

part of #36659

Moves the three inline parses in `inner_api/workspace/workspace.py` onto the `@model_validate` decorator — `EnterpriseWorkspace.post`, `EnterpriseWorkspaceNoOwnerEmail.post` and `EnterpriseWorkspaceMember.post`. Same change as #41374, #41490, #41491, #41500, #41501 and #41539.

Nothing else in `inner_api` this round: `agent/{llm,tools,files}.py` and `knowledge/retrieval.py` raise custom `*HttpError(400)` from a local `except ValidationError`, and `app/dsl.py:110` returns its own `{"code": "invalid_workflow_id"}, 400` — converting those would change documented error contracts rather than just move the parse.

## How did you test it?

- `pytest tests/unit_tests/controllers/inner_api/` — **155 passed**, against 152 on `main`; the three extra are the parametrized decorator test added here
- `ruff check` / `ruff format --check` — clean; `pyrefly check` — 0 diagnostics
- The three handler test classes patched `inner_api_ns` to supply the payload; they now put it in the request context and pass the validated model where the decorator injects it. Eight call sites, all in `test_workspace.py`, verified by handler identity
- Added a bound-method test for the decorators themselves, parametrized over all three handlers and sent as POST so the decorator reads the JSON body these endpoints actually use. Every other test in the file unwraps the view and builds the model by hand, so without it the decorators would ship unexercised. Verified by mutation: dropping any one of the three fails exactly one case
- Runtime signature check on all three wrapped handlers

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.
