### PR TITLE
feat(trace): migrate langfuse provider to v4 OTel-native ingestion

### DIFF
--- a/api/providers/trace/trace-langfuse/pyproject.toml
+++ b/api/providers/trace/trace-langfuse/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dify-trace-langfuse"
 version = "0.0.1"
 dependencies = [
-    "langfuse>=4.2.0,<5.0.0",
+    "langfuse>=4.14.2,<5.0.0",
 ]
 description = "Dify ops tracing provider (Langfuse)."
 

--- a/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/entities/langfuse_trace_entity.py
+++ b/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/entities/langfuse_trace_entity.py
@@ -101,6 +101,14 @@ class LangfuseTrace(BaseModel):
         description="You can make a trace public to share it via a public link. This allows others to view the trace "
         "without needing to log in or be members of your Langfuse project.",
     )
+    start_time: datetime | None = Field(
+        default=None,
+        description="The time at which the traced execution started. Used as the root observation start time.",
+    )
+    end_time: datetime | None = Field(
+        default=None,
+        description="The time at which the traced execution ended. Used as the root observation end time.",
+    )
 
     @field_validator("input", "output")
     @classmethod

--- a/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
@@ -1,21 +1,22 @@
+import hashlib
+import json
 import logging
 import os
+import re
+import threading
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import override
+from typing import Any, override
 
-import httpx
-from langfuse import __version__ as langfuse_version
-from langfuse.api import (
-    CreateGenerationBody,
-    CreateSpanBody,
-    IngestionEvent_GenerationCreate,
-    IngestionEvent_SpanCreate,
-    IngestionEvent_TraceCreate,
-    LangfuseAPI,
-    TraceBody,
-)
-from langfuse.api.commons.types.usage import Usage
+from langfuse import Langfuse, LangfuseOtelSpanAttributes
+from langfuse import LangfuseGeneration as SdkGenerationSpan
+from langfuse import LangfuseSpan as SdkSpan
+from opentelemetry import trace as otel_trace_api
+from opentelemetry.context import Context
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from sqlalchemy.orm import sessionmaker
 
 from core.ops.base_trace_instance import BaseTraceInstance
@@ -30,7 +31,6 @@ from core.ops.entities.trace_entity import (
     TraceTaskName,
     WorkflowTraceInfo,
 )
-from core.ops.utils import filter_none_values
 from core.repositories import DifyCoreRepositoryFactory
 from dify_trace_langfuse.config import LangfuseConfig
 from dify_trace_langfuse.entities.langfuse_trace_entity import (
@@ -48,6 +48,127 @@ from models.enums import MessageStatus
 
 logger = logging.getLogger(__name__)
 
+_HEX_32 = re.compile(r"^[0-9a-f]{32}$")
+
+_tracer_providers: dict[str, TracerProvider] = {}
+_tracer_providers_lock = threading.Lock()
+
+
+class _SeededIdGenerator(RandomIdGenerator):
+    """Random OTel id generator that can be seeded once per thread.
+
+    OTel offers no way to assign a chosen trace/span id at span creation, but the
+    v4 events model derives observation and trace identity from OTel ids. Seeding
+    the next generated id lets the writers below keep Dify's deterministic ids
+    (message_id, workflow_run_id, node_execution_id) so observations upsert and
+    link consistently across separate trace tasks.
+    """
+
+    def __init__(self) -> None:
+        self._seeds = threading.local()
+
+    def seed_next(self, *, trace_id: int | None = None, span_id: int | None = None) -> None:
+        if trace_id is not None:
+            self._seeds.trace_id = trace_id
+        if span_id is not None:
+            self._seeds.span_id = span_id
+
+    @override
+    def generate_trace_id(self) -> int:
+        seeded = getattr(self._seeds, "trace_id", None)
+        if seeded is not None:
+            self._seeds.trace_id = None
+            return seeded
+        return super().generate_trace_id()
+
+    @override
+    def generate_span_id(self) -> int:
+        seeded = getattr(self._seeds, "span_id", None)
+        if seeded is not None:
+            self._seeds.span_id = None
+            return seeded
+        return super().generate_span_id()
+
+
+def _tracer_provider_for(public_key: str) -> TracerProvider:
+    """Get or create the isolated TracerProvider for a Langfuse project.
+
+    Isolated: the langfuse SDK would otherwise attach its span processor to the
+    global OTel TracerProvider and siphon every Flask/Celery/SQLAlchemy span into
+    the tenant's Langfuse project (see langfuse upgrade guide v2 -> v3).
+
+    Shared per public key and never shut down here: LangfuseResourceManager is a
+    singleton keyed by public_key that binds to the first provider it sees and
+    ignores any provider passed later, so a fresh provider per instance would be
+    dead weight and shutting one down would silently drop all subsequent spans
+    for that project. The SDK's atexit hook handles final shutdown.
+    """
+    with _tracer_providers_lock:
+        provider = _tracer_providers.get(public_key)
+        if provider is None:
+            provider = TracerProvider(
+                resource=Resource.create({"service.name": "dify-langfuse-app-trace"}),
+                id_generator=_SeededIdGenerator(),
+            )
+            _tracer_providers[public_key] = provider
+        return provider
+
+
+def _deterministic_trace_id(seed: str) -> str:
+    normalized = seed.replace("-", "").lower()
+    if _HEX_32.match(normalized):
+        return normalized
+    return hashlib.sha256(seed.encode("utf-8")).digest()[:16].hex()
+
+
+def _deterministic_span_id(seed: str) -> str:
+    normalized = seed.replace("-", "").lower()
+    if _HEX_32.match(normalized):
+        return normalized[:16]
+    return hashlib.sha256(seed.encode("utf-8")).digest()[:8].hex()
+
+
+def _root_span_id(trace_id_hex: str) -> str:
+    return hashlib.sha256(f"root:{trace_id_hex}".encode()).digest()[:8].hex()
+
+
+def _to_ns(moment: datetime) -> int:
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return int(moment.timestamp() * 1_000_000_000)
+
+
+def _json_str(value: Any) -> str:
+    return json.dumps(value, default=str)
+
+
+def _span_level(level: LevelEnum | None) -> Any:
+    return level.value if level is not None else None
+
+
+def _usage_details(usage: GenerationUsage | None) -> dict[str, int] | None:
+    if usage is None:
+        return None
+    details = {
+        "input": usage.input if usage.input is not None else usage.promptTokens,
+        "output": usage.output if usage.output is not None else usage.completionTokens,
+        "total": usage.total,
+    }
+    filtered = {key: value for key, value in details.items() if value is not None}
+    return filtered or None
+
+
+def _cost_details(usage: GenerationUsage | None) -> dict[str, float] | None:
+    if usage is None:
+        return None
+    details = {
+        "input": usage.inputCost,
+        "output": usage.outputCost,
+        "total": usage.totalCost,
+    }
+    filtered = {key: value for key, value in details.items() if value is not None}
+    return filtered or None
+
 
 class LangFuseDataTrace(BaseTraceInstance):
     def __init__(
@@ -56,28 +177,29 @@ class LangFuseDataTrace(BaseTraceInstance):
     ):
         super().__init__(langfuse_config)
         timeout = int(os.environ.get("LANGFUSE_TIMEOUT", 5))
-        self._http_client: httpx.Client | None = httpx.Client(timeout=timeout)
-        self.langfuse_client = LangfuseAPI(
-            base_url=langfuse_config.host,
-            username=langfuse_config.public_key,
-            password=langfuse_config.secret_key,
-            x_langfuse_sdk_name="python",
-            x_langfuse_sdk_version=langfuse_version,
-            x_langfuse_public_key=langfuse_config.public_key,
+        self._tracer_provider: TracerProvider | None = _tracer_provider_for(langfuse_config.public_key)
+        self.langfuse_client = Langfuse(
+            public_key=langfuse_config.public_key,
+            secret_key=langfuse_config.secret_key,
+            host=langfuse_config.host,
             timeout=timeout,
-            httpx_client=self._http_client,
+            tracer_provider=self._tracer_provider,
         )
         self.file_base_url = os.getenv("FILES_URL", "http://127.0.0.1:5001")
 
     def close(self) -> None:
-        client = getattr(self, "_http_client", None)
-        if client is None:
+        """Flush pending spans.
+
+        The TracerProvider is shared by every instance for the same public key
+        (see _tracer_provider_for), so it must never be shut down here. Idempotent.
+        """
+        provider = getattr(self, "_tracer_provider", None)
+        if provider is None:
             return
-        self._http_client = None
         try:
-            client.close()
+            provider.force_flush()
         except Exception:
-            logger.debug("Failed to close Langfuse HTTP client", exc_info=True)
+            logger.debug("Failed to flush Langfuse TracerProvider", exc_info=True)
 
     def __del__(self) -> None:
         self.close()
@@ -102,23 +224,32 @@ class LangFuseDataTrace(BaseTraceInstance):
 
     @override
     def trace(self, trace_info: BaseTraceInfo):
-        match trace_info:
-            case WorkflowTraceInfo():
-                self.workflow_trace(trace_info)
-            case MessageTraceInfo():
-                self.message_trace(trace_info)
-            case ModerationTraceInfo():
-                self.moderation_trace(trace_info)
-            case SuggestedQuestionTraceInfo():
-                self.suggested_question_trace(trace_info)
-            case DatasetRetrievalTraceInfo():
-                self.dataset_retrieval_trace(trace_info)
-            case ToolTraceInfo():
-                self.tool_trace(trace_info)
-            case GenerateNameTraceInfo():
-                self.generate_name_trace(trace_info)
-            case _:
-                pass
+        try:
+            match trace_info:
+                case WorkflowTraceInfo():
+                    self.workflow_trace(trace_info)
+                case MessageTraceInfo():
+                    self.message_trace(trace_info)
+                case ModerationTraceInfo():
+                    self.moderation_trace(trace_info)
+                case SuggestedQuestionTraceInfo():
+                    self.suggested_question_trace(trace_info)
+                case DatasetRetrievalTraceInfo():
+                    self.dataset_retrieval_trace(trace_info)
+                case ToolTraceInfo():
+                    self.tool_trace(trace_info)
+                case GenerateNameTraceInfo():
+                    self.generate_name_trace(trace_info)
+                case _:
+                    pass
+        finally:
+            self._flush()
+
+    def _flush(self) -> None:
+        try:
+            self.langfuse_client.flush()
+        except Exception:
+            logger.debug("Failed to flush Langfuse spans", exc_info=True)
 
     def workflow_trace(self, trace_info: WorkflowTraceInfo):
         trace_id = trace_info.trace_id or trace_info.workflow_run_id
@@ -139,6 +270,8 @@ class LangFuseDataTrace(BaseTraceInstance):
                 session_id=trace_info.conversation_id,
                 tags=["message", "workflow"],
                 version=trace_info.workflow_run_version,
+                start_time=trace_info.start_time,
+                end_time=trace_info.end_time,
             )
             self.add_trace(langfuse_trace_data=trace_data)
             workflow_span_data = LangfuseSpan(
@@ -165,6 +298,8 @@ class LangFuseDataTrace(BaseTraceInstance):
                 session_id=trace_info.conversation_id,
                 tags=["workflow"],
                 version=trace_info.workflow_run_version,
+                start_time=trace_info.start_time,
+                end_time=trace_info.end_time,
             )
             self.add_trace(langfuse_trace_data=trace_data)
 
@@ -334,6 +469,8 @@ class LangFuseDataTrace(BaseTraceInstance):
             version=None,
             release=None,
             public=None,
+            start_time=trace_info.start_time,
+            end_time=trace_info.end_time,
         )
         self.add_trace(langfuse_trace_data=trace_data)
 
@@ -451,6 +588,8 @@ class LangFuseDataTrace(BaseTraceInstance):
             user_id=trace_info.tenant_id,
             metadata=trace_info.metadata,
             session_id=trace_info.conversation_id,
+            start_time=trace_info.start_time,
+            end_time=trace_info.end_time,
         )
 
         self.add_trace(langfuse_trace_data=name_generation_trace_data)
@@ -466,124 +605,161 @@ class LangFuseDataTrace(BaseTraceInstance):
         )
         self.add_span(langfuse_span_data=name_generation_span_data)
 
-    def _make_event_id(self) -> str:
-        return str(uuid.uuid4())
+    def _seed_ids(self, *, trace_id: int | None = None, span_id: int | None = None) -> None:
+        provider = self._tracer_provider
+        id_generator = provider.id_generator if provider is not None else None
+        if isinstance(id_generator, _SeededIdGenerator):
+            id_generator.seed_next(trace_id=trace_id, span_id=span_id)
 
-    def _now_iso(self) -> str:
-        return datetime.now(UTC).isoformat()
+    def _backdated_otel_span(self, *, name: str, start_time: datetime, context: Context):
+        # client._otel_tracer is the only tracer whose spans pass the SDK's export
+        # filter (scope "langfuse-sdk" + matching public_key), and the raw OTel
+        # start_span is the only API accepting a historical start_time
+        # (https://github.com/langfuse/langfuse/issues/9404).
+        return self.langfuse_client._otel_tracer.start_span(
+            name=name,
+            context=context,
+            start_time=_to_ns(start_time),
+        )
+
+    def _parent_context(self, trace_id_hex: str, parent_span_id_hex: str) -> Context:
+        parent = NonRecordingSpan(
+            SpanContext(
+                trace_id=int(trace_id_hex, 16),
+                span_id=int(parent_span_id_hex, 16),
+                is_remote=False,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            )
+        )
+        return otel_trace_api.set_span_in_context(parent, Context())
+
+    def _trace_attributes(self, data: LangfuseTrace) -> dict[str, Any]:
+        attributes: dict[str, Any] = {}
+        if data.name:
+            attributes[LangfuseOtelSpanAttributes.TRACE_NAME] = str(data.name)
+        if data.user_id:
+            attributes[LangfuseOtelSpanAttributes.TRACE_USER_ID] = data.user_id
+        if data.session_id:
+            attributes[LangfuseOtelSpanAttributes.TRACE_SESSION_ID] = data.session_id
+        if data.tags:
+            attributes[LangfuseOtelSpanAttributes.TRACE_TAGS] = [str(tag) for tag in data.tags]
+        if data.public is not None:
+            attributes[LangfuseOtelSpanAttributes.TRACE_PUBLIC] = data.public
+        if data.version:
+            attributes[LangfuseOtelSpanAttributes.VERSION] = data.version
+        if data.release:
+            attributes[LangfuseOtelSpanAttributes.RELEASE] = data.release
+        if data.input is not None:
+            attributes[LangfuseOtelSpanAttributes.TRACE_INPUT] = _json_str(data.input)
+        if data.output is not None:
+            attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT] = _json_str(data.output)
+        for key, value in (data.metadata or {}).items():
+            attributes[f"{LangfuseOtelSpanAttributes.TRACE_METADATA}.{key}"] = (
+                value if isinstance(value, str) else _json_str(value)
+            )
+        return attributes
 
     def add_trace(self, langfuse_trace_data: LangfuseTrace | None = None):
-        data = filter_none_values(langfuse_trace_data.model_dump()) if langfuse_trace_data else {}
+        data = langfuse_trace_data or LangfuseTrace()
         try:
-            body = TraceBody(
-                id=data.get("id"),
-                name=data.get("name"),
-                user_id=data.get("user_id"),
-                input=data.get("input"),
-                output=data.get("output"),
-                metadata=data.get("metadata"),
-                session_id=data.get("session_id"),
-                version=data.get("version"),
-                release=data.get("release"),
-                tags=data.get("tags"),
-                public=data.get("public"),
+            trace_id_hex = _deterministic_trace_id(data.id or uuid.uuid4().hex)
+            start_time = data.start_time or datetime.now(UTC)
+            end_time = data.end_time or start_time
+            self._seed_ids(
+                trace_id=int(trace_id_hex, 16),
+                span_id=int(_root_span_id(trace_id_hex), 16),
             )
-            event = IngestionEvent_TraceCreate(
-                body=body,
-                id=self._make_event_id(),
-                timestamp=self._now_iso(),
+            otel_span = self._backdated_otel_span(
+                name=str(data.name) if data.name else "trace",
+                start_time=start_time,
+                context=Context(),
             )
-            self.langfuse_client.ingestion.batch(batch=[event])
+            for key, value in self._trace_attributes(data).items():
+                otel_span.set_attribute(key, value)
+            root_span = SdkSpan(
+                otel_span=otel_span,
+                langfuse_client=self.langfuse_client,
+                input=data.input,
+                output=data.output,
+                metadata=data.metadata,
+            )
+            root_span.end(end_time=_to_ns(end_time))
             logger.debug("LangFuse Trace created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create trace: {str(e)}")
 
     def add_span(self, langfuse_span_data: LangfuseSpan | None = None):
-        data = filter_none_values(langfuse_span_data.model_dump()) if langfuse_span_data else {}
+        data = langfuse_span_data or LangfuseSpan()
         try:
-            body = CreateSpanBody(
-                id=data.get("id"),
-                trace_id=data.get("trace_id"),
-                name=data.get("name"),
-                start_time=data.get("start_time"),
-                end_time=data.get("end_time"),
-                input=data.get("input"),
-                output=data.get("output"),
-                metadata=data.get("metadata"),
-                level=data.get("level"),
-                status_message=data.get("status_message"),
-                parent_observation_id=data.get("parent_observation_id"),
-                version=data.get("version"),
+            trace_id_hex = _deterministic_trace_id(data.trace_id or data.id or uuid.uuid4().hex)
+            parent_span_id_hex = (
+                _deterministic_span_id(data.parent_observation_id)
+                if data.parent_observation_id
+                else _root_span_id(trace_id_hex)
             )
-            event = IngestionEvent_SpanCreate(
-                body=body,
-                id=self._make_event_id(),
-                timestamp=self._now_iso(),
+            if data.id:
+                self._seed_ids(span_id=int(_deterministic_span_id(data.id), 16))
+            start_time = data.start_time or datetime.now(UTC)
+            otel_span = self._backdated_otel_span(
+                name=str(data.name) if data.name else "span",
+                start_time=start_time,
+                context=self._parent_context(trace_id_hex, parent_span_id_hex),
             )
-            self.langfuse_client.ingestion.batch(batch=[event])
+            span = SdkSpan(
+                otel_span=otel_span,
+                langfuse_client=self.langfuse_client,
+                input=data.input,
+                output=data.output,
+                metadata=data.metadata,
+                version=data.version,
+                level=_span_level(data.level),
+                status_message=data.status_message,
+            )
+            span.end(end_time=_to_ns(data.end_time or start_time))
             logger.debug("LangFuse Span created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create span: {str(e)}")
 
-    def update_span(self, span, langfuse_span_data: LangfuseSpan | None = None):
-        format_span_data = filter_none_values(langfuse_span_data.model_dump()) if langfuse_span_data else {}
-
-        span.end(**format_span_data)
-
     def add_generation(self, langfuse_generation_data: LangfuseGeneration | None = None):
-        data = filter_none_values(langfuse_generation_data.model_dump()) if langfuse_generation_data else {}
+        data = langfuse_generation_data or LangfuseGeneration()
         try:
-            usage_data = data.pop("usage", None)
-            usage = None
-            if usage_data:
-                usage = Usage(
-                    input=usage_data.get("input", 0) or 0,
-                    output=usage_data.get("output", 0) or 0,
-                    total=usage_data.get("total", 0) or 0,
-                    unit=usage_data.get("unit"),
-                    input_cost=usage_data.get("inputCost"),
-                    output_cost=usage_data.get("outputCost"),
-                    total_cost=usage_data.get("totalCost"),
-                )
-
-            body = CreateGenerationBody(
-                id=data.get("id"),
-                trace_id=data.get("trace_id"),
-                name=data.get("name"),
-                start_time=data.get("start_time"),
-                end_time=data.get("end_time"),
-                model=data.get("model"),
-                model_parameters=data.get("model_parameters"),
-                input=data.get("input"),
-                output=data.get("output"),
-                usage=usage,
-                metadata=data.get("metadata"),
-                level=data.get("level"),
-                status_message=data.get("status_message"),
-                parent_observation_id=data.get("parent_observation_id"),
-                version=data.get("version"),
-                completion_start_time=data.get("completion_start_time"),
+            trace_id_hex = _deterministic_trace_id(data.trace_id or data.id or uuid.uuid4().hex)
+            parent_span_id_hex = (
+                _deterministic_span_id(data.parent_observation_id)
+                if data.parent_observation_id
+                else _root_span_id(trace_id_hex)
             )
-            event = IngestionEvent_GenerationCreate(
-                body=body,
-                id=self._make_event_id(),
-                timestamp=self._now_iso(),
+            if data.id:
+                self._seed_ids(span_id=int(_deterministic_span_id(data.id), 16))
+            start_time = data.start_time or datetime.now(UTC)
+            otel_span = self._backdated_otel_span(
+                name=str(data.name) if data.name else "generation",
+                start_time=start_time,
+                context=self._parent_context(trace_id_hex, parent_span_id_hex),
             )
-            self.langfuse_client.ingestion.batch(batch=[event])
+            generation = SdkGenerationSpan(
+                otel_span=otel_span,
+                langfuse_client=self.langfuse_client,
+                input=data.input,
+                output=data.output,
+                metadata=data.metadata,
+                version=data.version,
+                level=_span_level(data.level),
+                status_message=data.status_message,
+                completion_start_time=data.completion_start_time,
+                model=data.model,
+                model_parameters=data.model_parameters,
+                usage_details=_usage_details(data.usage),
+                cost_details=_cost_details(data.usage),
+            )
+            generation.end(end_time=_to_ns(data.end_time or start_time))
             logger.debug("LangFuse Generation created successfully")
         except Exception as e:
             raise ValueError(f"LangFuse Failed to create generation: {str(e)}")
 
-    def update_generation(self, generation, langfuse_generation_data: LangfuseGeneration | None = None):
-        format_generation_data = (
-            filter_none_values(langfuse_generation_data.model_dump()) if langfuse_generation_data else {}
-        )
-
-        generation.end(**format_generation_data)
-
     def api_check(self):
         try:
-            projects = self.langfuse_client.projects.get()
+            projects = self.langfuse_client.api.projects.get()
         except Exception as e:
             logger.debug("LangFuse API check failed", exc_info=True)
             raise ValueError(f"LangFuse API check failed: {str(e)}")
@@ -593,7 +769,7 @@ class LangFuseDataTrace(BaseTraceInstance):
 
     def get_project_key(self):
         try:
-            projects = self.langfuse_client.projects.get()
+            projects = self.langfuse_client.api.projects.get()
             return projects.data[0].id
         except Exception as e:
             logger.debug("LangFuse get project key failed", exc_info=True)

--- a/api/providers/trace/trace-langfuse/tests/unit_tests/langfuse_trace/test_langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/tests/unit_tests/langfuse_trace/test_langfuse_trace.py
@@ -1,6 +1,7 @@
 """Unit tests for Langfuse trace translation with real SQLite-backed lookups."""
 
 import collections
+import hashlib
 import logging
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -10,13 +11,21 @@ from unittest.mock import MagicMock
 import pytest
 from dify_trace_langfuse.config import LangfuseConfig
 from dify_trace_langfuse.entities.langfuse_trace_entity import (
+    GenerationUsage,
     LangfuseGeneration,
     LangfuseSpan,
     LangfuseTrace,
     LevelEnum,
     UnitEnum,
 )
-from dify_trace_langfuse.langfuse_trace import LangFuseDataTrace
+from dify_trace_langfuse.langfuse_trace import (
+    LangFuseDataTrace,
+    _deterministic_span_id,
+    _deterministic_trace_id,
+    _root_span_id,
+    _to_ns,
+)
+from opentelemetry import trace as otel_trace_api
 from sqlalchemy.orm import Session
 
 from core.ops.entities.trace_entity import (
@@ -47,31 +56,69 @@ def langfuse_config():
 def trace_instance(langfuse_config, monkeypatch: pytest.MonkeyPatch):
     # Mock Langfuse client to avoid network calls
     mock_client = MagicMock()
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", lambda **kwargs: mock_client)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: mock_client)
 
     instance = LangFuseDataTrace(langfuse_config)
     return instance
 
 
 def test_init(langfuse_config, monkeypatch: pytest.MonkeyPatch):
+    from opentelemetry.sdk.trace import TracerProvider
+
     mock_langfuse = MagicMock()
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", mock_langfuse)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", mock_langfuse)
     monkeypatch.setenv("FILES_URL", "http://test.url")
 
     instance = LangFuseDataTrace(langfuse_config)
 
     mock_langfuse.assert_called_once()
     kwargs = mock_langfuse.call_args.kwargs
-    assert kwargs["username"] == langfuse_config.public_key
-    assert kwargs["password"] == langfuse_config.secret_key
-    assert kwargs["base_url"] == langfuse_config.host
+    assert kwargs["public_key"] == langfuse_config.public_key
+    assert kwargs["secret_key"] == langfuse_config.secret_key
+    assert kwargs["host"] == langfuse_config.host
+    assert isinstance(kwargs["tracer_provider"], TracerProvider)
+    assert kwargs["tracer_provider"] is instance._tracer_provider
     assert instance.file_base_url == "http://test.url"
 
 
-def test_same_public_key_uses_independent_api_clients(monkeypatch: pytest.MonkeyPatch):
+def test_init_passes_isolated_tracer_provider_to_langfuse(langfuse_config, monkeypatch: pytest.MonkeyPatch):
+    """Regression test for the langfuse SDK global-provider side effect.
+
+    Without an explicit ``tracer_provider=`` kwarg, the Langfuse SDK attaches a
+    ``LangfuseSpanProcessor`` to the *global* OpenTelemetry TracerProvider —
+    siphoning every Flask / Celery / SQLAlchemy span in the process into the
+    tenant's Langfuse project. See the langfuse v2 -> v3 upgrade guide and
+    GitHub discussion langfuse/langfuse#9136.
+    """
+    from opentelemetry.sdk.trace import TracerProvider
+
+    captured: dict[str, object] = {}
+
+    def fake_langfuse(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", fake_langfuse)
+
+    instance = LangFuseDataTrace(langfuse_config)
+
+    assert "tracer_provider" in captured, (
+        "Langfuse() must receive an explicit tracer_provider=; without it the "
+        "SDK attaches its SpanProcessor to the global OTEL TracerProvider."
+    )
+
+    passed_provider = captured["tracer_provider"]
+    assert isinstance(passed_provider, TracerProvider)
+    assert passed_provider is instance._tracer_provider
+
+    global_provider = otel_trace_api.get_tracer_provider()
+    assert passed_provider is not global_provider
+
+
+def test_same_public_key_uses_per_instance_clients(monkeypatch: pytest.MonkeyPatch):
     clients = [MagicMock(), MagicMock()]
     create_client = MagicMock(side_effect=clients)
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", create_client)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", create_client)
 
     first = LangFuseDataTrace(
         LangfuseConfig(public_key="shared", secret_key="secret-a", host="https://tenant-a.example")
@@ -83,7 +130,7 @@ def test_same_public_key_uses_independent_api_clients(monkeypatch: pytest.Monkey
     assert first.langfuse_client is clients[0]
     assert second.langfuse_client is clients[1]
     assert [
-        (call.kwargs["base_url"], call.kwargs["username"], call.kwargs["password"])
+        (call.kwargs["host"], call.kwargs["public_key"], call.kwargs["secret_key"])
         for call in create_client.call_args_list
     ] == [
         ("https://tenant-a.example", "shared", "secret-a"),
@@ -91,16 +138,30 @@ def test_same_public_key_uses_independent_api_clients(monkeypatch: pytest.Monkey
     ]
 
 
-def test_close_is_idempotent(langfuse_config, monkeypatch: pytest.MonkeyPatch):
-    http_client = MagicMock()
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.httpx.Client", lambda **kwargs: http_client)
-    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.LangfuseAPI", MagicMock())
+def test_close_flushes_without_shutting_down_shared_provider(langfuse_config, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: MagicMock())
 
     instance = LangFuseDataTrace(langfuse_config)
+    provider_force_flush = MagicMock()
+    provider_shutdown = MagicMock()
+    monkeypatch.setattr(instance._tracer_provider, "force_flush", provider_force_flush)
+    monkeypatch.setattr(instance._tracer_provider, "shutdown", provider_shutdown)
+
     instance.close()
     instance.close()
 
-    http_client.close.assert_called_once()
+    assert provider_force_flush.call_count == 2
+    provider_shutdown.assert_not_called()
+    assert instance._tracer_provider is not None
+
+
+def test_instances_share_tracer_provider_per_public_key(langfuse_config, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: MagicMock())
+
+    first = LangFuseDataTrace(langfuse_config)
+    second = LangFuseDataTrace(langfuse_config)
+
+    assert first._tracer_provider is second._tracer_provider
 
 
 def test_trace_dispatch(trace_instance, monkeypatch: pytest.MonkeyPatch):
@@ -583,72 +644,194 @@ def test_generate_name_trace(trace_instance):
     assert span_data.trace_id == "conv-1"
 
 
-def test_add_trace_success(trace_instance):
-    data = LangfuseTrace(id="t1", name="trace")
-    trace_instance.add_trace(data)
-    trace_instance.langfuse_client.ingestion.batch.assert_called_once()
+@pytest.fixture
+def wrapper_mocks(monkeypatch: pytest.MonkeyPatch):
+    span_cls = MagicMock()
+    generation_cls = MagicMock()
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.SdkSpan", span_cls)
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.SdkGenerationSpan", generation_cls)
+    return SimpleNamespace(span=span_cls, generation=generation_cls)
 
 
-def test_add_trace_error(trace_instance):
-    trace_instance.langfuse_client.ingestion.batch.side_effect = Exception("error")
+TRACE_UUID = "7f9c2ba4-e88f-11eb-9a03-0242ac130003"
+PARENT_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_deterministic_id_helpers():
+    assert _deterministic_trace_id(TRACE_UUID) == TRACE_UUID.replace("-", "")
+    assert _deterministic_trace_id("trace-1") == hashlib.sha256(b"trace-1").digest()[:16].hex()
+    assert _deterministic_span_id(PARENT_UUID) == PARENT_UUID.replace("-", "")[:16]
+    assert _deterministic_span_id("run-1") == hashlib.sha256(b"run-1").digest()[:8].hex()
+    assert len(_root_span_id("a" * 32)) == 16
+
+
+def test_to_ns_treats_naive_datetimes_as_utc():
+    naive = datetime(2024, 1, 1, 0, 0, 0)
+    aware = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+    assert _to_ns(naive) == _to_ns(aware)
+
+
+def test_add_trace_creates_backdated_root_span(trace_instance, wrapper_mocks):
+    start = _dt()
+    end = _dt() + timedelta(seconds=2)
+    data = LangfuseTrace(
+        id=TRACE_UUID,
+        name="msg",
+        user_id="user-1",
+        session_id="conv-1",
+        tags=["message"],
+        metadata={"app_id": "app-1"},
+        start_time=start,
+        end_time=end,
+    )
+
+    trace_instance.add_trace(langfuse_trace_data=data)
+
+    start_span = trace_instance.langfuse_client._otel_tracer.start_span
+    start_span.assert_called_once()
+    kwargs = start_span.call_args.kwargs
+    assert kwargs["name"] == "msg"
+    assert kwargs["start_time"] == _to_ns(start)
+
+    otel_span = start_span.return_value
+    attribute_keys = {call.args[0] for call in otel_span.set_attribute.call_args_list}
+    assert "langfuse.trace.name" in attribute_keys
+    assert "user.id" in attribute_keys
+    assert "session.id" in attribute_keys
+    assert "langfuse.trace.tags" in attribute_keys
+    assert "langfuse.trace.metadata.app_id" in attribute_keys
+
+    wrapper_mocks.span.assert_called_once()
+    assert wrapper_mocks.span.call_args.kwargs["otel_span"] is otel_span
+    wrapper_mocks.span.return_value.end.assert_called_once_with(end_time=_to_ns(end))
+
+
+def test_add_trace_seeds_deterministic_trace_and_root_span_ids(trace_instance, wrapper_mocks):
+    data = LangfuseTrace(id=TRACE_UUID)
+
+    trace_instance.add_trace(langfuse_trace_data=data)
+
+    trace_id_hex = TRACE_UUID.replace("-", "")
+    id_generator = trace_instance._tracer_provider.id_generator
+    assert id_generator.generate_trace_id() == int(trace_id_hex, 16)
+    assert id_generator.generate_span_id() == int(_root_span_id(trace_id_hex), 16)
+
+
+def test_add_trace_error(trace_instance, wrapper_mocks):
+    trace_instance.langfuse_client._otel_tracer.start_span.side_effect = Exception("error")
     data = LangfuseTrace(id="t1", name="trace")
     with pytest.raises(ValueError, match="LangFuse Failed to create trace: error"):
         trace_instance.add_trace(data)
 
 
-def test_add_span_success(trace_instance):
-    data = LangfuseSpan(id="s1", name="span", trace_id="t1")
-    trace_instance.add_span(data)
-    trace_instance.langfuse_client.ingestion.batch.assert_called_once()
+def test_add_span_links_trace_and_explicit_parent(trace_instance, wrapper_mocks):
+    data = LangfuseSpan(id="node-1", name="node", trace_id=TRACE_UUID, parent_observation_id=PARENT_UUID)
+
+    trace_instance.add_span(langfuse_span_data=data)
+
+    start_span = trace_instance.langfuse_client._otel_tracer.start_span
+    context = start_span.call_args.kwargs["context"]
+    parent_context = otel_trace_api.get_current_span(context).get_span_context()
+    assert parent_context.trace_id == int(TRACE_UUID.replace("-", ""), 16)
+    assert parent_context.span_id == int(PARENT_UUID.replace("-", "")[:16], 16)
 
 
-def test_add_span_error(trace_instance):
-    trace_instance.langfuse_client.ingestion.batch.side_effect = Exception("error")
+def test_add_span_defaults_parent_to_trace_root(trace_instance, wrapper_mocks):
+    data = LangfuseSpan(id="s1", name="span", trace_id="trace-1")
+
+    trace_instance.add_span(langfuse_span_data=data)
+
+    trace_id_hex = _deterministic_trace_id("trace-1")
+    start_span = trace_instance.langfuse_client._otel_tracer.start_span
+    context = start_span.call_args.kwargs["context"]
+    parent_context = otel_trace_api.get_current_span(context).get_span_context()
+    assert parent_context.trace_id == int(trace_id_hex, 16)
+    assert parent_context.span_id == int(_root_span_id(trace_id_hex), 16)
+
+
+def test_add_span_backdates_and_ends_wrapper(trace_instance, wrapper_mocks):
+    start = _dt()
+    end = _dt() + timedelta(seconds=1)
+    data = LangfuseSpan(
+        id="s1",
+        name="span",
+        trace_id="t1",
+        start_time=start,
+        end_time=end,
+        level=LevelEnum.ERROR,
+        status_message="boom",
+    )
+
+    trace_instance.add_span(langfuse_span_data=data)
+
+    start_span = trace_instance.langfuse_client._otel_tracer.start_span
+    assert start_span.call_args.kwargs["start_time"] == _to_ns(start)
+    span_kwargs = wrapper_mocks.span.call_args.kwargs
+    assert span_kwargs["level"] == "ERROR"
+    assert span_kwargs["status_message"] == "boom"
+    wrapper_mocks.span.return_value.end.assert_called_once_with(end_time=_to_ns(end))
+
+
+def test_add_span_error(trace_instance, wrapper_mocks):
+    trace_instance.langfuse_client._otel_tracer.start_span.side_effect = Exception("error")
     data = LangfuseSpan(id="s1", name="span", trace_id="t1")
     with pytest.raises(ValueError, match="LangFuse Failed to create span: error"):
         trace_instance.add_span(data)
 
 
-def test_update_span(trace_instance):
-    span = MagicMock()
-    data = LangfuseSpan(id="s1", name="span", trace_id="t1")
-    trace_instance.update_span(span, data)
-    span.end.assert_called_once()
+def test_add_generation_maps_generation_fields(trace_instance, wrapper_mocks):
+    start = _dt()
+    end = _dt() + timedelta(seconds=1)
+    completion_start = start + timedelta(milliseconds=100)
+    data = LangfuseGeneration(
+        id="g1",
+        name="llm",
+        trace_id="t1",
+        model="gpt-4",
+        start_time=start,
+        end_time=end,
+        completion_start_time=completion_start,
+        usage=GenerationUsage(input=10, output=20, total=30, totalCost=0.5),
+    )
+
+    trace_instance.add_generation(langfuse_generation_data=data)
+
+    generation_kwargs = wrapper_mocks.generation.call_args.kwargs
+    assert generation_kwargs["model"] == "gpt-4"
+    assert generation_kwargs["usage_details"] == {"input": 10, "output": 20, "total": 30}
+    assert generation_kwargs["cost_details"] == {"total": 0.5}
+    assert generation_kwargs["completion_start_time"] == completion_start
+    wrapper_mocks.generation.return_value.end.assert_called_once_with(end_time=_to_ns(end))
 
 
-def test_add_generation_success(trace_instance):
-    data = LangfuseGeneration(id="g1", name="gen", trace_id="t1")
-    trace_instance.add_generation(data)
-    trace_instance.langfuse_client.ingestion.batch.assert_called_once()
-
-
-def test_add_generation_error(trace_instance):
-    trace_instance.langfuse_client.ingestion.batch.side_effect = Exception("error")
+def test_add_generation_error(trace_instance, wrapper_mocks):
+    trace_instance.langfuse_client._otel_tracer.start_span.side_effect = Exception("error")
     data = LangfuseGeneration(id="g1", name="gen", trace_id="t1")
     with pytest.raises(ValueError, match="LangFuse Failed to create generation: error"):
         trace_instance.add_generation(data)
 
 
-def test_update_generation(trace_instance):
-    gen = MagicMock()
-    data = LangfuseGeneration(id="g1", name="gen", trace_id="t1")
-    trace_instance.update_generation(gen, data)
-    gen.end.assert_called_once()
+def test_trace_dispatch_flushes_client(trace_instance, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(trace_instance, "message_trace", MagicMock())
+
+    trace_instance.trace(MagicMock(spec=MessageTraceInfo))
+
+    trace_instance.langfuse_client.flush.assert_called_once()
 
 
 def test_api_check_success(trace_instance):
-    trace_instance.langfuse_client.projects.get.return_value = MagicMock(data=[MagicMock()])
+    trace_instance.langfuse_client.api.projects.get.return_value = MagicMock(data=[MagicMock()])
     assert trace_instance.api_check() is True
 
 
 def test_api_check_rejects_empty_project_list(trace_instance):
-    trace_instance.langfuse_client.projects.get.return_value = MagicMock(data=[])
+    trace_instance.langfuse_client.api.projects.get.return_value = MagicMock(data=[])
     with pytest.raises(ValueError, match="no project found for the provided credentials"):
         trace_instance.api_check()
 
 
 def test_api_check_error(trace_instance):
-    trace_instance.langfuse_client.projects.get.side_effect = Exception("fail")
+    trace_instance.langfuse_client.api.projects.get.side_effect = Exception("fail")
     with pytest.raises(ValueError, match="LangFuse API check failed: fail"):
         trace_instance.api_check()
 
@@ -656,12 +839,12 @@ def test_api_check_error(trace_instance):
 def test_get_project_key_success(trace_instance):
     mock_data = MagicMock()
     mock_data.id = "proj-1"
-    trace_instance.langfuse_client.projects.get.return_value = MagicMock(data=[mock_data])
+    trace_instance.langfuse_client.api.projects.get.return_value = MagicMock(data=[mock_data])
     assert trace_instance.get_project_key() == "proj-1"
 
 
 def test_get_project_key_error(trace_instance):
-    trace_instance.langfuse_client.projects.get.side_effect = Exception("fail")
+    trace_instance.langfuse_client.api.projects.get.side_effect = Exception("fail")
     with pytest.raises(ValueError, match="LangFuse get project key failed: fail"):
         trace_instance.get_project_key()
 

--- a/api/providers/trace/trace-langfuse/tests/unit_tests/test_langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/tests/unit_tests/test_langfuse_trace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Tests for Langfuse TTFT reporting support."""
 
 from datetime import datetime, timedelta
@@ -13,7 +15,7 @@ from graphon.enums import BuiltinNodeTypes
 
 
 def _create_trace_instance() -> LangFuseDataTrace:
-    with patch("dify_trace_langfuse.langfuse_trace.LangfuseAPI", autospec=True):
+    with patch("dify_trace_langfuse.langfuse_trace.Langfuse", autospec=True):
         return LangFuseDataTrace(
             LangfuseConfig(
                 public_key="public-key",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -1886,7 +1886,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "langfuse", specifier = ">=4.2.0,<5.0.0" }]
+requires-dist = [{ name = "langfuse", specifier = ">=4.14.2,<5.0.0" }]
 
 [[package]]
 name = "dify-trace-langsmith"
@@ -3700,7 +3700,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langfuse"
-version = "4.2.0"
+version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -3710,11 +3710,12 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pydantic" },
+    { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/9c/b912a00ffae92ff9955cdd9b74fb839be58f631d4329ae2a8a0376f697f2/langfuse-4.2.0.tar.gz", hash = "sha256:d0bd26d5065cf6a59d7d1093b08d8910e2458dc3da7ed8ccec160db114c18342", size = 275582, upload-time = "2026-04-10T11:55:25.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/51/ed5569bc2dcc8fe767e3b315207a7511ad23d00d811f02bbf0d6f80bf906/langfuse-4.15.1.tar.gz", hash = "sha256:70cb47529a6ba78383c4f2a197eb3d3ab9d39529c9e6b568d392150c1f40dbb9", size = 432353, upload-time = "2026-08-28T07:55:15.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/0a/b84e3e68a690ccfe6d64953c572772c685fcb0915b7f2ee3a87c22e388ab/langfuse-4.2.0-py3-none-any.whl", hash = "sha256:bfd760bf10fd0228f297f6369436620f76d16b589de46393d65706b27e4e4082", size = 475449, upload-time = "2026-04-10T11:55:23.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f9/7160bafcfe9797575359a9e77f810cf26f57f55a7c5ceda602fd9e353ddf/langfuse-4.15.1-py3-none-any.whl", hash = "sha256:795760693a62895157b6f5d6c80f1ad524fd12380995f06f82fc3a627b88c8d4", size = 789929, upload-time = "2026-08-28T07:55:14.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #41542

Langfuse v4 rejects the legacy `POST /api/public/ingestion` trace/span/generation events (per-event `400` inside the `207` envelope) in its default/end-state `events_only` write mode, so every Dify trace is silently dropped against a v4 server unless it stays in the transitional `dual` mode (double ClickHouse writes). This PR rewrites the Langfuse trace provider onto the SDK v4 OpenTelemetry write path (`/api/public/otel`), the only supported v4 ingestion path:

- **Backdated spans**: Dify logs completed executions after the fact; the SDK has no public API for historical start times (langfuse/langfuse#9404), so spans are created through the SDK's tracer with explicit nanosecond `start_time`/`end_time` and wrapped in the SDK's public `LangfuseSpan`/`LangfuseGeneration` wrappers for attribute serialization.
- **Deterministic ids**: one `TracerProvider` per `public_key` with a seeded OTel id generator keeps trace/observation ids derived from Dify's message/workflow-run/node-execution ids, preserving upsert and parent-link semantics across separate trace tasks. The provider is shared and never shut down per-instance because the SDK's `LangfuseResourceManager` is a per-key singleton that binds to the first provider it sees.
- **Trace-level fields** (`name`, `user_id`, `session_id`, `tags`, metadata, input/output) map to `langfuse.trace.*` attributes on a root observation; `GenerationUsage` maps to `usage_details`/`cost_details`.
- **Delivery guarantees**: `trace()` flushes after each dispatch, matching the previous synchronous semantics under Celery.
- `LangfuseTrace` entity gains `start_time`/`end_time`; dead `update_span`/`update_generation` removed; langfuse SDK floor raised to 4.14.2 (the surface this was written and verified against).

Verified end-to-end against self-hosted Langfuse 4.18.0 running `events_only` + `direct`: all seven trace flows (message, generate_conversation_name, dataset_retrieval, suggested_question, moderation, workflow with nested node observations, tool) arrive with correct hierarchy, deterministic ids, backdated timestamps, usage and cost details — confirmed in the `events_full` ClickHouse store. Also verified backward-compatible against a `dual`-mode server.

## Screenshots

N/A (backend tracing change). Storage-level verification against Langfuse 4.18 `events_only`:

| observation | type | parent | notes |
| ----------- | ---- | ------ | ----- |
| message | SPAN | — (root) | trace attrs: name/user.id/session.id/tags |
| llm | GENERATION | message root | model, usage_details {input, output, total}, cost_details |
| workflow / Start / LLM / End | SPAN/GENERATION | nested | node observations under the workflow root |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Cursor