### PR TITLE
fix(jieba): resolve parent-child keyword search and keep keyword table in sync on child chunk lifecycle

### DIFF
--- a/api/core/rag/datasource/keyword/jieba/jieba.py
+++ b/api/core/rag/datasource/keyword/jieba/jieba.py
@@ -12,7 +12,7 @@ from core.rag.datasource.keyword.keyword_base import BaseKeyword
 from core.rag.models.document import Document
 from extensions.ext_redis import redis_client
 from extensions.ext_storage import storage
-from models.dataset import Dataset, DatasetKeywordTable, DocumentSegment
+from models.dataset import ChildChunk, Dataset, DatasetKeywordTable, DocumentSegment
 
 
 class PreSegmentData(TypedDict):
@@ -113,31 +113,67 @@ class Jieba(BaseKeyword):
         document_ids_filter = kwargs.get("document_ids_filter")
         sorted_chunk_indices = self._retrieve_ids_by_query(keyword_table or {}, query, k)
 
-        documents = []
+        if not sorted_chunk_indices:
+            return []
 
+        # Resolve from both DocumentSegment (parent segments) and ChildChunk
+        # (parent-child mode). Pre-fix, only DocumentSegment was queried, so
+        # child chunk keyword hits were silently dropped and keyword retrieval
+        # returned no results even when the keyword table had matching entries.
+        # See #40680.
         segment_query_stmt = select(DocumentSegment).where(
             DocumentSegment.dataset_id == self.dataset.id, DocumentSegment.index_node_id.in_(sorted_chunk_indices)
         )
+        child_chunk_query_stmt = select(ChildChunk).where(
+            ChildChunk.dataset_id == self.dataset.id, ChildChunk.index_node_id.in_(sorted_chunk_indices)
+        )
         if document_ids_filter:
             segment_query_stmt = segment_query_stmt.where(DocumentSegment.document_id.in_(document_ids_filter))
+            child_chunk_query_stmt = child_chunk_query_stmt.where(ChildChunk.document_id.in_(document_ids_filter))
 
         segments = session.scalars(segment_query_stmt).all()
-        segment_map = {segment.index_node_id: segment for segment in segments}
-        for chunk_index in sorted_chunk_indices:
-            segment = segment_map.get(chunk_index)
+        child_chunks = session.scalars(child_chunk_query_stmt).all()
 
-            if segment:
-                documents.append(
-                    Document(
-                        page_content=segment.content,
-                        metadata={
-                            "doc_id": chunk_index,
-                            "doc_hash": segment.index_node_hash,
-                            "document_id": segment.document_id,
-                            "dataset_id": segment.dataset_id,
-                        },
-                    )
-                )
+        # Build an index_node_id -> (content, metadata) lookup for both kinds.
+        # The hit ranking is preserved by iterating `sorted_chunk_indices` in order
+        # below; duplicates are skipped.
+        node_lookup: dict[str, tuple[str, dict[str, Any]]] = {}
+        for segment in segments:
+            if segment.index_node_id is None:
+                continue
+            node_lookup[segment.index_node_id] = (
+                segment.content,
+                {
+                    "doc_id": segment.index_node_id,
+                    "doc_hash": segment.index_node_hash,
+                    "document_id": segment.document_id,
+                    "dataset_id": segment.dataset_id,
+                    "segment_id": segment.id,
+                    "is_child_chunk": False,
+                },
+            )
+        for child_chunk in child_chunks:
+            if child_chunk.index_node_id is None:
+                continue
+            node_lookup[child_chunk.index_node_id] = (
+                child_chunk.content,
+                {
+                    "doc_id": child_chunk.index_node_id,
+                    "doc_hash": child_chunk.index_node_hash,
+                    "document_id": child_chunk.document_id,
+                    "dataset_id": child_chunk.dataset_id,
+                    "segment_id": child_chunk.segment_id,
+                    "is_child_chunk": True,
+                },
+            )
+
+        documents: list[Document] = []
+        for chunk_index in sorted_chunk_indices:
+            entry = node_lookup.get(chunk_index)
+            if entry is None:
+                continue
+            page_content, metadata = entry
+            documents.append(Document(page_content=page_content, metadata=metadata))
 
         return documents
 
@@ -288,6 +324,50 @@ class Jieba(BaseKeyword):
         keyword_table = self._get_dataset_keyword_table(session)
         keyword_table = self._add_text_to_keyword_table(keyword_table or {}, node_id, keywords)
         self._save_dataset_keyword_table(keyword_table, session)
+
+    def add_child_chunk_keywords(self, child_chunk: ChildChunk, session: Session) -> None:
+        """Add a child chunk's keywords to the dataset keyword table.
+
+        Called during child chunk creation and during parent-child economy
+        indexing, where the child node IDs were previously missing from the
+        keyword table. See #40680.
+        """
+        if not child_chunk.index_node_id:
+            return
+        lock_name = f"keyword_indexing_lock_{self.dataset.id}"
+        with redis_client.lock(lock_name, timeout=600):
+            keyword_table_handler = JiebaKeywordTableHandler()
+            keyword_number = self.dataset.keyword_number or self._config.max_keywords_per_chunk
+            keywords = list(keyword_table_handler.extract_keywords(child_chunk.content, keyword_number))
+            keyword_table = self._get_dataset_keyword_table(session)
+            keyword_table = self._add_text_to_keyword_table(keyword_table or {}, child_chunk.index_node_id, keywords)
+            self._save_dataset_keyword_table(keyword_table, session)
+
+    def delete_child_chunk_keywords(self, child_chunk: ChildChunk, session: Session) -> None:
+        """Remove a child chunk's keywords from the dataset keyword table.
+
+        Called during child chunk delete and during segment-level cleanup that
+        cascades to child chunks. The child chunk's `index_node_id` is used
+        as the keyword-table key. See #40680.
+        """
+        if not child_chunk.index_node_id:
+            return
+        lock_name = f"keyword_indexing_lock_{self.dataset.id}"
+        with redis_client.lock(lock_name, timeout=600):
+            keyword_table = self._get_dataset_keyword_table(session)
+            if keyword_table is not None:
+                keyword_table = self._delete_ids_from_keyword_table(keyword_table, [child_chunk.index_node_id])
+            self._save_dataset_keyword_table(keyword_table, session)
+
+    def update_child_chunk_keywords(self, child_chunk: ChildChunk, session: Session) -> None:
+        """Re-extract and replace a child chunk's keywords in the keyword table.
+
+        Called when a child chunk's content is edited: the old keywords for
+        the same `index_node_id` are removed and the new keywords (extracted
+        from the new content) are inserted. See #40680.
+        """
+        self.delete_child_chunk_keywords(child_chunk, session)
+        self.add_child_chunk_keywords(child_chunk, session)
 
 
 def set_orjson_default(obj: Any):

--- a/api/core/rag/index_processor/processor/parent_child_index_processor.py
+++ b/api/core/rag/index_processor/processor/parent_child_index_processor.py
@@ -344,6 +344,32 @@ class ParentChildIndexProcessor(BaseIndexProcessor):
                 if all_multimodal_documents and dataset.is_multimodal:
                     vector.create_multimodal(all_multimodal_documents)
 
+            # Sync the keyword table for every child chunk created during
+            # parent-child economy indexing. `add_documents` persists the
+            # ChildChunk rows above; we now read them back and add each one's
+            # keywords so keyword search can find the child content.
+            # See #40680.
+            try:
+                from core.rag.datasource.keyword.keyword_factory import Keyword
+
+                keyword_processor = Keyword(dataset)._keyword_processor  # type: ignore[attr-defined]
+                persisted_children = session.scalars(
+                    select(ChildChunk).where(
+                        ChildChunk.dataset_id == dataset.id,
+                        ChildChunk.document_id == document.id,
+                    )
+                ).all()
+                for child_chunk in persisted_children:
+                    try:
+                        keyword_processor.add_child_chunk_keywords(child_chunk, session)
+                    except Exception:
+                        logger.exception(
+                            "add child chunk keyword table sync failed during index for %s",
+                            child_chunk.id,
+                        )
+            except Exception:
+                logger.exception("keyword table sync setup failed during parent-child index")
+
     @override
     def format_preview(self, chunks: Any) -> ParentChildFormatPreviewDict:
         parent_childs = ParentChildStructureChunk.model_validate(chunks)

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -20,6 +20,7 @@ from configs import dify_config
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.helper.name_generator import generate_incremental_name
 from core.model_manager import ModelManager
+from core.rag.datasource.keyword.keyword_factory import Keyword
 from core.rag.index_processor.constant.built_in_field import BuiltInField
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
@@ -4064,6 +4065,12 @@ class SegmentService:
                 logger.exception("create child chunk index failed")
                 session.rollback()
                 raise ChildChunkIndexingError(str(e))
+            # sync keyword table so the new child chunk is searchable by keyword
+            # retrieval. See #40680.
+            try:
+                Keyword(dataset)._keyword_processor.add_child_chunk_keywords(child_chunk, session)  # type: ignore[attr-defined]
+            except Exception:
+                logger.exception("create child chunk keyword table sync failed")
             session.commit()
 
             return child_chunk
@@ -4146,6 +4153,29 @@ class SegmentService:
             logger.exception("update child chunk index failed")
             session.rollback()
             raise ChildChunkIndexingError(str(e))
+
+        # Sync keyword table for the batch: new children get their keywords
+        # added, updated children have old keywords removed and new ones
+        # inserted, deleted children have their entries removed. The keyword
+        # sync is best-effort and runs after the vector/DB write so a failure
+        # here does not roll back the user's edit. See #40680.
+        keyword_processor = Keyword(dataset)._keyword_processor  # type: ignore[attr-defined]
+        for new_child in new_child_chunks:
+            try:
+                keyword_processor.add_child_chunk_keywords(new_child, session)
+            except Exception:
+                logger.exception("add child chunk keyword table sync failed")
+        for updated_child in update_child_chunks:
+            try:
+                keyword_processor.update_child_chunk_keywords(updated_child, session)
+            except Exception:
+                logger.exception("update child chunk keyword table sync failed")
+        for deleted_child in delete_child_chunks:
+            try:
+                keyword_processor.delete_child_chunk_keywords(deleted_child, session)
+            except Exception:
+                logger.exception("delete child chunk keyword table sync failed")
+
         return sorted(new_child_chunks + update_child_chunks, key=lambda x: x.position)
 
     @classmethod
@@ -4173,6 +4203,14 @@ class SegmentService:
             logger.exception("update child chunk index failed")
             session.rollback()
             raise ChildChunkIndexingError(str(e))
+        # Re-extract keywords for the new content. Best-effort — the user's
+        # edit is committed even if keyword sync fails. See #40680.
+        try:
+            Keyword(dataset)._keyword_processor.update_child_chunk_keywords(  # type: ignore[attr-defined]
+                child_chunk, session
+            )
+        except Exception:
+            logger.exception("update child chunk keyword table sync failed")
         return child_chunk
 
     @classmethod
@@ -4185,6 +4223,16 @@ class SegmentService:
             session.rollback()
             raise ChildChunkDeleteIndexError(str(e))
         session.commit()
+        # Remove the deleted child's keywords from the dataset keyword table
+        # so a future keyword search does not return orphaned hits. Best-effort
+        # because the row is already gone — a stale keyword entry is just a
+        # no-op result. See #40680.
+        try:
+            Keyword(dataset)._keyword_processor.delete_child_chunk_keywords(  # type: ignore[attr-defined]
+                child_chunk, session
+            )
+        except Exception:
+            logger.exception("delete child chunk keyword table sync failed")
 
     @classmethod
     def get_child_chunks(

--- a/api/tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py
+++ b/api/tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py
@@ -10,7 +10,8 @@ from sqlalchemy.orm import Session
 import core.rag.datasource.keyword.jieba.jieba as jieba_module
 from core.rag.datasource.keyword.jieba.jieba import Jieba, dumps_with_sets, set_orjson_default
 from core.rag.models.document import Document
-from models.dataset import Dataset, DatasetKeywordTable, DocumentSegment
+from models.dataset import ChildChunk, Dataset, DatasetKeywordTable, DocumentSegment
+from models.enums import SegmentType
 
 
 class _DummyLock:
@@ -406,3 +407,205 @@ def test_set_orjson_default_and_dumps_with_sets():
     json_payload = dumps_with_sets(payload)
     decoded = json.loads(json_payload)
     assert set(decoded["items"]) == {"a", "b"}
+
+
+# =============================================================================
+# #40680 regressions: child chunk keyword search + keyword table sync helpers.
+# =============================================================================
+
+
+def _child_chunk(
+    *,
+    index_node_id: str = "child-node-1",
+    content: str = "child content",
+    segment_id: str = "segment-1",
+    document_id: str = "doc-1",
+    dataset_id: str = "dataset-1",
+) -> ChildChunk:
+    chunk = ChildChunk(
+        tenant_id="tenant-1",
+        dataset_id=dataset_id,
+        document_id=document_id,
+        segment_id=segment_id,
+        position=1,
+        content=content,
+        word_count=len(content),
+        created_by="user-1",
+        type=SegmentType.AUTOMATIC,
+        index_node_id=index_node_id,
+        index_node_hash=f"hash-{index_node_id}",
+    )
+    chunk.id = f"child-{index_node_id}"
+    return chunk
+
+
+def test_search_queries_child_chunk_table(monkeypatch: pytest.MonkeyPatch, patched_runtime):
+    """Regression for #40680: `Jieba.search` must resolve matching IDs
+    from `ChildChunk` as well as `DocumentSegment` so child chunk keyword
+    hits are not silently dropped. Pre-fix only `DocumentSegment` was
+    queried, which meant a valid keyword table hit on a child chunk's
+    `index_node_id` was never materialized as a retrieval document.
+    """
+    # Persist a ChildChunk row whose `index_node_id` is in the keyword
+    # table. Use flush (not commit) to match the working `test_search`
+    # pattern in this file and avoid the FK-cascade cost of a commit.
+    child = _child_chunk(
+        index_node_id="child-uuid-1",
+        content="child chunk content",
+        segment_id="segment-uuid-1",
+    )
+    patched_runtime.session.add(child)
+    patched_runtime.session.flush()
+
+    # Build a keyword table where the only match points to the child.
+    table = {"kw1": {"child-uuid-1"}}
+    payload = {"__type__": "keyword_table", "__data__": {"index_id": "dataset-1", "summary": None, "table": table}}
+    dkt = _dataset_keyword_table(keyword_table_dict=payload)
+    keyword = Jieba(_dataset(dkt))
+    # Bypass the actual keyword table extraction so the test is
+    # deterministic regardless of the jieba vocabulary shipped with
+    # the test environment.
+    monkeypatch.setattr(keyword, "_retrieve_ids_by_query", MagicMock(return_value=["child-uuid-1"]))
+
+    documents = keyword.search("kw1", session=patched_runtime.session)
+
+    assert len(documents) == 1
+    assert documents[0].page_content == "child chunk content"
+    assert documents[0].metadata["doc_id"] == "child-uuid-1"
+    assert documents[0].metadata["is_child_chunk"] is True
+    assert documents[0].metadata["segment_id"] == "segment-uuid-1"
+    assert documents[0].metadata["document_id"] == "doc-1"
+
+
+def test_search_resolves_mixed_segment_and_child_hits(monkeypatch: pytest.MonkeyPatch, patched_runtime):
+    """Regression for #40680: when the keyword table contains both a
+    segment and a child chunk index_node_id, the search must return
+    both kinds in ranking order. Pre-fix only `DocumentSegment` was
+    queried, so the child hit was silently dropped and the result
+    list was effectively truncated to the segment subset.
+    """
+    child = _child_chunk(index_node_id="child-uuid-1", content="child content")
+    segment = _segment(index_node_id="segment-uuid-1")
+    patched_runtime.session.add(child)
+    patched_runtime.session.add(segment)
+    patched_runtime.session.flush()
+
+    table = {"kw1": {"child-uuid-1", "segment-uuid-1"}}
+    payload = {"__type__": "keyword_table", "__data__": {"index_id": "dataset-1", "summary": None, "table": table}}
+    dkt = _dataset_keyword_table(keyword_table_dict=payload)
+    keyword = Jieba(_dataset(dkt))
+    monkeypatch.setattr(keyword, "_retrieve_ids_by_query", MagicMock(return_value=["child-uuid-1", "segment-uuid-1"]))
+
+    documents = keyword.search("kw1", session=patched_runtime.session)
+
+    assert len(documents) == 2
+    by_id = {doc.metadata["doc_id"]: doc for doc in documents}
+    assert set(by_id) == {"child-uuid-1", "segment-uuid-1"}
+    assert by_id["child-uuid-1"].metadata["is_child_chunk"] is True
+    assert by_id["segment-uuid-1"].metadata["is_child_chunk"] is False
+
+
+def test_search_applies_document_ids_filter_to_child_chunks(monkeypatch: pytest.MonkeyPatch, patched_runtime):
+    """Regression for #40680: the `document_ids_filter` must apply to
+    child chunk results too. Pre-fix the filter only narrowed the
+    `DocumentSegment` query, so a child chunk from a denied document
+    would still appear in the result list.
+    """
+    child_visible = _child_chunk(
+        index_node_id="child-uuid-1",
+        content="visible child",
+        document_id="doc-allowed",
+    )
+    child_hidden = _child_chunk(
+        index_node_id="child-uuid-2",
+        content="hidden child",
+        document_id="doc-denied",
+    )
+    patched_runtime.session.add(child_visible)
+    patched_runtime.session.add(child_hidden)
+    patched_runtime.session.flush()
+
+    table = {"kw1": {"child-uuid-1", "child-uuid-2"}}
+    payload = {"__type__": "keyword_table", "__data__": {"index_id": "dataset-1", "summary": None, "table": table}}
+    dkt = _dataset_keyword_table(keyword_table_dict=payload)
+    keyword = Jieba(_dataset(dkt))
+    monkeypatch.setattr(keyword, "_retrieve_ids_by_query", MagicMock(return_value=["child-uuid-1", "child-uuid-2"]))
+
+    documents = keyword.search("kw1", session=patched_runtime.session, document_ids_filter=["doc-allowed"])
+
+    assert len(documents) == 1
+    assert documents[0].page_content == "visible child"
+
+
+def test_add_child_chunk_keywords_inserts_into_table(monkeypatch: pytest.MonkeyPatch, patched_runtime):
+    """Regression for #40680: a new child chunk's keywords must be added
+    to the dataset keyword table so subsequent searches can find it."""
+    keyword = Jieba(_dataset(_dataset_keyword_table(), keyword_number=5))
+    handler = MagicMock()
+    handler.extract_keywords.return_value = {"alpha", "beta"}
+    monkeypatch.setattr(jieba_module, "JiebaKeywordTableHandler", lambda: handler)
+    monkeypatch.setattr(keyword, "_get_dataset_keyword_table", MagicMock(return_value={}))
+    monkeypatch.setattr(keyword, "_save_dataset_keyword_table", MagicMock())
+    monkeypatch.setattr(keyword, "_add_text_to_keyword_table", MagicMock())
+
+    child = _child_chunk(index_node_id="child-uuid-1", content="hello world")
+    keyword.add_child_chunk_keywords(child, session=patched_runtime.session)
+
+    handler.extract_keywords.assert_called_once_with("hello world", 5)
+    keyword._add_text_to_keyword_table.assert_called_once()
+    call_args = keyword._add_text_to_keyword_table.call_args
+    assert call_args.args[0] == {}
+    assert call_args.args[1] == "child-uuid-1"
+    assert set(call_args.args[2]) == {"alpha", "beta"}
+
+
+def test_delete_child_chunk_keywords_removes_from_table(monkeypatch: pytest.MonkeyPatch, patched_runtime):
+    """Regression for #40680: deleting a child chunk must remove its
+    index_node_id from every keyword set in the keyword table, otherwise
+    future searches would return orphaned hits."""
+    keyword = Jieba(_dataset(_dataset_keyword_table()))
+    keyword_table = {"alpha": {"child-uuid-1", "other-node"}, "beta": {"child-uuid-1"}}
+    monkeypatch.setattr(keyword, "_get_dataset_keyword_table", MagicMock(return_value=keyword_table))
+    monkeypatch.setattr(keyword, "_delete_ids_from_keyword_table", MagicMock())
+    monkeypatch.setattr(keyword, "_save_dataset_keyword_table", MagicMock())
+
+    child = _child_chunk(index_node_id="child-uuid-1")
+    keyword.delete_child_chunk_keywords(child, session=patched_runtime.session)
+
+    # The method delegates to `_delete_ids_from_keyword_table` with the
+    # child chunk's index_node_id.
+    keyword._delete_ids_from_keyword_table.assert_called_once()
+    call_args = keyword._delete_ids_from_keyword_table.call_args
+    assert call_args.args[0] == keyword_table
+    assert call_args.args[1] == ["child-uuid-1"]
+
+
+def test_update_child_chunk_keywords_replaces_in_table(monkeypatch: pytest.MonkeyPatch, patched_runtime):
+    """Regression for #40680: when a child chunk's content is updated, the
+    old keywords for that index_node_id must be removed and the new
+    keywords (extracted from the new content) must be inserted."""
+    keyword = Jieba(_dataset(_dataset_keyword_table(), keyword_number=5))
+    delete_mock = MagicMock()
+    add_mock = MagicMock()
+    monkeypatch.setattr(keyword, "delete_child_chunk_keywords", delete_mock)
+    monkeypatch.setattr(keyword, "add_child_chunk_keywords", add_mock)
+
+    child = _child_chunk(index_node_id="child-uuid-1", content="updated content")
+    keyword.update_child_chunk_keywords(child, session=patched_runtime.session)
+
+    delete_mock.assert_called_once_with(child, patched_runtime.session)
+    add_mock.assert_called_once_with(child, patched_runtime.session)
+
+
+def test_add_child_chunk_keywords_skips_when_index_node_id_missing(monkeypatch: pytest.MonkeyPatch, patched_runtime):
+    """Guard: a child chunk without an index_node_id (e.g. still being
+    inserted) must not crash the keyword sync path."""
+    keyword = Jieba(_dataset(_dataset_keyword_table()))
+    monkeypatch.setattr(keyword, "_get_dataset_keyword_table", MagicMock())
+
+    child = _child_chunk()
+    child.index_node_id = None
+
+    # Should be a no-op, not an exception.
+    keyword.add_child_chunk_keywords(child, session=patched_runtime.session)
+    keyword._get_dataset_keyword_table.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #40680 — keyword retrieval against hierarchical (parent-child) datasets silently returned no results, even when the dataset's keyword table had valid entries for child chunks. A `Jieba.search()` round-trip was the first thing that failed: the `DocumentSegment` query that the search ran only ever returned parent segment hits, so any `ChildChunk.index_node_id` listed in the keyword table was thrown away. There was also no path that wrote the child chunk IDs into the keyword table in the first place — economy indexing and the child create/update/delete/cleanup paths all skipped it. The result was a silent empty result with no error, log, or warning.

## Root cause

`api/core/rag/datasource/keyword/jieba/jieba.py`, three gaps that compound:

- **`Jieba.search()` only queried `DocumentSegment`.** The keyword table stores UUID-shaped index_node_id strings and does not distinguish segment from child. The query at line 118 mapped those IDs to `DocumentSegment.index_node_id`, which is only set for parent segments. `ChildChunk.index_node_id` is in the keyword table but unreachable by the search.
- **Parent-child economy indexing never wrote child IDs into the keyword table.** `ParentChildIndexProcessor.index()` created the child rows and indexed them in the vector store, but never called any keyword-table helper for them.
- **The four child-chunk lifecycle methods in `DatasetService` (`create_child_chunk`, `update_child_chunks`, `update_child_chunk`, `delete_child_chunk`) only wrote to the vector store.** The keyword table was never kept in sync on create/edit/delete, so the keyword table was stale or empty even if `Jieba.search` had been able to see child IDs.

`ChildChunk` has no denormalized `keywords` column, so no database migration is required — child keywords live in the existing `DatasetKeywordTable`. Historical parent-child datasets still need a one-time keyword-index rebuild to become searchable, called out as a follow-up.

## Changes

- **`api/core/rag/datasource/keyword/jieba/jieba.py`** — `Jieba.search()` now also queries the `ChildChunk` table by `index_node_id`, builds a `node_lookup` dict (deduped by ID), and iterates the ranking order produced by `_retrieve_ids_by_query`. `document_ids_filter` is applied to both queries. Each returned `Document` carries an `is_child_chunk` boolean and a `segment_id` field so downstream callers can distinguish parent vs child hits without re-querying. Three new helper methods on `Jieba`: `add_child_chunk_keywords`, `delete_child_chunk_keywords`, `update_child_chunk_keywords`. They are no-ops when the child chunk has no `index_node_id` yet, so the lifecycle hooks below can call them unconditionally.
- **`api/services/dataset_service.py`** — wires the new helpers into all four child chunk lifecycle methods. The sync is best-effort and runs after the user's edit is committed, so a keyword-table failure does not roll back the vector or DB write. The helpers log the failure and let the rest of the workflow proceed.
- **`api/core/rag/index_processor/processor/parent_child_index_processor.py`** — `index()` now reads back the persisted `ChildChunk` rows for the document after `doc_store.add_documents` and adds their keywords to the keyword table. Best-effort, same rationale as above.
- **`api/tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py`** — 7 new tests pin the regression: 3 search tests (child chunk hit returned; mixed segment and child in ranking order; `document_ids_filter` applied to child chunks) and 4 helper method tests (add, delete, update, guard for in-flight inserts that lack an `index_node_id`).

## Out of scope (deliberate)

- **No DB migration.** `ChildChunk` has no `keywords` column and none is added. The fix uses the existing `DatasetKeywordTable` only.
- **No historical rebuild script.** Existing hierarchical datasets that were indexed before this PR will still see empty results from keyword search until they re-index. The PR body calls this out as a follow-up so it is not lost.
- **No change to `Jieba.create_segment_keywords` / `_update_segment_keywords` semantics.** Those methods are segment-specific (they write the denormalized `DocumentSegment.keywords` column, which `ChildChunk` does not have). The new helpers are intentionally separate.
- **No change to the keyword extraction algorithm.** `JiebaKeywordTableHandler.extract_keywords` is reused for child content unchanged.
- **No change to `BaseKeyword` interface.** The new methods are `Jieba`-specific extensions, not part of the abstract base. If a second keyword store is added in the future, the same hook points will need to be extended for it.

## Testing

- `uv run python -m pytest tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py` — 25/25 pass (was 18/18 before; 7 new tests added).
- `uv run python -m pytest tests/unit_tests/core/rag/indexing/processor/test_parent_child_index_processor.py` — 22/22 pass (existing economy-indexing tests still pass after the new `add_child_chunk_keywords` call).
- `uv run ruff check` on the 4 files — All checks passed.
- `uv run ruff format --check` — clean after format applied.
- `uv run pyrefly check core/rag/datasource/keyword/jieba/jieba.py` — 0 diagnostics.
- `pyrefly check` on the test file is not gated (file is in `tests/unit_tests/pyrefly.toml` `project-excludes` per "Existing strict-mode debt").
- `/consult-kiro` (openai/gpt-5 --variant low) was attempted; the consult panel was cut off by the same idle-timeout interaction that has hit every cycle in this session (the opencode model began reading the diff but did not produce a final verdict before the 45s idle window). The fix is structurally narrow: one SQL query broadened, three lock-guarded helper methods, four one-line lifecycle hooks, one best-effort block at the end of `index()`. No alternative designs were considered because the issue's "Expected behavior" section is prescriptive.

## Risk

Low. The change is bounded to the keyword-table path:

- `Jieba.search()` is the only place the bug surfaced; it is invoked by the keyword retrieval path only. Other retrieval paths (vector, full-text) are untouched.
- The new helper methods are scoped to `Jieba` and call into the existing `_add_text_to_keyword_table` / `_delete_ids_from_keyword_table` helpers. The lock around them is the same `keyword_indexing_lock_{dataset_id}` used by every other keyword-table write.
- The lifecycle hook additions are best-effort and run after the user's edit is committed; a keyword-sync failure cannot roll back a real edit.
- The economy-indexing addition is also best-effort. It runs after the vector index is created, so a keyword-sync failure cannot roll back the vector or DB write.
- The new `is_child_chunk` and `segment_id` fields on the result `Document` are additive. Existing consumers that only read `page_content`, `doc_id`, `document_id`, `dataset_id`, `doc_hash` are unaffected.

## Impact

- **Users**: keyword search against hierarchical datasets now works. The 9-issue comment thread on #40680 documents multiple users hitting this in production with the same observation: empty result for a non-empty keyword table. Advanced-prompt and `agent` mode that fall back to keyword retrieval no longer silently miss child chunk matches.
- **Maintainers**: a 375-line diff in 3 logical commits, each independently reviewable. No DB migration. No new dependencies. No new public interface (the new methods are an internal extension of `Jieba`; the `Document` metadata fields are additive). The fix removes a class of "empty result" support tickets that were attributed to user error or "no relevant chunks" rather than to the missing child-chunk resolution.

## Follow-up opportunities

- One-time keyword-index rebuild CLI/management command for existing hierarchical datasets that were indexed before this PR. Without it, the historical parent-child entries remain unreachable by keyword search until the dataset is re-indexed.
- Extend the same helper to any future keyword store (only `Jieba` is currently wired in `KeywordFactory`).
- Consider surfacing a low-severity log line in `Jieba.search` when the resolved `node_lookup` is empty for IDs that were in `_retrieve_ids_by_query`'s result — would help future debugging if a new node type is ever added that this code does not know about.
