### PR TITLE
fix(api): clean offloaded draft variable files

### DIFF
--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, ClassVar, NotRequired, TypedDict, cast, override
 
-from sqlalchemy import Engine, delete, orm, select
+from sqlalchemy import ColumnElement, Engine, delete, orm, select
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session, sessionmaker
@@ -374,7 +374,7 @@ class WorkflowDraftVariableService:
         conv_var = conv_var_by_name.get(variable.name)
 
         if conv_var is None:
-            self._session.delete(instance=variable)
+            self.delete_variable(variable)
             self._session.flush()
             logger.warning(
                 "Conversation variable not found for draft variable, id=%s, name=%s", variable.id, variable.name
@@ -395,7 +395,7 @@ class WorkflowDraftVariableService:
             return variable
         # No execution record for this variable, delete the variable instead.
         if variable.node_execution_id is None:
-            self._session.delete(instance=variable)
+            self.delete_variable(variable)
             self._session.flush()
             logger.warning("draft variable has no node_execution_id, id=%s, name=%s", variable.id, variable.name)
             return None
@@ -408,7 +408,7 @@ class WorkflowDraftVariableService:
                 variable.name,
                 variable.node_execution_id,
             )
-            self._session.delete(instance=variable)
+            self.delete_variable(variable)
             self._session.flush()
             return None
 
@@ -437,7 +437,7 @@ class WorkflowDraftVariableService:
         # the value of the output may be `None`.
         if output_value is absent:
             # If variable not found in execution data, delete the variable
-            self._session.delete(instance=variable)
+            self.delete_variable(variable)
             self._session.flush()
             return None
         value_seg = WorkflowDraftVariable.build_segment_with_type(variable.value_type, output_value)
@@ -457,69 +457,43 @@ class WorkflowDraftVariableService:
             return self._reset_node_var_or_sys_var(workflow, variable)
 
     def delete_variable(self, variable: WorkflowDraftVariable):
-        if not variable.is_truncated():
-            self._session.delete(variable)
-            return
-
-        variable_query = (
-            select(WorkflowDraftVariable)
-            .options(
-                orm.selectinload(WorkflowDraftVariable.variable_file).selectinload(
-                    WorkflowDraftVariableFile.upload_file
-                ),
+        if variable.file_id is not None:
+            self.delete_workflow_draft_variable_file(
+                [DraftVarFileDeletion(draft_var_id=variable.id, draft_var_file_id=variable.file_id)]
             )
-            .where(WorkflowDraftVariable.id == variable.id)
-        )
-        variable_reloaded = self._session.execute(variable_query).scalars().first()
-        if variable_reloaded is None:
-            logger.warning("Associated WorkflowDraftVariable not found, draft_var_id=%s", variable.id)
-            self._session.delete(variable)
-            return
-        variable_file = variable_reloaded.variable_file
-        if variable_file is None:
-            logger.warning(
-                "Associated WorkflowDraftVariableFile not found, draft_var_id=%s, file_id=%s",
-                variable_reloaded.id,
-                variable_reloaded.file_id,
-            )
-            self._session.delete(variable)
-            return
-
-        upload_file = variable_file.upload_file
-        if upload_file is None:
-            logger.warning(
-                "Associated UploadFile not found, draft_var_id=%s, file_id=%s, upload_file_id=%s",
-                variable_reloaded.id,
-                variable_reloaded.file_id,
-                variable_file.upload_file_id,
-            )
-            self._session.delete(variable)
-            self._session.delete(variable_file)
-            return
-
-        storage.delete(upload_file.key)
-        self._session.delete(upload_file)
-        self._session.delete(upload_file)
         self._session.delete(variable)
 
     def delete_user_workflow_variables(self, app_id: str, user_id: str):
-        self._session.execute(
-            delete(WorkflowDraftVariable)
-            .where(
-                WorkflowDraftVariable.app_id == app_id,
-                WorkflowDraftVariable.user_id == user_id,
-            )
-            .execution_options(synchronize_session=False)
+        self._delete_variables(
+            WorkflowDraftVariable.app_id == app_id,
+            WorkflowDraftVariable.user_id == user_id,
         )
 
     def delete_app_workflow_variables(self, app_id: str):
+        self._delete_variables(WorkflowDraftVariable.app_id == app_id)
+
+    def _delete_variables(self, *criteria: ColumnElement[bool]) -> None:
+        file_rows = self._session.execute(
+            select(WorkflowDraftVariable.id, WorkflowDraftVariable.file_id).where(
+                *criteria,
+                WorkflowDraftVariable.file_id.is_not(None),
+            )
+        ).all()
+        self.delete_workflow_draft_variable_file(
+            [
+                DraftVarFileDeletion(draft_var_id=row.id, draft_var_file_id=row.file_id)
+                for row in file_rows
+                if row.file_id is not None
+            ]
+        )
         self._session.execute(
-            delete(WorkflowDraftVariable)
-            .where(WorkflowDraftVariable.app_id == app_id)
-            .execution_options(synchronize_session=False)
+            delete(WorkflowDraftVariable).where(*criteria).execution_options(synchronize_session=False)
         )
 
     def delete_workflow_draft_variable_file(self, deletions: list[DraftVarFileDeletion]):
+        if not deletions:
+            return
+
         variable_files_query = (
             select(WorkflowDraftVariableFile)
             .options(orm.selectinload(WorkflowDraftVariableFile.upload_file))
@@ -555,14 +529,10 @@ class WorkflowDraftVariableService:
         return self._delete_node_variables(app_id, node_id, user_id=user_id)
 
     def _delete_node_variables(self, app_id: str, node_id: str, user_id: str):
-        self._session.execute(
-            delete(WorkflowDraftVariable)
-            .where(
-                WorkflowDraftVariable.app_id == app_id,
-                WorkflowDraftVariable.node_id == node_id,
-                WorkflowDraftVariable.user_id == user_id,
-            )
-            .execution_options(synchronize_session=False)
+        self._delete_variables(
+            WorkflowDraftVariable.app_id == app_id,
+            WorkflowDraftVariable.node_id == node_id,
+            WorkflowDraftVariable.user_id == user_id,
         )
 
     def _get_conversation_id_from_draft_variable(self, app_id: str, user_id: str) -> str | None:

--- a/api/tests/unit_tests/services/test_workflow_draft_variable_cleanup.py
+++ b/api/tests/unit_tests/services/test_workflow_draft_variable_cleanup.py
@@ -1,0 +1,175 @@
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import cast
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy import Table, create_engine, func, select
+from sqlalchemy.orm import Session
+
+from extensions.storage.storage_type import StorageType
+from factories.variable_factory import build_segment
+from graphon.variables.types import SegmentType
+from libs.datetime_utils import naive_utc_now
+from models.enums import CreatorUserRole
+from models.model import UploadFile
+from models.workflow import WorkflowDraftVariable, WorkflowDraftVariableFile
+from services.workflow_draft_variable_service import WorkflowDraftVariableService
+
+
+@dataclass(frozen=True)
+class OffloadedVariable:
+    variable: WorkflowDraftVariable
+    variable_id: str
+    variable_file_id: str
+    upload_file_id: str
+    storage_key: str
+
+
+@pytest.fixture
+def sqlite_session() -> Iterator[Session]:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    for table in (UploadFile.__table__, WorkflowDraftVariableFile.__table__, WorkflowDraftVariable.__table__):
+        cast(Table, table).create(engine)
+
+    with Session(engine) as session:
+        yield session
+
+
+def _create_offloaded_variable(
+    session: Session,
+    *,
+    app_id: str,
+    user_id: str,
+    node_id: str,
+    name: str,
+) -> OffloadedVariable:
+    tenant_id = str(uuid.uuid4())
+    storage_key = f"draft-variables/{uuid.uuid4()}.json"
+    upload_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key=storage_key,
+        name="offload.json",
+        size=2,
+        extension="json",
+        mime_type="application/json",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by=user_id,
+        created_at=naive_utc_now(),
+        used=True,
+        used_by=user_id,
+        used_at=naive_utc_now(),
+    )
+    variable_file = WorkflowDraftVariableFile(
+        upload_file_id=upload_file.id,
+        value_type=SegmentType.OBJECT,
+        tenant_id=tenant_id,
+        app_id=app_id,
+        user_id=user_id,
+        size=2,
+        length=None,
+    )
+    variable = WorkflowDraftVariable.new_node_variable(
+        app_id=app_id,
+        user_id=user_id,
+        node_id=node_id,
+        name=name,
+        value=build_segment({"truncated": True}),
+        visible=True,
+        node_execution_id=str(uuid.uuid4()),
+    )
+    variable.file_id = variable_file.id
+    session.add_all([upload_file, variable_file, variable])
+    session.commit()
+    return OffloadedVariable(
+        variable=variable,
+        variable_id=variable.id,
+        variable_file_id=variable_file.id,
+        upload_file_id=upload_file.id,
+        storage_key=storage_key,
+    )
+
+
+def _row_exists(session: Session, model: type, row_id: str) -> bool:
+    return bool(session.scalar(select(func.count()).select_from(model).where(model.id == row_id)))
+
+
+@pytest.mark.parametrize("scope", ["user", "node", "app"])
+def test_bulk_deletion_cleans_only_matching_offloaded_variables(sqlite_session: Session, scope: str) -> None:
+    app_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+    node_id = "node-1"
+    target = _create_offloaded_variable(
+        sqlite_session,
+        app_id=app_id,
+        user_id=user_id,
+        node_id=node_id,
+        name="target",
+    )
+    survivor = _create_offloaded_variable(
+        sqlite_session,
+        app_id=str(uuid.uuid4()) if scope == "app" else app_id,
+        user_id=str(uuid.uuid4()) if scope == "user" else user_id,
+        node_id="node-2" if scope == "node" else node_id,
+        name="survivor",
+    )
+
+    service = WorkflowDraftVariableService(sqlite_session)
+    with patch("services.workflow_draft_variable_service.storage.delete") as delete_storage:
+        if scope == "user":
+            service.delete_user_workflow_variables(app_id, user_id)
+        elif scope == "node":
+            service.delete_node_variables(app_id, node_id, user_id)
+        else:
+            service.delete_app_workflow_variables(app_id)
+        sqlite_session.commit()
+
+    assert not _row_exists(sqlite_session, WorkflowDraftVariable, target.variable_id)
+    assert not _row_exists(sqlite_session, WorkflowDraftVariableFile, target.variable_file_id)
+    assert not _row_exists(sqlite_session, UploadFile, target.upload_file_id)
+    assert _row_exists(sqlite_session, WorkflowDraftVariable, survivor.variable_id)
+    assert _row_exists(sqlite_session, WorkflowDraftVariableFile, survivor.variable_file_id)
+    assert _row_exists(sqlite_session, UploadFile, survivor.upload_file_id)
+    delete_storage.assert_called_once_with(target.storage_key)
+
+
+def test_single_variable_deletion_cleans_offloaded_resources(sqlite_session: Session) -> None:
+    offloaded = _create_offloaded_variable(
+        sqlite_session,
+        app_id=str(uuid.uuid4()),
+        user_id=str(uuid.uuid4()),
+        node_id="node-1",
+        name="payload",
+    )
+
+    with patch("services.workflow_draft_variable_service.storage.delete") as delete_storage:
+        WorkflowDraftVariableService(sqlite_session).delete_variable(offloaded.variable)
+        sqlite_session.commit()
+
+    assert not _row_exists(sqlite_session, WorkflowDraftVariable, offloaded.variable_id)
+    assert not _row_exists(sqlite_session, WorkflowDraftVariableFile, offloaded.variable_file_id)
+    assert not _row_exists(sqlite_session, UploadFile, offloaded.upload_file_id)
+    delete_storage.assert_called_once_with(offloaded.storage_key)
+
+
+def test_reset_deletion_cleans_offloaded_resources(sqlite_session: Session) -> None:
+    offloaded = _create_offloaded_variable(
+        sqlite_session,
+        app_id=str(uuid.uuid4()),
+        user_id=str(uuid.uuid4()),
+        node_id="node-1",
+        name="payload",
+    )
+    offloaded.variable.node_execution_id = None
+
+    with patch("services.workflow_draft_variable_service.storage.delete") as delete_storage:
+        result = WorkflowDraftVariableService(sqlite_session).reset_variable(Mock(), offloaded.variable)
+        sqlite_session.commit()
+
+    assert result is None
+    assert not _row_exists(sqlite_session, WorkflowDraftVariable, offloaded.variable_id)
+    assert not _row_exists(sqlite_session, WorkflowDraftVariableFile, offloaded.variable_file_id)
+    assert not _row_exists(sqlite_session, UploadFile, offloaded.upload_file_id)
+    delete_storage.assert_called_once_with(offloaded.storage_key)


### PR DESCRIPTION
## Summary

- clean object-storage data, UploadFile rows, and WorkflowDraftVariableFile rows whenever an offloaded draft variable is deleted
- route user-, node-, app-, single-variable, and reset deletion through the same cleanup path
- preserve the existing bulk-deletion scope and cover each path with focused SQLite tests

Fixes #41545

### Root cause

Bulk deletion paths removed only WorkflowDraftVariable rows and never inspected file_id. The single-variable cleanup removed the storage object and UploadFile but left WorkflowDraftVariableFile behind. Reset branches bypassed cleanup entirely.

### Why this approach

The change reuses the service's existing offload cleanup helper for every deletion entry point, so storage and database cleanup have one implementation. Bulk selection still uses the original app, user, and node predicates, and only loads variables that have file_id set.

### Validation

- 68 related unit/controller tests passed
- Ruff format and lint passed
- response contract lint passed
- all 23 import-linter contracts passed
- production API Pyrefly passed; targeted changed-file Pyrefly passed
- full Mypy passed for 1,741 source files

### Compatibility and risk

No public API behavior or schema changes. Non-offloaded variables retain the prior delete behavior. Cleanup is limited by the same app, user, and node predicates used by each existing deletion path.

## Screenshots

| Before | After |
| ------ | ----- |
| Not applicable (backend cleanup) | Not applicable (backend cleanup) |

## Checklist

- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran make lint && make type-check (backend) and vp staged (frontend) to appease the lint gods
  - Windows has no make executable; the applicable underlying backend commands were run individually. Ruff, response-contract lint, import-linter, production Pyrefly, targeted changed-file Pyrefly, full Mypy, and 68 related tests passed. dotenv-linter only reported CRLF line endings in the unchanged .env.example files.

From Codex