### PR TITLE
refactor(workflow): migrate schedule cron input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4349,11 +4349,6 @@
       "count": 4
     }
   },
-  "web/app/components/workflow/nodes/trigger-schedule/panel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/web/app/components/workflow/nodes/trigger-schedule/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/__tests__/panel.spec.tsx
@@ -204,7 +204,12 @@ describe('TriggerSchedulePanel', () => {
 
       renderPanel('node-3', createData({ mode: 'cron' }))
 
-      fireEvent.change(screen.getByDisplayValue('0 0 * * *'), { target: { value: '*/5 * * * *' } })
+      fireEvent.change(
+        screen.getByRole('textbox', {
+          name: 'workflow.nodes.triggerSchedule.cronExpression',
+        }),
+        { target: { value: '*/5 * * * *' } },
+      )
 
       expect(handleCronExpressionChange).toHaveBeenCalledWith('*/5 * * * *')
     })
@@ -255,7 +260,11 @@ describe('TriggerSchedulePanel', () => {
           panelProps={panelProps}
         />,
       )
-      expect(screen.getByRole('textbox')).toHaveValue('')
+      expect(
+        screen.getByRole('textbox', {
+          name: 'workflow.nodes.triggerSchedule.cronExpression',
+        }),
+      ).toHaveValue('')
     })
 
     it('should render the hourly minute selector when the frequency is hourly', async () => {

--- a/web/app/components/workflow/nodes/trigger-schedule/panel.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/panel.tsx
@@ -1,10 +1,10 @@
 import type { FC } from 'react'
 import type { ScheduleTriggerNodeType } from './types'
 import type { NodePanelProps } from '@/app/components/workflow/types'
+import { Input } from '@langgenius/dify-ui/input'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import TimePicker from '@/app/components/base/date-and-time-picker/time-picker'
-import Input from '@/app/components/base/input'
 import Field from '@/app/components/workflow/nodes/_base/components/field'
 import FrequencySelector from './components/frequency-selector'
 import ModeToggle from './components/mode-toggle'
@@ -18,6 +18,7 @@ const i18nPrefix = 'nodes.triggerSchedule'
 
 const Panel: FC<NodePanelProps<ScheduleTriggerNodeType>> = ({ id, data }) => {
   const { t } = useTranslation()
+  const cronExpressionId = React.useId()
   const {
     inputs,
     setInputs,
@@ -112,12 +113,16 @@ const Panel: FC<NodePanelProps<ScheduleTriggerNodeType>> = ({ id, data }) => {
             {inputs.mode === 'cron' && (
               <div className="space-y-2">
                 <div>
-                  <label className="mb-2 block text-xs font-medium text-gray-500">
+                  <label
+                    htmlFor={cronExpressionId}
+                    className="mb-2 block text-xs font-medium text-gray-500"
+                  >
                     {t(($) => $['nodes.triggerSchedule.cronExpression'], { ns: 'workflow' })}
                   </label>
                   <Input
+                    id={cronExpressionId}
                     value={inputs.cron_expression || ''}
-                    onChange={(e) => handleCronExpressionChange(e.target.value)}
+                    onValueChange={(value) => handleCronExpressionChange(value)}
                     placeholder="0 0 * * *"
                     className="font-mono"
                   />


### PR DESCRIPTION
## Summary

- replace the legacy cron expression input with the Dify UI Input primitive
- associate the visible cron expression label with the native input
- query the control by its accessible role and name in the existing behavior tests

No visual changes are intended; the existing spacing, typography, and monospace treatment are preserved.

## Validation

- `pnpm -C web test --run app/components/workflow/nodes/trigger-schedule/__tests__/panel.spec.tsx`
- `pnpm vp check web/app/components/workflow/nodes/trigger-schedule/panel.tsx web/app/components/workflow/nodes/trigger-schedule/__tests__/panel.spec.tsx`

From Codex