### PR TITLE
refactor(workflow): migrate email subject input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3853,11 +3853,6 @@
       "count": 4
     }
   },
-  "web/app/components/workflow/nodes/human-input/components/delivery-method/email-configure-modal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/human-input/components/delivery-method/method-selector.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 2

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/__tests__/email-configure-modal.spec.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/__tests__/email-configure-modal.spec.tsx
@@ -115,9 +115,9 @@ describe('human-input/delivery-method/email-configure-modal', () => {
     )
 
     fireEvent.change(
-      screen.getByPlaceholderText(
-        'workflow.nodes.humanInput.deliveryMethod.emailConfigure.subjectPlaceholder',
-      ),
+      screen.getByRole('textbox', {
+        name: 'workflow.nodes.humanInput.deliveryMethod.emailConfigure.subject',
+      }),
       {
         target: { value: 'Budget alert' },
       },
@@ -151,9 +151,9 @@ describe('human-input/delivery-method/email-configure-modal', () => {
     )
 
     fireEvent.change(
-      screen.getByPlaceholderText(
-        'workflow.nodes.humanInput.deliveryMethod.emailConfigure.subjectPlaceholder',
-      ),
+      screen.getByRole('textbox', {
+        name: 'workflow.nodes.humanInput.deliveryMethod.emailConfigure.subject',
+      }),
       {
         target: { value: 'Subject ready' },
       },

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/email-configure-modal.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/email-configure-modal.tsx
@@ -3,13 +3,13 @@ import type { Node, NodeOutPutVar } from '@/app/components/workflow/types'
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { Input } from '@langgenius/dify-ui/input'
 import { Switch } from '@langgenius/dify-ui/switch'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiBugLine } from '@remixicon/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { memo, useCallback, useState } from 'react'
+import { memo, useCallback, useId, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import MailBodyInput from './mail-body-input'
 import Recipient from './recipient'
@@ -34,6 +34,7 @@ const EmailConfigureModal = ({
   availableNodes = [],
 }: EmailConfigureModalProps) => {
   const { t } = useTranslation()
+  const subjectId = useId()
   const { data: email } = useSuspenseQuery({
     ...userProfileQueryOptions(),
     select: (data) => data.profile.email,
@@ -116,15 +117,19 @@ const EmailConfigureModal = ({
         </div>
         <div className="mt-6 space-y-5">
           <div>
-            <div className="mb-1 flex h-6 items-center system-sm-medium text-text-secondary">
+            <label
+              htmlFor={subjectId}
+              className="mb-1 flex h-6 items-center system-sm-medium text-text-secondary"
+            >
               {t(($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.subject`], {
                 ns: 'workflow',
               })}
-            </div>
+            </label>
             <Input
+              id={subjectId}
               className="w-full"
               value={subject}
-              onChange={(e) => setSubject(e.target.value)}
+              onValueChange={setSubject}
               placeholder={t(
                 ($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.subjectPlaceholder`],
                 { ns: 'workflow' },


### PR DESCRIPTION
## Summary

- replace the legacy email subject input with the Dify UI Input primitive
- turn the existing visible subject text into the input label without changing its layout
- use the control accessible name in the existing save and validation tests

No visual changes are intended; the modal-owned spacing, label height, and input geometry are preserved.

## Validation

- `pnpm -C web test --run app/components/workflow/nodes/human-input/components/delivery-method/__tests__/email-configure-modal.spec.tsx`
- `pnpm vp check web/app/components/workflow/nodes/human-input/components/delivery-method/email-configure-modal.tsx web/app/components/workflow/nodes/human-input/components/delivery-method/__tests__/email-configure-modal.spec.tsx`

From Codex