### PR TITLE
refactor(plugins): migrate credential rename input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2626,9 +2626,6 @@
     },
     "jsx-a11y/no-static-element-interactions": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "web/app/components/plugins/plugin-auth/hooks/use-get-api.ts": {

--- a/web/app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx
@@ -184,8 +184,7 @@ describe('Item Component', () => {
       )
 
       const enterRenameMode = () => {
-        const firstButton = result.container.querySelectorAll('button')[0] as HTMLElement
-        fireEvent.click(firstButton)
+        fireEvent.click(screen.getByRole('button', { name: 'common.operation.rename' }))
       }
 
       return { ...result, onRename, enterRenameMode }
@@ -196,7 +195,7 @@ describe('Item Component', () => {
 
       enterRenameMode()
 
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('textbox', { name: 'common.operation.rename' })).toBeInTheDocument()
     })
 
     it('should show save and cancel buttons in rename mode', () => {
@@ -213,7 +212,7 @@ describe('Item Component', () => {
 
       enterRenameMode()
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('textbox', { name: 'common.operation.rename' })
       fireEvent.change(input, { target: { value: 'New Name' } })
       fireEvent.click(screen.getByText('common.operation.save'))
 
@@ -228,7 +227,7 @@ describe('Item Component', () => {
       const { enterRenameMode } = renderWithRenameEnabled()
 
       enterRenameMode()
-      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('textbox', { name: 'common.operation.rename' })).toBeInTheDocument()
 
       fireEvent.click(screen.getByText('common.operation.cancel'))
 
@@ -240,7 +239,7 @@ describe('Item Component', () => {
 
       enterRenameMode()
 
-      const input = screen.getByRole('textbox')
+      const input = screen.getByRole('textbox', { name: 'common.operation.rename' })
       fireEvent.change(input, { target: { value: 'Updated Value' } })
 
       expect(input).toHaveValue('Updated Value')

--- a/web/app/components/plugins/plugin-auth/authorized/item.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/item.tsx
@@ -2,6 +2,7 @@ import type { Credential } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { Input } from '@langgenius/dify-ui/input'
 import { StatusDot } from '@langgenius/dify-ui/status-dot'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { RiInformationLine } from '@remixicon/react'
@@ -9,7 +10,6 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { memo, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Badge from '@/app/components/base/badge'
-import Input from '@/app/components/base/input'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { useCredentialPermissions } from '@/hooks/use-credential-permissions'
 import { CredentialTypeEnum } from '../types'
@@ -85,10 +85,10 @@ const Item = ({
       {renaming && (
         <div className="flex w-full items-center space-x-1">
           <Input
-            wrapperClassName="grow rounded-md"
-            className="h-6"
+            aria-label={t(($) => $['operation.rename'], { ns: 'common' })}
+            className="h-6 grow"
             value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
+            onValueChange={setRenameValue}
             placeholder={t(($) => $['placeholder.input'], { ns: 'common' })}
             onClick={(e) => e.stopPropagation()}
           />


### PR DESCRIPTION
## Summary

- replace the legacy credential rename input with the Dify UI Input primitive
- preserve the compact 24 px inline editor and existing row click boundary
- give the input an accessible name and use semantic queries in the rename behavior tests

No visual changes are intended; flex growth remains owned by the inline credential row.

## Validation

- `pnpm -C web test --run app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx`
- `pnpm vp check web/app/components/plugins/plugin-auth/authorized/item.tsx web/app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx`

From Codex