### PR TITLE
fix(plugin): prevent install dialog error overflow

### DIFF
--- a/web/app/components/plugins/install-plugin/base/installed.tsx
+++ b/web/app/components/plugins/install-plugin/base/installed.tsx
@@ -80,8 +80,13 @@ const Installed: FC<Props> = ({
   }
   return (
     <>
-      <div className="flex flex-col items-start justify-center gap-2 self-stretch px-6 py-3">
-        <p className="system-md-regular text-text-secondary">
+      <div className="flex min-h-0 min-w-0 flex-col items-start justify-center gap-2 self-stretch overflow-x-hidden overflow-y-auto px-6 py-3">
+        <p
+          className={cn(
+            'w-full max-w-full min-w-0 system-md-regular text-text-secondary',
+            isFailed && 'wrap-anywhere whitespace-pre-wrap',
+          )}
+        >
           {isFailed && errMsg ? (
             errMsg
           ) : categoryTarget ? (
@@ -125,7 +130,7 @@ const Installed: FC<Props> = ({
         )}
       </div>
       {/* Action Buttons */}
-      <div className="flex items-center justify-end gap-2 self-stretch p-6 pt-5">
+      <div className="flex shrink-0 items-center justify-end gap-2 self-stretch p-6 pt-5">
         {categoryTarget ? (
           <Link
             href={categoryTarget.path}

--- a/web/app/components/plugins/install-plugin/install-from-github/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-github/index.tsx
@@ -3,7 +3,7 @@ import type { PluginCategoryEnum, PluginDeclaration, UpdateFromGitHubPayload } f
 import type { InstallState } from '@/app/components/plugins/types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { Field, FieldLabel } from '@langgenius/dify-ui/field'
 import { Form } from '@langgenius/dify-ui/form'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
@@ -180,10 +180,10 @@ const InstallFromGitHub: React.FC<InstallFromGitHubProps> = ({
       <DialogContent
         backdropProps={{ forceRender: true }}
         className={cn(
-          'w-140 max-w-none! overflow-hidden! text-left align-middle',
+          'w-140 overflow-hidden! text-left align-middle',
           cn(
             modalClassName,
-            `shadows-shadow-xl flex max-h-[calc(100dvh-48px)] min-w-140 flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0`,
+            'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0',
           ),
         )}
       >
@@ -201,7 +201,9 @@ const InstallFromGitHub: React.FC<InstallFromGitHubProps> = ({
 
         <div className="flex shrink-0 items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
           <div className="flex grow flex-col items-start gap-1">
-            <div className="self-stretch title-2xl-semi-bold text-text-primary">{getTitle()}</div>
+            <DialogTitle className="self-stretch title-2xl-semi-bold text-text-primary">
+              {getTitle()}
+            </DialogTitle>
             <div className="self-stretch system-xs-regular text-text-tertiary">
               {![
                 InstallStepFromGitHub.uploadFailed,

--- a/web/app/components/plugins/install-plugin/install-from-local-package/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/__tests__/index.spec.tsx
@@ -419,6 +419,9 @@ describe('InstallFromLocalPackage', () => {
       await waitFor(() => {
         expect(screen.getByTestId('ready-to-install-package')).toBeInTheDocument()
         expect(screen.getByTestId('package-step')).toHaveTextContent('uploadFailed')
+        expect(
+          screen.getByRole('dialog', { name: 'plugin.installModal.uploadFailed' }),
+        ).toBeInTheDocument()
       })
     })
 

--- a/web/app/components/plugins/install-plugin/install-from-local-package/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { Dependency, PluginCategoryEnum, PluginDeclaration } from '../../types'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogClose, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
@@ -90,10 +90,10 @@ const InstallFromLocalPackage: React.FC<InstallFromLocalPackageProps> = ({
       <DialogContent
         backdropProps={{ forceRender: true }}
         className={cn(
-          'w-140 max-w-none! overflow-hidden! text-left align-middle',
+          'w-140 overflow-hidden! text-left align-middle',
           cn(
             modalClassName,
-            'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] min-w-140 flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0',
+            'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0',
           ),
         )}
       >
@@ -109,8 +109,10 @@ const InstallFromLocalPackage: React.FC<InstallFromLocalPackageProps> = ({
           }
         />
 
-        <div className="flex items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
-          <div className="self-stretch title-2xl-semi-bold text-text-primary">{getTitle()}</div>
+        <div className="flex shrink-0 items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
+          <DialogTitle className="self-stretch title-2xl-semi-bold text-text-primary">
+            {getTitle()}
+          </DialogTitle>
         </div>
         {step === InstallStep.uploading && (
           <Uploading

--- a/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
@@ -86,14 +86,14 @@ const InstallFromMarketplace: React.FC<InstallFromMarketplaceProps> = ({
       <DialogContent
         backdropProps={{ forceRender: true }}
         className={cn(
-          'w-140 max-w-none! overflow-hidden! text-left align-middle',
+          'w-140 overflow-hidden! text-left align-middle',
           cn(
             modalClassName,
-            'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] min-w-140 flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0',
+            'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0',
           ),
         )}
       >
-        <div className="flex items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
+        <div className="flex shrink-0 items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
           <DialogTitle className="self-stretch title-2xl-semi-bold text-text-primary">
             {getTitle()}
           </DialogTitle>


### PR DESCRIPTION
## Summary

- wrap long installation error messages inside the shared result content area
- keep dialog headers and actions visible while allowing the result content to scroll
- preserve the 560px desktop width while allowing all plugin installation dialogs to shrink on narrow viewports
- add semantic dialog titles for local package and GitHub installation flows

Fixes SNP-737
