### PR TITLE
fix(web): allow custom file types with document and image uploads

### DIFF
--- a/web/app/components/base/file-uploader/__tests__/file-input.spec.tsx
+++ b/web/app/components/base/file-uploader/__tests__/file-input.spec.tsx
@@ -69,7 +69,46 @@ describe('FileInput', () => {
     )
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement
-    expect(input.accept).toBe('.csv,.xlsx')
+    expect(input.accept).toBe('.CSV,.XLSX')
+  })
+
+  it('should keep overlapping image extensions in custom accept filters', () => {
+    renderWithProvider(
+      <FileInput
+        fileConfig={createFileConfig({
+          allowed_file_types: ['custom'] as unknown as FileUpload['allowed_file_types'],
+          allowed_file_extensions: [
+            'JPG',
+            'JPEG',
+            'PNG',
+            'GIF',
+            'WEBP',
+            'SVG',
+            '.pdf',
+            '.json',
+            '.wps',
+            '.ofd',
+          ],
+        })}
+      />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input.accept).toBe('.JPG,.JPEG,.PNG,.GIF,.WEBP,.SVG,.PDF,.JSON,.WPS,.OFD')
+  })
+
+  it('should union built-in types with custom extensions', () => {
+    renderWithProvider(
+      <FileInput
+        fileConfig={createFileConfig({
+          allowed_file_types: ['image', 'custom'] as unknown as FileUpload['allowed_file_types'],
+          allowed_file_extensions: ['.json', '.wps', 'PNG'],
+        })}
+      />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input.accept).toBe('.JPG,.JPEG,.PNG,.GIF,.WEBP,.SVG,.JSON,.WPS')
   })
 
   it('should allow multiple files when number_limits > 1', () => {

--- a/web/app/components/base/file-uploader/__tests__/utils.spec.ts
+++ b/web/app/components/base/file-uploader/__tests__/utils.spec.ts
@@ -700,7 +700,7 @@ describe('file-uploader utils', () => {
       expect(result).toEqual([])
     })
 
-    it('should prioritize custom types over standard types', () => {
+    it('should union custom extensions with standard types', () => {
       const mockFileExts = {
         image: ['JPG', 'PNG'],
       }
@@ -713,10 +713,29 @@ describe('file-uploader utils', () => {
         [SupportUploadFileTypes.custom, 'image'],
         ['.csv', '.xml'],
       )
-      expect(result).toEqual(['CSV', 'XML'])
+      expect(result).toEqual(['JPG', 'PNG', 'CSV', 'XML'])
 
       // Restore original FILE_EXTS
       Object.assign(FILE_EXTS, originalFileExts)
+    })
+
+    it('should keep undotted custom extensions that overlap built-in image types', () => {
+      const result = getSupportFileExtensionList(
+        [SupportUploadFileTypes.custom],
+        ['JPG', 'JPEG', 'PNG', 'GIF', 'WEBP', 'SVG', '.pdf', '.json', '.wps', '.ofd'],
+      )
+      expect(result).toEqual([
+        'JPG',
+        'JPEG',
+        'PNG',
+        'GIF',
+        'WEBP',
+        'SVG',
+        'PDF',
+        'JSON',
+        'WPS',
+        'OFD',
+      ])
     })
   })
 

--- a/web/app/components/base/file-uploader/file-input.tsx
+++ b/web/app/components/base/file-uploader/file-input.tsx
@@ -1,8 +1,7 @@
 import type { FileUpload } from '@/app/components/base/features/types'
-import { FILE_EXTS } from '@/app/components/base/prompt-editor/constants'
-import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { useFile } from './hooks'
 import { useStore } from './store'
+import { getSupportFileExtensionList } from './utils'
 
 type FileInputProps = {
   fileConfig: FileUpload
@@ -25,12 +24,12 @@ const FileInput = ({ fileConfig }: FileInputProps) => {
     }
   }
 
-  const allowedFileTypes = fileConfig.allowed_file_types
-  const isCustom = allowedFileTypes?.includes(SupportUploadFileTypes.custom)
-  const exts = isCustom
-    ? fileConfig.allowed_file_extensions || []
-    : (allowedFileTypes?.map((type) => FILE_EXTS[type]) || []).flat().map((item) => `.${item}`)
-  const accept = exts.join(',')
+  const accept = getSupportFileExtensionList(
+    fileConfig.allowed_file_types || [],
+    fileConfig.allowed_file_extensions || [],
+  )
+    .map((item) => `.${item}`)
+    .join(',')
 
   return (
     <input

--- a/web/app/components/base/file-uploader/utils.ts
+++ b/web/app/components/base/file-uploader/utils.ts
@@ -196,14 +196,33 @@ export const getProcessedFilesFromResponse = (files: FileResponse[]) => {
     }
   })
 }
+const normalizeFileExtension = (ext: string) => ext.replace(/^\./, '').trim().toUpperCase()
+
 export const getSupportFileExtensionList = (
   allowFileTypes: string[],
   allowFileExtensions: string[],
 ) => {
-  if (allowFileTypes.includes(SupportUploadFileTypes.custom))
-    return allowFileExtensions.map((item) => item.slice(1).toUpperCase())
+  const seen = new Set<string>()
+  const result: string[] = []
 
-  return allowFileTypes.map((type) => FILE_EXTS[type]).flat()
+  const add = (ext?: string) => {
+    if (!ext) return
+    const normalized = normalizeFileExtension(ext)
+    if (!normalized || seen.has(normalized)) return
+    seen.add(normalized)
+    result.push(normalized)
+  }
+
+  for (const type of allowFileTypes) {
+    if (type === SupportUploadFileTypes.custom) continue
+    for (const ext of FILE_EXTS[type] || []) add(ext)
+  }
+
+  if (allowFileTypes.includes(SupportUploadFileTypes.custom)) {
+    for (const ext of allowFileExtensions) add(ext)
+  }
+
+  return result
 }
 
 export const isAllowedFileExtension = (

--- a/web/app/components/base/form/components/field/__tests__/file-types.spec.tsx
+++ b/web/app/components/base/form/components/field/__tests__/file-types.spec.tsx
@@ -76,24 +76,24 @@ describe('FileTypesField', () => {
     expect(screen.getByRole('button', { name: SupportUploadFileTypes.custom })).toBeInTheDocument()
   })
 
-  it('should keep only custom when users choose custom types', () => {
+  it('should allow custom together with standard types', () => {
     mockField.state.value.allowedFileTypes = [SupportUploadFileTypes.document]
     render(<FileTypesField label="Allowed file types" />)
 
     fireEvent.click(screen.getByRole('button', { name: SupportUploadFileTypes.custom }))
     expect(mockField.handleChange).toHaveBeenCalledWith({
-      allowedFileTypes: [SupportUploadFileTypes.custom],
+      allowedFileTypes: [SupportUploadFileTypes.document, SupportUploadFileTypes.custom],
       allowedFileExtensions: [],
     })
   })
 
-  it('should remove custom and add selected standard type', () => {
+  it('should add a standard type without clearing custom', () => {
     mockField.state.value.allowedFileTypes = [SupportUploadFileTypes.custom]
     render(<FileTypesField label="Allowed file types" />)
 
     fireEvent.click(screen.getByRole('button', { name: SupportUploadFileTypes.image }))
     expect(mockField.handleChange).toHaveBeenCalledWith({
-      allowedFileTypes: [SupportUploadFileTypes.image],
+      allowedFileTypes: [SupportUploadFileTypes.custom, SupportUploadFileTypes.image],
       allowedFileExtensions: [],
     })
   })

--- a/web/app/components/base/form/components/field/file-types.tsx
+++ b/web/app/components/base/form/components/field/file-types.tsx
@@ -22,20 +22,13 @@ const FileTypesField = ({ label, labelOptions, className }: FileTypesFieldProps)
 
   const handleSupportFileTypeChange = useCallback(
     (type: SupportUploadFileTypes) => {
-      let newAllowFileTypes = [...field.state.value.allowedFileTypes]
-      if (type === SupportUploadFileTypes.custom) {
-        if (!newAllowFileTypes.includes(SupportUploadFileTypes.custom))
-          newAllowFileTypes = [SupportUploadFileTypes.custom]
-        else newAllowFileTypes = newAllowFileTypes.filter((v) => v !== type)
-      } else {
-        newAllowFileTypes = newAllowFileTypes.filter((v) => v !== SupportUploadFileTypes.custom)
-        if (newAllowFileTypes.includes(type))
-          newAllowFileTypes = newAllowFileTypes.filter((v) => v !== type)
-        else newAllowFileTypes.push(type)
-      }
+      const current = field.state.value.allowedFileTypes
+      const nextAllowFileTypes = current.includes(type)
+        ? current.filter((v) => v !== type)
+        : [...current, type]
       field.handleChange({
         ...field.state.value,
-        allowedFileTypes: newAllowFileTypes,
+        allowedFileTypes: nextAllowFileTypes,
       })
     },
     [field],

--- a/web/app/components/workflow/nodes/_base/components/__tests__/file-support.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/file-support.spec.tsx
@@ -163,7 +163,7 @@ describe('File upload support components', () => {
       await user.click(screen.getByText('appDebug.variableConfig.file.custom.name'))
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          allowed_file_types: [SupportUploadFileTypes.custom],
+          allowed_file_types: [SupportUploadFileTypes.document, SupportUploadFileTypes.custom],
         }),
       )
 
@@ -181,6 +181,23 @@ describe('File upload support components', () => {
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
           allowed_file_types: [],
+        }),
+      )
+
+      rerender(
+        <FileUploadSetting
+          payload={createPayload({
+            allowed_file_types: [SupportUploadFileTypes.custom],
+          })}
+          isMultiple={false}
+          onChange={onChange}
+        />,
+      )
+
+      await user.click(screen.getByText('appDebug.variableConfig.file.image.name'))
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          allowed_file_types: [SupportUploadFileTypes.custom, SupportUploadFileTypes.image],
         }),
       )
     })

--- a/web/app/components/workflow/nodes/_base/components/file-upload-setting.tsx
+++ b/web/app/components/workflow/nodes/_base/components/file-upload-setting.tsx
@@ -45,18 +45,9 @@ const FileUploadSetting: FC<Props> = ({
   const handleSupportFileTypeChange = useCallback(
     (type: SupportUploadFileTypes) => {
       const newPayload = produce(payload, (draft) => {
-        if (type === SupportUploadFileTypes.custom) {
-          if (!draft.allowed_file_types.includes(SupportUploadFileTypes.custom))
-            draft.allowed_file_types = [SupportUploadFileTypes.custom]
-          else draft.allowed_file_types = draft.allowed_file_types.filter((v) => v !== type)
-        } else {
-          draft.allowed_file_types = draft.allowed_file_types.filter(
-            (v) => v !== SupportUploadFileTypes.custom,
-          )
-          if (draft.allowed_file_types.includes(type))
-            draft.allowed_file_types = draft.allowed_file_types.filter((v) => v !== type)
-          else draft.allowed_file_types.push(type)
-        }
+        if (draft.allowed_file_types.includes(type))
+          draft.allowed_file_types = draft.allowed_file_types.filter((v) => v !== type)
+        else draft.allowed_file_types.push(type)
       })
       onChange(newPayload)
     },


### PR DESCRIPTION
Fixes https://github.com/langgenius/dify/issues/41565

## Summary
Agent file upload settings treated **Other file types** as mutually exclusive with Document/Image, and the published web chat file picker silently dropped overlapping image extensions that were stored without a leading dot (e.g. `JPG` vs `.pdf`).

## Changes
- Toggle built-in buckets and custom types independently in `FileUploadSetting` and `FileTypesField`.
- Union `FILE_EXTS` for selected semantic types with custom extensions in `getSupportFileExtensionList`.
- Normalize extensions (dot/case) when building the input `accept` filter so configured types such as `JPG`/`JPEG`/`PNG`/`GIF`/`WEBP`/`SVG` and `.pdf`/`.json`/`.wps`/`.ofd` all appear.

## Tests
- Updated unit tests for the toggle behavior and accept-string union.
- `vitest run --project unit` on the four affected specs: 88 passed.