### PR TITLE
refactor(models): pass session into DocumentSegment and AppDatasetJoin accessors

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -974,17 +974,15 @@ class DocumentSegment(TypeBase):
         """Load the owning document with the caller-owned database session."""
         return session.get(Document, self.document_id)
 
-    @property
-    def previous_segment(self):
-        return db.session.scalar(
+    def previous_segment(self, session: Session) -> "DocumentSegment | None":
+        return session.scalar(
             select(DocumentSegment).where(
                 DocumentSegment.document_id == self.document_id, DocumentSegment.position == self.position - 1
             )
         )
 
-    @property
-    def next_segment(self):
-        return db.session.scalar(
+    def next_segment(self, session: Session) -> "DocumentSegment | None":
+        return session.scalar(
             select(DocumentSegment).where(
                 DocumentSegment.document_id == self.document_id, DocumentSegment.position == self.position + 1
             )
@@ -1204,9 +1202,8 @@ class AppDatasetJoin(TypeBase):
         DateTime, nullable=False, server_default=sa.func.current_timestamp(), init=False
     )
 
-    @property
-    def app(self):
-        return db.session.get(App, self.app_id)
+    def app(self, session: Session) -> App | None:
+        return session.get(App, self.app_id)
 
 
 class DatasetQuery(TypeBase):

--- a/api/tests/test_containers_integration_tests/models/test_dataset_models.py
+++ b/api/tests/test_containers_integration_tests/models/test_dataset_models.py
@@ -426,7 +426,7 @@ class TestDocumentSegmentNavigationProperties:
         db_session_with_containers.flush()
 
         # Act
-        prev_seg = segment.previous_segment
+        prev_seg = segment.previous_segment(session=db_session_with_containers)
 
         # Assert
         assert prev_seg is not None
@@ -483,7 +483,7 @@ class TestDocumentSegmentNavigationProperties:
         db_session_with_containers.flush()
 
         # Act
-        next_seg = segment.next_segment
+        next_seg = segment.next_segment(session=db_session_with_containers)
 
         # Assert
         assert next_seg is not None

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -1660,3 +1660,60 @@ class TestChildChunkSessionAccessors:
         assert child_chunk.dataset(session=sqlite_session) is None
         assert child_chunk.document(session=sqlite_session) is None
         assert child_chunk.segment(session=sqlite_session) is None
+
+
+class TestDocumentSegmentNeighborAccessors:
+    """Regression coverage for ``DocumentSegment.previous_segment`` and ``next_segment`` refactored
+    to take a caller-provided session.
+
+    These were ``@property`` accessors reaching for the global ``db.session`` internally; they are now
+    plain methods accepting a ``Session`` explicitly.
+    """
+
+    def test_accessors_resolve_neighboring_segments_via_caller_session(self, sqlite_session: Session):
+        dataset = _make_dataset(dataset_id=str(uuid4()), tenant_id=str(uuid4()))
+        document = _make_document(document_id=str(uuid4()), dataset_id=dataset.id, tenant_id=dataset.tenant_id)
+        segments = _make_segments(document, [0, 0, 0])
+        sqlite_session.add_all([dataset, document, *segments])
+        sqlite_session.flush()
+
+        middle_segment = segments[1]
+        assert middle_segment.previous_segment(session=sqlite_session) is segments[0]
+        assert middle_segment.next_segment(session=sqlite_session) is segments[2]
+
+    def test_accessors_return_none_when_neighbors_are_absent(self, sqlite_session: Session):
+        dataset = _make_dataset(dataset_id=str(uuid4()), tenant_id=str(uuid4()))
+        document = _make_document(document_id=str(uuid4()), dataset_id=dataset.id, tenant_id=dataset.tenant_id)
+        segment = _make_segments(document, [0])[0]
+        sqlite_session.add_all([dataset, document, segment])
+        sqlite_session.flush()
+
+        assert segment.previous_segment(session=sqlite_session) is None
+        assert segment.next_segment(session=sqlite_session) is None
+
+
+class TestAppDatasetJoinSessionAccessors:
+    """Regression coverage for ``AppDatasetJoin.app`` refactored to take a caller-provided session.
+
+    ``AppDatasetJoin.app`` was an ``@property`` accessor reaching for the global ``db.session`` internally;
+    it is now a plain method accepting a ``Session`` explicitly.
+    """
+
+    def test_app_accessor_resolves_app_via_caller_session(self, sqlite_session: Session):
+        app = _make_app(app_id=str(uuid4()))
+        join = AppDatasetJoin(
+            app_id=app.id,
+            dataset_id=str(uuid4()),
+        )
+        sqlite_session.add_all([app, join])
+        sqlite_session.flush()
+
+        assert join.app(session=sqlite_session) is app
+
+    def test_app_accessor_returns_none_when_app_absent(self, sqlite_session: Session):
+        join = AppDatasetJoin(
+            app_id=str(uuid4()),
+            dataset_id=str(uuid4()),
+        )
+
+        assert join.app(session=sqlite_session) is None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Partial fix for #40372

Following the initiative in #40372 / #37403 and merged follow-ups like #41370 (`ChildChunk`) and #41464 (`Workflow`), this PR converts three `@property` accessors in `api/models/dataset.py` that rely on the ambient `db.session` into explicit methods taking `session: Session`:

- **`DocumentSegment.previous_segment`**: `@property` reading `db.session.scalar(...)` → `previous_segment(self, session: Session) -> "DocumentSegment | None"`
- **`DocumentSegment.next_segment`**: `@property` reading `db.session.scalar(...)` → `next_segment(self, session: Session) -> "DocumentSegment | None"`
- **`AppDatasetJoin.app`**: `@property` reading `db.session.get(...)` → `app(self, session: Session) -> App | None`

**Scope check:** All three accessors have zero production callers — they are only referenced in test files. No call-site migration is needed.

### Changes

| File | What changed |
|------|-------------|
| `api/models/dataset.py` | Converted 3 `@property` accessors to explicit-session methods |
| `api/tests/test_containers_integration_tests/models/test_dataset_models.py` | Updated 2 integration test call sites to pass `session=` |
| `api/tests/unit_tests/models/test_dataset_models.py` | Added `TestDocumentSegmentNeighborAccessors` (2 tests) and `TestAppDatasetJoinSessionAccessors` (2 tests) |

### Verification

```
$ uv run --group dev pytest tests/unit_tests/models/test_dataset_models.py -q
66 passed in 2.12s

$ uv run ruff check models/dataset.py tests/unit_tests/models/test_dataset_models.py tests/test_containers_integration_tests/models/test_dataset_models.py
All checks passed!
```

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — N/A (internal refactor, no API surface change)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods