### PR TITLE
refactor(models): remove legacy db.session property wrappers on Dataset

### DIFF
--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_datasets.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_datasets.py
@@ -17,7 +17,7 @@ from controllers.console.wraps import (
     with_current_user,
 )
 from extensions.ext_database import db
-from fields.dataset_fields import DatasetDetailResponse
+from fields.dataset_fields import DatasetDetailResponse, dataset_detail_response_source
 from libs.helper import dump_response
 from libs.login import login_required
 from models import Account
@@ -116,6 +116,7 @@ class CreateEmptyRagPipelineDatasetApi(Resource):
         # The role of the current user in the ta table must be admin, owner, or editor, or dataset_operator
         if not current_user.is_dataset_editor:
             raise Forbidden()
+        session = db.session()
         dataset = DatasetService.create_empty_rag_pipeline_dataset(
             tenant_id=current_tenant_id,
             rag_pipeline_dataset_create_entity=RagPipelineDatasetCreateEntity(
@@ -129,6 +130,6 @@ class CreateEmptyRagPipelineDatasetApi(Resource):
                 permission=DatasetPermissionEnum.ONLY_ME,
                 partial_member_list=None,
             ),
-            session=db.session(),
+            session=session,
         )
-        return dump_response(DatasetDetailResponse, dataset), 201
+        return dump_response(DatasetDetailResponse, dataset_detail_response_source(dataset, session=session)), 201

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -212,16 +212,8 @@ class Dataset(Base):
     enable_api = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
     is_multimodal = mapped_column(sa.Boolean, default=False, nullable=False, server_default=sa.text("false"))
 
-    @property
-    def total_documents(self) -> int:
-        return self.get_total_documents(session=db.session())
-
     def get_total_documents(self, *, session: Session) -> int:
         return self.get_document_count(session=session)
-
-    @property
-    def total_available_documents(self) -> int:
-        return self.get_total_available_documents(session=db.session())
 
     def get_total_available_documents(self, *, session: Session) -> int:
         return (
@@ -258,19 +250,11 @@ class Dataset(Base):
     def get_created_by_account(self, *, session: Session) -> Account | None:
         return session.get(Account, self.created_by)
 
-    @property
-    def author_name(self) -> str | None:
-        return self.get_author_name(session=db.session())
-
     def get_author_name(self, *, session: Session) -> str | None:
         account = self.get_created_by_account(session=session)
         if account:
             return account.name
         return None
-
-    @property
-    def latest_process_rule(self):
-        return self.get_latest_process_rule(session=db.session())
 
     def get_latest_process_rule(self, *, session: Session) -> "DatasetProcessRule | None":
         return session.scalar(
@@ -390,10 +374,6 @@ class Dataset(Base):
         ).all()
 
         return tags or []
-
-    @property
-    def external_knowledge_info(self) -> dict[str, Any] | None:
-        return self.get_external_knowledge_info(session=db.session())
 
     def get_external_knowledge_info(self, *, session: Session) -> dict[str, Any] | None:
         if self.provider != "external":

--- a/api/tests/test_containers_integration_tests/models/test_dataset_models.py
+++ b/api/tests/test_containers_integration_tests/models/test_dataset_models.py
@@ -49,7 +49,7 @@ class TestDatasetDocumentProperties:
             db_session_with_containers.add(doc)
         db_session_with_containers.flush()
 
-        assert dataset.total_documents == 3
+        assert dataset.get_total_documents(session=db_session_with_containers) == 3
 
     def test_dataset_available_documents_count(self, db_session_with_containers: Session) -> None:
         """Test dataset can count available documents."""
@@ -104,7 +104,7 @@ class TestDatasetDocumentProperties:
         db_session_with_containers.add_all([doc_available, doc_pending, doc_disabled])
         db_session_with_containers.flush()
 
-        assert dataset.total_available_documents == 1
+        assert dataset.get_total_available_documents(session=db_session_with_containers) == 1
 
     def test_dataset_word_count_aggregation(self, db_session_with_containers: Session) -> None:
         """Test dataset can aggregate word count from documents."""


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 1. Associated issue: #40372 (claimed the slice in [this comment](https://github.com/langgenius/dify/issues/40372#issuecomment-5489439740)).

## Summary

Part of #40372, follow-up to #41370 / #41440.

Removes five legacy `@property` accessors on `Dataset` in `api/models/dataset.py` that still reach for the global `db.session` internally. Each of them is a thin wrapper around an existing session-aware `get_*` twin, and every call site has already been migrated to the twins (`DatasetDetailResponseSource` from `fields/dataset_fields.py` covers the response-validation reads for all dataset detail endpoints):

- `Dataset.total_documents` → `get_total_documents(session=...)`
- `Dataset.total_available_documents` → `get_total_available_documents(session=...)`
- `Dataset.author_name` → `get_author_name(session=...)`
- `Dataset.latest_process_rule` → `get_latest_process_rule(session=...)`
- `Dataset.external_knowledge_info` → `get_external_knowledge_info(session=...)`

I verified there are no remaining production reads of these five as properties (including implicit `from_attributes=True` reads — all three dataset-detail validation sites go through `dataset_detail_response_source`).

Not touching the other `Dataset` properties (some still have property readers), nor `Document.*` / `DocumentSegment.*` / the slices claimed by other contributors on the issue.

## Tests

The session-aware `get_*` twins already have unit coverage in `tests/unit_tests/models/test_dataset_models.py` (`test_session_aware_dataset_getters_use_caller_session`, `test_dataset_detail_getters_use_caller_session`), which keeps passing. Updated the two container-integration tests that still read `total_documents` / `total_available_documents` as properties to call the `get_*` twins explicitly.

## Screenshots

N/A (backend-only refactor).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Claude Code