### PR TITLE
refactor(service_api): dep-inject segment payloads with @model_validate

### DIFF
--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -15,6 +15,7 @@ from controllers.common.schema import (
     register_schema_models,
 )
 from controllers.common.session import with_session
+from controllers.console.wraps import model_validate
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import ProviderNotInitializeError
 from controllers.service_api.wraps import (
@@ -406,7 +407,16 @@ class DatasetSegmentApi(DatasetApiResource):
     @cloud_edition_billing_resource_check("vector_space", "dataset")
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
     @with_session
-    def post(self, session: Session, tenant_id: str, dataset_id: UUID, document_id: UUID, segment_id: UUID):
+    @model_validate(SegmentUpdatePayload)
+    def post(
+        self,
+        payload: SegmentUpdatePayload,
+        session: Session,
+        tenant_id: str,
+        dataset_id: UUID,
+        document_id: UUID,
+        segment_id: UUID,
+    ):
         _, current_tenant_id = current_account_with_tenant()
         dataset_id_str = str(dataset_id)
         # check dataset
@@ -440,8 +450,6 @@ class DatasetSegmentApi(DatasetApiResource):
                 raise ProviderNotInitializeError(ex.description)
         segment_id_str = str(segment_id)
         _, segment = _get_segment_for_document(session, dataset, document, segment_id_str)
-
-        payload = SegmentUpdatePayload.model_validate(service_api_ns.payload or {})
 
         updated_segment = SegmentService.update_segment(payload.segment, segment, document, dataset, session)
         summary = SummaryIndexService.get_segment_summary(
@@ -549,7 +557,16 @@ class ChildChunkApi(DatasetApiResource):
     @cloud_edition_billing_knowledge_limit_check("add_segment", "dataset")
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
     @with_session
-    def post(self, session: Session, tenant_id: str, dataset_id: UUID, document_id: UUID, segment_id: UUID):
+    @model_validate(ChildChunkCreatePayload)
+    def post(
+        self,
+        payload: ChildChunkCreatePayload,
+        session: Session,
+        tenant_id: str,
+        dataset_id: UUID,
+        document_id: UUID,
+        segment_id: UUID,
+    ):
         _, current_tenant_id = current_account_with_tenant()
         """Create child chunk."""
         dataset_id_str = str(dataset_id)
@@ -585,9 +602,6 @@ class ChildChunkApi(DatasetApiResource):
                 )
             except ProviderTokenNotInitError as ex:
                 raise ProviderNotInitializeError(ex.description)
-
-        # validate args
-        payload = ChildChunkCreatePayload.model_validate(service_api_ns.payload or {})
 
         try:
             child_chunk = SegmentService.create_child_chunk(payload.content, segment, document, dataset, session)
@@ -765,8 +779,10 @@ class DatasetChildChunkApi(DatasetApiResource):
     @cloud_edition_billing_knowledge_limit_check("add_segment", "dataset")
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
     @with_session
+    @model_validate(ChildChunkUpdatePayload)
     def patch(
         self,
+        payload: ChildChunkUpdatePayload,
         session: Session,
         tenant_id: str,
         dataset_id: UUID,
@@ -798,9 +814,6 @@ class DatasetChildChunkApi(DatasetApiResource):
         child_chunk = SegmentService.get_child_chunk_by_segment_ref(child_chunk_id_str, segment_ref, session=session)
         if not child_chunk:
             raise NotFound("Child chunk not found.")
-
-        # validate args
-        payload = ChildChunkUpdatePayload.model_validate(service_api_ns.payload or {})
 
         try:
             child_chunk = SegmentService.update_child_chunk(

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -2290,23 +2290,26 @@ class TestModelValidateDecorator(SQLiteEndpointTest):
         mock_feature_svc.get_knowledge_rate_limit.return_value = mock_rate_limit
 
     @pytest.mark.parametrize(
-        ("call", "route"),
+        ("call", "route", "method"),
         [
             (
                 lambda: DatasetSegmentApi().post(
                     tenant_id="t", dataset_id="d", document_id="doc-id", segment_id="seg-id"
                 ),
                 "/datasets/d/documents/doc-id/segments/seg-id",
+                "POST",
             ),
             (
                 lambda: ChildChunkApi().post(tenant_id="t", dataset_id="d", document_id="doc-id", segment_id="seg-id"),
                 "/datasets/d/documents/doc-id/segments/seg-id/child_chunks",
+                "POST",
             ),
             (
                 lambda: DatasetChildChunkApi().patch(
                     tenant_id="t", dataset_id="d", document_id="doc-id", segment_id="seg-id", child_chunk_id="cc-id"
                 ),
                 "/datasets/d/documents/doc-id/segments/seg-id/child_chunks/cc-id",
+                "PATCH",
             ),
         ],
     )
@@ -2320,10 +2323,11 @@ class TestModelValidateDecorator(SQLiteEndpointTest):
         mock_tenant: Mock,
         call: Callable[[], object],
         route: str,
+        method: str,
     ) -> None:
         self._setup_billing_mocks(mock_validate_token, mock_feature_svc, mock_tenant.id)
 
-        with app.test_request_context(route, method="POST", json={}, headers={"Authorization": "Bearer test_token"}):
+        with app.test_request_context(route, method=method, json={}, headers={"Authorization": "Bearer test_token"}):
             with pytest.raises(UnprocessableEntity) as exc_info:
                 call()
 

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -16,12 +16,13 @@ Focus on:
 
 import inspect
 import uuid
+from collections.abc import Callable
 from unittest.mock import ANY, Mock, patch
 
 import pytest
 from flask import Flask
 from sqlalchemy.orm import Session
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, UnprocessableEntity
 
 from controllers.service_api.dataset.segment import (
     ChildChunkApi,
@@ -2265,3 +2266,65 @@ class TestDatasetChildChunkApiDelete(SQLiteEndpointTest):
                     segment_id=segment_id,
                     child_chunk_id="cc-id",
                 )
+
+
+class TestModelValidateDecorator(SQLiteEndpointTest):
+    """The endpoint tests above supply valid bodies, so this is what covers the decorators."""
+
+    @staticmethod
+    def _setup_billing_mocks(mock_validate_token: Mock, mock_feature_svc: Mock, tenant_id: str) -> None:
+        """Configure mocks to neutralise billing/auth decorators."""
+        mock_validate_token.return_value = _api_token(tenant_id)
+
+        mock_features = Mock()
+        mock_features.billing.enabled = False
+        mock_feature_svc.get_features.return_value = mock_features
+
+        mock_vector_space = Mock()
+        mock_vector_space.limit = 10
+        mock_vector_space.size = 0
+        mock_feature_svc.get_vector_space.return_value = mock_vector_space
+
+        mock_rate_limit = Mock()
+        mock_rate_limit.enabled = False
+        mock_feature_svc.get_knowledge_rate_limit.return_value = mock_rate_limit
+
+    @pytest.mark.parametrize(
+        ("call", "route"),
+        [
+            (
+                lambda: DatasetSegmentApi().post(
+                    tenant_id="t", dataset_id="d", document_id="doc-id", segment_id="seg-id"
+                ),
+                "/datasets/d/documents/doc-id/segments/seg-id",
+            ),
+            (
+                lambda: ChildChunkApi().post(tenant_id="t", dataset_id="d", document_id="doc-id", segment_id="seg-id"),
+                "/datasets/d/documents/doc-id/segments/seg-id/child_chunks",
+            ),
+            (
+                lambda: DatasetChildChunkApi().patch(
+                    tenant_id="t", dataset_id="d", document_id="doc-id", segment_id="seg-id", child_chunk_id="cc-id"
+                ),
+                "/datasets/d/documents/doc-id/segments/seg-id/child_chunks/cc-id",
+            ),
+        ],
+    )
+    @patch("controllers.service_api.wraps.FeatureService")
+    @patch("controllers.service_api.wraps.validate_and_get_api_token")
+    def test_invalid_body_is_rejected_before_the_handler_runs(
+        self,
+        mock_validate_token: Mock,
+        mock_feature_svc: Mock,
+        app: Flask,
+        mock_tenant: Mock,
+        call: Callable[[], object],
+        route: str,
+    ) -> None:
+        self._setup_billing_mocks(mock_validate_token, mock_feature_svc, mock_tenant.id)
+
+        with app.test_request_context(route, method="POST", json={}, headers={"Authorization": "Bearer test_token"}):
+            with pytest.raises(UnprocessableEntity) as exc_info:
+                call()
+
+        assert exc_info.value.code == 422


### PR DESCRIPTION
## Summary

part of #36659

Moves three of the four inline parses in `service_api/dataset/segment.py` onto the `@model_validate` decorator. Claimed in [this comment](https://github.com/langgenius/dify/issues/36659#issuecomment-5489740759).

- `DatasetSegmentApi.post` — `SegmentUpdatePayload`
- `ChildChunkApi.post` — `ChildChunkCreatePayload`
- `DatasetChildChunkApi.patch` — `ChildChunkUpdatePayload`

## Deliberately left alone

`SegmentApi.post` (L221). Its parse sits inside `except ValidationError: return {"error": str(e)}, 400`, and `test_dataset_segment.py:1240` asserts both the status and the `error` key — converting it would change a tested contract rather than just move the parse.

## Test notes

The existing endpoint tests call these handlers with keyword arguments (`api.post(tenant_id=..., dataset_id=...)`) and the decorator injects the model positionally after `self`, so **none of them needed changing**.

They also all send valid bodies, which would leave the decorators unexercised — the failure mode is that a wrong or missing decorator ships green. So this adds one bound-method test parametrized over the three handlers, asserting the 422. Removing any one of the three decorators now fails exactly one case. `DatasetChildChunkApi.patch` had no test at all before this.

## Behaviour note

Validation now runs before each handler's `NotFound` guards, so a request that is both malformed and points at a missing dataset reports the malformed body. Same shift as the merged conversions in this campaign.

## How did you test it?

- `pytest tests/unit_tests/controllers/service_api/` — **775 passed**, against 772 on `main`; the three extra are the parametrized decorator test
- `ruff check` / `ruff format --check` — clean
- `pyrefly` on the controller — 0 diagnostics; on the test file, unchanged from `main`
- `lint-imports` — 23 contracts kept; response-contract lint — 503 valid, 0 mismatch
- Mutation-checked: dropping each of the three decorators in turn fails the suite

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.
