### PR TITLE
fix: handle published workflow request failures in access points

### DIFF
--- a/web/app/components/app/access-point/__tests__/built-in-access-points.spec.tsx
+++ b/web/app/components/app/access-point/__tests__/built-in-access-points.spec.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   } as Record<string, unknown>,
   workflow: {
     data: null as Record<string, unknown> | null,
+    isError: false,
     isPending: false,
   },
   webCard: vi.fn(),
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   },
   mcpCard: vi.fn(),
   triggerCard: vi.fn(),
+  useAppWorkflow: vi.fn(),
 }))
 
 vi.mock('react-i18next', async () => {
@@ -60,7 +62,10 @@ vi.mock('@/context/i18n', () => ({
 }))
 
 vi.mock('@/service/use-workflow', () => ({
-  useAppWorkflow: () => mocks.workflow,
+  useAppWorkflow: (...args: unknown[]) => {
+    mocks.useAppWorkflow(...args)
+    return mocks.workflow
+  },
 }))
 
 vi.mock('@/utils/permission', () => ({
@@ -118,6 +123,7 @@ describe('BuiltInAccessPoints', () => {
     }
     mocks.workflow = {
       data: null,
+      isError: false,
       isPending: false,
     }
     mocks.capabilities = {
@@ -150,6 +156,7 @@ describe('BuiltInAccessPoints', () => {
           nodes: [{ data: { type: 'start' } }],
         },
       },
+      isError: false,
       isPending: false,
     }
 
@@ -197,6 +204,7 @@ describe('BuiltInAccessPoints', () => {
           nodes: [{ data: { type: 'trigger-webhook' } }],
         },
       },
+      isError: false,
       isPending: false,
     }
 
@@ -222,6 +230,7 @@ describe('BuiltInAccessPoints', () => {
   it('keeps all cards visible while the published workflow is loading', () => {
     mocks.workflow = {
       data: null,
+      isError: false,
       isPending: true,
     }
 
@@ -232,5 +241,31 @@ describe('BuiltInAccessPoints', () => {
     expect(mocks.triggerCard).toHaveBeenCalledWith(
       expect.objectContaining({ availability: 'loading' }),
     )
+  })
+
+  it('does not show the unpublished card when loading the published workflow fails', () => {
+    mocks.workflow = {
+      data: null,
+      isError: true,
+      isPending: false,
+    }
+
+    render(<BuiltInAccessPoints appId="app-1" />)
+
+    expect(
+      screen.queryByText('deployments.studio.accessPoint.noPublishedTitle'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not retry forbidden published workflow requests', () => {
+    render(<BuiltInAccessPoints appId="app-1" />)
+
+    const options = mocks.useAppWorkflow.mock.calls.at(-1)?.[1] as {
+      retry: (failureCount: number, error: unknown) => boolean
+    }
+
+    expect(options.retry(0, new Response(null, { status: 403 }))).toBe(false)
+    expect(options.retry(0, new Response(null, { status: 500 }))).toBe(true)
+    expect(options.retry(3, new Response(null, { status: 500 }))).toBe(false)
   })
 })

--- a/web/app/components/app/access-point/built-in-access-points/index.tsx
+++ b/web/app/components/app/access-point/built-in-access-points/index.tsx
@@ -39,9 +39,17 @@ export function BuiltInAccessPoints({ appId, highlightedAccessPoint }: BuiltInAc
   const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const shouldFetchWorkflow = Boolean(appInfo && isAdvancedApp(appInfo))
-  const { data: workflow, isPending: workflowLoading } = useAppWorkflow(
-    shouldFetchWorkflow ? appId : '',
-  )
+  const {
+    data: workflow,
+    isError: workflowError,
+    isPending: workflowLoading,
+  } = useAppWorkflow(shouldFetchWorkflow ? appId : '', {
+    retry: (failureCount, error) => {
+      if (error instanceof Response && error.status === 403) return false
+
+      return failureCount < 3
+    },
+  })
   const capabilities = useMemo(
     () =>
       getAppACLCapabilities(appInfo?.permission_keys, {
@@ -72,7 +80,7 @@ export function BuiltInAccessPoints({ appId, highlightedAccessPoint }: BuiltInAc
 
   return (
     <div className="flex h-full flex-col gap-2">
-      {workflowState.isUnpublished && !workflowLoading && (
+      {workflowState.isUnpublished && !workflowLoading && !workflowError && (
         <div className="flex flex-col items-start gap-2 rounded-xl bg-background-section-burn p-3">
           <div className="flex flex-col gap-0.5">
             <span className="block system-md-semibold text-text-secondary">

--- a/web/service/use-workflow.ts
+++ b/web/service/use-workflow.ts
@@ -1,3 +1,4 @@
+import type { UseQueryOptions } from '@tanstack/react-query'
 import type { CommonResponse } from '@/models/common'
 import type { FlowType } from '@/types/common'
 import type {
@@ -18,8 +19,13 @@ import { appWorkflowQueryOptions, appWorkflowVersionsInfiniteQueryKey } from './
 
 const NAME_SPACE = 'workflow'
 
-export const useAppWorkflow = (appID: string) => {
-  return useQuery(appWorkflowQueryOptions(appID))
+type UseAppWorkflowOptions = Pick<UseQueryOptions, 'retry'>
+
+export const useAppWorkflow = (appID: string, options?: UseAppWorkflowOptions) => {
+  return useQuery({
+    ...appWorkflowQueryOptions(appID),
+    ...options,
+  })
 }
 
 const WorkflowRunHistoryKey = [NAME_SPACE, 'runHistory']


### PR DESCRIPTION
## Summary

- Hide the no-published-version guidance when the published workflow request fails.
- Stop retrying forbidden published workflow requests on the Access Point page while preserving retries for other failures.
- Add regression coverage for request errors and the 403 retry policy.

Fixes SNP-735

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.