### PR TITLE
refactor(inner_api): dep-inject request payloads with @model_validate

### DIFF
--- a/api/controllers/inner_api/app/dsl.py
+++ b/api/controllers/inner_api/app/dsl.py
@@ -14,7 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from controllers.common.schema import query_params_from_model, register_schema_model
-from controllers.console.wraps import setup_required
+from controllers.console.wraps import model_validate, setup_required
 from controllers.inner_api import inner_api_ns
 from controllers.inner_api.wraps import enterprise_inner_api_only
 from extensions.ext_database import db
@@ -61,9 +61,9 @@ class EnterpriseAppDSLImport(Resource):
             404: "Creator account not found or inactive",
         }
     )
-    def post(self, workspace_id: str):
+    @model_validate(InnerAppDSLImportPayload)
+    def post(self, args: InnerAppDSLImportPayload, workspace_id: str):
         """Import a DSL into a workspace on behalf of a specified creator."""
-        args = InnerAppDSLImportPayload.model_validate(inner_api_ns.payload or {})
 
         account = _get_active_account(args.creator_email)
         if account is None:

--- a/api/controllers/inner_api/mail.py
+++ b/api/controllers/inner_api/mail.py
@@ -4,7 +4,7 @@ from flask_restx import Resource
 from pydantic import BaseModel, Field
 
 from controllers.common.schema import register_schema_model
-from controllers.console.wraps import setup_required
+from controllers.console.wraps import model_validate, setup_required
 from controllers.inner_api import inner_api_ns
 from controllers.inner_api.wraps import inner_api_only
 from extensions.ext_application_services import application_services
@@ -27,8 +27,8 @@ class BaseMail(Resource):
     @inner_api_ns.doc("send_inner_mail")
     @inner_api_ns.doc(description="Send internal email")
     @inner_api_ns.expect(inner_api_ns.models[InnerMailPayload.__name__])
-    def post(self):
-        args = InnerMailPayload.model_validate(inner_api_ns.payload or {})
+    @model_validate(InnerMailPayload)
+    def post(self, args: InnerMailPayload):
         application_services().inner_mail.send(
             InnerMailMessage(
                 recipients=tuple(args.to),

--- a/api/controllers/inner_api/runtime_credentials.py
+++ b/api/controllers/inner_api/runtime_credentials.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from controllers.common.schema import register_schema_model
-from controllers.console.wraps import setup_required
+from controllers.console.wraps import model_validate, setup_required
 from controllers.inner_api import inner_api_ns
 from controllers.inner_api.wraps import enterprise_inner_api_only
 from core.helper import encrypter
@@ -67,8 +67,8 @@ class EnterpriseRuntimeCredentialsResolve(Resource):
         },
     )
     @inner_api_ns.expect(inner_api_ns.models[InnerRuntimeCredentialsResolvePayload.__name__])
-    def post(self):
-        args = InnerRuntimeCredentialsResolvePayload.model_validate(inner_api_ns.payload or {})
+    @model_validate(InnerRuntimeCredentialsResolvePayload)
+    def post(self, args: InnerRuntimeCredentialsResolvePayload):
         if not args.credentials:
             return {"credentials": []}, 200
 

--- a/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
+++ b/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
@@ -18,7 +18,6 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from werkzeug.exceptions import UnprocessableEntity
 
-from configs import dify_config
 from controllers.inner_api.app import dsl as dsl_module
 from controllers.inner_api.app.dsl import (
     EnterpriseAppDSLExport,
@@ -31,6 +30,7 @@ from models.account import AccountStatus, TenantAccountRole
 from models.model import AppMode, IconType
 from services.app_dsl_service import Import, ImportStatus
 from services.errors.app import IsDraftWorkflowError, WorkflowNotFoundError
+from tests.unit_tests.config_override import config_overrides_context
 
 
 def _persist_app(session: Session) -> App:
@@ -497,8 +497,7 @@ class TestModelValidateDecorator:
 
         with (
             patch("controllers.console.wraps._is_setup_completed", return_value=True),
-            patch.object(dify_config, "INNER_API", True),
-            patch.object(dify_config, "INNER_API_KEY", "inner-api-key"),
+            config_overrides_context(INNER_API=True, INNER_API_KEY="inner-api-key"),
             app.test_request_context(
                 method="POST",
                 json={},

--- a/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
+++ b/api/tests/unit_tests/controllers/inner_api/app/test_dsl.py
@@ -16,7 +16,9 @@ from pydantic import ValidationError
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from werkzeug.exceptions import UnprocessableEntity
 
+from configs import dify_config
 from controllers.inner_api.app import dsl as dsl_module
 from controllers.inner_api.app.dsl import (
     EnterpriseAppDSLExport,
@@ -185,13 +187,12 @@ class TestEnterpriseAppDSLImport:
         self._mock_dsl.import_app.return_value = self._make_import_result(ImportStatus.COMPLETED)
 
         unwrapped = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.app.dsl.inner_api_ns") as mock_ns:
-                mock_ns.payload = {
-                    "yaml_content": "version: 0.6.0\n",
-                    "creator_email": "user@example.com",
-                }
-                result = unwrapped(api_instance, workspace_id="ws-123")
+        payload = {
+            "yaml_content": "version: 0.6.0\n",
+            "creator_email": "user@example.com",
+        }
+        with app.test_request_context(json=payload):
+            result = unwrapped(api_instance, InnerAppDSLImportPayload.model_validate(payload), workspace_id="ws-123")
 
         body, status_code = result
         assert status_code == 200
@@ -208,10 +209,11 @@ class TestEnterpriseAppDSLImport:
         self._mock_dsl.import_app.return_value = self._make_import_result(ImportStatus.PENDING)
 
         unwrapped = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.app.dsl.inner_api_ns") as mock_ns:
-                mock_ns.payload = {"yaml_content": "test", "creator_email": "u@e.com"}
-                body, status_code = unwrapped(api_instance, workspace_id="ws-123")
+        payload = {"yaml_content": "test", "creator_email": "u@e.com"}
+        with app.test_request_context(json=payload):
+            body, status_code = unwrapped(
+                api_instance, InnerAppDSLImportPayload.model_validate(payload), workspace_id="ws-123"
+            )
 
         assert status_code == 202
         assert body["status"] == "pending"
@@ -225,10 +227,11 @@ class TestEnterpriseAppDSLImport:
         self._mock_dsl.import_app.return_value = self._make_import_result(ImportStatus.FAILED)
 
         unwrapped = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.app.dsl.inner_api_ns") as mock_ns:
-                mock_ns.payload = {"yaml_content": "test", "creator_email": "u@e.com"}
-                body, status_code = unwrapped(api_instance, workspace_id="ws-123")
+        payload = {"yaml_content": "test", "creator_email": "u@e.com"}
+        with app.test_request_context(json=payload):
+            body, status_code = unwrapped(
+                api_instance, InnerAppDSLImportPayload.model_validate(payload), workspace_id="ws-123"
+            )
 
         assert status_code == 400
         assert body["status"] == "failed"
@@ -239,10 +242,9 @@ class TestEnterpriseAppDSLImport:
         mock_get_account.return_value = None
 
         unwrapped = inspect.unwrap(api_instance.post)
-        with app.test_request_context():
-            with patch("controllers.inner_api.app.dsl.inner_api_ns") as mock_ns:
-                mock_ns.payload = {"yaml_content": "test", "creator_email": "missing@e.com"}
-                result = unwrapped(api_instance, workspace_id="ws-123")
+        payload = {"yaml_content": "test", "creator_email": "missing@e.com"}
+        with app.test_request_context(json=payload):
+            result = unwrapped(api_instance, InnerAppDSLImportPayload.model_validate(payload), workspace_id="ws-123")
 
         body, status_code = result
         assert status_code == 404
@@ -485,3 +487,23 @@ class TestEnterpriseAppDSLExport:
         body, status_code = result
         assert status_code == 404
         assert "app not found" in body["message"]
+
+
+class TestModelValidateDecorator:
+    """The handler tests above unwrap the view, so this is what covers the decorator."""
+
+    def test_invalid_body_is_rejected_before_the_handler_runs(self, app: Flask) -> None:
+        api_instance = EnterpriseAppDSLImport()
+
+        with (
+            patch("controllers.console.wraps._is_setup_completed", return_value=True),
+            patch.object(dify_config, "INNER_API", True),
+            patch.object(dify_config, "INNER_API_KEY", "inner-api-key"),
+            app.test_request_context(
+                method="POST",
+                json={},
+                headers={"X-Inner-Api-Key": "inner-api-key"},
+            ),
+            pytest.raises(UnprocessableEntity),
+        ):
+            api_instance.post(workspace_id="ws-123")

--- a/api/tests/unit_tests/controllers/inner_api/test_mail.py
+++ b/api/tests/unit_tests/controllers/inner_api/test_mail.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 from pydantic import ValidationError
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, UnprocessableEntity
 
 from controllers.inner_api.mail import BaseMail, BillingMail, EnterpriseMail, InnerMailPayload
 from controllers.inner_api.wraps import InnerApiUnauthorizedError
@@ -96,15 +96,30 @@ class TestBaseMail:
         services = SimpleNamespace(inner_mail=mail_service)
 
         with (
-            app.test_request_context(),
-            patch("controllers.inner_api.mail.inner_api_ns") as namespace,
+            app.test_request_context(method="POST", json=payload),
             patch("controllers.inner_api.mail.application_services", return_value=services),
         ):
-            namespace.payload = payload
             result = unwrap(resource_type.post)(resource_type())
 
         assert result == ({"message": "success"}, 200)
         mail_service.send.assert_called_once_with(expected)
+
+    @pytest.mark.parametrize("resource_type", [EnterpriseMail, BillingMail])
+    def test_invalid_body_is_rejected_before_the_application_service_runs(
+        self, resource_type: type[BaseMail], app: Flask
+    ) -> None:
+        """`super().post()` relies on the decorator to supply the payload, so this covers it."""
+        mail_service = MagicMock()
+        services = SimpleNamespace(inner_mail=mail_service)
+
+        with (
+            app.test_request_context(method="POST", json={}),
+            patch("controllers.inner_api.mail.application_services", return_value=services),
+            pytest.raises(UnprocessableEntity),
+        ):
+            unwrap(resource_type.post)(resource_type())
+
+        mail_service.send.assert_not_called()
 
 
 def test_disabled_inner_api_returns_not_found_before_setup(app: Flask, config_overrides: Callable[..., None]) -> None:

--- a/api/tests/unit_tests/controllers/inner_api/test_runtime_credentials.py
+++ b/api/tests/unit_tests/controllers/inner_api/test_runtime_credentials.py
@@ -10,13 +10,13 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import UnprocessableEntity
 
-from configs import dify_config
 from controllers.inner_api.runtime_credentials import (
     EnterpriseRuntimeCredentialsResolve,
     InnerRuntimeCredentialsResolvePayload,
 )
 from models.provider import ProviderCredential
 from models.tools import BuiltinToolProvider
+from tests.unit_tests.config_override import config_overrides_context
 
 
 def test_runtime_credentials_payload_accepts_items():
@@ -231,8 +231,7 @@ def test_invalid_body_is_rejected_before_the_handler_runs(app: Flask) -> None:
 
     with (
         patch("controllers.console.wraps._is_setup_completed", return_value=True),
-        patch.object(dify_config, "INNER_API", True),
-        patch.object(dify_config, "INNER_API_KEY", "inner-api-key"),
+        config_overrides_context(INNER_API=True, INNER_API_KEY="inner-api-key"),
         app.test_request_context(
             method="POST",
             json={},

--- a/api/tests/unit_tests/controllers/inner_api/test_runtime_credentials.py
+++ b/api/tests/unit_tests/controllers/inner_api/test_runtime_credentials.py
@@ -8,7 +8,9 @@ import pytest
 from flask import Flask
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
+from werkzeug.exceptions import UnprocessableEntity
 
+from configs import dify_config
 from controllers.inner_api.runtime_credentials import (
     EnterpriseRuntimeCredentialsResolve,
     InnerRuntimeCredentialsResolvePayload,
@@ -73,19 +75,18 @@ def test_runtime_model_credentials_resolve_returns_decrypted_values(
 
     handler = EnterpriseRuntimeCredentialsResolve()
     unwrapped = inspect.unwrap(handler.post)
-    with app.test_request_context():
-        with patch("controllers.inner_api.runtime_credentials.inner_api_ns") as mock_ns:
-            mock_ns.payload = {
-                "tenant_id": "tenant-1",
-                "credentials": [
-                    {
-                        "credential_id": "credential-1",
-                        "provider": "langgenius/openai/openai",
-                        "kind": "model",
-                    }
-                ],
+    payload = {
+        "tenant_id": "tenant-1",
+        "credentials": [
+            {
+                "credential_id": "credential-1",
+                "provider": "langgenius/openai/openai",
+                "kind": "model",
             }
-            body, status_code = unwrapped(handler)
+        ],
+    }
+    with app.test_request_context(json=payload):
+        body, status_code = unwrapped(handler, InnerRuntimeCredentialsResolvePayload.model_validate(payload))
 
     assert status_code == 200
     assert body["credentials"][0]["kind"] == "model"
@@ -104,13 +105,12 @@ def test_runtime_model_credentials_resolve_rejects_unknown_provider(mock_provide
 
     handler = EnterpriseRuntimeCredentialsResolve()
     unwrapped = inspect.unwrap(handler.post)
-    with app.test_request_context():
-        with patch("controllers.inner_api.runtime_credentials.inner_api_ns") as mock_ns:
-            mock_ns.payload = {
-                "tenant_id": "tenant-1",
-                "credentials": [{"credential_id": "credential-1", "provider": "missing", "kind": "model"}],
-            }
-            body, status_code = unwrapped(handler)
+    payload = {
+        "tenant_id": "tenant-1",
+        "credentials": [{"credential_id": "credential-1", "provider": "missing", "kind": "model"}],
+    }
+    with app.test_request_context(json=payload):
+        body, status_code = unwrapped(handler, InnerRuntimeCredentialsResolvePayload.model_validate(payload))
 
     assert status_code == 404
     assert "provider" in body["message"]
@@ -152,19 +152,18 @@ def test_runtime_tool_credentials_resolve_returns_decrypted_values(
 
     handler = EnterpriseRuntimeCredentialsResolve()
     unwrapped = inspect.unwrap(handler.post)
-    with app.test_request_context():
-        with patch("controllers.inner_api.runtime_credentials.inner_api_ns") as mock_ns:
-            mock_ns.payload = {
-                "tenant_id": "tenant-1",
-                "credentials": [
-                    {
-                        "credential_id": "credential-1",
-                        "provider": "langgenius/tavily/tavily",
-                        "kind": "tool",
-                    }
-                ],
+    payload = {
+        "tenant_id": "tenant-1",
+        "credentials": [
+            {
+                "credential_id": "credential-1",
+                "provider": "langgenius/tavily/tavily",
+                "kind": "tool",
             }
-            body, status_code = unwrapped(handler)
+        ],
+    }
+    with app.test_request_context(json=payload):
+        body, status_code = unwrapped(handler, InnerRuntimeCredentialsResolvePayload.model_validate(payload))
 
     assert status_code == 200
     assert body["credentials"][0]["kind"] == "tool"
@@ -201,13 +200,12 @@ def test_runtime_tool_credentials_resolve_rejects_unknown_credential(
 
     handler = EnterpriseRuntimeCredentialsResolve()
     unwrapped = inspect.unwrap(handler.post)
-    with app.test_request_context():
-        with patch("controllers.inner_api.runtime_credentials.inner_api_ns") as mock_ns:
-            mock_ns.payload = {
-                "tenant_id": "tenant-1",
-                "credentials": [{"credential_id": "missing", "provider": "langgenius/tavily/tavily", "kind": "tool"}],
-            }
-            body, status_code = unwrapped(handler)
+    payload = {
+        "tenant_id": "tenant-1",
+        "credentials": [{"credential_id": "missing", "provider": "langgenius/tavily/tavily", "kind": "tool"}],
+    }
+    with app.test_request_context(json=payload):
+        body, status_code = unwrapped(handler, InnerRuntimeCredentialsResolvePayload.model_validate(payload))
 
     assert status_code == 404
     assert "credential" in body["message"]
@@ -216,13 +214,30 @@ def test_runtime_tool_credentials_resolve_rejects_unknown_credential(
 def test_runtime_credentials_resolve_rejects_unknown_kind(app: Flask):
     handler = EnterpriseRuntimeCredentialsResolve()
     unwrapped = inspect.unwrap(handler.post)
-    with app.test_request_context():
-        with patch("controllers.inner_api.runtime_credentials.inner_api_ns") as mock_ns:
-            mock_ns.payload = {
-                "tenant_id": "tenant-1",
-                "credentials": [{"credential_id": "credential-1", "provider": "x", "kind": "secret"}],
-            }
-            body, status_code = unwrapped(handler)
+    payload = {
+        "tenant_id": "tenant-1",
+        "credentials": [{"credential_id": "credential-1", "provider": "x", "kind": "secret"}],
+    }
+    with app.test_request_context(json=payload):
+        body, status_code = unwrapped(handler, InnerRuntimeCredentialsResolvePayload.model_validate(payload))
 
     assert status_code == 400
     assert "kind" in body["message"]
+
+
+def test_invalid_body_is_rejected_before_the_handler_runs(app: Flask) -> None:
+    """The tests above unwrap the view, so this is what covers the decorator."""
+    handler = EnterpriseRuntimeCredentialsResolve()
+
+    with (
+        patch("controllers.console.wraps._is_setup_completed", return_value=True),
+        patch.object(dify_config, "INNER_API", True),
+        patch.object(dify_config, "INNER_API_KEY", "inner-api-key"),
+        app.test_request_context(
+            method="POST",
+            json={},
+            headers={"X-Inner-Api-Key": "inner-api-key"},
+        ),
+        pytest.raises(UnprocessableEntity),
+    ):
+        handler.post()


### PR DESCRIPTION
## Summary

Part of #36659. Converts the `Model.model_validate(inner_api_ns.payload or {})` calls
in three inner API controllers to the `@model_validate` decorator, following
#41374 / #41539.

| File | Handler | Payload |
|---|---|---|
| `api/controllers/inner_api/runtime_credentials.py` | `EnterpriseRuntimeCredentialsResolve.post` | `InnerRuntimeCredentialsResolvePayload` |
| `api/controllers/inner_api/app/dsl.py` | `EnterpriseAppDSLImport.post` | `InnerAppDSLImportPayload` |
| `api/controllers/inner_api/mail.py` | `BaseMail.post` | `InnerMailPayload` |

The decorator is applied innermost, below the `@inner_api_ns.expect(...)` docs
decorators, and the model becomes the first parameter after `self` — matching
the merged sites in this campaign.

These are the three sites I claimed in
https://github.com/langgenius/dify/issues/36659#issuecomment-5489740759.

**What is left in `inner_api` after this PR**, so the scope is explicit:

- `workspace/workspace.py` L58, L101, L140 — covered by #41540.
- `agent/llm.py`, `agent/tools.py`, `agent/files.py` (two sites), `knowledge/retrieval.py`
  — each wraps its parse in `except ValidationError` and raises a custom 400, which the
  decorator's 422 would change. `agent/{llm,tools}.py` and `knowledge/retrieval.py` have
  tests asserting that branch; `agent/files.py` does not, but it raises
  `AgentFileRequestHttpError(..., status_code=400)` all the same.
- `app/dsl.py:110` is a `request.args` GET site that *returns* a 400 body, not the
  `ns.payload` shape, so it is out of scope here either way.

## Test coverage

The existing tests for these handlers call them through `inspect.unwrap`, which
strips *every* decorator and passes an already-validated model in. That means a
straight conversion would have left the new layer completely unexercised, so
this PR adds tests that call the handlers the normal way:

- one test per site asserting `UnprocessableEntity` (422) for an invalid body,
  driven through the real decorator stack rather than an unwrapped view;
- `EnterpriseMail` and `BillingMail` forward to `BaseMail.post` via a
  no-argument `super().post()`, which now depends on the decorator to supply the
  payload — the existing parametrized delegation test now sends a real JSON body,
  and a parametrized invalid-body case asserts 422 and that the mail service is
  never reached.

Each of the three decorators was mutation-checked: deleting it turns the
corresponding tests red (1, 1, and 4 failures respectively).

The two tests that drive the real stack need `INNER_API` / `INNER_API_KEY` set, and use
`config_overrides_context` for that — direct `patch.object(dify_config, ...)` is banned by
`tests/unit_tests/test_config_overrides.py`. My first push got that wrong and went red; see
the comment below.

## Verification

Run locally. Note the scope: everything below is scoped to the changed surface, so it
cannot see failures elsewhere in the suite — CI is the authority, not this list.

- `pytest api/tests/unit_tests/controllers/inner_api/` — **150 passed** (146 on `main`, +4 new)
- `pytest api/tests/unit_tests/test_config_overrides.py` — the AST guard reports no violation
  anywhere in the unit-test tree
- `ruff check` / `ruff format --check` — clean
- `pyrefly check controllers/inner_api/` — 0 diagnostics
- `pyrefly check --config tests/unit_tests/pyrefly.toml tests/unit_tests/controllers/inner_api/` — 320 diagnostics, identical to the `main` baseline (**0 new**)
- `mypy --check-untyped-defs --disable-error-code=import-untyped controllers/inner_api/` — no
  issues (that is the flag set `make type-check-core` uses; without it you get the usual 205
  pre-existing `import-untyped` stub warnings)
- `lint-imports` — 25 contracts kept, 0 broken
- `dev/lint_response_contracts.py --fail-on-mismatch` — 0 mismatch
- no net-new `getattr(` in the diff

## Behaviour note

As on the earlier PRs in this campaign, invalid bodies now surface as 422
(`UnprocessableEntity`) from the decorator rather than whatever the handler
previously raised. That is the campaign's intended behaviour.

---
This PR was written with AI assistance.

