### PR TITLE
refactor(service-api): inject file upload service

### DIFF
--- a/api/controllers/service_api/app/file.py
+++ b/api/controllers/service_api/app/file.py
@@ -4,23 +4,23 @@ from flask_restx.api import HTTPStatus
 
 import services
 from controllers.common.errors import (
+    BlockedFileExtensionError,
     FilenameNotExistsError,
     FileTooLargeError,
     NoFileUploadedError,
     TooManyFilesError,
     UnsupportedFileTypeError,
 )
-from controllers.common.schema import register_schema_models
+from controllers.common.schema import JsonResponseWithStatus, register_response_schema_models
 from controllers.service_api import service_api_ns
 from controllers.service_api.schema import multipart_file_params
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
-from extensions.ext_database import db
+from extensions.ext_application_services import application_services
 from fields.file_fields import FileResponse
 from libs.helper import dump_response
 from models import App, EndUser
-from services.file_service import FileService
 
-register_schema_models(service_api_ns, FileResponse)
+register_response_schema_models(service_api_ns, FileResponse)
 
 
 @service_api_ns.route("/files/upload")
@@ -37,7 +37,8 @@ class FileApi(Resource):
             400: (
                 "- `no_file_uploaded` : No file was provided in the request.\n"
                 "- `too_many_files` : Only one file is allowed per request.\n"
-                "- `filename_not_exists_error` : The uploaded file has no filename."
+                "- `filename_not_exists_error` : The uploaded file has no filename.\n"
+                "- `file_extension_blocked` : The file extension is blocked for security reasons."
             ),
             413: "`file_too_large` : File size exceeded.",
             415: "`unsupported_file_type` : File type not allowed.",
@@ -57,7 +58,7 @@ class FileApi(Resource):
     )
     @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.FORM))  # type: ignore
     @service_api_ns.response(HTTPStatus.CREATED, "File uploaded", service_api_ns.models[FileResponse.__name__])
-    def post(self, app_model: App, end_user: EndUser):
+    def post(self, app_model: App, end_user: EndUser) -> JsonResponseWithStatus:
         """Upload a file for use in conversations.
 
         Accepts a single file upload via multipart/form-data.
@@ -74,18 +75,21 @@ class FileApi(Resource):
             raise UnsupportedFileTypeError()
 
         if not file.filename:
-            raise FilenameNotExistsError
+            raise FilenameNotExistsError()
 
         try:
-            upload_file = FileService(db.engine).upload_file(
+            upload_file = application_services().files.upload_file(
                 filename=file.filename,
                 content=file.stream.read(),
                 mimetype=file.mimetype,
                 user=end_user,
+                tenant_id=app_model.tenant_id,
             )
         except services.errors.file.FileTooLargeError as file_too_large_error:
-            raise FileTooLargeError(file_too_large_error.description)
-        except services.errors.file.UnsupportedFileTypeError:
-            raise UnsupportedFileTypeError()
+            raise FileTooLargeError(file_too_large_error.description) from file_too_large_error
+        except services.errors.file.UnsupportedFileTypeError as unsupported_file_type_error:
+            raise UnsupportedFileTypeError() from unsupported_file_type_error
+        except services.errors.file.BlockedFileExtensionError as blocked_file_extension_error:
+            raise BlockedFileExtensionError() from blocked_file_extension_error
 
         return dump_response(FileResponse, upload_file), 201

--- a/api/controllers/service_api/app/file.py
+++ b/api/controllers/service_api/app/file.py
@@ -83,7 +83,6 @@ class FileApi(Resource):
                 content=file.stream.read(),
                 mimetype=file.mimetype,
                 user=end_user,
-                tenant_id=app_model.tenant_id,
             )
         except services.errors.file.FileTooLargeError as file_too_large_error:
             raise FileTooLargeError(file_too_large_error.description) from file_too_large_error

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -190,6 +190,7 @@ class ApplicationServices:
     schema_definitions: SchemaDefinitionService
     setup: SetupService
     feature_queries: FeatureQueryService
+    files: FileService
     oauth_server: OAuthServerService
     init_validation: InitValidationService
     notifications: NotificationService
@@ -267,6 +268,7 @@ def build_application_services(
         builtin=builtin_catalog,
     )
     workspace_query_repository = WorkspaceQueryRepository(session_factory=database_client)
+    file_service = FileService(session_factory=database_client)
     return ApplicationServices(
         accounts=AccountServices(
             avatar=AccountAvatarService(
@@ -415,7 +417,7 @@ def build_application_services(
         ),
         web_app_runtime=WebAppRuntimeQueryService(
             runtime=app_definition_repository,
-            file_service=FileService(session_factory=database_client),
+            file_service=file_service,
             workspace_features=feature_gateway.get_workspace_features,
             files_url=dify_config.FILES_URL,
         ),
@@ -434,6 +436,7 @@ def build_application_services(
             features=feature_gateway,
             app_dsl_version=CURRENT_APP_DSL_VERSION,
         ),
+        files=file_service,
         oauth_server=_build_oauth_server_service(database_client=database_client, redis=redis),
         init_validation=InitValidationService(
             state=installation_state,

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -2000,7 +2000,7 @@ Upload a file for use when sending messages, enabling multimodal understanding o
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 201 | File uploaded successfully. | **application/json**: [FileResponse](#fileresponse)<br> |
-| 400 | - `no_file_uploaded` : No file was provided in the request. - `too_many_files` : Only one file is allowed per request. - `filename_not_exists_error` : The uploaded file has no filename. |  |
+| 400 | - `no_file_uploaded` : No file was provided in the request. - `too_many_files` : Only one file is allowed per request. - `filename_not_exists_error` : The uploaded file has no filename. - `file_extension_blocked` : The file extension is blocked for security reasons. |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 413 | `file_too_large` : File size exceeded. |  |

--- a/api/tests/unit_tests/commands/test_generate_swagger_specs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_specs.py
@@ -330,6 +330,9 @@ def test_generate_specs_writes_service_api_reference_descriptions(tmp_path: Path
     assert chat_success_content["application/json"]["schema"] == {"$ref": "#/components/schemas/ChatBlockingResponse"}
     assert chat_success_content["text/event-stream"]["schema"] == {"type": "string"}
 
+    upload_bad_request = payload["paths"]["/files/upload"]["post"]["responses"]["400"]["description"]
+    assert "`file_extension_blocked`" in upload_bad_request
+
     schemas = payload["components"]["schemas"]
     expected_property_descriptions = {
         ("AgentThought", "tool_labels"): "Labels for tools used.",

--- a/api/tests/unit_tests/controllers/service_api/app/test_file.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_file.py
@@ -19,6 +19,7 @@ import pytest
 from flask import Flask
 
 from controllers.common.errors import (
+    BlockedFileExtensionError,
     FilenameNotExistsError,
     FileTooLargeError,
     NoFileUploadedError,
@@ -234,12 +235,10 @@ class TestFileApiPost:
     which preserves ``__wrapped__``.
     """
 
-    @patch("controllers.service_api.app.file.FileService")
-    @patch("controllers.service_api.app.file.db")
+    @patch("controllers.service_api.app.file.application_services")
     def test_upload_file_success(
         self,
-        mock_db,
-        mock_file_svc_cls,
+        mock_application_services,
         app: Flask,
         mock_app_model,
         mock_end_user,
@@ -263,10 +262,11 @@ class TestFileApiPost:
         mock_upload.original_url = None
         mock_upload.reference = None
         mock_upload.user_id = None
-        mock_upload.tenant_id = None
+        mock_upload.tenant_id = mock_app_model.tenant_id
         mock_upload.conversation_id = None
         mock_upload.file_key = None
-        mock_file_svc_cls.return_value.upload_file.return_value = mock_upload
+        file_service = mock_application_services.return_value.files
+        file_service.upload_file.return_value = mock_upload
 
         data = {"file": (BytesIO(b"file content"), "test.pdf", "application/pdf")}
 
@@ -284,7 +284,16 @@ class TestFileApiPost:
             )
 
         assert status == 201
-        mock_file_svc_cls.return_value.upload_file.assert_called_once()
+        assert response["id"] == mock_upload.id
+        assert response["name"] == "test.pdf"
+        assert response["tenant_id"] == mock_app_model.tenant_id
+        file_service.upload_file.assert_called_once_with(
+            filename="test.pdf",
+            content=b"file content",
+            mimetype="application/pdf",
+            user=mock_end_user,
+            tenant_id=mock_app_model.tenant_id,
+        )
 
     def test_upload_no_file(self, app: Flask, mock_app_model, mock_end_user):
         """Test NoFileUploadedError when no file in request."""
@@ -339,12 +348,28 @@ class TestFileApiPost:
             with pytest.raises(UnsupportedFileTypeError):
                 unwrap(api.post)(api, app_model=mock_app_model, end_user=mock_end_user)
 
-    @patch("controllers.service_api.app.file.FileService")
-    @patch("controllers.service_api.app.file.db")
+    def test_upload_no_filename(self, app: Flask, mock_app_model, mock_end_user):
+        """Test FilenameNotExistsError when the uploaded file has no filename."""
+        from io import BytesIO
+
+        from controllers.service_api.app.file import FileApi
+
+        data = {"file": (BytesIO(b"content"), "", "application/pdf")}
+
+        with app.test_request_context(
+            "/files/upload",
+            method="POST",
+            content_type="multipart/form-data",
+            data=data,
+        ):
+            api = FileApi()
+            with pytest.raises(FilenameNotExistsError):
+                unwrap(api.post)(api, app_model=mock_app_model, end_user=mock_end_user)
+
+    @patch("controllers.service_api.app.file.application_services")
     def test_upload_file_too_large(
         self,
-        mock_db,
-        mock_file_svc_cls,
+        mock_application_services,
         app: Flask,
         mock_app_model,
         mock_end_user,
@@ -355,9 +380,8 @@ class TestFileApiPost:
         import services.errors.file
         from controllers.service_api.app.file import FileApi
 
-        mock_file_svc_cls.return_value.upload_file.side_effect = services.errors.file.FileTooLargeError(
-            "File exceeds 15MB limit"
-        )
+        service_error = services.errors.file.FileTooLargeError("File exceeds 15MB limit")
+        mock_application_services.return_value.files.upload_file.side_effect = service_error
 
         data = {"file": (BytesIO(b"big content"), "big.pdf", "application/pdf")}
 
@@ -368,15 +392,15 @@ class TestFileApiPost:
             data=data,
         ):
             api = FileApi()
-            with pytest.raises(FileTooLargeError):
+            with pytest.raises(FileTooLargeError) as raised:
                 unwrap(api.post)(api, app_model=mock_app_model, end_user=mock_end_user)
 
-    @patch("controllers.service_api.app.file.FileService")
-    @patch("controllers.service_api.app.file.db")
+        assert raised.value.__cause__ is service_error
+
+    @patch("controllers.service_api.app.file.application_services")
     def test_upload_unsupported_file_type(
         self,
-        mock_db,
-        mock_file_svc_cls,
+        mock_application_services,
         app: Flask,
         mock_app_model,
         mock_end_user,
@@ -387,7 +411,8 @@ class TestFileApiPost:
         import services.errors.file
         from controllers.service_api.app.file import FileApi
 
-        mock_file_svc_cls.return_value.upload_file.side_effect = services.errors.file.UnsupportedFileTypeError()
+        service_error = services.errors.file.UnsupportedFileTypeError()
+        mock_application_services.return_value.files.upload_file.side_effect = service_error
 
         data = {"file": (BytesIO(b"content"), "test.xyz", "application/octet-stream")}
 
@@ -398,5 +423,45 @@ class TestFileApiPost:
             data=data,
         ):
             api = FileApi()
-            with pytest.raises(UnsupportedFileTypeError):
+            with pytest.raises(UnsupportedFileTypeError) as raised:
                 unwrap(api.post)(api, app_model=mock_app_model, end_user=mock_end_user)
+
+        assert raised.value.__cause__ is service_error
+
+    @patch("controllers.service_api.app.file.application_services")
+    def test_upload_blocked_file_extension(
+        self,
+        mock_application_services,
+        app: Flask,
+        mock_app_model,
+        mock_end_user,
+    ):
+        """Test BlockedFileExtensionError from FileService."""
+        from io import BytesIO
+
+        import services.errors.file
+        from controllers.service_api.app.file import FileApi
+
+        service_error = services.errors.file.BlockedFileExtensionError("File extension '.exe' is blocked")
+        mock_application_services.return_value.files.upload_file.side_effect = service_error
+
+        data = {"file": (BytesIO(b"content"), "blocked.exe", "application/octet-stream")}
+
+        with app.test_request_context(
+            "/files/upload",
+            method="POST",
+            content_type="multipart/form-data",
+            data=data,
+        ):
+            api = FileApi()
+            with pytest.raises(BlockedFileExtensionError) as raised:
+                unwrap(api.post)(api, app_model=mock_app_model, end_user=mock_end_user)
+
+        assert raised.value.code == 400
+        assert raised.value.error_code == "file_extension_blocked"
+        assert raised.value.data == {
+            "code": "file_extension_blocked",
+            "message": "The file extension is blocked for security reasons.",
+            "status": 400,
+        }
+        assert raised.value.__cause__ is service_error

--- a/api/tests/unit_tests/controllers/service_api/app/test_file.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_file.py
@@ -219,11 +219,13 @@ def mock_app_model():
 
 
 @pytest.fixture
-def mock_end_user():
+def mock_end_user(mock_app_model):
     from models import EndUser
 
     user = EndUser(
         id=str(uuid.uuid4()),
+        tenant_id=mock_app_model.tenant_id,
+        app_id=mock_app_model.id,
     )
     return user
 
@@ -262,7 +264,7 @@ class TestFileApiPost:
         mock_upload.original_url = None
         mock_upload.reference = None
         mock_upload.user_id = None
-        mock_upload.tenant_id = mock_app_model.tenant_id
+        mock_upload.tenant_id = mock_end_user.tenant_id
         mock_upload.conversation_id = None
         mock_upload.file_key = None
         file_service = mock_application_services.return_value.files
@@ -286,13 +288,12 @@ class TestFileApiPost:
         assert status == 201
         assert response["id"] == mock_upload.id
         assert response["name"] == "test.pdf"
-        assert response["tenant_id"] == mock_app_model.tenant_id
+        assert response["tenant_id"] == mock_end_user.tenant_id
         file_service.upload_file.assert_called_once_with(
             filename="test.pdf",
             content=b"file content",
             mimetype="application/pdf",
             user=mock_end_user,
-            tenant_id=mock_app_model.tenant_id,
         )
 
     def test_upload_no_file(self, app: Flask, mock_app_model, mock_end_user):

--- a/api/tests/unit_tests/extensions/test_ext_application_services.py
+++ b/api/tests/unit_tests/extensions/test_ext_application_services.py
@@ -45,6 +45,7 @@ from services.billing_service import BillingService
 from services.compliance_download_service import ComplianceDownloadService
 from services.enterprise.enterprise_service import WebAppSettings
 from services.errors.enterprise import EnterpriseAPIError, EnterpriseAPINotFoundError
+from services.file_service import FileService
 from services.init_validation_service import InvalidInitializationPasswordError
 from services.partner_tenant_binding_service import PartnerTenantBindingService
 from services.retention.workflow_run.archive_download_task_cache import WorkflowRunArchiveDownloadTaskCache
@@ -190,6 +191,21 @@ def test_build_application_services_wires_tag_boundary(
     )
 
     assert isinstance(services.tags, TagApplicationService)
+
+
+def test_build_application_services_reuses_file_service(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    services = ext_application_services.build_application_services(
+        database_client=sqlite_session_factory,
+        deployment_edition=DeploymentEdition.COMMUNITY,
+        initialization_password="",
+        redis=MagicMock(spec=RedisClientWrapper),
+    )
+
+    assert isinstance(services.files, FileService)
+    assert services.files._session_maker is sqlite_session_factory
+    assert services.web_app_runtime._file_service is services.files
 
 
 def test_build_application_services_wires_workflow_run_archives(


### PR DESCRIPTION
## Summary

part of #39993

This is the base PR in a stack that migrates the file controllers one API surface at a time.

- inject the shared `FileService` through `application_services()` instead of constructing it from Flask database globals in the Service API controller
- reuse the same `FileService` instance in `WebAppRuntimeQueryService`
- preserve tenant resolution from the authenticated end user
- register `FileResponse` as a response schema and add the precise controller return type
- map blocked file extensions to the existing `400 file_extension_blocked` response instead of an empty `invalid_param` error
- regenerate the Service API OpenAPI Markdown and add focused controller, wiring, and Swagger coverage

## Behavior changes

- blocked file extensions now return `400 file_extension_blocked` with the generic security-safe message
- successful uploads keep the existing `201` response body and tenant association
- other upload status codes and response bodies are unchanged

## Validation

- 65 focused unit tests
- `make type-check-core`
- `pnpm --dir packages/contracts type-check`
- Ruff and generated-contract checks