### PR TITLE
fix(web): announce agent draft status

### DIFF
--- a/web/features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx
+++ b/web/features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx
@@ -127,7 +127,7 @@ describe('AgentRosterList', () => {
     expect(screen.queryByText('agent')).not.toBeInTheDocument()
   })
 
-  it('exposes each agent card with the agent name', () => {
+  it('exposes each agent card with its name, draft status, and description', () => {
     renderList([createAgent()])
 
     const list = screen.getByRole('list')
@@ -136,7 +136,9 @@ describe('AgentRosterList', () => {
 
     expect(card.parentElement).toBe(list)
     expect(cardLink).toHaveAttribute('href', '/agents/agent-1/configure')
-    expect(cardLink).toHaveAccessibleDescription('Find and summarize market materials.')
+    expect(cardLink).toHaveAccessibleDescription(
+      'agentV2.roster.usageStatus.draft Find and summarize market materials.',
+    )
   })
 
   it('uses the Figma-aligned card title and role typography', () => {

--- a/web/features/agent-v2/roster/components/agent-roster-list.tsx
+++ b/web/features/agent-v2/roster/components/agent-roster-list.tsx
@@ -204,6 +204,7 @@ function AgentRosterItem({ agent }: { agent: AgentAppPartial }) {
   const { formatTime } = useTimestamp()
   const nameId = useId()
   const descriptionId = useId()
+  const draftStatusId = useId()
   const [activeDialog, setActiveDialog] = useState<'delete' | 'duplicate' | 'edit' | null>(null)
   const { exportAppDsl, isExporting } = useExportAppDsl()
   const updatedAt =
@@ -217,6 +218,12 @@ function AgentRosterItem({ agent }: { agent: AgentAppPartial }) {
   const publishedReferences = agent.published_references ?? []
   const hasPublishedReferences = publishedReferences.length > 0
   const isDraft = agent.active_config_is_published !== true
+  const accessibleDescriptionIds = [
+    isDraft ? draftStatusId : '',
+    agent.description ? descriptionId : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
   const parsedIconType = zAgentIconType.safeParse(agent.icon_type).data
   const imageUrl =
     parsedIconType === 'image'
@@ -265,7 +272,7 @@ function AgentRosterItem({ agent }: { agent: AgentAppPartial }) {
             <Link
               href={`/agents/${agent.id}/configure`}
               aria-labelledby={nameId}
-              aria-describedby={agent.description ? descriptionId : undefined}
+              aria-describedby={accessibleDescriptionIds || undefined}
               className="flex h-full min-w-0 cursor-pointer touch-manipulation flex-col rounded-xl pb-9 outline-hidden"
             >
               <div className="flex items-center gap-3 pt-3.5 pr-4 pb-2 pl-3.5">
@@ -294,7 +301,10 @@ function AgentRosterItem({ agent }: { agent: AgentAppPartial }) {
               {isDraft && (
                 <div className="pointer-events-none absolute top-[-0.5px] right-0 flex h-5 items-start overflow-hidden">
                   <div className="h-5 w-3 bg-background-section-burn [clip-path:polygon(0_0,100%_0,100%_100%)]" />
-                  <div className="flex h-5 items-center bg-background-section-burn pr-2 pl-0.5 system-2xs-medium-uppercase text-text-tertiary">
+                  <div
+                    id={draftStatusId}
+                    className="flex h-5 items-center bg-background-section-burn pr-2 pl-0.5 system-2xs-medium-uppercase text-text-tertiary"
+                  >
                     {t(($) => $['roster.usageStatus.draft'])}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- include the visible Agent draft badge in the card link accessible description
- preserve the existing accessible name, layout, focus order, and sibling action controls
- update the existing card semantics test to cover the full description

## Rationale

`aria-describedby` is the owner of supplementary card information. The Agent card already associates its text description with the full-card link, but omitted the visible draft status. Associating both referenced elements keeps the draft status perceivable without changing the link name or adding another interactive element.

## Testing

- `pnpm exec vp test run --project unit features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx`
- `pnpm exec vp check web/features/agent-v2/roster/components/agent-roster-list.tsx web/features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx`
- `pnpm lint:a11y features/agent-v2/roster/components/agent-roster-list.tsx features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx`
- `pnpm check`