### PR TITLE
fix(api): sync default Web App title on app rename

### DIFF
--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -865,6 +865,14 @@ class AppService:
                 raise AgentNameConflictError() from exc
             raise
 
+    @staticmethod
+    def _sync_default_site_title_on_rename(app: App, old_name: str, *, updated_by: str, session: Session) -> None:
+        with session.no_autoflush:
+            site = session.scalar(select(Site).where(Site.app_id == app.id).limit(1))
+        if site is not None and site.title == old_name:
+            site.title = app.name
+            site.updated_by = updated_by
+
     def update_app(self, app: App, args: ArgsDict, *, session: Session) -> App:
         """
         Update app
@@ -873,6 +881,7 @@ class AppService:
         :return: App instance
         """
         assert current_user is not None
+        old_name = app.name
         app.name = args["name"]
         app.description = args["description"]
         icon_type = args.get("icon_type")
@@ -902,6 +911,7 @@ class AppService:
             updated_at=app.updated_at,
             session=session,
         )
+        self._sync_default_site_title_on_rename(app, old_name, updated_by=current_user.id, session=session)
         self._commit_app_identity_update(app, session=session)
 
         app_was_updated.send(app)
@@ -916,6 +926,7 @@ class AppService:
         :return: App instance
         """
         assert current_user is not None
+        old_name = app.name
         app.name = name
         app.updated_by = current_user.id
         app.updated_at = naive_utc_now()
@@ -926,6 +937,7 @@ class AppService:
             updated_at=app.updated_at,
             session=session,
         )
+        self._sync_default_site_title_on_rename(app, old_name, updated_by=current_user.id, session=session)
         self._commit_app_identity_update(app, session=session)
 
         app_was_updated.send(app)

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -23,7 +23,8 @@ from models.agent import (
     WorkflowAgentBindingType,
     WorkflowAgentNodeBinding,
 )
-from models.model import App, AppMode, AppModelConfig, IconType
+from models.enums import CustomizeTokenStrategy
+from models.model import App, AppMode, AppModelConfig, IconType, Site
 from models.workflow import Workflow, WorkflowType
 from services.agent.errors import AgentAccessNotReadyError, AgentNameConflictError
 from services.app_service import AppListParams, AppService, CreateAppParams
@@ -65,6 +66,19 @@ def _persist_app(session: Session, *, tenant_id: str, name: str = "Visible App")
     session.add(app)
     session.commit()
     return app
+
+
+def _persist_site(session: Session, *, app_id: str, title: str) -> Site:
+    site = Site(
+        app_id=app_id,
+        title=title,
+        default_language="en-US",
+        customize_token_strategy=CustomizeTokenStrategy.NOT_ALLOW,
+        code=f"site-{uuid4()}",
+    )
+    session.add(site)
+    session.commit()
+    return site
 
 
 def _persist_agent_app(
@@ -621,6 +635,98 @@ class TestAgentAppType:
         assert backing_agent.icon_background == "#123456"
         assert backing_agent.updated_by == account_id
         assert backing_agent.updated_at == updated_app.updated_at
+
+    def test_update_app_syncs_default_site_title_on_rename(self, sqlite_session: Session):
+        app = _persist_app(sqlite_session, tenant_id=str(uuid4()), name="Old App")
+        site = _persist_site(sqlite_session, app_id=app.id, title="Old App")
+        account_id = str(uuid4())
+
+        with (
+            patch("services.app_service.current_user", _account_identity(account_id)),
+            patch("services.app_service.app_was_updated.send"),
+        ):
+            AppService().update_app(
+                app,
+                {
+                    "name": "New App",
+                    "description": "updated",
+                    "icon_type": "emoji",
+                    "icon": "sparkles",
+                    "icon_background": "#123456",
+                    "use_icon_as_answer_icon": False,
+                    "max_active_requests": 0,
+                },
+                session=sqlite_session,
+            )
+
+        sqlite_session.expire_all()
+        refreshed_site = sqlite_session.get(Site, site.id)
+        assert refreshed_site is not None
+        assert refreshed_site.title == "New App"
+        assert refreshed_site.updated_by == account_id
+
+    def test_update_app_preserves_customized_site_title(self, sqlite_session: Session):
+        app = _persist_app(sqlite_session, tenant_id=str(uuid4()), name="Old App")
+        site = _persist_site(sqlite_session, app_id=app.id, title="Custom Web App Title")
+        account_id = str(uuid4())
+
+        with (
+            patch("services.app_service.current_user", _account_identity(account_id)),
+            patch("services.app_service.app_was_updated.send"),
+        ):
+            AppService().update_app(
+                app,
+                {
+                    "name": "New App",
+                    "description": "updated",
+                    "icon_type": "emoji",
+                    "icon": "sparkles",
+                    "icon_background": "#123456",
+                    "use_icon_as_answer_icon": False,
+                    "max_active_requests": 0,
+                },
+                session=sqlite_session,
+            )
+
+        sqlite_session.expire_all()
+        refreshed_site = sqlite_session.get(Site, site.id)
+        assert refreshed_site is not None
+        assert refreshed_site.title == "Custom Web App Title"
+        assert refreshed_site.updated_by is None
+
+    def test_update_app_name_syncs_default_site_title_on_rename(self, sqlite_session: Session):
+        app = _persist_app(sqlite_session, tenant_id=str(uuid4()), name="Old App")
+        site = _persist_site(sqlite_session, app_id=app.id, title="Old App")
+        account_id = str(uuid4())
+
+        with (
+            patch("services.app_service.current_user", _account_identity(account_id)),
+            patch("services.app_service.app_was_updated.send"),
+        ):
+            AppService().update_app_name(app, "New App", session=sqlite_session)
+
+        sqlite_session.expire_all()
+        refreshed_site = sqlite_session.get(Site, site.id)
+        assert refreshed_site is not None
+        assert refreshed_site.title == "New App"
+        assert refreshed_site.updated_by == account_id
+
+    def test_update_app_name_preserves_customized_site_title(self, sqlite_session: Session):
+        app = _persist_app(sqlite_session, tenant_id=str(uuid4()), name="Old App")
+        site = _persist_site(sqlite_session, app_id=app.id, title="Custom Web App Title")
+        account_id = str(uuid4())
+
+        with (
+            patch("services.app_service.current_user", _account_identity(account_id)),
+            patch("services.app_service.app_was_updated.send"),
+        ):
+            AppService().update_app_name(app, "New App", session=sqlite_session)
+
+        sqlite_session.expire_all()
+        refreshed_site = sqlite_session.get(Site, site.id)
+        assert refreshed_site is not None
+        assert refreshed_site.title == "Custom Web App Title"
+        assert refreshed_site.updated_by is None
 
     def test_update_agent_app_preserves_role_when_args_omit_it(self, sqlite_session: Session):
         app, backing_agent = _persist_agent_app(sqlite_session)

--- a/e2e/features/apps/web-app-service.feature
+++ b/e2e/features/apps/web-app-service.feature
@@ -16,3 +16,10 @@ Feature: Manage Web App service
     Then the Web App should be in service
     When the anonymous visitor reloads the Web App
     Then the published workflow Web App should be accessible
+
+  Scenario: Published workflow Web App uses the renamed default app title
+    Given I am signed in as the default E2E admin
+    And a new runnable workflow app has been published
+    When I rename the published workflow app
+    And an anonymous visitor opens the Web App
+    Then the published workflow Web App should show the renamed default title

--- a/e2e/features/step-definitions/apps/web-app-service.steps.ts
+++ b/e2e/features/step-definitions/apps/web-app-service.steps.ts
@@ -7,6 +7,8 @@ import { syncRunnableWorkflowDraft } from '../../../support/api/workflows'
 import { createE2EResourceName } from '../../../support/naming'
 import { baseURL, defaultLocale } from '../../../test-env'
 
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 Given('a new runnable workflow app has been published', async function (this: DifyWorld) {
   const client = this.getConsoleClient()
   const app = await createTestApp(client, createE2EResourceName('App', 'WebApp'), 'workflow')
@@ -46,6 +48,26 @@ When('the anonymous visitor reloads the Web App', async function (this: DifyWorl
   await this.sharedAppPage.reload({ timeout: 20_000 })
 })
 
+When('I rename the published workflow app', async function (this: DifyWorld) {
+  const appId = this.createdAppIds.at(-1)
+  if (!appId) throw new Error('No workflow app has been created.')
+
+  const renamedAppName = createE2EResourceName('App', 'RenamedWebApp')
+  await this.getConsoleClient().apps.byAppId.put({
+    body: {
+      name: renamedAppName,
+      description: '',
+      icon_type: 'emoji',
+      icon: '🤖',
+      icon_background: '#FFEAD5',
+      use_icon_as_answer_icon: false,
+      max_active_requests: 0,
+    },
+    params: { app_id: appId },
+  })
+  this.lastCreatedAppName = renamedAppName
+})
+
 When('I disable the Web App', async function (this: DifyWorld) {
   const webAppSwitch = getWebAppSwitch(this)
 
@@ -82,6 +104,16 @@ Then('the published workflow Web App should be accessible', async function (this
     timeout: 15_000,
   })
 })
+
+Then(
+  'the published workflow Web App should show the renamed default title',
+  async function (this: DifyWorld) {
+    if (!this.sharedAppPage) throw new Error('The anonymous visitor has not opened the Web App.')
+    if (!this.lastCreatedAppName) throw new Error('No renamed app name is available.')
+
+    await expect(this.sharedAppPage).toHaveTitle(new RegExp(escapeRegExp(this.lastCreatedAppName)))
+  },
+)
 
 Then('the published workflow Web App should be unavailable', async function (this: DifyWorld) {
   if (!this.sharedAppPage) throw new Error('The anonymous visitor has not opened the Web App.')


### PR DESCRIPTION
## Summary

- Sync the generated Web App/Site title when an app is renamed, but only if the site title still matches the old default app name.
- Preserve customized Web App titles during app rename flows.
- Cover both `update_app` and `update_app_name` with unit regressions, plus a workflow Web App E2E scenario for the published title.

Fixes #41593

## Test Plan

- `uv run --project api --dev ruff format api/services/app_service.py api/tests/unit_tests/services/test_app_service.py && uv run --project api --dev ruff check api/services/app_service.py api/tests/unit_tests/services/test_app_service.py`
- `uv run --project api --dev pytest api/tests/unit_tests/services/test_app_service.py -k "site_title"`
- `uv run --project api --dev pytest api/tests/unit_tests/services/test_app_service.py`
- `pnpm -C e2e type-check`
- `pnpm -C e2e exec tsx ./node_modules/@cucumber/cucumber/bin/cucumber.js --config ./cucumber.config.ts --dry-run --name "Published workflow Web App uses the renamed default app title"`

I also attempted to run the full target E2E locally:

- `pnpm -C e2e e2e:full -- --name "Published workflow Web App uses the renamed default app title"`

That could not complete in this environment because the Docker binary is unavailable (`spawn docker ENOENT`).
