### PR TITLE
fix(rerank): honor an enabled zero score threshold

### DIFF
--- a/api/core/rag/rerank/weight_rerank.py
+++ b/api/core/rag/rerank/weight_rerank.py
@@ -67,7 +67,9 @@ class WeightRerankRunner(BaseRerankRunner):
                 self.weights.vector_setting.vector_weight * query_vector_score
                 + self.weights.keyword_setting.keyword_weight * query_score
             )
-            if score_threshold and score < score_threshold:
+            # `None` disables the threshold; a user-configured 0.0 is an
+            # active threshold and must be honored. See #41488.
+            if score_threshold is not None and score < score_threshold:
                 continue
             if document.metadata is not None:
                 document.metadata["score"] = score

--- a/api/tests/unit_tests/core/rag/rerank/test_reranker.py
+++ b/api/tests/unit_tests/core/rag/rerank/test_reranker.py
@@ -880,6 +880,82 @@ class TestWeightRerankRunner:
         # Assert: Only documents above threshold are returned
         assert all(doc.metadata["score"] >= 0.5 for doc in result)
 
+    def test_score_threshold_zero_filters_negative_scores_weighted(
+        self,
+        weights_config,
+        sample_documents_with_vectors,
+    ):
+        """Regression for #41488: an enabled threshold of `0.0` must
+        filter out documents with a negative combined weighted score.
+        Pre-fix `if score_threshold and ...` short-circuited on the
+        falsy `0.0` and silently dropped the filter, so negative-score
+        documents were returned despite the user enabling a zero threshold.
+        """
+        runner = WeightRerankRunner(tenant_id="tenant123", weights=weights_config)
+
+        # Stub the two private scorers so the combined score per document
+        # is fully controlled by the test, independent of fixture internals.
+        scores_by_doc = [0.4, -0.1, 0.0]
+
+        def _kw(_self, _query, docs):
+            return list(scores_by_doc[: len(docs)])
+
+        def _cos(_self, _tenant, _query, docs, _setting):
+            return [0.0] * len(docs)
+
+        with patch.object(WeightRerankRunner, "_calculate_keyword_score", _kw), patch.object(
+            WeightRerankRunner, "_calculate_cosine", _cos
+        ):
+            result = runner.run(
+                query="test",
+                documents=sample_documents_with_vectors,
+                score_threshold=0.0,
+            )
+
+        # doc2 has combined score -0.1 and must be filtered out under an
+        # enabled threshold of 0.0. doc1 (0.4) and doc3 (0.0) survive.
+        surviving_ids = [doc.metadata["doc_id"] for doc in result]
+        assert surviving_ids == ["doc1", "doc3"]
+        for doc in result:
+            assert doc.metadata["score"] >= 0.0
+
+    def test_score_threshold_none_disables_filtering_weighted(
+        self,
+        weights_config,
+        sample_documents_with_vectors,
+    ):
+        """Regression for #41488: `None` is the only "disabled" sentinel.
+        When the user has not configured a threshold, `None` is passed
+        through and every document is returned regardless of score.
+        """
+        runner = WeightRerankRunner(tenant_id="tenant123", weights=weights_config)
+
+        # Mixed positive and negative scores — none should be filtered.
+        scores_by_doc = [0.5, -0.5, 0.0]
+
+        def _kw(_self, _query, docs):
+            return list(scores_by_doc[: len(docs)])
+
+        def _cos(_self, _tenant, _query, docs, _setting):
+            return [0.0] * len(docs)
+
+        with patch.object(WeightRerankRunner, "_calculate_keyword_score", _kw), patch.object(
+            WeightRerankRunner, "_calculate_cosine", _cos
+        ):
+            # Explicitly pass score_threshold=None (also the default).
+            result = runner.run(
+                query="test",
+                documents=sample_documents_with_vectors,
+                score_threshold=None,
+            )
+            assert len(result) == len(sample_documents_with_vectors)
+            # And the default-argument path also disables filtering.
+            result_default = runner.run(
+                query="test",
+                documents=sample_documents_with_vectors,
+            )
+            assert len(result_default) == len(sample_documents_with_vectors)
+
     def test_top_k_selection_weighted(
         self,
         weights_config,

--- a/api/tests/unit_tests/core/rag/rerank/test_reranker.py
+++ b/api/tests/unit_tests/core/rag/rerank/test_reranker.py
@@ -903,8 +903,9 @@ class TestWeightRerankRunner:
         def _cos(_self, _tenant, _query, docs, _setting):
             return [0.0] * len(docs)
 
-        with patch.object(WeightRerankRunner, "_calculate_keyword_score", _kw), patch.object(
-            WeightRerankRunner, "_calculate_cosine", _cos
+        with (
+            patch.object(WeightRerankRunner, "_calculate_keyword_score", _kw),
+            patch.object(WeightRerankRunner, "_calculate_cosine", _cos),
         ):
             result = runner.run(
                 query="test",
@@ -939,8 +940,9 @@ class TestWeightRerankRunner:
         def _cos(_self, _tenant, _query, docs, _setting):
             return [0.0] * len(docs)
 
-        with patch.object(WeightRerankRunner, "_calculate_keyword_score", _kw), patch.object(
-            WeightRerankRunner, "_calculate_cosine", _cos
+        with (
+            patch.object(WeightRerankRunner, "_calculate_keyword_score", _kw),
+            patch.object(WeightRerankRunner, "_calculate_cosine", _cos),
         ):
             # Explicitly pass score_threshold=None (also the default).
             result = runner.run(


### PR DESCRIPTION
## Summary

Fixes #41488.

The truthiness check `if score_threshold and ...` in `WeightRerankRunner.run` short-circuited on the falsy value `0.0`, so a user-configured threshold of `0.0` was silently ignored and negative-score documents were returned despite the filter being enabled.

## Fix

```python
# before
if score_threshold and score < score_threshold:
    continue

# after
if score_threshold is not None and score < score_threshold:
    continue
```

`None` remains the only "disabled" sentinel. `0.0` is now honored as an active threshold (filter out scores below 0.0; keep scores at 0.0 and above).

## Tests

Two regression tests in `api/tests/unit_tests/core/rag/rerank/test_reranker.py::TestWeightRerankRunner`:

- `test_score_threshold_zero_filters_negative_scores_weighted`: `score_threshold=0.0` filters out a document with a negative combined score (`-0.1`) and retains documents with scores `0.4` and `0.0`. Pre-fix this test fails because the negative-score document leaks through.
- `test_score_threshold_none_disables_filtering_weighted`: `score_threshold=None` (explicit and default-argument path) keeps every document regardless of score, preserving the existing disabled behavior.

The first test was verified to fail against the pre-fix source and pass after the change. Full `TestWeightRerankRunner` class: 10/10 pass.

## Scope

Single-bug fix in `api/core/rag/rerank/weight_rerank.py` plus targeted regression tests. Caller-side cleanup (translating `0.0` → `None` where a caller encodes a disabled threshold as `0.0`) is intentionally out of scope; that belongs in a separate change in the config/API layer if maintainers want it.

## Out of scope (separate concerns)

- Normalizing caller-side `0.0` to `None` for any caller that incorrectly used `0.0` as a disabled sentinel.
- Documenting the threshold semantics on the runner's public docstring.

## Verification

- `uv run ruff check` on changed files: clean
- Targeted pytest on `TestWeightRerankRunner`: 10/10 pass
- Regression check: pre-fix the new zero-threshold test fails as expected

Fixes #41488