### PR TITLE
refactor(console): inject file service

### DIFF
--- a/api/controllers/console/files.py
+++ b/api/controllers/console/files.py
@@ -19,17 +19,18 @@ from controllers.common.errors import (
 from controllers.common.fields import AllowedExtensionsResponse, TextContentResponse
 from controllers.common.schema import JsonResponseWithStatus, register_response_schema_models
 from controllers.console import console_ns
+from controllers.console.flask_admission import console_account_admission
 from controllers.console.wraps import (
     account_initialization_required,
     cloud_edition_billing_resource_check,
     setup_required,
-    with_current_tenant_id,
     with_current_user,
 )
 from extensions.ext_application_services import application_services
 from fields.file_fields import FileResponse, UploadConfig
 from libs.helper import dump_response
 from libs.login import login_required
+from machinery.context import RequestContext
 from models import Account, UploadFile
 from services.feature_service import FeatureService
 
@@ -106,15 +107,12 @@ def upload_file_from_request(*, current_user: Account, resource_tenant_id: str |
 
 @console_ns.route("/files/upload")
 class FileApi(Resource):
-    @setup_required
-    @login_required
-    @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[UploadConfig.__name__])
-    @with_current_tenant_id
-    def get(self, current_tenant_id: str) -> JsonResponseWithStatus:
+    @console_account_admission()
+    def get(self, request_context: RequestContext) -> JsonResponseWithStatus:
         config = UploadConfig(
             file_size_limit=dify_config.UPLOAD_FILE_SIZE_LIMIT,
-            knowledge_file_size_limit=FeatureService.get_knowledge_file_size_limit(current_tenant_id),
+            knowledge_file_size_limit=FeatureService.get_knowledge_file_size_limit(request_context.active_workspace_id),
             batch_count_limit=dify_config.UPLOAD_FILE_BATCH_LIMIT,
             file_upload_limit=dify_config.BATCH_UPLOAD_LIMIT,
             image_file_size_limit=dify_config.UPLOAD_IMAGE_FILE_SIZE_LIMIT,
@@ -143,12 +141,11 @@ class FileApi(Resource):
 
 @console_ns.route("/files/<uuid:file_id>/preview")
 class FilePreviewApi(Resource):
-    @setup_required
-    @login_required
-    @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[TextContentResponse.__name__])
-    @with_current_tenant_id
-    def get(self, current_tenant_id: str, file_id: UUID) -> dict[str, object]:
+    @console_account_admission()
+    def get(self, request_context: RequestContext, file_id: UUID) -> dict[str, object]:
+        current_tenant_id = request_context.active_workspace_id
+        assert current_tenant_id is not None, "Console account admission did not resolve an active workspace"
         file_id_str = str(file_id)
         text = application_services().files.get_file_preview(file_id=file_id_str, tenant_id=current_tenant_id)
         return dump_response(TextContentResponse, {"content": text})
@@ -156,11 +153,9 @@ class FilePreviewApi(Resource):
 
 @console_ns.route("/files/support-type")
 class FileSupportTypeApi(Resource):
-    @setup_required
-    @login_required
-    @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[AllowedExtensionsResponse.__name__])
-    def get(self) -> dict[str, object]:
+    @console_account_admission()
+    def get(self, _request_context: RequestContext) -> dict[str, object]:
         return dump_response(
             AllowedExtensionsResponse,
             {"allowed_extensions": list(DOCUMENT_EXTENSIONS)},

--- a/api/controllers/console/files.py
+++ b/api/controllers/console/files.py
@@ -17,7 +17,8 @@ from controllers.common.errors import (
     UnsupportedFileTypeError,
 )
 from controllers.common.fields import AllowedExtensionsResponse, TextContentResponse
-from controllers.common.schema import register_response_schema_models, register_schema_models
+from controllers.common.schema import JsonResponseWithStatus, register_response_schema_models
+from controllers.console import console_ns
 from controllers.console.wraps import (
     account_initialization_required,
     cloud_edition_billing_resource_check,
@@ -25,18 +26,20 @@ from controllers.console.wraps import (
     with_current_tenant_id,
     with_current_user,
 )
-from extensions.ext_database import db
+from extensions.ext_application_services import application_services
 from fields.file_fields import FileResponse, UploadConfig
 from libs.helper import dump_response
 from libs.login import login_required
 from models import Account, UploadFile
 from services.feature_service import FeatureService
-from services.file_service import FileService
 
-from . import console_ns
-
-register_schema_models(console_ns, UploadConfig, FileResponse)
-register_response_schema_models(console_ns, AllowedExtensionsResponse, TextContentResponse)
+register_response_schema_models(
+    console_ns,
+    UploadConfig,
+    FileResponse,
+    AllowedExtensionsResponse,
+    TextContentResponse,
+)
 
 PREVIEW_WORDS_LIMIT = 3000
 
@@ -70,7 +73,7 @@ def upload_file_from_request(*, current_user: Account, resource_tenant_id: str |
     file = request.files["file"]
 
     if not file.filename:
-        raise FilenameNotExistsError
+        raise FilenameNotExistsError()
     if source == "datasets" and not current_user.is_dataset_editor:
         raise Forbidden()
 
@@ -84,7 +87,7 @@ def upload_file_from_request(*, current_user: Account, resource_tenant_id: str |
     )
 
     try:
-        return FileService(db.engine).upload_file(
+        return application_services().files.upload_file(
             filename=file.filename,
             content=file.stream.read(),
             mimetype=file.mimetype,
@@ -94,11 +97,11 @@ def upload_file_from_request(*, current_user: Account, resource_tenant_id: str |
             default_file_size_limit=default_file_size_limit,
         )
     except services.errors.file.FileTooLargeError as file_too_large_error:
-        raise FileTooLargeError(file_too_large_error.description)
-    except services.errors.file.UnsupportedFileTypeError:
-        raise UnsupportedFileTypeError()
+        raise FileTooLargeError(file_too_large_error.description) from file_too_large_error
+    except services.errors.file.UnsupportedFileTypeError as unsupported_file_type_error:
+        raise UnsupportedFileTypeError() from unsupported_file_type_error
     except services.errors.file.BlockedFileExtensionError as blocked_extension_error:
-        raise BlockedFileExtensionError(blocked_extension_error.description)
+        raise BlockedFileExtensionError(blocked_extension_error.description) from blocked_extension_error
 
 
 @console_ns.route("/files/upload")
@@ -108,7 +111,7 @@ class FileApi(Resource):
     @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[UploadConfig.__name__])
     @with_current_tenant_id
-    def get(self, current_tenant_id: str):
+    def get(self, current_tenant_id: str) -> JsonResponseWithStatus:
         config = UploadConfig(
             file_size_limit=dify_config.UPLOAD_FILE_SIZE_LIMIT,
             knowledge_file_size_limit=FeatureService.get_knowledge_file_size_limit(current_tenant_id),
@@ -123,7 +126,7 @@ class FileApi(Resource):
             single_chunk_attachment_limit=dify_config.SINGLE_CHUNK_ATTACHMENT_LIMIT,
             attachment_image_file_size_limit=dify_config.ATTACHMENT_IMAGE_FILE_SIZE_LIMIT,
         )
-        return config.model_dump(mode="json"), 200
+        return dump_response(UploadConfig, config), 200
 
     @setup_required
     @login_required
@@ -132,7 +135,7 @@ class FileApi(Resource):
     @console_ns.doc(consumes=["multipart/form-data"], params=FILE_UPLOAD_PARAMS)
     @console_ns.response(201, "File uploaded successfully", console_ns.models[FileResponse.__name__])
     @with_current_user
-    def post(self, current_user: Account):
+    def post(self, current_user: Account) -> JsonResponseWithStatus:
         upload_file = upload_file_from_request(current_user=current_user)
 
         return dump_response(FileResponse, upload_file), 201
@@ -145,10 +148,10 @@ class FilePreviewApi(Resource):
     @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[TextContentResponse.__name__])
     @with_current_tenant_id
-    def get(self, current_tenant_id: str, file_id: UUID):
+    def get(self, current_tenant_id: str, file_id: UUID) -> dict[str, object]:
         file_id_str = str(file_id)
-        text = FileService(db.engine).get_file_preview(file_id_str, current_tenant_id)
-        return TextContentResponse(content=text).model_dump(mode="json")
+        text = application_services().files.get_file_preview(file_id=file_id_str, tenant_id=current_tenant_id)
+        return dump_response(TextContentResponse, {"content": text})
 
 
 @console_ns.route("/files/support-type")
@@ -157,5 +160,8 @@ class FileSupportTypeApi(Resource):
     @login_required
     @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[AllowedExtensionsResponse.__name__])
-    def get(self):
-        return AllowedExtensionsResponse(allowed_extensions=list(DOCUMENT_EXTENSIONS)).model_dump(mode="json")
+    def get(self) -> dict[str, object]:
+        return dump_response(
+            AllowedExtensionsResponse,
+            {"allowed_extensions": list(DOCUMENT_EXTENSIONS)},
+        )

--- a/api/controllers/console/files.py
+++ b/api/controllers/console/files.py
@@ -145,7 +145,6 @@ class FilePreviewApi(Resource):
     @console_account_admission()
     def get(self, request_context: RequestContext, file_id: UUID) -> dict[str, object]:
         current_tenant_id = request_context.active_workspace_id
-        assert current_tenant_id is not None, "Console account admission did not resolve an active workspace"
         file_id_str = str(file_id)
         text = application_services().files.get_file_preview(file_id=file_id_str, tenant_id=current_tenant_id)
         return dump_response(TextContentResponse, {"content": text})

--- a/api/controllers/web/files.py
+++ b/api/controllers/web/files.py
@@ -2,22 +2,22 @@ from flask import request
 
 import services
 from controllers.common.errors import (
+    BlockedFileExtensionError,
     FilenameNotExistsError,
     FileTooLargeError,
     NoFileUploadedError,
     TooManyFilesError,
     UnsupportedFileTypeError,
 )
-from controllers.common.schema import register_schema_models
+from controllers.common.schema import JsonResponseWithStatus, register_response_schema_models
 from controllers.web import web_ns
 from controllers.web.wraps import WebApiResource
-from extensions.ext_database import db
+from extensions.ext_application_services import application_services
 from fields.file_fields import FileResponse
 from libs.helper import dump_response
 from models.model import App, EndUser
-from services.file_service import FileService
 
-register_schema_models(web_ns, FileResponse)
+register_response_schema_models(web_ns, FileResponse)
 
 
 @web_ns.route("/files/upload")
@@ -27,13 +27,18 @@ class FileApi(WebApiResource):
     @web_ns.doc(
         responses={
             201: "File uploaded successfully",
-            400: "Bad request - invalid file or parameters",
-            413: "File too large",
-            415: "Unsupported file type",
+            400: (
+                "- `no_file_uploaded` : No file was provided in the request.\n"
+                "- `too_many_files` : Only one file is allowed per request.\n"
+                "- `filename_not_exists_error` : The uploaded file has no filename.\n"
+                "- `file_extension_blocked` : The file extension is blocked for security reasons."
+            ),
+            413: "`file_too_large` : File size exceeded.",
+            415: "`unsupported_file_type` : File type not allowed.",
         }
     )
     @web_ns.response(201, "File uploaded successfully", web_ns.models[FileResponse.__name__])
-    def post(self, app_model: App, end_user: EndUser):
+    def post(self, app_model: App, end_user: EndUser) -> JsonResponseWithStatus:
         """Upload a file for use in web applications.
 
         Accepts file uploads for use within web applications, supporting
@@ -57,6 +62,7 @@ class FileApi(WebApiResource):
             FilenameNotExistsError: File has no filename
             FileTooLargeError: File exceeds size limit
             UnsupportedFileTypeError: File type not supported
+            BlockedFileExtensionError: File extension is blocked
         """
         if "file" not in request.files:
             raise NoFileUploadedError()
@@ -66,14 +72,14 @@ class FileApi(WebApiResource):
 
         file = request.files["file"]
         if not file.filename:
-            raise FilenameNotExistsError
+            raise FilenameNotExistsError()
 
         source = request.form.get("source")
         if source not in ("datasets", None):
             source = None
 
         try:
-            upload_file = FileService(db.engine).upload_file(
+            upload_file = application_services().files.upload_file(
                 filename=file.filename,
                 content=file.stream.read(),
                 mimetype=file.mimetype,
@@ -81,8 +87,10 @@ class FileApi(WebApiResource):
                 source="datasets" if source == "datasets" else None,
             )
         except services.errors.file.FileTooLargeError as file_too_large_error:
-            raise FileTooLargeError(file_too_large_error.description)
-        except services.errors.file.UnsupportedFileTypeError:
-            raise UnsupportedFileTypeError()
+            raise FileTooLargeError(file_too_large_error.description) from file_too_large_error
+        except services.errors.file.UnsupportedFileTypeError as unsupported_file_type_error:
+            raise UnsupportedFileTypeError() from unsupported_file_type_error
+        except services.errors.file.BlockedFileExtensionError as blocked_file_extension_error:
+            raise BlockedFileExtensionError() from blocked_file_extension_error
 
         return dump_response(FileResponse, upload_file), 201

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -280,15 +280,16 @@ Raises:
     FilenameNotExistsError: File has no filename
     FileTooLargeError: File exceeds size limit
     UnsupportedFileTypeError: File type not supported
+    BlockedFileExtensionError: File extension is blocked
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 201 | File uploaded successfully | **application/json**: [FileResponse](#fileresponse)<br> |
-| 400 | Bad request - invalid file or parameters |  |
-| 413 | File too large |  |
-| 415 | Unsupported file type |  |
+| 400 | - `no_file_uploaded` : No file was provided in the request. - `too_many_files` : Only one file is allowed per request. - `filename_not_exists_error` : The uploaded file has no filename. - `file_extension_blocked` : The file extension is blocked for security reasons. |  |
+| 413 | `file_too_large` : File size exceeded. |  |
+| 415 | `unsupported_file_type` : File type not allowed. |  |
 
 ### [POST] /forgot-password
 Send password reset email

--- a/api/tests/unit_tests/commands/test_generate_swagger_specs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_specs.py
@@ -605,6 +605,17 @@ def test_generate_specs_writes_service_api_reference_descriptions(tmp_path: Path
     }
 
 
+def test_generate_specs_writes_web_file_upload_error_codes(tmp_path: Path):
+    module = _load_generate_swagger_specs_module()
+
+    written_paths = module.generate_specs(tmp_path)
+    web_path = next(path for path in written_paths if path.name == "web-openapi.json")
+    payload = json.loads(web_path.read_text(encoding="utf-8"))
+
+    upload_bad_request = payload["paths"]["/files/upload"]["post"]["responses"]["400"]["description"]
+    assert "`file_extension_blocked`" in upload_bad_request
+
+
 def test_standalone_inline_model_name_includes_list_constraints():
     module = _load_generate_swagger_specs_module()
 

--- a/api/tests/unit_tests/controllers/console/test_files.py
+++ b/api/tests/unit_tests/controllers/console/test_files.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import pytest
 from flask import Flask
-from sqlalchemy import Engine
 from werkzeug.exceptions import Forbidden
 
 from configs import dify_config
@@ -92,17 +91,9 @@ def mock_account_context(mock_current_user):
 
 
 @pytest.fixture
-def mock_db(sqlite_engine: Engine):
-    with patch("controllers.console.files.db") as db_mock:
-        db_mock.engine = sqlite_engine
-        yield db_mock
-
-
-@pytest.fixture
-def mock_file_service(mock_db):
-    with patch("controllers.console.files.FileService") as fs:
-        instance = fs.return_value
-        yield instance
+def mock_file_service():
+    with patch("controllers.console.files.application_services") as services:
+        yield services.return_value.files
 
 
 class TestFileApiGet:
@@ -196,6 +187,15 @@ class TestFileApiPost:
         assert status == 201
         assert response["id"] == "file-id-123"
         assert response["name"] == "test.txt"
+        mock_file_service.upload_file.assert_called_once_with(
+            filename="test.txt",
+            content=b"hello",
+            mimetype="text/plain",
+            user=mock_account_context,
+            tenant_id=None,
+            source=None,
+            default_file_size_limit=None,
+        )
 
     def test_upload_with_resource_tenant(self, app: Flask, mock_account_context, mock_file_service):
         upload_file = _upload_file()
@@ -276,8 +276,10 @@ class TestFileApiPost:
         }
 
         with app.test_request_context(method="POST", data=data):
-            with pytest.raises(FileTooLargeError):
+            with pytest.raises(FileTooLargeError) as error_info:
                 post_method(api, mock_account_context)
+
+        assert error_info.value.__cause__ is error
 
     def test_unsupported_file_type(self, app: Flask, mock_account_context, mock_file_service):
         api = FileApi()
@@ -293,8 +295,10 @@ class TestFileApiPost:
         }
 
         with app.test_request_context(method="POST", data=data):
-            with pytest.raises(UnsupportedFileTypeError):
+            with pytest.raises(UnsupportedFileTypeError) as error_info:
                 post_method(api, mock_account_context)
+
+        assert error_info.value.__cause__ is error
 
     def test_blocked_extension(self, app: Flask, mock_account_context, mock_file_service):
         api = FileApi()
@@ -310,8 +314,11 @@ class TestFileApiPost:
         }
 
         with app.test_request_context(method="POST", data=data):
-            with pytest.raises(BlockedFileExtensionError):
+            with pytest.raises(BlockedFileExtensionError) as error_info:
                 post_method(api, mock_account_context)
+
+        assert error_info.value.description == error.description
+        assert error_info.value.__cause__ is error
 
 
 class TestFilePreviewApi:
@@ -324,6 +331,7 @@ class TestFilePreviewApi:
             result = get_method(api, "tenant-123", "1234")
 
         assert result == {"content": "preview text"}
+        mock_file_service.get_file_preview.assert_called_once_with(file_id="1234", tenant_id="tenant-123")
 
 
 class TestFileSupportTypeApi:

--- a/api/tests/unit_tests/controllers/console/test_files.py
+++ b/api/tests/unit_tests/controllers/console/test_files.py
@@ -23,6 +23,7 @@ from controllers.console.files import (
     upload_file_from_request,
 )
 from extensions.storage.storage_type import StorageType
+from machinery.context import RequestContext
 from models import Account
 from models.account import AccountStatus, TenantAccountRole
 from models.enums import CreatorUserRole
@@ -54,6 +55,15 @@ def _upload_file(*, file_id: str = "file-id-123", size: int = 1024) -> UploadFil
     )
     upload_file.id = file_id
     return upload_file
+
+
+def _request_context(*, workspace_id: str = "tenant-1") -> RequestContext:
+    return RequestContext(
+        request_id="request-1",
+        trace_id="trace-1",
+        account_id="account-1",
+        active_workspace_id=workspace_id,
+    )
 
 
 @pytest.fixture
@@ -108,7 +118,7 @@ class TestFileApiGet:
                 return_value=50,
             ) as get_knowledge_file_size_limit,
         ):
-            data, status = get_method(api, "tenant-1")
+            data, status = get_method(api, _request_context())
 
         assert status == 200
         assert "file_size_limit" in data
@@ -328,7 +338,7 @@ class TestFilePreviewApi:
         mock_file_service.get_file_preview.return_value = "preview text"
 
         with app.test_request_context():
-            result = get_method(api, "tenant-123", "1234")
+            result = get_method(api, _request_context(workspace_id="tenant-123"), "1234")
 
         assert result == {"content": "preview text"}
         mock_file_service.get_file_preview.assert_called_once_with(file_id="1234", tenant_id="tenant-123")
@@ -340,6 +350,6 @@ class TestFileSupportTypeApi:
         get_method = unwrap(api.get)
 
         with app.test_request_context():
-            result = get_method(api)
+            result = get_method(api, _request_context())
 
         assert result == {"allowed_extensions": list(DOCUMENT_EXTENSIONS)}

--- a/api/tests/unit_tests/controllers/console/test_files_security.py
+++ b/api/tests/unit_tests/controllers/console/test_files_security.py
@@ -1,6 +1,5 @@
 import builtins
 import io
-from unittest.mock import patch
 
 import pytest
 from flask.views import MethodView
@@ -8,15 +7,11 @@ from werkzeug.exceptions import Forbidden
 
 from controllers.common.errors import (
     FilenameNotExistsError,
-    FileTooLargeError,
     NoFileUploadedError,
     TooManyFilesError,
-    UnsupportedFileTypeError,
 )
 from models import Account
 from models.account import AccountStatus, TenantAccountRole
-from services.errors.file import FileTooLargeError as ServiceFileTooLargeError
-from services.errors.file import UnsupportedFileTypeError as ServiceUnsupportedFileTypeError
 
 if not hasattr(builtins, "MethodView"):
     builtins.MethodView = MethodView  # type: ignore[attr-defined]
@@ -128,34 +123,7 @@ class TestFileUploadSecurity:
             raise Forbidden()
         # Test passes if no exception is raised
 
-    # Test 4: Service error handling
-    @patch("controllers.console.files.FileService.upload_file")
-    def test_should_handle_file_too_large_error(self, mock_upload):
-        """Test that service FileTooLargeError is properly converted"""
-        mock_upload.side_effect = ServiceFileTooLargeError("File too large")
-
-        try:
-            mock_upload(filename="test.txt", content=b"data", mimetype="text/plain", user=None, source=None)
-        except ServiceFileTooLargeError as e:
-            # Simulate the error conversion in FileApi.post()
-            with pytest.raises(FileTooLargeError):
-                raise FileTooLargeError(e.description)
-
-    @patch("controllers.console.files.FileService.upload_file")
-    def test_should_handle_unsupported_file_type_error(self, mock_upload):
-        """Test that service UnsupportedFileTypeError is properly converted"""
-        mock_upload.side_effect = ServiceUnsupportedFileTypeError()
-
-        try:
-            mock_upload(
-                filename="test.exe", content=b"data", mimetype="application/octet-stream", user=None, source=None
-            )
-        except ServiceUnsupportedFileTypeError:
-            # Simulate the error conversion in FileApi.post()
-            with pytest.raises(UnsupportedFileTypeError):
-                raise UnsupportedFileTypeError()
-
-    # Test 5: File type security
+    # Test 4: File type security
     def test_should_identify_dangerous_file_extensions(self):
         """Test detection of potentially dangerous file extensions"""
         dangerous_extensions = [
@@ -201,7 +169,7 @@ class TestFileUploadSecurity:
             parts = filename.split(".")
             assert len(parts) > 2, f"Filename {filename} should have multiple extensions"
 
-    # Test 6: Configuration validation
+    # Test 5: Configuration validation
     def test_upload_configuration_structure(self):
         """Test that upload configuration has correct structure"""
         # Simulate the configuration returned by FileApi.get()

--- a/api/tests/unit_tests/controllers/web/test_files.py
+++ b/api/tests/unit_tests/controllers/web/test_files.py
@@ -8,18 +8,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
-from sqlalchemy import Engine
 
 from controllers.common.errors import (
+    BlockedFileExtensionError,
     FilenameNotExistsError,
     FileTooLargeError,
     NoFileUploadedError,
     TooManyFilesError,
+    UnsupportedFileTypeError,
 )
 from controllers.web.files import FileApi
 from extensions.storage.storage_type import StorageType
+from libs.exception import BaseHTTPException
 from models.enums import CreatorUserRole, EndUserType
 from models.model import App, AppMode, EndUser, UploadFile
+from services.errors import file as file_errors
 
 
 def _app_model() -> App:
@@ -85,35 +88,90 @@ class TestFileApi:
             with pytest.raises(FilenameNotExistsError):
                 FileApi().post(_app_model(), _end_user())
 
-    @patch("controllers.web.files.FileService")
-    @patch("controllers.web.files.db")
+    @pytest.mark.parametrize(
+        ("path", "form_source", "expected_source"),
+        [
+            ("/files/upload", None, None),
+            ("/files/upload", "datasets", "datasets"),
+            ("/files/upload", "invalid", None),
+            ("/files/upload?source=datasets", None, None),
+        ],
+    )
+    @patch("controllers.web.files.application_services")
     def test_upload_success(
-        self, mock_db: MagicMock, mock_file_svc_cls: MagicMock, app: Flask, sqlite_engine: Engine
+        self,
+        mock_application_services: MagicMock,
+        app: Flask,
+        path: str,
+        form_source: str | None,
+        expected_source: str | None,
     ) -> None:
-        mock_db.engine = sqlite_engine
-        mock_file_svc_cls.return_value.upload_file.return_value = _upload_file()
+        file_service = mock_application_services.return_value.files
+        file_service.upload_file.return_value = _upload_file()
+        app_model = _app_model()
+        end_user = _end_user()
 
-        data = {"file": (BytesIO(b"content"), "test.txt")}
-        with app.test_request_context("/files/upload", method="POST", data=data, content_type="multipart/form-data"):
-            result, status = FileApi().post(_app_model(), _end_user())
+        data: dict[str, object] = {"file": (BytesIO(b"content"), "test.txt", "text/plain")}
+        if form_source is not None:
+            data["source"] = form_source
+        with app.test_request_context(path, method="POST", data=data, content_type="multipart/form-data"):
+            result, status = FileApi().post(app_model, end_user)
 
         assert status == 201
         assert result["id"] == "file-1"
         assert result["name"] == "test.txt"
-
-    @patch("controllers.web.files.FileService")
-    @patch("controllers.web.files.db")
-    def test_file_too_large_from_service(
-        self, mock_db: MagicMock, mock_file_svc_cls: MagicMock, app: Flask, sqlite_engine: Engine
-    ) -> None:
-        import services.errors.file
-
-        mock_db.engine = sqlite_engine
-        mock_file_svc_cls.return_value.upload_file.side_effect = services.errors.file.FileTooLargeError(
-            description="max 10MB"
+        assert result["tenant_id"] == app_model.tenant_id
+        file_service.upload_file.assert_called_once_with(
+            filename="test.txt",
+            content=b"content",
+            mimetype="text/plain",
+            user=end_user,
+            source=expected_source,
         )
+
+    @pytest.mark.parametrize(
+        ("service_error", "expected_error", "expected_status", "expected_code", "expected_message"),
+        [
+            (file_errors.FileTooLargeError("max 10MB"), FileTooLargeError, 413, "file_too_large", "max 10MB"),
+            (
+                file_errors.UnsupportedFileTypeError(),
+                UnsupportedFileTypeError,
+                415,
+                "unsupported_file_type",
+                "File type not allowed.",
+            ),
+            (
+                file_errors.BlockedFileExtensionError("File extension '.exe' is blocked"),
+                BlockedFileExtensionError,
+                400,
+                "file_extension_blocked",
+                "The file extension is blocked for security reasons.",
+            ),
+        ],
+    )
+    @patch("controllers.web.files.application_services")
+    def test_service_error_mapping(
+        self,
+        mock_application_services: MagicMock,
+        app: Flask,
+        service_error: Exception,
+        expected_error: type[BaseHTTPException],
+        expected_status: int,
+        expected_code: str,
+        expected_message: str,
+    ) -> None:
+        mock_application_services.return_value.files.upload_file.side_effect = service_error
 
         data = {"file": (BytesIO(b"big"), "big.txt")}
         with app.test_request_context("/files/upload", method="POST", data=data, content_type="multipart/form-data"):
-            with pytest.raises(FileTooLargeError):
+            with pytest.raises(expected_error) as raised:
                 FileApi().post(_app_model(), _end_user())
+
+        assert raised.value.code == expected_status
+        assert raised.value.error_code == expected_code
+        assert raised.value.data == {
+            "code": expected_code,
+            "message": expected_message,
+            "status": expected_status,
+        }
+        assert raised.value.__cause__ is service_error

--- a/packages/contracts/generated/api/web/orpc.gen.ts
+++ b/packages/contracts/generated/api/web/orpc.gen.ts
@@ -367,11 +367,12 @@ export const emailCodeLogin = {
  * FilenameNotExistsError: File has no filename
  * FileTooLargeError: File exceeds size limit
  * UnsupportedFileTypeError: File type not supported
+ * BlockedFileExtensionError: File extension is blocked
  */
 export const post9 = oc
   .route({
     description:
-      'Upload a file for use in web applications\nAccepts file uploads for use within web applications, supporting\nmultiple file types with automatic validation and storage.\n\nArgs:\n    app_model: The associated application model\n    end_user: The end user uploading the file\n\nForm Parameters:\n    file: The file to upload (required)\n    source: Optional source type (datasets or None)\n\nReturns:\n    dict: File information including ID, URL, and metadata\n    int: HTTP status code 201 for success\n\nRaises:\n    NoFileUploadedError: No file provided in request\n    TooManyFilesError: Multiple files provided (only one allowed)\n    FilenameNotExistsError: File has no filename\n    FileTooLargeError: File exceeds size limit\n    UnsupportedFileTypeError: File type not supported',
+      'Upload a file for use in web applications\nAccepts file uploads for use within web applications, supporting\nmultiple file types with automatic validation and storage.\n\nArgs:\n    app_model: The associated application model\n    end_user: The end user uploading the file\n\nForm Parameters:\n    file: The file to upload (required)\n    source: Optional source type (datasets or None)\n\nReturns:\n    dict: File information including ID, URL, and metadata\n    int: HTTP status code 201 for success\n\nRaises:\n    NoFileUploadedError: No file provided in request\n    TooManyFilesError: Multiple files provided (only one allowed)\n    FilenameNotExistsError: File has no filename\n    FileTooLargeError: File exceeds size limit\n    UnsupportedFileTypeError: File type not supported\n    BlockedFileExtensionError: File extension is blocked',
     inputStructure: 'detailed',
     method: 'POST',
     operationId: 'postFilesUpload',


### PR DESCRIPTION
## Summary

- Resolve Console file upload and preview through the injected `ApplicationServices.files` instance instead of constructing `FileService` from `db.engine`.
- Register file response models in serialization mode and use `dump_response` as the response serialization boundary.
- Preserve the shared Trial upload helper, resource-tenant override, and existing multipart behavior.


