### PR TITLE
refactor(web): migrate external API selection input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2222,9 +2222,6 @@
   "web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "web/app/components/datasets/formatted-text/flavours/__tests__/edit-slice.spec.tsx": {

--- a/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
 import { RiAddLine } from '@remixicon/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import * as React from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { useModalContext } from '@/context/modal-context'
 import { useRouter } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
@@ -30,6 +30,7 @@ const ExternalApiSelection: React.FC<ExternalApiSelectionProps> = ({
     consoleQuery.datasets.externalKnowledgeApi.get.queryOptions({ input: {} })
   const { data } = useQuery(externalKnowledgeApiQueryOptions)
   const externalKnowledgeApiList = data?.data ?? []
+  const externalKnowledgeIdInputId = useId()
   const [selectedApiId, setSelectedApiId] = useState(external_knowledge_api_id)
   const { setShowExternalKnowledgeAPIModal } = useModalContext()
 
@@ -94,14 +95,18 @@ const ExternalApiSelection: React.FC<ExternalApiSelectionProps> = ({
       </div>
       <div className="flex flex-col gap-1 self-stretch">
         <div className="flex flex-col self-stretch">
-          <label className="system-sm-semibold text-text-secondary">
+          <label
+            htmlFor={externalKnowledgeIdInputId}
+            className="system-sm-semibold text-text-secondary"
+          >
             {t(($) => $.externalKnowledgeId, { ns: 'dataset' })}
           </label>
         </div>
         <Input
+          id={externalKnowledgeIdInputId}
           value={external_knowledge_id}
-          onChange={(e) =>
-            onChange({ external_knowledge_id: e.target.value, external_knowledge_api_id })
+          onValueChange={(value) =>
+            onChange({ external_knowledge_id: value, external_knowledge_api_id })
           }
           placeholder={t(($) => $.externalKnowledgeIdPlaceholder, { ns: 'dataset' }) ?? ''}
         />

--- a/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelection.spec.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelection.spec.tsx
@@ -112,7 +112,7 @@ describe('ExternalApiSelection', () => {
     }
     render(<Harness />)
 
-    await user.type(screen.getByPlaceholderText('dataset.externalKnowledgeIdPlaceholder'), 'kb-123')
+    await user.type(screen.getByRole('textbox', { name: 'dataset.externalKnowledgeId' }), 'kb-123')
 
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({ external_knowledge_id: 'kb-123' }),


### PR DESCRIPTION
## Summary

- replace the legacy external knowledge ID input with the Dify UI Input primitive
- associate the visible label with the input and use the primitive value-change contract
- query the field by its accessible role and name in the existing behavior test

## Validation

- pnpm --dir web test --run app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelection.spec.tsx
- pnpm vp check on the changed files
- Chrome visual check on /datasets/connect, including default and focused styles

From Codex