### PR TITLE
refactor(web): migrate dataset settings name input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2222,9 +2222,6 @@
   "web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "web/app/components/datasets/formatted-text/flavours/__tests__/edit-slice.spec.tsx": {

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -392,9 +392,6 @@
     "jsx-a11y/no-static-element-interactions": {
       "count": 1
     },
-    "no-restricted-imports": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 1
     }

--- a/web/app/components/app/configuration/dataset-config/settings-modal/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/settings-modal/__tests__/index.spec.tsx
@@ -284,7 +284,7 @@ describe('SettingsModal', () => {
       await renderSettingsModal(dataset)
 
       // Assert
-      expect(screen.getByPlaceholderText('datasetSettings.form.namePlaceholder')).toHaveValue(
+      expect(screen.getByRole('textbox', { name: 'datasetSettings.form.name' })).toHaveValue(
         'Test Dataset',
       )
       expect(screen.getByPlaceholderText('datasetSettings.form.descPlaceholder')).toHaveValue(
@@ -333,7 +333,7 @@ describe('SettingsModal', () => {
       const user = userEvent.setup()
       await renderSettingsModal(createDataset())
 
-      const nameInput = screen.getByPlaceholderText('datasetSettings.form.namePlaceholder')
+      const nameInput = screen.getByRole('textbox', { name: 'datasetSettings.form.name' })
 
       // Act
       await user.clear(nameInput)
@@ -417,7 +417,7 @@ describe('SettingsModal', () => {
       const user = userEvent.setup()
       await renderSettingsModal(createDataset())
 
-      const nameInput = screen.getByPlaceholderText('datasetSettings.form.namePlaceholder')
+      const nameInput = screen.getByRole('textbox', { name: 'datasetSettings.form.name' })
 
       // Act
       await user.clear(nameInput)
@@ -483,7 +483,7 @@ describe('SettingsModal', () => {
       // Act
       await renderSettingsModal(dataset)
 
-      const nameInput = screen.getByPlaceholderText('datasetSettings.form.namePlaceholder')
+      const nameInput = screen.getByRole('textbox', { name: 'datasetSettings.form.name' })
       await user.clear(nameInput)
       await user.type(nameInput, 'Updated Internal Dataset')
       await user.click(screen.getByRole('button', { name: 'common.operation.save' }))

--- a/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/settings-modal/index.tsx
@@ -5,14 +5,14 @@ import type { DataSet } from '@/models/datasets'
 import type { RetrievalConfig } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { RiCloseLine } from '@remixicon/react'
 import { isEqual } from 'es-toolkit/predicate'
 import { useQueryState } from 'nuqs'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from '@/app/components/app/configuration/toast'
-import Input from '@/app/components/base/input'
 import { isReRankModelSelected } from '@/app/components/datasets/common/check-rerank-model'
 import { IndexingType } from '@/app/components/datasets/create/step-two'
 import IndexMethod from '@/app/components/datasets/settings/index-method'
@@ -58,6 +58,7 @@ const SettingsModal: FC<SettingsModalProps> = ({
   const translateRetrieval: RetrievalTranslate = (selector, options) => t(selector, options)
   const docLink = useDocLink()
   const ref = useRef(null)
+  const nameInputId = useId()
   const isExternal = currentDataset.provider === 'external'
   const [, setSettingsDestination] = useQueryState(settingsQueryParamName, settingsQueryParser)
   const [loading, setLoading] = useState(false)
@@ -232,13 +233,14 @@ const SettingsModal: FC<SettingsModalProps> = ({
       <div className="overflow-y-auto border-b border-divider-regular p-6 pt-5 pb-17">
         <div className={cn(rowClass, 'items-center')}>
           <div className={labelClass}>
-            <div className="system-sm-semibold text-text-secondary">
+            <label htmlFor={nameInputId} className="system-sm-semibold text-text-secondary">
               {t(($) => $['form.name'], { ns: 'datasetSettings' })}
-            </div>
+            </label>
           </div>
           <Input
+            id={nameInputId}
             value={localeCurrentDataset.name}
-            onChange={(e) => handleValueChange('name', e.target.value)}
+            onValueChange={(value) => handleValueChange('name', value)}
             className="block h-9"
             placeholder={t(($) => $['form.namePlaceholder'], { ns: 'datasetSettings' }) || ''}
           />

--- a/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
 import { RiAddLine } from '@remixicon/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import * as React from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { useModalContext } from '@/context/modal-context'
 import { useRouter } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
@@ -30,6 +30,7 @@ const ExternalApiSelection: React.FC<ExternalApiSelectionProps> = ({
     consoleQuery.datasets.externalKnowledgeApi.get.queryOptions({ input: {} })
   const { data } = useQuery(externalKnowledgeApiQueryOptions)
   const externalKnowledgeApiList = data?.data ?? []
+  const externalKnowledgeIdInputId = useId()
   const [selectedApiId, setSelectedApiId] = useState(external_knowledge_api_id)
   const { setShowExternalKnowledgeAPIModal } = useModalContext()
 
@@ -94,14 +95,18 @@ const ExternalApiSelection: React.FC<ExternalApiSelectionProps> = ({
       </div>
       <div className="flex flex-col gap-1 self-stretch">
         <div className="flex flex-col self-stretch">
-          <label className="system-sm-semibold text-text-secondary">
+          <label
+            htmlFor={externalKnowledgeIdInputId}
+            className="system-sm-semibold text-text-secondary"
+          >
             {t(($) => $.externalKnowledgeId, { ns: 'dataset' })}
           </label>
         </div>
         <Input
+          id={externalKnowledgeIdInputId}
           value={external_knowledge_id}
-          onChange={(e) =>
-            onChange({ external_knowledge_id: e.target.value, external_knowledge_api_id })
+          onValueChange={(value) =>
+            onChange({ external_knowledge_id: value, external_knowledge_api_id })
           }
           placeholder={t(($) => $.externalKnowledgeIdPlaceholder, { ns: 'dataset' }) ?? ''}
         />

--- a/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelection.spec.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/__tests__/ExternalApiSelection.spec.tsx
@@ -112,7 +112,7 @@ describe('ExternalApiSelection', () => {
     }
     render(<Harness />)
 
-    await user.type(screen.getByPlaceholderText('dataset.externalKnowledgeIdPlaceholder'), 'kb-123')
+    await user.type(screen.getByRole('textbox', { name: 'dataset.externalKnowledgeId' }), 'kb-123')
 
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({ external_knowledge_id: 'kb-123' }),


### PR DESCRIPTION
## Summary

- replace the legacy dataset settings name input with the Dify UI Input primitive
- preserve the existing two-column layout while associating the visible name label with its input
- keep the modal-owned controlled draft and update tests to query the accessible field name

## Validation

- pnpm --dir web test --run app/components/app/configuration/dataset-config/settings-modal/__tests__/index.spec.tsx
- pnpm vp check on the changed files

Stacked on #41610.

From Codex