### PR TITLE
refactor(web): migrate webhook table input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4335,11 +4335,6 @@
       "count": 4
     }
   },
-  "web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/trigger-webhook/components/parameter-table.tsx": {
     "typescript/no-non-null-asserted-optional-chain": {
       "count": 1

--- a/web/app/components/workflow/nodes/trigger-webhook/components/__tests__/generic-table.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/__tests__/generic-table.spec.tsx
@@ -82,7 +82,9 @@ describe('GenericTable', () => {
       />,
     )
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'my key' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), {
+      target: { value: 'my key' },
+    })
 
     expect(onChange).toHaveBeenLastCalledWith([{ name: 'my_key', enabled: false }])
   })
@@ -102,7 +104,7 @@ describe('GenericTable', () => {
       />,
     )
 
-    const inputs = screen.getAllByRole('textbox')
+    const inputs = screen.getAllByRole('textbox', { name: 'Name' })
     expect(inputs).toHaveLength(3)
     expect(screen.getAllByRole('button', { name: 'Delete row' })).toHaveLength(2)
 

--- a/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
@@ -2,6 +2,7 @@
 import type { FC, ReactNode } from 'react'
 import { Checkbox } from '@langgenius/dify-ui/checkbox'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Input } from '@langgenius/dify-ui/input'
 import {
   Select,
   SelectItem,
@@ -16,7 +17,6 @@ import {
 import { RiDeleteBinLine } from '@remixicon/react'
 import * as React from 'react'
 import { useCallback, useMemo } from 'react'
-import Input from '@/app/components/base/input'
 import { replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
 
 // Tiny utility to judge whether a cell value is effectively present
@@ -110,6 +110,7 @@ const renderInputCell = (
 ) => {
   return (
     <Input
+      aria-label={column.title}
       value={(value as string) || ''}
       onChange={(e) => {
         if (column.key === 'key' || column.key === 'name')
@@ -124,9 +125,8 @@ const renderInputCell = (
       }}
       placeholder={column.placeholder}
       disabled={readonly}
-      wrapperClassName="w-full min-w-0"
       className={cn(
-        'h-6 rounded-none border-0 bg-transparent p-0 shadow-none',
+        'h-6 min-w-0 rounded-none border-0 bg-transparent p-0 shadow-none',
         'hover:border-transparent hover:bg-transparent focus:border-transparent focus:bg-transparent',
         'system-sm-regular text-text-secondary placeholder:text-text-quaternary',
       )}


### PR DESCRIPTION
## Summary

- replace the legacy webhook table text input with the Dify UI Input primitive
- preserve the table-specific native change normalization and narrow-cell styling
- name each input from its column owner and assert the accessible name in browser-mode tests

## Validation

- pnpm --dir web test --run app/components/workflow/nodes/trigger-webhook/components/__tests__/generic-table.spec.tsx
- pnpm vp check on the changed files

Stacked on #41611.

From Codex