### PR TITLE
refactor(web): migrate access point mutations

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -5112,7 +5112,7 @@
       "count": 1
     },
     "typescript/no-explicit-any": {
-      "count": 4
+      "count": 3
     }
   },
   "web/service/base.ts": {

--- a/web/app/components/app/access-point/__tests__/access-point-card.spec.tsx
+++ b/web/app/components/app/access-point/__tests__/access-point-card.spec.tsx
@@ -32,7 +32,7 @@ describe('AccessPointCard', () => {
     ['loading', 'common.loading', true],
     ['unsupported', 'deployments.studio.accessPoint.notSupported', false],
     ['unavailable', 'deployments.health.ENVIRONMENT_STATUS_FAILED', false],
-  ])('renders the %s state independently', (status, label, busy) => {
+  ])('renders the %s state independently', (status, label, isLoading) => {
     render(
       <AccessPointCard
         title="Web App"
@@ -47,7 +47,7 @@ describe('AccessPointCard', () => {
 
     expect(screen.getByText(label)).toBeInTheDocument()
     const card = screen.getByRole('region', { name: 'Web App' })
-    if (busy) expect(card).toHaveAttribute('aria-busy', 'true')
+    if (isLoading) expect(card).toHaveAttribute('aria-busy', 'true')
     else expect(card).not.toHaveAttribute('aria-busy')
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
   })

--- a/web/app/components/app/access-point/__tests__/built-in-access-points.spec.tsx
+++ b/web/app/components/app/access-point/__tests__/built-in-access-points.spec.tsx
@@ -74,11 +74,9 @@ vi.mock('@/utils/permission', () => ({
 
 vi.mock('../shared/use-access-point-actions', () => ({
   useAccessPointActions: () => ({
-    changeApiStatus: vi.fn(),
-    changeSiteStatus: vi.fn(),
+    handleAppStateChanged: vi.fn(),
     handleResult: vi.fn(),
     refreshAppDetail: vi.fn(),
-    regenerateSiteCode: vi.fn(),
     saveSiteConfig: vi.fn(),
   }),
 }))

--- a/web/app/components/app/access-point/__tests__/service-api-card.spec.tsx
+++ b/web/app/components/app/access-point/__tests__/service-api-card.spec.tsx
@@ -1,11 +1,40 @@
+import type { ReactElement } from 'react'
 import type { AccessPointAppInfo } from '../shared/utils'
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createQueryClientWrapper } from '@/test/console/query-client'
 import { render } from '@/test/console/render'
+import { createTestQueryClient } from '@/test/query-client'
 import { AppModeEnum } from '@/types/app'
 import { ServiceApiAccessPointCard } from '../built-in-access-points/service-api-card'
 
 const mocks = vi.hoisted(() => ({
   apiSecretKeyButtonProps: vi.fn(),
+  toastError: vi.fn(),
+  updateApiStatus: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@langgenius/dify-ui/toast', () => ({
+  toast: {
+    error: mocks.toastError,
+  },
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    apps: {
+      byAppId: {
+        apiEnable: {
+          post: {
+            mutationOptions: (options = {}) => ({
+              mutationFn: mocks.updateApiStatus,
+              ...options,
+            }),
+          },
+        },
+      },
+    },
+  },
 }))
 
 vi.mock('@/context/i18n', () => ({
@@ -36,6 +65,10 @@ function createAppInfo(
   } as AccessPointAppInfo
 }
 
+function renderWithQueryClient(ui: ReactElement) {
+  return render(ui, { wrapper: createQueryClientWrapper(createTestQueryClient()) })
+}
+
 describe('ServiceApiAccessPointCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -48,12 +81,12 @@ describe('ServiceApiAccessPointCard', () => {
     [AppModeEnum.AGENT_CHAT, '/api-reference/guides/chat'],
     [AppModeEnum.COMPLETION, '/api-reference/guides/completion'],
   ])('links %s apps to the matching external API reference', (mode, path) => {
-    render(
+    renderWithQueryClient(
       <ServiceApiAccessPointCard
         appInfo={createAppInfo(mode)}
         availability="available"
         canManage
-        onChangeStatus={vi.fn().mockResolvedValue(undefined)}
+        onAppStateChanged={vi.fn()}
       />,
     )
 
@@ -64,13 +97,36 @@ describe('ServiceApiAccessPointCard', () => {
     expect(apiReferenceLink).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
+  it('updates API status through the generated contract', async () => {
+    const user = userEvent.setup()
+    const onAppStateChanged = vi.fn()
+    renderWithQueryClient(
+      <ServiceApiAccessPointCard
+        appInfo={createAppInfo(AppModeEnum.WORKFLOW)}
+        availability="available"
+        canManage
+        onAppStateChanged={onAppStateChanged}
+      />,
+    )
+
+    await user.click(screen.getByRole('switch'))
+
+    await waitFor(() => {
+      expect(mocks.updateApiStatus.mock.calls[0]?.[0]).toEqual({
+        params: { app_id: 'app-1' },
+        body: { enable_api: false },
+      })
+      expect(onAppStateChanged).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('shows loading without reporting an environment failure', () => {
-    render(
+    renderWithQueryClient(
       <ServiceApiAccessPointCard
         appInfo={createAppInfo(AppModeEnum.WORKFLOW)}
         availability="loading"
         canManage
-        onChangeStatus={vi.fn().mockResolvedValue(undefined)}
+        onAppStateChanged={vi.fn()}
       />,
     )
 
@@ -83,12 +139,12 @@ describe('ServiceApiAccessPointCard', () => {
   })
 
   it('keeps API keys and external documentation available when the API is stopped', () => {
-    render(
+    renderWithQueryClient(
       <ServiceApiAccessPointCard
         appInfo={createAppInfo(AppModeEnum.WORKFLOW, { enable_api: false })}
         availability="available"
         canManage
-        onChangeStatus={vi.fn().mockResolvedValue(undefined)}
+        onAppStateChanged={vi.fn()}
       />,
     )
 
@@ -101,12 +157,12 @@ describe('ServiceApiAccessPointCard', () => {
   })
 
   it('disables API management without release permission', () => {
-    render(
+    renderWithQueryClient(
       <ServiceApiAccessPointCard
         appInfo={createAppInfo(AppModeEnum.WORKFLOW)}
         availability="available"
         canManage={false}
-        onChangeStatus={vi.fn().mockResolvedValue(undefined)}
+        onAppStateChanged={vi.fn()}
       />,
     )
 
@@ -115,12 +171,12 @@ describe('ServiceApiAccessPointCard', () => {
   })
 
   it('disables API keys and external documentation when the access point is unavailable', () => {
-    render(
+    renderWithQueryClient(
       <ServiceApiAccessPointCard
         appInfo={createAppInfo(AppModeEnum.WORKFLOW)}
         availability="unavailable"
         canManage
-        onChangeStatus={vi.fn().mockResolvedValue(undefined)}
+        onAppStateChanged={vi.fn()}
       />,
     )
 

--- a/web/app/components/app/access-point/__tests__/use-access-point-actions.spec.ts
+++ b/web/app/components/app/access-point/__tests__/use-access-point-actions.spec.ts
@@ -1,14 +1,22 @@
-import { act } from '@testing-library/react'
-import { renderHookWithConsoleQuery } from '@/test/console/query-data'
+import { act, renderHook } from '@testing-library/react'
+import { createQueryClientWrapper } from '@/test/console/query-client'
+import { createTestQueryClient } from '@/test/query-client'
 import { useAccessPointActions } from '../shared/use-access-point-actions'
 
 const mocks = vi.hoisted(() => ({
+  apiEnableMutation: vi.fn().mockResolvedValue({}),
+  emit: vi.fn(),
+  fetchAppDetail: vi.fn().mockResolvedValue({ id: 'app-1' }),
+  getSocket: vi.fn(),
   onAppStateUpdate: vi.fn(() => vi.fn()),
+  resetSiteAccessTokenMutation: vi.fn().mockResolvedValue({}),
   setAppDetail: vi.fn(),
-  updateAppSiteStatus: vi.fn().mockResolvedValue({}),
+  siteEnableMutation: vi.fn().mockResolvedValue({}),
+  toast: vi.fn(),
+  updateAppSiteConfig: vi.fn().mockResolvedValue({}),
 }))
 
-vi.mock('@langgenius/dify-ui/toast', () => ({ toast: vi.fn() }))
+vi.mock('@langgenius/dify-ui/toast', () => ({ toast: mocks.toast }))
 
 vi.mock('@/app/components/app/store', () => ({
   useStore: (selector: (state: { setAppDetail: typeof mocks.setAppDetail }) => unknown) =>
@@ -20,29 +28,143 @@ vi.mock('@/app/components/workflow/collaboration/core/collaboration-manager', ()
 }))
 
 vi.mock('@/app/components/workflow/collaboration/core/websocket-manager', () => ({
-  webSocketClient: { getSocket: vi.fn() },
+  webSocketClient: { getSocket: mocks.getSocket },
 }))
 
 vi.mock('@/service/apps', () => ({
-  fetchAppDetail: vi.fn().mockResolvedValue({}),
-  updateAppSiteAccessToken: vi.fn(),
-  updateAppSiteConfig: vi.fn(),
-  updateAppSiteStatus: mocks.updateAppSiteStatus,
+  fetchAppDetail: mocks.fetchAppDetail,
+  updateAppSiteConfig: mocks.updateAppSiteConfig,
 }))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    apps: {
+      get: { key: () => ['apps'] },
+      recent: { get: { key: () => ['apps', 'recent'] } },
+      starred: { get: { key: () => ['apps', 'starred'] } },
+      byAppId: {
+        get: {
+          queryKey: ({ input }: { input: { params: { app_id: string } } }) => [
+            'app-detail',
+            input.params.app_id,
+          ],
+        },
+        apiEnable: {
+          post: {
+            mutationOptions: () => ({ mutationFn: mocks.apiEnableMutation }),
+          },
+        },
+        siteEnable: {
+          post: {
+            mutationOptions: () => ({ mutationFn: mocks.siteEnableMutation }),
+          },
+        },
+        site: {
+          accessTokenReset: {
+            post: {
+              mutationOptions: () => ({ mutationFn: mocks.resetSiteAccessTokenMutation }),
+            },
+          },
+        },
+      },
+    },
+  },
+}))
+
+function renderActions(appId = 'app-1', canEdit = true) {
+  const queryClient = createTestQueryClient()
+  const rendered = renderHook(() => useAccessPointActions(appId, canEdit), {
+    wrapper: createQueryClientWrapper(queryClient),
+  })
+
+  return { ...rendered, queryClient }
+}
 
 describe('useAccessPointActions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.getSocket.mockReturnValue({ emit: mocks.emit })
   })
 
-  it('allows the API status to be changed independently of app editing', async () => {
-    const { result } = renderHookWithConsoleQuery(() => useAccessPointActions('app-1', false))
+  it('updates API status through the generated contract independently of app editing', async () => {
+    const { queryClient, result } = renderActions('app-1', false)
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
 
-    await act(() => result.current.changeApiStatus(true))
+    await act(async () => {
+      await result.current.changeApiStatus(true)
+    })
 
-    expect(mocks.updateAppSiteStatus).toHaveBeenCalledWith({
-      url: '/apps/app-1/api-enable',
+    expect(mocks.apiEnableMutation.mock.calls[0]?.[0]).toEqual({
+      params: { app_id: 'app-1' },
       body: { enable_api: true },
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['app-detail', 'app-1'] })
+    expect(mocks.fetchAppDetail).toHaveBeenCalledWith({ url: '/apps', id: 'app-1' })
+    expect(mocks.setAppDetail).toHaveBeenCalledWith({ id: 'app-1' })
+    expect(mocks.emit).toHaveBeenCalledWith(
+      'collaboration_event',
+      expect.objectContaining({
+        type: 'app_state_update',
+        timestamp: expect.any(Number),
+      }),
+    )
+    expect(mocks.toast).toHaveBeenCalledWith('common.actionMsg.modifiedSuccessfully', {
+      type: 'success',
+    })
+  })
+
+  it('keeps site status changes behind app editing permission', async () => {
+    const { result } = renderActions('app-1', false)
+
+    await act(async () => {
+      await result.current.changeSiteStatus(true)
+    })
+
+    expect(mocks.siteEnableMutation).not.toHaveBeenCalled()
+  })
+
+  it('updates site status through the generated contract', async () => {
+    const { result } = renderActions()
+
+    await act(async () => {
+      await result.current.changeSiteStatus(false)
+    })
+
+    expect(mocks.siteEnableMutation.mock.calls[0]?.[0]).toEqual({
+      params: { app_id: 'app-1' },
+      body: { enable_site: false },
+    })
+  })
+
+  it('resets the site access token through the generated contract', async () => {
+    const { result } = renderActions()
+
+    await act(async () => {
+      await result.current.regenerateSiteCode()
+    })
+
+    expect(mocks.resetSiteAccessTokenMutation.mock.calls[0]?.[0]).toEqual({
+      params: { app_id: 'app-1' },
+    })
+    expect(mocks.toast).toHaveBeenCalledWith('common.actionMsg.generatedSuccessfully', {
+      type: 'success',
+    })
+  })
+
+  it('reports mutation failure without refreshing or broadcasting stale state', async () => {
+    mocks.apiEnableMutation.mockRejectedValueOnce(new Error('request failed'))
+    const { queryClient, result } = renderActions()
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await act(async () => {
+      await result.current.changeApiStatus(true)
+    })
+
+    expect(invalidateQueries).not.toHaveBeenCalled()
+    expect(mocks.fetchAppDetail).not.toHaveBeenCalled()
+    expect(mocks.getSocket).not.toHaveBeenCalled()
+    expect(mocks.toast).toHaveBeenCalledWith('common.actionMsg.modifiedUnsuccessfully', {
+      type: 'error',
     })
   })
 })

--- a/web/app/components/app/access-point/__tests__/use-access-point-actions.spec.ts
+++ b/web/app/components/app/access-point/__tests__/use-access-point-actions.spec.ts
@@ -1,17 +1,15 @@
-import { act, renderHook } from '@testing-library/react'
+import type { ConfigParams } from '@/app/components/app/overview/settings'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { createQueryClientWrapper } from '@/test/console/query-client'
 import { createTestQueryClient } from '@/test/query-client'
 import { useAccessPointActions } from '../shared/use-access-point-actions'
 
 const mocks = vi.hoisted(() => ({
-  apiEnableMutation: vi.fn().mockResolvedValue({}),
   emit: vi.fn(),
   fetchAppDetail: vi.fn().mockResolvedValue({ id: 'app-1' }),
   getSocket: vi.fn(),
   onAppStateUpdate: vi.fn(() => vi.fn()),
-  resetSiteAccessTokenMutation: vi.fn().mockResolvedValue({}),
   setAppDetail: vi.fn(),
-  siteEnableMutation: vi.fn().mockResolvedValue({}),
   toast: vi.fn(),
   updateAppSiteConfig: vi.fn().mockResolvedValue({}),
 }))
@@ -49,27 +47,27 @@ vi.mock('@/service/client', () => ({
             input.params.app_id,
           ],
         },
-        apiEnable: {
-          post: {
-            mutationOptions: () => ({ mutationFn: mocks.apiEnableMutation }),
-          },
-        },
-        siteEnable: {
-          post: {
-            mutationOptions: () => ({ mutationFn: mocks.siteEnableMutation }),
-          },
-        },
-        site: {
-          accessTokenReset: {
-            post: {
-              mutationOptions: () => ({ mutationFn: mocks.resetSiteAccessTokenMutation }),
-            },
-          },
-        },
       },
     },
   },
 }))
+
+const siteConfig = {
+  chat_color_theme: '#000000',
+  chat_color_theme_inverted: false,
+  copyright: '',
+  custom_disclaimer: '',
+  default_language: 'en-US',
+  description: 'Description',
+  icon: '🤖',
+  icon_type: 'emoji',
+  input_placeholder: '',
+  privacy_policy: '',
+  prompt_public: false,
+  show_workflow_steps: false,
+  title: 'App',
+  use_icon_as_answer_icon: false,
+} satisfies ConfigParams
 
 function renderActions(appId = 'app-1', canEdit = true) {
   const queryClient = createTestQueryClient()
@@ -86,21 +84,15 @@ describe('useAccessPointActions', () => {
     mocks.getSocket.mockReturnValue({ emit: mocks.emit })
   })
 
-  it('updates API status through the generated contract independently of app editing', async () => {
-    const { queryClient, result } = renderActions('app-1', false)
-    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+  it('refreshes and broadcasts a successful access point result', async () => {
+    const { result } = renderActions()
 
-    await act(async () => {
-      await result.current.changeApiStatus(true)
-    })
+    act(() => result.current.handleResult(null))
 
-    expect(mocks.apiEnableMutation.mock.calls[0]?.[0]).toEqual({
-      params: { app_id: 'app-1' },
-      body: { enable_api: true },
+    await waitFor(() => {
+      expect(mocks.fetchAppDetail).toHaveBeenCalledWith({ url: '/apps', id: 'app-1' })
+      expect(mocks.setAppDetail).toHaveBeenCalledWith({ id: 'app-1' })
     })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['app-detail', 'app-1'] })
-    expect(mocks.fetchAppDetail).toHaveBeenCalledWith({ url: '/apps', id: 'app-1' })
-    expect(mocks.setAppDetail).toHaveBeenCalledWith({ id: 'app-1' })
     expect(mocks.emit).toHaveBeenCalledWith(
       'collaboration_event',
       expect.objectContaining({
@@ -113,58 +105,43 @@ describe('useAccessPointActions', () => {
     })
   })
 
-  it('keeps site status changes behind app editing permission', async () => {
-    const { result } = renderActions('app-1', false)
-
-    await act(async () => {
-      await result.current.changeSiteStatus(true)
-    })
-
-    expect(mocks.siteEnableMutation).not.toHaveBeenCalled()
-  })
-
-  it('updates site status through the generated contract', async () => {
+  it('reports a failed result without refreshing or broadcasting stale state', () => {
     const { result } = renderActions()
 
-    await act(async () => {
-      await result.current.changeSiteStatus(false)
-    })
+    act(() => result.current.handleResult(new Error('request failed')))
 
-    expect(mocks.siteEnableMutation.mock.calls[0]?.[0]).toEqual({
-      params: { app_id: 'app-1' },
-      body: { enable_site: false },
-    })
-  })
-
-  it('resets the site access token through the generated contract', async () => {
-    const { result } = renderActions()
-
-    await act(async () => {
-      await result.current.regenerateSiteCode()
-    })
-
-    expect(mocks.resetSiteAccessTokenMutation.mock.calls[0]?.[0]).toEqual({
-      params: { app_id: 'app-1' },
-    })
-    expect(mocks.toast).toHaveBeenCalledWith('common.actionMsg.generatedSuccessfully', {
-      type: 'success',
-    })
-  })
-
-  it('reports mutation failure without refreshing or broadcasting stale state', async () => {
-    mocks.apiEnableMutation.mockRejectedValueOnce(new Error('request failed'))
-    const { queryClient, result } = renderActions()
-    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
-
-    await act(async () => {
-      await result.current.changeApiStatus(true)
-    })
-
-    expect(invalidateQueries).not.toHaveBeenCalled()
     expect(mocks.fetchAppDetail).not.toHaveBeenCalled()
     expect(mocks.getSocket).not.toHaveBeenCalled()
     expect(mocks.toast).toHaveBeenCalledWith('common.actionMsg.modifiedUnsuccessfully', {
       type: 'error',
     })
+  })
+
+  it('invalidates app detail and lists after saving legacy site configuration', async () => {
+    const { queryClient, result } = renderActions()
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await act(async () => {
+      await result.current.saveSiteConfig(siteConfig)
+    })
+
+    expect(mocks.updateAppSiteConfig).toHaveBeenCalledWith({
+      url: '/apps/app-1/site',
+      body: siteConfig,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['app-detail', 'app-1'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['apps'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['apps', 'starred'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['apps', 'recent'] })
+  })
+
+  it('keeps site configuration behind app editing permission', async () => {
+    const { result } = renderActions('app-1', false)
+
+    await act(async () => {
+      await result.current.saveSiteConfig(siteConfig)
+    })
+
+    expect(mocks.updateAppSiteConfig).not.toHaveBeenCalled()
   })
 })

--- a/web/app/components/app/access-point/__tests__/web-app-card.spec.tsx
+++ b/web/app/components/app/access-point/__tests__/web-app-card.spec.tsx
@@ -4,10 +4,51 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BlockEnum, InputVarType } from '@/app/components/workflow/types'
 import { AccessMode } from '@/models/access-control'
+import { createQueryClientWrapper } from '@/test/console/query-client'
 import { render } from '@/test/console/render'
+import { createTestQueryClient } from '@/test/query-client'
 import { AppModeEnum } from '@/types/app'
 import { basePath } from '@/utils/var'
 import { WebAppAccessPointCard } from '../built-in-access-points/web-app-card'
+
+const mocks = vi.hoisted(() => ({
+  resetSiteAccessToken: vi.fn().mockResolvedValue({}),
+  toastError: vi.fn(),
+  updateSiteStatus: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@langgenius/dify-ui/toast', () => ({
+  toast: {
+    error: mocks.toastError,
+  },
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    apps: {
+      byAppId: {
+        siteEnable: {
+          post: {
+            mutationOptions: (options = {}) => ({
+              mutationFn: mocks.updateSiteStatus,
+              ...options,
+            }),
+          },
+        },
+        site: {
+          accessTokenReset: {
+            post: {
+              mutationOptions: (options = {}) => ({
+                mutationFn: mocks.resetSiteAccessToken,
+                ...options,
+              }),
+            },
+          },
+        },
+      },
+    },
+  },
+}))
 
 vi.mock('@/service/access-control/use-app-access-control', () => ({
   useAppWhiteListSubjects: () => ({
@@ -68,21 +109,29 @@ function renderCard(
   mode: AppModeEnum,
   availability: 'available' | 'loading' | 'unavailable' = 'available',
   workflow?: PublishedWorkflow,
+  {
+    canEdit = true,
+    onAppStateChanged = vi.fn().mockResolvedValue(undefined),
+  }: {
+    canEdit?: boolean
+    onAppStateChanged?: () => Promise<void>
+  } = {},
 ) {
+  const queryClient = createTestQueryClient()
   render(
     <WebAppAccessPointCard
       appInfo={createAppInfo(mode)}
       availability={availability}
-      canEdit
+      canEdit={canEdit}
       canDeploy
       canManageAccess
       showAccessControl
-      onChangeStatus={vi.fn().mockResolvedValue(undefined)}
+      onAppStateChanged={onAppStateChanged}
       onRefreshApp={vi.fn().mockResolvedValue(undefined)}
-      onRegenerate={vi.fn().mockResolvedValue(undefined)}
       onSaveSiteConfig={vi.fn().mockResolvedValue(undefined)}
       workflow={workflow}
     />,
+    { wrapper: createQueryClientWrapper(queryClient) },
   )
 }
 
@@ -128,6 +177,10 @@ const workflowWithHiddenInput: NonNullable<PublishedWorkflow> = {
 }
 
 describe('WebAppAccessPointCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   afterEach(() => {
     vi.restoreAllMocks()
   })
@@ -159,6 +212,88 @@ describe('WebAppAccessPointCard', () => {
     await user.click(screen.getByRole('button', { name: /embedIntoSite/ }))
 
     expect(screen.getByRole('dialog', { name: 'embed into site' })).toBeInTheDocument()
+  })
+
+  it('updates site status through the generated contract', async () => {
+    const user = userEvent.setup()
+    const onAppStateChanged = vi.fn().mockResolvedValue(undefined)
+    renderCard(AppModeEnum.CHAT, 'available', undefined, { onAppStateChanged })
+
+    await user.click(screen.getByRole('switch'))
+
+    await waitFor(() => {
+      expect(mocks.updateSiteStatus.mock.calls[0]?.[0]).toEqual({
+        params: { app_id: 'app-1' },
+        body: { enable_site: false },
+      })
+      expect(onAppStateChanged).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('keeps the status switch pending until the app state refresh completes', async () => {
+    const user = userEvent.setup()
+    let resolveRefresh: (() => void) | undefined
+    const refresh = new Promise<void>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const onAppStateChanged = vi.fn(() => refresh)
+    renderCard(AppModeEnum.CHAT, 'available', undefined, { onAppStateChanged })
+
+    const statusSwitch = screen.getByRole('switch')
+    await user.click(statusSwitch)
+
+    await waitFor(() => {
+      expect(onAppStateChanged).toHaveBeenCalledTimes(1)
+      expect(statusSwitch).toHaveAttribute('aria-busy', 'true')
+      expect(statusSwitch).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    resolveRefresh?.()
+
+    await waitFor(() => {
+      expect(statusSwitch).not.toHaveAttribute('aria-busy', 'true')
+      expect(statusSwitch).not.toHaveAttribute('aria-disabled', 'true')
+    })
+  })
+
+  it('keeps site status changes behind app editing permission', async () => {
+    const user = userEvent.setup()
+    renderCard(AppModeEnum.CHAT, 'available', undefined, { canEdit: false })
+
+    await user.click(screen.getByRole('switch'))
+
+    expect(mocks.updateSiteStatus).not.toHaveBeenCalled()
+  })
+
+  it('resets the site access token through the generated contract', async () => {
+    const user = userEvent.setup()
+    const onAppStateChanged = vi.fn().mockResolvedValue(undefined)
+    renderCard(AppModeEnum.CHAT, 'available', undefined, { onAppStateChanged })
+
+    await user.click(screen.getByRole('button', { name: /overview\.appInfo\.regenerate/ }))
+    await user.click(screen.getByRole('button', { name: /operation\.confirm/ }))
+
+    await waitFor(() => {
+      expect(mocks.resetSiteAccessToken.mock.calls[0]?.[0]).toEqual({
+        params: { app_id: 'app-1' },
+      })
+      expect(onAppStateChanged).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('keeps generated mutation failures inside the card owner', async () => {
+    const user = userEvent.setup()
+    const error = new Error('request failed')
+    const onAppStateChanged = vi.fn().mockResolvedValue(undefined)
+    mocks.updateSiteStatus.mockRejectedValueOnce(error)
+    renderCard(AppModeEnum.CHAT, 'available', undefined, { onAppStateChanged })
+
+    await user.click(screen.getByRole('switch'))
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith('common.actionMsg.modifiedUnsuccessfully')
+    })
+    expect(onAppStateChanged).not.toHaveBeenCalled()
   })
 
   it('passes hidden Chatflow inputs to the embed dialog', async () => {

--- a/web/app/components/app/access-point/built-in-access-points/index.tsx
+++ b/web/app/components/app/access-point/built-in-access-points/index.tsx
@@ -122,9 +122,8 @@ export function BuiltInAccessPoints({ appId, highlightedAccessPoint }: BuiltInAc
           canDeploy={capabilities.canDeploy}
           canManageAccess={capabilities.canReleaseAndVersion}
           showAccessControl={systemFeatures.webapp_auth.enabled}
-          onChangeStatus={actions.changeSiteStatus}
+          onAppStateChanged={actions.handleAppStateChanged}
           onRefreshApp={actions.refreshAppDetail}
-          onRegenerate={actions.regenerateSiteCode}
           onSaveSiteConfig={actions.saveSiteConfig}
           workflow={workflow}
           highlighted={highlightedAccessPoint === 'webApp'}
@@ -133,7 +132,7 @@ export function BuiltInAccessPoints({ appId, highlightedAccessPoint }: BuiltInAc
           appInfo={appInfo}
           availability={appCardAvailability}
           canManage={capabilities.canReleaseAndVersion}
-          onChangeStatus={actions.changeApiStatus}
+          onAppStateChanged={actions.handleAppStateChanged}
           highlighted={highlightedAccessPoint === 'serviceApi'}
         />
         <MCPAccessPointCard

--- a/web/app/components/app/access-point/built-in-access-points/mcp-card.tsx
+++ b/web/app/components/app/access-point/built-in-access-points/mcp-card.tsx
@@ -145,9 +145,9 @@ export function MCPAccessPointCard({
         icon="i-custom-vender-integrations-mcp"
         status={status}
         highlighted={highlighted}
-        busy={statusUpdating}
         switchDisabled={!canEdit}
         switchLabel={t(($) => $['mcp.server.title'], { ns: 'tools' })}
+        switchLoading={statusUpdating}
         onEnabledChange={loading || unavailable ? undefined : handleStatusChange}
         actions={
           <Button

--- a/web/app/components/app/access-point/built-in-access-points/service-api-card.tsx
+++ b/web/app/components/app/access-point/built-in-access-points/service-api-card.tsx
@@ -2,6 +2,10 @@
 
 import type { AccessPointAvailability } from '../shared/access-point-status'
 import type { AccessPointAppInfo } from '../shared/utils'
+import { toast } from '@langgenius/dify-ui/toast'
+import { useMutation } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { consoleQuery } from '@/service/client'
 import { getAccessPointStatus } from '../shared/access-point-status'
 import { ServiceApiCardView } from '../shared/service-api-card-view'
 import { getBuiltInAccessUrls } from '../shared/utils'
@@ -11,7 +15,7 @@ type ServiceApiAccessPointCardProps = {
   availability: AccessPointAvailability
   canManage: boolean
   highlighted?: boolean
-  onChangeStatus: (enabled: boolean) => Promise<void>
+  onAppStateChanged: () => Promise<void>
 }
 
 export function ServiceApiAccessPointCard({
@@ -19,11 +23,29 @@ export function ServiceApiAccessPointCard({
   availability,
   canManage,
   highlighted,
-  onChangeStatus,
+  onAppStateChanged,
 }: ServiceApiAccessPointCardProps) {
+  const { t } = useTranslation()
+  const updateApiStatus = useMutation(
+    consoleQuery.apps.byAppId.apiEnable.post.mutationOptions({
+      onSuccess: onAppStateChanged,
+      onError: () => {
+        toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
+      },
+    }),
+  )
   const { api: apiUrl } = getBuiltInAccessUrls(appInfo)
   const running = availability === 'available' && appInfo.enable_api
   const status = getAccessPointStatus(availability, running)
+
+  const handleStatusChange = (enabled: boolean) => {
+    if (!canManage) return
+
+    updateApiStatus.mutate({
+      params: { app_id: appInfo.id },
+      body: { enable_api: enabled },
+    })
+  }
 
   return (
     <ServiceApiCardView
@@ -38,7 +60,8 @@ export function ServiceApiAccessPointCard({
       status={status}
       highlighted={highlighted}
       switchDisabled={!canManage}
-      onEnabledChange={availability === 'available' ? onChangeStatus : undefined}
+      switchLoading={updateApiStatus.isPending}
+      onEnabledChange={availability === 'available' ? handleStatusChange : undefined}
     />
   )
 }

--- a/web/app/components/app/access-point/built-in-access-points/trigger-card.tsx
+++ b/web/app/components/app/access-point/built-in-access-points/trigger-card.tsx
@@ -123,7 +123,6 @@ export function TriggerAccessPointCard({
       status={status}
       highlighted={highlighted}
       showStatus={!active}
-      busy={statusUpdating}
     >
       {loading && (
         <div className="flex h-full min-h-40 flex-col gap-4 px-4 py-5">

--- a/web/app/components/app/access-point/built-in-access-points/web-app-card.tsx
+++ b/web/app/components/app/access-point/built-in-access-points/web-app-card.tsx
@@ -14,6 +14,8 @@ import {
   AlertDialogTitle,
 } from '@langgenius/dify-ui/alert-dialog'
 import { Button } from '@langgenius/dify-ui/button'
+import { toast } from '@langgenius/dify-ui/toast'
+import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AccessControl from '@/app/components/app/app-access-control'
@@ -24,6 +26,7 @@ import { WorkflowLaunchDialog } from '@/app/components/app/overview/workflow-lau
 import AppIcon from '@/app/components/base/app-icon'
 import { AccessMode } from '@/models/access-control'
 import { useAppWhiteListSubjects } from '@/service/access-control/use-app-access-control'
+import { consoleQuery } from '@/service/client'
 import { AppModeEnum } from '@/types/app'
 import { AccessPointCard } from '../shared/access-point-card'
 import { getAccessPointStatus } from '../shared/access-point-status'
@@ -53,9 +56,8 @@ type WebAppAccessPointCardProps = {
   canManageAccess: boolean
   highlighted?: boolean
   showAccessControl: boolean
-  onChangeStatus: (enabled: boolean) => Promise<void>
+  onAppStateChanged: () => Promise<void>
   onRefreshApp: () => Promise<void>
-  onRegenerate: () => Promise<void>
   onSaveSiteConfig: (params: ConfigParams) => Promise<void>
   workflow: PublishedWorkflow
 }
@@ -67,9 +69,8 @@ export function WebAppAccessPointCard({
   canDeploy,
   canManageAccess,
   highlighted,
-  onChangeStatus,
+  onAppStateChanged,
   onRefreshApp,
-  onRegenerate,
   onSaveSiteConfig,
   showAccessControl,
   workflow,
@@ -81,7 +82,26 @@ export function WebAppAccessPointCard({
   const [showAccess, setShowAccess] = useState(false)
   const [showRegenerate, setShowRegenerate] = useState(false)
   const [showWorkflowLaunch, setShowWorkflowLaunch] = useState(false)
-  const [regenerating, setRegenerating] = useState(false)
+  const updateSiteStatus = useMutation(
+    consoleQuery.apps.byAppId.siteEnable.post.mutationOptions({
+      onSuccess: onAppStateChanged,
+      onError: () => {
+        toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
+      },
+    }),
+  )
+  const resetSiteAccessToken = useMutation(
+    consoleQuery.apps.byAppId.site.accessTokenReset.post.mutationOptions({
+      onSuccess: async () => {
+        await onAppStateChanged()
+        setShowRegenerate(false)
+      },
+      onError: () => {
+        toast.error(t(($) => $['actionMsg.generatedUnsuccessfully'], { ns: 'common' }))
+        setShowRegenerate(false)
+      },
+    }),
+  )
   const { webApp: webAppUrl } = getBuiltInAccessUrls(appInfo)
   const running = availability === 'available' && appInfo.enable_site
   const supportsEmbedded =
@@ -100,11 +120,19 @@ export function WebAppAccessPointCard({
     appInfo.access_mode !== AccessMode.SPECIFIC_GROUPS_MEMBERS ||
     Boolean(accessSubjects?.groups?.length || accessSubjects?.members?.length)
 
-  const handleRegenerate = async () => {
-    setRegenerating(true)
-    await onRegenerate()
-    setRegenerating(false)
-    setShowRegenerate(false)
+  const handleStatusChange = (enabled: boolean) => {
+    if (!canEdit) return
+
+    updateSiteStatus.mutate({
+      params: { app_id: appInfo.id },
+      body: { enable_site: enabled },
+    })
+  }
+
+  const handleRegenerate = () => {
+    if (!canEdit || resetSiteAccessToken.isPending) return
+
+    resetSiteAccessToken.mutate({ params: { app_id: appInfo.id } })
   }
 
   const status = getAccessPointStatus(availability, running)
@@ -129,7 +157,8 @@ export function WebAppAccessPointCard({
         highlighted={highlighted}
         switchDisabled={!canEdit}
         switchLabel={t(($) => $['overview.appInfo.title'], { ns: 'appOverview' })}
-        onEnabledChange={availability === 'available' ? onChangeStatus : undefined}
+        switchLoading={updateSiteStatus.isPending}
+        onEnabledChange={availability === 'available' ? handleStatusChange : undefined}
         actions={
           <>
             {hiddenLaunchVariables.length > 0 && (
@@ -195,7 +224,7 @@ export function WebAppAccessPointCard({
             ns: 'appOverview',
           })}
           regenerateDisabled={!canEdit}
-          regenerating={regenerating}
+          regenerating={resetSiteAccessToken.isPending}
           onRegenerate={() => setShowRegenerate(true)}
         />
         {showAccessControl && (
@@ -265,7 +294,10 @@ export function WebAppAccessPointCard({
             <AlertDialogCancelButton>
               {t(($) => $['operation.cancel'], { ns: 'common' })}
             </AlertDialogCancelButton>
-            <AlertDialogConfirmButton onClick={() => void handleRegenerate()}>
+            <AlertDialogConfirmButton
+              disabled={resetSiteAccessToken.isPending}
+              onClick={handleRegenerate}
+            >
               {t(($) => $['operation.confirm'], { ns: 'common' })}
             </AlertDialogConfirmButton>
           </AlertDialogActions>

--- a/web/app/components/app/access-point/deployed-environment-access-points/environment-service-api-card.tsx
+++ b/web/app/components/app/access-point/deployed-environment-access-points/environment-service-api-card.tsx
@@ -78,7 +78,7 @@ export function EnvironmentServiceApiCard({
       highlighted={highlighted}
       switchDisabled={!canManage}
       onEnabledChange={apiQuery.isSuccess ? handleEnabledChange : undefined}
-      busy={apiMutation.isPending}
+      switchLoading={apiMutation.isPending}
     />
   )
 }

--- a/web/app/components/app/access-point/deployed-environment-access-points/environment-web-app-card.tsx
+++ b/web/app/components/app/access-point/deployed-environment-access-points/environment-web-app-card.tsx
@@ -174,7 +174,7 @@ export function EnvironmentWebAppCard({
         switchDisabled={!canManage}
         switchLabel={t(($) => $['overview.appInfo.title'], { ns: 'appOverview' })}
         onEnabledChange={siteQuery.isSuccess ? handleEnabledChange : undefined}
-        busy={siteMutation.isPending}
+        switchLoading={siteMutation.isPending}
         actions={
           <>
             <Button

--- a/web/app/components/app/access-point/shared/access-point-card.tsx
+++ b/web/app/components/app/access-point/shared/access-point-card.tsx
@@ -15,18 +15,17 @@ type AccessPointCardProps = {
   icon: ReactNode | string
   status: AccessPointStatus
   title: string
-  busy?: boolean
   className?: string
   highlighted?: boolean
   onEnabledChange?: (enabled: boolean) => void
   showStatus?: boolean
   switchDisabled?: boolean
   switchLabel?: string
+  switchLoading?: boolean
 }
 
 export function AccessPointCard({
   actions,
-  busy = false,
   children,
   className,
   description,
@@ -37,6 +36,7 @@ export function AccessPointCard({
   status,
   switchDisabled = false,
   switchLabel,
+  switchLoading = false,
   title,
 }: AccessPointCardProps) {
   const { t } = useTranslation()
@@ -99,7 +99,7 @@ export function AccessPointCard({
               <Switch
                 checked={isEnabled}
                 disabled={switchDisabled}
-                loading={busy}
+                loading={switchLoading}
                 aria-label={switchLabel || title}
                 onCheckedChange={onEnabledChange}
               />

--- a/web/app/components/app/access-point/shared/service-api-card-view.tsx
+++ b/web/app/components/app/access-point/shared/service-api-card-view.tsx
@@ -20,9 +20,9 @@ type ServiceApiCardViewProps = {
   available: boolean
   status: AccessPointStatus
   switchDisabled: boolean
-  busy?: boolean
   highlighted?: boolean
   onEnabledChange?: (enabled: boolean) => void
+  switchLoading?: boolean
 }
 
 export function ServiceApiCardView({
@@ -30,11 +30,11 @@ export function ServiceApiCardView({
   apiUrl,
   appMode,
   available,
-  busy = false,
   highlighted,
   onEnabledChange,
   status,
   switchDisabled,
+  switchLoading = false,
 }: ServiceApiCardViewProps) {
   const { t } = useTranslation()
   const docLink = useDocLink()
@@ -53,7 +53,7 @@ export function ServiceApiCardView({
       switchDisabled={switchDisabled}
       switchLabel={t(($) => $['overview.apiInfo.title'], { ns: 'appOverview' })}
       onEnabledChange={onEnabledChange}
-      busy={busy}
+      switchLoading={switchLoading}
       actions={
         <>
           <ApiSecretKeyButton {...apiKeyButtonProps} />

--- a/web/app/components/app/access-point/shared/use-access-point-actions.ts
+++ b/web/app/components/app/access-point/shared/use-access-point-actions.ts
@@ -4,7 +4,7 @@ import type { ConfigParams } from '@/app/components/app/overview/settings'
 import type { App } from '@/types/app'
 import type { I18nKeysByPrefix } from '@/types/i18n'
 import { toast } from '@langgenius/dify-ui/toast'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore as useAppStore } from '@/app/components/app/store'
@@ -18,16 +18,6 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const setAppDetail = useAppStore((state) => state.setAppDetail)
-  const { mutateAsync: updateSiteStatus } = useMutation(
-    consoleQuery.apps.byAppId.siteEnable.post.mutationOptions(),
-  )
-  const { mutateAsync: updateApiStatus } = useMutation(
-    consoleQuery.apps.byAppId.apiEnable.post.mutationOptions(),
-  )
-  const { mutateAsync: resetSiteAccessToken } = useMutation(
-    consoleQuery.apps.byAppId.site.accessTokenReset.post.mutationOptions(),
-  )
-
   const refreshAppDetail = useCallback(async () => {
     try {
       const appDetail = await fetchAppDetail({ url: '/apps', id: appId })
@@ -37,34 +27,33 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
     }
   }, [appId, setAppDetail])
 
+  const handleAppStateChanged = useCallback(async () => {
+    const refresh = refreshAppDetail()
+    const socket = webSocketClient.getSocket(appId)
+    if (socket) {
+      const timestamp = Date.now()
+      socket.emit('collaboration_event', {
+        type: 'app_state_update',
+        data: { timestamp },
+        timestamp,
+      })
+    }
+
+    await refresh
+  }, [appId, refreshAppDetail])
+
   const handleResult = useCallback(
     (error: Error | null, message?: I18nKeysByPrefix<'common', 'actionMsg.'>) => {
       const type = error ? 'error' : 'success'
       const resolvedMessage = message ?? (error ? 'modifiedUnsuccessfully' : 'modifiedSuccessfully')
 
-      if (!error) {
-        void queryClient.invalidateQueries({
-          queryKey: consoleQuery.apps.byAppId.get.queryKey({
-            input: { params: { app_id: appId } },
-          }),
-        })
-        void refreshAppDetail()
-        const socket = webSocketClient.getSocket(appId)
-        if (socket) {
-          const timestamp = Date.now()
-          socket.emit('collaboration_event', {
-            type: 'app_state_update',
-            data: { timestamp },
-            timestamp,
-          })
-        }
-      }
+      if (!error) void handleAppStateChanged()
 
       toast(t(($) => $[`actionMsg.${resolvedMessage}`], { ns: 'common' }) as string, {
         type,
       })
     },
-    [appId, queryClient, refreshAppDetail, t],
+    [handleAppStateChanged, t],
   )
 
   useEffect(() => {
@@ -72,33 +61,6 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
 
     return collaborationManager.onAppStateUpdate(refreshAppDetail)
   }, [appId, refreshAppDetail])
-
-  const changeSiteStatus = useCallback(
-    async (enabled: boolean) => {
-      if (!canEdit) return
-      const [error] = await asyncRunSafe(
-        updateSiteStatus({
-          params: { app_id: appId },
-          body: { enable_site: enabled },
-        }),
-      )
-      handleResult(error)
-    },
-    [appId, canEdit, handleResult, updateSiteStatus],
-  )
-
-  const changeApiStatus = useCallback(
-    async (enabled: boolean) => {
-      const [error] = await asyncRunSafe(
-        updateApiStatus({
-          params: { app_id: appId },
-          body: { enable_api: enabled },
-        }),
-      )
-      handleResult(error)
-    },
-    [appId, handleResult, updateApiStatus],
-  )
 
   const saveSiteConfig = useCallback(
     async (params: ConfigParams) => {
@@ -110,6 +72,11 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
         }) as Promise<App>,
       )
       if (!error) {
+        void queryClient.invalidateQueries({
+          queryKey: consoleQuery.apps.byAppId.get.queryKey({
+            input: { params: { app_id: appId } },
+          }),
+        })
         void queryClient.invalidateQueries({ queryKey: consoleQuery.apps.get.key() })
         void queryClient.invalidateQueries({ queryKey: consoleQuery.apps.starred.get.key() })
         void queryClient.invalidateQueries({ queryKey: consoleQuery.apps.recent.get.key() })
@@ -119,22 +86,10 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
     [appId, canEdit, handleResult, queryClient],
   )
 
-  const regenerateSiteCode = useCallback(async () => {
-    if (!canEdit) return
-    const [error] = await asyncRunSafe(
-      resetSiteAccessToken({
-        params: { app_id: appId },
-      }),
-    )
-    handleResult(error, error ? 'generatedUnsuccessfully' : 'generatedSuccessfully')
-  }, [appId, canEdit, handleResult, resetSiteAccessToken])
-
   return {
-    changeApiStatus,
-    changeSiteStatus,
+    handleAppStateChanged,
     handleResult,
     refreshAppDetail,
-    regenerateSiteCode,
     saveSiteConfig,
   }
 }

--- a/web/app/components/app/access-point/shared/use-access-point-actions.ts
+++ b/web/app/components/app/access-point/shared/use-access-point-actions.ts
@@ -1,22 +1,16 @@
 'use client'
 
 import type { ConfigParams } from '@/app/components/app/overview/settings'
-import type { UpdateAppSiteCodeResponse } from '@/models/app'
 import type { App } from '@/types/app'
 import type { I18nKeysByPrefix } from '@/types/i18n'
 import { toast } from '@langgenius/dify-ui/toast'
-import { useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { collaborationManager } from '@/app/components/workflow/collaboration/core/collaboration-manager'
 import { webSocketClient } from '@/app/components/workflow/collaboration/core/websocket-manager'
-import {
-  fetchAppDetail,
-  updateAppSiteAccessToken,
-  updateAppSiteConfig,
-  updateAppSiteStatus,
-} from '@/service/apps'
+import { fetchAppDetail, updateAppSiteConfig } from '@/service/apps'
 import { consoleQuery } from '@/service/client'
 import { asyncRunSafe } from '@/utils'
 
@@ -24,6 +18,15 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const setAppDetail = useAppStore((state) => state.setAppDetail)
+  const { mutateAsync: updateSiteStatus } = useMutation(
+    consoleQuery.apps.byAppId.siteEnable.post.mutationOptions(),
+  )
+  const { mutateAsync: updateApiStatus } = useMutation(
+    consoleQuery.apps.byAppId.apiEnable.post.mutationOptions(),
+  )
+  const { mutateAsync: resetSiteAccessToken } = useMutation(
+    consoleQuery.apps.byAppId.site.accessTokenReset.post.mutationOptions(),
+  )
 
   const refreshAppDetail = useCallback(async () => {
     try {
@@ -40,6 +43,11 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
       const resolvedMessage = message ?? (error ? 'modifiedUnsuccessfully' : 'modifiedSuccessfully')
 
       if (!error) {
+        void queryClient.invalidateQueries({
+          queryKey: consoleQuery.apps.byAppId.get.queryKey({
+            input: { params: { app_id: appId } },
+          }),
+        })
         void refreshAppDetail()
         const socket = webSocketClient.getSocket(appId)
         if (socket) {
@@ -56,7 +64,7 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
         type,
       })
     },
-    [appId, refreshAppDetail, t],
+    [appId, queryClient, refreshAppDetail, t],
   )
 
   useEffect(() => {
@@ -68,28 +76,28 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
   const changeSiteStatus = useCallback(
     async (enabled: boolean) => {
       if (!canEdit) return
-      const [error] = await asyncRunSafe<App>(
-        updateAppSiteStatus({
-          url: `/apps/${appId}/site-enable`,
+      const [error] = await asyncRunSafe(
+        updateSiteStatus({
+          params: { app_id: appId },
           body: { enable_site: enabled },
-        }) as Promise<App>,
+        }),
       )
       handleResult(error)
     },
-    [appId, canEdit, handleResult],
+    [appId, canEdit, handleResult, updateSiteStatus],
   )
 
   const changeApiStatus = useCallback(
     async (enabled: boolean) => {
-      const [error] = await asyncRunSafe<App>(
-        updateAppSiteStatus({
-          url: `/apps/${appId}/api-enable`,
+      const [error] = await asyncRunSafe(
+        updateApiStatus({
+          params: { app_id: appId },
           body: { enable_api: enabled },
-        }) as Promise<App>,
+        }),
       )
       handleResult(error)
     },
-    [appId, handleResult],
+    [appId, handleResult, updateApiStatus],
   )
 
   const saveSiteConfig = useCallback(
@@ -113,13 +121,13 @@ export function useAccessPointActions(appId: string, canEdit: boolean) {
 
   const regenerateSiteCode = useCallback(async () => {
     if (!canEdit) return
-    const [error] = await asyncRunSafe<UpdateAppSiteCodeResponse>(
-      updateAppSiteAccessToken({
-        url: `/apps/${appId}/site/access-token-reset`,
-      }) as Promise<UpdateAppSiteCodeResponse>,
+    const [error] = await asyncRunSafe(
+      resetSiteAccessToken({
+        params: { app_id: appId },
+      }),
     )
     handleResult(error, error ? 'generatedUnsuccessfully' : 'generatedSuccessfully')
-  }, [appId, canEdit, handleResult])
+  }, [appId, canEdit, handleResult, resetSiteAccessToken])
 
   return {
     changeApiStatus,

--- a/web/features/agent-v2/agent-detail/access/components/web-app-access-card.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/web-app-access-card.tsx
@@ -161,7 +161,6 @@ export function WebAppAccessCard({
             }
           },
         )
-        toast.success(tCommon(($) => $['actionMsg.generatedSuccessfully']))
       },
       onError: () => {
         toast.error(tCommon(($) => $['actionMsg.generatedUnsuccessfully']))

--- a/web/models/app.ts
+++ b/web/models/app.ts
@@ -12,7 +12,7 @@ import type {
   WeaveConfig,
 } from '@/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/type'
 import type { Dependency } from '@/app/components/plugins/types'
-import type { App, AppModeEnum, SiteConfig } from '@/types/app'
+import type { App, AppModeEnum } from '@/types/app'
 
 export const DSLImportMode = {
   YAML_CONTENT: 'yaml-content',
@@ -49,8 +49,6 @@ export type DSLImportResponse = {
   permission_keys: string[]
   warnings?: DSLImportWarning[]
 }
-
-export type UpdateAppSiteCodeResponse = { app_id: string } & SiteConfig
 
 export type UpdateAppModelConfigResponse = { result: string }
 

--- a/web/service/apps.ts
+++ b/web/service/apps.ts
@@ -6,7 +6,6 @@ import type {
   TracingConfig,
   TracingStatus,
   UpdateAppModelConfigResponse,
-  UpdateAppSiteCodeResponse,
   WebhookTriggerResponse,
 } from '@/models/app'
 import type { CommonResponse } from '@/models/common'
@@ -170,24 +169,6 @@ export const importDSLConfirm = ({
 
 export const deleteApp = (appID: string): Promise<CommonResponse> => {
   return del<CommonResponse>(`apps/${appID}`)
-}
-
-export const updateAppSiteStatus = ({
-  url,
-  body,
-}: {
-  url: string
-  body: Record<string, any>
-}): Promise<AppDetailResponse> => {
-  return post<AppDetailResponse>(url, { body })
-}
-
-export const updateAppSiteAccessToken = ({
-  url,
-}: {
-  url: string
-}): Promise<UpdateAppSiteCodeResponse> => {
-  return post<UpdateAppSiteCodeResponse>(url)
 }
 
 export const updateAppSiteConfig = ({

--- a/web/service/client.spec.ts
+++ b/web/service/client.spec.ts
@@ -1,4 +1,5 @@
 import type { ApiBasedExtensionResponse } from '@dify/contracts/api/console/api-based-extension/types.gen'
+import type { AppDetail, AppSiteResponse } from '@dify/contracts/api/console/apps/types.gen'
 import type { TagResponse as Tag } from '@dify/contracts/api/console/tags/types.gen'
 import type { DocumentProcessingTaskEvent } from '@dify/contracts/knowledge-fs/types.gen'
 import type { MutationFunctionContext, QueryFunctionContext } from '@tanstack/react-query'
@@ -661,6 +662,82 @@ describe('consoleQuery account profile mutation defaults', () => {
 })
 
 describe('consoleQuery app mutation defaults', () => {
+  it('should invalidate the exact app detail after access mutations', async () => {
+    const consoleQuery = await loadConsoleQuery()
+    const queryClient = new QueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockImplementation(() => new Promise(() => {}))
+    const context = createMutationContext(queryClient)
+    const appDetail: AppDetail = {
+      enable_api: true,
+      enable_site: true,
+      id: 'app-1',
+      mode: 'chat',
+      name: 'App',
+    }
+    const appSite: AppSiteResponse = {
+      app_id: 'app-1',
+      customize_token_strategy: 'fixed',
+      default_language: 'en-US',
+      prompt_public: false,
+      show_workflow_steps: false,
+      title: 'App',
+      use_icon_as_answer_icon: false,
+    }
+
+    const results = [
+      consoleQuery.apps.byAppId.apiEnable.post
+        .mutationOptions()
+        .onSettled?.(
+          appDetail,
+          null,
+          { params: { app_id: 'app-1' }, body: { enable_api: true } },
+          undefined,
+          context,
+        ),
+      consoleQuery.apps.byAppId.siteEnable.post
+        .mutationOptions()
+        .onSettled?.(
+          appDetail,
+          null,
+          { params: { app_id: 'app-2' }, body: { enable_site: true } },
+          undefined,
+          context,
+        ),
+      consoleQuery.apps.byAppId.site.accessTokenReset.post
+        .mutationOptions()
+        .onSettled?.(appSite, null, { params: { app_id: 'app-3' } }, undefined, context),
+      consoleQuery.apps.byAppId.siteEnable.post
+        .mutationOptions()
+        .onSettled?.(
+          undefined,
+          new Error('request failed'),
+          { params: { app_id: 'app-4' }, body: { enable_site: false } },
+          undefined,
+          context,
+        ),
+    ]
+
+    expect(results).toEqual([undefined, undefined, undefined, undefined])
+    expect(invalidateQueries).toHaveBeenCalledTimes(3)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: consoleQuery.apps.byAppId.get.queryKey({
+        input: { params: { app_id: 'app-1' } },
+      }),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: consoleQuery.apps.byAppId.get.queryKey({
+        input: { params: { app_id: 'app-2' } },
+      }),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: consoleQuery.apps.byAppId.get.queryKey({
+        input: { params: { app_id: 'app-3' } },
+      }),
+    })
+  })
+
   it('should write an updated app into its exact detail cache', async () => {
     const consoleQuery = await loadConsoleQuery()
     const queryClient = new QueryClient()

--- a/web/service/client.ts
+++ b/web/service/client.ts
@@ -525,6 +525,22 @@ export const consoleQuery: RouterUtils<typeof consoleClient> = createTanstackQue
           },
         },
         byAppId: {
+          // Shared invalidation uses onSettled so feature-owned onSuccess callbacks can coexist.
+          apiEnable: {
+            post: {
+              mutationOptions: {
+                onSettled: (_data, error, variables, _onMutateResult, context) => {
+                  if (error) return
+
+                  void context.client.invalidateQueries({
+                    queryKey: consoleQuery.apps.byAppId.get.queryKey({
+                      input: { params: variables.params },
+                    }),
+                  })
+                },
+              },
+            },
+          },
           delete: {
             mutationOptions: {
               onSuccess: (_data, _variables, _onMutateResult, context) =>
@@ -555,6 +571,38 @@ export const consoleQuery: RouterUtils<typeof consoleClient> = createTanstackQue
                 void context.client.invalidateQueries({
                   queryKey: consoleQuery.apps.recent.get.key(),
                 })
+              },
+            },
+          },
+          siteEnable: {
+            post: {
+              mutationOptions: {
+                onSettled: (_data, error, variables, _onMutateResult, context) => {
+                  if (error) return
+
+                  void context.client.invalidateQueries({
+                    queryKey: consoleQuery.apps.byAppId.get.queryKey({
+                      input: { params: variables.params },
+                    }),
+                  })
+                },
+              },
+            },
+          },
+          site: {
+            accessTokenReset: {
+              post: {
+                mutationOptions: {
+                  onSettled: (_data, error, variables, _onMutateResult, context) => {
+                    if (error) return
+
+                    void context.client.invalidateQueries({
+                      queryKey: consoleQuery.apps.byAppId.get.queryKey({
+                        input: { params: variables.params },
+                      }),
+                    })
+                  },
+                },
               },
             },
           },


### PR DESCRIPTION
## Summary

- move the built-in Web App and Service API mutations to the cards that own their interaction and pending state
- route site/API status and site token-reset requests through generated oRPC TanStack Query contracts
- keep shared app-detail invalidation in generated query defaults while allowing feature-owned success callbacks to coexist
- preserve the temporary Zustand refresh and collaboration broadcast as an explicit migration boundary
- remove the legacy dynamic-URL service wrappers, their response assertions, and the obsolete response type
- rely on visible status and URL updates for success feedback while retaining error toasts for failed mutations
- reduce the legacy lint suppression count together with the deleted `any` occurrence

## Scope

This intentionally keeps `fetchAppDetail` and `updateAppSiteConfig`. App detail still has legacy Zustand consumers, and the generated site-update payload does not cover the existing `enable_sso` UI contract. No frontend DTO shim or replacement service abstraction is introduced.

## Cache and callback ownership

- generated query defaults own shared `apps.byAppId.get` invalidation
- each access-point card owns its mutation, pending state, permission guard, and local error feedback
- Agent V2 keeps its feature-local cache projection without replacing the shared invalidation callback
- the existing access-point coordinator temporarily owns only Zustand refresh and collaboration broadcast

## Testing

- `vp test run --project unit app/components/app/access-point/__tests__ features/agent-v2/agent-detail/access/components/__tests__/access-surface-cards.spec.tsx service/client.spec.ts` (143 tests)
- `pnpm -w check`
- `vp run knip`
- `git diff --check`

From Codex