### PR TITLE
fix: handle agent tool call interruption

### DIFF
--- a/dify-agent/docs/dify-agent/user-manual/history-layer/index.md
+++ b/dify-agent/docs/dify-agent/user-manual/history-layer/index.md
@@ -54,8 +54,13 @@ cancelled runs. A failure or cancellation before the capture contains any
 messages preserves the previously restored history. An interrupted capture can
 include a partial response or tool-return request marked `state="interrupted"`;
 pydantic-ai repairs that state when the snapshot is used by a later independent
-run. Without this layer, compaction and interrupted messages affect only the
-current run.
+run. If the run was cancelled, timed out, or failed while tool calls were still
+executing and none of them had returned yet, Dify Agent marks the trailing
+tool-calling response `state="interrupted"` before persisting; pydantic-ai then
+closes every unanswered call with a synthesized `outcome="interrupted"` tool
+return when the next run starts, so the model is never sent a tool call without
+a result. Without this layer, compaction and interrupted messages affect only
+the current run.
 
 ## Resume a conversation
 
@@ -102,7 +107,12 @@ Dify Agent handles memory conservatively:
 6. Run-level system instructions are removed before history is persisted.
 7. Interrupted partial messages retain pydantic-ai's `state="interrupted"` marker
    so a later independent run can repair and continue from the checkpoint.
-8. Failed and cancelled runs keep their terminal status; their snapshot is a
+8. A failed, timed-out, or cancelled run whose history ends in a tool-calling
+   response is persisted with that response marked `state="interrupted"`, so
+   the next run receives synthesized `outcome="interrupted"` tool returns for
+   those calls. Pending `ask_human` deferred tool calls from a successful run
+   are not affected; they stay open for `deferred_tool_results`.
+9. Failed and cancelled runs keep their terminal status; their snapshot is a
    checkpoint, not a successful continuation of the interrupted run.
 
 ## Persist snapshots outside the client process

--- a/dify-agent/src/dify_agent/runtime/history.py
+++ b/dify-agent/src/dify_agent/runtime/history.py
@@ -14,7 +14,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 from typing import Protocol
 
-from pydantic_ai.messages import ModelMessage, ModelRequest
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse
 
 from agenton_collections.layers.pydantic_ai import PYDANTIC_AI_HISTORY_LAYER_TYPE_ID, PydanticAIHistoryLayer
 from dify_agent.protocol import DIFY_AGENT_HISTORY_LAYER_ID
@@ -78,9 +78,21 @@ def replace_run_history(
     history_layer.replace_messages(persistent_messages)
 
 
+def mark_interrupted_tool_calls(messages: Sequence[ModelMessage]) -> list[ModelMessage]:
+    """Mark tool calls as interrupt and let pydantic-ai close them with synthesized outcome."""
+    marked = list(messages)
+    if not marked:
+        return marked
+    trailing = marked[-1]
+    if isinstance(trailing, ModelResponse) and trailing.tool_calls and trailing.state != "interrupted":
+        marked[-1] = replace(trailing, state="interrupted")
+    return marked
+
+
 __all__ = [
     "SupportsHistoryLayerLookup",
     "get_history_layer",
+    "mark_interrupted_tool_calls",
     "replace_run_history",
     "validate_history_layer_composition",
 ]

--- a/dify-agent/src/dify_agent/runtime/runner.py
+++ b/dify-agent/src/dify_agent/runtime/runner.py
@@ -82,6 +82,7 @@ from dify_agent.runtime.event_sink import (
 )
 from dify_agent.runtime.history import (
     get_history_layer,
+    mark_interrupted_tool_calls,
     replace_run_history,
     validate_history_layer_composition,
 )
@@ -402,9 +403,12 @@ class AgentRunRunner:
                                     capabilities=[compaction] if compaction is not None else None,
                                     usage_limits=UsageLimits(request_limit=_MAX_AGENT_STEPS_PER_RUN),
                                 )
-                        finally:
+                        except BaseException:
                             if captured_messages:
-                                replace_run_history(history_layer, captured_messages)
+                                replace_run_history(history_layer, mark_interrupted_tool_calls(captured_messages))
+                            raise
+                        if captured_messages:
+                            replace_run_history(history_layer, captured_messages)
                 except TimeoutError as exc:
                     if not run_timeout.expired():
                         raise

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -21,7 +21,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.function import DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults
 from pydantic_ai.usage import UsageLimits
@@ -1007,6 +1007,74 @@ def test_runner_captures_interrupted_history_when_task_is_cancelled(monkeypatch:
     assert runner.terminal_session_snapshot is not None
     assert all(layer.lifecycle_state is LifecycleState.SUSPENDED for layer in runner.terminal_session_snapshot.layers)
     _assert_interrupted_history(runner.terminal_session_snapshot, stored_history)
+
+
+def test_runner_marks_interrupted_tool_calls_when_cancelled_during_tool_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_started = asyncio.Event()
+    stored_history = [
+        ModelRequest(parts=[UserPromptPart(content="old user")]),
+        ModelResponse(parts=[TextPart(content="old assistant")]),
+    ]
+
+    async def slow_tool(query: str) -> str:
+        del query
+        tool_started.set()
+        await asyncio.Event().wait()
+        return "never"
+
+    async def stream_response(_messages: list[ModelMessage], _info: object) -> AsyncIterator[str | DeltaToolCalls]:
+        yield {0: DeltaToolCall(name="slow_tool", json_args='{"query": "q"}', tool_call_id="call-1")}
+
+    def fake_get_model(_self: DifyPluginLLMLayer, *, http_client: httpx.AsyncClient, agent_run_id: str):
+        return FunctionModel(stream_function=stream_response)
+
+    monkeypatch.setattr(DifyPluginLLMLayer, "get_model", fake_get_model)
+    static_tools_provider = LayerProvider.from_factory(
+        layer_type=StaticToolsTestLayer,
+        create=lambda _config: StaticToolsTestLayer(tool_entries=(slow_tool,)),
+    )
+    request = _request("current user", include_history=True)
+    request.composition.layers.insert(1, RunLayerSpec(name="static-tools", type=cast(str, StaticToolsTestLayer.type_id)))
+    request.session_snapshot = _history_session_snapshot(stored_history)
+    request.session_snapshot.layers.insert(
+        1, LayerSessionSnapshot(name="static-tools", lifecycle_state=LifecycleState.SUSPENDED, runtime_state={})
+    )
+    sink = InMemoryRunEventSink()
+
+    async def scenario() -> AgentRunRunner:
+        async with httpx.AsyncClient() as client:
+            runner = AgentRunRunner(
+                sink=sink,
+                request=request,
+                run_id="run-cancel-tool-call",
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                layer_providers=(*create_default_layer_providers(), static_tools_provider),
+            )
+            task = asyncio.create_task(runner.run())
+            await asyncio.wait_for(tool_started.wait(), timeout=1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            return runner
+
+    runner = asyncio.run(scenario())
+
+    assert runner.terminal_session_snapshot is not None
+    saved_history = _history_messages_from_snapshot(runner.terminal_session_snapshot)
+    assert saved_history[: len(stored_history)] == stored_history
+    assert len(saved_history) == len(stored_history) + 2
+    current_request = saved_history[-2]
+    assert isinstance(current_request, ModelRequest)
+    assert len(current_request.parts) == 1
+    assert isinstance(current_request.parts[0], UserPromptPart)
+    assert current_request.parts[0].content == "current user"
+    tool_call_response = saved_history[-1]
+    assert isinstance(tool_call_response, ModelResponse)
+    assert tool_call_response.state == "interrupted"
+    assert [part.tool_call_id for part in tool_call_response.tool_calls] == ["call-1"]
 
 
 def test_runner_emits_deferred_tool_call_and_persists_pending_history(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -1036,7 +1036,9 @@ def test_runner_marks_interrupted_tool_calls_when_cancelled_during_tool_executio
         create=lambda _config: StaticToolsTestLayer(tool_entries=(slow_tool,)),
     )
     request = _request("current user", include_history=True)
-    request.composition.layers.insert(1, RunLayerSpec(name="static-tools", type=cast(str, StaticToolsTestLayer.type_id)))
+    request.composition.layers.insert(
+        1, RunLayerSpec(name="static-tools", type=cast(str, StaticToolsTestLayer.type_id))
+    )
     request.session_snapshot = _history_session_snapshot(stored_history)
     request.session_snapshot.layers.insert(
         1, LayerSessionSnapshot(name="static-tools", lifecycle_state=LifecycleState.SUSPENDED, runtime_state={})

--- a/dify-agent/tests/local/dify_agent/runtime/test_runtime_history.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runtime_history.py
@@ -1,7 +1,19 @@
 import asyncio
 
 import pytest
-from pydantic_ai.messages import ModelRequest, ModelResponse, SystemPromptPart, TextPart, UserPromptPart
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    INTERRUPTED_TOOL_RETURN_CONTENT,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 
 from agenton.compositor import Compositor, LayerNode
 from agenton_collections.layers.pydantic_ai import (
@@ -13,6 +25,7 @@ from dify_agent.protocol.schemas import RunComposition, RunLayerSpec
 from dify_agent.runtime.compositor_factory import create_default_layer_providers
 from dify_agent.runtime.history import (
     get_history_layer,
+    mark_interrupted_tool_calls,
     replace_run_history,
     validate_history_layer_composition,
 )
@@ -112,3 +125,115 @@ def test_replace_run_history_persists_full_history_without_instructions() -> Non
     source_request = messages[0]
     assert isinstance(source_request, ModelRequest)
     assert source_request.instructions == "current instructions"
+
+
+def test_mark_interrupted_tool_calls_marks_trailing_tool_calling_response() -> None:
+    response = ModelResponse(
+        parts=[
+            TextPart(content="calling"),
+            ToolCallPart(tool_name="search", args={"q": "a"}, tool_call_id="call-1"),
+            ToolCallPart(tool_name="fetch", args={"url": "b"}, tool_call_id="call-2"),
+        ]
+    )
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content="user")]), response]
+
+    marked = mark_interrupted_tool_calls(messages)
+
+    assert marked[0] == messages[0]
+    assert len(marked) == 2
+    trailing = marked[-1]
+    assert isinstance(trailing, ModelResponse)
+    assert trailing.state == "interrupted"
+    assert trailing.parts == response.parts
+    assert response.state == "complete"
+    assert mark_interrupted_tool_calls(marked) == marked
+
+
+def test_mark_interrupted_tool_calls_leaves_other_trailing_shapes_unchanged() -> None:
+    partial_tool_return_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="user")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name="search", args={}, tool_call_id="call-1"),
+                ToolCallPart(tool_name="fetch", args={}, tool_call_id="call-2"),
+            ]
+        ),
+        ModelRequest(
+            parts=[ToolReturnPart(tool_name="search", content="found", tool_call_id="call-1")],
+            state="interrupted",
+        ),
+    ]
+    answered_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="user")]),
+        ModelResponse(parts=[ToolCallPart(tool_name="search", args={}, tool_call_id="call-1")]),
+        ModelRequest(parts=[ToolReturnPart(tool_name="search", content="found", tool_call_id="call-1")]),
+        ModelResponse(parts=[TextPart(content="done")]),
+    ]
+    text_only_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="user")]),
+        ModelResponse(parts=[TextPart(content="partial")], state="interrupted"),
+    ]
+
+    assert mark_interrupted_tool_calls(partial_tool_return_history) == partial_tool_return_history
+    assert mark_interrupted_tool_calls(answered_history) == answered_history
+    assert mark_interrupted_tool_calls(text_only_history) == text_only_history
+    assert mark_interrupted_tool_calls([]) == []
+
+
+@pytest.mark.parametrize(
+    "interrupted_history",
+    [
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content="first")]),
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(tool_name="search", args={"q": "a"}, tool_call_id="call-1"),
+                        ToolCallPart(tool_name="search", args={"q": "b"}, tool_call_id="call-2"),
+                    ]
+                ),
+            ],
+            id="no-results",
+        ),
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content="first")]),
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(tool_name="search", args={"q": "a"}, tool_call_id="call-1"),
+                        ToolCallPart(tool_name="search", args={"q": "b"}, tool_call_id="call-2"),
+                    ]
+                ),
+                ModelRequest(
+                    parts=[ToolReturnPart(tool_name="search", content="found", tool_call_id="call-1")],
+                    state="interrupted",
+                ),
+            ],
+            id="partial-results",
+        ),
+    ],
+)
+def test_marked_interrupted_tool_calls_are_repaired_by_pydantic_ai_on_the_next_prompt(
+    interrupted_history: list[ModelMessage],
+) -> None:
+    seen_requests: list[list[ModelMessage]] = []
+
+    def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen_requests.append(list(messages))
+        return ModelResponse(parts=[TextPart(content="answer")])
+
+    agent = Agent(FunctionModel(respond))
+
+    async def scenario() -> str:
+        result = await agent.run("second", message_history=mark_interrupted_tool_calls(interrupted_history))
+        return result.output
+
+    assert asyncio.run(scenario()) == "answer"
+    assert len(seen_requests) == 1
+    sent_parts = [part for message in seen_requests[0] for part in message.parts]
+    tool_returns = {part.tool_call_id: part for part in sent_parts if isinstance(part, ToolReturnPart)}
+    assert set(tool_returns) == {"call-1", "call-2"}
+    assert tool_returns["call-2"].outcome == "interrupted"
+    assert tool_returns["call-2"].content == INTERRUPTED_TOOL_RETURN_CONTENT
+    assert isinstance(sent_parts[-1], UserPromptPart)
+    assert sent_parts[-1].content == "second"


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Mark last message state as "interrupted" and leave tool call response synthesizing to pydantic-ai
resolves #41616 

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
