### PR TITLE
fix(agent-v2): preserve Swagger API tool credentials across refresh

### DIFF
--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -706,10 +706,7 @@ class AgentSoulDifyToolConfig(BaseModel):
             raise ValueError("Dify tool requires provider_id or plugin_id + provider")
         if self.credential_type != "unauthorized" and (self.credential_ref is None or not self.credential_ref.id):
             provider_id = self.provider_id
-            if (
-                provider_id
-                and self.provider_type in {ToolProviderType.API, ToolProviderType.WORKFLOW}
-            ):
+            if provider_id and self.provider_type in {ToolProviderType.API, ToolProviderType.WORKFLOW}:
                 self.credential_ref = AgentSoulDifyToolCredentialRef(
                     type="provider",
                     id=provider_id,

--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -705,7 +705,18 @@ class AgentSoulDifyToolConfig(BaseModel):
         if not self.provider_id and not (self.plugin_id and self.provider):
             raise ValueError("Dify tool requires provider_id or plugin_id + provider")
         if self.credential_type != "unauthorized" and (self.credential_ref is None or not self.credential_ref.id):
-            raise ValueError("credential_ref.id is required for credentialed Dify tools")
+            provider_id = self.provider_id
+            if (
+                provider_id
+                and self.provider_type in {ToolProviderType.API, ToolProviderType.WORKFLOW}
+            ):
+                self.credential_ref = AgentSoulDifyToolCredentialRef(
+                    type="provider",
+                    id=provider_id,
+                    provider=provider_id,
+                )
+            else:
+                raise ValueError("credential_ref.id is required for credentialed Dify tools")
         # ``name`` is reserved for a future user-rename UX. Until that lands
         # the model-visible name is forced to match ``tool_name``; reject
         # explicit values so a frontend bug surfaces immediately instead of

--- a/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
+++ b/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
@@ -392,6 +392,28 @@ def test_manual_metadata_filtering_condition_accepts_composer_ui_identifiers():
     assert condition.metadata_id == "ad6cf326-eadf-46e8-a2d5-9cb892d2cc84"
 
 
+def test_agent_soul_dify_tool_config_backfills_api_provider_credential_ref():
+    config = AgentSoulConfig.model_validate(
+        {
+            "tools": {
+                "dify_tools": [
+                    {
+                        "provider_id": "api-provider-1",
+                        "provider_type": "api",
+                        "tool_name": "get_pet",
+                        "credential_type": "api-key",
+                    }
+                ]
+            }
+        }
+    )
+
+    tool = config.tools.dify_tools[0]
+    assert tool.credential_ref is not None
+    assert tool.credential_ref.id == "api-provider-1"
+    assert tool.credential_ref.provider == "api-provider-1"
+
+
 def test_agent_soul_model_config_is_first_class_without_credentials():
     config = AgentSoulConfig(
         model=AgentSoulModelConfig(

--- a/web/features/agent-v2/agent-composer/__tests__/store.spec.ts
+++ b/web/features/agent-v2/agent-composer/__tests__/store.spec.ts
@@ -481,6 +481,89 @@ describe('agent composer store conversions', () => {
     ])
   })
 
+  it('should preserve provider-scoped api tool credentials across save and hydrate', () => {
+    const formState = agentSoulConfigToFormState({
+      tools: {
+        dify_tools: [
+          {
+            provider: 'petstore',
+            provider_id: 'api-provider-1',
+            provider_type: 'api',
+            tool_name: 'get_pet',
+            credential_type: 'api-key',
+            credential_ref: {
+              id: 'api-provider-1',
+              provider: 'api-provider-1',
+              type: 'provider',
+            },
+          },
+        ],
+      },
+    })
+    const publishConfig = formStateToAgentSoulConfig({ formState })
+
+    expect(formState.tools).toEqual([
+      expect.objectContaining({
+        id: 'api-provider-1',
+        credentialId: 'api-provider-1',
+        credentialType: 'api-key',
+        credentialVariant: 'authorized',
+      }),
+    ])
+    expect(publishConfig.tools?.dify_tools).toEqual([
+      expect.objectContaining({
+        provider_id: 'api-provider-1',
+        provider_type: 'api',
+        credential_type: 'api-key',
+        credential_ref: {
+          id: 'api-provider-1',
+          provider: 'api-provider-1',
+          type: 'provider',
+        },
+      }),
+    ])
+  })
+
+  it('should save authorized swagger tools without an explicit credential id', () => {
+    const publishConfig = formStateToAgentSoulConfig({
+      formState: {
+        ...defaultAgentSoulConfigFormState,
+        tools: [
+          {
+            id: 'api-provider-1',
+            kind: 'provider',
+            name: 'petstore',
+            iconClassName: 'i-custom-public-other-default-tool-icon text-text-tertiary',
+            providerType: 'api',
+            credentialType: 'api-key',
+            credentialVariant: 'authorized',
+            actions: [
+              {
+                id: 'api-provider-1:get_pet',
+                name: 'Get Pet',
+                toolName: 'get_pet',
+                description: 'Fetch a pet by id.',
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    expect(publishConfig.tools?.dify_tools).toEqual([
+      expect.objectContaining({
+        provider_id: 'api-provider-1',
+        provider_type: 'api',
+        credential_type: 'api-key',
+        credential_ref: {
+          id: 'api-provider-1',
+          provider: 'api-provider-1',
+          type: 'provider',
+        },
+      }),
+    ])
+  })
+
   it('should preserve oauth2 credential references when saving tool config', () => {
     const baseConfig = {
       tools: {

--- a/web/features/agent-v2/agent-composer/conversions.ts
+++ b/web/features/agent-v2/agent-composer/conversions.ts
@@ -288,14 +288,40 @@ const toProviderToolFormState = (
   }
 }
 
+const PROVIDER_SCOPED_CREDENTIAL_PROVIDER_TYPES = new Set(['api', 'workflow'])
+
+const hasProviderScopedAuthorization = (tool: AgentProviderTool) =>
+  PROVIDER_SCOPED_CREDENTIAL_PROVIDER_TYPES.has(tool.providerType ?? '') &&
+  tool.credentialVariant === 'authorized'
+
+const resolveDifyToolCredentialId = (tool: AgentProviderTool) =>
+  tool.credentialId ?? (hasProviderScopedAuthorization(tool) ? tool.id : undefined)
+
+const resolveDifyToolCredentialType = (tool: AgentProviderTool) => {
+  if (resolveDifyToolCredentialId(tool)) {
+    return tool.credentialType === 'oauth2' ? ('oauth2' as const) : ('api-key' as const)
+  }
+
+  return 'unauthorized' as const
+}
+
+const resolveDifyToolCredentialRef = (tool: AgentProviderTool) => {
+  const credentialId = resolveDifyToolCredentialId(tool)
+  if (!credentialId) return undefined
+
+  return {
+    id: credentialId,
+    provider: tool.id,
+    type: 'provider' as const,
+  }
+}
+
 const toDifyToolConfigs = (
   tools: AgentTool[],
   toolSettings: Record<string, Record<string, unknown>>,
 ) =>
   tools.flatMap((tool) => {
     if (tool.kind !== 'provider') return []
-
-    const credentialType = tool.credentialId ? (tool.credentialType ?? 'api-key') : 'unauthorized'
 
     return tool.actions.map((action) => ({
       enabled: true,
@@ -305,14 +331,8 @@ const toDifyToolConfigs = (
       provider_type: tool.providerType,
       tool_name: action.toolName,
       runtime_parameters: toToolRuntimeParameters(toolSettings[action.id]),
-      credential_type: credentialType,
-      credential_ref: tool.credentialId
-        ? {
-            id: tool.credentialId,
-            provider: tool.id,
-            type: 'provider' as const,
-          }
-        : undefined,
+      credential_type: resolveDifyToolCredentialType(tool),
+      credential_ref: resolveDifyToolCredentialRef(tool),
     }))
   })
 

--- a/web/features/agent-v2/agent-composer/store-modules/__tests__/tools.spec.ts
+++ b/web/features/agent-v2/agent-composer/store-modules/__tests__/tools.spec.ts
@@ -46,6 +46,22 @@ const unauthorizedOAuthTool = {
   credentialType: 'oauth2',
 } satisfies AgentProviderToolDefaultValue
 
+const authorizedApiTool = {
+  provider_id: 'api-provider-1',
+  provider_type: 'api',
+  provider_name: 'petstore',
+  provider_show_name: 'Petstore',
+  tool_name: 'get_pet',
+  tool_label: 'Get Pet',
+  title: 'Get Pet',
+  tool_description: 'Fetch a pet by id.',
+  is_team_authorization: true,
+  params: {},
+  paramSchemas: [],
+  allowDelete: true,
+  credentialRequired: true,
+} satisfies AgentProviderToolDefaultValue
+
 describe('agent composer tools store', () => {
   describe('addProviderTools', () => {
     it('should not mark tools that do not need credentials as unauthorized', () => {
@@ -80,6 +96,18 @@ describe('agent composer tools store', () => {
           credentialId: undefined,
           credentialType: 'oauth2',
           credentialVariant: 'unauthorized',
+        }),
+      ])
+    })
+
+    it('should bind provider-scoped credentials for authorized swagger tools', () => {
+      const nextTools = addProviderTools([], [authorizedApiTool])
+
+      expect(nextTools).toEqual([
+        expect.objectContaining({
+          credentialId: 'api-provider-1',
+          credentialType: 'api-key',
+          credentialVariant: 'authorized',
         }),
       ])
     })

--- a/web/features/agent-v2/agent-composer/store-modules/tools.ts
+++ b/web/features/agent-v2/agent-composer/store-modules/tools.ts
@@ -75,13 +75,24 @@ const getCredentialVariant = (tool: AgentProviderToolDefaultValue) => {
   return tool.is_team_authorization ? ('authorized' as const) : ('unauthorized' as const)
 }
 
+const usesProviderScopedCredentials = (tool: AgentProviderToolDefaultValue) =>
+  tool.provider_type === 'api' || tool.provider_type === 'workflow'
+
+const resolveProviderCredentialId = (tool: AgentProviderToolDefaultValue) => {
+  if (tool.credential_id) return tool.credential_id
+
+  if (usesProviderScopedCredentials(tool) && tool.is_team_authorization) return tool.provider_id
+
+  return undefined
+}
+
 const getCredentialType = (tool: AgentProviderToolDefaultValue) => {
   if (!tool.credentialRequired) return undefined
 
   if (tool.credentialType === 'oauth2') return 'oauth2' as const
 
   if (!tool.allowDelete)
-    return tool.credential_id ? ('api-key' as const) : ('unauthorized' as const)
+    return resolveProviderCredentialId(tool) ? ('api-key' as const) : ('unauthorized' as const)
 
   return tool.is_team_authorization ? ('api-key' as const) : ('unauthorized' as const)
 }
@@ -133,7 +144,7 @@ export const addProviderTools = (
       iconDark: selectedTool.provider_icon_dark,
       providerType: selectedTool.provider_type,
       allowDelete: selectedTool.allowDelete,
-      credentialId: selectedTool.credential_id,
+      credentialId: resolveProviderCredentialId(selectedTool),
       credentialKey: selectedTool.is_team_authorization
         ? 'agentDetail.configure.tools.credential.authOne'
         : undefined,


### PR DESCRIPTION
## Summary

Fixes #41534 — Swagger/custom API tools showed **Unauthorized** after page refresh and blocked publishing.

**Root cause:** Custom API tools authorize at the **provider** level (`is_team_authorization`), not via a separate per-tool credential id. Agent V2 treated missing `credentialId` as unauthorized when serializing soul config, so a refresh/autosave round-trip stripped valid tool auth.

## Changes

- **Frontend (`conversions.ts`)**: When saving api/workflow tools marked authorized, derive `credential_ref` from the provider id instead of requiring a separate credential id.
- **Frontend (`store-modules/tools.ts`)**: Bind provider id as `credentialId` when adding authorized Swagger/workflow tools.
- **Backend (`agent_config_entities.py`)**: Backfill missing `credential_ref` for legacy api/workflow configs that have `credential_type: api-key` but no ref (prevents validation 500s on load).

## Test plan

- [x] `vitest` — `store.spec.ts`, `tools.spec.ts` (26 tests)
- [x] `pytest` — `test_agent_soul_dify_tool_config_backfills_api_provider_credential_ref`
- [ ] Manual: add Swagger tool to Agent V2 → refresh page → tool stays authorized → publish succeeds