### PR TITLE
refactor(web): migrate webapp reset password inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -78,18 +78,8 @@
       "count": 1
     }
   },
-  "web/app/(shareLayout)/webapp-reset-password/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/(shareLayout)/webapp-reset-password/layout.tsx": {
     "typescript/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "web/app/(shareLayout)/webapp-reset-password/page.tsx": {
-    "no-restricted-imports": {
       "count": 1
     }
   },

--- a/web/app/(shareLayout)/webapp-reset-password/check-code/page.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/check-code/page.tsx
@@ -87,6 +87,7 @@ export default function CheckCode() {
           name="code"
           inputMode="numeric"
           autoComplete="one-time-code"
+          spellCheck={false}
           value={code}
           onValueChange={setVerifyCode}
           maxLength={6}

--- a/web/app/(shareLayout)/webapp-reset-password/check-code/page.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/check-code/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiArrowLeftLine, RiMailSendFill } from '@remixicon/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 import useDocumentTitle from '@/hooks/use-document-title'
@@ -83,8 +83,12 @@ export default function CheckCode() {
           {t(($) => $['checkCode.verificationCode'], { ns: 'login' })}
         </label>
         <Input
+          id="code"
+          name="code"
+          inputMode="numeric"
+          autoComplete="one-time-code"
           value={code}
-          onChange={(e) => setVerifyCode(e.target.value)}
+          onValueChange={setVerifyCode}
           maxLength={6}
           className="mt-1"
           placeholder={t(($) => $['checkCode.verificationCodePlaceholder'], { ns: 'login' }) || ''}

--- a/web/app/(shareLayout)/webapp-reset-password/page.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiArrowLeftLine, RiLockPasswordLine } from '@remixicon/react'
 import { noop } from 'es-toolkit/function'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { COUNT_DOWN_TIME_MS, useSetCountdownLeftTime } from '@/app/components/signin/storage'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -81,7 +81,7 @@ export default function CheckCode() {
               disabled={loading}
               value={email}
               placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) as string}
-              onChange={(e) => setEmail(e.target.value)}
+              onValueChange={setEmail}
             />
           </div>
           <div className="mt-3">

--- a/web/app/(shareLayout)/webapp-reset-password/page.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/page.tsx
@@ -77,7 +77,10 @@ export default function CheckCode() {
           <div className="mt-1">
             <Input
               id="email"
+              name="email"
               type="email"
+              autoComplete="email"
+              spellCheck={false}
               disabled={loading}
               value={email}
               placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) as string}


### PR DESCRIPTION
## Summary

- migrate the WebApp reset-password email and code controls to Dify UI Input
- preserve page state and visuals while fixing native email/OTP metadata and label association

## Validation

- `vp check 'app/(shareLayout)/webapp-reset-password/page.tsx' 'app/(shareLayout)/webapp-reset-password/check-code/page.tsx'`
- local browser geometry and computed styles match the pre-migration baseline