### PR TITLE
refactor(web): migrate webapp email code inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -83,16 +83,6 @@
       "count": 1
     }
   },
-  "web/app/(shareLayout)/webapp-signin/check-code/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/(shareLayout)/webapp-signin/normalForm.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 2

--- a/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
+++ b/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
@@ -133,6 +133,7 @@ export default function CheckCode() {
           name="code"
           inputMode="numeric"
           autoComplete="one-time-code"
+          spellCheck={false}
           value={code}
           onValueChange={setCode}
           maxLength={6}

--- a/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
+++ b/web/app/(shareLayout)/webapp-signin/check-code/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 import type { FormEvent } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiArrowLeftLine, RiMailSendFill } from '@remixicon/react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { resolveWebAppLoginRedirect } from '@/app/(shareLayout)/webapp-signin/login-redirect'
-import Input from '@/app/components/base/input'
 import Countdown from '@/app/components/signin/countdown'
 import { useLocale } from '@/context/i18n'
 import { useWebAppStore } from '@/context/web-app-context'
@@ -130,8 +130,11 @@ export default function CheckCode() {
         <Input
           ref={codeInputRef}
           id="code"
+          name="code"
+          inputMode="numeric"
+          autoComplete="one-time-code"
           value={code}
-          onChange={(e) => setCode(e.target.value)}
+          onValueChange={setCode}
           maxLength={6}
           className="mt-1"
           placeholder={t(($) => $['checkCode.verificationCodePlaceholder'], { ns: 'login' }) || ''}

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { resolveWebAppLoginRedirect } from '@/app/(shareLayout)/webapp-signin/login-redirect'
-import Input from '@/app/components/base/input'
 import { COUNT_DOWN_TIME_MS, useSetCountdownLeftTime } from '@/app/components/signin/storage'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -82,7 +82,7 @@ export default function MailAndCodeAuth() {
             spellCheck={false}
             value={email}
             placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) as string}
-            onChange={(e) => setEmail(e.target.value)}
+            onValueChange={setEmail}
           />
         </div>
         <div className="mt-3">


### PR DESCRIPTION
## Summary

- migrate WebApp email-code sign-in controls to Dify UI Input
- preserve auth, redirect, and focus ownership while adding native OTP metadata

## Validation

- focused `vp check`
- 6 focused unit tests passed