### PR TITLE
fix(mcp): include FILE and FILE_LIST workflow inputs in tools/list inputSchema

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -105,6 +105,7 @@ ignore_imports =
     libs.external_api -> core
     libs.external_api -> core.errors.error
     libs.external_api -> extensions.ext_logging
+    extensions.ext_database -> extensions.ext_logging
     libs.flask_utils -> models
     libs.helper -> core.app.features.rate_limiting.rate_limit
     libs.helper -> models

--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -37,7 +37,13 @@ from graphon.enums import WorkflowNodeExecutionMetadataKey
 from graphon.model_runtime.entities.llm_entities import LLMResult
 from graphon.model_runtime.entities.message_entities import PromptMessage, SystemPromptMessage, UserPromptMessage
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
+from graphon.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+)
 from models import App, Message, WorkflowNodeExecutionModel
 from models.workflow import Workflow
 
@@ -306,7 +312,19 @@ class LLMGenerator:
                     tenant_id=tenant_id,
                     model_type=ModelType.LLM,
                 )
-        except InvokeAuthorizationError:
+        except (
+            InvokeAuthorizationError,
+            InvokeConnectionError,
+            InvokeRateLimitError,
+            InvokeBadRequestError,
+        ):
+            # Model-resolution failures during suggested-questions generation are
+            # a soft enhancement: a missing/expired credential, an unreachable
+            # provider, a per-tenant rate limit, or a malformed model config
+            # must NEVER surface as an error to the client or break the
+            # already-produced answer. Match the silent-degradation contract
+            # documented on `generate_workflow_instruction_suggestions` and
+            # return an empty suggestion list.
             return []
 
         prompt_messages: list[PromptMessage] = [UserPromptMessage(content=prompt)]

--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -339,6 +339,27 @@ def process_mapping_response(app: App, response: Mapping) -> str:
             raise ValueError("Invalid app mode: " + str(app.mode))
 
 
+def _mcp_file_object_shape() -> dict[str, Any]:
+    """JSON-Schema shape for a single Dify file input value (FILE).
+
+    Mirrors ``controllers.openapi._input_schema._file_object_shape`` so an
+    MCP client and an OpenAPI client see the same file-object contract when
+    they call into the same workflow app. ``additionalProperties: True``
+    keeps room for forward-compatible fields (the upstream file-API
+    contract is not yet pinned).
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string"},
+            "transfer_method": {"type": "string"},
+            "url": {"type": "string"},
+            "upload_file_id": {"type": "string"},
+        },
+        "additionalProperties": True,
+    }
+
+
 def convert_input_form_to_parameters(
     user_input_form: list[VariableEntity],
     parameters_dict: dict[str, str],
@@ -348,11 +369,10 @@ def convert_input_form_to_parameters(
     required = []
 
     for item in user_input_form:
-        if item.type in (
-            VariableEntityType.FILE,
-            VariableEntityType.FILE_LIST,
-            VariableEntityType.EXTERNAL_DATA_TOOL,
-        ):
+        # EXTERNAL_DATA_TOOL is a Dify-internal concept (variables bound to
+        # an external-data-tool plugin at publish time); it is not a value
+        # the MCP client can supply, so keep skipping it.
+        if item.type == VariableEntityType.EXTERNAL_DATA_TOOL:
             continue
         parameters[item.variable] = {}
         if item.required:
@@ -370,6 +390,15 @@ def convert_input_form_to_parameters(
             parameters[item.variable]["type"] = "number"
         elif item.type == VariableEntityType.CHECKBOX:
             parameters[item.variable]["type"] = "boolean"
+        elif item.type == VariableEntityType.FILE:
+            parameters[item.variable] = _mcp_file_object_shape()
+            parameters[item.variable]["description"] = description
+        elif item.type == VariableEntityType.FILE_LIST:
+            parameters[item.variable] = {
+                "type": "array",
+                "items": _mcp_file_object_shape(),
+            }
+            parameters[item.variable]["description"] = description
         elif item.type == VariableEntityType.JSON_OBJECT:
             parameters[item.variable]["type"] = "object"
             if item.json_schema:

--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -60,3 +60,14 @@ def init_app(app: DifyApp):
             _ = db.engine  # triggers engine creation with the configured options
     except Exception:
         logger.exception("Failed to initialize SQLAlchemy engine during app startup")
+
+    # SQLAlchemy attaches its own echo handlers to ``sqlalchemy.engine`` (and
+    # sub-loggers like ``sqlalchemy.pool``) at engine creation. Those handlers
+    # bypass the root logger's ``LOG_TZ``-aware formatter because
+    # ``sqlalchemy.engine`` has ``propagate = False`` (see
+    # ``extensions.ext_logging``). Apply the same ``LOG_TZ`` converter to
+    # their formatters so engine log timestamps stay consistent with the
+    # rest of the application logs.
+    from extensions.ext_logging import apply_timezone_to_sqlalchemy_loggers
+
+    apply_timezone_to_sqlalchemy_loggers()

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -90,6 +90,49 @@ def _apply_timezone(handlers: list[logging.Handler]):
                 handler.formatter.converter = time_converter  # type: ignore[attr-defined]
 
 
+def apply_timezone_to_sqlalchemy_loggers() -> None:
+    """Apply the LOG_TZ converter to the formatters of SQLAlchemy logger handlers.
+
+    ``sqlalchemy.engine`` (and its sub-loggers like ``sqlalchemy.pool``) have
+    ``propagate = False`` set in :func:`init_app` to avoid duplicate logs, so the
+    root handlers' ``LOG_TZ``-aware formatter never gets a chance to format
+    SQLAlchemy records. As a result, when ``SQLALCHEMY_ECHO`` is enabled, engine
+    log timestamps are emitted in the server's local timezone while the
+    surrounding application logs are converted to ``LOG_TZ``, producing
+    inconsistent timestamps within a single log stream.
+
+    This helper walks the SQLAlchemy logger hierarchy and applies the same
+    ``LOG_TZ`` converter to the formatters of any handlers that SQLAlchemy
+    itself has attached, so engine log timestamps agree with the rest of the
+    application logs.
+
+    Must be called AFTER the SQLAlchemy engine is created (i.e. after
+    ``ext_database.init_app()`` triggers engine creation via ``db.engine``), so
+    that any echo handler has been attached. The function is a no-op when
+    ``LOG_OUTPUT_FORMAT`` is not ``"text"`` or when ``LOG_TZ`` is unset.
+    """
+    if dify_config.LOG_OUTPUT_FORMAT != "text":
+        return
+    log_tz = dify_config.LOG_TZ
+    if not log_tz:
+        return
+
+    from datetime import datetime
+
+    import pytz
+
+    timezone = pytz.timezone(log_tz)
+
+    def time_converter(seconds):
+        return datetime.fromtimestamp(seconds, tz=timezone).timetuple()
+
+    for name in ("sqlalchemy.engine", "sqlalchemy", "sqlalchemy.pool"):
+        sql_logger = logging.getLogger(name)
+        for handler in sql_logger.handlers:
+            if isinstance(handler.formatter, logging.Formatter):
+                handler.formatter.converter = time_converter  # type: ignore[attr-defined]
+
+
 class _TextFormatter(logging.Formatter):
     """Text formatter that ensures trace_id and req_id are always present."""
 

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -19,7 +19,13 @@ from graphon.enums import WorkflowNodeExecutionStatus
 from graphon.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMUsage
 from graphon.model_runtime.entities.message_entities import AssistantPromptMessage
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
+from graphon.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+)
 from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import App, AppMode, Message
 from models.workflow import (
@@ -267,6 +273,31 @@ class TestLLMGenerator:
             mock_manager.return_value.get_default_model_instance.side_effect = InvokeAuthorizationError("Auth failed")
             questions = LLMGenerator.generate_suggested_questions_after_answer("tenant_id", "histories")
             assert questions == []
+
+    @pytest.mark.parametrize(
+        "model_resolution_error",
+        [
+            InvokeConnectionError("provider unreachable"),
+            InvokeRateLimitError("per-tenant rate limit"),
+            InvokeBadRequestError("malformed model config"),
+        ],
+    )
+    def test_generate_suggested_questions_after_answer_swallows_transient_invoke_errors(
+        self, mock_model_instance, model_resolution_error
+    ):
+        """#41592: model-resolution failures (unreachable provider, per-tenant
+        rate limit, malformed config) must degrade silently to an empty list,
+        matching the contract documented on
+        ``generate_workflow_instruction_suggestions`` and the existing
+        ``InvokeAuthorizationError`` handling at the same site.
+        """
+        with patch("core.llm_generator.llm_generator.ModelManager.for_tenant") as mock_manager:
+            mock_manager.return_value.get_default_model_instance.side_effect = model_resolution_error
+            questions = LLMGenerator.generate_suggested_questions_after_answer("tenant_id", "histories")
+            assert questions == []
+            # ``invoke_llm`` must NOT be called — we never even reached the
+            # generation step.
+            mock_model_instance.invoke_llm.assert_not_called()
 
     def test_generate_suggested_questions_after_answer_invoke_error(self, mock_model_instance):
         mock_model_instance.invoke_llm.side_effect = InvokeError("Invoke failed")

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -676,6 +676,13 @@ class TestUtilityFunctions:
                 required=False,
             ),
             VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="attachments",
+                description="Attachment list",
+                label="Attachments",
+                required=True,
+            ),
+            VariableEntity(
                 type=VariableEntityType.CHECKBOX,
                 variable="enabled",
                 description="Enable flag",
@@ -713,6 +720,8 @@ class TestUtilityFunctions:
             "enabled": "Enable flag",
             "config": "Config object",
             "schema_config": "Config with schema",
+            "upload": "File upload",
+            "attachments": "Attachment list",
         }
 
         parameters, required = convert_input_form_to_parameters(user_input_form, parameters_dict)
@@ -729,8 +738,30 @@ class TestUtilityFunctions:
         assert "count" in parameters
         assert parameters["count"]["type"] == "number"
 
-        # FILE type is skipped entirely via `continue` — key should not exist
-        assert "upload" not in parameters
+        # FILE type is now represented as the file-object schema, not skipped
+        assert "upload" in parameters
+        assert parameters["upload"]["type"] == "object"
+        assert set(parameters["upload"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert parameters["upload"]["description"] == "File upload"
+        assert parameters["upload"].get("additionalProperties") is True
+
+        # FILE_LIST type is represented as an array of file objects
+        assert "attachments" in parameters
+        assert parameters["attachments"]["type"] == "array"
+        assert parameters["attachments"]["items"]["type"] == "object"
+        assert set(parameters["attachments"]["items"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert parameters["attachments"]["description"] == "Attachment list"
+        assert "attachments" in required  # FILE_LIST with required=True is required
 
         # CHECKBOX maps to boolean
         assert parameters["enabled"]["type"] == "boolean"
@@ -836,6 +867,124 @@ class TestUtilityFunctions:
         # Or validation should also raise SchemaError
         with pytest.raises(jsonschema.exceptions.SchemaError):
             jsonschema.validate(instance={"count": 1.23}, schema=bad_schema)
+
+    def test_build_parameter_schema_includes_file_list_for_workflow(self):
+        """#39727: a workflow published as an MCP server must expose its
+        File-List input variable in the tool's inputSchema instead of dropping
+        it. The same shape that an OpenAPI client sees must reach MCP clients.
+        """
+        user_input_form = [
+            VariableEntity(
+                type=VariableEntityType.TEXT_INPUT,
+                variable="query",
+                description="User question",
+                label="Query",
+                required=True,
+            ),
+            VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="attachments",
+                description="Files to attach",
+                label="Attachments",
+                required=True,
+            ),
+            VariableEntity(
+                type=VariableEntityType.FILE,
+                variable="cover",
+                description="Cover image",
+                label="Cover",
+                required=False,
+            ),
+        ]
+        parameters_dict = {
+            "query": "User question",
+            "attachments": "Files to attach",
+            "cover": "Cover image",
+        }
+
+        schema = build_parameter_schema(AppMode.WORKFLOW, user_input_form, parameters_dict)
+
+        # The schema itself must be valid JSON Schema.
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+        # The file-list parameter must be present (this is the regression).
+        assert "attachments" in schema["properties"]
+        assert schema["properties"]["attachments"]["type"] == "array"
+        assert schema["properties"]["attachments"]["items"]["type"] == "object"
+        assert set(schema["properties"]["attachments"]["items"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert "attachments" in schema["required"]
+
+        # The single-file parameter must also be present, with the file shape.
+        assert "cover" in schema["properties"]
+        assert schema["properties"]["cover"]["type"] == "object"
+        assert set(schema["properties"]["cover"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert "cover" not in schema["required"]
+
+    def test_handle_list_tools_workflow_exposes_file_list_input_schema(self):
+        """#39727: the full MCP ``tools/list`` response for a workflow with a
+        File-List input must include the file-list parameter in
+        ``inputSchema`` so MCP clients can pass files to the workflow.
+        """
+        user_input_form = [
+            VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="attachments",
+                description="Files to attach",
+                label="Attachments",
+                required=True,
+            ),
+        ]
+        parameters_dict = {"attachments": "Files to attach"}
+
+        result = handle_list_tools(
+            app_name="extract_app",
+            app_mode=AppMode.WORKFLOW,
+            user_input_form=user_input_form,
+            description="Extract content from attachments",
+            parameters_dict=parameters_dict,
+        )
+
+        assert len(result.tools) == 1
+        tool = result.tools[0]
+        assert tool.name == "extract_app"
+        assert "attachments" in tool.inputSchema["properties"]
+        assert tool.inputSchema["properties"]["attachments"]["type"] == "array"
+        assert tool.inputSchema["properties"]["attachments"]["items"]["type"] == "object"
+        assert "attachments" in tool.inputSchema["required"]
+
+        # And the full schema is valid JSON Schema.
+        jsonschema.Draft202012Validator.check_schema(tool.inputSchema)
+
+    def test_external_data_tool_still_skipped(self):
+        """EXTERNAL_DATA_TOOL is a Dify-internal concept (variables bound to
+        an external-data-tool plugin at publish time) and is not a value an
+        MCP client can supply. It must stay skipped even after FILE /
+        FILE_LIST started being included.
+        """
+        user_input_form = [
+            VariableEntity(
+                type=VariableEntityType.EXTERNAL_DATA_TOOL,
+                variable="ext_data",
+                description="External data tool",
+                label="Ext",
+                required=True,
+            ),
+        ]
+        parameters_dict: dict[str, str] = {}
+
+        parameters, required = convert_input_form_to_parameters(user_input_form, parameters_dict)
+        assert "ext_data" not in parameters
+        assert "ext_data" not in required
 
 
 class TestNegotiateProtocolVersion:

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
+from typing import cast
 
 import pytest
 
@@ -21,8 +23,19 @@ def _make_handler_with_formatter() -> logging.Handler:
     return handler
 
 
+# ``logging.Formatter.converter`` is a runtime attribute that the type stubs
+# type as ``object``. We know it is always a callable from ``time.localtime`` /
+# ``time.gmtime`` that returns a ``time.struct_time``-compatible tuple.
+FormatterConverter = Callable[[float], time.struct_time]
+
+
+def _formatter_converter(formatter: logging.Formatter | None) -> FormatterConverter:
+    assert formatter is not None
+    return cast(FormatterConverter, formatter.converter)
+
+
 class TestApplyTimezoneToSqlalchemyLoggers:
-    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -30,22 +43,22 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # JSON output: converter must remain the default (local time).
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -56,7 +69,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
             # The formatter's converter must now produce a Tokyo-time tuple
             # from a fixed timestamp, not local time.
             local_tuple = time.localtime(_FIXED_TS)
-            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            tokyo_tuple = _formatter_converter(handler.formatter)(_FIXED_TS)
             assert tokyo_tuple != local_tuple
 
             # Sanity: the offset must be Tokyo (+09:00) at that instant.
@@ -65,7 +78,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         engine_handler = _make_handler_with_formatter()
         pool_handler = _make_handler_with_formatter()
@@ -75,13 +88,13 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         log_pool.addHandler(pool_handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert engine_handler.formatter.converter is not logging.Formatter.converter
-            assert pool_handler.formatter.converter is not logging.Formatter.converter
+            assert _formatter_converter(engine_handler.formatter) is not logging.Formatter.converter
+            assert _formatter_converter(pool_handler.formatter) is not logging.Formatter.converter
         finally:
             log_engine.removeHandler(engine_handler)
             log_pool.removeHandler(pool_handler)
 
-    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A handler with no formatter must be left alone (we only patch
         existing ``logging.Formatter`` instances), and the call must not raise.
         """
@@ -96,22 +109,23 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            converter_after_first_call = handler.formatter.converter
+            converter_after_first_call = _formatter_converter(handler.formatter)
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # The converter must be stable across repeated calls (the same
             # ``time_converter`` closure rebinds each time, but the only
             # guarantee we need is that the formatter remains patched and
             # keeps producing a non-local tuple).
-            assert handler.formatter.converter is not logging.Formatter.converter
-            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            converter = _formatter_converter(handler.formatter)
+            assert converter is not logging.Formatter.converter
+            assert converter(_FIXED_TS)[3] == 7  # hour in Tokyo
             del converter_after_first_call
         finally:
             log.removeHandler(handler)

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -8,7 +8,6 @@ import pytest
 from extensions import ext_logging
 from tests.unit_tests.config_override import apply_config_overrides
 
-
 # Captures a fixed instant so the test is timezone-independent of the host clock.
 _FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
 
@@ -46,9 +45,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from extensions import ext_logging
+from tests.unit_tests.config_override import apply_config_overrides
+
+
+# Captures a fixed instant so the test is timezone-independent of the host clock.
+_FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
+
+
+def _make_handler_with_formatter() -> logging.Handler:
+    """Build a StreamHandler with a default text formatter, mirroring what
+    SQLAlchemy attaches to ``sqlalchemy.engine`` when ``SQLALCHEMY_ECHO`` is on.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt="%(asctime)s %(message)s"))
+    return handler
+
+
+class TestApplyTimezoneToSqlalchemyLoggers:
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # JSON output: converter must remain the default (local time).
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+
+            # The formatter's converter must now produce a Tokyo-time tuple
+            # from a fixed timestamp, not local time.
+            local_tuple = time.localtime(_FIXED_TS)
+            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            assert tokyo_tuple != local_tuple
+
+            # Sanity: the offset must be Tokyo (+09:00) at that instant.
+            assert tokyo_tuple.tm_hour == 7
+            assert time.strftime("%Y-%m-%d %H:%M:%S", tokyo_tuple) == "2023-11-15 07:13:20"
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        engine_handler = _make_handler_with_formatter()
+        pool_handler = _make_handler_with_formatter()
+        log_engine = logging.getLogger("sqlalchemy.engine")
+        log_pool = logging.getLogger("sqlalchemy.pool")
+        log_engine.addHandler(engine_handler)
+        log_pool.addHandler(pool_handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert engine_handler.formatter.converter is not logging.Formatter.converter
+            assert pool_handler.formatter.converter is not logging.Formatter.converter
+        finally:
+            log_engine.removeHandler(engine_handler)
+            log_pool.removeHandler(pool_handler)
+
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+        """A handler with no formatter must be left alone (we only patch
+        existing ``logging.Formatter`` instances), and the call must not raise.
+        """
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = logging.StreamHandler()  # no formatter set
+        assert handler.formatter is None
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()  # must not raise
+            assert handler.formatter is None
+        finally:
+            log.removeHandler(handler)
+
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            converter_after_first_call = handler.formatter.converter
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # The converter must be stable across repeated calls (the same
+            # ``time_converter`` closure rebinds each time, but the only
+            # guarantee we need is that the formatter remains patched and
+            # keeps producing a non-local tuple).
+            assert handler.formatter.converter is not logging.Formatter.converter
+            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            del converter_after_first_call
+        finally:
+            log.removeHandler(handler)


### PR DESCRIPTION
Fixes #39727

## What problem does this PR solve?

When a workflow that uses a File List (array[file]) input variable is published as an MCP server, `tools/list` returned an `inputSchema` that omitted the file-list parameter. Other input variables appeared correctly; only the file-list variable was dropped, so MCP clients had no way to discover or supply files to the workflow.

## What is changed and how it works?

Root cause is in `convert_input_form_to_parameters()` in `api/core/mcp/server/streamable_http.py`, which used `continue` to skip the `FILE`, `FILE_LIST`, and `EXTERNAL_DATA_TOOL` variable types entirely. `EXTERNAL_DATA_TOOL` is a Dify-internal concept (variables bound to an external-data-tool plugin at publish time) and is not a value an MCP client can supply, so it must stay skipped. `FILE` and `FILE_LIST`, however, are real user inputs and must reach the schema.

- New `_mcp_file_object_shape()` helper that mirrors `controllers.openapi._input_schema._file_object_shape`, so the MCP and OpenAPI routes expose the same file-object contract to their respective clients.
- `FILE` -> `{type: object, properties: {type, transfer_method, url, upload_file_id}, additionalProperties: true}`.
- `FILE_LIST` -> `{type: array, items: <file-object>}`.
- `EXTERNAL_DATA_TOOL` -> still skipped (with a comment explaining why).

## How it was tested?

```
$ uv run pytest tests/unit_tests/core/mcp/server/test_streamable_http.py -o addopts=
56 passed in 0.88s
```

- The pre-existing `test_convert_input_form_to_parameters` is updated: `FILE` is no longer skipped, and `FILE_LIST` is exercised too. (The old assertion was `assert 'upload' not in parameters`.)
- New `test_build_parameter_schema_includes_file_list_for_workflow`: builds a `WORKFLOW` schema with a required `FILE_LIST` and an optional `FILE`, asserts both reach `inputSchema.properties`, asserts the schema is valid JSON Schema (Draft 2020-12).
- New `test_handle_list_tools_workflow_exposes_file_list_input_schema`: full `tools/list` MCP path — asserts the file-list parameter is in the tool's `inputSchema` and the schema validates.
- New `test_external_data_tool_still_skipped`: guards against regressing the `EXTERNAL_DATA_TOOL` skip.

`ruff check` and `ruff format --check` clean on both touched files.