### PR TITLE
fix(web): narrow Next.js proxy scope

### DIFF
--- a/web/__tests__/proxy-frame-options.spec.ts
+++ b/web/__tests__/proxy-frame-options.spec.ts
@@ -1,5 +1,6 @@
+import { unstable_doesMiddlewareMatch } from 'next/experimental/testing/server'
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
-import { canEmbedPath, proxy } from '@/proxy'
+import { canEmbedPath, config, proxy } from '@/proxy'
 
 const mockEnv = vi.hoisted(() => ({
   NEXT_PUBLIC_ALLOW_EMBED: false,
@@ -20,6 +21,66 @@ const createRequest = (url: string) => {
     nextUrl,
   } as Parameters<typeof proxy>[0]
 }
+
+describe('proxy matcher', () => {
+  it.each([
+    '/',
+    '/apps',
+    '/apiary',
+    '/apps.rsc',
+    '/auth/refresh',
+    '/chat/app-token',
+    '/chat/app-token.js',
+    '/console/apiary',
+    '/datasets/dataset-id/api',
+    '/education/bg.png',
+    '/education/apply',
+    '/embed.js',
+    '/integrations/foo.js',
+    '/logo/logo.svg',
+    '/marketplace',
+    '/pdf.worker.min.mjs',
+    '/_next/data/build-id/apps.json',
+  ])('keeps Proxy coverage for application and public asset request %s', (url) => {
+    expect(unstable_doesMiddlewareMatch({ config, nextConfig: {}, url })).toBe(true)
+  })
+
+  it.each([
+    '/api',
+    '/api/files',
+    '/console/api',
+    '/console/api/apps',
+    '/_next/image?url=%2Flogo%2Flogo.png&w=640&q=75',
+    '/_next/static/chunks/app.js',
+    '/favicon.ico',
+  ])('skips API and static asset request %s', (url) => {
+    expect(unstable_doesMiddlewareMatch({ config, nextConfig: {}, url })).toBe(false)
+  })
+
+  it('keeps matching route prefetches that need current-path request headers', () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: '/apps',
+        headers: {
+          'next-router-prefetch': '1',
+          purpose: 'prefetch',
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('applies the same matcher contract behind a base path', () => {
+    const nextConfig = { basePath: '/dify' }
+
+    expect(unstable_doesMiddlewareMatch({ config, nextConfig, url: '/dify/apps' })).toBe(true)
+    expect(unstable_doesMiddlewareMatch({ config, nextConfig, url: '/dify/api/files' })).toBe(false)
+    expect(unstable_doesMiddlewareMatch({ config, nextConfig, url: '/dify/favicon.ico' })).toBe(
+      false,
+    )
+  })
+})
 
 describe('proxy frame options', () => {
   afterEach(() => {

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -10,14 +10,13 @@ const allowedDevOrigins = process.env.NEXT_ALLOWED_DEV_ORIGINS?.split(',')
 const nextConfig: NextConfig = {
   basePath: env.NEXT_PUBLIC_BASE_PATH,
   ...(allowedDevOrigins?.length ? { allowedDevOrigins } : {}),
-  transpilePackages: ['@t3-oss/env-core', '@t3-oss/env-nextjs', 'echarts', 'zrender'],
+  transpilePackages: ['echarts', 'zrender'],
   serverExternalPackages: ['loro-crdt'],
   turbopack: {
     rules: codeInspectorPlugin({
       bundler: 'turbopack',
     }),
   },
-  productionBrowserSourceMaps: false, // enable browser source map generation during the production build
   typescript: {
     // https://nextjs.org/docs/api-reference/next.config.js/ignoring-typescript-errors
     ignoreBuildErrors: true,

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -120,18 +120,15 @@ export function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
+     * Match all request paths except:
      * - api (API routes)
+     * - console/api (Console API routes)
      * - _next/static (static files)
+     * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
     {
-      source: '/((?!_next/static|favicon.ico).*)',
-      // source: '/(.*)',
-      // missing: [
-      //   { type: 'header', key: 'next-router-prefetch' },
-      //   { type: 'header', key: 'purpose', value: 'prefetch' },
-      // ],
+      source: '/((?!api(?:/|$)|console/api(?:/|$)|_next/(?:static|image)(?:/|$)|favicon\\.ico$).*)',
     },
   ],
 }


### PR DESCRIPTION
## Summary

- exclude backend API and Next.js framework asset requests from Proxy
- preserve application, prefetch, and public asset Proxy coverage
- remove redundant Next.js source map and environment package transpilation settings

Closes #41639