### PR TITLE
fix(dify-agent): report E2B capacity exhaustion

### DIFF
--- a/dify-agent/src/dify_agent/runtime_backend/__init__.py
+++ b/dify-agent/src/dify_agent/runtime_backend/__init__.py
@@ -2,6 +2,7 @@
 
 from .errors import (
     BindingAcquireError,
+    BindingCapacityExhaustedError,
     BindingCreateError,
     BindingDestroyError,
     BindingLostError,
@@ -27,6 +28,7 @@ from .protocols import (
 
 __all__ = [
     "BindingAcquireError",
+    "BindingCapacityExhaustedError",
     "BindingCreateError",
     "BindingDestroyError",
     "BindingLostError",

--- a/dify-agent/src/dify_agent/runtime_backend/e2b.py
+++ b/dify-agent/src/dify_agent/runtime_backend/e2b.py
@@ -22,6 +22,7 @@ from dify_agent.adapters.shell.protocols import ShellCommandProtocol
 from dify_agent.adapters.shell.shellctl import ShellctlClientProtocol
 from dify_agent.runtime_backend.errors import (
     BindingAcquireError,
+    BindingCapacityExhaustedError,
     BindingCreateError,
     BindingDestroyError,
     BindingLostError,
@@ -61,6 +62,10 @@ logger = logging.getLogger(__name__)
 
 class _E2BControlPlaneNotFoundError(RuntimeError):
     """Typed boundary error for SDK resources that no longer exist."""
+
+
+class _E2BControlPlaneCapacityExhaustedError(RuntimeError):
+    """Typed boundary error for provider-side Sandbox capacity exhaustion."""
 
 
 class _E2BFileEntry(Protocol):
@@ -135,7 +140,7 @@ class E2BSDKControlPlane:
         metadata: dict[str, str],
         on_timeout: Literal["kill", "pause"],
     ) -> _E2BSandbox:
-        from e2b import AsyncSandbox, NotFoundException, SandboxNotFoundException
+        from e2b import AsyncSandbox, NotFoundException, RateLimitException, SandboxNotFoundException
 
         try:
             return cast(
@@ -154,6 +159,8 @@ class E2BSDKControlPlane:
             )
         except (SandboxNotFoundException, NotFoundException) as exc:
             raise _E2BControlPlaneNotFoundError(str(exc)) from exc
+        except RateLimitException as exc:
+            raise _E2BControlPlaneCapacityExhaustedError(str(exc)) from exc
 
     async def connect(self, handle: str, *, timeout: int) -> _E2BSandbox:
         from e2b import AsyncSandbox, NotFoundException, SandboxNotFoundException
@@ -269,6 +276,8 @@ class E2BExecutionBindingBackend:
                 action=lambda: sandbox.pause(keep_memory=True),
             )
             return ExecutionBindingAllocation(binding_ref=sandbox_id, workspace_ref=sandbox_id)
+        except _E2BControlPlaneCapacityExhaustedError as exc:
+            raise BindingCapacityExhaustedError(str(exc)) from exc
         except BaseException as exc:
             if sandbox is not None:
                 try:

--- a/dify-agent/src/dify_agent/runtime_backend/errors.py
+++ b/dify-agent/src/dify_agent/runtime_backend/errors.py
@@ -21,6 +21,10 @@ class BindingCreateError(RuntimeBackendError):
     pass
 
 
+class BindingCapacityExhaustedError(BindingCreateError):
+    """The selected runtime backend cannot allocate another Binding."""
+
+
 class BindingAcquireError(RuntimeBackendError):
     pass
 
@@ -47,6 +51,7 @@ class WorkspaceUnavailableError(RuntimeBackendError):
 
 __all__ = [
     "BindingAcquireError",
+    "BindingCapacityExhaustedError",
     "BindingCreateError",
     "BindingDestroyError",
     "BindingLostError",

--- a/dify-agent/src/dify_agent/server/execution_bindings.py
+++ b/dify-agent/src/dify_agent/server/execution_bindings.py
@@ -8,6 +8,7 @@ from dify_agent.protocol import (
     DestroyExecutionBindingRequest,
 )
 from dify_agent.runtime_backend import (
+    BindingCapacityExhaustedError,
     BindingCreateError,
     BindingDestroyError,
     ExecutionBindingBackend,
@@ -48,6 +49,8 @@ class ExecutionBindingService:
             )
         except SharedWorkspaceUnsupportedError as exc:
             raise ExecutionBindingServiceError("shared_workspace_unsupported", str(exc), status_code=409) from exc
+        except BindingCapacityExhaustedError as exc:
+            raise ExecutionBindingServiceError("binding_capacity_exhausted", str(exc), status_code=429) from exc
         except BindingCreateError as exc:
             raise ExecutionBindingServiceError("binding_create_failed", str(exc), status_code=502) from exc
         return CreateExecutionBindingResponse(

--- a/dify-agent/tests/local/dify_agent/runtime_backend/test_e2b.py
+++ b/dify-agent/tests/local/dify_agent/runtime_backend/test_e2b.py
@@ -14,6 +14,7 @@ from shellctl.client import ShellctlClientError
 
 from dify_agent.runtime_backend import (
     BindingAcquireError,
+    BindingCapacityExhaustedError,
     BindingCreateError,
     BindingLostError,
     ExecutionBindingCreateSpec,
@@ -286,6 +287,35 @@ async def test_e2b_sdk_create_disables_public_traffic(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.anyio
+async def test_e2b_sdk_create_maps_provider_capacity_exhaustion(monkeypatch: pytest.MonkeyPatch) -> None:
+    from e2b import AsyncSandbox, RateLimitException
+
+    calls = 0
+
+    async def create(
+        _cls: type[AsyncSandbox],
+        _template: str,
+        **_options: object,
+    ) -> _Sandbox:
+        nonlocal calls
+        calls += 1
+        raise RateLimitException("maximum concurrent sandboxes reached")
+
+    monkeypatch.setattr(AsyncSandbox, "create", classmethod(create))
+    control_plane = E2BSDKControlPlane(api_key="e2b-secret")
+
+    with pytest.raises(e2b_module._E2BControlPlaneCapacityExhaustedError, match="maximum concurrent"):
+        _ = await control_plane.create(
+            "prepared-template",
+            timeout=120,
+            metadata={"dify.resource": "runtime-sandbox"},
+            on_timeout="pause",
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.anyio
 async def test_e2b_connect_retries_one_transport_failure(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -436,6 +466,31 @@ async def test_e2b_create_and_snapshot_create_are_not_retried(monkeypatch: pytes
 
     assert control.created == [("prepared-template", "pause")]
     assert snapshot_sandbox.snapshots == 1
+
+
+@pytest.mark.anyio
+async def test_e2b_create_maps_capacity_exhaustion_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    control = _ControlPlane(
+        create_errors=[e2b_module._E2BControlPlaneCapacityExhaustedError("maximum concurrent sandboxes reached")]
+    )
+    backend = _binding_backend(control)
+
+    async def fail_sleep(_delay: float) -> None:
+        raise AssertionError("capacity exhaustion must not retry")
+
+    monkeypatch.setattr(e2b_module.asyncio, "sleep", fail_sleep)
+    with pytest.raises(BindingCapacityExhaustedError, match="maximum concurrent sandboxes reached"):
+        _ = await backend.create_binding(
+            ExecutionBindingCreateSpec(
+                tenant_id="tenant-1",
+                agent_id="agent-1",
+                binding_id="binding-1",
+                workspace_id="workspace-1",
+                existing_workspace_ref=None,
+            )
+        )
+
+    assert control.created == [("prepared-template", "pause")]
 
 
 @pytest.mark.anyio

--- a/dify-agent/tests/local/dify_agent/server/test_execution_bindings.py
+++ b/dify-agent/tests/local/dify_agent/server/test_execution_bindings.py
@@ -1,23 +1,30 @@
 from dataclasses import dataclass, field
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 
 from dify_agent.protocol import CreateExecutionBindingRequest, DestroyExecutionBindingRequest
 from dify_agent.runtime_backend import (
+    BindingCapacityExhaustedError,
     ExecutionBindingAllocation,
     ExecutionBindingCreateSpec,
     ExecutionBindingDestroySpec,
 )
 from dify_agent.server.execution_bindings import ExecutionBindingService
+from dify_agent.server.routes.execution_bindings import create_execution_bindings_router
 
 
 @dataclass(slots=True)
 class _Backend:
     created: list[ExecutionBindingCreateSpec] = field(default_factory=list)
     destroyed: list[ExecutionBindingDestroySpec] = field(default_factory=list)
+    create_error: Exception | None = None
 
     async def create_binding(self, spec: ExecutionBindingCreateSpec) -> ExecutionBindingAllocation:
         self.created.append(spec)
+        if self.create_error is not None:
+            raise self.create_error
         return ExecutionBindingAllocation(binding_ref="opaque-binding", workspace_ref="opaque-workspace")
 
     async def destroy_binding(self, spec: ExecutionBindingDestroySpec) -> None:
@@ -64,3 +71,32 @@ async def test_execution_binding_service_forwards_final_contract() -> None:
             destroy_workspace=True,
         )
     ]
+
+
+def test_execution_binding_route_reports_capacity_exhaustion_as_429() -> None:
+    backend = _Backend(create_error=BindingCapacityExhaustedError("maximum concurrent sandboxes reached"))
+    service = ExecutionBindingService(backend=backend)  # pyright: ignore[reportArgumentType]
+    app = FastAPI()
+    app.include_router(create_execution_bindings_router(lambda: service))
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/execution-bindings",
+            json={
+                "tenant_id": "tenant-1",
+                "agent_id": "agent-1",
+                "binding_id": "binding-1",
+                "workspace_id": "workspace-1",
+                "existing_workspace_ref": None,
+                "home_snapshot_ref": None,
+            },
+        )
+
+    assert response.status_code == 429
+    assert response.json() == {
+        "detail": {
+            "code": "binding_capacity_exhausted",
+            "message": "maximum concurrent sandboxes reached",
+        }
+    }
+    assert len(backend.created) == 1


### PR DESCRIPTION
## Summary

- map E2B `RateLimitException` during Sandbox creation to a provider-neutral `BindingCapacityExhaustedError`
- return HTTP 429 with `binding_capacity_exhausted` instead of the generic HTTP 502 `binding_create_failed`
- keep Binding creation strictly single-attempt and leave all other E2B, Local, and Enterprise failures unchanged
- add SDK-boundary, backend, and FastAPI wire-contract regression coverage

This is a draft stacked follow-up to #41623 and relates to #41619. Its temporary stack base contains #41623 plus the latest `main`; once #41623 is synchronized, this PR can be retargeted directly to that branch without changing the capacity-fix commit.

## Screenshots

Not applicable; backend-only error classification.

## Validation

- focused E2B and execution-binding tests: 38 passed
- `make -C dify-agent check`
- `make -C dify-agent typecheck`
- `make -C dify-agent test`: 842 passed, 26 skipped
- verified against the installed E2B 2.38 SDK boundary, where HTTP 429 maps to `RateLimitException`

## Checklist

- [x] This change does not require a documentation update.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] Regression tests cover every introduced mapping layer and keep the change atomic.
- [x] I ran the Dify Agent lint, typecheck, and complete test suite.

From Codex
