### PR TITLE
fix(web): render a meaningful message in the OAuth callback when no opener (#39752)

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -105,6 +105,7 @@ ignore_imports =
     libs.external_api -> core
     libs.external_api -> core.errors.error
     libs.external_api -> extensions.ext_logging
+    extensions.ext_database -> extensions.ext_logging
     libs.flask_utils -> models
     libs.helper -> core.app.features.rate_limiting.rate_limit
     libs.helper -> models

--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -37,7 +37,13 @@ from graphon.enums import WorkflowNodeExecutionMetadataKey
 from graphon.model_runtime.entities.llm_entities import LLMResult
 from graphon.model_runtime.entities.message_entities import PromptMessage, SystemPromptMessage, UserPromptMessage
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
+from graphon.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+)
 from models import App, Message, WorkflowNodeExecutionModel
 from models.workflow import Workflow
 
@@ -306,7 +312,19 @@ class LLMGenerator:
                     tenant_id=tenant_id,
                     model_type=ModelType.LLM,
                 )
-        except InvokeAuthorizationError:
+        except (
+            InvokeAuthorizationError,
+            InvokeConnectionError,
+            InvokeRateLimitError,
+            InvokeBadRequestError,
+        ):
+            # Model-resolution failures during suggested-questions generation are
+            # a soft enhancement: a missing/expired credential, an unreachable
+            # provider, a per-tenant rate limit, or a malformed model config
+            # must NEVER surface as an error to the client or break the
+            # already-produced answer. Match the silent-degradation contract
+            # documented on `generate_workflow_instruction_suggestions` and
+            # return an empty suggestion list.
             return []
 
         prompt_messages: list[PromptMessage] = [UserPromptMessage(content=prompt)]

--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -339,6 +339,27 @@ def process_mapping_response(app: App, response: Mapping) -> str:
             raise ValueError("Invalid app mode: " + str(app.mode))
 
 
+def _mcp_file_object_shape() -> dict[str, Any]:
+    """JSON-Schema shape for a single Dify file input value (FILE).
+
+    Mirrors ``controllers.openapi._input_schema._file_object_shape`` so an
+    MCP client and an OpenAPI client see the same file-object contract when
+    they call into the same workflow app. ``additionalProperties: True``
+    keeps room for forward-compatible fields (the upstream file-API
+    contract is not yet pinned).
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string"},
+            "transfer_method": {"type": "string"},
+            "url": {"type": "string"},
+            "upload_file_id": {"type": "string"},
+        },
+        "additionalProperties": True,
+    }
+
+
 def convert_input_form_to_parameters(
     user_input_form: list[VariableEntity],
     parameters_dict: dict[str, str],
@@ -348,11 +369,10 @@ def convert_input_form_to_parameters(
     required = []
 
     for item in user_input_form:
-        if item.type in (
-            VariableEntityType.FILE,
-            VariableEntityType.FILE_LIST,
-            VariableEntityType.EXTERNAL_DATA_TOOL,
-        ):
+        # EXTERNAL_DATA_TOOL is a Dify-internal concept (variables bound to
+        # an external-data-tool plugin at publish time); it is not a value
+        # the MCP client can supply, so keep skipping it.
+        if item.type == VariableEntityType.EXTERNAL_DATA_TOOL:
             continue
         parameters[item.variable] = {}
         if item.required:
@@ -370,6 +390,15 @@ def convert_input_form_to_parameters(
             parameters[item.variable]["type"] = "number"
         elif item.type == VariableEntityType.CHECKBOX:
             parameters[item.variable]["type"] = "boolean"
+        elif item.type == VariableEntityType.FILE:
+            parameters[item.variable] = _mcp_file_object_shape()
+            parameters[item.variable]["description"] = description
+        elif item.type == VariableEntityType.FILE_LIST:
+            parameters[item.variable] = {
+                "type": "array",
+                "items": _mcp_file_object_shape(),
+            }
+            parameters[item.variable]["description"] = description
         elif item.type == VariableEntityType.JSON_OBJECT:
             parameters[item.variable]["type"] = "object"
             if item.json_schema:

--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -60,3 +60,14 @@ def init_app(app: DifyApp):
             _ = db.engine  # triggers engine creation with the configured options
     except Exception:
         logger.exception("Failed to initialize SQLAlchemy engine during app startup")
+
+    # SQLAlchemy attaches its own echo handlers to ``sqlalchemy.engine`` (and
+    # sub-loggers like ``sqlalchemy.pool``) at engine creation. Those handlers
+    # bypass the root logger's ``LOG_TZ``-aware formatter because
+    # ``sqlalchemy.engine`` has ``propagate = False`` (see
+    # ``extensions.ext_logging``). Apply the same ``LOG_TZ`` converter to
+    # their formatters so engine log timestamps stay consistent with the
+    # rest of the application logs.
+    from extensions.ext_logging import apply_timezone_to_sqlalchemy_loggers
+
+    apply_timezone_to_sqlalchemy_loggers()

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -90,6 +90,49 @@ def _apply_timezone(handlers: list[logging.Handler]):
                 handler.formatter.converter = time_converter  # type: ignore[attr-defined]
 
 
+def apply_timezone_to_sqlalchemy_loggers() -> None:
+    """Apply the LOG_TZ converter to the formatters of SQLAlchemy logger handlers.
+
+    ``sqlalchemy.engine`` (and its sub-loggers like ``sqlalchemy.pool``) have
+    ``propagate = False`` set in :func:`init_app` to avoid duplicate logs, so the
+    root handlers' ``LOG_TZ``-aware formatter never gets a chance to format
+    SQLAlchemy records. As a result, when ``SQLALCHEMY_ECHO`` is enabled, engine
+    log timestamps are emitted in the server's local timezone while the
+    surrounding application logs are converted to ``LOG_TZ``, producing
+    inconsistent timestamps within a single log stream.
+
+    This helper walks the SQLAlchemy logger hierarchy and applies the same
+    ``LOG_TZ`` converter to the formatters of any handlers that SQLAlchemy
+    itself has attached, so engine log timestamps agree with the rest of the
+    application logs.
+
+    Must be called AFTER the SQLAlchemy engine is created (i.e. after
+    ``ext_database.init_app()`` triggers engine creation via ``db.engine``), so
+    that any echo handler has been attached. The function is a no-op when
+    ``LOG_OUTPUT_FORMAT`` is not ``"text"`` or when ``LOG_TZ`` is unset.
+    """
+    if dify_config.LOG_OUTPUT_FORMAT != "text":
+        return
+    log_tz = dify_config.LOG_TZ
+    if not log_tz:
+        return
+
+    from datetime import datetime
+
+    import pytz
+
+    timezone = pytz.timezone(log_tz)
+
+    def time_converter(seconds):
+        return datetime.fromtimestamp(seconds, tz=timezone).timetuple()
+
+    for name in ("sqlalchemy.engine", "sqlalchemy", "sqlalchemy.pool"):
+        sql_logger = logging.getLogger(name)
+        for handler in sql_logger.handlers:
+            if isinstance(handler.formatter, logging.Formatter):
+                handler.formatter.converter = time_converter  # type: ignore[attr-defined]
+
+
 class _TextFormatter(logging.Formatter):
     """Text formatter that ensures trace_id and req_id are always present."""
 

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -19,7 +19,13 @@ from graphon.enums import WorkflowNodeExecutionStatus
 from graphon.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMUsage
 from graphon.model_runtime.entities.message_entities import AssistantPromptMessage
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
+from graphon.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+)
 from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import App, AppMode, Message
 from models.workflow import (
@@ -267,6 +273,31 @@ class TestLLMGenerator:
             mock_manager.return_value.get_default_model_instance.side_effect = InvokeAuthorizationError("Auth failed")
             questions = LLMGenerator.generate_suggested_questions_after_answer("tenant_id", "histories")
             assert questions == []
+
+    @pytest.mark.parametrize(
+        "model_resolution_error",
+        [
+            InvokeConnectionError("provider unreachable"),
+            InvokeRateLimitError("per-tenant rate limit"),
+            InvokeBadRequestError("malformed model config"),
+        ],
+    )
+    def test_generate_suggested_questions_after_answer_swallows_transient_invoke_errors(
+        self, mock_model_instance, model_resolution_error
+    ):
+        """#41592: model-resolution failures (unreachable provider, per-tenant
+        rate limit, malformed config) must degrade silently to an empty list,
+        matching the contract documented on
+        ``generate_workflow_instruction_suggestions`` and the existing
+        ``InvokeAuthorizationError`` handling at the same site.
+        """
+        with patch("core.llm_generator.llm_generator.ModelManager.for_tenant") as mock_manager:
+            mock_manager.return_value.get_default_model_instance.side_effect = model_resolution_error
+            questions = LLMGenerator.generate_suggested_questions_after_answer("tenant_id", "histories")
+            assert questions == []
+            # ``invoke_llm`` must NOT be called — we never even reached the
+            # generation step.
+            mock_model_instance.invoke_llm.assert_not_called()
 
     def test_generate_suggested_questions_after_answer_invoke_error(self, mock_model_instance):
         mock_model_instance.invoke_llm.side_effect = InvokeError("Invoke failed")

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -676,6 +676,13 @@ class TestUtilityFunctions:
                 required=False,
             ),
             VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="attachments",
+                description="Attachment list",
+                label="Attachments",
+                required=True,
+            ),
+            VariableEntity(
                 type=VariableEntityType.CHECKBOX,
                 variable="enabled",
                 description="Enable flag",
@@ -713,6 +720,8 @@ class TestUtilityFunctions:
             "enabled": "Enable flag",
             "config": "Config object",
             "schema_config": "Config with schema",
+            "upload": "File upload",
+            "attachments": "Attachment list",
         }
 
         parameters, required = convert_input_form_to_parameters(user_input_form, parameters_dict)
@@ -729,8 +738,30 @@ class TestUtilityFunctions:
         assert "count" in parameters
         assert parameters["count"]["type"] == "number"
 
-        # FILE type is skipped entirely via `continue` — key should not exist
-        assert "upload" not in parameters
+        # FILE type is now represented as the file-object schema, not skipped
+        assert "upload" in parameters
+        assert parameters["upload"]["type"] == "object"
+        assert set(parameters["upload"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert parameters["upload"]["description"] == "File upload"
+        assert parameters["upload"].get("additionalProperties") is True
+
+        # FILE_LIST type is represented as an array of file objects
+        assert "attachments" in parameters
+        assert parameters["attachments"]["type"] == "array"
+        assert parameters["attachments"]["items"]["type"] == "object"
+        assert set(parameters["attachments"]["items"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert parameters["attachments"]["description"] == "Attachment list"
+        assert "attachments" in required  # FILE_LIST with required=True is required
 
         # CHECKBOX maps to boolean
         assert parameters["enabled"]["type"] == "boolean"
@@ -836,6 +867,124 @@ class TestUtilityFunctions:
         # Or validation should also raise SchemaError
         with pytest.raises(jsonschema.exceptions.SchemaError):
             jsonschema.validate(instance={"count": 1.23}, schema=bad_schema)
+
+    def test_build_parameter_schema_includes_file_list_for_workflow(self):
+        """#39727: a workflow published as an MCP server must expose its
+        File-List input variable in the tool's inputSchema instead of dropping
+        it. The same shape that an OpenAPI client sees must reach MCP clients.
+        """
+        user_input_form = [
+            VariableEntity(
+                type=VariableEntityType.TEXT_INPUT,
+                variable="query",
+                description="User question",
+                label="Query",
+                required=True,
+            ),
+            VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="attachments",
+                description="Files to attach",
+                label="Attachments",
+                required=True,
+            ),
+            VariableEntity(
+                type=VariableEntityType.FILE,
+                variable="cover",
+                description="Cover image",
+                label="Cover",
+                required=False,
+            ),
+        ]
+        parameters_dict = {
+            "query": "User question",
+            "attachments": "Files to attach",
+            "cover": "Cover image",
+        }
+
+        schema = build_parameter_schema(AppMode.WORKFLOW, user_input_form, parameters_dict)
+
+        # The schema itself must be valid JSON Schema.
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+        # The file-list parameter must be present (this is the regression).
+        assert "attachments" in schema["properties"]
+        assert schema["properties"]["attachments"]["type"] == "array"
+        assert schema["properties"]["attachments"]["items"]["type"] == "object"
+        assert set(schema["properties"]["attachments"]["items"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert "attachments" in schema["required"]
+
+        # The single-file parameter must also be present, with the file shape.
+        assert "cover" in schema["properties"]
+        assert schema["properties"]["cover"]["type"] == "object"
+        assert set(schema["properties"]["cover"]["properties"].keys()) == {
+            "type",
+            "transfer_method",
+            "url",
+            "upload_file_id",
+        }
+        assert "cover" not in schema["required"]
+
+    def test_handle_list_tools_workflow_exposes_file_list_input_schema(self):
+        """#39727: the full MCP ``tools/list`` response for a workflow with a
+        File-List input must include the file-list parameter in
+        ``inputSchema`` so MCP clients can pass files to the workflow.
+        """
+        user_input_form = [
+            VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="attachments",
+                description="Files to attach",
+                label="Attachments",
+                required=True,
+            ),
+        ]
+        parameters_dict = {"attachments": "Files to attach"}
+
+        result = handle_list_tools(
+            app_name="extract_app",
+            app_mode=AppMode.WORKFLOW,
+            user_input_form=user_input_form,
+            description="Extract content from attachments",
+            parameters_dict=parameters_dict,
+        )
+
+        assert len(result.tools) == 1
+        tool = result.tools[0]
+        assert tool.name == "extract_app"
+        assert "attachments" in tool.inputSchema["properties"]
+        assert tool.inputSchema["properties"]["attachments"]["type"] == "array"
+        assert tool.inputSchema["properties"]["attachments"]["items"]["type"] == "object"
+        assert "attachments" in tool.inputSchema["required"]
+
+        # And the full schema is valid JSON Schema.
+        jsonschema.Draft202012Validator.check_schema(tool.inputSchema)
+
+    def test_external_data_tool_still_skipped(self):
+        """EXTERNAL_DATA_TOOL is a Dify-internal concept (variables bound to
+        an external-data-tool plugin at publish time) and is not a value an
+        MCP client can supply. It must stay skipped even after FILE /
+        FILE_LIST started being included.
+        """
+        user_input_form = [
+            VariableEntity(
+                type=VariableEntityType.EXTERNAL_DATA_TOOL,
+                variable="ext_data",
+                description="External data tool",
+                label="Ext",
+                required=True,
+            ),
+        ]
+        parameters_dict: dict[str, str] = {}
+
+        parameters, required = convert_input_form_to_parameters(user_input_form, parameters_dict)
+        assert "ext_data" not in parameters
+        assert "ext_data" not in required
 
 
 class TestNegotiateProtocolVersion:

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
+from typing import cast
 
 import pytest
 
@@ -21,8 +23,19 @@ def _make_handler_with_formatter() -> logging.Handler:
     return handler
 
 
+# ``logging.Formatter.converter`` is a runtime attribute that the type stubs
+# type as ``object``. We know it is always a callable from ``time.localtime`` /
+# ``time.gmtime`` that returns a ``time.struct_time``-compatible tuple.
+FormatterConverter = Callable[[float], time.struct_time]
+
+
+def _formatter_converter(formatter: logging.Formatter | None) -> FormatterConverter:
+    assert formatter is not None
+    return cast(FormatterConverter, formatter.converter)
+
+
 class TestApplyTimezoneToSqlalchemyLoggers:
-    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -30,22 +43,22 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # JSON output: converter must remain the default (local time).
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -56,7 +69,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
             # The formatter's converter must now produce a Tokyo-time tuple
             # from a fixed timestamp, not local time.
             local_tuple = time.localtime(_FIXED_TS)
-            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            tokyo_tuple = _formatter_converter(handler.formatter)(_FIXED_TS)
             assert tokyo_tuple != local_tuple
 
             # Sanity: the offset must be Tokyo (+09:00) at that instant.
@@ -65,7 +78,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         engine_handler = _make_handler_with_formatter()
         pool_handler = _make_handler_with_formatter()
@@ -75,13 +88,13 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         log_pool.addHandler(pool_handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert engine_handler.formatter.converter is not logging.Formatter.converter
-            assert pool_handler.formatter.converter is not logging.Formatter.converter
+            assert _formatter_converter(engine_handler.formatter) is not logging.Formatter.converter
+            assert _formatter_converter(pool_handler.formatter) is not logging.Formatter.converter
         finally:
             log_engine.removeHandler(engine_handler)
             log_pool.removeHandler(pool_handler)
 
-    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A handler with no formatter must be left alone (we only patch
         existing ``logging.Formatter`` instances), and the call must not raise.
         """
@@ -96,22 +109,23 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            converter_after_first_call = handler.formatter.converter
+            converter_after_first_call = _formatter_converter(handler.formatter)
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # The converter must be stable across repeated calls (the same
             # ``time_converter`` closure rebinds each time, but the only
             # guarantee we need is that the formatter remains patched and
             # keeps producing a non-local tuple).
-            assert handler.formatter.converter is not logging.Formatter.converter
-            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            converter = _formatter_converter(handler.formatter)
+            assert converter is not logging.Formatter.converter
+            assert converter(_FIXED_TS)[3] == 7  # hour in Tokyo
             del converter_after_first_call
         finally:
             log.removeHandler(handler)

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -8,7 +8,6 @@ import pytest
 from extensions import ext_logging
 from tests.unit_tests.config_override import apply_config_overrides
 
-
 # Captures a fixed instant so the test is timezone-independent of the host clock.
 _FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
 
@@ -46,9 +45,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from extensions import ext_logging
+from tests.unit_tests.config_override import apply_config_overrides
+
+
+# Captures a fixed instant so the test is timezone-independent of the host clock.
+_FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
+
+
+def _make_handler_with_formatter() -> logging.Handler:
+    """Build a StreamHandler with a default text formatter, mirroring what
+    SQLAlchemy attaches to ``sqlalchemy.engine`` when ``SQLALCHEMY_ECHO`` is on.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt="%(asctime)s %(message)s"))
+    return handler
+
+
+class TestApplyTimezoneToSqlalchemyLoggers:
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # JSON output: converter must remain the default (local time).
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+
+            # The formatter's converter must now produce a Tokyo-time tuple
+            # from a fixed timestamp, not local time.
+            local_tuple = time.localtime(_FIXED_TS)
+            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            assert tokyo_tuple != local_tuple
+
+            # Sanity: the offset must be Tokyo (+09:00) at that instant.
+            assert tokyo_tuple.tm_hour == 7
+            assert time.strftime("%Y-%m-%d %H:%M:%S", tokyo_tuple) == "2023-11-15 07:13:20"
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        engine_handler = _make_handler_with_formatter()
+        pool_handler = _make_handler_with_formatter()
+        log_engine = logging.getLogger("sqlalchemy.engine")
+        log_pool = logging.getLogger("sqlalchemy.pool")
+        log_engine.addHandler(engine_handler)
+        log_pool.addHandler(pool_handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert engine_handler.formatter.converter is not logging.Formatter.converter
+            assert pool_handler.formatter.converter is not logging.Formatter.converter
+        finally:
+            log_engine.removeHandler(engine_handler)
+            log_pool.removeHandler(pool_handler)
+
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+        """A handler with no formatter must be left alone (we only patch
+        existing ``logging.Formatter`` instances), and the call must not raise.
+        """
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = logging.StreamHandler()  # no formatter set
+        assert handler.formatter is None
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()  # must not raise
+            assert handler.formatter is None
+        finally:
+            log.removeHandler(handler)
+
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            converter_after_first_call = handler.formatter.converter
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # The converter must be stable across repeated calls (the same
+            # ``time_converter`` closure rebinds each time, but the only
+            # guarantee we need is that the formatter remains patched and
+            # keeps producing a non-local tuple).
+            assert handler.formatter.converter is not logging.Formatter.converter
+            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            del converter_after_first_call
+        finally:
+            log.removeHandler(handler)

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -5002,11 +5002,6 @@
       "count": 2
     }
   },
-  "web/hooks/use-oauth.ts": {
-    "typescript/no-explicit-any": {
-      "count": 1
-    }
-  },
   "web/hooks/use-pay.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 4

--- a/web/app/oauth-callback/__tests__/page.spec.tsx
+++ b/web/app/oauth-callback/__tests__/page.spec.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createReactI18nextMock } from '@/test/i18n-mock'
+
+vi.mock('react-i18next', () =>
+  createReactI18nextMock({
+    'oauth.callback.success': 'Authorization complete',
+    'oauth.callback.successHint': 'You can now close this tab and return to the previous page.',
+    'oauth.callback.error': 'Authorization failed',
+    'oauth.callback.errorHint': 'Please return to the previous page and try again.',
+    'login.signBtn': 'Sign in',
+  }),
+)
+
+vi.mock('@/hooks/use-oauth', () => ({
+  useOAuthCallback: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-document-title', () => ({
+  default: vi.fn(),
+}))
+
+const { useOAuthCallback } = await import('@/hooks/use-oauth')
+const OAuthCallback = (await import('../page')).default
+
+const setOpener = (opener: Window | null) => {
+  Object.defineProperty(window, 'opener', { configurable: true, writable: true, value: opener })
+}
+
+describe('OAuthCallback page', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    setOpener(null)
+  })
+
+  it('renders an empty <div /> when opened as a popup (hasOpener=true) so the popup can close cleanly', () => {
+    setOpener({ postMessage: vi.fn() } as unknown as Window)
+    vi.mocked(useOAuthCallback).mockReturnValue({
+      hasOpener: true,
+      finished: false,
+      error: null,
+      errorDescription: null,
+    })
+
+    const { container } = render(<OAuthCallback />)
+    expect(container.firstChild).not.toBeNull()
+    expect(container.firstChild!.nodeName).toBe('DIV')
+    expect(container.firstChild!.childNodes.length).toBe(0)
+  })
+
+  it('renders a success message when opened in a new tab with a subscription_id (#39752)', () => {
+    setOpener(null)
+    vi.mocked(useOAuthCallback).mockReturnValue({
+      hasOpener: false,
+      finished: true,
+      error: null,
+      errorDescription: null,
+    })
+
+    render(<OAuthCallback />)
+    expect(screen.getByText('Authorization complete')).toBeInTheDocument()
+    expect(
+      screen.getByText('You can now close this tab and return to the previous page.'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders an error message with the provider description when the provider reported an error (#39752)', () => {
+    setOpener(null)
+    vi.mocked(useOAuthCallback).mockReturnValue({
+      hasOpener: false,
+      finished: true,
+      error: 'access_denied',
+      errorDescription: 'Please re-authorize the app.',
+    })
+
+    render(<OAuthCallback />)
+    expect(screen.getByText('Authorization failed')).toBeInTheDocument()
+    expect(screen.getByText('Please re-authorize the app.')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic error hint when the provider did not supply an error_description', () => {
+    setOpener(null)
+    vi.mocked(useOAuthCallback).mockReturnValue({
+      hasOpener: false,
+      finished: true,
+      error: 'server_error',
+      errorDescription: null,
+    })
+
+    render(<OAuthCallback />)
+    expect(screen.getByText('Authorization failed')).toBeInTheDocument()
+    expect(
+      screen.getByText('Please return to the previous page and try again.'),
+    ).toBeInTheDocument()
+  })
+})

--- a/web/app/oauth-callback/page.tsx
+++ b/web/app/oauth-callback/page.tsx
@@ -6,9 +6,30 @@ import { useOAuthCallback } from '@/hooks/use-oauth'
 const OAuthCallback = () => {
   const { t } = useTranslation()
   useDocumentTitle(t(($) => $.signBtn, { ns: 'login' }))
-  useOAuthCallback()
+  const { hasOpener, finished, error, errorDescription } = useOAuthCallback()
 
-  return <div />
+  // When the page is opened as a popup by the console, the hook posts the
+  // OAuth result to the opener and calls window.close(). The page only
+  // needs to render a fallback message when the page was opened in a new
+  // tab (no `window.opener`); see issue #39752.
+  if (hasOpener || !finished) return <div />
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background-default-subtle p-6">
+      <div className="w-full max-w-md rounded-2xl border border-components-panel-border bg-components-panel-bg p-8 text-center shadow-sm">
+        <h1 className="text-xl font-semibold text-text-primary">
+          {error
+            ? t(($) => $['callback.error'], { ns: 'oauth' })
+            : t(($) => $['callback.success'], { ns: 'oauth' })}
+        </h1>
+        <p className="mt-2 text-sm text-text-secondary">
+          {error
+            ? errorDescription || t(($) => $['callback.errorHint'], { ns: 'oauth' })
+            : t(($) => $['callback.successHint'], { ns: 'oauth' })}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 export default OAuthCallback

--- a/web/hooks/__tests__/use-oauth.spec.ts
+++ b/web/hooks/__tests__/use-oauth.spec.ts
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useOAuthCallback } from '../use-oauth'
+
+const originalOpener = window.opener
+const originalClose = window.close
+
+const setOpener = (opener: Window | null) => {
+  Object.defineProperty(window, 'opener', { configurable: true, writable: true, value: opener })
+}
+
+describe('useOAuthCallback', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    setOpener(originalOpener)
+    window.close = originalClose
+  })
+
+  it('posts a success message and closes the popup when window.opener is present and a subscription_id is in the query', () => {
+    const postMessage = vi.fn()
+    setOpener({ origin: 'https://console.example.test', postMessage } as unknown as Window)
+    const close = vi.fn()
+    window.close = close
+    window.history.replaceState({}, '', '/oauth-callback?subscription_id=sub-123')
+
+    const { result } = renderHook(() => useOAuthCallback())
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'oauth_callback', success: true, subscriptionId: 'sub-123' },
+      'https://console.example.test',
+    )
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(result.current.hasOpener).toBe(true)
+    expect(result.current.finished).toBe(true)
+  })
+
+  it('posts an error message and closes the popup when window.opener is present and an error is in the query', () => {
+    const postMessage = vi.fn()
+    setOpener({ origin: 'https://console.example.test', postMessage } as unknown as Window)
+    const close = vi.fn()
+    window.close = close
+    window.history.replaceState(
+      {},
+      '',
+      '/oauth-callback?error=access_denied&error_description=User%20denied%20access',
+    )
+
+    renderHook(() => useOAuthCallback())
+
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: 'oauth_callback',
+        success: false,
+        error: 'access_denied',
+        errorDescription: 'User denied access',
+      },
+      'https://console.example.test',
+    )
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to targetOrigin "*" when window.opener has no origin (e.g. file:// popup)', () => {
+    const postMessage = vi.fn()
+    setOpener({ postMessage } as unknown as Window)
+    const close = vi.fn()
+    window.close = close
+    window.history.replaceState({}, '', '/oauth-callback?subscription_id=sub-1')
+
+    renderHook(() => useOAuthCallback())
+
+    expect(postMessage).toHaveBeenCalledWith(expect.any(Object), '*')
+  })
+
+  it('exposes success state without posting a message when window.opener is missing (new-tab case) (#39752)', () => {
+    setOpener(null)
+    const close = vi.fn()
+    window.close = close
+    window.history.replaceState({}, '', '/oauth-callback?subscription_id=sub-tab-1')
+
+    const { result } = renderHook(() => useOAuthCallback())
+
+    // No opener, so we must NOT try to close (would close the only tab).
+    expect(close).not.toHaveBeenCalled()
+    // The page needs the state to render a meaningful message instead of an empty <div />.
+    expect(result.current.hasOpener).toBe(false)
+    expect(result.current.finished).toBe(true)
+    expect(result.current.error).toBeNull()
+    expect(result.current.errorDescription).toBeNull()
+  })
+
+  it('exposes the provider error in state when window.opener is missing (#39752)', () => {
+    setOpener(null)
+    const close = vi.fn()
+    window.close = close
+    window.history.replaceState(
+      {},
+      '',
+      '/oauth-callback?error=access_denied&error_description=Please%20re-authorize',
+    )
+
+    const { result } = renderHook(() => useOAuthCallback())
+
+    expect(close).not.toHaveBeenCalled()
+    expect(result.current.hasOpener).toBe(false)
+    expect(result.current.finished).toBe(true)
+    expect(result.current.error).toBe('access_denied')
+    expect(result.current.errorDescription).toBe('Please re-authorize')
+  })
+
+  it('initial state mirrors the current window.opener so the first paint can decide which UI to render', () => {
+    setOpener({ origin: 'https://console.example.test', postMessage: vi.fn() } as unknown as Window)
+    const { result } = renderHook(() => useOAuthCallback())
+    expect(result.current.hasOpener).toBe(true)
+
+    setOpener(null)
+    const { result: result2 } = renderHook(() => useOAuthCallback())
+    expect(result2.current.hasOpener).toBe(false)
+  })
+})

--- a/web/hooks/use-oauth.ts
+++ b/web/hooks/use-oauth.ts
@@ -1,51 +1,88 @@
 'use client'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { validateRedirectUrl } from '@/utils/urlValidation'
 
-export const useOAuthCallback = () => {
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search)
-    const subscriptionId = urlParams.get('subscription_id')
-    const error = urlParams.get('error')
-    const errorDescription = urlParams.get('error_description')
-
-    if (window.opener) {
-      // Use window.opener.origin instead of '*' for security
-      const targetOrigin = window.opener?.origin || '*'
-
-      if (subscriptionId) {
-        window.opener.postMessage(
-          {
-            type: 'oauth_callback',
-            success: true,
-            subscriptionId,
-          },
-          targetOrigin,
-        )
-      } else if (error) {
-        window.opener.postMessage(
-          {
-            type: 'oauth_callback',
-            success: false,
-            error,
-            errorDescription,
-          },
-          targetOrigin,
-        )
-      } else {
-        window.opener.postMessage(
-          {
-            type: 'oauth_callback',
-          },
-          targetOrigin,
-        )
-      }
-      window.close()
-    }
-  }, [])
+export type OAuthCallbackState = {
+  /** True when the callback tab/popup was opened by another window via window.open. */
+  hasOpener: boolean
+  /** True after the callback has posted a message to the opener (or decided not to). */
+  finished: boolean
+  /** Provider-supplied error code, if any. */
+  error: string | null
+  /** Provider-supplied error description, if any. */
+  errorDescription: string | null
 }
 
-export const openOAuthPopup = (url: string, callback: (data?: any) => void) => {
+export const useOAuthCallback = (): OAuthCallbackState => {
+  const urlParams = useMemo(() => new URLSearchParams(window.location.search), [])
+  const subscriptionId = urlParams.get('subscription_id')
+  const error = urlParams.get('error')
+  const errorDescription = urlParams.get('error_description')
+
+  // The state must be available on the first render so the page can decide
+  // which UI to render (empty <div /> for the popup path, or a fallback
+  // message for the no-opener path) — see #39752. The URL params and the
+  // (immutable per page load) presence of window.opener are stable, so the
+  // empty dep list is intentional.
+  const state: OAuthCallbackState = useMemo(
+    () => ({
+      hasOpener: !!window.opener,
+      finished: true,
+      error,
+      errorDescription,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
+
+  useEffect(() => {
+    if (!window.opener) return
+
+    // Use window.opener.origin instead of '*' for security
+    const targetOrigin = window.opener?.origin || '*'
+
+    if (subscriptionId) {
+      window.opener.postMessage(
+        {
+          type: 'oauth_callback',
+          success: true,
+          subscriptionId,
+        },
+        targetOrigin,
+      )
+    } else if (error) {
+      window.opener.postMessage(
+        {
+          type: 'oauth_callback',
+          success: false,
+          error,
+          errorDescription,
+        },
+        targetOrigin,
+      )
+    } else {
+      window.opener.postMessage(
+        {
+          type: 'oauth_callback',
+        },
+        targetOrigin,
+      )
+    }
+    window.close()
+  }, [error, errorDescription, subscriptionId])
+
+  return state
+}
+
+type OAuthCallbackMessage = {
+  type: 'oauth_callback'
+  success?: boolean
+  subscriptionId?: string
+  error?: string
+  errorDescription?: string
+}
+
+export const openOAuthPopup = (url: string, callback: (data?: OAuthCallbackMessage) => void) => {
   const width = 600
   const height = 600
   const left = window.screenX + (window.outerWidth - width) / 2

--- a/web/i18n/ar-TN/oauth.json
+++ b/web/i18n/ar-TN/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "الاتصال بـ",
   "continue": "متابعة",
   "error.authAppInfoFetchFailed": "فشل جلب معلومات التطبيق للتفويض",

--- a/web/i18n/de-DE/oauth.json
+++ b/web/i18n/de-DE/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Verbinden mit",
   "continue": "Fortsetzen",
   "error.authAppInfoFetchFailed": "Fehler beim Abrufen der App-Informationen für die Autorisierung",

--- a/web/i18n/en-US/oauth.json
+++ b/web/i18n/en-US/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Connect to",
   "continue": "Continue",
   "error.authAppInfoFetchFailed": "Failed to fetch app info for authorization",

--- a/web/i18n/es-ES/oauth.json
+++ b/web/i18n/es-ES/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Conectar a",
   "continue": "Continuar",
   "error.authAppInfoFetchFailed": "No se pudo obtener la información de la aplicación para la autorización",

--- a/web/i18n/fa-IR/oauth.json
+++ b/web/i18n/fa-IR/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "متصل به",
   "continue": "ادامه دهید",
   "error.authAppInfoFetchFailed": "عدم موفقیت در دریافت اطلاعات برنامه برای مجوز",

--- a/web/i18n/fr-FR/oauth.json
+++ b/web/i18n/fr-FR/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Se connecter à",
   "continue": "Continuer",
   "error.authAppInfoFetchFailed": "Échec de la récupération des informations de l'application pour l'autorisation",

--- a/web/i18n/hi-IN/oauth.json
+++ b/web/i18n/hi-IN/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "संयोजित करें",
   "continue": "जारी रखें",
   "error.authAppInfoFetchFailed": "प्राधिकरण के लिए ऐप जानकारी प्राप्त करने में असफल हुआ",

--- a/web/i18n/id-ID/oauth.json
+++ b/web/i18n/id-ID/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Hubungkan",
   "continue": "Lanjut",
   "error.authAppInfoFetchFailed": "Gagal mengambil info aplikasi untuk otorisasi",

--- a/web/i18n/it-IT/oauth.json
+++ b/web/i18n/it-IT/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Connetti a",
   "continue": "Continua",
   "error.authAppInfoFetchFailed": "Impossibile recuperare le informazioni sull'app per l'autorizzazione",

--- a/web/i18n/ja-JP/oauth.json
+++ b/web/i18n/ja-JP/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "接続する",
   "continue": "続行",
   "error.authAppInfoFetchFailed": "認証のためのアプリ情報の取得に失敗しました",

--- a/web/i18n/ko-KR/oauth.json
+++ b/web/i18n/ko-KR/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "연결",
   "continue": "계속",
   "error.authAppInfoFetchFailed": "인증을 위한 앱 정보를 가져오지 못했습니다.",

--- a/web/i18n/lo-LA/oauth.json
+++ b/web/i18n/lo-LA/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "ເຊື່ອມຕໍ່ກັບ",
   "continue": "ດຳເນີນການຕໍ່",
   "error.authAppInfoFetchFailed": "ບໍ່ສາມາດດຶງຂໍ້ມູນແອັບຯເພື່ອການອະນຸມັດໄດ້",

--- a/web/i18n/nl-NL/oauth.json
+++ b/web/i18n/nl-NL/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Connect to",
   "continue": "Continue",
   "error.authAppInfoFetchFailed": "Failed to fetch app info for authorization",

--- a/web/i18n/pl-PL/oauth.json
+++ b/web/i18n/pl-PL/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Połącz z",
   "continue": "Kontynuuj",
   "error.authAppInfoFetchFailed": "Nie udało się pobrać informacji o aplikacji w celu autoryzacji",

--- a/web/i18n/pt-BR/oauth.json
+++ b/web/i18n/pt-BR/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Conectar a",
   "continue": "Continue",
   "error.authAppInfoFetchFailed": "Falha ao buscar informações do aplicativo para autorização",

--- a/web/i18n/ro-RO/oauth.json
+++ b/web/i18n/ro-RO/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Conectează la",
   "continue": "Continuați",
   "error.authAppInfoFetchFailed": "Nu s-au putut obține informațiile aplicației pentru autorizare",

--- a/web/i18n/ru-RU/oauth.json
+++ b/web/i18n/ru-RU/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Подключиться к",
   "continue": "Продолжить",
   "error.authAppInfoFetchFailed": "Не удалось получить информацию об приложении для авторизации",

--- a/web/i18n/sl-SI/oauth.json
+++ b/web/i18n/sl-SI/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Poveži se z",
   "continue": "Nadaljuj",
   "error.authAppInfoFetchFailed": "Pridobivanje informacij o aplikaciji za avtorizacijo ni uspelo",

--- a/web/i18n/th-TH/oauth.json
+++ b/web/i18n/th-TH/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "เชื่อมต่อกับ",
   "continue": "ดำเนินต่อไป",
   "error.authAppInfoFetchFailed": "ไม่สามารถดึงข้อมูลแอปเพื่อการอนุญาตได้",

--- a/web/i18n/tr-TR/oauth.json
+++ b/web/i18n/tr-TR/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Bağlan",
   "continue": "Devam et",
   "error.authAppInfoFetchFailed": "Yetkilendirme için uygulama bilgisi alınamadı",

--- a/web/i18n/uk-UA/oauth.json
+++ b/web/i18n/uk-UA/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Підключитися до",
   "continue": "Продовжувати",
   "error.authAppInfoFetchFailed": "Не вдалося отримати інформацію про додаток для авторизації",

--- a/web/i18n/vi-VN/oauth.json
+++ b/web/i18n/vi-VN/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "Kết nối với",
   "continue": "Tiếp tục",
   "error.authAppInfoFetchFailed": "Không thể lấy thông tin ứng dụng để xác thực",

--- a/web/i18n/zh-Hans/oauth.json
+++ b/web/i18n/zh-Hans/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "连接到",
   "continue": "继续",
   "error.authAppInfoFetchFailed": "获取待授权应用的信息失败",

--- a/web/i18n/zh-Hant/oauth.json
+++ b/web/i18n/zh-Hant/oauth.json
@@ -1,4 +1,8 @@
 {
+  "callback.error": "Authorization failed",
+  "callback.errorHint": "Please return to the previous page and try again.",
+  "callback.success": "Authorization complete",
+  "callback.successHint": "You can now close this tab and return to the previous page.",
   "connect": "連接到",
   "continue": "繼續",
   "error.authAppInfoFetchFailed": "無法獲取應用程式授權信息",


### PR DESCRIPTION
Fixes #39752

## What problem does this PR solve?

The MCP OAuth callback page (`/oauth-callback`) was an empty `<div />` that only did anything when the page was opened as a popup with `window.opener` available. When the user opened the OAuth URL in a new tab (no opener), the hook did nothing and the page sat at an empty white screen — the exact "blank page" the issue reports.

## What is changed and how it works?

- `web/hooks/use-oauth.ts`: `useOAuthCallback` now returns a state object with `hasOpener`, `finished`, `error`, and `errorDescription`. The state is computed from the URL params and the presence of `window.opener` at first render (no `useState`-in-`useEffect` pattern, so the state is available on the first paint). The popup path is unchanged: it still posts the OAuth result to the opener and calls `window.close()`. As a small bonus, the sibling `openOAuthPopup` callback type is now `OAuthCallbackMessage` instead of `any`, which lets us drop the `no-explicit-any` lint suppression.
- `web/app/oauth-callback/page.tsx`: renders the empty `<div />` in popup mode and a meaningful success / error message in no-opener mode. Uses the four new i18n keys via the bracket-notation selector pattern (e.g. `t(($) => $['callback.success'], { ns: 'oauth' })`) because the keys are flat.
- `web/i18n/*/oauth.json`: adds the four new keys to every supported locale. English values are used as fallbacks for the non-English locales; a localization pass can replace them later.

## How it was tested?

```
$ pnpm test hooks/__tests__/use-oauth.spec.ts app/oauth-callback/__tests__/page.spec.tsx
unit  hooks/__tests__/use-oauth.spec.ts  (6 tests)
unit  app/oauth-callback/__tests__/page.spec.tsx  (4 tests)
10 passed
```

- `hooks/__tests__/use-oauth.spec.ts` (6 tests): popup success / error / fallback targetOrigin, the no-opener case (new tab), provider-error propagation, and the initial-state-mirrors-opener contract.
- `app/oauth-callback/__tests__/page.spec.tsx` (4 tests): empty `<div />` in popup mode, success message in new-tab mode, error message with provider description, error message without provider description.
- `tsslint` and `vp staged` pre-commit check clean on the touched files.