### PR TITLE
refactor(console,web): dep-inject query params with @model_validate

### DIFF
--- a/api/controllers/console/extension.py
+++ b/api/controllers/console/extension.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field, RootModel, field_validator
 
@@ -91,9 +90,8 @@ class CodeBasedExtensionAPI(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self):
-        query = CodeBasedExtensionQuery.model_validate(request.args.to_dict(flat=True))
-
+    @model_validate(CodeBasedExtensionQuery)
+    def get(self, query: CodeBasedExtensionQuery):
         return CodeBasedExtensionResponse(
             module=query.module,
             data=CodeBasedExtensionService.get_code_based_extension(query.module),

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -10,6 +10,7 @@ from constants import HEADER_NAME_APP_CODE
 from controllers.common.errors import InvalidArgumentError
 from controllers.common.fields import AccessModeResponse, BooleanResultResponse, Parameters
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
+from controllers.console.wraps import model_validate
 from controllers.web import web_ns
 from controllers.web.error import (
     AgentNotPublishedError,
@@ -133,9 +134,8 @@ class AppAccessMode(Resource):
         }
     )
     @web_ns.response(200, "Success", web_ns.models[AccessModeResponse.__name__])
-    def get(self):
-        raw_args = request.args.to_dict()
-        args = AppAccessModeQuery.model_validate(raw_args)
+    @model_validate(AppAccessModeQuery)
+    def get(self, args: AppAccessModeQuery):
         try:
             access_mode = application_services().webapp_access.get_access_mode(
                 app_id=args.app_id,

--- a/api/tests/unit_tests/controllers/console/test_extension.py
+++ b/api/tests/unit_tests/controllers/console/test_extension.py
@@ -8,6 +8,7 @@ from unittest.mock import ANY, MagicMock
 import pytest
 from flask import Flask
 from flask.views import MethodView as FlaskMethodView
+from werkzeug.exceptions import UnprocessableEntity
 
 from tests.unit_tests.config_override import apply_config_overrides
 
@@ -103,6 +104,13 @@ def test_code_based_extension_get_returns_service_data(app: Flask, monkeypatch: 
 
     assert response == {"module": "workflow.tools", "data": service_result}
     service_mock.assert_called_once_with("workflow.tools")
+
+
+def test_code_based_extension_get_rejects_a_missing_module(app: Flask) -> None:
+    """`module` is required, so this is what covers the decorator's rejection path."""
+    with app.test_request_context("/console/api/code-based-extension", method="GET"):
+        with pytest.raises(UnprocessableEntity):
+            CodeBasedExtensionAPI().get()
 
 
 def test_api_based_extension_get_returns_tenant_extensions(app: Flask, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary

Part of #36659. Converts the two remaining `Model.model_validate(request.args.to_dict(...))` statements in these controllers to the `@model_validate` decorator, following the merged query-param sites in #41562.

| File | Handler | Model |
|---|---|---|
| `api/controllers/console/extension.py` | `CodeBasedExtensionAPI.get` | `CodeBasedExtensionQuery` |
| `api/controllers/web/app.py` | `AppAccessMode.get` | `AppAccessModeQuery` |

Both are GET handlers whose parse is the first statement of the method, with no guard clause and no `try`/`except` above it. The decorator's GET branch is `request.args.to_dict(flat=True)`, which is what both sites already do — `web/app.py` writes `to_dict()`, but `flat=True` is that parameter's default.

Claimed in https://github.com/langgenius/dify/issues/36659#issuecomment-5506304674.

## Behaviour change

`CodeBasedExtensionQuery.module` is required, and the old call was not wrapped in a `try`/`except`, so `GET /console/api/code-based-extension` with no `module` raised an uncaught pydantic `ValidationError`. It now returns 422 from the decorator. Nothing asserted the old behaviour, so this is a strict improvement rather than a contract change — but it is a change, so I added a test pinning the new one.

`AppAccessModeQuery` is all-optional and always validates, so that handler's behaviour is unchanged.

## Verification

Run locally against the changed surface; CI is the authority for the rest of the suite.

- `pytest tests/unit_tests/controllers/console/ tests/unit_tests/controllers/web/` — **2342 passed** vs **2341** on `main` (+1, the new test). Both runs also hit the same pre-existing `test_datasets_document_download.py::test_batch_download_zip_response_is_openable_zip` failure, which reproduces unmodified on `main` (a Windows file-lock issue in my environment).
- Mutation-checked: deleting the `extension.py` decorator fails 2 tests, the `web/app.py` one fails 4.
- `ruff check` / `ruff format --check` — clean. `ruff` also dropped the now-unused `from flask import request` in `extension.py`; `web/app.py` still uses it.
- `pyrefly check` on both controllers — 0 diagnostics
- `pyrefly --config tests/unit_tests/pyrefly.toml` on both test files — 10 diagnostics, identical to the `main` baseline (**0 new**)
- `mypy --check-untyped-defs --disable-error-code=import-untyped` — no issues
- `lint-imports` 25 kept / 0 broken; `dev/lint_response_contracts.py --fail-on-mismatch` 0 mismatch
- `tests/unit_tests/test_config_overrides.py` AST guard — no violations
- no net-new `getattr(` in the diff

---
This PR was written with AI assistance.
