### PR TITLE
refactor(service_api): dep-inject the dataset create payload with @model_validate

### DIFF
--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -504,10 +504,9 @@ class DatasetListApi(DatasetApiResource):
     )
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
     @with_session
-    def post(self, session: Session, tenant_id):
+    @model_validate(DatasetCreatePayload)
+    def post(self, payload: DatasetCreatePayload, session: Session, tenant_id):
         """Resource for creating datasets."""
-        payload = DatasetCreatePayload.model_validate(service_api_ns.payload or {})
-
         embedding_model_provider = payload.embedding_model_provider
         embedding_model = payload.embedding_model
         if embedding_model_provider and embedding_model:

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
@@ -7,12 +7,13 @@ persisted through the shared SQLite session fixture.
 import uuid
 from datetime import UTC, datetime
 from inspect import unwrap
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask, request
 from sqlalchemy.orm import Session
-from werkzeug.exceptions import Forbidden, NotFound
+from werkzeug.exceptions import Forbidden, NotFound, UnprocessableEntity
 
 import services
 from controllers.service_api.dataset.error import DatasetInUseError, DatasetNameDuplicateError, InvalidActionError
@@ -269,7 +270,7 @@ class TestDatasetListApiPost:
         tenant: Tenant,
         controller_session: Session,
     ) -> None:
-        from controllers.service_api.dataset.dataset import DatasetListApi
+        from controllers.service_api.dataset.dataset import DatasetCreatePayload, DatasetListApi
 
         mock_dataset_svc.create_empty_dataset.return_value = make_dataset(
             controller_session, tenant, account, name="New Dataset"
@@ -281,7 +282,10 @@ class TestDatasetListApiPost:
             json={"name": "New Dataset"},
         ):
             api = DatasetListApi()
-            response, status = unwrap(api.post)(api, controller_session, tenant_id=tenant.id)
+            # `post` is wrapped in @model_validate, so the unwrapped view expects
+            # the validated model where the decorator would have injected it.
+            validated_payload = DatasetCreatePayload.model_validate(request.get_json() or {})
+            response, status = unwrap(api.post)(api, validated_payload, controller_session, tenant_id=tenant.id)
 
         assert status == 200
         assert_dataset_detail_shape(response)
@@ -297,7 +301,7 @@ class TestDatasetListApiPost:
         tenant: Tenant,
         controller_session: Session,
     ) -> None:
-        from controllers.service_api.dataset.dataset import DatasetListApi
+        from controllers.service_api.dataset.dataset import DatasetCreatePayload, DatasetListApi
 
         mock_dataset_svc.create_empty_dataset.side_effect = services.errors.dataset.DatasetNameDuplicateError()
 
@@ -307,8 +311,29 @@ class TestDatasetListApiPost:
             json={"name": "Existing Dataset"},
         ):
             api = DatasetListApi()
+            validated_payload = DatasetCreatePayload.model_validate(request.get_json() or {})
             with pytest.raises(DatasetNameDuplicateError):
-                unwrap(api.post)(api, controller_session, tenant_id=tenant.id)
+                unwrap(api.post)(api, validated_payload, controller_session, tenant_id=tenant.id)
+
+    @pytest.mark.usefixtures("account")
+    @patch("controllers.service_api.wraps.FeatureService")
+    @patch("controllers.service_api.wraps.validate_and_get_api_token")
+    def test_invalid_body_is_rejected_before_the_handler_runs(
+        self,
+        mock_validate_token: MagicMock,
+        mock_feature_svc: MagicMock,
+        app: Flask,
+        tenant: Tenant,
+    ) -> None:
+        """The tests above unwrap the view, so this is what covers the decorator."""
+        from controllers.service_api.dataset.dataset import DatasetListApi
+
+        mock_validate_token.return_value = SimpleNamespace(tenant_id=tenant.id)
+        mock_feature_svc.get_knowledge_rate_limit.return_value = SimpleNamespace(enabled=False)
+
+        with app.test_request_context("/datasets", method="POST", json={}):
+            with pytest.raises(UnprocessableEntity):
+                DatasetListApi().post(tenant_id=tenant.id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Part of #36659. Converts the last `Model.model_validate(service_api_ns.payload or {})` statement in `service_api/dataset/dataset.py` — `DatasetListApi.post` (`POST /datasets`) — to the `@model_validate` decorator.

Six handlers in this same file are already converted (L672, 946, 984, 1021, 1051, 1088), and this follows their exact shape: the decorator innermost, below `@with_session`, with the model as the first parameter after `self`.

I left this one site out when I claimed the rest of the file in #41490, because #40902 touched the same method. That reason no longer applies — #40902's nearest hunk here is `@@ -539,7`, 30 lines below the parse, removing an unrelated `initialize_created_app_rbac_access_task.delay` call. Claimed in https://github.com/langgenius/dify/issues/36659#issuecomment-5506683694.

## Test coverage

This is the part worth a look. The tests in this file call their handlers through `inspect.unwrap`, which strips every decorator and passes an already-validated model in — so a straight conversion would have shipped the new layer completely unexercised. I verified that: with the decorator deleted, all 353 tests still passed.

So this PR adds a test that calls `DatasetListApi().post()` the normal way and asserts `UnprocessableEntity` for an invalid body. Deleting the decorator now fails it.

The two existing `DatasetListApi.post` tests were updated the same way the file already handles converted handlers — see the `DatasetApi.patch` test at L486, which builds the model explicitly and passes it where the decorator would have injected it.

## Verification

Run locally against the changed surface; CI is the authority for the rest of the suite.

- `pytest tests/unit_tests/controllers/service_api/` — **776 passed** vs **775** on `main` (+1, the new test)
- Mutation-checked: deleting the decorator fails exactly the new test
- `ruff check` / `ruff format --check` — clean
- `pyrefly check` on the controller — 0 diagnostics
- `pyrefly --config tests/unit_tests/pyrefly.toml` on the test dir — 721 diagnostics, identical to the `main` baseline (**0 new**)
- `mypy --check-untyped-defs --disable-error-code=import-untyped` — no issues
- `lint-imports` 25 kept / 0 broken; `dev/lint_response_contracts.py --fail-on-mismatch` 0 mismatch
- `tests/unit_tests/test_config_overrides.py` AST guard — no violations
- no net-new `getattr(` in the diff

## Behaviour note

As on the earlier PRs in this campaign, an invalid body now surfaces as 422 from the decorator rather than the uncaught pydantic `ValidationError` the handler previously raised.

---
This PR was written with AI assistance.
