### PR TITLE
fix(web): stabilize Home and Studio route titles

### DIFF
--- a/web/app/(commonLayout)/apps/page.tsx
+++ b/web/app/(commonLayout)/apps/page.tsx
@@ -1,4 +1,9 @@
 import { Apps } from '@/app/components/apps'
+import { getRouteMetadata } from '@/app/route-metadata'
+
+export function generateMetadata() {
+  return getRouteMetadata('common', ($) => $['menus.apps'])
+}
 
 export default function AppsPage() {
   return <Apps />

--- a/web/app/(commonLayout)/page.tsx
+++ b/web/app/(commonLayout)/page.tsx
@@ -1,4 +1,10 @@
+import { getRouteMetadata } from '@/app/route-metadata'
 import { HomePage } from '@/features/home/page'
+
+export function generateMetadata() {
+  return getRouteMetadata('common', ($) => $['mainNav.home'])
+}
+
 export default function Page() {
   return <HomePage />
 }

--- a/web/app/__tests__/route-metadata.spec.ts
+++ b/web/app/__tests__/route-metadata.spec.ts
@@ -1,4 +1,6 @@
 import { generateMetadata as generateAgentsMetadata } from '../(commonLayout)/agents/page'
+import { generateMetadata as generateAppsMetadata } from '../(commonLayout)/apps/page'
+import { generateMetadata as generateHomeMetadata } from '../(commonLayout)/page'
 import { generateMetadata as generateWebappCheckCodeMetadata } from '../(shareLayout)/webapp-reset-password/check-code/layout'
 import { generateMetadata as generateWebappResetPasswordMetadata } from '../(shareLayout)/webapp-reset-password/layout'
 import { generateMetadata as generateWebappSetPasswordMetadata } from '../(shareLayout)/webapp-reset-password/set-password/layout'
@@ -28,9 +30,11 @@ vi.mock('../(shareLayout)/webapp-reset-password/reset-password-layout', () => ({
   default: () => null,
 }))
 vi.mock('../init/InitPasswordPopup', () => ({ default: () => null }))
+vi.mock('@/app/components/apps', () => ({ Apps: () => null }))
 vi.mock('@/features/agent-v2/roster/page', () => ({ default: () => null }))
+vi.mock('@/features/home/page', () => ({ HomePage: () => null }))
 
-describe('fixed authentication route metadata', () => {
+describe('fixed route metadata', () => {
   it.each([
     [generateResetPasswordMetadata, 'Reset Password'],
     [generateCheckCodeMetadata, 'Check your email'],
@@ -46,6 +50,8 @@ describe('fixed authentication route metadata', () => {
     [generateInitMetadata, 'Admin initialization password'],
     [generateOAuthCallbackMetadata, 'Sign in'],
     [generateAgentsMetadata, 'Agents'],
+    [generateAppsMetadata, 'Studio'],
+    [generateHomeMetadata, 'Home'],
   ])('provides the localized title %s', async (generateMetadata, expectedTitle) => {
     await expect(generateMetadata()).resolves.toMatchObject({ title: expectedTitle })
   })

--- a/web/app/components/apps/index.tsx
+++ b/web/app/components/apps/index.tsx
@@ -5,11 +5,9 @@ import type { TryAppSelection } from '@/types/try-app'
 import type { TrackCreateAppParams } from '@/utils/create-app-tracking'
 import { useAtomValue } from 'jotai'
 import { useCallback, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import { EducationExpireNotice } from '@/app/education/expire-notice'
 import AppListContext from '@/context/app-list-context'
 import { workspacePermissionKeysAtom } from '@/context/permission-state'
-import useDocumentTitle from '@/hooks/use-document-title'
 import { useImportDSL } from '@/hooks/use-import-dsl'
 import { DSLImportMode } from '@/models/app'
 import dynamic from '@/next/dynamic'
@@ -31,15 +29,12 @@ const ImportFromMarketplaceTemplateModal = dynamic(
 const AppListProvider = AppListContext.Provider
 
 const AppsContent = () => {
-  const { t } = useTranslation()
   const searchParams = useSearchParams()
   const { replace } = useRouter()
   const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const canCreateApp = hasPermission(workspacePermissionKeys, 'app.create_and_management')
   const templateId = searchParams.get('template-id')
   const templateDismissedRef = useRef(false)
-
-  useDocumentTitle(t(($) => $['menus.apps'], { ns: 'common' }))
 
   const [currentTryAppParams, setCurrentTryAppParams] = useState<TryAppSelection | undefined>(
     undefined,

--- a/web/features/home/home-content/home-content.tsx
+++ b/web/features/home/home-content/home-content.tsx
@@ -29,7 +29,6 @@ import { STEP_BY_STEP_TOUR_TASKS } from '@/app/components/step-by-step-tour/task
 import { useLocale } from '@/context/i18n'
 import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
-import useDocumentTitle from '@/hooks/use-document-title'
 import { useImportDSL } from '@/hooks/use-import-dsl'
 import { DSLImportMode } from '@/models/app'
 import dynamic from '@/next/dynamic'
@@ -56,7 +55,6 @@ const HOME_STEP_BY_STEP_TOUR_TASK_ID = 'home' satisfies StepByStepTourTaskId
 
 export function HomeContent() {
   const { t } = useTranslation()
-  useDocumentTitle(t(($) => $['mainNav.home'], { ns: 'common' }))
   const locale = useLocale()
   const queryClient = useQueryClient()
   const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)


### PR DESCRIPTION
## Summary

- move the fixed Home and Studio titles from client effects to their App Router page metadata owners
- reuse the existing server-side localized metadata helper and root branding template
- remove the duplicate title effects from the Home and Apps content components

Fixes SNP-740

## Validation

- `vp staged`
- `vp test run --project unit app/__tests__/route-metadata.spec.ts features/home/home-content/__tests__/home-content.spec.tsx app/components/apps/__tests__/index.spec.tsx` (65 tests)
- browser-verified direct loads and SPA navigation for `/` and `/apps` on localhost:3000

## Screenshots

Not applicable; this changes document metadata without changing visible page layout.

From Codex
