### PR TITLE
docs(api): Fix reformat script path in api/README.md

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -96,7 +96,7 @@ The scripts resolve paths relative to their location, so you can run them from a
    uv run pytest tests/integration_tests/  # Integration tests
 
    # Code quality
-   ./dev/reformat               # Run all formatters and linters
+   ../dev/reformat              # Run all formatters and linters
    uv run ruff check --fix ./   # Fix linting issues
    uv run ruff format ./        # Format code
    uv run pyrefly check         # Type checking


### PR DESCRIPTION
## Summary

`api/README.md` tells the reader to run the formatters from the `api` directory, but the documented command points at a script that is not there:

```
$ cd api && ./dev/reformat
bash: ./dev/reformat: No such file or directory
```

`dev/reformat` lives at the repository root, so from `api/` the correct path is `../dev/reformat`. The other commands in that section are already written relative to `api/`, so only this one line changes.

## Screenshots

Not applicable — documentation only.

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've updated the documentation accordingly.

From Claude Code
