### PR TITLE
fix(retention): verify marker absence after DeleteObject in archive maintenance

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -105,6 +105,7 @@ ignore_imports =
     libs.external_api -> core
     libs.external_api -> core.errors.error
     libs.external_api -> extensions.ext_logging
+    extensions.ext_database -> extensions.ext_logging
     libs.flask_utils -> models
     libs.helper -> core.app.features.rate_limiting.rate_limit
     libs.helper -> models

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import uuid
 from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import Any, Literal, cast
@@ -299,6 +300,22 @@ def _resolve_identity_mode(requested: IdentityMode | None, *, current: IdentityM
     return mode
 
 
+def _validate_uuid(value: str) -> str:
+    """Validate that a string is a UUID and return it unchanged.
+
+    Used by the MCP provider Pydantic payloads so the API layer fails with
+    a clean 400 (Pydantic ValidationError) instead of letting a non-UUID
+    ``provider_id`` reach SQLAlchemy and bubble up as a 500
+    ``psycopg2.errors.InvalidTextRepresentation: invalid input syntax for
+    type uuid: "fast-mcp"`` from the Postgres backend — see #41649.
+    """
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise ValueError(f"invalid uuid: {value!r}") from exc
+    return value
+
+
 class MCPProviderCreatePayload(MCPProviderBasePayload):
     pass
 
@@ -306,14 +323,29 @@ class MCPProviderCreatePayload(MCPProviderBasePayload):
 class MCPProviderUpdatePayload(MCPProviderBasePayload):
     provider_id: str
 
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
+
 
 class MCPProviderDeletePayload(BaseModel):
     provider_id: str
+
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
 
 
 class MCPAuthPayload(BaseModel):
     provider_id: str
     authorization_code: str | None = None
+
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
 
 
 class MCPCallbackQuery(BaseModel):

--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -60,3 +60,14 @@ def init_app(app: DifyApp):
             _ = db.engine  # triggers engine creation with the configured options
     except Exception:
         logger.exception("Failed to initialize SQLAlchemy engine during app startup")
+
+    # SQLAlchemy attaches its own echo handlers to ``sqlalchemy.engine`` (and
+    # sub-loggers like ``sqlalchemy.pool``) at engine creation. Those handlers
+    # bypass the root logger's ``LOG_TZ``-aware formatter because
+    # ``sqlalchemy.engine`` has ``propagate = False`` (see
+    # ``extensions.ext_logging``). Apply the same ``LOG_TZ`` converter to
+    # their formatters so engine log timestamps stay consistent with the
+    # rest of the application logs.
+    from extensions.ext_logging import apply_timezone_to_sqlalchemy_loggers
+
+    apply_timezone_to_sqlalchemy_loggers()

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -90,6 +90,49 @@ def _apply_timezone(handlers: list[logging.Handler]):
                 handler.formatter.converter = time_converter  # type: ignore[attr-defined]
 
 
+def apply_timezone_to_sqlalchemy_loggers() -> None:
+    """Apply the LOG_TZ converter to the formatters of SQLAlchemy logger handlers.
+
+    ``sqlalchemy.engine`` (and its sub-loggers like ``sqlalchemy.pool``) have
+    ``propagate = False`` set in :func:`init_app` to avoid duplicate logs, so the
+    root handlers' ``LOG_TZ``-aware formatter never gets a chance to format
+    SQLAlchemy records. As a result, when ``SQLALCHEMY_ECHO`` is enabled, engine
+    log timestamps are emitted in the server's local timezone while the
+    surrounding application logs are converted to ``LOG_TZ``, producing
+    inconsistent timestamps within a single log stream.
+
+    This helper walks the SQLAlchemy logger hierarchy and applies the same
+    ``LOG_TZ`` converter to the formatters of any handlers that SQLAlchemy
+    itself has attached, so engine log timestamps agree with the rest of the
+    application logs.
+
+    Must be called AFTER the SQLAlchemy engine is created (i.e. after
+    ``ext_database.init_app()`` triggers engine creation via ``db.engine``), so
+    that any echo handler has been attached. The function is a no-op when
+    ``LOG_OUTPUT_FORMAT`` is not ``"text"`` or when ``LOG_TZ`` is unset.
+    """
+    if dify_config.LOG_OUTPUT_FORMAT != "text":
+        return
+    log_tz = dify_config.LOG_TZ
+    if not log_tz:
+        return
+
+    from datetime import datetime
+
+    import pytz
+
+    timezone = pytz.timezone(log_tz)
+
+    def time_converter(seconds):
+        return datetime.fromtimestamp(seconds, tz=timezone).timetuple()
+
+    for name in ("sqlalchemy.engine", "sqlalchemy", "sqlalchemy.pool"):
+        sql_logger = logging.getLogger(name)
+        for handler in sql_logger.handlers:
+            if isinstance(handler.formatter, logging.Formatter):
+                handler.formatter.converter = time_converter  # type: ignore[attr-defined]
+
+
 class _TextFormatter(logging.Formatter):
     """Text formatter that ensures trace_id and req_id are always present."""
 

--- a/api/services/retention/workflow_run/bundle_archive_maintenance.py
+++ b/api/services/retention/workflow_run/bundle_archive_maintenance.py
@@ -31,7 +31,12 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import Session, sessionmaker
 
 from extensions.ext_database import db
-from libs.archive_storage import ArchiveStorage, ArchiveStorageNotConfiguredError, get_archive_storage
+from libs.archive_storage import (
+    ArchiveStorage,
+    ArchiveStorageError,
+    ArchiveStorageNotConfiguredError,
+    get_archive_storage,
+)
 from models.trigger import WorkflowTriggerLog
 from models.workflow import (
     WorkflowAppLog,
@@ -1195,11 +1200,97 @@ class WorkflowRunBundleArchiveMaintenance:
         payload = json.dumps({"created_at": datetime.datetime.now(datetime.UTC).isoformat()}).encode("utf-8")
         storage.put_object(f"{object_prefix}/{marker_name}", payload)
 
+    # Bounded retry for the post-delete HEAD check on the marker. The
+    # archive storage may transiently fail (or return stale state) right
+    # after a delete; we retry a few times before declaring the delete
+    # failed. This is a marker-only path so the budget is tight.
+    _MARKER_DELETE_VERIFY_ATTEMPTS = 5
+    _MARKER_DELETE_VERIFY_BASE_DELAY = 0.5
+
     @staticmethod
     def _delete_marker(storage: ArchiveStorage, object_prefix: str, marker_name: str) -> None:
+        """Delete a transition marker, verifying the post-delete state.
+
+        Issue #41620: a transport timeout on the DeleteObject call cannot
+        tell us whether the remote object store applied the delete. The
+        pre-fix code did a pre-delete existence check, then a single
+        delete, and called it a day — a successful remote delete that the
+        client didn't see still failed the bundle. The new code treats
+        the post-delete state as the success criterion:
+
+        1. If the marker is already absent, no-op.
+        2. Otherwise, call ``delete_object`` (the call may raise on
+           transport error; we retry that path with bounded backoff).
+        3. After a successful ``delete_object`` (or a retryable error
+           followed by another attempt), do a HEAD via
+           ``object_exists()``. Only return when the marker is
+           authoritatively absent.
+        4. If the marker still exists after the budget is exhausted, or
+           a non-retryable error is raised, fail closed.
+
+        Failure here blocks a single shard from advancing; the rest of
+        the retention pipeline is unaffected. The whole call is
+        fail-closed (raises on any uncertainty) — this PR is the
+        "trust the remote state, not the client outcome" half of the
+        fix; the "retry transport errors" half is what makes the path
+        recover from a transient outage without manual intervention.
+        """
         marker_key = f"{object_prefix}/{marker_name}"
-        if storage.object_exists(marker_key):
-            storage.delete_object(marker_key)
+
+        attempts = WorkflowRunBundleArchiveMaintenance._MARKER_DELETE_VERIFY_ATTEMPTS
+        base_delay = WorkflowRunBundleArchiveMaintenance._MARKER_DELETE_VERIFY_BASE_DELAY
+
+        last_error: Exception | None = None
+        for attempt in range(attempts):
+            # Step 1: short-circuit if the marker is already gone.
+            if not storage.object_exists(marker_key):
+                return
+
+            # Step 2: try the delete. ``ArchiveStorageError`` from
+            # ``delete_object`` covers both ``ClientError`` (non-404)
+            # and ``BotoCoreError`` (network, timeouts, etc.). The
+            # ``is_retryable`` predicate keeps transient transport
+            # errors in the retry loop and lets real failures out
+            # immediately (fail-closed).
+            try:
+                storage.delete_object(marker_key)
+            except ArchiveStorageError as exc:
+                if not _is_retryable_archive_error(exc):
+                    raise
+                last_error = exc
+                time.sleep(base_delay * (2**attempt))
+                continue
+
+            # Step 3: verify the post-delete state via HEAD. A
+            # transport error here is also retryable.
+            try:
+                still_exists = storage.object_exists(marker_key)
+            except ArchiveStorageError as exc:
+                if not _is_retryable_archive_error(exc):
+                    raise
+                last_error = exc
+                time.sleep(base_delay * (2**attempt))
+                continue
+
+            if not still_exists:
+                return
+
+            # The delete call succeeded but the marker is still there.
+            # Either the delete was a no-op (already absent before the
+            # HEAD returned) and a concurrent caller re-created it, or
+            # the storage layer's eventual consistency is lagging.
+            # Either way: retry. Only fail after the budget is gone.
+            time.sleep(base_delay * (2**attempt))
+
+        # Step 4: budget exhausted. The marker is still on the server
+        # (or we kept getting retryable errors). Fail closed so the
+        # caller can decide whether to retry the whole bundle.
+        raise ArchiveStorageError(
+            f"Failed to confirm deletion of marker '{marker_name}' at "
+            f"'{object_prefix}' after {attempts} attempts; refusing to "
+            f"advance the bundle while the marker is still on the server. "
+            f"Last error: {last_error!r}"
+        )
 
     @staticmethod
     def _chunks(values: Sequence[Any], size: int) -> list[Sequence[Any]]:
@@ -1226,3 +1317,48 @@ class WorkflowRunBundleArchiveMaintenance:
                 summary.table_counts[table_name] = summary.table_counts.get(table_name, 0) + count
         else:
             summary.bundles_failed += 1
+
+
+# Module-level helper used by ``_delete_marker`` to distinguish transient
+# transport errors (worth retrying) from real failures (fail-closed).
+def _is_retryable_archive_error(exc: ArchiveStorageError) -> bool:
+    """Return True when an ``ArchiveStorageError`` looks like a transient
+    transport failure that the next attempt might succeed against.
+
+    The error is the one ``ArchiveStorage.delete_object`` and
+    ``ArchiveStorage.object_exists`` raise — they wrap both
+    ``botocore.exceptions.ClientError`` (a 5xx S3/R2 response, a
+    throttling SlowDown, or a RequestTimeout) and
+    ``botocore.exceptions.BotoCoreError`` (DNS, connect, read-timeout,
+    etc.). Boto does not surface a typed "retryable" flag, so we look at
+    the wrapped ``ClientError`` response code when one is present and
+    fall back to True for the network-level ``BotoCoreError`` family —
+    the same family botocore's own retry layer would normally retry.
+    """
+    cause = exc.__cause__ or exc.__context__
+    if cause is None:
+        return False
+
+    response = getattr(cause, "response", None)
+    if response is not None:
+        code = response.get("Error", {}).get("Code")
+        retryable_codes = {
+            "InternalError",
+            "RequestTimeout",
+            "RequestTimeoutException",
+            "ServiceUnavailable",
+            "SlowDown",
+            "ThrottlingException",
+            "TooManyRequests",
+            "TransientError",
+        }
+        if code in retryable_codes:
+            return True
+        if code is not None:
+            # A non-retryable 4xx error (NoSuchKey, AccessDenied, etc.) —
+            # retrying will not help.
+            return False
+
+    # BotoCoreError covers connection, timeout, SSL, EOF, etc. These are
+    # transient by their nature; treat them as retryable.
+    return True

--- a/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
@@ -1,0 +1,79 @@
+"""Regression tests for #41649.
+
+The MCP provider Pydantic payloads used to accept any string as
+``provider_id``. The PUT/DELETE/auth endpoints would then pass that
+string to SQLAlchemy, which raised a Postgres
+``InvalidTextRepresentation: invalid input syntax for type uuid: "fast-mcp"``
+and bubbled back as a generic 500. The fix validates ``provider_id`` as
+a UUID at the Pydantic layer so the API returns a clean 400 instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from controllers.console.workspace.tool_providers import (
+    MCPAuthPayload,
+    MCPProviderDeletePayload,
+    MCPProviderUpdatePayload,
+)
+
+_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+class TestMCPProviderUpdatePayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        payload = MCPProviderUpdatePayload(
+            provider_id=_UUID,
+            server_url="https://example.test",
+            name="n",
+            icon="i",
+            icon_type="emoji",
+            server_identifier="fast-mcp",
+        )
+        assert payload.provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderUpdatePayload(
+                provider_id="fast-mcp",
+                server_url="https://example.test",
+                name="n",
+                icon="i",
+                icon_type="emoji",
+                server_identifier="fast-mcp",
+            )
+        assert "provider_id" in str(exc_info.value)
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderUpdatePayload(
+                provider_id="",
+                server_url="https://example.test",
+                name="n",
+                icon="i",
+                icon_type="emoji",
+                server_identifier="fast-mcp",
+            )
+        assert "provider_id" in str(exc_info.value)
+
+
+class TestMCPProviderDeletePayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        assert MCPProviderDeletePayload(provider_id=_UUID).provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderDeletePayload(provider_id="not-a-uuid")
+        assert "provider_id" in str(exc_info.value)
+
+
+class TestMCPAuthPayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        assert MCPAuthPayload(provider_id=_UUID).provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPAuthPayload(provider_id="not-a-uuid")
+        assert "provider_id" in str(exc_info.value)

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
+from typing import cast
 
 import pytest
 
@@ -21,8 +23,19 @@ def _make_handler_with_formatter() -> logging.Handler:
     return handler
 
 
+# ``logging.Formatter.converter`` is a runtime attribute that the type stubs
+# type as ``object``. We know it is always a callable from ``time.localtime`` /
+# ``time.gmtime`` that returns a ``time.struct_time``-compatible tuple.
+FormatterConverter = Callable[[float], time.struct_time]
+
+
+def _formatter_converter(formatter: logging.Formatter | None) -> FormatterConverter:
+    assert formatter is not None
+    return cast(FormatterConverter, formatter.converter)
+
+
 class TestApplyTimezoneToSqlalchemyLoggers:
-    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -30,22 +43,22 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # JSON output: converter must remain the default (local time).
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -56,7 +69,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
             # The formatter's converter must now produce a Tokyo-time tuple
             # from a fixed timestamp, not local time.
             local_tuple = time.localtime(_FIXED_TS)
-            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            tokyo_tuple = _formatter_converter(handler.formatter)(_FIXED_TS)
             assert tokyo_tuple != local_tuple
 
             # Sanity: the offset must be Tokyo (+09:00) at that instant.
@@ -65,7 +78,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         engine_handler = _make_handler_with_formatter()
         pool_handler = _make_handler_with_formatter()
@@ -75,13 +88,13 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         log_pool.addHandler(pool_handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert engine_handler.formatter.converter is not logging.Formatter.converter
-            assert pool_handler.formatter.converter is not logging.Formatter.converter
+            assert _formatter_converter(engine_handler.formatter) is not logging.Formatter.converter
+            assert _formatter_converter(pool_handler.formatter) is not logging.Formatter.converter
         finally:
             log_engine.removeHandler(engine_handler)
             log_pool.removeHandler(pool_handler)
 
-    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A handler with no formatter must be left alone (we only patch
         existing ``logging.Formatter`` instances), and the call must not raise.
         """
@@ -96,22 +109,23 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            converter_after_first_call = handler.formatter.converter
+            converter_after_first_call = _formatter_converter(handler.formatter)
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # The converter must be stable across repeated calls (the same
             # ``time_converter`` closure rebinds each time, but the only
             # guarantee we need is that the formatter remains patched and
             # keeps producing a non-local tuple).
-            assert handler.formatter.converter is not logging.Formatter.converter
-            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            converter = _formatter_converter(handler.formatter)
+            assert converter is not logging.Formatter.converter
+            assert converter(_FIXED_TS)[3] == 7  # hour in Tokyo
             del converter_after_first_call
         finally:
             log.removeHandler(handler)

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -8,7 +8,6 @@ import pytest
 from extensions import ext_logging
 from tests.unit_tests.config_override import apply_config_overrides
 
-
 # Captures a fixed instant so the test is timezone-independent of the host clock.
 _FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
 
@@ -46,9 +45,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from extensions import ext_logging
+from tests.unit_tests.config_override import apply_config_overrides
+
+
+# Captures a fixed instant so the test is timezone-independent of the host clock.
+_FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
+
+
+def _make_handler_with_formatter() -> logging.Handler:
+    """Build a StreamHandler with a default text formatter, mirroring what
+    SQLAlchemy attaches to ``sqlalchemy.engine`` when ``SQLALCHEMY_ECHO`` is on.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt="%(asctime)s %(message)s"))
+    return handler
+
+
+class TestApplyTimezoneToSqlalchemyLoggers:
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # JSON output: converter must remain the default (local time).
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+
+            # The formatter's converter must now produce a Tokyo-time tuple
+            # from a fixed timestamp, not local time.
+            local_tuple = time.localtime(_FIXED_TS)
+            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            assert tokyo_tuple != local_tuple
+
+            # Sanity: the offset must be Tokyo (+09:00) at that instant.
+            assert tokyo_tuple.tm_hour == 7
+            assert time.strftime("%Y-%m-%d %H:%M:%S", tokyo_tuple) == "2023-11-15 07:13:20"
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        engine_handler = _make_handler_with_formatter()
+        pool_handler = _make_handler_with_formatter()
+        log_engine = logging.getLogger("sqlalchemy.engine")
+        log_pool = logging.getLogger("sqlalchemy.pool")
+        log_engine.addHandler(engine_handler)
+        log_pool.addHandler(pool_handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert engine_handler.formatter.converter is not logging.Formatter.converter
+            assert pool_handler.formatter.converter is not logging.Formatter.converter
+        finally:
+            log_engine.removeHandler(engine_handler)
+            log_pool.removeHandler(pool_handler)
+
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+        """A handler with no formatter must be left alone (we only patch
+        existing ``logging.Formatter`` instances), and the call must not raise.
+        """
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = logging.StreamHandler()  # no formatter set
+        assert handler.formatter is None
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()  # must not raise
+            assert handler.formatter is None
+        finally:
+            log.removeHandler(handler)
+
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            converter_after_first_call = handler.formatter.converter
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # The converter must be stable across repeated calls (the same
+            # ``time_converter`` closure rebinds each time, but the only
+            # guarantee we need is that the formatter remains patched and
+            # keeps producing a non-local tuple).
+            assert handler.formatter.converter is not logging.Formatter.converter
+            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            del converter_after_first_call
+        finally:
+            log.removeHandler(handler)

--- a/api/tests/unit_tests/services/retention/workflow_run/test_delete_marker_41620.py
+++ b/api/tests/unit_tests/services/retention/workflow_run/test_delete_marker_41620.py
@@ -1,0 +1,211 @@
+"""Regression tests for #41620.
+
+``_delete_marker`` previously did one ``delete_object`` and walked away;
+a transport timeout on the delete call left the bundle reported as
+failed even when the remote delete had already succeeded. The fix
+treats the post-delete marker state (verified via ``object_exists()``)
+as the success criterion, with bounded retries for transient transport
+errors and fail-closed behavior when the marker is still on the
+server after the budget is exhausted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from libs.archive_storage import ArchiveStorageError
+from services.retention.workflow_run.bundle_archive_maintenance import (
+    WorkflowRunBundleArchiveMaintenance,
+    _is_retryable_archive_error,
+)
+
+
+def _make_storage(exists_sequence: list[bool]) -> MagicMock:
+    """Storage stub whose ``object_exists`` returns successive values."""
+    storage = MagicMock()
+    storage.object_exists.side_effect = exists_sequence
+    return storage
+
+
+def _retryable_error() -> ArchiveStorageError:
+    """A retryable ArchiveStorageError (5xx, wrapped ClientError)."""
+    return _chained_error(code="ServiceUnavailable", message="transient")
+
+
+def _non_retryable_error() -> ArchiveStorageError:
+    """A non-retryable ArchiveStorageError (4xx, wrapped ClientError)."""
+    return _chained_error(code="AccessDenied", message="nope")
+
+
+def _chained_error(*, code: str | None, message: str) -> ArchiveStorageError:
+    """Build an ``ArchiveStorageError`` with a real (non-MagicMock) cause.
+
+    ``__cause__`` must be a ``BaseException`` instance, so we wrap a real
+    fake ``botocore`` exception rather than a ``MagicMock``. Using a
+    try/except + ``raise X from Y`` keeps the call site a single
+    expression (Python 3.12 forbids ``raise`` in expression context).
+    """
+    if code is None:
+        cause: Exception = _FakeBotoCoreError()
+    else:
+        cause = _FakeClientError(code)
+    try:
+        raise ArchiveStorageError(message) from cause
+    except ArchiveStorageError as err:
+        return err
+
+
+class _FakeClientError(Exception):
+    """Stand-in for ``botocore.exceptions.ClientError`` with a ``.response``."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(f"client-error:{code}")
+        self.response = {"Error": {"Code": code}}
+
+
+class _FakeBotoCoreError(Exception):
+    """Stand-in for ``botocore.exceptions.BotoCoreError`` (no ``.response``)."""
+
+    def __init__(self) -> None:
+        super().__init__("boto-core-error")
+
+
+class TestIsRetryableArchiveError:
+    def test_5xx_codes_are_retryable(self):
+        for code in (
+            "InternalError",
+            "RequestTimeout",
+            "ServiceUnavailable",
+            "SlowDown",
+            "ThrottlingException",
+            "TooManyRequests",
+            "TransientError",
+        ):
+            err = _chained_error(code=code, message=code)
+            assert _is_retryable_archive_error(err), code
+
+    def test_4xx_codes_are_not_retryable(self):
+        for code in ("AccessDenied", "NoSuchKey", "InvalidArgument"):
+            err = _chained_error(code=code, message=code)
+            assert not _is_retryable_archive_error(err), code
+
+    def test_botocore_error_without_response_is_retryable(self):
+        # BotoCoreError covers connection / timeout / SSL — these are
+        # transient by nature.
+        err = _chained_error(code=None, message="boto-core-error")
+        assert _is_retryable_archive_error(err)
+
+    def test_error_without_cause_is_not_retryable(self):
+        # Without a wrapped exception we have no signal that the
+        # failure is transient. Fail closed.
+        assert not _is_retryable_archive_error(ArchiveStorageError("bare"))
+
+
+class TestDeleteMarker:
+    def test_marker_already_absent_is_a_noop(self):
+        """If the marker is already gone, ``_delete_marker`` must not
+        call ``delete_object`` and must return success without retrying."""
+        storage = _make_storage(exists_sequence=[False])
+
+        WorkflowRunBundleArchiveMaintenance._delete_marker(storage, "prefix", "marker.json")
+
+        storage.delete_object.assert_not_called()
+        storage.object_exists.assert_called_once()
+
+    def test_delete_succeeds_and_marker_removed(self):
+        """The pre-delete check sees the marker; ``delete_object`` is
+        called; the post-delete HEAD confirms absence; the method
+        returns success and does not retry."""
+        storage = _make_storage(exists_sequence=[True, False])
+
+        with patch("time.sleep") as sleep:
+            WorkflowRunBundleArchiveMaintenance._delete_marker(storage, "prefix", "marker.json")
+
+        storage.delete_object.assert_called_once_with("prefix/marker.json")
+        assert storage.object_exists.call_count == 2
+        sleep.assert_not_called()
+
+    def test_retryable_error_then_success(self):
+        """A retryable ``ArchiveStorageError`` from ``delete_object`` is
+        retried, and the next call succeeds."""
+        storage = MagicMock()
+        # Two pre-checks (both see the marker) and one post-check (the
+        # marker is gone after the second delete).
+        storage.object_exists.side_effect = [True, True, False]
+        # First delete call raises a retryable error; the retry succeeds.
+        storage.delete_object.side_effect = [_retryable_error(), None]
+
+        with patch("time.sleep") as sleep:
+            WorkflowRunBundleArchiveMaintenance._delete_marker(storage, "prefix", "marker.json")
+
+        assert storage.delete_object.call_count == 2
+        # The first retry's backoff fires once.
+        sleep.assert_called_once()
+
+    def test_retryable_error_then_marker_still_present_then_success(self):
+        """A retryable error followed by a successful delete whose
+        post-delete HEAD still sees the marker (eventual consistency)
+        is retried; the second delete+HEAD finally confirms absence."""
+        storage = MagicMock()
+        # pre-check True, retry #1 post-delete True, retry #2 post-delete False
+        storage.object_exists.side_effect = [True, True, False]
+        # First delete: error. Second delete: success.
+        storage.delete_object.side_effect = [_retryable_error(), None]
+
+        with patch("time.sleep"):
+            WorkflowRunBundleArchiveMaintenance._delete_marker(storage, "prefix", "marker.json")
+
+        assert storage.delete_object.call_count == 2
+        # The object_exists check fired 3 times: pre-check, post-delete
+        # after retry #1, post-delete after retry #2.
+        assert storage.object_exists.call_count == 3
+
+    def test_non_retryable_error_fails_closed_immediately(self):
+        """A non-retryable 4xx (e.g. AccessDenied) is not retried."""
+        storage = MagicMock()
+        storage.object_exists.return_value = True
+        storage.delete_object.side_effect = _non_retryable_error()
+
+        with patch("time.sleep") as sleep:
+            with pytest.raises(ArchiveStorageError):
+                WorkflowRunBundleArchiveMaintenance._delete_marker(storage, "prefix", "marker.json")
+
+        storage.delete_object.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_marker_still_present_after_budget_is_exhausted_fails_closed(self):
+        """When the marker is still on the server after every attempt,
+        the method must raise (fail-closed) so the bundle is not
+        marked succeeded with a stale transition marker present."""
+        storage = MagicMock()
+        storage.object_exists.return_value = True
+        # First call: retryable. Subsequent: success. But the HEAD
+        # always sees the marker still there.
+        storage.delete_object.side_effect = [_retryable_error()] + [None] * 10
+        # Pre-check True, every post-delete HEAD also True.
+        storage.object_exists.side_effect = [True] * 20
+
+        with patch("time.sleep"):
+            with pytest.raises(ArchiveStorageError) as exc_info:
+                WorkflowRunBundleArchiveMaintenance._delete_marker(storage, "prefix", "marker.json")
+
+        assert "refusing to advance the bundle" in str(exc_info.value)
+        # We never returned — the budget is bounded.
+        assert storage.delete_object.call_count == 5
+
+    def test_non_retryable_post_delete_head_error_fails_closed(self):
+        """A non-retryable error on the post-delete HEAD (not the
+        delete itself) must not be retried."""
+        storage = MagicMock()
+        storage.object_exists.return_value = True
+        # First object_exists: pre-check, True.
+        # Second object_exists: post-delete HEAD, raises.
+        storage.object_exists.side_effect = [True, _non_retryable_error()]
+
+        with patch("time.sleep") as sleep:
+            with pytest.raises(ArchiveStorageError):
+                WorkflowRunBundleArchiveMaintenance._delete_marker(storage, "prefix", "marker.json")
+
+        sleep.assert_not_called()


### PR DESCRIPTION
Fixes #41620

## What problem does this PR solve?

The V2 archive retention pipeline uses transition markers (`_DELETE_STARTED`, `_DELETED`, etc.) to make delete/restore idempotent. `_delete_marker()` did a pre-delete existence check, then a single `delete_object` call, and called it a day. A transport timeout on the delete call cannot determine whether the remote object store applied the delete — the pre-fix code treated a successful remote delete that the client didn't see as a bundle failure, leaving the bundle stuck in a failed state until manual intervention.

## What is changed and how it works?

The new `_delete_marker` treats the post-delete marker state as the success criterion, with bounded retries for transient transport errors and fail-closed behavior when the marker is still on the server after the budget is exhausted:

1. If the marker is already absent, no-op.
2. Otherwise, call `delete_object` (the call may raise on transport error; we retry that path with bounded exponential backoff).
3. After a successful `delete_object` (or a retryable error followed by another attempt), do a HEAD via `object_exists()`. Return success only when the marker is authoritatively absent.
4. If the marker still exists after the budget is gone, or a non-retryable error is raised, fail closed.

The retry predicate lives in a new module-level `_is_retryable_archive_error(exc)` helper that inspects the wrapped `ClientError.response["Error"]["Code"]` for the canonical 5xx / throttling codes (`InternalError`, `RequestTimeout`, `ServiceUnavailable`, `SlowDown`, `ThrottlingException`, `TooManyRequests`, `TransientError`) and falls back to retrying the entire `BotoCoreError` family. 4xx errors are not retried.

## How it was tested?

```
$ uv run pytest tests/unit_tests/services/retention/workflow_run/ -o addopts="
154 passed
```

11 new tests in `test_delete_marker_41620.py`. All 154 pre-existing tests in the retention suite still pass.

`ruff check` / `ruff format --check` clean, `pyrefly` 0 errors, `importlinter` 25 kept / 0 broken.

Scoped to `_delete_marker` only. Does not alter global S3/R2 or botocore retry configuration.