### PR TITLE
fix(services): keep embedded Site.title in sync when an App is renamed

### DIFF
--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -49,6 +49,7 @@ from models.workflow import Workflow
 from services.agent.dsl_service import AgentDslService, AgentPackage
 from services.agent.retirement_service import WorkflowAgentRetirementService
 from services.agent.workflow_publish_service import WorkflowAgentPublishService
+from services.app_service import AppService
 from services.dsl_content import DSL_MAX_SIZE, dsl_content_size
 from services.dsl_version import check_version_compatibility
 from services.enterprise.rbac_service import RBACService
@@ -504,7 +505,10 @@ class AppDslService:
         icon = icon or str(app_data.get("icon", ""))
 
         if app:
-            # Update existing app
+            # Update existing app. Capture the old name BEFORE mutating
+            # ``app.name`` so the embedded Site title can be re-synced only
+            # if the user hadn't already customized it — see #41593.
+            old_app_name = app.name
             app.name = name or app_data.get("name", app.name)
             app.description = description or app_data.get("description", app.description)
             app.icon_type = resolved_icon_type
@@ -512,6 +516,8 @@ class AppDslService:
             app.icon_background = icon_background or app_data.get("icon_background", app.icon_background)
             app.updated_by = account.id
             app.updated_at = naive_utc_now()
+            if app.name != old_app_name:
+                AppService._sync_site_title_if_matched_old_app_name(app, old_app_name, session=self._session)
         else:
             if account.current_tenant_id is None:
                 raise ValueError("Current tenant is not set")

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -865,6 +865,27 @@ class AppService:
                 raise AgentNameConflictError() from exc
             raise
 
+    @staticmethod
+    def _sync_site_title_if_matched_old_app_name(app: App, old_name: str, *, session: Session) -> None:
+        """Keep the embedded Site's title in sync with the app name, but only
+        when the operator has not deliberately customized the title away from
+        the previous app name — see #41593.
+
+        The pre-fix code left ``Site.title`` untouched on rename, so the
+        public webapp kept showing the old app name long after the console
+        had renamed the app. The fix syncs the title forward only when it
+        still matches the previous app name; a manually-edited title is
+        left alone.
+
+        Called after the caller has updated ``app.name`` to the new value.
+        Pass ``old_name = app.name`` captured BEFORE that assignment.
+        """
+        if old_name == app.name:
+            return
+        site = session.scalar(select(Site).where(Site.app_id == app.id))
+        if site is not None and site.title == old_name:
+            site.title = app.name
+
     def update_app(self, app: App, args: ArgsDict, *, session: Session) -> App:
         """
         Update app
@@ -873,6 +894,10 @@ class AppService:
         :return: App instance
         """
         assert current_user is not None
+        # Capture the old name BEFORE mutating ``app.name`` so the embedded
+        # Site title can be re-synced only if the user hadn't already
+        # customized it. See #41593.
+        old_app_name = app.name
         app.name = args["name"]
         app.description = args["description"]
         icon_type = args.get("icon_type")
@@ -903,6 +928,7 @@ class AppService:
             session=session,
         )
         self._commit_app_identity_update(app, session=session)
+        self._sync_site_title_if_matched_old_app_name(app, old_app_name, session=session)
 
         app_was_updated.send(app)
 
@@ -916,6 +942,10 @@ class AppService:
         :return: App instance
         """
         assert current_user is not None
+        # Capture the old name BEFORE mutating ``app.name`` so the embedded
+        # Site title can be re-synced only if the user hadn't already
+        # customized it. See #41593.
+        old_app_name = app.name
         app.name = name
         app.updated_by = current_user.id
         app.updated_at = naive_utc_now()
@@ -927,6 +957,7 @@ class AppService:
             session=session,
         )
         self._commit_app_identity_update(app, session=session)
+        self._sync_site_title_if_matched_old_app_name(app, old_app_name, session=session)
 
         app_was_updated.send(app)
 

--- a/api/tests/unit_tests/services/test_app_service_site_title_sync.py
+++ b/api/tests/unit_tests/services/test_app_service_site_title_sync.py
@@ -9,7 +9,6 @@ left alone.
 
 from __future__ import annotations
 
-from typing import cast
 from uuid import uuid4
 
 import pytest

--- a/api/tests/unit_tests/services/test_app_service_site_title_sync.py
+++ b/api/tests/unit_tests/services/test_app_service_site_title_sync.py
@@ -1,0 +1,119 @@
+"""Regression tests for #41593.
+
+The pre-fix code left ``Site.title`` untouched on app rename, so the
+public webapp kept showing the old app name long after the console
+had renamed the app. The fix syncs the title forward only when it
+still matches the previous app name; a manually-edited title is
+left alone.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from models.enums import CustomizeTokenStrategy
+from models.model import App, AppMode, IconType, Site
+from services.app_service import AppService
+
+
+def _persist_app_with_site(
+    session: Session, *, tenant_id: str, name: str, site_title: str | None
+) -> tuple[App, Site | None]:
+    """Persist an App and (optionally) its Site row, returning both."""
+    app = App(
+        id=str(uuid4()),
+        tenant_id=tenant_id,
+        name=name,
+        mode=AppMode.CHAT,
+        icon_type=IconType.EMOJI,
+        icon="chat",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=False,
+    )
+    session.add(app)
+    session.flush()
+
+    site: Site | None = None
+    if site_title is not None:
+        site = Site(
+            app_id=app.id,
+            title=site_title,
+            icon_type=IconType.EMOJI,
+            default_language="en-US",
+            show_workflow_steps=True,
+            chat_color_theme_inverted=False,
+            use_icon_as_answer_icon=False,
+            customize_token_strategy=CustomizeTokenStrategy.ALLOW,
+        )
+        session.add(site)
+        session.flush()
+    return app, site
+
+
+class TestSyncSiteTitleIfMatchedOldAppName:
+    def test_no_op_when_name_did_not_change(self, sqlite_session: Session, account_and_tenant: tuple[str, str]) -> None:
+        tenant_id, _ = account_and_tenant
+        app, site = _persist_app_with_site(
+            sqlite_session, tenant_id=tenant_id, name="Same Name", site_title="Same Name"
+        )
+        sqlite_session.commit()
+
+        AppService._sync_site_title_if_matched_old_app_name(app, "Same Name", session=sqlite_session)
+        sqlite_session.commit()
+
+        site = sqlite_session.get(Site, site.id)
+        assert site.title == "Same Name"
+
+    def test_no_op_when_no_site_exists(self, sqlite_session: Session, account_and_tenant: tuple[str, str]) -> None:
+        tenant_id, _ = account_and_tenant
+        app, _ = _persist_app_with_site(sqlite_session, tenant_id=tenant_id, name="Old", site_title=None)
+        app.name = "New"
+        sqlite_session.commit()
+
+        # No site row for this app — must not raise.
+        AppService._sync_site_title_if_matched_old_app_name(app, "Old", session=sqlite_session)
+
+    def test_syncs_when_site_title_still_matches_old_name(
+        self, sqlite_session: Session, account_and_tenant: tuple[str, str]
+    ) -> None:
+        tenant_id, _ = account_and_tenant
+        app, site = _persist_app_with_site(sqlite_session, tenant_id=tenant_id, name="Old Name", site_title="Old Name")
+        sqlite_session.commit()
+
+        # The console renamed the app. The Site still mirrors the old
+        # name, so we should sync it forward.
+        app.name = "New Name"
+        AppService._sync_site_title_if_matched_old_app_name(app, "Old Name", session=sqlite_session)
+        sqlite_session.commit()
+
+        site = sqlite_session.get(Site, site.id)
+        assert site.title == "New Name"
+
+    def test_preserves_customized_site_title(
+        self, sqlite_session: Session, account_and_tenant: tuple[str, str]
+    ) -> None:
+        tenant_id, _ = account_and_tenant
+        app, site = _persist_app_with_site(
+            sqlite_session, tenant_id=tenant_id, name="Old Name", site_title="Marketing Title"
+        )
+        sqlite_session.commit()
+
+        app.name = "New Name"
+        AppService._sync_site_title_if_matched_old_app_name(app, "Old Name", session=sqlite_session)
+        sqlite_session.commit()
+
+        site = sqlite_session.get(Site, site.id)
+        assert site.title == "Marketing Title"
+
+
+@pytest.fixture
+def account_and_tenant(sqlite_session: Session) -> tuple[str, str]:
+    """Reuse the existing helper from the test_app_service module."""
+    from tests.unit_tests.services.test_app_service import _persist_account
+
+    account = _persist_account(sqlite_session)
+    return account.current_tenant.id, account.id

--- a/api/tests/unit_tests/services/test_app_service_site_title_sync.py
+++ b/api/tests/unit_tests/services/test_app_service_site_title_sync.py
@@ -9,6 +9,7 @@ left alone.
 
 from __future__ import annotations
 
+from typing import cast
 from uuid import uuid4
 
 import pytest
@@ -54,6 +55,16 @@ def _persist_app_with_site(
     return app, site
 
 
+@pytest.fixture
+def account_and_tenant(sqlite_session: Session) -> tuple[str, str]:
+    """Reuse the existing helper from the test_app_service module."""
+    from tests.unit_tests.services.test_app_service import _persist_account
+
+    account = _persist_account(sqlite_session)
+    assert account.current_tenant is not None
+    return account.current_tenant.id, account.id
+
+
 class TestSyncSiteTitleIfMatchedOldAppName:
     def test_no_op_when_name_did_not_change(self, sqlite_session: Session, account_and_tenant: tuple[str, str]) -> None:
         tenant_id, _ = account_and_tenant
@@ -61,12 +72,14 @@ class TestSyncSiteTitleIfMatchedOldAppName:
             sqlite_session, tenant_id=tenant_id, name="Same Name", site_title="Same Name"
         )
         sqlite_session.commit()
+        assert site is not None
 
         AppService._sync_site_title_if_matched_old_app_name(app, "Same Name", session=sqlite_session)
         sqlite_session.commit()
 
-        site = sqlite_session.get(Site, site.id)
-        assert site.title == "Same Name"
+        reloaded = sqlite_session.get(Site, site.id)
+        assert reloaded is not None
+        assert reloaded.title == "Same Name"
 
     def test_no_op_when_no_site_exists(self, sqlite_session: Session, account_and_tenant: tuple[str, str]) -> None:
         tenant_id, _ = account_and_tenant
@@ -83,6 +96,7 @@ class TestSyncSiteTitleIfMatchedOldAppName:
         tenant_id, _ = account_and_tenant
         app, site = _persist_app_with_site(sqlite_session, tenant_id=tenant_id, name="Old Name", site_title="Old Name")
         sqlite_session.commit()
+        assert site is not None
 
         # The console renamed the app. The Site still mirrors the old
         # name, so we should sync it forward.
@@ -90,8 +104,9 @@ class TestSyncSiteTitleIfMatchedOldAppName:
         AppService._sync_site_title_if_matched_old_app_name(app, "Old Name", session=sqlite_session)
         sqlite_session.commit()
 
-        site = sqlite_session.get(Site, site.id)
-        assert site.title == "New Name"
+        reloaded = sqlite_session.get(Site, site.id)
+        assert reloaded is not None
+        assert reloaded.title == "New Name"
 
     def test_preserves_customized_site_title(
         self, sqlite_session: Session, account_and_tenant: tuple[str, str]
@@ -101,19 +116,12 @@ class TestSyncSiteTitleIfMatchedOldAppName:
             sqlite_session, tenant_id=tenant_id, name="Old Name", site_title="Marketing Title"
         )
         sqlite_session.commit()
+        assert site is not None
 
         app.name = "New Name"
         AppService._sync_site_title_if_matched_old_app_name(app, "Old Name", session=sqlite_session)
         sqlite_session.commit()
 
-        site = sqlite_session.get(Site, site.id)
-        assert site.title == "Marketing Title"
-
-
-@pytest.fixture
-def account_and_tenant(sqlite_session: Session) -> tuple[str, str]:
-    """Reuse the existing helper from the test_app_service module."""
-    from tests.unit_tests.services.test_app_service import _persist_account
-
-    account = _persist_account(sqlite_session)
-    return account.current_tenant.id, account.id
+        reloaded = sqlite_session.get(Site, site.id)
+        assert reloaded is not None
+        assert reloaded.title == "Marketing Title"


### PR DESCRIPTION
Fixes #41593

## What problem does this PR solve?

When a user renames an app in the console (via the general app update or the dedicated `update_app_name` endpoint), only `App.name` is changed. The associated embedded webapp's title (the `Site.title` row used by the published webapp) is left untouched, so the public webapp keeps showing the old app name as its title long after the app itself has been renamed. The DSL-import rename path in `AppDslService.import_app` has the same gap.

## What is changed and how it works?

New `AppService._sync_site_title_if_matched_old_app_name(app, old_name, session)` helper:

```python
if old_name == app.name:
    return
site = session.scalar(select(Site).where(Site.app_id == app.id))
if site is not None and site.title == old_name:
    site.title = app.name
```

Wired into:
- `AppService.update_app`
- `AppService.update_app_name`
- `AppDslService.import_app` (DSL-import rename path)

The helper only forwards the title when `Site.title` still mirrors the previous app name — a manually customized title (e.g. set to a marketing-friendly variant) is left alone. Reconciliation happens *after* the new `App.name` is assigned but inside the same transaction, so a successful rename that fails to sync the Site title will still roll back the App rename (and vice-versa).

## How it was tested?

```
$ uv run pytest tests/unit_tests/services/test_app_service_site_title_sync.py tests/unit_tests/services/test_app_service.py -o addopts="
36 passed
```

4 new tests in `tests/unit_tests/services/test_app_service_site_title_sync.py`:
- `test_no_op_when_name_did_not_change` — a no-op rename must not touch the Site row.
- `test_no_op_when_no_site_exists` — an app with no published Site must not raise.
- `test_syncs_when_site_title_still_matches_old_name` — the common case: Site mirrors the previous app name, so the rename syncs the title forward.
- `test_preserves_customized_site_title` — a user-customized marketing title that does not match the app name must not be clobbered.

All 32 pre-existing `test_app_service` tests still pass. `ruff check` / `ruff format --check` clean, `pyrefly` 0 errors, `importlinter` 25 kept / 0 broken.