### PR TITLE
fix(database): apply LOG_TZ to SQLAlchemy engine logger timestamps

### DIFF
--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -4,6 +4,7 @@ import gevent
 from sqlalchemy import event
 from sqlalchemy.pool import Pool
 
+from configs import dify_config
 from dify_app import DifyApp
 from models.engine import db
 
@@ -60,3 +61,57 @@ def init_app(app: DifyApp):
             _ = db.engine  # triggers engine creation with the configured options
     except Exception:
         logger.exception("Failed to initialize SQLAlchemy engine during app startup")
+
+    # Mirror ext_logging._apply_timezone on the SQLAlchemy logger hierarchy
+    # so engine/pool/dialect log timestamps honor dify_config.LOG_TZ.
+    _apply_timezone_to_sqlalchemy_loggers()
+
+
+def _apply_timezone_to_sqlalchemy_loggers() -> None:
+    """Apply LOG_TZ to every handler on the ``sqlalchemy`` logger tree.
+
+    SQLAlchemy attaches its own ``StreamHandler`` to ``sqlalchemy.engine``
+    (and descendants like ``sqlalchemy.pool`` / ``sqlalchemy.engine.Engine``)
+    when ``echo=True`` is enabled. Those handlers use a default
+    ``logging.Formatter`` whose ``converter`` is ``time.localtime``, which
+    ignores ``dify_config.LOG_TZ`` and yields timestamps that disagree
+    with the rest of the application log stream.
+
+    This helper walks the SQLAlchemy logger hierarchy and rewrites the
+    ``converter`` on every handler's formatter, mirroring the pattern in
+    ``ext_logging._apply_timezone``.
+
+    A no-op when ``LOG_TZ`` is unset or when SQLAlchemy has not yet
+    attached any handlers (e.g. ``echo`` is not enabled). The eager
+    engine build in ``init_app`` makes the common case (engine logger
+    with a handler) visible to this helper; handlers attached later
+    (e.g. when ``echo`` is toggled at runtime) will need another call.
+    """
+    log_tz = dify_config.LOG_TZ
+    if not log_tz:
+        return
+
+    from datetime import datetime
+
+    import pytz
+
+    timezone = pytz.timezone(log_tz)
+
+    def time_converter(seconds: float):
+        return datetime.fromtimestamp(seconds, tz=timezone).timetuple()
+
+    sqla_logger = logging.getLogger("sqlalchemy")
+    for descendant in _iter_logger_descendants(sqla_logger):
+        for handler in descendant.handlers:
+            formatter = handler.formatter
+            if formatter is not None and hasattr(formatter, "converter"):
+                formatter.converter = time_converter  # type: ignore[attr-defined]
+
+
+def _iter_logger_descendants(root: logging.Logger):
+    """Yield ``root`` and every ``logging.Logger`` whose name starts with ``root.name + '.'``."""
+    prefix = root.name + "."
+    yield root
+    for name, child in list(root.manager.loggerDict.items()):
+        if isinstance(child, logging.Logger) and name.startswith(prefix):
+            yield child

--- a/api/tests/unit_tests/extensions/test_ext_database.py
+++ b/api/tests/unit_tests/extensions/test_ext_database.py
@@ -1,0 +1,147 @@
+"""Tests for the SQLAlchemy LOG_TZ timestamp fix (issue #41594)."""
+
+import logging
+from contextlib import contextmanager
+from datetime import datetime
+from unittest.mock import patch
+
+import pytz
+
+from extensions.ext_database import _apply_timezone_to_sqlalchemy_loggers
+
+
+@contextmanager
+def _track_handler(logger_name, fmt="%(asctime)s [%(levelname)s] %(message)s"):
+    """Attach a fresh NullHandler to ``logger_name`` and yield it.
+
+    Removes the handler on teardown so tests do not leak.
+    """
+    logger = logging.getLogger(logger_name)
+    handler = logging.NullHandler()
+    handler.setFormatter(logging.Formatter(fmt))
+    logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_apply_timezone_no_op_when_log_tz_unset():
+    """No handlers touched when LOG_TZ is empty/None."""
+    with _track_handler("sqlalchemy.engine") as handler:
+        original_converter = handler.formatter.converter
+        with patch("configs.dify_config.LOG_TZ", None):
+            _apply_timezone_to_sqlalchemy_loggers()
+        assert handler.formatter.converter is original_converter
+
+
+def test_apply_timezone_no_op_when_log_tz_empty_string():
+    """Empty-string LOG_TZ is treated the same as None."""
+    with _track_handler("sqlalchemy.engine") as handler:
+        original_converter = handler.formatter.converter
+        with patch("configs.dify_config.LOG_TZ", ""):
+            _apply_timezone_to_sqlalchemy_loggers()
+        assert handler.formatter.converter is original_converter
+
+
+def test_apply_timezone_sets_converter_on_sqlalchemy_engine_logger():
+    """Handler on ``sqlalchemy.engine`` gets the LOG_TZ-aware converter."""
+    with _track_handler("sqlalchemy.engine") as handler:
+        original_converter = handler.formatter.converter
+        with patch("configs.dify_config.LOG_TZ", "Asia/Tokyo"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        new_converter = handler.formatter.converter
+        assert new_converter is not original_converter
+        # The converter should produce a Tokyo-timezone struct_time
+        struct = new_converter(0.0)  # 1970-01-01 00:00:00 UTC
+        assert datetime.fromtimestamp(0, tz=pytz.timezone("Asia/Tokyo")).timetuple() == struct
+
+
+def test_apply_timezone_walks_descendant_loggers():
+    """``sqlalchemy.pool`` (a child of ``sqlalchemy``) also gets the converter."""
+    with _track_handler("sqlalchemy.pool") as handler:
+        original_converter = handler.formatter.converter
+        with patch("configs.dify_config.LOG_TZ", "Europe/Berlin"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        assert handler.formatter.converter is not original_converter
+
+
+def test_apply_timezone_preserves_format_string():
+    """Setting the converter must not change the format string."""
+    fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    with _track_handler("sqlalchemy.engine", fmt=fmt) as handler:
+        with patch("configs.dify_config.LOG_TZ", "UTC"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        assert handler.formatter._fmt == fmt
+
+
+def test_apply_timezone_no_handlers_is_safe():
+    """Calling when no SQLAlchemy logger has handlers is a no-op (no errors)."""
+    with patch("configs.dify_config.LOG_TZ", "America/New_York"):
+        # Should not raise even though no SQLAlchemy loggers have handlers
+        _apply_timezone_to_sqlalchemy_loggers()
+
+
+def test_apply_timezone_uses_log_tz_offset_correctly():
+    """Sanity-check the converter: same UTC instant, different tz labels."""
+    with _track_handler("sqlalchemy.engine") as handler:
+        with patch("configs.dify_config.LOG_TZ", "Asia/Tokyo"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        tokyo = handler.formatter.converter(0.0)
+
+    with _track_handler("sqlalchemy.engine") as handler:
+        with patch("configs.dify_config.LOG_TZ", "UTC"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        utc = handler.formatter.converter(0.0)
+
+    # Tokyo is UTC+9, so 1970-01-01 00:00:00 UTC == 1970-01-01 09:00:00 Tokyo
+    assert tokyo.tm_hour == 9
+    assert utc.tm_hour == 0
+    assert tokyo.tm_year == utc.tm_year
+    assert tokyo.tm_yday == utc.tm_yday
+
+
+def test_apply_timezone_is_idempotent():
+    """Running the helper twice must not error and should keep the converter."""
+    with _track_handler("sqlalchemy.engine") as handler:
+        with patch("configs.dify_config.LOG_TZ", "Europe/London"):
+            _apply_timezone_to_sqlalchemy_loggers()
+            first_converter = handler.formatter.converter
+            first_output = first_converter(0.0)
+            _apply_timezone_to_sqlalchemy_loggers()
+            second_converter = handler.formatter.converter
+            second_output = second_converter(0.0)
+        # Behavioural equivalence: the converter is rebuilt on each call
+        # (a fresh closure), so identity is not preserved — but the
+        # output for the same instant must match.
+        assert first_output == second_output
+
+
+def test_apply_timezone_skips_non_sqlalchemy_loggers():
+    """Loggers whose name only happens to start with the same bytes stay untouched."""
+    with _track_handler("sqlalchemyish") as handler:
+        original_converter = handler.formatter.converter
+        with patch("configs.dify_config.LOG_TZ", "Asia/Tokyo"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        assert handler.formatter.converter is original_converter
+
+
+def test_apply_timezone_handlers_attached_after_call_stay_unset():
+    """Documented behavior: a handler attached after the helper runs is not updated.
+
+    Callers who toggle ``echo`` at runtime need to re-run the helper.
+    """
+    with patch("configs.dify_config.LOG_TZ", "Asia/Tokyo"):
+        _apply_timezone_to_sqlalchemy_loggers()
+    with _track_handler("sqlalchemy.engine") as handler:
+        original_converter = handler.formatter.converter
+        with patch("configs.dify_config.LOG_TZ", "Asia/Tokyo"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        # The handler was attached after the first call, so the second
+        # call is what updates it.
+        assert handler.formatter.converter is not original_converter
+        # A third call from a different LOG_TZ updates it again.
+        with patch("configs.dify_config.LOG_TZ", "UTC"):
+            _apply_timezone_to_sqlalchemy_loggers()
+        third_converter = handler.formatter.converter
+        assert third_converter is not original_converter


### PR DESCRIPTION
## Summary

Fixes #41594.

When SQLAlchemy is configured with `echo=True`, it attaches a default `StreamHandler` to the `sqlalchemy.engine` logger (and descendants like `sqlalchemy.pool`, `sqlalchemy.engine.Engine`). That handler's default `Formatter` uses `time.localtime` as its timestamp converter, which ignores `dify_config.LOG_TZ`. As a result, SQL/engine log records carry timestamps in the server's default timezone while the surrounding application logs are already converted to the configured timezone — producing inconsistent, hard-to-correlate timestamps within a single log stream.

The rest of the platform already honors `LOG_TZ`: `ext_logging._apply_timezone` walks every application handler and sets `formatter.converter` to a `LOG_TZ`-aware callable. This PR applies the same pattern to the SQLAlchemy logger hierarchy.

## Fix

`api/extensions/ext_database.py`: add a private helper that walks the `sqlalchemy` logger tree and rewrites the converter on each handler's formatter, then call it at the end of `init_app()`. The eager engine build already in `init_app` materializes the common case (`echo=True` → `sqlalchemy.engine` already has a handler) so the helper sees the live handlers.

```python
def _apply_timezone_to_sqlalchemy_loggers() -> None:
    log_tz = dify_config.LOG_TZ
    if not log_tz:
        return
    from datetime import datetime
    import pytz
    timezone = pytz.timezone(log_tz)
    def time_converter(seconds: float):
        return datetime.fromtimestamp(seconds, tz=timezone).timetuple()
    sqla_logger = logging.getLogger("sqlalchemy")
    for descendant in _iter_logger_descendants(sqla_logger):
        for handler in descendant.handlers:
            formatter = handler.formatter
            if formatter is not None and hasattr(formatter, "converter"):
                formatter.converter = time_converter
```

`_iter_logger_descendants` walks the flat `manager.loggerDict` and yields every logger whose name starts with `sqlalchemy.`, then yields the root. The `hasattr(formatter, "converter")` guard is defensive against formatter subclasses that use `__slots__` and would raise on attribute assignment.

## Tests

10 new tests in `api/tests/unit_tests/extensions/test_ext_database.py`:

- `test_apply_timezone_no_op_when_log_tz_unset` — `LOG_TZ=None` leaves handlers untouched.
- `test_apply_timezone_no_op_when_log_tz_empty_string` — same, for empty string.
- `test_apply_timezone_sets_converter_on_sqlalchemy_engine_logger` — the converter is replaced and produces a TZ-aware `struct_time` (verified against `Asia/Tokyo`).
- `test_apply_timezone_walks_descendant_loggers` — `sqlalchemy.pool` (a child) gets the converter.
- `test_apply_timezone_preserves_format_string` — only `converter` is rewritten, the format string is untouched.
- `test_apply_timezone_no_handlers_is_safe` — calling when no SQLAlchemy logger has handlers does not raise.
- `test_apply_timezone_uses_log_tz_offset_correctly` — same UTC instant, different `LOG_TZ` values produce different `tm_hour` (Tokyo=9, UTC=0).
- `test_apply_timezone_is_idempotent` — calling twice is safe and behaviorally equivalent.
- `test_apply_timezone_skips_non_sqlalchemy_loggers` — loggers whose name only happens to start with the same bytes (e.g. `sqlalchemyish`) are not touched.
- `test_apply_timezone_handlers_attached_after_call_stay_unset` — pins the documented behavior: handlers attached after `init_app` need another call.

## Scope

Single-bug fix in `api/extensions/ext_database.py` plus targeted tests in the existing `extensions` test area. The fix mirrors the existing `ext_logging._apply_timezone` pattern, does not introduce new abstractions, and only mutates `formatter.converter` on handlers under the `sqlalchemy` namespace.

## Out of scope (called out for transparency)

- Moving the helper into `ext_logging.py` as a generic `_apply_timezone_to_logger_tree(root_name)` for cohesion. Kept narrow for the maintainer preference; trivial follow-up if desired.
- Auto-updating handlers attached after `init_app` (e.g. when `echo` is toggled at runtime). The current fix is sufficient for the common case; later handlers would need an additional call. The last test pins this behavior so future contributors see it.
- SQLAlchemy formatters that override `formatTime` and ignore `converter`. Out of scope; standard `logging.Formatter` is the only path used today.

## Verification

- `uv run ruff check` on changed files: clean.
- `uv run ruff format --check` on changed files: 2 files already formatted.
- Targeted pytest on `test_ext_database.py`: 10/10 pass.
- Pre-fix regression check: tests fail at collection (helper does not exist), confirming the tests pin the new function.

Fixes #41594
