### PR TITLE
fix(schedule): avoid leaking Redis connections when dispatching triggers

### DIFF
--- a/api/schedule/workflow_schedule_task.py
+++ b/api/schedule/workflow_schedule_task.py
@@ -1,6 +1,6 @@
 import logging
 
-from celery import current_app, group, shared_task
+from celery import current_app, shared_task
 from sqlalchemy import and_, select
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -102,8 +102,8 @@ def _process_schedules(session: Session, schedules: list[WorkflowSchedulePlan], 
         tasks_to_dispatch.append(schedule.id)
 
     if tasks_to_dispatch:
-        job = group(run_schedule_trigger.s(schedule_id) for schedule_id in tasks_to_dispatch)
-        job.apply_async(producer=producer)
+        for schedule_id in tasks_to_dispatch:
+            run_schedule_trigger.s(schedule_id).apply_async(producer=producer)
 
         logger.debug("Dispatched %d tasks in parallel", len(tasks_to_dispatch))
 

--- a/api/tests/test_containers_integration_tests/trigger/conftest.py
+++ b/api/tests/test_containers_integration_tests/trigger/conftest.py
@@ -105,49 +105,20 @@ def app_model(
     db_session_with_containers.commit()
 
 
-class MockCeleryGroup:
-    """Mock for celery group() function that collects dispatched tasks.
+class MockCelerySignature:
+    """Mock for celery task signature that collects dispatched tasks."""
 
-    Matches the Celery group API loosely, accepting arbitrary kwargs on apply_async
-    (e.g. producer) so production code can pass broker-related options without
-    breaking tests.
-    """
+    def __init__(self, dispatched: list[dict[str, Any]] | None = None) -> None:
+        self.schedule_id: str | None = None
+        self.dispatched = dispatched if dispatched is not None else []
 
-    def __init__(self) -> None:
-        self.collected: list[dict[str, Any]] = []
-        self._applied = False
-        self.last_apply_async_kwargs: dict[str, Any] | None = None
-
-    def __call__(self, items: Any) -> MockCeleryGroup:
-        self.collected = list(items)
-        return self
+    def s(self, schedule_id: str) -> MockCelerySignature:
+        signature = MockCelerySignature(self.dispatched)
+        signature.schedule_id = schedule_id
+        return signature
 
     def apply_async(self, **kwargs: Any) -> None:
-        # Accept arbitrary kwargs like producer to be compatible with Celery
-        self._applied = True
-        self.last_apply_async_kwargs = kwargs
-
-    @property
-    def applied(self) -> bool:
-        return self._applied
-
-
-class MockCelerySignature:
-    """Mock for celery task signature that returns task info dict."""
-
-    def s(self, schedule_id: str) -> dict[str, str]:
-        return {"schedule_id": schedule_id}
-
-
-@pytest.fixture
-def mock_celery_group() -> MockCeleryGroup:
-    """
-    Provide a mock celery group for testing task dispatch.
-
-    Returns:
-        MockCeleryGroup: Mock group that collects dispatched tasks
-    """
-    return MockCeleryGroup()
+        self.dispatched.append({"schedule_id": self.schedule_id, **kwargs})
 
 
 @pytest.fixture

--- a/api/tests/test_containers_integration_tests/trigger/test_trigger_e2e.py
+++ b/api/tests/test_containers_integration_tests/trigger/test_trigger_e2e.py
@@ -47,7 +47,7 @@ from services.trigger.schedule_service import ScheduleService
 from services.workflow_service import WorkflowService
 from tasks import trigger_processing_tasks
 
-from .conftest import MockCeleryGroup, MockCelerySignature, MockPluginSubscription
+from .conftest import MockCelerySignature, MockPluginSubscription
 
 # Test constants
 WEBHOOK_ID_PRODUCTION = "wh1234567890123456789012"
@@ -242,12 +242,11 @@ def test_schedule_poll_dispatches_due_plan(
     db_session_with_containers: Session,
     tenant_and_account: tuple[Tenant, Account],
     app_model: App,
-    mock_celery_group: MockCeleryGroup,
     mock_celery_signature: MockCelerySignature,
     monkeypatch: pytest.MonkeyPatch,
     schedule_type: str,
 ) -> None:
-    """Schedule plans (both visual and cron) should be polled and dispatched when due."""
+    """Schedule plans (both visual and cron) should be dispatched independently."""
     tenant, _ = tenant_and_account
 
     app_trigger = AppTrigger(
@@ -271,14 +270,12 @@ def test_schedule_poll_dispatches_due_plan(
 
     next_time = naive_utc_now() + timedelta(hours=1)
     monkeypatch.setattr(workflow_schedule_task, "calculate_next_run_at", lambda *_args, **_kwargs: next_time)
-    monkeypatch.setattr(workflow_schedule_task, "group", mock_celery_group)
     monkeypatch.setattr(workflow_schedule_task, "run_schedule_trigger", mock_celery_signature)
 
     poll_workflow_schedules()
 
-    assert mock_celery_group.collected, f"Should dispatch signatures for due {schedule_type} schedules"
-    scheduled_ids = {sig["schedule_id"] for sig in mock_celery_group.collected}
-    assert plan.id in scheduled_ids
+    dispatched = [item for item in mock_celery_signature.dispatched if isinstance(item, dict)]
+    assert any(item["schedule_id"] == plan.id for item in dispatched)
 
 
 def test_schedule_visual_debug_poll_generates_event(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Dispatch scheduled workflow triggers individually instead of creating an unused Celery group result, preventing the result-consumer Redis connection from remaining open after scheduled executions.

Fixes #41578

## Screenshots

| Before | After |
| ------ | ----- |
| Not applicable; backend-only change | Not applicable; backend-only change |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods