### PR TITLE
fix(api): apply LOG_FORMAT and LOG_TZ to SQLAlchemy engine log handlers

### DIFF
--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -5,6 +5,7 @@ from sqlalchemy import event
 from sqlalchemy.pool import Pool
 
 from dify_app import DifyApp
+from extensions.ext_logging import apply_log_config_to_sqlalchemy_handlers
 from models.engine import db
 
 logger = logging.getLogger(__name__)
@@ -60,3 +61,7 @@ def init_app(app: DifyApp):
             _ = db.engine  # triggers engine creation with the configured options
     except Exception:
         logger.exception("Failed to initialize SQLAlchemy engine during app startup")
+
+    # Engine creation is what installs SQLAlchemy's own log handler when echo is enabled,
+    # so the configured log format and timezone can only be applied to it from here.
+    apply_log_config_to_sqlalchemy_handlers()

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -9,6 +9,9 @@ from typing import override
 from configs import dify_config
 from dify_app import DifyApp
 
+# Loggers SQLAlchemy emits engine/SQL records through when ``SQLALCHEMY_ECHO`` is enabled.
+_SQLALCHEMY_LOGGER_NAMES = ("sqlalchemy.engine", "sqlalchemy.engine.Engine")
+
 
 def init_app(app: DifyApp):
     """Initialize logging with support for text or JSON format."""
@@ -56,6 +59,31 @@ def init_app(app: DifyApp):
     # Apply timezone if specified (only for text format)
     if dify_config.LOG_OUTPUT_FORMAT == "text":
         _apply_timezone(log_handlers)
+
+
+def apply_log_config_to_sqlalchemy_handlers():
+    """Align SQLAlchemy's own log handlers with the configured log format and timezone.
+
+    When ``SQLALCHEMY_ECHO`` is enabled, SQLAlchemy installs a stdout handler with a hardcoded
+    formatter on the engine logger (see ``sqlalchemy.log.InstanceLogger``). That formatter never
+    goes through ``init_app``, so emitted-SQL records ignore ``LOG_FORMAT`` and ``LOG_TZ`` and end
+    up with timestamps that cannot be correlated with the surrounding application logs.
+
+    This must run after the engine has been created, since the handler does not exist before then.
+    It is a no-op when echo is disabled, because SQLAlchemy installs no handler in that case.
+    """
+    formatter = _create_formatter()
+    handlers = [
+        handler for logger_name in _SQLALCHEMY_LOGGER_NAMES for handler in logging.getLogger(logger_name).handlers
+    ]
+    if not handlers:
+        return
+
+    for handler in handlers:
+        handler.setFormatter(formatter)
+
+    if dify_config.LOG_OUTPUT_FORMAT == "text":
+        _apply_timezone(handlers)
 
 
 def _create_formatter() -> logging.Formatter:

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -1,0 +1,65 @@
+import logging
+import sys
+from datetime import datetime
+
+import pytest
+import pytz
+
+from configs import dify_config
+from extensions.ext_logging import apply_log_config_to_sqlalchemy_handlers
+
+_SQLALCHEMY_ENGINE_LOGGER = "sqlalchemy.engine.Engine"
+
+
+@pytest.fixture
+def sqlalchemy_engine_handler():
+    """Install the same kind of handler SQLAlchemy adds when ``SQLALCHEMY_ECHO`` is enabled."""
+    logger = logging.getLogger(_SQLALCHEMY_ENGINE_LOGGER)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_apply_log_config_to_sqlalchemy_handlers_applies_format_and_timezone(
+    sqlalchemy_engine_handler: logging.Handler, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(dify_config, "LOG_OUTPUT_FORMAT", "text")
+    monkeypatch.setattr(dify_config, "LOG_TZ", "Asia/Tokyo")
+
+    apply_log_config_to_sqlalchemy_handlers()
+
+    formatter = sqlalchemy_engine_handler.formatter
+    assert formatter is not None
+    assert formatter._fmt == dify_config.LOG_FORMAT
+
+    # The converter must report the configured timezone rather than the server default.
+    seconds = datetime(2026, 1, 1, 12, 0, 0, tzinfo=pytz.utc).timestamp()
+    expected = datetime.fromtimestamp(seconds, tz=pytz.timezone("Asia/Tokyo")).timetuple()
+    assert formatter.converter(seconds) == expected  # type: ignore[misc]
+
+
+def test_apply_log_config_to_sqlalchemy_handlers_without_timezone(
+    sqlalchemy_engine_handler: logging.Handler, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(dify_config, "LOG_OUTPUT_FORMAT", "text")
+    monkeypatch.setattr(dify_config, "LOG_TZ", None)
+
+    apply_log_config_to_sqlalchemy_handlers()
+
+    formatter = sqlalchemy_engine_handler.formatter
+    assert formatter is not None
+    assert formatter._fmt == dify_config.LOG_FORMAT
+
+
+def test_apply_log_config_to_sqlalchemy_handlers_is_noop_without_handlers(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(dify_config, "LOG_OUTPUT_FORMAT", "text")
+    monkeypatch.setattr(dify_config, "LOG_TZ", "Asia/Tokyo")
+
+    # No handler is installed when echo is disabled, so nothing should be touched or raised.
+    apply_log_config_to_sqlalchemy_handlers()
+
+    assert logging.getLogger(_SQLALCHEMY_ENGINE_LOGGER).handlers == []


### PR DESCRIPTION
### Summary

Fixes #41594.

When `SQLALCHEMY_ECHO` is enabled, SQLAlchemy installs its own stdout handler with a hardcoded formatter on the engine logger (`sqlalchemy.log.InstanceLogger.__init__` → `_add_default_handler`). That handler never goes through `ext_logging.init_app`, so emitted-SQL records ignore `LOG_FORMAT` and `LOG_TZ` and carry timestamps in the server's default timezone while the surrounding application and Celery logs are already converted — the inconsistent, hard-to-correlate timestamps reported in the issue.

### What changed

- `extensions/ext_logging.py`: new `apply_log_config_to_sqlalchemy_handlers()` that applies the configured formatter, and the `LOG_TZ` converter, to whatever handlers SQLAlchemy installed on its engine loggers. It returns immediately when there are none.
- `extensions/ext_database.py`: calls it right after the engine is eagerly built, which is the earliest point that handler can exist.

The change is a no-op when `SQLALCHEMY_ECHO` is disabled, since SQLAlchemy installs no handler in that case.

### Tests

`api/tests/unit_tests/extensions/test_ext_logging.py` covers the timezone conversion, the no-`LOG_TZ` case, and the no-handler no-op.

```
pytest api/tests/unit_tests/extensions/test_ext_logging.py  # 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoVYtAzgM9SEUX8nJp1Gv6
