### PR TITLE
fix(api): degrade silently on any invoke error while resolving the suggested-questions model

### DIFF
--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -37,7 +37,7 @@ from graphon.enums import WorkflowNodeExecutionMetadataKey
 from graphon.model_runtime.entities.llm_entities import LLMResult
 from graphon.model_runtime.entities.message_entities import PromptMessage, SystemPromptMessage, UserPromptMessage
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
+from graphon.model_runtime.errors.invoke import InvokeError
 from models import App, Message, WorkflowNodeExecutionModel
 from models.workflow import Workflow
 
@@ -306,7 +306,10 @@ class LLMGenerator:
                     tenant_id=tenant_id,
                     model_type=ModelType.LLM,
                 )
-        except InvokeAuthorizationError:
+        except InvokeError:
+            # Suggested questions are optional, so any model-resolution failure (bad credentials,
+            # unreachable provider, rate limit, malformed model config) degrades silently.
+            logger.debug("Failed to resolve a model for suggested questions", exc_info=True)
             return []
 
         prompt_messages: list[PromptMessage] = [UserPromptMessage(content=prompt)]

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -19,7 +19,13 @@ from graphon.enums import WorkflowNodeExecutionStatus
 from graphon.model_runtime.entities.llm_entities import LLMMode, LLMResult, LLMUsage
 from graphon.model_runtime.entities.message_entities import AssistantPromptMessage
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
+from graphon.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+)
 from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import App, AppMode, Message
 from models.workflow import (
@@ -265,6 +271,20 @@ class TestLLMGenerator:
     def test_generate_suggested_questions_after_answer_auth_error(self, mock_model_instance):
         with patch("core.llm_generator.llm_generator.ModelManager.for_tenant") as mock_manager:
             mock_manager.return_value.get_default_model_instance.side_effect = InvokeAuthorizationError("Auth failed")
+            questions = LLMGenerator.generate_suggested_questions_after_answer("tenant_id", "histories")
+            assert questions == []
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            InvokeConnectionError("Provider unreachable"),
+            InvokeRateLimitError("Rate limited"),
+            InvokeBadRequestError("Malformed model config"),
+        ],
+    )
+    def test_generate_suggested_questions_after_answer_model_resolution_error(self, mock_model_instance, error):
+        with patch("core.llm_generator.llm_generator.ModelManager.for_tenant") as mock_manager:
+            mock_manager.return_value.get_default_model_instance.side_effect = error
             questions = LLMGenerator.generate_suggested_questions_after_answer("tenant_id", "histories")
             assert questions == []
 


### PR DESCRIPTION
### Summary

Fixes #41592.

In `generate_suggested_questions_after_answer`, the model-resolution block caught only `InvokeAuthorizationError`. Resolution can just as easily raise `InvokeConnectionError`, `InvokeRateLimitError` or `InvokeBadRequestError` (provider unreachable, per-tenant rate limit, malformed model config). Those fell through to the broad `except Exception`, which logs the failure with `logger.exception` — so an ordinary, expected condition was reported as an unexpected error instead of following the silent-degradation path the authorization case already used.

Note the issue text says the broad handler re-raises; on `main` it returns `[]`, so the user-visible symptom today is the noisy error log rather than a propagated exception. The handling is still wrong for the same reason.

### What changed

`except InvokeAuthorizationError` → `except InvokeError`, the shared base of all four and the exception this module already catches everywhere else (`:502`, `:564`, `:595`, `:674`, …). The cause is kept at debug level so it can still be investigated.

### Tests

Extended `api/tests/unit_tests/core/llm_generator/test_llm_generator.py` with a parametrized case covering connection, rate-limit, and bad-request errors during model resolution; the existing authorization-error test is unchanged and still passes.

```
pytest api/tests/unit_tests/core/llm_generator/test_llm_generator.py -k suggested_questions  # 10 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoVYtAzgM9SEUX8nJp1Gv6
