### PR TITLE
fix(rag): make automatic metadata filtering work for time-typed fields

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -8,6 +8,7 @@ from collections import Counter, defaultdict
 from collections.abc import Generator, Mapping
 from typing import Any, Union, cast
 
+import dateutil.parser
 from flask import Flask, current_app
 from opentelemetry.trace import get_current_span
 from sqlalchemy import and_, func, literal, or_, select, update
@@ -93,7 +94,7 @@ from models.dataset import (
 )
 from models.dataset import Document as DatasetDocument
 from models.dataset import Document as DocumentModel
-from models.enums import CreatorUserRole, DatasetQuerySource
+from models.enums import CreatorUserRole, DatasetMetadataType, DatasetQuerySource
 from services.external_knowledge_service import ExternalDatasetService
 from services.feature_service import FeatureService
 
@@ -1585,7 +1586,10 @@ class DatasetRetrieval:
         # get all metadata field
         metadata_stmt = select(DatasetMetadata).where(DatasetMetadata.dataset_id.in_(dataset_ids))
         metadata_fields = session.scalars(metadata_stmt).all()
-        all_metadata_fields = [metadata_field.name for metadata_field in metadata_fields]
+        all_metadata_fields = [
+            {"name": metadata_field.name, "type": metadata_field.type} for metadata_field in metadata_fields
+        ]
+        metadata_field_types = {metadata_field.name: metadata_field.type for metadata_field in metadata_fields}
         # get metadata model config
         if metadata_model_config is None:
             raise ValueError("metadata_model_config is required")
@@ -1622,18 +1626,50 @@ class DatasetRetrieval:
             if "metadata_map" in result_text_json:
                 metadata_map = result_text_json["metadata_map"]
                 for item in metadata_map:
-                    if item.get("metadata_field_name") in all_metadata_fields:
-                        automatic_metadata_filters.append(
-                            {
-                                "metadata_name": item.get("metadata_field_name"),
-                                "value": item.get("metadata_field_value"),
-                                "condition": item.get("comparison_operator"),
-                            }
-                        )
+                    metadata_name = item.get("metadata_field_name")
+                    if metadata_name not in metadata_field_types:
+                        continue
+                    condition = item.get("comparison_operator")
+                    value = self._normalize_metadata_filter_value(
+                        metadata_field_types[metadata_name], item.get("metadata_field_value")
+                    )
+                    if value is None and condition not in ("empty", "not empty"):
+                        # A value the model could not express in the stored representation would
+                        # otherwise be compared against a column of another type and fail the query.
+                        continue
+                    automatic_metadata_filters.append(
+                        {
+                            "metadata_name": metadata_name,
+                            "value": value,
+                            "condition": condition,
+                        }
+                    )
         except Exception as e:
             logger.warning(e, exc_info=True)
             return None
         return automatic_metadata_filters
+
+    @staticmethod
+    def _normalize_metadata_filter_value(metadata_type: str, value: Any) -> Any:
+        """Convert a model-produced filter value into the representation stored in ``doc_metadata``.
+
+        ``time`` metadata is persisted as a Unix timestamp, but models answer date questions with a
+        human-readable date such as ``2024-01-01``. Comparing that string against the numeric value
+        makes the query fail, so parse it back into a timestamp. Values that cannot be parsed return
+        ``None`` so the caller can drop the filter instead of building a comparison that errors out.
+        """
+        if metadata_type != DatasetMetadataType.TIME or value is None:
+            return value
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int | float):
+            return value
+
+        try:
+            return dateutil.parser.parse(str(value)).timestamp()
+        except (ValueError, OverflowError):
+            logger.warning("Cannot interpret %r as a time metadata value, ignoring the filter", value)
+            return None
 
     @classmethod
     def process_metadata_filter_func(
@@ -1780,7 +1816,11 @@ class DatasetRetrieval:
         )
 
     def _get_prompt_template(
-        self, model_config: ModelConfigWithCredentialsEntity, mode: str, metadata_fields: list[str], query: str
+        self,
+        model_config: ModelConfigWithCredentialsEntity,
+        mode: str,
+        metadata_fields: list[dict[str, str]],
+        query: str,
     ):
         model_mode = ModelMode(mode)
         input_text = query

--- a/api/core/rag/retrieval/template_prompts.py
+++ b/api/core/rag/retrieval/template_prompts.py
@@ -4,14 +4,17 @@ METADATA_FILTER_SYSTEM_PROMPT = """
     ### Task
     Your task is to ONLY extract the metadatas that exist in the input text from the provided metadata list and Use the following operators ["contains", "not contains", "start with", "end with", "is", "is not", "empty", "not empty", "=", "≠", ">", "<", "≥", "≤", "before", "after"] to express logical relationships, then return result in JSON format with the key "metadata_fields" and value "metadata_field_value" and comparison operator "comparison_operator".
     ### Format
-    The input text is in the variable input_text. Metadata are specified as a list in the variable metadata_fields.
+    The input text is in the variable input_text. Metadata are specified in the variable metadata_fields as a list of
+    objects with a "name" and a "type" ("string", "number" or "time"). Values of "time" fields must be returned as a
+    Unix timestamp in seconds.
     ### Constraint
     DO NOT include anything other than the JSON array in your response.
 """  # noqa: E501
 
 METADATA_FILTER_USER_PROMPT_1 = """
     { "input_text": "I want to know which company’s email address test@example.com is?",
-    "metadata_fields": ["filename", "email", "phone", "address"]
+    "metadata_fields": [{"name": "filename", "type": "string"}, {"name": "email", "type": "string"},
+        {"name": "phone", "type": "string"}, {"name": "address", "type": "string"}]
     }
 """
 
@@ -25,14 +28,15 @@ METADATA_FILTER_ASSISTANT_PROMPT_1 = """
 """
 
 METADATA_FILTER_USER_PROMPT_2 = """
-    {"input_text": "What are the movies with a score of more than 9 in 2024?",
-    "metadata_fields": ["name", "year", "rating", "country"]}
+    {"input_text": "What are the movies with a score of more than 9 released after 2024-01-01?",
+    "metadata_fields": [{"name": "name", "type": "string"}, {"name": "release_date", "type": "time"},
+        {"name": "rating", "type": "number"}, {"name": "country", "type": "string"}]}
 """
 
 METADATA_FILTER_ASSISTANT_PROMPT_2 = """
 ```json
     {"metadata_map": [
-        {"metadata_field_name": "year", "metadata_field_value": "2024", "comparison_operator": "="},
+        {"metadata_field_name": "release_date", "metadata_field_value": 1704067200, "comparison_operator": "after"},
         {"metadata_field_name": "rating", "metadata_field_value": "9", "comparison_operator": ">"},
     ]}
 ```
@@ -49,16 +53,18 @@ You are a text metadata extract engine that extract text's metadata based on use
 ### Task
 # Your task is to ONLY extract the metadatas that exist in the input text from the provided metadata list and Use the following operators ["=", "!=", ">", "<", ">=", "<="] to express logical relationships, then return result in JSON format with the key "metadata_fields" and value "metadata_field_value" and comparison operator "comparison_operator".
 ### Format
-The input text is in the variable input_text. Metadata are specified as a list in the variable metadata_fields.
+The input text is in the variable input_text. Metadata are specified in the variable metadata_fields as a list of
+objects with a "name" and a "type" ("string", "number" or "time"). Values of "time" fields must be returned as a
+Unix timestamp in seconds.
 ### Constraint
 DO NOT include anything other than the JSON array in your response.
 ### Example
 Here is the chat example between human and assistant, inside <example></example> XML tags.
 <example>
-User:{{"input_text": ["I want to know which company’s email address test@example.com is?"], "metadata_fields": ["filename", "email", "phone", "address"]}}
+User:{{"input_text": ["I want to know which company’s email address test@example.com is?"], "metadata_fields": [{{"name": "filename", "type": "string"}}, {{"name": "email", "type": "string"}}, {{"name": "phone", "type": "string"}}, {{"name": "address", "type": "string"}}]}}
 Assistant:{{"metadata_map": [{{"metadata_field_name": "email", "metadata_field_value": "test@example.com", "comparison_operator": "="}}]}}
-User:{{"input_text": "What are the movies with a score of more than 9 in 2024?", "metadata_fields": ["name", "year", "rating", "country"]}}
-Assistant:{{"metadata_map": [{{"metadata_field_name": "year", "metadata_field_value": "2024", "comparison_operator": "="}, {{"metadata_field_name": "rating", "metadata_field_value": "9", "comparison_operator": ">"}}]}}
+User:{{"input_text": "What are the movies with a score of more than 9 released after 2024-01-01?", "metadata_fields": [{{"name": "name", "type": "string"}}, {{"name": "release_date", "type": "time"}}, {{"name": "rating", "type": "number"}}, {{"name": "country", "type": "string"}}]}}
+Assistant:{{"metadata_map": [{{"metadata_field_name": "release_date", "metadata_field_value": 1704067200, "comparison_operator": "after"}}, {{"metadata_field_name": "rating", "metadata_field_value": "9", "comparison_operator": ">"}}]}}
 </example>
 ### User Input
 {{"input_text" : "{input_text}", "metadata_fields" : {metadata_fields}}}

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -4301,7 +4301,7 @@ class TestDatasetRetrievalAdditionalHelpers:
             assert "stop" not in config.parameters
 
     def test_automatic_metadata_filter_func(self, retrieval: DatasetRetrieval) -> None:
-        metadata_field = SimpleNamespace(name="author")
+        metadata_field = SimpleNamespace(name="author", type="string")
         model_instance = Mock()
         model_instance.invoke_llm.return_value = iter([Mock()])
         model_config = ModelConfigWithCredentialsEntity.model_construct(
@@ -4365,6 +4365,80 @@ class TestDatasetRetrievalAdditionalHelpers:
                     user_id="u1",
                     metadata_model_config=AppModelConfig(provider="openai", name="gpt", mode="chat"),
                 )
+
+    def test_automatic_metadata_filter_func_normalizes_time_values(self, retrieval: DatasetRetrieval) -> None:
+        """A date the model answers with must be converted to the stored Unix timestamp."""
+        model_instance = Mock()
+        model_instance.invoke_llm.return_value = iter([Mock()])
+        model_config = ModelConfigWithCredentialsEntity.model_construct(
+            provider="openai",
+            model="gpt",
+            model_schema=Mock(),
+            mode="chat",
+            provider_model_bundle=Mock(),
+            credentials={},
+            parameters={},
+            stop=[],
+        )
+        usage = LLMUsage.from_metadata({"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})
+        session_scalars = Mock()
+        session_scalars.all.return_value = [SimpleNamespace(name="release_date", type="time")]
+        session = MagicMock()
+        session.scalars.return_value = session_scalars
+
+        with (
+            patch.object(retrieval, "_fetch_model_config", return_value=(model_instance, model_config)),
+            patch.object(retrieval, "_get_prompt_template", return_value=(["prompt"], [])) as mock_prompt_template,
+            patch.object(retrieval, "_handle_invoke_result", return_value=("{}", usage)),
+            patch("core.rag.retrieval.dataset_retrieval.parse_and_check_json_markdown") as mock_parse,
+            patch.object(retrieval, "_record_usage"),
+        ):
+            mock_parse.return_value = {
+                "metadata_map": [
+                    {
+                        "metadata_field_name": "release_date",
+                        "metadata_field_value": "2024-01-01T00:00:00+00:00",
+                        "comparison_operator": "after",
+                    },
+                    {
+                        "metadata_field_name": "release_date",
+                        "metadata_field_value": "sometime last year",
+                        "comparison_operator": "after",
+                    },
+                ]
+            }
+            result = retrieval._automatic_metadata_filter_func(
+                session,
+                dataset_ids=["d1"],
+                query="what was released after 2024-01-01?",
+                tenant_id="tenant-1",
+                user_id="u1",
+                metadata_model_config=AppModelConfig(provider="openai", name="gpt", mode="chat"),
+            )
+
+        # The parsable date becomes a timestamp; the unparsable one is dropped instead of
+        # being compared against the numeric value and failing the query.
+        assert result == [{"metadata_name": "release_date", "value": 1704067200.0, "condition": "after"}]
+        # The field type has to reach the prompt, otherwise the model cannot know the expected format.
+        assert mock_prompt_template.call_args.kwargs["metadata_fields"] == [{"name": "release_date", "type": "time"}]
+
+    @pytest.mark.parametrize(
+        ("metadata_type", "value", "expected"),
+        [
+            ("string", "2024-01-01", "2024-01-01"),
+            ("number", "9", "9"),
+            ("time", 1704067200, 1704067200),
+            ("time", 1704067200.0, 1704067200.0),
+            ("time", "2024-01-01T00:00:00+00:00", 1704067200.0),
+            ("time", "not a date", None),
+            ("time", True, None),
+            ("time", None, None),
+        ],
+    )
+    def test_normalize_metadata_filter_value(
+        self, retrieval: DatasetRetrieval, metadata_type: str, value: object, expected: object
+    ) -> None:
+        assert retrieval._normalize_metadata_filter_value(metadata_type, value) == expected
 
     def test_get_metadata_filter_condition(self, retrieval: DatasetRetrieval) -> None:
         scalars_result = Mock()
@@ -5613,7 +5687,7 @@ class TestInternalHooksCoverage:
                 )
 
         session_scalars = Mock()
-        session_scalars.all.return_value = [SimpleNamespace(name="author")]
+        session_scalars.all.return_value = [SimpleNamespace(name="author", type="string")]
         with (
             patch("core.rag.retrieval.dataset_retrieval.db.session.scalars", return_value=session_scalars),
             patch.object(retrieval, "_fetch_model_config", return_value=(Mock(), Mock())),


### PR DESCRIPTION
### Summary

Fixes #41597.

`DatasetRetrieval._automatic_metadata_filter_func` built the extraction prompt from `all_metadata_fields`, which was only a list of field *names* — the field's `type` was loaded but never passed along. With nothing telling it otherwise, the model answers a date question with a human-readable date (`"2024-01-01"`), which then reaches `process_metadata_filter_func` and is compared with `before`/`after` against the Unix timestamp stored in `doc_metadata`. The query fails and automatic metadata filtering is unusable on any `time` field, including the built-in `upload_date` / `last_update_date`.

### What changed

- Pass `{"name": ..., "type": ...}` for every field into the prompt, and update the metadata-filter prompts (system, few-shot and completion variants) to describe the new shape and to state that `time` values must be Unix timestamps. The second few-shot example now demonstrates exactly that.
- Normalize the value the model returns against the field's declared type before building a filter. Numbers pass through; a date string is parsed back into a timestamp; a value that still cannot be interpreted drops its filter rather than producing a comparison that errors out.

Manual filtering is untouched — this only affects the `automatic` metadata-filtering mode.

### Tests

Added to `api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py`:

- a `_automatic_metadata_filter_func` case with a `time` field, asserting the parsable date becomes a timestamp, the unparsable one is dropped, and the field type actually reaches the prompt;
- a parametrized table over `_normalize_metadata_filter_value` for the string/number/time and int/float/str/bool/None combinations.

Two existing fixtures gained the `type` attribute their `DatasetMetadata` rows always had.

```
pytest api/tests/unit_tests/core/rag/retrieval/  # 179 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoVYtAzgM9SEUX8nJp1Gv6
