### PR TITLE
docs: align /audio-to-text 400 codes with reachable errors

### DIFF
--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -57,12 +57,10 @@ class AudioApi(Resource):
         responses={
             200: "Successfully converted audio to text.",
             400: (
-                "- `app_unavailable` : App unavailable or misconfigured.\n"
+                "- `no_audio_uploaded` : Please upload your audio.\n"
                 "- `speech_to_text_disabled` : Speech-to-text is disabled for this app.\n"
                 "- `provider_not_support_speech_to_text` : Model provider does not support speech-to-text.\n"
                 "- `provider_not_initialize` : No valid model provider credentials found.\n"
-                "- `provider_quota_exceeded` : Model provider quota exhausted.\n"
-                "- `model_currently_not_support` : Current model does not support this operation.\n"
                 "- `completion_request_error` : Speech recognition request failed."
             ),
             413: "`audio_too_large` : Audio file size exceeded the limit.",

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -288,7 +288,7 @@ Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `au
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 200 | Successfully converted audio to text. | **application/json**: [AudioTranscriptResponse](#audiotranscriptresponse)<br> |
-| 400 | - `app_unavailable` : App unavailable or misconfigured. - `speech_to_text_disabled` : Speech-to-text is disabled for this app. - `provider_not_support_speech_to_text` : Model provider does not support speech-to-text. - `provider_not_initialize` : No valid model provider credentials found. - `provider_quota_exceeded` : Model provider quota exhausted. - `model_currently_not_support` : Current model does not support this operation. - `completion_request_error` : Speech recognition request failed. |  |
+| 400 | - `no_audio_uploaded` : Please upload your audio. - `speech_to_text_disabled` : Speech-to-text is disabled for this app. - `provider_not_support_speech_to_text` : Model provider does not support speech-to-text. - `provider_not_initialize` : No valid model provider credentials found. - `completion_request_error` : Speech recognition request failed. |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 413 | `audio_too_large` : Audio file size exceeded the limit. |  |


### PR DESCRIPTION
## Summary

Fixes #39928

The `/audio-to-text` OpenAPI 400 list still advertised error codes that this endpoint does not raise. Format list and size limit on current `main` already match the implementation (`mp3`/`m4a`/`wav`/`amr`/`mpga`, 30 MB). The in-app `template_chat` / `template_advanced_chat` MDX files named in the issue are no longer in the repo.

This PR updates the remaining in-repo surfaces:

- drop `app_unavailable`, `provider_quota_exceeded`, and `model_currently_not_support` from the `/audio-to-text` 400 list
- document `no_audio_uploaded`, which `AudioService._invoke_speech_to_text` does raise
- keep `speech_to_text_disabled`, `provider_not_support_speech_to_text`, `provider_not_initialize`, and `completion_request_error`

No runtime exception handling was changed.

## How to verify

1. Compare `api/controllers/service_api/app/audio.py` with `api/services/audio_service.py`: STT raises no-audio, disabled, unsupported type, too large, provider-not-support, and invoke failures. It does not raise the three removed 400 codes.
2. Confirm `api/openapi/markdown/service-openapi.md` `/audio-to-text` 400 row matches that list.
3. Confirm the request-body description still says MIME types `audio/mp3`, `audio/mpga`, `audio/m4a`, `audio/x-m4a`, `audio/wav`, `audio/amr` and a 30 MB limit.

## Demo

N/A — docs only.
