### PR TITLE
Return service unavailable for transient app token database failures

### DIFF
--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -12,6 +12,7 @@ from flask_restx import Resource
 from flask_restx.utils import merge
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 from werkzeug.exceptions import Forbidden, NotFound, ServiceUnavailable, Unauthorized
 
@@ -61,6 +62,7 @@ class FetchUserArg(BaseModel):
 
 APP_TOKEN_FORBIDDEN_RESPONSE = {
     403: "Forbidden - token scope, app, dataset, or workspace access denied",
+    503: "Service unavailable - app token validation could not reach the database",
 }
 
 DATASET_TOKEN_AUTH_RESPONSES = {
@@ -73,6 +75,21 @@ VECTOR_SPACE_UNAVAILABLE_RESPONSE = {
         "plan only; retry the request later."
     ),
 }
+
+
+_TRANSIENT_DB_ERROR_PATTERNS = (
+    "could not receive data from server",
+    "connection timed out",
+    "connection reset",
+    "server closed the connection unexpectedly",
+)
+
+
+def _is_transient_db_error(exc: OperationalError) -> bool:
+    if exc.connection_invalidated:
+        return True
+    message = f"{exc} {exc.orig or ''}".lower()
+    return any(pattern in message for pattern in _TRANSIENT_DB_ERROR_PATTERNS)
 
 
 def _document_app_token_contract(view_func: Callable[..., object], fetch_user_arg: FetchUserArg | None) -> None:
@@ -112,7 +129,12 @@ def validate_app_token[**P, R](
         def decorated_view(*args: P.args, **kwargs: P.kwargs) -> R:
             api_token = validate_and_get_api_token("app")
 
-            app_model = db.session.get(App, api_token.app_id)
+            try:
+                app_model = db.session.get(App, api_token.app_id)
+            except OperationalError as exc:
+                if _is_transient_db_error(exc):
+                    raise ServiceUnavailable("Unable to validate app token. Please try again later.") from exc
+                raise
             if not app_model:
                 raise Forbidden("The app no longer exists.")
 
@@ -122,7 +144,12 @@ def validate_app_token[**P, R](
             if not app_model.enable_api:
                 raise Forbidden("The app's API service has been disabled.")
 
-            tenant = db.session.get(Tenant, app_model.tenant_id)
+            try:
+                tenant = db.session.get(Tenant, app_model.tenant_id)
+            except OperationalError as exc:
+                if _is_transient_db_error(exc):
+                    raise ServiceUnavailable("Unable to validate app token. Please try again later.") from exc
+                raise
             if tenant is None:
                 raise ValueError("Tenant does not exist.")
             if tenant.status == TenantStatus.ARCHIVE:

--- a/api/tests/unit_tests/controllers/service_api/test_wraps.py
+++ b/api/tests/unit_tests/controllers/service_api/test_wraps.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 from flask import Flask
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, scoped_session
 from werkzeug.exceptions import Forbidden, NotFound, ServiceUnavailable, Unauthorized
 
@@ -247,6 +248,90 @@ class TestValidateAppToken:
             with pytest.raises(Forbidden) as exc_info:
                 protected_view()
             assert "no longer exists" in str(exc_info.value)
+
+    @patch("controllers.service_api.wraps.validate_and_get_api_token")
+    @pytest.mark.parametrize("sqlite_session", [(App,)], indirect=True)
+    def test_postgresql_operational_error_during_app_lookup_raises_service_unavailable(
+        self, mock_validate_token, app: Flask, sqlite_session: Session
+    ):
+        mock_validate_token.return_value = _api_token(
+            tenant_id=str(uuid.uuid4()),
+            app_id=str(uuid.uuid4()),
+            token_type=ApiTokenType.APP,
+        )
+        sqlite_session.get = Mock(
+            side_effect=OperationalError(
+                "SELECT", {}, RuntimeError("could not receive data from server: Connection timed out")
+            )
+        )
+
+        @validate_app_token
+        def protected_view(**kwargs):
+            return {"success": True}
+
+        with (
+            app.test_request_context("/", method="GET"),
+            patch("controllers.service_api.wraps.db.session", sqlite_session),
+        ):
+            with pytest.raises(ServiceUnavailable):
+                protected_view()
+
+    @patch("controllers.service_api.wraps.validate_and_get_api_token")
+    @pytest.mark.parametrize("sqlite_session", [(App, Tenant)], indirect=True)
+    def test_postgresql_operational_error_during_tenant_lookup_raises_service_unavailable(
+        self, mock_validate_token, app: Flask, sqlite_session: Session
+    ):
+        tenant, _, _ = _persist_workspace(sqlite_session)
+        app_model = _app_model(tenant_id=tenant.id)
+        sqlite_session.add(app_model)
+        sqlite_session.commit()
+        mock_validate_token.return_value = _api_token(
+            tenant_id=tenant.id,
+            app_id=app_model.id,
+            token_type=ApiTokenType.APP,
+        )
+        sqlite_session.get = Mock(
+            side_effect=[
+                app_model,
+                OperationalError(
+                    "SELECT", {}, RuntimeError("could not receive data from server: Connection timed out")
+                ),
+            ]
+        )
+
+        @validate_app_token
+        def protected_view(**kwargs):
+            return {"success": True}
+
+        with (
+            app.test_request_context("/", method="GET"),
+            patch("controllers.service_api.wraps.db.session", sqlite_session),
+        ):
+            with pytest.raises(ServiceUnavailable):
+                protected_view()
+
+    @patch("controllers.service_api.wraps.validate_and_get_api_token")
+    @pytest.mark.parametrize("sqlite_session", [(App,)], indirect=True)
+    def test_non_transient_operational_error_during_app_lookup_is_not_service_unavailable(
+        self, mock_validate_token, app: Flask, sqlite_session: Session
+    ):
+        mock_validate_token.return_value = _api_token(
+            tenant_id=str(uuid.uuid4()),
+            app_id=str(uuid.uuid4()),
+            token_type=ApiTokenType.APP,
+        )
+        sqlite_session.get = Mock(side_effect=OperationalError("SELECT", {}, RuntimeError("relation does not exist")))
+
+        @validate_app_token
+        def protected_view(**kwargs):
+            return {"success": True}
+
+        with (
+            app.test_request_context("/", method="GET"),
+            patch("controllers.service_api.wraps.db.session", sqlite_session),
+        ):
+            with pytest.raises(OperationalError):
+                protected_view()
 
     @patch("controllers.service_api.wraps.validate_and_get_api_token")
     @pytest.mark.parametrize("sqlite_session", [(App,)], indirect=True)


### PR DESCRIPTION
## Summary

- Return HTTP 503 when app token validation encounters a transient database connection failure.
- Preserve non-transient database errors for the existing error handling path.
- Add regression coverage for app and tenant lookups.

Fixes #41626

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods