### PR TITLE
fix(api): default missing retriever_resources to empty list

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1821,7 +1821,7 @@ class Message(Base):
 
     @property
     def retriever_resources(self) -> Any:
-        return self.message_metadata_dict.get("retriever_resources") if self.message_metadata else []
+        return self.message_metadata_dict.get("retriever_resources", []) if self.message_metadata else []
 
     @property
     def message_files(self) -> list[MessageFileInfo]:

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -857,6 +857,62 @@ class TestMessageModel:
         # Assert
         assert result == {}
 
+    def test_retriever_resources_missing_key_returns_empty_list(self):
+        """message_metadata present without retriever_resources must yield [].
+
+        Regression for #41688: web GET /messages failed Pydantic list validation
+        when metadata existed but the key was absent (property returned None).
+        """
+        message = Message(
+            app_id=str(uuid4()),
+            conversation_id=str(uuid4()),
+            query="Test query",
+            message={"role": "user", "content": "Test"},
+            answer="Test answer",
+            message_unit_price=Decimal("0.0001"),
+            answer_unit_price=Decimal("0.0002"),
+            currency="USD",
+            from_source=ConversationFromSource.API,
+            message_metadata=json.dumps({"usage": {"tokens": 1}}),
+        )
+
+        assert message.retriever_resources == []
+
+    def test_retriever_resources_none_metadata_returns_empty_list(self):
+        """No message_metadata should still expose retriever_resources as []."""
+        message = Message(
+            app_id=str(uuid4()),
+            conversation_id=str(uuid4()),
+            query="Test query",
+            message={"role": "user", "content": "Test"},
+            answer="Test answer",
+            message_unit_price=Decimal("0.0001"),
+            answer_unit_price=Decimal("0.0002"),
+            currency="USD",
+            from_source=ConversationFromSource.API,
+            message_metadata=None,
+        )
+
+        assert message.retriever_resources == []
+
+    def test_retriever_resources_present_passthrough(self):
+        """Existing retriever_resources list should be returned unchanged."""
+        resources = [{"dataset_id": "ds-1", "document_id": "doc-1"}]
+        message = Message(
+            app_id=str(uuid4()),
+            conversation_id=str(uuid4()),
+            query="Test query",
+            message={"role": "user", "content": "Test"},
+            answer="Test answer",
+            message_unit_price=Decimal("0.0001"),
+            answer_unit_price=Decimal("0.0002"),
+            currency="USD",
+            from_source=ConversationFromSource.API,
+            message_metadata=json.dumps({"retriever_resources": resources}),
+        )
+
+        assert message.retriever_resources == resources
+
     def test_message_to_dict_serialization(self):
         """Test message to_dict method."""
         # Arrange


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Embedded web apps fail to load conversation history when any message has `message_metadata` but no `retriever_resources` key (common for Chatflow/Agent apps without Knowledge Retrieval).

`GET /messages` builds `WebMessageListItem` from `Message.retriever_resources`. That property did:

```python
return self.message_metadata_dict.get("retriever_resources") if self.message_metadata else []
```

If metadata exists but the key is absent, `.get(...)` returns `None`, and Pydantic rejects the required `list[RetrieverResource]` field:

```
1 validation error for WebMessageListItem
retriever_resources
  Input should be a valid list
  [type=list_type, input_value=None, input_type=NoneType]
```

The service API path was already guarded in #17304; the web path still used the unguarded property. This PR defaults the missing key to `[]`, matching the no-metadata branch and the expected schema.

Fixes #41688

## Screenshots

| Before | After |
| ------ | ----- |
| N/A (API validation) | N/A (API validation) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods