### PR TITLE
chore(dify-ui): migrate class merging to cn

### DIFF
--- a/packages/dify-ui/package.json
+++ b/packages/dify-ui/package.json
@@ -171,8 +171,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "clsx": "catalog:",
-    "tailwind-merge": "catalog:"
+    "cn": "catalog:"
   },
   "devDependencies": {
     "@base-ui/react": "catalog:",

--- a/packages/dify-ui/src/cn.ts
+++ b/packages/dify-ui/src/cn.ts
@@ -1,9 +1,1 @@
-import type { ClassValue } from 'clsx'
-import { clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
-
-function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
-
-export { cn }
+export { cn } from 'cn'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,9 +261,9 @@ catalogs:
     cli-table3:
       specifier: 0.6.5
       version: 0.6.5
-    clsx:
-      specifier: 2.1.1
-      version: 2.1.1
+    cn:
+      specifier: 0.2.4
+      version: 0.2.4
     code-inspector-plugin:
       specifier: 1.6.6
       version: 1.6.6
@@ -552,9 +552,6 @@ catalogs:
     string-ts:
       specifier: 2.3.1
       version: 2.3.1
-    tailwind-merge:
-      specifier: 3.6.0
-      version: 3.6.0
     tailwindcss:
       specifier: 4.3.3
       version: 4.3.3
@@ -954,12 +951,9 @@ importers:
 
   packages/dify-ui:
     dependencies:
-      clsx:
+      cn:
         specifier: 'catalog:'
-        version: 2.1.1
-      tailwind-merge:
-        specifier: 'catalog:'
-        version: 3.6.0
+        version: 0.2.4
     devDependencies:
       '@base-ui/react':
         specifier: 'catalog:'
@@ -5415,6 +5409,11 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cn@0.2.4:
+    resolution: {integrity: sha512-SzQvoh5FwizWtQg9+JueKdjWhlfCZMdu5DqNHm9q1wUlRVmKb9WXlepR9bTTbPwzEOyX1ujJ6lcCppmn3bNUCg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   code-inspector-plugin@1.6.6:
     resolution: {integrity: sha512-NQ8CWmMbFiZ+ck34Zxw4/awjIYcyutNPiVCdPe2hVXMD/NG2D+aWAz8NI2krOIagGnbny8j/YCyoiDsNRbnAbQ==}
@@ -12703,6 +12702,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cn@0.2.4: {}
+
   code-inspector-plugin@1.6.6(supports-color@11.0.0):
     dependencies:
       '@code-inspector/core': 1.6.6(supports-color@11.0.0)
@@ -17089,7 +17090,7 @@ time:
   chokidar@5.0.0: '2025-11-25T23:28:06.854Z'
   class-variance-authority@0.7.1: '2024-11-26T08:20:34.604Z'
   cli-table3@0.6.5: '2024-05-12T16:36:50.079Z'
-  clsx@2.1.1: '2024-04-23T05:26:04.645Z'
+  cn@0.2.4: '2026-09-02T09:26:36.212Z'
   code-inspector-plugin@1.6.6: '2026-07-07T04:00:26.523Z'
   concurrently@10.0.5: '2026-08-15T03:33:20.323Z'
   copy-to-clipboard@4.0.2: '2026-04-24T22:15:18.933Z'
@@ -17187,7 +17188,6 @@ time:
   storybook@10.5.10: '2026-08-20T10:52:53.637Z'
   streamdown@2.6.0: '2026-08-24T14:07:33.027Z'
   string-ts@2.3.1: '2025-11-28T17:33:10.099Z'
-  tailwind-merge@3.6.0: '2026-05-10T12:56:43.142Z'
   tailwindcss@4.3.3: '2026-07-16T12:03:35.267Z'
   tldts@7.4.11: '2026-08-24T07:31:22.093Z'
   tsx@4.23.13: '2026-08-30T00:46:16.265Z'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -148,7 +148,7 @@ catalog:
   chokidar: 5.0.0
   class-variance-authority: 0.7.1
   cli-table3: 0.6.5
-  clsx: 2.1.1
+  cn: 0.2.4
   code-inspector-plugin: 1.6.6
   concurrently: 10.0.5
   copy-to-clipboard: 4.0.2
@@ -245,7 +245,6 @@ catalog:
   storybook: 10.5.10
   streamdown: 2.6.0
   string-ts: 2.3.1
-  tailwind-merge: 3.6.0
   tailwindcss: 4.3.3
   tldts: 7.4.11
   tsx: 4.23.13


### PR DESCRIPTION
## Summary

- replace the `clsx` and `tailwind-merge` wrapper with the drop-in `cn` package
- preserve the existing `@langgenius/dify-ui/cn` public entrypoint
- update the workspace catalog and lockfile for `cn@0.2.4`

No issue was provided for this dependency migration.

## Screenshots

Not applicable; this change has no visual impact.

## Verification

- `vp staged`
- `vp check packages/dify-ui`
- `vp check web` (0 errors; existing warnings remain)
- direct `cn` smoke test for conditional joining and Tailwind conflict resolution

The Dify UI browser unit suite could not start because the local Playwright Chromium executable is not installed.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [ ] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [x] I ran `vp staged` (frontend) to appease the lint gods

From Codex