### PR TITLE
fix(api): enforce RBAC on MCP provider details

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1582,6 +1582,7 @@ class ToolMCPDetailApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
+    @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.MCP_MANAGE, resource_required=False)
     @with_current_tenant_id
     def get(self, tenant_id: str, provider_id: str):
         with sessionmaker(db.engine).begin() as session:

--- a/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_credential_mutation_permissions.py
@@ -9,7 +9,11 @@ from controllers.console.agent.roster import AgentAppApi
 from controllers.console.datasets.data_source import DataSourceApi
 from controllers.console.datasets.rag_pipeline.datasource_auth import DatasourceAuth
 from controllers.console.workspace.model_providers import ModelProviderCredentialApi
-from controllers.console.workspace.tool_providers import ToolBuiltinProviderAddApi, ToolOAuthCustomClient
+from controllers.console.workspace.tool_providers import (
+    ToolBuiltinProviderAddApi,
+    ToolMCPDetailApi,
+    ToolOAuthCustomClient,
+)
 
 
 @pytest.mark.parametrize(
@@ -66,6 +70,17 @@ def test_tool_oauth_custom_client_get_requires_admin_and_rbac() -> None:
     rbac_config = getclosurevars(rbac_wrapper).nonlocals
     assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
     assert rbac_config["scene"] == RBACPermission.CREDENTIAL_MANAGE
+    assert rbac_config["resource_required"] is False
+
+
+def test_tool_mcp_detail_get_requires_mcp_management_permission() -> None:
+    """MCP provider details must be restricted to workspace MCP managers."""
+    method = ToolMCPDetailApi.get
+
+    rbac_wrapper = unwrap(method, stop=lambda wrapper: "rbac_permission_required" in wrapper.__code__.co_qualname)
+    rbac_config = getclosurevars(rbac_wrapper).nonlocals
+    assert rbac_config["resource_type"] == RBACResourceScope.WORKSPACE
+    assert rbac_config["scene"] == RBACPermission.MCP_MANAGE
     assert rbac_config["resource_required"] is False
 
 


### PR DESCRIPTION
## Summary

Fixes #41547.

`ToolMCPDetailApi.get` returned MCP provider details without enforcing the workspace `MCP_MANAGE` permission. This change adds the same workspace-level RBAC gate used by the create, update, delete, authorization, and refresh endpoints.

A focused unit test verifies the RBAC decorator configuration and prevents this endpoint from losing its access-control requirement.

## Screenshots

Not applicable; this is an API authorization change.

## Checklist

- [x] This change does not require a documentation update.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] Added a focused test for the changed behavior.
- [ ] Ran the full `make lint && make type-check` suite. The targeted pytest invocation was attempted, but first-time dependency installation exceeded the available execution window; Python compilation and `git diff --check` passed.

From Codex
