### PR TITLE
fix(api): map plugin-daemon runtime-not-ready to retryable 503

### DIFF
--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -43,6 +43,7 @@ from core.errors.error import (
     QuotaExceededError,
 )
 from core.helper.trace_id_helper import get_external_trace_id, get_trace_session_id, omit_trace_session_id_from_payload
+from core.plugin.impl.exc import PluginDaemonUnavailableError
 from enums import CloudPlan, DeploymentEdition
 from graphon.model_runtime.errors.invoke import InvokeError
 from libs import helper
@@ -272,6 +273,8 @@ class CompletionApi(Resource):
             raise ProviderModelCurrentlyNotSupportError()
         except InvokeError as e:
             raise CompletionRequestError(e.description)
+        except PluginDaemonUnavailableError:
+            raise
         except ValueError as e:
             raise e
         except Exception:
@@ -458,6 +461,8 @@ class ChatApi(Resource):
             raise InvokeRateLimitHttpError(ex.description)
         except InvokeError as e:
             raise CompletionRequestError(e.description)
+        except PluginDaemonUnavailableError:
+            raise
         except ValueError as e:
             raise e
         except Exception:

--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -11,6 +11,7 @@ from core.app.apps.exc import AppGenerateError
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.task_entities import AppBlockingResponse, AppStreamResponse
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
+from core.plugin.impl.exc import PluginDaemonUnavailableError
 from graphon.model_runtime.errors.invoke import InvokeError, InvokeRateLimitError
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,7 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
 
         error_responses: dict[type[Exception], dict[str, JsonValue]] = {
             ValueError: {"code": "invalid_param", "status": 400},
+            PluginDaemonUnavailableError: {"code": "plugin_daemon_unavailable", "status": 503},
             ProviderTokenNotInitError: {"code": "provider_not_initialize", "status": 400},
             QuotaExceededError: {
                 "code": "provider_quota_exceeded",

--- a/api/core/app/task_pipeline/based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/based_generate_task_pipeline.py
@@ -18,6 +18,7 @@ from core.app.entities.task_entities import (
 )
 from core.errors.error import QuotaExceededError
 from core.moderation.output_moderation import ModerationRule, OutputModeration
+from core.plugin.impl.exc import PluginDaemonUnavailableError
 from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
 from models.enums import MessageStatus
 from models.model import Message
@@ -55,7 +56,7 @@ class BasedGenerateTaskPipeline[AppGenerateEntityT: AppGenerateEntity]:
         match e:
             case InvokeAuthorizationError():
                 err = InvokeAuthorizationError("Incorrect API key provided")
-            case InvokeError() | ValueError() | AgentBackendError():
+            case InvokeError() | ValueError() | AgentBackendError() | PluginDaemonUnavailableError():
                 err = e
             case _:
                 description = getattr(e, "description", None)

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -26,12 +26,17 @@ from core.plugin.impl.exc import (
     PluginDaemonInternalServerError,
     PluginDaemonNotFoundError,
     PluginDaemonUnauthorizedError,
+    PluginDaemonUnavailableError,
     PluginInvokeError,
     PluginLLMPollingUnsupportedError,
     PluginNotFoundError,
     PluginPermissionDeniedError,
     PluginRuntimeError,
     PluginUniqueIdentifierError,
+    is_plugin_runtime_unavailable,
+)
+from core.plugin.impl.exc import (
+    PluginDaemonError as PluginDaemonTypedError,
 )
 from core.trigger.errors import (
     EventIgnoreError,
@@ -149,7 +154,7 @@ class BasePluginClient:
             response = _httpx_client.request(**request_kwargs)
         except httpx.RequestError:
             logger.exception("Request to Plugin Daemon Service failed")
-            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
+            raise PluginDaemonUnavailableError(description="Request to Plugin Daemon Service failed")
 
         return response
 
@@ -259,7 +264,7 @@ class BasePluginClient:
                         yield line
         except httpx.RequestError:
             logger.exception("Stream request to Plugin Daemon Service failed")
-            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
+            raise PluginDaemonUnavailableError(description="Request to Plugin Daemon Service failed")
 
     def _stream_request_with_model[T: BaseModel | dict[str, Any] | list[Any] | bool | str](
         self,
@@ -312,10 +317,9 @@ class BasePluginClient:
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
             logger.exception("Failed to request plugin daemon, status: %s, url: %s", e.response.status_code, path)
-            if e.response.status_code < 500:
-                raise PluginDaemonClientSideError(description=str(e))
-            else:
-                raise PluginDaemonInternalServerError(description=str(e))
+            self._raise_for_plugin_daemon_http_error(e)
+        except (PluginDaemonTypedError, PluginDaemonInnerError):
+            raise
         except Exception as e:
             msg = f"Failed to request plugin daemon, url: {path}"
             logger.exception("Failed to request plugin daemon, url: %s", path)
@@ -340,6 +344,8 @@ class BasePluginClient:
             try:
                 error = PluginDaemonError.model_validate(json.loads(rep.message))
             except Exception as e:
+                if is_plugin_runtime_unavailable(rep.message):
+                    raise PluginDaemonUnavailableError(description=rep.message) from e
                 raise ValueError(f"{rep.message}, code: {rep.code}") from e
 
             self._handle_plugin_daemon_error(error.error_type, error.message)
@@ -377,6 +383,8 @@ class BasePluginClient:
                 raise ValueError(line_data.get("error", line))
 
             if rep.code != 0:
+                if is_plugin_runtime_unavailable(rep.message):
+                    raise PluginDaemonUnavailableError(description=rep.message)
                 if rep.code == -500:
                     try:
                         error = PluginDaemonError.model_validate(json.loads(rep.message))
@@ -391,10 +399,36 @@ class BasePluginClient:
                 raise ValueError(f"got empty data from plugin daemon: {frame.f_lineno if frame else 'unknown'}")
             yield rep.data
 
+    def _raise_for_plugin_daemon_http_error(self, error: httpx.HTTPStatusError) -> None:
+        """Classify a plugin-daemon HTTP error from its JSON body, not status alone.
+
+        Dispatch can return HTTP 404 with ``PluginDaemonInternalServerError``
+        when the plugin runtime is not registered yet. That is a transient
+        availability failure, not a client-side invalid parameter.
+        """
+        try:
+            json_response = error.response.json()
+            rep = PluginDaemonBasicResponse[dict[str, Any]].model_validate(json_response)
+            if is_plugin_runtime_unavailable(rep.message):
+                raise PluginDaemonUnavailableError(description=rep.message)
+            if rep.code != 0:
+                parsed_error = PluginDaemonError.model_validate(json.loads(rep.message))
+                self._handle_plugin_daemon_error(parsed_error.error_type, parsed_error.message)
+        except (PluginDaemonTypedError, PluginDaemonInnerError):
+            raise
+        except Exception:
+            logger.debug("Failed to parse plugin daemon HTTP error body", exc_info=True)
+
+        if error.response.status_code < 500:
+            raise PluginDaemonClientSideError(description=str(error)) from error
+        raise PluginDaemonInternalServerError(description=str(error)) from error
+
     def _handle_plugin_daemon_error(self, error_type: str, message: str):
         """
         handle the error from plugin daemon
         """
+        if is_plugin_runtime_unavailable(message):
+            raise PluginDaemonUnavailableError(description=message)
         match error_type:
             case PluginDaemonInnerError.__name__:
                 raise PluginDaemonInnerError(code=-500, message=message)

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 from urllib.parse import unquote
 
 import httpx
@@ -399,7 +399,7 @@ class BasePluginClient:
                 raise ValueError(f"got empty data from plugin daemon: {frame.f_lineno if frame else 'unknown'}")
             yield rep.data
 
-    def _raise_for_plugin_daemon_http_error(self, error: httpx.HTTPStatusError) -> None:
+    def _raise_for_plugin_daemon_http_error(self, error: httpx.HTTPStatusError) -> NoReturn:
         """Classify a plugin-daemon HTTP error from its JSON body, not status alone.
 
         Dispatch can return HTTP 404 with ``PluginDaemonInternalServerError``

--- a/api/core/plugin/impl/exc.py
+++ b/api/core/plugin/impl/exc.py
@@ -45,6 +45,30 @@ class PluginDaemonNotFoundError(PluginDaemonInternalError):
     description: str = "Not Found"
 
 
+class PluginDaemonUnavailableError(PluginDaemonInternalError):
+    """Plugin daemon or plugin runtime is temporarily unavailable and the request is retryable."""
+
+    description: str = "Plugin daemon unavailable"
+
+
+_PLUGIN_RUNTIME_UNAVAILABLE_MARKERS = (
+    "plugin runtime not found",
+    "no available node",
+    "request to plugin daemon service failed",
+)
+
+
+def is_plugin_runtime_unavailable(message: str) -> bool:
+    """Return True when a plugin-daemon error describes a transient runtime outage.
+
+    Matches restart/recovery windows such as empty Redis plugin state and
+    ``no available node, plugin runtime not found``. Does not treat a missing
+    plugin installation (``plugin not found``) as unavailable.
+    """
+    lowered = message.lower()
+    return any(marker in lowered for marker in _PLUGIN_RUNTIME_UNAVAILABLE_MARKERS)
+
+
 class PluginDaemonBadRequestError(PluginDaemonClientSideError):
     description: str = "Bad Request"
 

--- a/api/core/plugin/impl/model.py
+++ b/api/core/plugin/impl/model.py
@@ -16,7 +16,12 @@ from core.plugin.entities.plugin_daemon import (
     TTSAudioChunk,
 )
 from core.plugin.impl.base import BasePluginClient
-from core.plugin.impl.exc import PluginInvokeError, PluginLLMPollingUnsupportedError
+from core.plugin.impl.exc import (
+    PluginDaemonUnavailableError,
+    PluginInvokeError,
+    PluginLLMPollingUnsupportedError,
+    is_plugin_runtime_unavailable,
+)
 from graphon.model_runtime.entities.llm_entities import LLMPollingResult, LLMResultChunk
 from graphon.model_runtime.entities.message_entities import PromptMessage, PromptMessageTool
 from graphon.model_runtime.entities.model_entities import AIModelEntity, ModelType
@@ -215,7 +220,9 @@ class PluginModelClient(BasePluginClient):
         try:
             yield from response
         except PluginDaemonInnerError as e:
-            raise ValueError(e.message + str(e.code))
+            if is_plugin_runtime_unavailable(e.message):
+                raise PluginDaemonUnavailableError(description=e.message) from e
+            raise ValueError(e.message + str(e.code)) from e
 
     def start_llm_polling(
         self,
@@ -615,7 +622,9 @@ class PluginModelClient(BasePluginClient):
                 hex_str = result.result
                 yield TTSAudioChunk(binascii.unhexlify(hex_str), mime_type=result.mime_type)
         except PluginDaemonInnerError as e:
-            raise ValueError(e.message + str(e.code))
+            if is_plugin_runtime_unavailable(e.message):
+                raise PluginDaemonUnavailableError(description=e.message) from e
+            raise ValueError(e.message + str(e.code)) from e
 
     def get_tts_model_voices(
         self,

--- a/api/libs/external_api.py
+++ b/api/libs/external_api.py
@@ -10,7 +10,7 @@ from werkzeug.http import HTTP_STATUS_CODES
 
 from configs import dify_config
 from core.errors.error import AppInvokeQuotaExceededError
-from core.plugin.impl.exc import PluginRuntimeError
+from core.plugin.impl.exc import PluginDaemonUnavailableError, PluginRuntimeError
 from extensions.ext_logging import get_request_id
 from libs.flask_restx_compat import install_swagger_compatibility
 from libs.token import build_force_logout_cookie_headers
@@ -117,6 +117,16 @@ def register_external_error_handlers(api: Api, body_formatter: ErrorBodyFormatte
         }
         return _finalize(e, data, status_code), status_code
 
+    def handle_plugin_daemon_unavailable_error(e: PluginDaemonUnavailableError):
+        got_request_exception.send(current_app, exception=e)
+        status_code = 503
+        data = {
+            "code": "plugin_daemon_unavailable",
+            "message": e.description,
+            "status": status_code,
+        }
+        return _finalize(e, data, status_code), status_code
+
     def handle_general_exception(e: Exception):
         got_request_exception.send(current_app, exception=e)
 
@@ -139,6 +149,7 @@ def register_external_error_handlers(api: Api, body_formatter: ErrorBodyFormatte
     api.errorhandler(ValueError)(handle_value_error)
     api.errorhandler(AppInvokeQuotaExceededError)(handle_quota_exceeded)
     api.errorhandler(PluginRuntimeError)(handle_plugin_runtime_error)
+    api.errorhandler(PluginDaemonUnavailableError)(handle_plugin_daemon_unavailable_error)
     api.errorhandler(Exception)(handle_general_exception)
 
 

--- a/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
@@ -13,7 +13,8 @@ from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.queue_entities import QueueErrorEvent
 from core.app.task_pipeline.based_generate_task_pipeline import BasedGenerateTaskPipeline
 from core.errors.error import QuotaExceededError
-from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError, InvokeRateLimitError
+from core.plugin.impl.exc import PluginDaemonUnavailableError
+from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeRateLimitError
 from models.enums import ConversationFromSource, MessageStatus
 from models.model import AppMode, Message
 
@@ -76,10 +77,26 @@ class TestBasedGenerateTaskPipeline:
         assert isinstance(err, InvokeAuthorizationError)
         assert str(err) == "Incorrect API key provided"
 
-    def test_handle_error_preserves_invoke_error(self, pipeline):
-        event = QueueErrorEvent(error=InvokeError("bad"))
+    def test_handle_error_preserves_plugin_daemon_unavailable_error(self, pipeline):
+        event = QueueErrorEvent(error=PluginDaemonUnavailableError("no available node, plugin runtime not found"))
         err = pipeline.handle_error(event=event)
         assert err is event.error
+
+    def test_stream_converter_maps_plugin_daemon_unavailable_error(self):
+        data = AppGenerateResponseConverter._error_to_stream_response(
+            PluginDaemonUnavailableError("no available node, plugin runtime not found")
+        )
+
+        assert data == {
+            "code": "plugin_daemon_unavailable",
+            "status": 503,
+            "message": "no available node, plugin runtime not found",
+        }
+
+    def test_stream_converter_keeps_value_error_as_invalid_param(self):
+        data = AppGenerateResponseConverter._error_to_stream_response(ValueError("query is required"))
+
+        assert data == {"code": "invalid_param", "status": 400, "message": "query is required"}
 
     def test_handle_error_preserves_agent_backend_run_failed_error(self, pipeline):
         event = QueueErrorEvent(

--- a/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
@@ -2,13 +2,21 @@ import json
 from collections.abc import Callable
 from urllib.parse import quote
 
+import httpx
 import pytest
 from pytest_mock import MockerFixture
 
 from core.plugin.endpoint.exc import EndpointSetupFailedError
 from core.plugin.entities.plugin_daemon import PluginDaemonInnerError, PluginListResponse
 from core.plugin.impl.base import PLUGIN_DAEMON_MAX_PATH_LENGTH, BasePluginClient
-from core.plugin.impl.exc import PluginLLMPollingUnsupportedError, PluginRuntimeError
+from core.plugin.impl.exc import (
+    PluginDaemonBadRequestError,
+    PluginDaemonClientSideError,
+    PluginDaemonUnavailableError,
+    PluginLLMPollingUnsupportedError,
+    PluginNotFoundError,
+    PluginRuntimeError,
+)
 from core.trigger.errors import (
     EventIgnoreError,
     TriggerInvokeError,
@@ -218,3 +226,117 @@ class TestBasePluginClientImpl:
             "Plugin runtime request failed: Runtime.ExitError: Runtime exited with error: exit status 1"
         )
         assert exc_info.value.lambda_request_id == lambda_request_id
+
+    def test_handle_plugin_daemon_error_maps_runtime_not_found_to_unavailable(self):
+        client = BasePluginClient()
+
+        with pytest.raises(PluginDaemonUnavailableError) as exc_info:
+            client._handle_plugin_daemon_error(
+                "PluginDaemonInternalServerError",
+                "no available node, plugin runtime not found",
+            )
+
+        assert "plugin runtime not found" in exc_info.value.description
+
+    def test_handle_plugin_daemon_error_keeps_genuine_bad_request(self):
+        client = BasePluginClient()
+
+        with pytest.raises(PluginDaemonBadRequestError):
+            client._handle_plugin_daemon_error("PluginDaemonBadRequestError", "Missing required parameter")
+
+    def test_handle_plugin_daemon_error_keeps_plugin_not_installed(self):
+        client = BasePluginClient()
+
+        with pytest.raises(PluginNotFoundError):
+            client._handle_plugin_daemon_error("PluginNotFoundError", "plugin not found")
+
+    def test_stream_maps_runtime_not_found_inner_error_to_unavailable(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        payload = json.dumps(
+            {
+                "code": -500,
+                "message": json.dumps(
+                    {
+                        "error_type": "PluginDaemonInternalServerError",
+                        "message": "no available node, plugin runtime not found",
+                        "args": None,
+                    }
+                ),
+                "data": None,
+            }
+        )
+        mocker.patch.object(client, "_stream_request", return_value=iter([payload]))
+
+        with pytest.raises(PluginDaemonUnavailableError):
+            list(client._request_with_plugin_daemon_response_stream("POST", "plugin/tenant/dispatch/llm/invoke", bool))
+
+    def test_stream_unparseable_runtime_not_found_is_unavailable(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        mocker.patch.object(
+            client,
+            "_stream_request",
+            return_value=iter(['{"code":-500,"message":"no available node, plugin runtime not found","data":null}']),
+        )
+
+        with pytest.raises(PluginDaemonUnavailableError):
+            list(client._request_with_plugin_daemon_response_stream("POST", "plugin/tenant/dispatch/llm/invoke", bool))
+
+    def test_http_404_runtime_not_found_is_unavailable(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        request = httpx.Request("POST", "http://plugin-daemon/plugin/tenant/dispatch/llm/invoke")
+        response = httpx.Response(
+            404,
+            json={
+                "code": -500,
+                "message": json.dumps(
+                    {
+                        "error_type": "PluginDaemonInternalServerError",
+                        "message": "no available node, plugin runtime not found",
+                        "args": None,
+                    }
+                ),
+                "data": None,
+            },
+            request=request,
+        )
+        mocker.patch.object(client, "_request", return_value=response)
+
+        with pytest.raises(PluginDaemonUnavailableError):
+            client._request_with_plugin_daemon_response("POST", "plugin/tenant/dispatch/llm/invoke", bool)
+
+    def test_http_404_plugin_not_installed_stays_not_found(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        request = httpx.Request("POST", "http://plugin-daemon/plugin/tenant/dispatch/llm/invoke")
+        response = httpx.Response(
+            404,
+            json={
+                "code": -404,
+                "message": json.dumps({"error_type": "PluginNotFoundError", "message": "plugin not found"}),
+                "data": None,
+            },
+            request=request,
+        )
+        mocker.patch.object(client, "_request", return_value=response)
+
+        with pytest.raises(PluginNotFoundError):
+            client._request_with_plugin_daemon_response("POST", "plugin/tenant/dispatch/llm/invoke", bool)
+
+    def test_http_404_without_daemon_body_stays_client_side(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        request = httpx.Request("POST", "http://plugin-daemon/plugin/tenant/dispatch/llm/invoke")
+        response = httpx.Response(404, text="not found", request=request)
+        mocker.patch.object(client, "_request", return_value=response)
+
+        with pytest.raises(PluginDaemonClientSideError):
+            client._request_with_plugin_daemon_response("POST", "plugin/tenant/dispatch/llm/invoke", bool)
+
+    def test_unavailable_error_is_not_wrapped_as_value_error(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        mocker.patch.object(
+            client,
+            "_request",
+            side_effect=PluginDaemonUnavailableError("Request to Plugin Daemon Service failed"),
+        )
+
+        with pytest.raises(PluginDaemonUnavailableError, match="Request to Plugin Daemon Service failed"):
+            client._request_with_plugin_daemon_response("GET", "plugin/tenant/path", bool)

--- a/api/tests/unit_tests/core/plugin/impl/test_exc_impl.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_exc_impl.py
@@ -1,9 +1,15 @@
 import json
 
+import pytest
 from pytest_mock import MockerFixture
 
 from core.plugin.impl import exc as exc_module
-from core.plugin.impl.exc import PluginDaemonError, PluginInvokeError
+from core.plugin.impl.exc import (
+    PluginDaemonError,
+    PluginDaemonUnavailableError,
+    PluginInvokeError,
+    is_plugin_runtime_unavailable,
+)
 
 
 class TestPluginImplExceptions:
@@ -41,3 +47,25 @@ class TestPluginImplExceptions:
         err = PluginInvokeError("not-json")
 
         assert err._get_error_object() == {}
+
+
+class TestPluginRuntimeUnavailableClassification:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "no available node, plugin runtime not found",
+            "Request to Plugin Daemon Service failed",
+        ],
+    )
+    def test_runtime_outage_messages_are_unavailable(self, message: str):
+        assert is_plugin_runtime_unavailable(message) is True
+
+    def test_missing_plugin_installation_is_not_unavailable(self):
+        assert is_plugin_runtime_unavailable("plugin not found") is False
+
+    def test_invalid_parameter_message_is_not_unavailable(self):
+        assert is_plugin_runtime_unavailable("Missing required parameter") is False
+
+    def test_unavailable_error_is_not_a_value_error(self):
+        err = PluginDaemonUnavailableError("no available node, plugin runtime not found")
+        assert not isinstance(err, ValueError)

--- a/api/tests/unit_tests/core/plugin/impl/test_model_client.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_model_client.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from core.plugin.entities.plugin_daemon import PluginDaemonInnerError
-from core.plugin.impl.exc import PluginInvokeError, PluginLLMPollingUnsupportedError
+from core.plugin.impl.exc import PluginDaemonUnavailableError, PluginInvokeError, PluginLLMPollingUnsupportedError
 from core.plugin.impl.model import PluginModelClient
 from graphon.model_runtime.entities.llm_entities import LLMPollingResult, LLMPollingStatus, LLMResult, LLMUsage
 from graphon.model_runtime.entities.message_entities import AssistantPromptMessage
@@ -208,6 +208,28 @@ class TestPluginModelClient:
         mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=_boom())
 
         with pytest.raises(ValueError, match="invoke failed-500"):
+            list(
+                client.invoke_llm(
+                    tenant_id="tenant-1",
+                    user_id="user-1",
+                    plugin_id="org/plugin:1",
+                    provider="provider-a",
+                    model="gpt-test",
+                    credentials={},
+                    prompt_messages=[],
+                )
+            )
+
+    def test_invoke_llm_maps_runtime_not_found_to_unavailable(self, mocker: MockerFixture):
+        client = PluginModelClient()
+
+        def _boom():
+            raise PluginDaemonInnerError(code=-500, message="no available node, plugin runtime not found")
+            yield  # pragma: no cover
+
+        mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=_boom())
+
+        with pytest.raises(PluginDaemonUnavailableError, match="plugin runtime not found"):
             list(
                 client.invoke_llm(
                     tenant_id="tenant-1",

--- a/api/tests/unit_tests/core/plugin/test_plugin_runtime.py
+++ b/api/tests/unit_tests/core/plugin/test_plugin_runtime.py
@@ -184,10 +184,9 @@ class TestPluginRuntimeExecution:
         # Arrange
         with patch("httpx.request", side_effect=httpx.RequestError("Connection failed"), autospec=True):
             # Act & Assert
-            with pytest.raises(PluginDaemonInnerError) as exc_info:
+            with pytest.raises(PluginDaemonUnavailableError) as exc_info:
                 plugin_client._request("GET", "plugin/test-tenant/test")
-            assert exc_info.value.code == -500
-            assert "Request to Plugin Daemon Service failed" in exc_info.value.message
+            assert "Request to Plugin Daemon Service failed" in exc_info.value.description
 
 
 class TestPluginRuntimeSandboxIsolation:
@@ -729,9 +728,9 @@ class TestPluginRuntimeCommunication:
         # Arrange
         with patch("httpx.stream", side_effect=httpx.RequestError("Stream connection failed"), autospec=True):
             # Act & Assert
-            with pytest.raises(PluginDaemonInnerError) as exc_info:
+            with pytest.raises(PluginDaemonUnavailableError) as exc_info:
                 list(plugin_client._stream_request("POST", "plugin/test-tenant/stream"))
-            assert exc_info.value.code == -500
+            assert "Request to Plugin Daemon Service failed" in exc_info.value.description
 
     def test_request_with_model_parsing(self, plugin_client, mock_config):
         """Test request with direct model parsing (without daemon response wrapper)."""
@@ -1298,10 +1297,10 @@ class TestPluginRuntimeAdvancedScenarios:
 
         with patch("httpx.request", side_effect=side_effect, autospec=True):
             # Act & Assert - First two calls should fail
-            with pytest.raises(PluginDaemonInnerError):
+            with pytest.raises(PluginDaemonUnavailableError):
                 plugin_client._request("GET", "plugin/test-tenant/test")
 
-            with pytest.raises(PluginDaemonInnerError):
+            with pytest.raises(PluginDaemonUnavailableError):
                 plugin_client._request("GET", "plugin/test-tenant/test")
 
             # Third call should succeed
@@ -1573,9 +1572,9 @@ class TestPluginRuntimePerformanceScenarios:
         # Arrange
         with patch("httpx.request", side_effect=httpx.TimeoutException("Request timed out after 30s"), autospec=True):
             # Act & Assert
-            with pytest.raises(PluginDaemonInnerError) as exc_info:
+            with pytest.raises(PluginDaemonUnavailableError) as exc_info:
                 plugin_client._request("GET", "plugin/test-tenant/slow-endpoint")
-            assert exc_info.value.code == -500
+            assert "Request to Plugin Daemon Service failed" in exc_info.value.description
 
     def test_concurrent_request_simulation(self, plugin_client, mock_config):
         """Test simulation of concurrent requests (sequential execution in test)."""

--- a/api/tests/unit_tests/core/plugin/test_plugin_runtime.py
+++ b/api/tests/unit_tests/core/plugin/test_plugin_runtime.py
@@ -30,6 +30,7 @@ from core.plugin.impl.exc import (
     PluginDaemonInternalServerError,
     PluginDaemonNotFoundError,
     PluginDaemonUnauthorizedError,
+    PluginDaemonUnavailableError,
     PluginInvokeError,
     PluginNotFoundError,
     PluginPermissionDeniedError,
@@ -317,23 +318,25 @@ class TestPluginRuntimeResourceLimits:
             call_kwargs = mock_request.call_args[1]
             assert call_kwargs["timeout"] is not None
 
-    def test_timeout_error_handling(self, plugin_client, mock_config):
+    def test_timeout_error_handling(self, plugin_client, mock_config, mocker):
         """Test handling of timeout errors."""
-        # Arrange
-        with patch("httpx.request", side_effect=httpx.TimeoutException("Request timeout"), autospec=True):
-            # Act & Assert
-            with pytest.raises(PluginDaemonInnerError) as exc_info:
-                plugin_client._request("GET", "plugin/test-tenant/test")
-            assert exc_info.value.code == -500
+        mocker.patch(
+            "core.plugin.impl.base._httpx_client.request",
+            side_effect=httpx.TimeoutException("Request timeout"),
+        )
 
-    def test_streaming_request_timeout(self, plugin_client, mock_config):
+        with pytest.raises(PluginDaemonUnavailableError, match="Request to Plugin Daemon Service failed"):
+            plugin_client._request("GET", "plugin/test-tenant/test")
+
+    def test_streaming_request_timeout(self, plugin_client, mock_config, mocker):
         """Test timeout handling for streaming requests."""
-        # Arrange
-        with patch("httpx.stream", side_effect=httpx.TimeoutException("Stream timeout"), autospec=True):
-            # Act & Assert
-            with pytest.raises(PluginDaemonInnerError) as exc_info:
-                list(plugin_client._stream_request("POST", "plugin/test-tenant/stream"))
-            assert exc_info.value.code == -500
+        mocker.patch(
+            "core.plugin.impl.base._httpx_client.stream",
+            side_effect=httpx.TimeoutException("Stream timeout"),
+        )
+
+        with pytest.raises(PluginDaemonUnavailableError, match="Request to Plugin Daemon Service failed"):
+            list(plugin_client._stream_request("POST", "plugin/test-tenant/stream"))
 
     def test_resource_limit_error_from_daemon(self, plugin_client, mock_config):
         """Test handling of resource limit errors from plugin daemon."""

--- a/api/tests/unit_tests/libs/test_external_api.py
+++ b/api/tests/unit_tests/libs/test_external_api.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest, Unauthorized
 
 from constants import COOKIE_NAME_ACCESS_TOKEN, COOKIE_NAME_CSRF_TOKEN, COOKIE_NAME_REFRESH_TOKEN
 from core.errors.error import AppInvokeQuotaExceededError
-from core.plugin.impl.exc import PluginRuntimeError
+from core.plugin.impl.exc import PluginDaemonUnavailableError, PluginRuntimeError
 from libs.exception import BaseHTTPException
 from libs.external_api import ExternalApi
 from libs.rate_limit import _BearerRateLimited
@@ -47,6 +47,11 @@ def _create_api_app():
                 "Plugin runtime request failed: Runtime.ExitError: Runtime exited with error: exit status 1",
                 lambda_request_id="lambda-request-id",
             )
+
+    @api.route("/plugin-daemon-unavailable")
+    class PluginDaemonUnavailable(Resource):
+        def get(self):
+            raise PluginDaemonUnavailableError("no available node, plugin runtime not found")
 
     # Note: We avoid altering default_mediatype to keep normal error paths
 
@@ -131,6 +136,19 @@ def test_external_api_plugin_runtime_error(mocker):
             "lambda_request_id": "lambda-request-id",
         },
         "status": 502,
+    }
+
+
+def test_external_api_plugin_daemon_unavailable():
+    app = _create_api_app()
+
+    res = app.test_client().get("/api/plugin-daemon-unavailable")
+
+    assert res.status_code == 503
+    assert res.get_json() == {
+        "code": "plugin_daemon_unavailable",
+        "message": "no available node, plugin runtime not found",
+        "status": 503,
     }
 
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #41675`.

## Summary

Fixes #41675

When `plugin-daemon` restarts, Redis has no plugin runtime state yet. Dispatch then returns HTTP 404 with `PluginDaemonInternalServerError` / `no available node, plugin runtime not found`. The API treated that as a client error:

1. HTTP 404 was classified as `PluginDaemonClientSideError` from status alone, or stream `-500` bodies were turned into `PluginDaemonInnerError` / `ValueError`.
2. `invoke_llm` wrapped `PluginDaemonInnerError` as `ValueError`.
3. Connection failures to a down daemon were also wrapped as `ValueError("Failed to request plugin daemon...")`.
4. `ExternalApi.handle_value_error` mapped any `ValueError` to HTTP 400 `invalid_param`.

A valid Chatflow `POST /v1/chat-messages` therefore looked like bad input until the runtime registered again.

This change classifies only transient plugin-runtime / daemon-unavailable failures as `PluginDaemonUnavailableError` and maps that type to HTTP 503 `plugin_daemon_unavailable`. Genuine invalid parameters stay 400 `invalid_param`. Missing plugin installations (`plugin not found`) stay `PluginNotFoundError`.

Error-code change: retryable plugin-daemon outages now return `{ "code": "plugin_daemon_unavailable", "status": 503 }` instead of `{ "code": "invalid_param", "status": 400 }`.

Tests cover daemon-client classification, `invoke_llm` mapping, ExternalApi 503 handling, generate-pipeline preservation, and the stream error converter. `ValueError` still maps to 400.

`make lint` and `make type-check` passed. Targeted unit tests around plugin-daemon exception mapping passed (170 tests).

## Screenshots

Unit tests for this change (`170 passed in 45.20s`), plus `make lint` and `make type-check`:

![pytest 170 passed](https://raw.githubusercontent.com/kabishou11/dify/pr-41675-assets/pr-41696-pytest.png)

HTTP mapping for `POST /v1/chat-messages` while plugin-daemon is restarting:

![before 400 vs after 503](https://raw.githubusercontent.com/kabishou11/dify/pr-41675-assets/pr-41696-http.png)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) to appease the lint gods
