### PR TITLE
fix(ssrf_proxy): do not treat Squid-forwarded upstream 401/403 as an SSRF block

### DIFF
--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -240,12 +240,26 @@ def make_request(
 
             # Check for SSRF protection by Squid proxy
             if response.status_code in (401, 403):
-                # Check if this is a Squid SSRF rejection
+                # Distinguish Squid's own response (where Squid generated
+                # the 401/403 for an ACL match) from a Squid-forwarded
+                # upstream response (where the upstream server returned
+                # 401/403 and Squid only added a ``Via`` header). Only the
+                # first is an SSRF rejection; the second is
+                # application-level authorization on the target and must
+                # surface to the caller as the original status, not be
+                # re-raised as ToolSSRFError. See #41434.
                 server_header = response.headers.get("server", "").lower()
                 via_header = response.headers.get("via", "").lower()
 
-                # Squid typically identifies itself in Server or Via headers
-                if "squid" in server_header or "squid" in via_header:
+                # Squid identifies itself as the origin server in the
+                # ``Server`` header (``Server: squid/4.10``). The ``Via``
+                # header is only used as a fallback when the upstream
+                # response strips the ``Server`` header entirely; Squid
+                # also adds a ``Via`` header to every request it forwards,
+                # so a non-empty ``Server`` from the upstream always wins
+                # over the forwarded ``Via`` marker.
+                is_squid_own_response = "squid" in server_header or (not server_header and "squid" in via_header)
+                if is_squid_own_response:
                     # The deny ACL is usually ``to_private_networks`` (RFC1918 +
                     # loopback / link-local / CGN / IPv6 ULA, etc.). We don't know
                     # which specific ACL tripped from Squid's response alone, but

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -460,3 +460,50 @@ def test_squid_block_with_internal_10_x_url_mentions_allowlist(mock_get_client) 
 
     assert "10.0.0.42" in str(exc_info.value)
     assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
+
+
+@patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
+def test_squid_forwarded_401_from_upstream_is_not_treated_as_ssrf_block(mock_get_client) -> None:
+    """Regression for #41434: when Squid forwards a 401/403 from the
+    upstream server, the response carries the upstream's ``Server`` header
+    and a ``Via`` header that Squid added as a forwarder. The detection
+    must NOT treat the forwarded ``Via`` marker as evidence that Squid
+    itself generated the response; only the upstream's ``Server`` header
+    should decide. Preserving the original status lets application-level
+    authorization errors surface to the caller instead of being rewritten
+    as a misleading SSRF-block error.
+    """
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.status_code = 401
+    # nginx is the upstream; Squid added the Via header as a forwarder.
+    response.headers = {
+        "server": "nginx",
+        "via": "1.1 xxxx (squid/6.13)",
+    }
+    mock_client.send.return_value = response
+    mock_get_client.return_value = mock_client
+
+    # Should return the upstream response, not raise ToolSSRFError.
+    returned = make_request("GET", "http://public.example.com/protected")
+    assert returned.status_code == 401
+
+
+@patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
+def test_squid_forwarded_403_from_upstream_is_not_treated_as_ssrf_block(mock_get_client) -> None:
+    """Same as the 401 case, but with 403 — the symmetric 403 path that
+    was also misclassified by the original ``or 'squid' in via_header``
+    check. Pins both status codes that the SSRF-detection block covers.
+    """
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.status_code = 403
+    response.headers = {
+        "server": "nginx/1.25",
+        "via": "1.1 xxxx (squid/6.13)",
+    }
+    mock_client.send.return_value = response
+    mock_get_client.return_value = mock_client
+
+    returned = make_request("GET", "http://public.example.com/forbidden")
+    assert returned.status_code == 403


### PR DESCRIPTION
## Summary

Fixes #41434.

When the Squid SSRF proxy is enabled and the upstream server returns 401/403, Squid forwards that response with its own `Via:` header attached (e.g. `Via: 1.1 xxxx (squid/6.13)`). The pre-fix check `if "squid" in server_header or "squid" in via_header` then triggered on the forwarded `Via:` marker and rewrote the upstream's status as `ToolSSRFError`, masking the real problem (application-level authorization on the target) behind a misleading "blocked by SSRF protection" error.

Squid's own error pages (ACL deny, etc.) identify themselves in the `Server` header (`Server: squid/4.10`). Squid also adds a `Via:` header to every request it forwards, so a non-empty `Server` from the upstream should always win over the forwarded `Via` marker. The fix keeps the `Server` check as the primary indicator and only falls back to the `Via` check when the upstream's `Server` header is empty (the pre-existing test case where Squid returns 401 with no `Server` header).

## Fix

`api/core/helper/ssrf_proxy.py`:

```python
# before
if "squid" in server_header or "squid" in via_header:
    raise ToolSSRFError(...)

# after
is_squid_own_response = "squid" in server_header or (
    not server_header and "squid" in via_header
)
if is_squid_own_response:
    raise ToolSSRFError(...)
```

The existing 3 Squid tests (block via Server, block via empty-Server + Via, 10.x URL mention) still pass. Two new regression tests cover the bug.

## Tests

Two new tests in `api/tests/unit_tests/core/helper/test_ssrf_proxy.py`:

- `test_squid_forwarded_401_from_upstream_is_not_treated_as_ssrf_block` — `Server: nginx`, `Via: 1.1 xxxx (squid/6.13)`, status 401. Pre-fix raises `ToolSSRFError`; post-fix returns the upstream response as-is.
- `test_squid_forwarded_403_from_upstream_is_not_treated_as_ssrf_block` — same pattern with 403. Pins both status codes the SSRF-detection block covers.

Both tests fail against the pre-fix source and pass after the change. The 3 pre-existing Squid tests (block, 401 via empty-Server, 10.x URL) still pass — confirming the fallback path is preserved.

## Scope

Single-bug fix in 1 source file plus 2 regression tests. No new abstractions. The change is bounded to the 401/403 detection branch; no other SSRF-related logic is touched.

## Out of scope (called out for transparency)

- Switching to a more robust Squid-detection signal (e.g. body inspection, or a Squid-specific error page fingerprint). The header-based check is what the existing tests document as the contract.
- Adding handling for 5xx Squid errors. The current branch only covers 401/403 by design (the same 401/403 status from upstream vs Squid mismatch).
- A `connect_timeout` / network-error path that also might misclassify. Out of scope; the issue is specifically about the 401/403 branch.

## Verification

- `uv run ruff check` on changed files: clean.
- `uv run ruff format --check` on changed files: clean.
- Targeted pytest on `test_ssrf_proxy.py` (filtered to Squid tests): 5/5 pass (3 pre-existing + 2 new).
- Pre-fix regression check: 2 new tests fail at the `ToolSSRFError` raise site, confirming the tests pin the bug.

Fixes #41434
