### PR TITLE
fix(web): guard LLM node model_selector against persisted null

### DIFF
--- a/web/app/components/workflow/nodes/llm/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/llm/__tests__/utils.spec.ts
@@ -1,4 +1,8 @@
-import type { EnvironmentVariable, ModelConfig } from '@/app/components/workflow/types'
+import type {
+  EnvironmentVariable,
+  ModelConfig,
+  ValueSelector,
+} from '@/app/components/workflow/types'
 import { AppModeEnum } from '@/types/app'
 import {
   getLLMEnvironmentModel,
@@ -156,6 +160,15 @@ describe('llm utils', () => {
 
     it('keeps the static model for a legacy non-environment selector', () => {
       const selector = ['start', 'MODEL_NAME']
+
+      expect(isEnvironmentModelSource(selector)).toBe(false)
+      expect(resolveLLMNodeModel(model, selector, environmentVariables)).toBe(model)
+    })
+
+    it('keeps the static model when the persisted selector is null', () => {
+      // A DSL exported from an older/AI-generated workflow can persist `model_selector: null`
+      // instead of omitting the key; this must not crash the same way `undefined` doesn't.
+      const selector = null as unknown as ValueSelector
 
       expect(isEnvironmentModelSource(selector)).toBe(false)
       expect(resolveLLMNodeModel(model, selector, environmentVariables)).toBe(model)

--- a/web/app/components/workflow/nodes/llm/utils.ts
+++ b/web/app/components/workflow/nodes/llm/utils.ts
@@ -24,7 +24,7 @@ const isLLMEnvironmentVariableValue = (value: unknown): value is LLMEnvironmentV
 }
 
 export const isEnvironmentModelSource = (modelSelector: ValueSelector | undefined) =>
-  modelSelector !== undefined && (modelSelector.length === 0 || modelSelector[0] === 'env')
+  modelSelector != null && (modelSelector.length === 0 || modelSelector[0] === 'env')
 
 export const getLLMEnvironmentModel = (
   modelSelector: ValueSelector | undefined,


### PR DESCRIPTION
> [!IMPORTANT]
> Fixes #41706

## Summary

`isEnvironmentModelSource()` only treated `undefined` as "no environment
selector" for an LLM node's `model_selector` field. A workflow whose
`model_selector` was persisted as `null` (rather than omitted) crashed
as soon as the Workflow Studio editor ran its per-node checklist
validation on load, tripping the page-level error boundary and making
the whole canvas unusable — not just that one node.

This widens the guard to a null-check instead of an undefined-check,
matching how every other consumer of this field in the LLM node
already treats it (e.g. `getLLMEnvironmentModel` uses `!modelSelector`).
Added a regression test covering the `null` case.

## Screenshots

N/A — logic-only fix, no UI change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods