### PR TITLE
fix(api): skip invalid plugin-daemon list items instead of failing the whole page

### DIFF
--- a/api/core/plugin/impl/agent.py
+++ b/api/core/plugin/impl/agent.py
@@ -6,7 +6,11 @@ from core.plugin.entities.plugin_daemon import (
     PluginAgentProviderEntity,
 )
 from core.plugin.entities.request import PluginInvokeContext
-from core.plugin.impl.base import BasePluginClient
+from core.plugin.impl.base import (
+    BasePluginClient,
+    keep_declaration_items_with_identity,
+    plugin_daemon_item_identity_hint,
+)
 from core.plugin.utils.chunk_merger import merge_blob_chunks
 from models.provider_ids import GenericProviderID
 
@@ -18,11 +22,23 @@ class PluginAgentClient(BasePluginClient):
         """
 
         def transformer(json_response: dict[str, Any]):
-            for provider in json_response.get("data", []):
-                declaration = provider.get("declaration", {}) or {}
-                provider_name = declaration.get("identity", {}).get("name")
-                for strategy in declaration.get("strategies", []):
-                    strategy["identity"]["provider"] = provider_name
+            providers = json_response.get("data")
+            if not isinstance(providers, list):
+                return json_response
+            for provider in providers:
+                if not isinstance(provider, dict):
+                    continue
+                declaration = provider.get("declaration")
+                if not isinstance(declaration, dict):
+                    continue
+                identity = declaration.get("identity")
+                provider_name = identity.get("name") if isinstance(identity, dict) else None
+                declaration["strategies"] = keep_declaration_items_with_identity(
+                    declaration.get("strategies"),
+                    provider_name,
+                    item_kind="strategy",
+                    provider_hint=plugin_daemon_item_identity_hint(provider),
+                )
 
             return json_response
 

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, cast
+from typing import Any, cast, get_args, get_origin
 from urllib.parse import unquote
 
 import httpx
@@ -115,6 +115,113 @@ def _normalize_plugin_daemon_response_for_type(json_response: Any, type_: type[o
             }
 
     return json_response
+
+
+def plugin_daemon_item_identity_hint(item: Any) -> str:
+    """Build a log-friendly identity from a plugin-daemon list element."""
+    if not isinstance(item, dict):
+        return f"non-object {type(item).__name__}"
+
+    parts: list[str] = []
+    for key in ("plugin_id", "provider", "plugin_unique_identifier"):
+        value = item.get(key)
+        if value is not None and value != "":
+            parts.append(f"{key}={value}")
+
+    declaration = item.get("declaration")
+    if isinstance(declaration, dict):
+        identity = declaration.get("identity")
+        if isinstance(identity, dict):
+            name = identity.get("name")
+            if name:
+                parts.append(f"identity.name={name}")
+
+    return ", ".join(parts) if parts else "unknown identity"
+
+
+def keep_declaration_items_with_identity(
+    items: Any,
+    provider_name: Any,
+    *,
+    item_kind: str,
+    provider_hint: str,
+    mutate_item: Callable[[dict[str, Any]], None] | None = None,
+) -> list[Any]:
+    """Keep inner declaration items that have a dict identity and set identity.provider.
+
+    A missing identity on one tool/datasource/event/strategy is skipped so it cannot
+    KeyError the whole management list.
+    """
+    if not isinstance(items, list):
+        return []
+
+    kept_items: list[Any] = []
+    for item in items:
+        if not isinstance(item, dict) or not isinstance(item.get("identity"), dict):
+            logger.warning(
+                "Skipping %s without a usable identity in plugin provider (%s)",
+                item_kind,
+                provider_hint,
+            )
+            continue
+        item["identity"]["provider"] = provider_name
+        try:
+            if mutate_item is not None:
+                mutate_item(item)
+        except Exception as exc:
+            logger.warning(
+                "Skipping %s that failed transformation in plugin provider (%s): %s",
+                item_kind,
+                provider_hint,
+                exc,
+            )
+            continue
+        kept_items.append(item)
+    return kept_items
+
+
+def _plugin_daemon_structured_list_item_type(type_: Any) -> type[BaseModel] | None:
+    if get_origin(type_) is not list:
+        return None
+    args = get_args(type_)
+    if not args:
+        return None
+    item_type = args[0]
+    try:
+        if inspect.isclass(item_type) and issubclass(item_type, BaseModel):
+            return item_type
+    except TypeError:
+        return None
+    return None
+
+
+def _filter_valid_plugin_daemon_list_items[T: BaseModel](
+    items: list[Any],
+    item_type: type[T],
+    path: str,
+) -> list[T]:
+    valid_items: list[T] = []
+    for index, item in enumerate(items):
+        identity = plugin_daemon_item_identity_hint(item)
+        if not isinstance(item, dict):
+            logger.warning(
+                "Skipping invalid plugin daemon list item at index %s for %s (%s): expected an object",
+                index,
+                path,
+                identity,
+            )
+            continue
+        try:
+            valid_items.append(item_type.model_validate(item))
+        except Exception as exc:
+            logger.warning(
+                "Skipping invalid plugin daemon list item at index %s for %s (%s): %s",
+                index,
+                path,
+                identity,
+                exc,
+            )
+    return valid_items
 
 
 class BasePluginClient:
@@ -306,6 +413,11 @@ class BasePluginClient:
     ) -> T:
         """
         Make a request to the plugin daemon inner API and return the response as a model.
+
+        List payloads of Pydantic models are validated per item: malformed elements are
+        skipped and logged so one invalid plugin declaration cannot fail the whole page.
+        Single-object payloads stay strict. HTTP errors and daemon ``code != 0`` are
+        unchanged.
         """
         try:
             response = self._request(method, path, headers, data, params, files)
@@ -321,13 +433,19 @@ class BasePluginClient:
             logger.exception("Failed to request plugin daemon, url: %s", path)
             raise ValueError(msg) from e
 
+        list_item_type: type[BaseModel] | None = None
         try:
             json_response = response.json()
             if transformer:
                 json_response = transformer(json_response)
             json_response = _normalize_plugin_daemon_response_for_type(json_response, type_)
+            list_item_type = _plugin_daemon_structured_list_item_type(type_)
             # https://stackoverflow.com/questions/59634937/variable-foo-class-is-not-valid-as-type-but-why
-            rep = PluginDaemonBasicResponse[type_].model_validate(json_response)  # type: ignore
+            if list_item_type is not None:
+                # Validate the envelope only; individual list elements are checked below.
+                rep = PluginDaemonBasicResponse[list[Any]].model_validate(json_response)
+            else:
+                rep = PluginDaemonBasicResponse[type_].model_validate(json_response)  # type: ignore
         except Exception as e:
             msg = (
                 f"Failed to parse response from plugin daemon to PluginDaemonBasicResponse [{str(type_.__name__)}],"
@@ -347,7 +465,10 @@ class BasePluginClient:
             frame = inspect.currentframe()
             raise ValueError(f"got empty data from plugin daemon: {frame.f_lineno if frame else 'unknown'}")
 
-        return rep.data
+        if list_item_type is not None:
+            items = rep.data if isinstance(rep.data, list) else []
+            return cast(T, _filter_valid_plugin_daemon_list_items(items, list_item_type, path))
+        return cast(T, rep.data)
 
     def _request_with_plugin_daemon_response_stream[T: BaseModel | dict[str, Any] | list[Any] | bool | str](
         self,

--- a/api/core/plugin/impl/datasource.py
+++ b/api/core/plugin/impl/datasource.py
@@ -14,10 +14,41 @@ from core.plugin.entities.plugin_daemon import (
     PluginBasicBooleanResponse,
     PluginDatasourceProviderEntity,
 )
-from core.plugin.impl.base import BasePluginClient
+from core.plugin.impl.base import (
+    BasePluginClient,
+    keep_declaration_items_with_identity,
+    plugin_daemon_item_identity_hint,
+)
 from core.schemas.resolver import resolve_dify_schema_refs
 from models.provider_ids import DatasourceProviderID, GenericProviderID
 from services.tools.tools_transform_service import ToolTransformService
+
+
+def _resolve_output_schema_refs(item: dict[str, Any]) -> None:
+    if item.get("output_schema"):
+        item["output_schema"] = resolve_dify_schema_refs(item["output_schema"])
+
+
+def _datasource_providers_list_transformer(json_response: dict[str, Any]) -> dict[str, Any]:
+    providers = json_response.get("data")
+    if not isinstance(providers, list):
+        return json_response
+    for provider in providers:
+        if not isinstance(provider, dict):
+            continue
+        declaration = provider.get("declaration")
+        if not isinstance(declaration, dict):
+            continue
+        identity = declaration.get("identity")
+        provider_name = identity.get("name") if isinstance(identity, dict) else None
+        declaration["datasources"] = keep_declaration_items_with_identity(
+            declaration.get("datasources"),
+            provider_name,
+            item_kind="datasource",
+            provider_hint=plugin_daemon_item_identity_hint(provider),
+            mutate_item=_resolve_output_schema_refs,
+        )
+    return json_response
 
 
 class PluginDatasourceManager(BasePluginClient):
@@ -26,25 +57,12 @@ class PluginDatasourceManager(BasePluginClient):
         Fetch datasource providers for the given tenant.
         """
 
-        def transformer(json_response: dict[str, Any]) -> dict[str, Any]:
-            if json_response.get("data"):
-                for provider in json_response.get("data", []):
-                    declaration = provider.get("declaration", {}) or {}
-                    provider_name = declaration.get("identity", {}).get("name")
-                    for datasource in declaration.get("datasources", []):
-                        datasource["identity"]["provider"] = provider_name
-                        # resolve refs
-                        if datasource.get("output_schema"):
-                            datasource["output_schema"] = resolve_dify_schema_refs(datasource["output_schema"])
-
-            return json_response
-
         response = self._request_with_plugin_daemon_response(
             "GET",
             f"plugin/{tenant_id}/management/datasources",
             list[PluginDatasourceProviderEntity],
             params={"page": 1, "page_size": 256},
-            transformer=transformer,
+            transformer=_datasource_providers_list_transformer,
         )
         local_file_datasource_provider = PluginDatasourceProviderEntity.model_validate(
             self._get_local_file_datasource_provider()
@@ -68,25 +86,12 @@ class PluginDatasourceManager(BasePluginClient):
         Fetch datasource providers for the given tenant.
         """
 
-        def transformer(json_response: dict[str, Any]) -> dict[str, Any]:
-            if json_response.get("data"):
-                for provider in json_response.get("data", []):
-                    declaration = provider.get("declaration", {}) or {}
-                    provider_name = declaration.get("identity", {}).get("name")
-                    for datasource in declaration.get("datasources", []):
-                        datasource["identity"]["provider"] = provider_name
-                        # resolve refs
-                        if datasource.get("output_schema"):
-                            datasource["output_schema"] = resolve_dify_schema_refs(datasource["output_schema"])
-
-            return json_response
-
         response = self._request_with_plugin_daemon_response(
             "GET",
             f"plugin/{tenant_id}/management/datasources",
             list[PluginDatasourceProviderEntity],
             params={"page": 1, "page_size": 256},
-            transformer=transformer,
+            transformer=_datasource_providers_list_transformer,
         )
 
         for provider in response:

--- a/api/core/plugin/impl/tool.py
+++ b/api/core/plugin/impl/tool.py
@@ -7,11 +7,20 @@ from configs import dify_config
 
 # from core.plugin.entities.plugin import GenericProviderID, ToolProviderID
 from core.plugin.entities.plugin_daemon import CredentialType, PluginBasicBooleanResponse, PluginToolProviderEntity
-from core.plugin.impl.base import BasePluginClient
+from core.plugin.impl.base import (
+    BasePluginClient,
+    keep_declaration_items_with_identity,
+    plugin_daemon_item_identity_hint,
+)
 from core.plugin.utils.chunk_merger import merge_blob_chunks
 from core.schemas.resolver import resolve_dify_schema_refs
 from core.tools.entities.tool_entities import ToolInvokeMessage, ToolParameter
 from models.provider_ids import GenericProviderID, ToolProviderID
+
+
+def _resolve_output_schema_refs(item: dict[str, Any]) -> None:
+    if item.get("output_schema"):
+        item["output_schema"] = resolve_dify_schema_refs(item["output_schema"])
 
 
 class PluginToolManager(BasePluginClient):
@@ -21,14 +30,24 @@ class PluginToolManager(BasePluginClient):
         """
 
         def transformer(json_response: dict[str, Any]):
-            for provider in json_response.get("data", []):
-                declaration = provider.get("declaration", {}) or {}
-                provider_name = declaration.get("identity", {}).get("name")
-                for tool in declaration.get("tools", []):
-                    tool["identity"]["provider"] = provider_name
-                    # resolve refs
-                    if tool.get("output_schema"):
-                        tool["output_schema"] = resolve_dify_schema_refs(tool["output_schema"])
+            providers = json_response.get("data")
+            if not isinstance(providers, list):
+                return json_response
+            for provider in providers:
+                if not isinstance(provider, dict):
+                    continue
+                declaration = provider.get("declaration")
+                if not isinstance(declaration, dict):
+                    continue
+                identity = declaration.get("identity")
+                provider_name = identity.get("name") if isinstance(identity, dict) else None
+                declaration["tools"] = keep_declaration_items_with_identity(
+                    declaration.get("tools"),
+                    provider_name,
+                    item_kind="tool",
+                    provider_hint=plugin_daemon_item_identity_hint(provider),
+                    mutate_item=_resolve_output_schema_refs,
+                )
 
             return json_response
 

--- a/api/core/plugin/impl/trigger.py
+++ b/api/core/plugin/impl/trigger.py
@@ -11,7 +11,11 @@ from core.plugin.entities.request import (
     TriggerSubscriptionResponse,
     TriggerValidateProviderCredentialsResponse,
 )
-from core.plugin.impl.base import BasePluginClient
+from core.plugin.impl.base import (
+    BasePluginClient,
+    keep_declaration_items_with_identity,
+    plugin_daemon_item_identity_hint,
+)
 from core.plugin.utils.http_parser import serialize_request
 from core.trigger.entities.entities import Subscription
 from models.provider_ids import TriggerProviderID
@@ -24,11 +28,28 @@ class PluginTriggerClient(BasePluginClient):
         """
 
         def transformer(json_response: dict[str, Any]) -> dict[str, Any]:
-            for provider in json_response.get("data", []):
-                declaration = provider.get("declaration", {}) or {}
-                provider_id = provider.get("plugin_id") + "/" + provider.get("provider")
-                for event in declaration.get("events", []):
-                    event["identity"]["provider"] = provider_id
+            providers = json_response.get("data")
+            if not isinstance(providers, list):
+                return json_response
+            for provider in providers:
+                if not isinstance(provider, dict):
+                    continue
+                declaration = provider.get("declaration")
+                if not isinstance(declaration, dict):
+                    continue
+                plugin_id = provider.get("plugin_id")
+                provider_name = provider.get("provider")
+                provider_id = (
+                    f"{plugin_id}/{provider_name}"
+                    if isinstance(plugin_id, str) and isinstance(provider_name, str)
+                    else None
+                )
+                declaration["events"] = keep_declaration_items_with_identity(
+                    declaration.get("events"),
+                    provider_id,
+                    item_kind="event",
+                    provider_hint=plugin_daemon_item_identity_hint(provider),
+                )
 
             return json_response
 

--- a/api/tests/unit_tests/core/plugin/impl/test_agent_client.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_agent_client.py
@@ -45,6 +45,40 @@ class TestPluginAgentClient:
         assert result[0].declaration.identity.name == "org/plugin/remote"
         assert result[0].declaration.strategies[0].identity.provider == "org/plugin/remote"
 
+    def test_fetch_agent_strategy_providers_skips_strategy_without_identity(self, mocker: MockerFixture):
+        client = PluginAgentClient()
+        sibling = _agent_provider("good")
+
+        def fake_request(method, path, type_, **kwargs):
+            transformer = kwargs["transformer"]
+            payload = {
+                "data": [
+                    {
+                        "declaration": {
+                            "identity": {"name": "good"},
+                            "strategies": [{"identity": {"provider": "old"}}],
+                        }
+                    },
+                    {
+                        "declaration": {
+                            "identity": {"name": "broken"},
+                            "strategies": [{"name": "missing-identity"}],
+                        }
+                    },
+                ]
+            }
+            transformed = transformer(payload)
+            assert transformed["data"][0]["declaration"]["strategies"][0]["identity"]["provider"] == "good"
+            assert transformed["data"][1]["declaration"]["strategies"] == []
+            return [sibling]
+
+        request_mock = mocker.patch.object(client, "_request_with_plugin_daemon_response", side_effect=fake_request)
+
+        result = client.fetch_agent_strategy_providers("tenant-1")
+
+        assert request_mock.call_count == 1
+        assert result[0].declaration.identity.name == "org/plugin/good"
+
     def test_fetch_agent_strategy_provider(self, mocker: MockerFixture):
         client = PluginAgentClient()
         provider = _agent_provider("provider")

--- a/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
@@ -1,14 +1,22 @@
 import json
+import logging
 from collections.abc import Callable
 from urllib.parse import quote
 
+import httpx
 import pytest
 from pytest_mock import MockerFixture
 
 from core.plugin.endpoint.exc import EndpointSetupFailedError
-from core.plugin.entities.plugin_daemon import PluginDaemonInnerError, PluginListResponse
+from core.plugin.entities.plugin_daemon import PluginDaemonInnerError, PluginListResponse, PluginToolProviderEntity
 from core.plugin.impl.base import PLUGIN_DAEMON_MAX_PATH_LENGTH, BasePluginClient
-from core.plugin.impl.exc import PluginLLMPollingUnsupportedError, PluginRuntimeError
+from core.plugin.impl.exc import (
+    PluginDaemonClientSideError,
+    PluginDaemonInternalServerError,
+    PluginDaemonUnauthorizedError,
+    PluginLLMPollingUnsupportedError,
+    PluginRuntimeError,
+)
 from core.trigger.errors import (
     EventIgnoreError,
     TriggerInvokeError,
@@ -18,11 +26,13 @@ from core.trigger.errors import (
 
 
 class _ResponseStub:
-    def __init__(self, payload):
+    def __init__(self, payload, raise_for_status_error: Exception | None = None):
         self._payload = payload
+        self._raise_for_status_error = raise_for_status_error
 
     def raise_for_status(self):
-        return None
+        if self._raise_for_status_error is not None:
+            raise self._raise_for_status_error
 
     def json(self):
         return self._payload
@@ -40,6 +50,45 @@ class _StreamContext:
 
     def iter_lines(self):
         return self._lines
+
+
+def _i18n(text: str) -> dict[str, str]:
+    return {"en_US": text}
+
+
+def _tool_provider_payload(
+    *,
+    plugin_id: str = "langgenius/weather",
+    provider: str = "weather",
+    tools: list[dict] | None = None,
+) -> dict:
+    if tools is None:
+        tools = [
+            {
+                "identity": {
+                    "author": "langgenius",
+                    "name": "get_weather",
+                    "label": _i18n("Get Weather"),
+                    "provider": provider,
+                },
+                "description": {"human": _i18n("Get weather"), "llm": "Get weather"},
+            }
+        ]
+    return {
+        "provider": provider,
+        "plugin_unique_identifier": f"{plugin_id}:0.0.1@abc",
+        "plugin_id": plugin_id,
+        "declaration": {
+            "identity": {
+                "author": "langgenius",
+                "name": provider,
+                "description": _i18n(provider),
+                "icon": "icon.svg",
+                "label": _i18n(provider),
+            },
+            "tools": tools,
+        },
+    }
 
 
 class TestBasePluginClientImpl:
@@ -218,3 +267,148 @@ class TestBasePluginClientImpl:
             "Plugin runtime request failed: Runtime.ExitError: Runtime exited with error: exit status 1"
         )
         assert exc_info.value.lambda_request_id == lambda_request_id
+
+    def test_request_with_plugin_daemon_response_skips_invalid_list_items(self, mocker: MockerFixture, caplog):
+        client = BasePluginClient()
+        valid = _tool_provider_payload()
+        malformed = {
+            "plugin_id": "langgenius/broken",
+            "provider": "broken",
+            "plugin_unique_identifier": "langgenius/broken:0.0.1@def",
+        }
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub({"code": 0, "message": "", "data": [valid, malformed, "not-an-object"]}),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = client._request_with_plugin_daemon_response(
+                "GET",
+                "plugin/tenant/management/tools",
+                list[PluginToolProviderEntity],
+            )
+
+        assert len(result) == 1
+        assert result[0].plugin_id == "langgenius/weather"
+        assert "plugin_id=langgenius/broken" in caplog.text
+        assert "non-object str" in caplog.text
+
+    def test_request_with_plugin_daemon_response_all_invalid_list_returns_empty(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub({"code": 0, "message": "", "data": [{"bad": True}, 12]}),
+        )
+
+        result = client._request_with_plugin_daemon_response(
+            "GET",
+            "plugin/tenant/management/tools",
+            list[PluginToolProviderEntity],
+        )
+
+        assert result == []
+
+    def test_request_with_plugin_daemon_response_single_object_stays_strict(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub({"code": 0, "message": "", "data": {"plugin_id": "langgenius/broken"}}),
+        )
+
+        with pytest.raises(ValueError, match="Failed to parse response from plugin daemon"):
+            client._request_with_plugin_daemon_response(
+                "GET",
+                "plugin/tenant/management/tool",
+                PluginToolProviderEntity,
+            )
+
+    def test_request_with_plugin_daemon_response_primitive_list_stays_strict(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub({"code": 0, "message": "", "data": [True, "nope"]}),
+        )
+
+        with pytest.raises(ValueError, match="Failed to parse response from plugin daemon"):
+            client._request_with_plugin_daemon_response(
+                "POST",
+                "plugin/tenant/management/tools/check_existence",
+                list[bool],
+            )
+
+    def test_request_with_plugin_daemon_response_list_preserves_daemon_code_error(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub(
+                {"code": -1, "message": "daemon exploded", "data": [_tool_provider_payload(), {"bad": True}]}
+            ),
+        )
+
+        with pytest.raises(ValueError, match="daemon exploded, code: -1"):
+            client._request_with_plugin_daemon_response(
+                "GET",
+                "plugin/tenant/management/tools",
+                list[PluginToolProviderEntity],
+            )
+
+    def test_request_with_plugin_daemon_response_list_preserves_typed_daemon_error(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        error_message = json.dumps({"error_type": "PluginDaemonUnauthorizedError", "message": "Unauthorized access"})
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub({"code": -1, "message": error_message, "data": [_tool_provider_payload()]}),
+        )
+
+        with pytest.raises(PluginDaemonUnauthorizedError):
+            client._request_with_plugin_daemon_response(
+                "GET",
+                "plugin/tenant/management/tools",
+                list[PluginToolProviderEntity],
+            )
+
+    def test_request_with_plugin_daemon_response_http_4xx_unchanged(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        request = httpx.Request("GET", "http://plugin-daemon/plugin/tenant/management/tools")
+        response = httpx.Response(400, request=request)
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub(
+                {},
+                raise_for_status_error=httpx.HTTPStatusError("Bad Request", request=request, response=response),
+            ),
+        )
+
+        with pytest.raises(PluginDaemonClientSideError):
+            client._request_with_plugin_daemon_response(
+                "GET",
+                "plugin/tenant/management/tools",
+                list[PluginToolProviderEntity],
+            )
+
+    def test_request_with_plugin_daemon_response_http_5xx_unchanged(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        request = httpx.Request("GET", "http://plugin-daemon/plugin/tenant/management/tools")
+        response = httpx.Response(503, request=request)
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub(
+                {},
+                raise_for_status_error=httpx.HTTPStatusError("Service Unavailable", request=request, response=response),
+            ),
+        )
+
+        with pytest.raises(PluginDaemonInternalServerError):
+            client._request_with_plugin_daemon_response(
+                "GET",
+                "plugin/tenant/management/tools",
+                list[PluginToolProviderEntity],
+            )

--- a/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
@@ -5,6 +5,7 @@ from urllib.parse import quote
 
 import httpx
 import pytest
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from core.plugin.endpoint.exc import EndpointSetupFailedError
@@ -89,6 +90,58 @@ def _tool_provider_payload(
             "tools": tools,
         },
     }
+
+
+def _valid_tool_declaration(name: str, provider: str) -> dict:
+    return {
+        "identity": {
+            "author": "langgenius",
+            "name": name,
+            "label": _i18n(name),
+            "provider": provider,
+        },
+        "description": {"human": _i18n(name), "llm": name},
+        "parameters": [],
+    }
+
+
+def _issue_41605_csv_files_provider() -> dict:
+    """Provider matching #41605: tools[6].parameters[0] sets multiple=true on a files parameter."""
+    tools = [_valid_tool_declaration(f"tool-{index}", "csv-import") for index in range(6)]
+    tools.append(
+        {
+            "identity": {
+                "author": "langgenius",
+                "name": "import_csv",
+                "label": _i18n("Import CSV"),
+                "provider": "csv-import",
+            },
+            "description": {"human": _i18n("Import CSV"), "llm": "Import CSV"},
+            "parameters": [
+                {
+                    "name": "csv_files",
+                    "label": _i18n("CSV files"),
+                    "type": "files",
+                    "form": "llm",
+                    "required": False,
+                    "multiple": True,
+                    "options": None,
+                    "placeholder": None,
+                }
+            ],
+        }
+    )
+    return _tool_provider_payload(plugin_id="community/csv-import", provider="csv-import", tools=tools)
+
+
+def _issue_41605_management_tools_list() -> list[dict]:
+    """List shaped like the #41605 traceback: data[3] is the invalid provider."""
+    leading = [
+        _tool_provider_payload(plugin_id=f"langgenius/provider-{index}", provider=f"provider-{index}")
+        for index in range(3)
+    ]
+    trailing = _tool_provider_payload(plugin_id="langgenius/search", provider="search")
+    return [*leading, _issue_41605_csv_files_provider(), trailing]
 
 
 class TestBasePluginClientImpl:
@@ -293,6 +346,42 @@ class TestBasePluginClientImpl:
         assert result[0].plugin_id == "langgenius/weather"
         assert "plugin_id=langgenius/broken" in caplog.text
         assert "non-object str" in caplog.text
+
+    def test_request_with_plugin_daemon_response_skips_multiple_true_on_non_select_parameter(
+        self, mocker: MockerFixture, caplog
+    ):
+        """#41605: multiple=true on a files parameter at data[3].tools[6].parameters[0]."""
+        invalid_provider = _issue_41605_csv_files_provider()
+        with pytest.raises(ValidationError, match="multiple is only valid"):
+            PluginToolProviderEntity.model_validate(invalid_provider)
+        assert len(invalid_provider["declaration"]["tools"]) == 7
+        assert invalid_provider["declaration"]["tools"][6]["parameters"][0]["name"] == "csv_files"
+
+        mixed_list = _issue_41605_management_tools_list()
+        assert mixed_list[3]["plugin_id"] == "community/csv-import"
+
+        client = BasePluginClient()
+        mocker.patch.object(
+            client,
+            "_request",
+            return_value=_ResponseStub({"code": 0, "message": "", "data": mixed_list}),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = client._request_with_plugin_daemon_response(
+                "GET",
+                "plugin/tenant/management/tools",
+                list[PluginToolProviderEntity],
+            )
+
+        assert [provider.plugin_id for provider in result] == [
+            "langgenius/provider-0",
+            "langgenius/provider-1",
+            "langgenius/provider-2",
+            "langgenius/search",
+        ]
+        assert "plugin_id=community/csv-import" in caplog.text
+        assert "multiple is only valid for select and dynamic-select parameters" in caplog.text
 
     def test_request_with_plugin_daemon_response_all_invalid_list_returns_empty(self, mocker: MockerFixture):
         client = BasePluginClient()

--- a/api/tests/unit_tests/core/plugin/impl/test_datasource_manager.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_datasource_manager.py
@@ -54,6 +54,44 @@ class TestPluginDatasourceManager:
         assert result[1].declaration.datasources[0].identity.provider == "org/plugin/remote"
         repack.assert_called_once_with(tenant_id="tenant-1", provider=provider)
 
+    def test_fetch_datasource_providers_skips_datasource_without_identity(self, mocker: MockerFixture):
+        manager = PluginDatasourceManager()
+        sibling = _datasource_provider("good")
+        mocker.patch("core.plugin.impl.datasource.ToolTransformService.repack_provider")
+        mocker.patch("core.plugin.impl.datasource.resolve_dify_schema_refs", return_value={"resolved": True})
+
+        def fake_request(method, path, type_, **kwargs):
+            transformer = kwargs["transformer"]
+            payload = {
+                "data": [
+                    {
+                        "plugin_id": "org/plugin",
+                        "declaration": {
+                            "identity": {"name": "good"},
+                            "datasources": [{"identity": {"provider": "old"}, "output_schema": {"$ref": "#/doc"}}],
+                        },
+                    },
+                    {
+                        "plugin_id": "org/broken",
+                        "declaration": {
+                            "identity": {"name": "broken"},
+                            "datasources": [{"name": "missing-identity"}],
+                        },
+                    },
+                ]
+            }
+            transformed = transformer(payload)
+            assert transformed["data"][0]["declaration"]["datasources"][0]["identity"]["provider"] == "good"
+            assert transformed["data"][1]["declaration"]["datasources"] == []
+            return [sibling]
+
+        request_mock = mocker.patch.object(manager, "_request_with_plugin_daemon_response", side_effect=fake_request)
+
+        result = manager.fetch_datasource_providers("tenant-1")
+
+        assert request_mock.call_count == 1
+        assert result[1].declaration.identity.name == "org/plugin/good"
+
     def test_fetch_installed_datasource_providers(self, mocker: MockerFixture):
         manager = PluginDatasourceManager()
         provider = _datasource_provider("remote")

--- a/api/tests/unit_tests/core/plugin/impl/test_tool_manager.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_tool_manager.py
@@ -6,6 +6,17 @@ from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.impl.tool import PluginToolManager
 
 
+class _ResponseStub:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
 def _tool_provider(name: str = "provider") -> SimpleNamespace:
     return SimpleNamespace(
         plugin_id="org/plugin",
@@ -45,6 +56,119 @@ class TestPluginToolManager:
         assert request_mock.call_count == 1
         assert result[0].declaration.identity.name == "org/plugin/remote"
         assert result[0].declaration.tools[0].identity.provider == "org/plugin/remote"
+
+    def test_fetch_tool_providers_skips_tool_without_identity(self, mocker: MockerFixture):
+        manager = PluginToolManager()
+        sibling = _tool_provider("good")
+        broken = _tool_provider("broken")
+        mocker.patch("core.plugin.impl.tool.resolve_dify_schema_refs", return_value={"resolved": True})
+
+        def fake_request(method, path, type_, **kwargs):
+            transformer = kwargs["transformer"]
+            payload = {
+                "data": [
+                    {
+                        "plugin_id": "org/plugin",
+                        "declaration": {
+                            "identity": {"name": "good"},
+                            "tools": [{"identity": {"provider": "old"}, "output_schema": {"$ref": "#/x"}}],
+                        },
+                    },
+                    {
+                        "plugin_id": "org/broken",
+                        "declaration": {
+                            "identity": {"name": "broken"},
+                            "tools": [{"name": "missing-identity"}, "not-a-dict"],
+                        },
+                    },
+                ]
+            }
+            transformed = transformer(payload)
+            assert len(transformed["data"]) == 2
+            assert transformed["data"][0]["declaration"]["tools"][0]["identity"]["provider"] == "good"
+            assert transformed["data"][1]["declaration"]["tools"] == []
+            return [sibling, broken]
+
+        request_mock = mocker.patch.object(manager, "_request_with_plugin_daemon_response", side_effect=fake_request)
+
+        result = manager.fetch_tool_providers("tenant-1")
+
+        assert request_mock.call_count == 1
+        assert [provider.declaration.identity.name for provider in result] == [
+            "org/plugin/good",
+            "org/plugin/broken",
+        ]
+
+    def test_fetch_tool_providers_keeps_siblings_when_one_declaration_is_invalid(self, mocker: MockerFixture):
+        manager = PluginToolManager()
+        valid = {
+            "provider": "weather",
+            "plugin_unique_identifier": "langgenius/weather:0.0.1@abc",
+            "plugin_id": "langgenius/weather",
+            "declaration": {
+                "identity": {
+                    "author": "langgenius",
+                    "name": "weather",
+                    "description": {"en_US": "Weather"},
+                    "icon": "icon.svg",
+                    "label": {"en_US": "Weather"},
+                },
+                "tools": [
+                    {
+                        "identity": {
+                            "author": "langgenius",
+                            "name": "get_weather",
+                            "label": {"en_US": "Get Weather"},
+                            "provider": "weather",
+                        },
+                        "description": {"human": {"en_US": "Get weather"}, "llm": "Get weather"},
+                    },
+                    {"name": "broken-tool-without-identity"},
+                ],
+            },
+        }
+        sibling = {
+            "provider": "search",
+            "plugin_unique_identifier": "langgenius/search:0.0.1@def",
+            "plugin_id": "langgenius/search",
+            "declaration": {
+                "identity": {
+                    "author": "langgenius",
+                    "name": "search",
+                    "description": {"en_US": "Search"},
+                    "icon": "icon.svg",
+                    "label": {"en_US": "Search"},
+                },
+                "tools": [
+                    {
+                        "identity": {
+                            "author": "langgenius",
+                            "name": "web_search",
+                            "label": {"en_US": "Web Search"},
+                            "provider": "search",
+                        },
+                        "description": {"human": {"en_US": "Search the web"}, "llm": "Search the web"},
+                    }
+                ],
+            },
+        }
+        mocker.patch.object(
+            manager,
+            "_request",
+            return_value=_ResponseStub(
+                {
+                    "code": 0,
+                    "message": "",
+                    "data": [valid, {"plugin_id": "langgenius/corrupt", "provider": "corrupt"}, sibling],
+                }
+            ),
+        )
+
+        result = manager.fetch_tool_providers("tenant-1")
+
+        assert [provider.plugin_id for provider in result] == ["langgenius/weather", "langgenius/search"]
+        assert [tool.identity.name for tool in result[0].declaration.tools] == ["get_weather"]
+        assert result[1].declaration.identity.name == "langgenius/search/search"
 
     def test_fetch_tool_provider(self, mocker: MockerFixture):
         manager = PluginToolManager()

--- a/api/tests/unit_tests/core/plugin/impl/test_tool_manager.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_tool_manager.py
@@ -4,6 +4,7 @@ from pytest_mock import MockerFixture
 
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.impl.tool import PluginToolManager
+from tests.unit_tests.core.plugin.impl.test_base_client_impl import _issue_41605_management_tools_list
 
 
 class _ResponseStub:
@@ -169,6 +170,24 @@ class TestPluginToolManager:
         assert [provider.plugin_id for provider in result] == ["langgenius/weather", "langgenius/search"]
         assert [tool.identity.name for tool in result[0].declaration.tools] == ["get_weather"]
         assert result[1].declaration.identity.name == "langgenius/search/search"
+
+    def test_fetch_tool_providers_skips_multiple_true_on_non_select_parameter(self, mocker: MockerFixture):
+        manager = PluginToolManager()
+        mocker.patch.object(
+            manager,
+            "_request",
+            return_value=_ResponseStub({"code": 0, "message": "", "data": _issue_41605_management_tools_list()}),
+        )
+
+        result = manager.fetch_tool_providers("tenant-1")
+
+        assert [provider.plugin_id for provider in result] == [
+            "langgenius/provider-0",
+            "langgenius/provider-1",
+            "langgenius/provider-2",
+            "langgenius/search",
+        ]
+        assert result[-1].declaration.identity.name == "langgenius/search/search"
 
     def test_fetch_tool_provider(self, mocker: MockerFixture):
         manager = PluginToolManager()

--- a/api/tests/unit_tests/core/plugin/impl/test_trigger_client.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_trigger_client.py
@@ -90,6 +90,44 @@ class TestPluginTriggerClient:
         assert result[0].declaration.identity.name == "org/plugin/remote"
         assert result[0].declaration.events[0].identity.provider == "org/plugin/remote"
 
+    def test_fetch_trigger_providers_skips_event_without_identity(self, mocker: MockerFixture):
+        client = PluginTriggerClient()
+        sibling = _trigger_provider("good")
+
+        def fake_request(*args, **kwargs):
+            transformer = kwargs["transformer"]
+            payload = {
+                "data": [
+                    {
+                        "plugin_id": "org/plugin",
+                        "provider": "good",
+                        "declaration": {"events": [{"identity": {"provider": "old"}}]},
+                    },
+                    {
+                        "plugin_id": None,
+                        "provider": "broken",
+                        "declaration": {"events": [{"identity": {"provider": "old"}}]},
+                    },
+                    {
+                        "plugin_id": "org/plugin",
+                        "provider": "ok",
+                        "declaration": {"events": [{"name": "missing-identity"}]},
+                    },
+                ]
+            }
+            transformed = transformer(payload)
+            assert transformed["data"][0]["declaration"]["events"][0]["identity"]["provider"] == "org/plugin/good"
+            assert transformed["data"][1]["declaration"]["events"][0]["identity"]["provider"] is None
+            assert transformed["data"][2]["declaration"]["events"] == []
+            return [sibling]
+
+        request_mock = mocker.patch.object(client, "_request_with_plugin_daemon_response", side_effect=fake_request)
+
+        result = client.fetch_trigger_providers("tenant-1")
+
+        assert request_mock.call_count == 1
+        assert result[0].declaration.identity.name == "org/plugin/good"
+
     def test_fetch_trigger_provider(self, mocker: MockerFixture):
         client = PluginTriggerClient()
         provider = _trigger_provider("provider")


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #41703`.

## Summary

Fixes #41703

Related: #41605

`BasePluginClient._request_with_plugin_daemon_response` validated `PluginDaemonBasicResponse[list[T]]` atomically. One malformed plugin declaration (or a list transformer `KeyError` on a missing `identity`) failed the entire management list. Console then mapped the resulting `ValueError` to HTTP 400 `invalid_param`, so Tools / Models / Triggers / Datasources could not load any providers until the bad plugin was uninstalled.

This change:

- Validates **list** payloads per item. Invalid elements are skipped with a warning that includes `plugin_id` / `provider` / `plugin_unique_identifier` when available. The valid remainder is returned; an all-invalid list returns `[]`.
- Keeps **single-object** fetches (`management/tool`, `management/trigger`, …) strict.
- Hardens list transformers in `tool.py`, `datasource.py`, `trigger.py`, and `agent.py` so a missing `identity` on one inner item does not take down sibling providers.
- Does **not** change HTTP errors or daemon `code != 0` handling. Invalid declarations are not treated as daemon-unavailable (that path belongs to #41675).

Regression fixture from #41605: `data.3.declaration.tools.6.parameters.0` with `multiple: true` on a non-select `files` parameter. Mixed with valid providers, the list returns the remainder instead of raising `ValueError`.

## Screenshots

Backend parse path. Targeted unit tests covering mixed lists, all-invalid lists, strict single-object fetches, transformer sibling isolation, unchanged HTTP / `code != 0` behavior, and the #41605 `multiple`-on-non-select fixture: **67 passed**.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) to appease the lint gods
