### PR TITLE
fix: continue workflow stream delivery after broken pipes

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -31,7 +31,7 @@ from graphon.runtime import GraphRuntimeState
 logger = logging.getLogger(__name__)
 
 
-def _is_broken_pipe_error(error: BaseException) -> bool:
+def is_broken_pipe_error(error: BaseException) -> bool:
     current_error: BaseException | None = error
     while current_error is not None:
         if isinstance(current_error, BrokenPipeError):
@@ -225,7 +225,7 @@ class AppQueueManager(ABC):
         try:
             result = redis_client.get(stopped_cache_key)
         except (BrokenPipeError, RedisError) as exc:
-            if not _is_broken_pipe_error(exc):
+            if not is_broken_pipe_error(exc):
                 raise
             logger.warning(
                 "Ignoring broken pipe while checking task stop flag; task=%s key=%s",

--- a/api/tasks/app_generate/workflow_execute_task.py
+++ b/api/tasks/app_generate/workflow_execute_task.py
@@ -364,7 +364,8 @@ def _publish_streaming_response(
     `_AppRunner.run()` only handles failures before the generator is returned.
     Once we start iterating the runtime stream, this helper becomes the last
     place that can guarantee SSE consumers eventually see a terminal workflow
-    lifecycle event.
+    lifecycle event. Delivery failures must not stop generator iteration because
+    terminal handlers may still need to persist application state.
     """
     normalized_workflow_run_id = str(workflow_run_id)
 
@@ -419,6 +420,7 @@ def _publish_streaming_response(
     terminal_published = False
     last_task_id = normalized_workflow_run_id
     stream_error_message: str | None = None
+    delivery_error: Exception | None = None
 
     try:
         for event in response_stream:
@@ -426,6 +428,12 @@ def _publish_streaming_response(
             task_id = _get_task_id(event)
             if task_id is not None:
                 last_task_id = task_id
+
+            if event_name == "error":
+                stream_error_message = _get_error_message(event) or stream_error_message
+
+            if delivery_error is not None:
+                continue
 
             try:
                 if isinstance(event, BaseModel):
@@ -436,14 +444,21 @@ def _publish_streaming_response(
                 logger.exception("error while encoding event")
                 continue
 
-            topic.publish(payload.encode())
+            try:
+                topic.publish(payload.encode())
+            except Exception as exc:
+                delivery_error = exc
+                logger.exception(
+                    "Failed to publish workflow stream event for run %s; draining response stream before retrying "
+                    "terminal delivery",
+                    normalized_workflow_run_id,
+                )
+                continue
 
             if event_name == "workflow_started":
                 started_published = True
             elif event_name in terminal_events:
                 terminal_published = True
-            elif event_name == "error":
-                stream_error_message = _get_error_message(event) or stream_error_message
     except Exception as exc:
         if not terminal_published:
             logger.exception(
@@ -456,6 +471,26 @@ def _publish_streaming_response(
                 publish_started=not started_published,
             )
         raise
+
+    if delivery_error is not None:
+        if not terminal_published:
+            logger.error(
+                "Workflow response delivery for run %s failed; publishing fallback terminal event after draining "
+                "the response stream",
+                normalized_workflow_run_id,
+            )
+            try:
+                _publish_failed_terminal_event(
+                    error_message=str(delivery_error) or delivery_error.__class__.__name__,
+                    task_id=last_task_id,
+                    publish_started=not started_published,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to publish fallback terminal event for workflow run %s",
+                    normalized_workflow_run_id,
+                )
+        raise delivery_error
 
     if not terminal_published:
         logger.warning(

--- a/api/tasks/app_generate/workflow_execute_task.py
+++ b/api/tasks/app_generate/workflow_execute_task.py
@@ -8,10 +8,12 @@ from typing import Annotated, Any
 from celery import shared_task
 from flask import current_app, json
 from pydantic import BaseModel, Discriminator, Field, Tag
+from redis.exceptions import ConnectionError as RedisConnectionError
 from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.app.apps.advanced_chat.app_generator import AdvancedChatAppGenerator
+from core.app.apps.base_app_queue_manager import is_broken_pipe_error
 from core.app.apps.execution_coordinator import clear_app_task_cancellation_signals
 from core.app.apps.message_based_app_generator import MessageBasedAppGenerator
 from core.app.apps.workflow.app_generator import WorkflowAppGenerator
@@ -364,8 +366,8 @@ def _publish_streaming_response(
     `_AppRunner.run()` only handles failures before the generator is returned.
     Once we start iterating the runtime stream, this helper becomes the last
     place that can guarantee SSE consumers eventually see a terminal workflow
-    lifecycle event. Delivery failures must not stop generator iteration because
-    terminal handlers may still need to persist application state.
+    lifecycle event. Broken-pipe delivery failures must not stop generator
+    iteration because terminal handlers may still need to persist application state.
     """
     normalized_workflow_run_id = str(workflow_run_id)
 
@@ -420,7 +422,7 @@ def _publish_streaming_response(
     terminal_published = False
     last_task_id = normalized_workflow_run_id
     stream_error_message: str | None = None
-    delivery_error: Exception | None = None
+    broken_pipe_error: BrokenPipeError | RedisConnectionError | None = None
 
     try:
         for event in response_stream:
@@ -432,7 +434,7 @@ def _publish_streaming_response(
             if event_name == "error":
                 stream_error_message = _get_error_message(event) or stream_error_message
 
-            if delivery_error is not None:
+            if broken_pipe_error is not None:
                 continue
 
             try:
@@ -446,11 +448,13 @@ def _publish_streaming_response(
 
             try:
                 topic.publish(payload.encode())
-            except Exception as exc:
-                delivery_error = exc
+            except (BrokenPipeError, RedisConnectionError) as exc:
+                if not is_broken_pipe_error(exc):
+                    raise
+                broken_pipe_error = exc
                 logger.exception(
-                    "Failed to publish workflow stream event for run %s; draining response stream before retrying "
-                    "terminal delivery",
+                    "Broken pipe while publishing workflow stream event for run %s; draining response stream before "
+                    "retrying terminal delivery",
                     normalized_workflow_run_id,
                 )
                 continue
@@ -472,7 +476,7 @@ def _publish_streaming_response(
             )
         raise
 
-    if delivery_error is not None:
+    if broken_pipe_error is not None:
         if not terminal_published:
             logger.error(
                 "Workflow response delivery for run %s failed; publishing fallback terminal event after draining "
@@ -481,16 +485,18 @@ def _publish_streaming_response(
             )
             try:
                 _publish_failed_terminal_event(
-                    error_message=str(delivery_error) or delivery_error.__class__.__name__,
+                    error_message=str(broken_pipe_error) or broken_pipe_error.__class__.__name__,
                     task_id=last_task_id,
                     publish_started=not started_published,
                 )
-            except Exception:
+            except (BrokenPipeError, RedisConnectionError) as exc:
+                if not is_broken_pipe_error(exc):
+                    raise
                 logger.exception(
                     "Failed to publish fallback terminal event for workflow run %s",
                     normalized_workflow_run_id,
                 )
-        raise delivery_error
+        raise broken_pipe_error
 
     if not terminal_published:
         logger.warning(

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -456,22 +456,30 @@ def test_publish_streaming_response_recovers_when_workflow_started_publish_fails
     assert "publishing fallback terminal event" in caplog.text
 
 
-def test_publish_streaming_response_publishes_failed_terminal_without_duplicate_started_on_publish_error(
+def test_publish_streaming_response_drains_stream_before_reraising_publish_error(
     mock_topic: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ):
     caplog.set_level(logging.ERROR, logger="tasks.app_generate.workflow_execute_task")
-    response_stream = iter(
-        [
-            {
-                "event": "workflow_started",
-                "task_id": "task-id",
-                "workflow_run_id": "workflow-run-id",
-                "data": {"id": "workflow-run-id", "workflow_id": "workflow-id", "inputs": {}, "created_at": 1},
-            },
-            {"event": "node_started", "task_id": "task-id"},
-        ]
-    )
+    message_finalized = False
+
+    def response_stream() -> Generator[Mapping[str, object], None, None]:
+        nonlocal message_finalized
+
+        yield {
+            "event": "workflow_started",
+            "task_id": "task-id",
+            "workflow_run_id": "workflow-run-id",
+            "data": {"id": "workflow-run-id", "workflow_id": "workflow-id", "inputs": {}, "created_at": 1},
+        }
+        yield {"event": "node_started", "task_id": "task-id"}
+        message_finalized = True
+        yield {
+            "event": "workflow_finished",
+            "task_id": "task-id",
+            "data": {"status": WorkflowExecutionStatus.SUCCEEDED},
+        }
+
     successful_payloads: list[dict[str, object] | str] = []
 
     def _publish(payload: bytes) -> None:
@@ -484,7 +492,7 @@ def test_publish_streaming_response_publishes_failed_terminal_without_duplicate_
 
     with pytest.raises(RuntimeError, match="broker write failed"):
         _publish_streaming_response(
-            response_stream,
+            response_stream(),
             "workflow-run-id",
             app_mode=AppMode.ADVANCED_CHAT,
             workflow_id="workflow-id",
@@ -492,12 +500,48 @@ def test_publish_streaming_response_publishes_failed_terminal_without_duplicate_
             started_reason=WorkflowStartReason.INITIAL,
         )
 
+    assert message_finalized is True
     assert [payload["event"] for payload in successful_payloads] == ["workflow_started", "workflow_finished"]
     assert successful_payloads[1]["task_id"] == "task-id"
     assert successful_payloads[1]["data"]["status"] == WorkflowExecutionStatus.FAILED
     assert successful_payloads[1]["data"]["error"] == "broker write failed"
     assert "workflow-run-id" in caplog.text
     assert "publishing fallback terminal event" in caplog.text
+
+
+def test_publish_streaming_response_preserves_delivery_error_when_fallback_publish_fails(
+    mock_topic: MagicMock,
+):
+    delivery_error = RuntimeError("broker write failed")
+    fallback_error = RuntimeError("fallback publish failed")
+    message_finalized = False
+
+    def response_stream() -> Generator[Mapping[str, object], None, None]:
+        nonlocal message_finalized
+
+        yield {"event": "workflow_started", "task_id": "task-id"}
+        message_finalized = True
+        yield {
+            "event": "workflow_finished",
+            "task_id": "task-id",
+            "data": {"status": WorkflowExecutionStatus.SUCCEEDED},
+        }
+
+    mock_topic.publish.side_effect = [delivery_error, fallback_error]
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _publish_streaming_response(
+            response_stream(),
+            "workflow-run-id",
+            app_mode=AppMode.ADVANCED_CHAT,
+            workflow_id="workflow-id",
+            inputs={},
+            started_reason=WorkflowStartReason.INITIAL,
+        )
+
+    assert exc_info.value is delivery_error
+    assert message_finalized is True
+    assert mock_topic.publish.call_count == 2
 
 
 def test_publish_streaming_response_recovers_when_workflow_finished_publish_fails_first(

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import uuid
@@ -12,6 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from pydantic import BaseModel
+from redis.exceptions import ConnectionError as RedisConnectionError
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -75,6 +77,12 @@ def _decode_published_payload(payload: bytes) -> dict[str, object] | str:
 
 def _published_payloads(topic: MagicMock) -> list[dict[str, object] | str]:
     return [_decode_published_payload(call.args[0]) for call in topic.publish.call_args_list]
+
+
+def _redis_broken_pipe_error() -> RedisConnectionError:
+    error = RedisConnectionError("Error 32 while writing to socket. Broken pipe.")
+    error.__context__ = BrokenPipeError(errno.EPIPE, "Broken pipe")
+    return error
 
 
 def _make_account(*, account_id: str = "account-id") -> Account:
@@ -461,6 +469,7 @@ def test_publish_streaming_response_drains_stream_before_reraising_publish_error
     caplog: pytest.LogCaptureFixture,
 ):
     caplog.set_level(logging.ERROR, logger="tasks.app_generate.workflow_execute_task")
+    publish_error = _redis_broken_pipe_error()
     message_finalized = False
 
     def response_stream() -> Generator[Mapping[str, object], None, None]:
@@ -485,12 +494,12 @@ def test_publish_streaming_response_drains_stream_before_reraising_publish_error
     def _publish(payload: bytes) -> None:
         decoded = _decode_published_payload(payload)
         if isinstance(decoded, dict) and decoded.get("event") == "node_started":
-            raise RuntimeError("broker write failed")
+            raise publish_error
         successful_payloads.append(decoded)
 
     mock_topic.publish.side_effect = _publish
 
-    with pytest.raises(RuntimeError, match="broker write failed"):
+    with pytest.raises(RedisConnectionError) as exc_info:
         _publish_streaming_response(
             response_stream(),
             "workflow-run-id",
@@ -500,20 +509,21 @@ def test_publish_streaming_response_drains_stream_before_reraising_publish_error
             started_reason=WorkflowStartReason.INITIAL,
         )
 
+    assert exc_info.value is publish_error
     assert message_finalized is True
     assert [payload["event"] for payload in successful_payloads] == ["workflow_started", "workflow_finished"]
     assert successful_payloads[1]["task_id"] == "task-id"
     assert successful_payloads[1]["data"]["status"] == WorkflowExecutionStatus.FAILED
-    assert successful_payloads[1]["data"]["error"] == "broker write failed"
+    assert successful_payloads[1]["data"]["error"] == "Error 32 while writing to socket. Broken pipe."
     assert "workflow-run-id" in caplog.text
     assert "publishing fallback terminal event" in caplog.text
 
 
-def test_publish_streaming_response_preserves_delivery_error_when_fallback_publish_fails(
+def test_publish_streaming_response_preserves_delivery_error_when_fallback_hits_broken_pipe(
     mock_topic: MagicMock,
 ):
-    delivery_error = RuntimeError("broker write failed")
-    fallback_error = RuntimeError("fallback publish failed")
+    delivery_error = _redis_broken_pipe_error()
+    fallback_error = _redis_broken_pipe_error()
     message_finalized = False
 
     def response_stream() -> Generator[Mapping[str, object], None, None]:
@@ -529,7 +539,7 @@ def test_publish_streaming_response_preserves_delivery_error_when_fallback_publi
 
     mock_topic.publish.side_effect = [delivery_error, fallback_error]
 
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RedisConnectionError) as exc_info:
         _publish_streaming_response(
             response_stream(),
             "workflow-run-id",
@@ -542,6 +552,45 @@ def test_publish_streaming_response_preserves_delivery_error_when_fallback_publi
     assert exc_info.value is delivery_error
     assert message_finalized is True
     assert mock_topic.publish.call_count == 2
+
+
+def test_publish_streaming_response_does_not_drain_stream_after_other_redis_errors(
+    mock_topic: MagicMock,
+):
+    publish_error = RedisConnectionError("Connection refused")
+    message_finalized = False
+
+    def response_stream() -> Generator[Mapping[str, object], None, None]:
+        nonlocal message_finalized
+
+        yield {"event": "workflow_started", "task_id": "task-id"}
+        yield {"event": "node_started", "task_id": "task-id"}
+        message_finalized = True
+        yield {
+            "event": "workflow_finished",
+            "task_id": "task-id",
+            "data": {"status": WorkflowExecutionStatus.SUCCEEDED},
+        }
+
+    def publish(payload: bytes) -> None:
+        decoded = _decode_published_payload(payload)
+        if isinstance(decoded, dict) and decoded.get("event") == "node_started":
+            raise publish_error
+
+    mock_topic.publish.side_effect = publish
+
+    with pytest.raises(RedisConnectionError) as exc_info:
+        _publish_streaming_response(
+            response_stream(),
+            "workflow-run-id",
+            app_mode=AppMode.ADVANCED_CHAT,
+            workflow_id="workflow-id",
+            inputs={},
+            started_reason=WorkflowStartReason.INITIAL,
+        )
+
+    assert exc_info.value is publish_error
+    assert message_finalized is False
 
 
 def test_publish_streaming_response_recovers_when_workflow_finished_publish_fails_first(


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex. Human review is required before merging; the PR author is responsible for the final content.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41712.

A Redis broken pipe during response publication can stop the Chatflow generator before it persists the message answer. Skip only the event whose publication fails with `EPIPE`, then keep consuming the generator and attempting to publish subsequent events through redis-py's connection pool. A successfully delivered workflow terminal event is preserved without a synthetic failure or re-raising an earlier, logged broken pipe.

Log the exception before clearing traceback frames throughout its cause/context chain, and retain only an error string for fallback terminal delivery. Non-`EPIPE` delivery errors and generator failures retain their existing propagation behavior. If no terminal event was delivered, attempt the existing failed-terminal fallback; a further broken pipe is logged and its frames are cleared.

### Validation

- 66 related unit tests passed, covering recovery, repeated failures, successful/partial/paused terminal delivery, weak-reference checks for frame resource release, and propagation of other errors:
  `LITELLM_LOCAL_MODEL_COST_MAP=True uv run --project api --dev pytest api/tests/unit_tests/tasks/test_workflow_execute_task.py api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py -q --no-cov`
- `make lint` passed.
- `make type-check PATH_TO_CHECK='api/core/app/apps/base_app_queue_manager.py api/tasks/app_generate/workflow_execute_task.py'` passed: scoped pyrefly and full mypy (1,752 source files).
- The unscoped `make type-check` previously stopped at the test pyrefly configurations with `No Python files matched pattern`; the targeted invocation above avoids that configuration failure. Backend integration tests are left to CI.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A: backend-only change | N/A: backend-only change |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

No user-facing documentation or frontend changes are required. The exact validation scope and the unscoped type-check limitation are listed above.

From Codex
