### PR TITLE
fix(api): reject case-insensitive email duplicates

### DIFF
--- a/api/repositories/account_repository.py
+++ b/api/repositories/account_repository.py
@@ -2,7 +2,7 @@
 
 from typing import override
 
-from sqlalchemy import case, delete, select
+from sqlalchemy import case, delete, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from models.account import Account, AccountIntegrate, AccountStatus, InvitationCode, InvitationCodeStatus
@@ -189,7 +189,14 @@ class SQLAlchemyAccountRepository(AccountRepository, ConsoleAuthAccountRepositor
                 return AccountEmailResetResult(status=AccountEmailResetStatus.ACCOUNT_NOT_FOUND)
             if account.email.lower() != expected_old_email.lower():
                 return AccountEmailResetResult(status=AccountEmailResetStatus.EMAIL_CHANGED)
-            if session.scalar(select(Account.id).where(Account.email == new_email).limit(1)) is not None:
+            if account.email == new_email:
+                return AccountEmailResetResult(status=AccountEmailResetStatus.EMAIL_IN_USE)
+            duplicate_stmt = (
+                select(Account.id)
+                .where(func.lower(Account.email) == new_email.lower(), Account.id != account_id)
+                .limit(1)
+            )
+            if session.scalar(duplicate_stmt) is not None:
                 return AccountEmailResetResult(status=AccountEmailResetStatus.EMAIL_IN_USE)
 
             account.email = new_email

--- a/api/tests/unit_tests/repositories/test_account_repository.py
+++ b/api/tests/unit_tests/repositories/test_account_repository.py
@@ -7,16 +7,26 @@ from sqlalchemy.orm import Session, sessionmaker
 from models.account import Account, AccountIntegrate, AccountStatus, InvitationCode, InvitationCodeStatus
 from repositories.account_integration_repository import SQLAlchemyAccountIntegrationRepository
 from repositories.account_repository import SQLAlchemyAccountRepository
-from services.entities.account_entities import AccountInitialization, AccountPasswordDigest, AccountProfileChanges
+from services.entities.account_entities import (
+    AccountEmailResetStatus,
+    AccountInitialization,
+    AccountPasswordDigest,
+    AccountProfileChanges,
+)
 from services.entities.account_login_entities import (
     AccountSessionPreparation,
     PasswordLoginCompletion,
 )
 
 
-def _persist_account(session: Session) -> Account:
-    account = Account(name="Original", email="account@example.com")
-    account.id = "account-1"
+def _persist_account(
+    session: Session,
+    *,
+    account_id: str = "account-1",
+    email: str = "account@example.com",
+) -> Account:
+    account = Account(name="Original", email=email)
+    account.id = account_id
     account.interface_language = "en-US"
     account.interface_theme = "light"
     account.timezone = "UTC"
@@ -305,3 +315,71 @@ def test_account_repository_updates_email_and_removes_integrations_atomically(
     assert persisted.email == "new@example.com"
     assert persisted.normalized_email == "new@example.com"
     assert sqlite_session.get(AccountIntegrate, integration_id) is None
+
+
+def test_account_repository_rejects_case_variant_of_another_account_email(
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _persist_account(sqlite_session)
+    _persist_account(sqlite_session, account_id="account-2", email="Taken@Example.com")
+    repository = SQLAlchemyAccountRepository(sqlite_session_factory)
+
+    result = repository.reset_email(
+        "account-1",
+        expected_old_email="account@example.com",
+        new_email="taken@example.com",
+    )
+
+    assert result.status == AccountEmailResetStatus.EMAIL_IN_USE
+    sqlite_session.expire_all()
+    persisted = sqlite_session.get(Account, "account-1")
+    assert persisted is not None
+    assert persisted.email == "account@example.com"
+
+
+def test_account_repository_rejects_unchanged_email_without_removing_integrations(
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _persist_account(sqlite_session)
+    integration = AccountIntegrate(
+        account_id="account-1",
+        provider="google",
+        open_id="google-user",
+        encrypted_token="encrypted-token",
+    )
+    sqlite_session.add(integration)
+    sqlite_session.commit()
+    integration_id = integration.id
+    repository = SQLAlchemyAccountRepository(sqlite_session_factory)
+
+    result = repository.reset_email(
+        "account-1",
+        expected_old_email="account@example.com",
+        new_email="account@example.com",
+    )
+
+    assert result.status == AccountEmailResetStatus.EMAIL_IN_USE
+    sqlite_session.expire_all()
+    assert sqlite_session.get(AccountIntegrate, integration_id) is not None
+
+
+def test_account_repository_allows_changing_only_the_current_accounts_email_case(
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _persist_account(sqlite_session, email="Account@Example.com")
+    repository = SQLAlchemyAccountRepository(sqlite_session_factory)
+
+    result = repository.reset_email(
+        "account-1",
+        expected_old_email="account@example.com",
+        new_email="account@example.com",
+    )
+
+    assert result.status == AccountEmailResetStatus.UPDATED
+    sqlite_session.expire_all()
+    persisted = sqlite_session.get(Account, "account-1")
+    assert persisted is not None
+    assert persisted.email == "account@example.com"


### PR DESCRIPTION
## Summary

Fixes #41096.

The change-email repository guard compared `Account.email` case-sensitively, allowing an account to change to a case variant of another account's email address when legacy mixed-case rows exist.

This change keeps the existing exact no-op rejection, then checks other accounts with `LOWER(email)` before updating. The current account is excluded so a case-only normalization remains possible.

Regression tests cover:

- rejecting a case variant of another account's email;
- rejecting an unchanged email without deleting account integrations;
- allowing a case-only update of the current account's email.

The repository's `email_exists` method is intentionally unchanged because its UI contract is outside this write-path fix.

## Screenshots

Not applicable; backend repository behavior only.

## Checklist

- [x] This change does not require a documentation update.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and kept the change atomic.
- [x] Targeted repository tests pass: `11 passed`.
- [x] Ruff check, Ruff format check, and `git diff --check` pass.
- [ ] Full `make lint && make type-check` was not run.

From Codex
