### PR TITLE
refactor(models): remove legacy db.session property wrappers on Document

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -622,10 +622,6 @@ class Document(Base):
             return data_source_info_dict
         return {}
 
-    @property
-    def data_source_detail_dict(self) -> dict[str, Any]:
-        return self.get_data_source_detail_dict(session=db.session())
-
     def get_data_source_detail_dict(self, *, session: Session) -> dict[str, Any]:
         if self.data_source_info:
             if self.data_source_type == "upload_file":
@@ -665,10 +661,6 @@ class Document(Base):
             return session.get(DatasetProcessRule, self.dataset_process_rule_id)
         return None
 
-    @property
-    def dataset(self) -> Dataset | None:
-        return self.get_dataset(session=db.session())
-
     def get_dataset(self, *, session: Session) -> Dataset | None:
         """Load the owning dataset with the caller-owned database session."""
         return session.get(Dataset, self.dataset_id)
@@ -694,10 +686,6 @@ class Document(Base):
             or 0
         )
 
-    @property
-    def uploader(self):
-        return self.get_uploader(session=db.session())
-
     def get_uploader(self, *, session: Session) -> str | None:
         user = session.scalar(select(Account).where(Account.id == self.created_by))
         return user.name if user else None
@@ -709,10 +697,6 @@ class Document(Base):
     @property
     def last_update_date(self):
         return self.updated_at
-
-    @property
-    def doc_metadata_details(self) -> list[DocMetadataDetailItem] | None:
-        return self.get_doc_metadata_details(session=db.session())
 
     def get_doc_metadata_details(self, *, session: Session) -> list[DocMetadataDetailItem] | None:
         if self.doc_metadata:

--- a/api/tests/unit_tests/controllers/console/test_document_detail_api_data_source_info.py
+++ b/api/tests/unit_tests/controllers/console/test_document_detail_api_data_source_info.py
@@ -7,6 +7,7 @@ and data_source_detail_dict for all data_source_type values, including "local_fi
 
 import json
 from typing import Literal, NotRequired, TypedDict
+from unittest.mock import MagicMock
 
 from models.dataset import Document
 
@@ -116,7 +117,7 @@ class TestDocumentDetailDataSourceInfo:
         )
 
         # data_source_detail_dict should return raw data for notion_import
-        detail_result = document.data_source_detail_dict
+        detail_result = document.get_data_source_detail_dict(session=MagicMock())
         assert detail_result == notion_data
 
         # Test website_crawl
@@ -127,7 +128,7 @@ class TestDocumentDetailDataSourceInfo:
         )
 
         # data_source_detail_dict should return raw data for website_crawl
-        detail_result = document.data_source_detail_dict
+        detail_result = document.get_data_source_detail_dict(session=MagicMock())
         assert detail_result == website_data
 
     def test_local_file_data_source_detail_dict_without_db(self):
@@ -139,5 +140,5 @@ class TestDocumentDetailDataSourceInfo:
         )
 
         # Should return empty dict for local_file type (handled in the model)
-        detail_result = document.data_source_detail_dict
+        detail_result = document.get_data_source_detail_dict(session=MagicMock())
         assert detail_result == {}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 1. Associated issue: #40372 (claimed in [this comment](https://github.com/langgenius/dify/issues/40372#issuecomment-5521818358); scope narrowed as explained below).

## Summary

Part of #40372, follow-up to #41647.

Removes four `Document` legacy `@property` accessors in `api/models/dataset.py` that reach for the global `db.session` internally — each a thin wrapper around an existing session-aware `get_*` twin, with no remaining property reads anywhere (response validation goes through `DocumentWithSession`, and the service_api document endpoints already call the `get_*` twins explicitly):

- `Document.data_source_detail_dict` → `get_data_source_detail_dict(session=...)`
- `Document.dataset` → `get_dataset(session=...)`
- `Document.uploader` → `get_uploader(session=...)`
- `Document.doc_metadata_details` → `get_doc_metadata_details(session=...)`

**Scope note**: the original claim listed seven accessors, but `Document.segment_count`, `hit_count`, and `dataset_process_rule` turned out to have intra-model consumers (`Document.to_dict`, `average_segment_length`, `process_rule_dict`), so removing them cleanly requires threading a session through `to_dict` — a larger change than this slice. They are left untouched (and unclaimed) for a follow-up.

## Tests

Updated the three unit tests in `test_document_detail_api_data_source_info.py` that read `data_source_detail_dict` as a property to call `get_data_source_detail_dict(session=...)` (these paths never touch the session, so a mock suffices). The `get_*` twins keep their existing coverage in `test_document_fields.py` / `test_dataset_models.py`, all passing.

## Screenshots

N/A (backend-only refactor).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Claude Code