### PR TITLE
fix(api): insert service-api upload records in the request session

### DIFF
--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -409,7 +409,11 @@ def _create_document_by_text(session: Session, tenant_id: str, dataset_id: UUID)
         raise ValueError("current_user is required")
 
     upload_file = FileService(db.engine).upload_text(
-        text=payload.text, text_name=payload.name, user_id=current_user.id, tenant_id=tenant_id_str
+        text=payload.text,
+        text_name=payload.name,
+        user_id=current_user.id,
+        tenant_id=tenant_id_str,
+        session=session,
     )
     data_source = {
         "type": "upload_file",
@@ -474,7 +478,11 @@ def _update_document_by_text(
         if not current_user:
             raise ValueError("current_user is required")
         upload_file = FileService(db.engine).upload_text(
-            text=str(text), text_name=str(name), user_id=current_user.id, tenant_id=tenant_id
+            text=str(text),
+            text_name=str(name),
+            user_id=current_user.id,
+            tenant_id=tenant_id,
+            session=session,
         )
         data_source = {
             "type": "upload_file",
@@ -792,6 +800,7 @@ class DocumentAddByFileApi(DatasetApiResource):
                 user=current_user,
                 source="datasets",
                 default_file_size_limit=FeatureService.get_knowledge_file_size_limit(tenant_id),
+                session=session,
             )
         except services.errors.file.FileTooLargeError as file_too_large_error:
             raise FileTooLargeError(file_too_large_error.description)
@@ -870,6 +879,7 @@ def _update_document_by_file(
                 user=current_user,
                 source="datasets",
                 default_file_size_limit=FeatureService.get_knowledge_file_size_limit(tenant_id),
+                session=session,
             )
         except services.errors.file.FileTooLargeError as file_too_large_error:
             raise FileTooLargeError(file_too_large_error.description)

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -58,7 +58,19 @@ class FileService:
         source: Literal["datasets"] | None = None,
         source_url: str = "",
         default_file_size_limit: int | None = None,
+        session: Session | None = None,
     ) -> UploadFile:
+        """Persist an uploaded file and record it in the ``upload_files`` table.
+
+        Args:
+            session: when provided, the record is inserted (and flushed) inside the
+                caller's transaction instead of a dedicated session + immediate commit.
+                The row then stays visible to every later statement in that transaction
+                regardless of the database isolation level, and is committed (or rolled
+                back) together with the rest of the caller's unit of work. Callers that
+                need the row committed before yielding control (e.g. before enqueuing an
+                async job) should omit this argument.
+        """
         # get file extension
         extension = os.path.splitext(filename)[1].lstrip(".").lower()
 
@@ -115,14 +127,27 @@ class FileService:
             source_url=source_url,
         )
 
-        with self._session_maker(expire_on_commit=False) as session:
-            session.add(upload_file)
-            session.commit()
+        self._persist_upload_file_record(upload_file, session)
 
         if not upload_file.source_url:
             upload_file.source_url = file_helpers.get_signed_file_url(upload_file_id=upload_file.id)
 
         return upload_file
+
+    def _persist_upload_file_record(self, upload_file: UploadFile, session: Session | None) -> None:
+        """Insert an ``upload_files`` row, optionally inside the caller's transaction.
+
+        With ``session`` the row is flushed (not committed) so later statements on the
+        same session observe it under any isolation level, and the caller owns the
+        commit/rollback. Without it, a dedicated session commits immediately.
+        """
+        if session is not None:
+            session.add(upload_file)
+            session.flush()
+        else:
+            with self._session_maker(expire_on_commit=False) as dedicated_session:
+                dedicated_session.add(upload_file)
+                dedicated_session.commit()
 
     @staticmethod
     def is_file_size_within_limit(
@@ -187,7 +212,22 @@ class FileService:
             return self.get_file_presigned_url(file_id=file_id, tenant_id=tenant_id)
         return file_helpers.get_signed_file_url(upload_file_id=file_id)
 
-    def upload_text(self, text: str, text_name: str, user_id: str, tenant_id: str) -> UploadFile:
+    def upload_text(
+        self,
+        text: str,
+        text_name: str,
+        user_id: str,
+        tenant_id: str,
+        *,
+        session: Session | None = None,
+    ) -> UploadFile:
+        """Persist ``text`` as a ``.txt`` file and record it in the ``upload_files`` table.
+
+        Args:
+            session: when provided, the record is inserted (and flushed) inside the
+                caller's transaction instead of a dedicated session + immediate commit;
+                see :meth:`upload_file` for the visibility/ownership contract.
+        """
         if len(text_name) > 200:
             text_name = text_name[:200]
         # user uuid as file name
@@ -215,9 +255,7 @@ class FileService:
             used_at=naive_utc_now(),
         )
 
-        with self._session_maker(expire_on_commit=False) as session:
-            session.add(upload_file)
-            session.commit()
+        self._persist_upload_file_record(upload_file, session)
 
         return upload_file
 

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
@@ -1415,6 +1415,7 @@ class TestDocumentAddByTextApi(SQLiteControllerTest):
         )
         assert "data_source_info_dict" not in response["document"]
         assert mock_doc_svc.save_document_with_dataset_id.call_args.kwargs["session"] is self.session
+        assert mock_file_svc.upload_text.call_args.kwargs["session"] is self.session
 
     @patch("controllers.service_api.wraps.FeatureService")
     @patch("controllers.service_api.wraps.validate_and_get_api_token")
@@ -1586,6 +1587,7 @@ class TestDocumentUpdateByTextApiPost(SQLiteControllerTest):
             {"document": _expected_document_response(mock_document), "batch": "batch-1"},
             200,
         )
+        assert mock_file_svc_cls.return_value.upload_text.call_args.kwargs["session"] is self.session
 
     @patch("controllers.service_api.wraps.FeatureService")
     @patch("controllers.service_api.wraps.validate_and_get_api_token")
@@ -1675,6 +1677,7 @@ class TestDocumentAddByFileApiPost(SQLiteControllerTest):
             {"document": _expected_document_response(mock_document), "batch": "batch-file"},
             200,
         )
+        assert mock_file_svc_cls.return_value.upload_file.call_args.kwargs["session"] is self.session
 
     @patch(
         "controllers.service_api.dataset.document.FeatureService.get_knowledge_file_size_limit",
@@ -2021,3 +2024,4 @@ class TestDocumentUpdateByFileApiPatch(SQLiteControllerTest):
             {"document": _expected_document_response(mock_document), "batch": "batch-1"},
             200,
         )
+        assert mock_file_svc_cls.return_value.upload_file.call_args.kwargs["session"] is self.session

--- a/api/tests/unit_tests/services/test_file_service.py
+++ b/api/tests/unit_tests/services/test_file_service.py
@@ -365,6 +365,47 @@ class TestFileService:
             assert len(result.name) == 200
             assert db_session.get(UploadFile, result.id) is not None
 
+    def test_upload_text_persists_in_provided_session(self, file_service: FileService, db_session: Session):
+        """With an explicit session the record is flushed into it, not committed separately."""
+        with (
+            patch("services.file_service.storage"),
+            patch.object(file_service, "_session_maker") as mock_session_maker,
+        ):
+            result = file_service.upload_text(
+                text="sample text",
+                text_name="test.txt",
+                user_id="user_id",
+                tenant_id="tenant_id",
+                session=db_session,
+            )
+
+        mock_session_maker.assert_not_called()
+        assert db_session.get(UploadFile, result.id) is not None
+        db_session.commit()
+        assert db_session.get(UploadFile, result.id) is not None
+
+    def test_upload_file_persists_in_provided_session(self, file_service: FileService, db_session: Session):
+        """With an explicit session the record is flushed into it, not committed separately."""
+        with (
+            patch("services.file_service.storage"),
+            patch("services.file_service.file_helpers.get_signed_file_url") as mock_get_url,
+            patch.object(file_service, "_session_maker") as mock_session_maker,
+        ):
+            mock_get_url.return_value = "http://signed-url"
+            result = file_service.upload_file(
+                filename="test.txt",
+                content=b"test",
+                mimetype="text/plain",
+                user=_account(),
+                session=db_session,
+            )
+
+        mock_session_maker.assert_not_called()
+        assert result.source_url == "http://signed-url"
+        assert db_session.get(UploadFile, result.id) is not None
+        db_session.commit()
+        assert db_session.get(UploadFile, result.id) is not None
+
     def test_get_file_preview_success(self, file_service: FileService, db_session: Session):
         self._persist_upload_file(db_session, extension="pdf", mime_type="application/pdf")
 


### PR DESCRIPTION
create-by-text / create-by-file (and their update aliases) uploaded the file through FileService, which committed the upload_files row on a dedicated connection while the request session's transaction had already established a snapshot. Under MySQL's default REPEATABLE READ the subsequent lookup in save_document_with_dataset_id could not see the just-committed row and failed with 400 "One or more files not found." (PostgreSQL's READ COMMITTED default masks the issue.)

Add an optional session parameter to FileService.upload_text and .upload_file: when provided, the record is flushed into the caller's transaction instead of being committed on a separate connection, so later statements in the same request always observe it regardless of isolation level, and the record commits or rolls back atomically with the rest of the request. The service-api dataset document controllers now pass the request session; other callers (e.g. the rag pipeline proxy, which must enqueue a committed row id) keep the previous commit-immediately behavior by omitting the argument.

## Summary

Fixes #41735

### Fix

Add an optional `session` parameter to `FileService.upload_text()` / `FileService.upload_file()`.
When provided, the record is **flushed into the caller's transaction** instead of being committed on
a dedicated connection:

- the row is visible to every later statement in the same session regardless of isolation level
  (a transaction always sees its own writes);
- the record now commits/rolls back **atomically** with the rest of the request — previously a failed
  request left an orphaned `upload_files` row behind;
- callers that depend on the row being committed before yielding control (e.g. the rag-pipeline
  proxy, which enqueues the row id to Celery) simply omit the argument and keep the existing
  commit-immediately behavior — fully backward compatible.

The four service-api dataset document controllers (`create-by-text`, `update-by-text`,
`create-by-file`, `update-by-file`) now pass the request session.

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

## Testing

- New unit tests: `upload_text` / `upload_file` with an explicit session persist into it without
  opening a dedicated session (`tests/unit_tests/services/test_file_service.py`)
- Updated 4 controller tests to assert the request session is forwarded
  (`tests/unit_tests/controllers/service_api/dataset/test_document.py`) — 141 unit tests pass
- Manually verified on a MySQL 8.0 (REPEATABLE-READ) deployment: all four endpoints return `200`
  and the document indexes normally with this change

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
