### PR TITLE
fix(dataset): always dispatch segment cleanup for disabled segments

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3870,26 +3870,30 @@ class SegmentService:
         if cache_result is not None:
             raise ValueError("Segment is deleting.")
 
-        # enabled segment need to delete index
-        if segment.enabled:
-            # send delete segment index task
-            redis_client.setex(indexing_cache_key, 600, 1)
+        # Always dispatch the cleanup task. Even when the segment is
+        # disabled, the parent document is disabled/archived, or the
+        # indexer hasn't completed, the task must still remove the
+        # segment's durable attachment records (SegmentAttachmentBinding
+        # rows and the corresponding UploadFile metadata). The task
+        # gates the index-side cleanup on the document's state. See
+        # #41457.
+        redis_client.setex(indexing_cache_key, 600, 1)
 
-            # Get child chunk IDs before parent segment is deleted
-            child_node_ids = []
-            if segment.index_node_id:
-                child_node_ids = list(
-                    session.scalars(
-                        select(ChildChunk.index_node_id).where(
-                            ChildChunk.segment_id == segment.id,
-                            ChildChunk.dataset_id == dataset.id,
-                        )
-                    ).all()
-                )
-
-            delete_segment_from_index_task.delay(
-                [segment.index_node_id], dataset.id, document.id, [segment.id], child_node_ids
+        # Get child chunk IDs before parent segment is deleted
+        child_node_ids = []
+        if segment.index_node_id:
+            child_node_ids = list(
+                session.scalars(
+                    select(ChildChunk.index_node_id).where(
+                        ChildChunk.segment_id == segment.id,
+                        ChildChunk.dataset_id == dataset.id,
+                    )
+                ).all()
             )
+
+        delete_segment_from_index_task.delay(
+            [segment.index_node_id], dataset.id, document.id, [segment.id], child_node_ids
+        )
 
         session.delete(segment)
         # update document word count

--- a/api/tasks/delete_segment_from_index_task.py
+++ b/api/tasks/delete_segment_from_index_task.py
@@ -38,6 +38,36 @@ def delete_segment_from_index_task(
             if not dataset_document:
                 return
 
+            # Always clean up attachment records, regardless of the
+            # parent document's enabled/archived/indexing_status state.
+            # Disabling, archiving, or leaving indexing incomplete must
+            # not orphan SegmentAttachmentBinding or UploadFile rows. See
+            # #41457.
+            if dataset.is_multimodal:
+                segment_attachment_bindings = session.scalars(
+                    select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.segment_id.in_(segment_ids))
+                ).all()
+                if segment_attachment_bindings:
+                    attachment_ids = [binding.attachment_id for binding in segment_attachment_bindings]
+                    index_processor = IndexProcessorFactory(dataset_document.doc_form).init_index_processor()
+                    index_processor.clean(
+                        session=session, dataset=dataset, node_ids=attachment_ids, with_keywords=False
+                    )
+                    segment_attachment_bind_ids = [i.id for i in segment_attachment_bindings]
+
+                    for i in range(0, len(segment_attachment_bind_ids), 1000):
+                        segment_attachment_bind_delete_stmt = delete(SegmentAttachmentBinding).where(
+                            SegmentAttachmentBinding.id.in_(segment_attachment_bind_ids[i : i + 1000])
+                        )
+                        session.execute(segment_attachment_bind_delete_stmt)
+
+                    # delete upload file
+                    session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
+                    session.commit()
+
+            # Index cleanup is gated by the parent document's state. The
+            # attachment cleanup above has already committed and is not
+            # affected by this branch.
             if (
                 not dataset_document.enabled
                 or dataset_document.archived
@@ -60,27 +90,6 @@ def delete_segment_from_index_task(
                 session=session,
             )
             session.commit()
-            if dataset.is_multimodal:
-                # delete segment attachment binding
-                segment_attachment_bindings = session.scalars(
-                    select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.segment_id.in_(segment_ids))
-                ).all()
-                if segment_attachment_bindings:
-                    attachment_ids = [binding.attachment_id for binding in segment_attachment_bindings]
-                    index_processor.clean(
-                        session=session, dataset=dataset, node_ids=attachment_ids, with_keywords=False
-                    )
-                    segment_attachment_bind_ids = [i.id for i in segment_attachment_bindings]
-
-                    for i in range(0, len(segment_attachment_bind_ids), 1000):
-                        segment_attachment_bind_delete_stmt = delete(SegmentAttachmentBinding).where(
-                            SegmentAttachmentBinding.id.in_(segment_attachment_bind_ids[i : i + 1000])
-                        )
-                        session.execute(segment_attachment_bind_delete_stmt)
-
-                    # delete upload file
-                    session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
-                    session.commit()
 
             end_at = time.perf_counter()
             logger.info(click.style(f"Segment deleted from index latency: {end_at - start_at}", fg="green"))

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -840,6 +840,37 @@ class TestSegmentServiceMutations:
             with pytest.raises(ValueError, match="Segment is deleting"):
                 SegmentService.delete_segment(segment, document, dataset, MagicMock())
 
+    def test_delete_segment_dispatches_task_for_disabled_segment(self):
+        """Regression for #41457: disabled-segment deletion must still dispatch
+        the cleanup task so the segment's attachment records are removed.
+        Pre-fix the dispatch was gated on ``segment.enabled``, which left
+        SegmentAttachmentBinding / UploadFile rows orphaned when the user
+        disabled a segment before deleting it.
+        """
+        session = MagicMock()
+        segment = _make_segment(enabled=False, index_node_id="parent-node")
+        document = _make_document(word_count=10)
+        dataset = _make_dataset()
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.delete_segment_from_index_task") as delete_task,
+        ):
+            mock_redis.get.return_value = None
+            session.scalars.return_value.all.return_value = []
+
+            SegmentService.delete_segment(segment, document, dataset, session)
+
+        mock_redis.setex.assert_called_once_with(f"segment_{segment.id}_delete_indexing", 600, 1)
+        delete_task.delay.assert_called_once_with(
+            ["parent-node"],
+            dataset.id,
+            document.id,
+            [segment.id],
+            [],
+        )
+        session.delete.assert_called_once_with(segment)
+
     def test_delete_segments_removes_records_and_clamps_document_word_count(self):
         session = MagicMock()
         dataset = _make_dataset()

--- a/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
+++ b/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
@@ -1,15 +1,17 @@
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy import event
+from sqlalchemy import event, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.rag.index_processor.constant.index_type import IndexStructureType
-from models.dataset import Dataset, Document, DocumentSegment
-from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from models.dataset import Dataset, Document, DocumentSegment, SegmentAttachmentBinding
+from models.enums import CreatorUserRole, DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from models.model import UploadFile
 from tasks.delete_segment_from_index_task import delete_segment_from_index_task
 from tasks.disable_segment_from_index_task import disable_segment_from_index_task
 from tasks.disable_segments_from_index_task import disable_segments_from_index_task
@@ -152,3 +154,107 @@ def test_delete_segment_commits_index_cleanup_without_attachments(
         delete_segment_from_index_task.run(["node-1"], dataset.id, document.id, [segment.id])
 
     assert phase_events == ["clean", "commit"]
+
+
+def test_delete_segment_runs_attachment_cleanup_when_document_disabled(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    """Regression for #41457: the attachment cleanup path must run
+    even when the parent document is disabled, archived, or not
+    fully indexed. Pre-fix the document-state check at the top of
+    the task returned before any cleanup ran, which left
+    SegmentAttachmentBinding and UploadFile rows orphaned.
+    """
+    tenant_id = str(uuid.uuid4())
+    created_by = str(uuid.uuid4())
+    dataset = Dataset(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        name="Disabled doc dataset",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        created_by=created_by,
+        is_multimodal=True,
+    )
+    # Document is disabled — pre-fix this would have short-circuited
+    # the entire task and skipped attachment cleanup.
+    document = Document(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="document.txt",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by=created_by,
+        indexing_status=IndexingStatus.COMPLETED,
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+        enabled=False,
+        archived=False,
+    )
+    segment = DocumentSegment(
+        tenant_id=tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
+        content="content",
+        word_count=1,
+        tokens=1,
+        created_by=created_by,
+        index_node_id="node-1",
+        index_node_hash="hash-1",
+        status=SegmentStatus.COMPLETED,
+    )
+    binding = SegmentAttachmentBinding(
+        tenant_id=tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        segment_id=segment.id,
+        attachment_id="attachment-1",
+    )
+    upload = UploadFile(
+        tenant_id=tenant_id,
+        storage_type="local",
+        key="attachments/attachment-1",
+        name="image.png",
+        size=10,
+        extension="png",
+        mime_type="image/png",
+        created_by=created_by,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_at=datetime.now(UTC),
+        used=False,
+    )
+    with sqlite_session_factory() as session:
+        session.add_all([dataset, document, segment, binding, upload])
+        session.commit()
+        binding_id = binding.id
+        upload_id = upload.id
+        segment_id = segment.id
+        dataset_id = dataset.id
+        document_id = document.id
+        # Overwrite the auto-generated upload id with a deterministic one
+        # so the SegmentAttachmentBinding.attachment_id points to a real
+        # UploadFile.id the task can delete.
+        session.execute(UploadFile.__table__.update().where(UploadFile.id == upload_id).values(id="attachment-1"))
+        session.commit()
+
+    processor = MagicMock()
+    processor.clean.side_effect = lambda *_args, **_kwargs: None
+
+    with patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory:
+        processor_factory.return_value.init_index_processor.return_value = processor
+        delete_segment_from_index_task.run(["node-1"], dataset_id, document_id, [segment_id])
+
+    # Attachment cleanup ran: the SegmentAttachmentBinding row is gone.
+    with sqlite_session_factory() as session:
+        assert session.scalar(select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.id == binding_id)) is None
+        assert session.scalar(select(UploadFile).where(UploadFile.id == upload_id)) is None
+    # The index processor was still invoked for the attachment cleanup,
+    # even though the document is disabled.
+    assert processor.clean.call_count >= 1
+    # The first invocation is the attachment cleanup; the call passed
+    # the attachment IDs.
+    first_call_kwargs = processor.clean.call_args_list[0].kwargs
+    assert first_call_kwargs["node_ids"] == ["attachment-1"]
+    assert first_call_kwargs["with_keywords"] is False


### PR DESCRIPTION
## Summary

Fixes #41457.

`SegmentService.delete_segment` gated the `delete_segment_from_index_task` dispatch on `segment.enabled`, so deleting a disabled segment never enqueued the cleanup task. Even when the task WAS dispatched, the task itself short-circuited on the parent document's `enabled` / `archived` / `indexing_status` state, so the attachment cleanup path (SegmentAttachmentBinding + UploadFile rows) was skipped when the parent document was in any non-cleanup state.

The expected behavior from the issue body: deleting a segment should remove its durable attachment records regardless of whether the segment or its parent document is currently eligible for index operations.

## Fix

`api/services/dataset_service.py` — `SegmentService.delete_segment` no longer skips the task dispatch when `segment.enabled` is False. The body of the previous `if segment.enabled:` block was unindented; the task is now always enqueued.

`api/tasks/delete_segment_from_index_task.py` — the task now runs the attachment cleanup (SegmentAttachmentBinding + UploadFile) BEFORE the document-state check. The document-state check still gates the index-side cleanup (the vector-store and summary-index clean paths), so the contract on the index side is preserved. The two branches are now independent: attachment cleanup commits its own delete statements before returning, and the index-side cleanup only runs when the document is enabled + not archived + indexing is completed.

## Tests

Two new regression tests:

- `test_delete_segment_dispatches_task_for_disabled_segment` (in `api/tests/unit_tests/services/test_dataset_service_segment.py`) — service-level. Constructs a `_make_segment(enabled=False, ...)` and asserts that `delete_segment_from_index_task.delay` is still called with the expected args. Pre-fix the call is skipped (regression captured).
- `test_delete_segment_runs_attachment_cleanup_when_document_disabled` (in `api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py`) — task-level. Persists a real `Dataset` (`is_multimodal=True`), `Document` (`enabled=False`), `DocumentSegment`, `SegmentAttachmentBinding`, and `UploadFile` via the existing `sqlite_session_factory` fixture. Runs `delete_segment_from_index_task` and asserts the binding and upload rows are removed and the index processor was invoked for the attachment cleanup.

The 3 pre-existing task tests (`test_disable_segment_commits_index_cleanup`, `test_disable_segments_commits_index_cleanup`, `test_delete_segment_commits_index_cleanup_without_attachments`) still pass — confirming the index-side cleanup contract is preserved.

## Scope

Two source files: one service method now always dispatches; one task body restructured to separate the attachment cleanup branch from the document-state-gated index cleanup. No new abstractions, no behavior change for the existing index-cleanup path.

## Out of scope (called out for transparency)

- Splitting the attachment cleanup into a separate Celery task. The current "single task, two branches" shape is the minimum to fix the issue and avoids the celery-task proliferation that the maintainer usually pushes back on.
- Auto-cleanup of attachments when the parent document is disabled, archived, or stops mid-indexing (rather than at segment-delete time). The issue body does not call for this; the fix is only at the segment-delete boundary.
- Backfilling the existing orphan rows in production. Operators with affected instances will need to run the workaround `col.data.delete_many(where=Filter.by_property("document_id").equal(doc_id))` from the issue body until the segment-delete path runs for each affected document.

## Verification

- `uv run ruff check` on changed files: All checks passed.
- `uv run ruff format --check` on changed files: All already formatted.
- Targeted pytest on `test_segment_index_cleanup_tasks.py`: 4/4 pass (3 pre-existing + 1 new).
- Pre-fix regression check: the new task-level test fails at the missing-cleanup site; the new service-level test fails at the missing-dispatch site. Both confirm the tests pin the new function behavior.

Fixes #41457
