### PR TITLE
fix(api): disable proxy buffering on SSE streaming responses

### DIFF
--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -432,6 +432,10 @@ def compact_generate_response(
             _stream_with_request_context(generate()),
             status=200,
             mimetype="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
         )
 
 

--- a/api/tests/unit_tests/libs/test_helper.py
+++ b/api/tests/unit_tests/libs/test_helper.py
@@ -1,8 +1,16 @@
 from datetime import datetime
 
 import pytest
+from flask import Flask
 
-from libs.helper import OptionalTimestampField, alphanumeric, email, escape_like_pattern, extract_tenant_id
+from libs.helper import (
+    OptionalTimestampField,
+    alphanumeric,
+    compact_generate_response,
+    email,
+    escape_like_pattern,
+    extract_tenant_id,
+)
 from models.account import Account
 from models.model import EndUser
 
@@ -153,6 +161,21 @@ class TestEmailValidator:
     def test_invalid_email_rejected(self):
         with pytest.raises(ValueError, match="not a valid email"):
             email("not-an-email")
+
+
+class TestCompactGenerateResponseStreaming:
+    """Regression for #41556: intermediate proxies buffering SSE streams into bursty chunks."""
+
+    def test_streaming_response_disables_proxy_buffering(self, app: Flask):
+        def stream_response():
+            yield "data: chunk-1\n\n"
+            yield "data: chunk-2\n\n"
+
+        with app.test_request_context():
+            response = compact_generate_response(stream_response())
+
+        assert response.headers.get("X-Accel-Buffering") == "no"
+        assert response.headers.get("Cache-Control") == "no-cache"
 
 
 class TestAlphanumericValidator:


### PR DESCRIPTION
## Summary

Fixes #41556.

Several users report Dify's streaming responses arriving in bursts —
whole paragraphs landing every few seconds instead of a steady
token-by-token trickle — even when calling the same model directly
(outside Dify) streams smoothly, and even for self-hosted deployments
placing their own reverse proxy in front of Dify (the reporter
mentions "I use https").

`compact_generate_response()` in `api/libs/helper.py` builds the SSE
`Response` for every streaming chat/completion/workflow endpoint
(service API, console API, web API). It set no headers telling
intermediate proxies not to buffer the stream. Dify's own bundled
`docker/nginx/proxy.conf.template` already sets `proxy_buffering off`,
but that only protects deployments that terminate at Dify's bundled
nginx — any additional nginx-compatible proxy a self-hosted operator
adds in front of it (e.g. for TLS termination, a corporate gateway, a
cloud load balancer) has no way to know it should disable buffering
unless the response itself says so, or the operator manually
replicates the same directives in their own config.

This PR adds the standard `X-Accel-Buffering: no` (and
`Cache-Control: no-cache`) response headers to `compact_generate_response`,
matching what `controllers/inner_api/agent/llm.py` already does for
its own SSE endpoint. Any nginx-compatible proxy honors
`X-Accel-Buffering: no` automatically, without requiring the deployer
to hand-configure `proxy_buffering off` themselves.

I also traced the rest of the internal streaming pipeline (plugin
daemon SSE ingestion, the app-generator queue, and the SSE emission
layer) and found it forwards each event immediately with no
accumulation — the missing response header was the one concrete,
fixable gap.

## Test plan

Added `TestCompactGenerateResponseStreaming` in
`api/tests/unit_tests/libs/test_helper.py`, asserting the streaming
`Response` carries `X-Accel-Buffering: no` and `Cache-Control: no-cache`.

Confirmed the test fails without the fix:

```
$ git checkout HEAD~1 -- api/libs/helper.py   # pre-fix helper.py
$ uv run --project api --group dev pytest api/tests/unit_tests/libs/test_helper.py::TestCompactGenerateResponseStreaming -v
FAILED ...test_streaming_response_disables_proxy_buffering
AssertionError: assert None == 'no'
 +  where None = get('X-Accel-Buffering')
$ git checkout HEAD -- api/libs/helper.py     # restore the fix
```

And passes with the fix, along with the full existing `libs` and
`controllers` unit test suites:

```
$ uv run --project api --group dev pytest api/tests/unit_tests/libs api/tests/unit_tests/controllers \
    --ignore=api/tests/unit_tests/controllers/openapi/test_app_list_query.py \
    --ignore=api/tests/unit_tests/controllers/openapi/test_apps_permitted_external_query.py
4479 passed, 32 warnings, 138 subtests passed in 107.25s
```

(the two `--ignore`d files fail to import even on an unmodified
checkout — a pre-existing relative-import issue unrelated to this
change.)

```
$ uv run --project api --dev ruff format --check api/libs/helper.py api/tests/unit_tests/libs/test_helper.py
2 files already formatted
$ uv run --project api --dev ruff check api/libs/helper.py api/tests/unit_tests/libs/test_helper.py
All checks passed!
$ uv --directory api run mypy libs/helper.py --exclude-gitignore --check-untyped-defs --disable-error-code=import-untyped
Success: no issues found in 1 source file
```

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Ran `ruff format`/`ruff check` and `mypy` on the changed files (see above). Did not run the full-repo `make lint`/`make type-check` (whole-codebase mypy run is too slow for this session); the changed files pass cleanly on their own.

From Claude Code
