### PR TITLE
fix(trigger): sync plugin relationships on publish

### DIFF
--- a/api/events/event_handlers/sync_plugin_trigger_when_app_created.py
+++ b/api/events/event_handlers/sync_plugin_trigger_when_app_created.py
@@ -1,6 +1,6 @@
 import logging
 
-from events.app_event import app_draft_workflow_was_synced
+from events.app_event import app_draft_workflow_was_synced, app_published_workflow_was_updated
 from models.model import App, AppMode
 from models.workflow import Workflow
 from services.trigger.trigger_service import TriggerService
@@ -9,14 +9,26 @@ logger = logging.getLogger(__name__)
 
 
 @app_draft_workflow_was_synced.connect
-def handle(sender, synced_draft_workflow: Workflow, **kwargs):
+@app_published_workflow_was_updated.connect
+def handle(
+    sender,
+    synced_draft_workflow: Workflow | None = None,
+    published_workflow: Workflow | None = None,
+    **kwargs,
+):
     """
-    While creating a workflow or updating a workflow, we may need to sync
-    its plugin trigger relationships in DB.
+    Sync plugin trigger relationships when a draft changes or is published.
+
+    The published workflow must be reconciled as well because production trigger
+    dispatch relies on these relationships, while debug dispatch does not.
     """
     app: App = sender
     if app.mode != AppMode.WORKFLOW.value:
         # only handle workflow app, chatflow is not supported yet
         return
 
-    TriggerService.sync_plugin_trigger_relationships(app, synced_draft_workflow)
+    workflow = published_workflow if published_workflow is not None else synced_draft_workflow
+    if workflow is None:
+        return
+
+    TriggerService.sync_plugin_trigger_relationships(app, workflow)

--- a/api/tests/unit_tests/events/event_handlers/test_sync_plugin_trigger_when_app_created.py
+++ b/api/tests/unit_tests/events/event_handlers/test_sync_plugin_trigger_when_app_created.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from events.event_handlers.sync_plugin_trigger_when_app_created import handle
+from models.model import AppMode
+
+
+def test_syncs_plugin_trigger_relationships_from_published_workflow() -> None:
+    app = SimpleNamespace(mode=AppMode.WORKFLOW.value)
+    published_workflow = object()
+
+    with patch(
+        "events.event_handlers.sync_plugin_trigger_when_app_created.TriggerService.sync_plugin_trigger_relationships"
+    ) as sync_relationships:
+        handle(app, published_workflow=published_workflow)
+
+    sync_relationships.assert_called_once_with(app, published_workflow)
+
+
+def test_keeps_draft_workflow_relationship_sync() -> None:
+    app = SimpleNamespace(mode=AppMode.WORKFLOW.value)
+    draft_workflow = object()
+
+    with patch(
+        "events.event_handlers.sync_plugin_trigger_when_app_created.TriggerService.sync_plugin_trigger_relationships"
+    ) as sync_relationships:
+        handle(app, synced_draft_workflow=draft_workflow)
+
+    sync_relationships.assert_called_once_with(app, draft_workflow)

--- a/api/tests/unit_tests/events/event_handlers/test_sync_plugin_trigger_when_app_created.py
+++ b/api/tests/unit_tests/events/event_handlers/test_sync_plugin_trigger_when_app_created.py
@@ -1,13 +1,15 @@
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 from events.event_handlers.sync_plugin_trigger_when_app_created import handle
 from models.model import AppMode
+from models.workflow import Workflow
 
 
 def test_syncs_plugin_trigger_relationships_from_published_workflow() -> None:
     app = SimpleNamespace(mode=AppMode.WORKFLOW.value)
-    published_workflow = object()
+    published_workflow = cast(Workflow, object())
 
     with patch(
         "events.event_handlers.sync_plugin_trigger_when_app_created.TriggerService.sync_plugin_trigger_relationships"
@@ -19,7 +21,7 @@ def test_syncs_plugin_trigger_relationships_from_published_workflow() -> None:
 
 def test_keeps_draft_workflow_relationship_sync() -> None:
     app = SimpleNamespace(mode=AppMode.WORKFLOW.value)
-    draft_workflow = object()
+    draft_workflow = cast(Workflow, object())
 
     with patch(
         "events.event_handlers.sync_plugin_trigger_when_app_created.TriggerService.sync_plugin_trigger_relationships"


### PR DESCRIPTION
## Summary

- synchronize plugin-trigger relationships from the exact workflow version being published
- keep the existing draft-workflow synchronization path intact
- add regression coverage for both published and draft synchronization signals

This fixes the production-only failure mode where a trigger can succeed in Test Run but published events find no subscriber relationship and never start a workflow.

Fixes #41752

## Screenshots

Not applicable (backend-only change).

## Validation

- `ruff check` passed for the changed handler and test
- `ruff format --check` passed for the changed handler and test
- Python compilation passed for both changed files
- Added focused unit tests for the published and draft signal paths
- The focused pytest run could not collect in this Windows environment because the repository's optional native dependency chain requires Microsoft Visual C++ Build Tools; hosted CI remains the authoritative test run

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Documentation is not affected by this backend bug fix.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods. Focused backend checks are listed above.

From Codex
