### PR TITLE
fix(skills): tolerate __MACOSX metadata folder when importing a Skill package

### DIFF
--- a/api/services/skill_management_service.py
+++ b/api/services/skill_management_service.py
@@ -3752,14 +3752,17 @@ class SkillManagementService:
         # Identify the root by the unique top-level `<root>/SKILL.md`, rather than
         # requiring every path to share one first segment: tools like macOS Finder's
         # "Compress" add a sibling `__MACOSX/` metadata folder that must not defeat
-        # stripping of the real skill folder.
+        # stripping of the real skill folder. Entries outside the detected root
+        # (like `__MACOSX/...`) are dropped rather than passed through, matching
+        # skill_package_service._normalize_members(ignore_outside_selected_root=True).
         skill_md_roots = {
             path.split("/", 1)[0] for path in paths if path.count("/") == 1 and path.endswith(f"/{_SKILL_MD}")
         }
         if len(skill_md_roots) != 1:
             return {path: path for path in paths}
         root = next(iter(skill_md_roots))
-        return {path: path.removeprefix(f"{root}/") for path in paths}
+        prefix = f"{root}/"
+        return {path: path.removeprefix(prefix) for path in paths if path == root or path.startswith(prefix)}
 
     def _draft_payload_from_zip(
         self,
@@ -3780,6 +3783,8 @@ class SkillManagementService:
                 skill_md_content = ""
                 for info in infos:
                     raw_path = normalize_skill_file_path(info.filename.strip("/"))
+                    if raw_path not in path_map:
+                        continue
                     path = normalize_skill_file_path(path_map[raw_path])
                     if info.is_dir():
                         items.append(SkillDraftTreeItemPayload(path=path, kind=SkillFileKind.DIRECTORY))

--- a/api/services/skill_management_service.py
+++ b/api/services/skill_management_service.py
@@ -3747,14 +3747,19 @@ class SkillManagementService:
 
     @staticmethod
     def _strip_single_root(paths: list[str]) -> dict[str, str]:
-        if not paths:
-            return {}
-        first_segments = {path.split("/", 1)[0] for path in paths if "/" in path}
-        root = next(iter(first_segments)) if len(first_segments) == 1 else None
-        if root is None or f"{root}/{_SKILL_MD}" not in paths or _SKILL_MD in paths:
+        if not paths or _SKILL_MD in paths:
             return {path: path for path in paths}
-        stripped = {path: path.removeprefix(f"{root}/") for path in paths}
-        return stripped
+        # Identify the root by the unique top-level `<root>/SKILL.md`, rather than
+        # requiring every path to share one first segment: tools like macOS Finder's
+        # "Compress" add a sibling `__MACOSX/` metadata folder that must not defeat
+        # stripping of the real skill folder.
+        skill_md_roots = {
+            path.split("/", 1)[0] for path in paths if path.count("/") == 1 and path.endswith(f"/{_SKILL_MD}")
+        }
+        if len(skill_md_roots) != 1:
+            return {path: path for path in paths}
+        root = next(iter(skill_md_roots))
+        return {path: path.removeprefix(f"{root}/") for path in paths}
 
     def _draft_payload_from_zip(
         self,

--- a/api/tests/unit_tests/services/test_skill_management_service.py
+++ b/api/tests/unit_tests/services/test_skill_management_service.py
@@ -2684,7 +2684,10 @@ def test_import_skill_package_strips_root_alongside_macos_metadata_folder() -> N
     )
 
     assert imported["name"] == "expense-sop"
-    assert "SKILL.md" in [item["path"] for item in imported["files"]]
+    imported_paths = [item["path"] for item in imported["files"]]
+    assert "SKILL.md" in imported_paths
+    assert "references/policy.md" in imported_paths
+    assert not any(path.startswith("__MACOSX") for path in imported_paths)
 
 
 def test_import_skill_package_rejects_missing_frontmatter_description() -> None:

--- a/api/tests/unit_tests/services/test_skill_management_service.py
+++ b/api/tests/unit_tests/services/test_skill_management_service.py
@@ -2664,6 +2664,29 @@ def test_import_skill_package_creates_draft_and_rejects_name_conflicts() -> None
     assert exc_info.value.code == "skill_name_conflict"
 
 
+def test_import_skill_package_strips_root_alongside_macos_metadata_folder() -> None:
+    package = io.BytesIO()
+    with zipfile.ZipFile(package, "w") as archive:
+        archive.writestr(
+            "expense-sop/SKILL.md",
+            "---\nname: expense-sop\ndescription: Expenses\n---\n# Expenses",
+        )
+        archive.writestr("expense-sop/references/policy.md", "Policy")
+        # macOS Finder "Compress" adds an AppleDouble metadata sibling folder
+        # for archives whose source files carry extended attributes.
+        archive.writestr("__MACOSX/expense-sop/._SKILL.md", b"\x00")
+
+    service = SkillManagementService(tool_file_manager=_FakeToolFileManager())
+    imported = service.import_skill(
+        tenant_id=TENANT,
+        user_id=USER,
+        payload=SkillImportPayload(content=package.getvalue(), filename="expense-sop.zip"),
+    )
+
+    assert imported["name"] == "expense-sop"
+    assert "SKILL.md" in [item["path"] for item in imported["files"]]
+
+
 def test_import_skill_package_rejects_missing_frontmatter_description() -> None:
     package = io.BytesIO()
     with zipfile.ZipFile(package, "w") as archive:


### PR DESCRIPTION
## Summary

Fixes #41307

- `SkillManagementService._strip_single_root` (used by `POST /workspaces/current/skills/import`, the "Import Skill package" flow on the Skills page) required **every** path in the uploaded zip to share exactly one top-level folder before it would strip that folder and locate `SKILL.md`.
- macOS Finder's "Compress" adds a sibling `__MACOSX/` AppleDouble metadata folder to the zip whenever a source file carries extended attributes (e.g. `com.apple.quarantine` on a downloaded file). That second top-level folder made the "exactly one shared first segment" check fail, so the importer fell back to treating paths as unstripped, didn't find a root-level `SKILL.md`, and rejected an otherwise valid package with "This package has no SKILL.md. Add the file and import it again."
- Reproduced from the reporter's screenshots: a `find-skills/` folder containing `SKILL.md` and `scripts/`, zipped via macOS Finder, fails to import; a package zipped without such metadata succeeds — matching the "compatibility issue" the reporter described.
- Fix: detect the root from the unique top-level `<root>/SKILL.md` entry instead of requiring all paths to share one first segment, matching the approach `services/agent/skill_package_service.py` already uses for the Agent skill-package uploader (`_can_strip_single_top_level_folder`). Foreign top-level entries (like `__MACOSX/...`) no longer defeat root detection, and — matching `_normalize_members(ignore_outside_selected_root=True)` in that same file — they are now dropped from the imported draft entirely instead of being carried through as literal files/directories.

## Root cause detail

```python
# before
first_segments = {path.split("/", 1)[0] for path in paths if "/" in path}
root = next(iter(first_segments)) if len(first_segments) == 1 else None
```

Any second top-level folder — regardless of whether it contains `SKILL.md` — set `len(first_segments) != 1`, disabling stripping entirely.

```python
# after
skill_md_roots = {
    path.split("/", 1)[0] for path in paths if path.count("/") == 1 and path.endswith(f"/{_SKILL_MD}")
}
```

Root is now derived only from where the unique top-level `SKILL.md` actually lives. Once the root is found, `_strip_single_root` only keeps paths equal to the root or starting with `<root>/`; anything else (e.g. `__MACOSX/...`) is excluded from the returned map, and `_draft_payload_from_zip` skips any archive member whose raw path isn't in that map — so foreign entries are excluded from the imported draft, not merely left un-stripped.

## Test plan

`test_import_skill_package_strips_root_alongside_macos_metadata_folder` zips `expense-sop/SKILL.md`, `expense-sop/references/policy.md`, and a `__MACOSX/expense-sop/._SKILL.md` metadata entry, and asserts `import_skill` succeeds, that `SKILL.md` and `references/policy.md` are present in the imported files, and that no `__MACOSX*` path is present.

- Confirmed the test fails against the unmodified (pre-fix) code with the exact reported error:
  ```
  services.skill_management_service.SkillManagementServiceError: Skill package must contain SKILL.md
  ```
- Confirmed the strengthened `__MACOSX` assertion fails against the intermediate version of this fix that stripped the root but did not filter foreign entries (the `__MACOSX/...` paths ended up as literal files/directories in the imported draft, including a real `ToolFile` row/blob for the binary AppleDouble entry).
- After the full fix:
  ```
  $ uv run --project api pytest api/tests/unit_tests/services/test_skill_management_service.py -q
  95 passed in 76.77s
  ```
- `uv run --project api ruff check` on changed files: clean

From Claude
