### PR TITLE
fix(web): render markdown content in the correct text direction for RTL locales

### DIFF
--- a/web/app/components/base/markdown/__tests__/index.spec.tsx
+++ b/web/app/components/base/markdown/__tests__/index.spec.tsx
@@ -1,10 +1,17 @@
 import type { StreamdownProps } from 'streamdown'
 import type { SimplePluginInfo } from '../streamdown-wrapper'
 import { render, screen } from '@testing-library/react'
+import { useTranslation } from '#i18n'
 import { Markdown } from '../index'
 
 const { mockReactMarkdownWrapper } = vi.hoisted(() => ({
   mockReactMarkdownWrapper: vi.fn(),
+}))
+
+vi.mock('#i18n', () => ({
+  useTranslation: vi.fn(() => ({
+    i18n: { language: 'en-US' },
+  })),
 }))
 
 vi.mock('@/next/dynamic', () => ({
@@ -38,6 +45,25 @@ const getLastWrapperProps = (): CapturedProps => {
 describe('Markdown', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useTranslation).mockReturnValue({
+      i18n: { language: 'en-US' },
+    } as ReturnType<typeof useTranslation>)
+  })
+
+  it('should not set a text direction for the default English locale', () => {
+    render(<Markdown content="Hello World" />)
+    expect(screen.getByTestId('markdown-body')).not.toHaveAttribute('dir')
+  })
+
+  it.each([
+    ['fa-IR', 'سلام'],
+    ['ar-TN', 'مرحبا'],
+  ])('should render right-to-left for the %s locale', (language, content) => {
+    vi.mocked(useTranslation).mockReturnValue({
+      i18n: { language },
+    } as ReturnType<typeof useTranslation>)
+    render(<Markdown content={content} />)
+    expect(screen.getByTestId('markdown-body')).toHaveAttribute('dir', 'rtl')
   })
 
   it('should render wrapper content', () => {

--- a/web/app/components/base/markdown/index.tsx
+++ b/web/app/components/base/markdown/index.tsx
@@ -2,6 +2,8 @@ import type { SimplePluginInfo, StreamdownWrapperProps } from './streamdown-wrap
 import { cn } from '@langgenius/dify-ui/cn'
 import { flow } from 'es-toolkit/compat'
 import { memo, useMemo } from 'react'
+import { useLocale } from '@/context/i18n'
+import { getTextDirection } from '@/i18n-config/language'
 import dynamic from '@/next/dynamic'
 import { preprocessLaTeX, preprocessThinkTag } from './markdown-utils'
 
@@ -44,10 +46,13 @@ export const Markdown = memo((props: MarkdownProps) => {
     mode,
     className,
   } = props
+  const locale = useLocale()
+  const dir = getTextDirection(locale) === 'rtl' ? 'rtl' : undefined
   const latexContent = useMemo(() => preprocess(content), [content])
 
   return (
     <div
+      dir={dir}
       className={cn('markdown-body', 'text-text-primary!', className)}
       data-testid="markdown-body"
     >

--- a/web/i18n-config/language.ts
+++ b/web/i18n-config/language.ts
@@ -79,6 +79,12 @@ export const getAccessControlTemplateLanguage = (locale: string): AccessControlT
   return ACCESS_CONTROL_TEMPLATE_LANGUAGE[locale] || 'en'
 }
 
+const RTL_LOCALES: ReadonlySet<string> = new Set(['fa-IR', 'ar-TN'])
+
+export const getTextDirection = (locale: string): 'ltr' | 'rtl' => {
+  return RTL_LOCALES.has(locale) ? 'rtl' : 'ltr'
+}
+
 export const NOTICE_I18N = {
   title: {
     en_US: 'Important Notice',


### PR DESCRIPTION
## Summary
- Chat question/answer bubbles are rendered through the shared `Markdown` component, which never set a `dir` attribute, so RTL-locale content (e.g. Farsi, Arabic) always rendered left-to-right.
- Adds `getTextDirection(locale)` in `web/i18n-config/language.ts`, following the existing locale-lookup pattern in that file (`getDocLanguage`, `getAccessControlTemplateLanguage`), covering every RTL locale Dify currently ships translations for (`fa-IR`, `ar-TN`).
- `Markdown` now derives `dir` from the active locale via this helper and applies it to the `markdown-body` container, the single shared renderer for both chat bubbles.

fixes #41758

## Test plan
- [x] `vitest run --project unit app/components/base/markdown/__tests__/index.spec.tsx` — added cases covering `fa-IR`, `ar-TN`, and the default `en-US` (no `dir` override).
- [x] `pnpm run type-check` passes.