### PR TITLE
fix(binding-files): keep UTF-8 text preview when max_bytes splits a character

### DIFF
--- a/dify-agent/src/dify_agent/server/binding_files.py
+++ b/dify-agent/src/dify_agent/server/binding_files.py
@@ -109,9 +109,15 @@ data = data[:max_bytes]
 try:
     text = data.decode("utf-8")
     binary = False
-except UnicodeDecodeError:
-    text = None
-    binary = True
+except UnicodeDecodeError as exc:
+    # Truncation may split a trailing multi-byte code point. Keep the longest
+    # complete UTF-8 prefix; genuine invalid bytes still classify as binary.
+    if truncated and exc.reason == "unexpected end of data" and exc.end == len(data):
+        text = data[: exc.start].decode("utf-8")
+        binary = False
+    else:
+        text = None
+        binary = True
 payload = {
     "path": response_path,
     "size": size,

--- a/dify-agent/tests/local/dify_agent/server/test_binding_files.py
+++ b/dify-agent/tests/local/dify_agent/server/test_binding_files.py
@@ -318,6 +318,66 @@ async def test_real_read_script_handles_boundary_truncation_and_binary(tmp_path:
 
 
 @pytest.mark.anyio
+async def test_real_read_script_handles_utf8_truncation_at_multibyte_boundary(tmp_path: Path) -> None:
+    service, backend, commands, workspace, _ = _local_service(tmp_path)
+
+    latin = "ñ".encode("utf-8")  # 2-byte: c3 b1
+    euro = "€".encode("utf-8")  # 3-byte: e2 82 ac
+    smile = "😀".encode("utf-8")  # 4-byte: f0 9f 98 80
+    cjk = "中".encode("utf-8")  # 3-byte: e4 b8 ad
+
+    (workspace / "latin.txt").write_bytes(b"a" + latin)
+    (workspace / "euro.txt").write_bytes(b"a" + euro)
+    (workspace / "smile.txt").write_bytes(b"a" + smile)
+    (workspace / "cjk.txt").write_bytes(b"a" + cjk)
+    (workspace / "invalid.txt").write_bytes(b"a\xff" + euro)
+
+    latin_result = await service.read_file(
+        BindingFileReadRequest(backend_binding_ref="binding-ref", path="latin.txt", max_bytes=2)
+    )
+    euro_result = await service.read_file(
+        BindingFileReadRequest(backend_binding_ref="binding-ref", path="euro.txt", max_bytes=2)
+    )
+    smile_result = await service.read_file(
+        BindingFileReadRequest(backend_binding_ref="binding-ref", path="smile.txt", max_bytes=3)
+    )
+    cjk_result = await service.read_file(
+        BindingFileReadRequest(backend_binding_ref="binding-ref", path="cjk.txt", max_bytes=3)
+    )
+    invalid_result = await service.read_file(
+        BindingFileReadRequest(backend_binding_ref="binding-ref", path="invalid.txt", max_bytes=4)
+    )
+
+    assert latin_result.size == 3
+    assert latin_result.truncated is True
+    assert latin_result.binary is False
+    assert latin_result.text == "a"
+
+    assert euro_result.size == 4
+    assert euro_result.truncated is True
+    assert euro_result.binary is False
+    assert euro_result.text == "a"
+
+    assert smile_result.size == 5
+    assert smile_result.truncated is True
+    assert smile_result.binary is False
+    assert smile_result.text == "a"
+
+    assert cjk_result.size == 4
+    assert cjk_result.truncated is True
+    assert cjk_result.binary is False
+    assert cjk_result.text == "a"
+
+    assert invalid_result.size == 5
+    assert invalid_result.truncated is True
+    assert invalid_result.binary is True
+    assert invalid_result.text is None
+
+    assert commands.deletes == ["local-job-1", "local-job-2", "local-job-3", "local-job-4", "local-job-5"]
+    assert backend.releases == 5
+
+
+@pytest.mark.anyio
 async def test_real_browse_script_output_over_command_cap_normalizes_to_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Binding file previews currently decode a hard `max_bytes` slice with strict UTF-8. When that slice cuts through a valid multi-byte character, `decode("utf-8")` fails and the whole file is reported as binary.

This is one defect with two reproductions from #41760. Both are fixed by this PR:

1. Minimal: `note.txt` = `a€` (`61 e2 82 ac`) with `max_bytes: 2`
2. Default preview: 262143 ASCII bytes followed by `€` with `max_bytes: 262144`

This change keeps the longest complete UTF-8 prefix when the preview is truncated at an incomplete trailing sequence (`UnicodeDecodeError.reason == "unexpected end of data"` at the end of the buffer). Files with invalid UTF-8 elsewhere are still classified as binary.

Fixes #41760

## Changes

- `dify-agent/src/dify_agent/server/binding_files.py`: recover truncated text previews that split a 2/3/4-byte UTF-8 character
- `dify-agent/tests/local/dify_agent/server/test_binding_files.py`: cover 2-, 3-, and 4-byte splits plus an invalid byte in the middle of the file

## Test plan

- [x] `pytest tests/local/dify_agent/server/test_binding_files.py` (34 passed)
- [x] Manual `POST /execution-bindings/files/read` on `note.txt` (`a€`) with `max_bytes: 2` returned `{"path":"note.txt","size":4,"truncated":true,"binary":false,"text":"a"}`
- [x] Manual 4-byte split (`a😀`, `max_bytes: 3`) returned `{"binary":false,"text":"a","truncated":true}`
- [x] Manual invalid UTF-8 in the middle (`a\xff€`, `max_bytes: 4`) still returned `{"binary":true,"text":null}`
