### PR TITLE
fix(api): grant WebApp access to file input default values

### DIFF
--- a/api/core/app/apps/base_app_generator.py
+++ b/api/core/app/apps/base_app_generator.py
@@ -13,9 +13,15 @@ from core.app.apps.draft_variable_saver import (
     NoopDraftVariableSaver,
 )
 from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
-from core.app.file_access import DatabaseFileAccessController, FileAccessScope, bind_file_access_scope
+from core.app.file_access import (
+    DatabaseFileAccessController,
+    FileAccessScope,
+    bind_file_access_scope,
+    grant_upload_file_access,
+)
 from extensions.ext_database import db
 from factories import file_factory
+from factories.file_factory.common import resolve_mapping_file_id
 from graphon.enums import NodeType
 from graphon.file import File, FileUploadConfig
 from graphon.variables.input_entities import VariableEntityType
@@ -126,6 +132,53 @@ class BaseAppGenerator:
             )
         )
 
+    @staticmethod
+    def _variable_uses_default(*, variable_entity: "VariableEntity", raw_value: Any) -> bool:
+        if variable_entity.required or variable_entity.default is None:
+            return False
+        if raw_value is None:
+            return True
+        if (
+            variable_entity.type in {VariableEntityType.FILE, VariableEntityType.FILE_LIST}
+            and not variable_entity.required
+            and isinstance(raw_value, str)
+            and not raw_value
+        ):
+            return False
+        return False
+
+    @staticmethod
+    def _grant_default_upload_file_access(
+        *,
+        user_inputs: Mapping[str, Any],
+        variables: Sequence["VariableEntity"],
+    ) -> None:
+        granted_upload_file_ids: list[str] = []
+        for variable_entity in variables:
+            if variable_entity.type not in {VariableEntityType.FILE, VariableEntityType.FILE_LIST}:
+                continue
+            if not BaseAppGenerator._variable_uses_default(
+                variable_entity=variable_entity,
+                raw_value=user_inputs.get(variable_entity.variable),
+            ):
+                continue
+
+            default = variable_entity.default
+            if variable_entity.type == VariableEntityType.FILE and isinstance(default, dict):
+                upload_file_id = resolve_mapping_file_id(default, "upload_file_id")
+                if upload_file_id:
+                    granted_upload_file_ids.append(upload_file_id)
+            elif variable_entity.type == VariableEntityType.FILE_LIST and isinstance(default, list):
+                for item in default:
+                    if not isinstance(item, dict):
+                        continue
+                    upload_file_id = resolve_mapping_file_id(item, "upload_file_id")
+                    if upload_file_id:
+                        granted_upload_file_ids.append(upload_file_id)
+
+        if granted_upload_file_ids:
+            grant_upload_file_access(granted_upload_file_ids)
+
     def _prepare_user_inputs(
         self,
         *,
@@ -134,13 +187,14 @@ class BaseAppGenerator:
         tenant_id: str,
         strict_type_validation: bool = False,
     ) -> Mapping[str, Any]:
-        user_inputs = user_inputs or {}
+        raw_user_inputs = user_inputs or {}
         # Filter input variables from form configuration, handle required fields, default values, and option values
         user_inputs = {
-            var.variable: self._validate_inputs(value=user_inputs.get(var.variable), variable_entity=var)
+            var.variable: self._validate_inputs(value=raw_user_inputs.get(var.variable), variable_entity=var)
             for var in variables
         }
         user_inputs = {k: self._sanitize_value(v) for k, v in user_inputs.items()}
+        self._grant_default_upload_file_access(user_inputs=raw_user_inputs, variables=variables)
         # Convert files in inputs to File
         entity_dictionary = {item.variable: item for item in variables}
         # Convert single file to File

--- a/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
@@ -1,14 +1,20 @@
 import logging
+import uuid
+from datetime import UTC, datetime
 from unittest.mock import Mock
 
 import pytest
-from sqlalchemy import inspect
-from sqlalchemy.orm import Session
+from sqlalchemy import Engine, inspect
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.app.apps.base_app_generator import BaseAppGenerator
+from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
+from core.app.file_access import FileAccessScope, bind_file_access_scope, get_current_file_access_scope
+from extensions.storage.storage_type import StorageType
 from graphon.enums import BuiltinNodeTypes, WorkflowExecutionStatus
+from graphon.file import File
 from graphon.variables.input_entities import VariableEntity, VariableEntityType
-from models import CreatorUserRole, Workflow, WorkflowRun, WorkflowRunTriggeredFrom, WorkflowType
+from models import CreatorUserRole, UploadFile, Workflow, WorkflowRun, WorkflowRunTriggeredFrom, WorkflowType
 
 
 def _workflow_run(*, graph: str | None) -> WorkflowRun:
@@ -611,3 +617,114 @@ class TestBaseAppGeneratorExtras:
         )
 
         assert saver is not None
+
+
+def test_prepare_user_inputs_grants_access_to_account_owned_default_file_list(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_engine: Engine,
+):
+    tenant_id = "tenant-id"
+    account_upload_file_id = str(uuid.uuid4())
+    end_user_id = "end-user-id"
+
+    UploadFile.metadata.create_all(sqlite_engine, tables=[UploadFile.__table__])
+    sqlite_session_maker = sessionmaker(bind=sqlite_engine, expire_on_commit=False)
+    monkeypatch.setattr("core.db.session_factory._session_maker", sqlite_session_maker)
+
+    upload_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key="default_key",
+        name="default.jpg",
+        size=1024,
+        extension="jpg",
+        mime_type="image/jpeg",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-id",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        used=False,
+        source_url="http://example.com/default.jpg",
+    )
+    upload_file.id = account_upload_file_id
+
+    with sqlite_session_maker() as session:
+        session.add(upload_file)
+        session.commit()
+
+    default_mapping = {
+        "transfer_method": "local_file",
+        "upload_file_id": account_upload_file_id,
+        "type": "image",
+    }
+    variables = [
+        VariableEntity(
+            variable="attachments",
+            label="attachments",
+            type=VariableEntityType.FILE_LIST,
+            required=False,
+            default=[default_mapping],
+            allowed_file_types=[],
+            allowed_file_extensions=[],
+            allowed_file_upload_methods=[],
+        )
+    ]
+
+    scope = FileAccessScope(
+        tenant_id=tenant_id,
+        user_id=end_user_id,
+        user_from=UserFrom.END_USER,
+        invoke_from=InvokeFrom.WEB_APP,
+    )
+    base_app_generator = BaseAppGenerator()
+
+    with bind_file_access_scope(scope):
+        prepared = base_app_generator._prepare_user_inputs(
+            user_inputs={},
+            variables=variables,
+            tenant_id=tenant_id,
+        )
+
+        current_scope = get_current_file_access_scope()
+        assert current_scope is not None
+        assert account_upload_file_id in current_scope.granted_upload_file_ids
+        assert len(prepared["attachments"]) == 1
+        assert isinstance(prepared["attachments"][0], File)
+        assert prepared["attachments"][0].filename == "default.jpg"
+
+
+def test_prepare_user_inputs_does_not_grant_access_for_user_provided_file_list(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    grant_access = Mock()
+    monkeypatch.setattr("core.app.apps.base_app_generator.grant_upload_file_access", grant_access)
+    monkeypatch.setattr(
+        "core.app.apps.base_app_generator.file_factory.build_from_mappings",
+        lambda mappings, tenant_id, config, access_controller=None: ["file-object"],
+    )
+
+    variables = [
+        VariableEntity(
+            variable="attachments",
+            label="attachments",
+            type=VariableEntityType.FILE_LIST,
+            required=False,
+            default=[{"transfer_method": "local_file", "upload_file_id": "default-file-id", "type": "image"}],
+            allowed_file_types=[],
+            allowed_file_extensions=[],
+            allowed_file_upload_methods=[],
+        )
+    ]
+
+    user_file_mapping = {
+        "transfer_method": "local_file",
+        "upload_file_id": "user-file-id",
+        "type": "image",
+    }
+
+    BaseAppGenerator()._prepare_user_inputs(
+        user_inputs={"attachments": [user_file_mapping]},
+        variables=variables,
+        tenant_id="tenant-id",
+    )
+
+    grant_access.assert_not_called()


### PR DESCRIPTION
## Summary

- Grant upload file access for studio-configured **FILE** and **FILE_LIST** input defaults before resolving user inputs in WebApp runs
- Fixes the ownership mismatch where default files are uploaded by the Account in Studio but WebApp executes as an EndUser, causing `Invalid upload file`
- Adds regression tests covering default file-list access under EndUser scope and ensuring user-provided files are not auto-granted

## Context

Fixes #41727

When a Chatflow File List input has a default value, Preview works but WebApp fails with `Invalid upload file`. Preview runs as the Account (ownership filter skipped); WebApp runs as an EndUser (`requires_user_ownership=True`), so account-owned default uploads are rejected.

This uses the existing `grant_upload_file_access` mechanism (same approach as knowledge-base retrieved images in v1.15.0).

## Test plan

- [x] `uv run pytest tests/unit_tests/core/app/apps/test_base_app_generator.py -q` (22 passed)
- [x] New test: account-owned default file list resolves under EndUser WebApp scope
- [x] New test: user-provided file list does not trigger default-file granting