### PR TITLE
fix: close unclosed think tags around agent tool calls

### DIFF
--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -27,6 +27,7 @@ from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 
 from .events import AgentLogEvent
 from .exceptions import AgentNodeError, AgentVariableTypeError, ToolFileNotFoundError
+from .think_tags import ThinkStreamState
 
 _file_access_controller = DatabaseFileAccessController()
 
@@ -54,7 +55,7 @@ class AgentMessageTransformer:
             conversation_id=conversation_id,
         )
 
-        text = ""
+        think_state = ThinkStreamState()
         files: list[File] = []
         json_list: list[dict | list] = []
 
@@ -125,10 +126,10 @@ class AgentMessageTransformer:
                 )
             elif message.type == ToolInvokeMessage.MessageType.TEXT:
                 assert isinstance(message.message, ToolInvokeMessage.TextMessage)
-                text += message.message.text
+                chunk = think_state.feed_text(message.message.text)
                 yield StreamChunkEvent(
                     selector=[node_id, "text"],
-                    chunk=message.message.text,
+                    chunk=chunk,
                     is_final=False,
                 )
             elif message.type == ToolInvokeMessage.MessageType.JSON:
@@ -152,8 +153,9 @@ class AgentMessageTransformer:
                 linked_file = self._file_from_link_message(message=message, tenant_id=tenant_id)
                 if linked_file is not None:
                     files.append(linked_file)
+                yield from self._close_open_think(think_state=think_state, node_id=node_id)
                 stream_text = f"{'File' if linked_file is not None else 'Link'}: {message.message.text}\n"
-                text += stream_text
+                think_state.feed_text(stream_text)
                 yield StreamChunkEvent(
                     selector=[node_id, "text"],
                     chunk=stream_text,
@@ -249,6 +251,8 @@ class AgentMessageTransformer:
                 else:
                     agent_logs.append(agent_log)
 
+                yield from self._close_open_think(think_state=think_state, node_id=node_id)
+
                 yield agent_log
 
         json_output: list[dict[str, Any] | list[Any]] = []
@@ -271,6 +275,8 @@ class AgentMessageTransformer:
         else:
             json_output.append({"data": []})
 
+        yield from self._close_open_think(think_state=think_state, node_id=node_id)
+
         yield StreamChunkEvent(
             selector=[node_id, "text"],
             chunk="",
@@ -288,7 +294,7 @@ class AgentMessageTransformer:
             node_run_result=NodeRunResult(
                 status=WorkflowNodeExecutionStatus.SUCCEEDED,
                 outputs={
-                    "text": text,
+                    "text": think_state.text,
                     "usage": jsonable_encoder(llm_usage),
                     "files": ArrayFileSegment(value=files),
                     "json": json_output,
@@ -302,6 +308,17 @@ class AgentMessageTransformer:
                 inputs=parameters_for_log,
                 llm_usage=llm_usage,
             )
+        )
+
+    @staticmethod
+    def _close_open_think(*, think_state: ThinkStreamState, node_id: str) -> Generator[StreamChunkEvent, None, None]:
+        closed = think_state.close_if_open()
+        if closed is None:
+            return
+        yield StreamChunkEvent(
+            selector=[node_id, "text"],
+            chunk=closed,
+            is_final=False,
         )
 
     @staticmethod

--- a/api/core/workflow/nodes/agent/think_tags.py
+++ b/api/core/workflow/nodes/agent/think_tags.py
@@ -1,0 +1,109 @@
+"""Normalize unclosed ``<think>`` tags in agent/workflow text streams.
+
+Reasoning models (GLM, DeepSeek, etc.) wrap chain-of-thought in ``<think>``
+tags. A tool call often interrupts generation before ``</think>`` is emitted,
+so a later ``<think>`` or the final answer stays nested in the still-open tag
+and the UI renders the reply as thinking. See https://github.com/langgenius/dify/issues/41558
+"""
+
+from __future__ import annotations
+
+THINK_OPEN = "<think>"
+THINK_CLOSE = "</think>"
+
+
+def has_unclosed_think(text: str) -> bool:
+    """Return True when a ``<think>`` is still open in ``text``."""
+    _, inside, _ = _walk(text, inside=False, content_since_open=False, close_at_end=False)
+    return inside
+
+
+def close_unclosed_think_tags(text: str) -> str:
+    """Insert missing ``</think>`` before a nested open tag and at end of text."""
+    repaired, _, _ = _walk(text, inside=False, content_since_open=False, close_at_end=True)
+    return repaired
+
+
+def normalize_think_chunk(
+    chunk: str,
+    *,
+    inside: bool,
+    content_since_open: bool = False,
+) -> tuple[str, bool, bool]:
+    """Repair nested opens in a stream chunk and return updated open state.
+
+    Does not append a trailing ``</think>`` — the caller closes on tool-call
+    interruptions and at end of stream.
+    """
+    return _walk(chunk, inside=inside, content_since_open=content_since_open, close_at_end=False)
+
+
+class ThinkStreamState:
+    """Track concatenated text and whether a ``<think>`` block is still open."""
+
+    def __init__(self) -> None:
+        self.text = ""
+        self.inside = False
+        self.content_since_open = False
+
+    def feed_text(self, chunk: str) -> str:
+        repaired, self.inside, self.content_since_open = normalize_think_chunk(
+            chunk,
+            inside=self.inside,
+            content_since_open=self.content_since_open,
+        )
+        self.text += repaired
+        return repaired
+
+    def close_if_open(self) -> str | None:
+        if not self.inside:
+            return None
+        self.inside = False
+        self.content_since_open = False
+        self.text += THINK_CLOSE
+        return THINK_CLOSE
+
+
+def _walk(
+    text: str,
+    *,
+    inside: bool,
+    content_since_open: bool,
+    close_at_end: bool,
+) -> tuple[str, bool, bool]:
+    parts: list[str] = []
+    i = 0
+    length = len(text)
+    open_len = len(THINK_OPEN)
+    close_len = len(THINK_CLOSE)
+
+    while i < length:
+        if text.startswith(THINK_OPEN, i):
+            if inside and content_since_open:
+                parts.append(THINK_CLOSE)
+            elif inside:
+                i += open_len
+                continue
+            parts.append(THINK_OPEN)
+            inside = True
+            content_since_open = False
+            i += open_len
+            continue
+        if text.startswith(THINK_CLOSE, i):
+            parts.append(THINK_CLOSE)
+            inside = False
+            content_since_open = False
+            i += close_len
+            continue
+        ch = text[i]
+        parts.append(ch)
+        if inside and not ch.isspace():
+            content_since_open = True
+        i += 1
+
+    if close_at_end and inside:
+        parts.append(THINK_CLOSE)
+        inside = False
+        content_since_open = False
+
+    return "".join(parts), inside, content_since_open

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -11,7 +11,7 @@ from core.workflow.nodes.agent.exceptions import ToolFileNotFoundError
 from core.workflow.nodes.agent.message_transformer import AgentMessageTransformer
 from graphon.enums import BuiltinNodeTypes
 from graphon.file import File, FileTransferMethod, FileType
-from graphon.node_events import StreamCompletedEvent
+from graphon.node_events import StreamChunkEvent, StreamCompletedEvent
 from graphon.variables.segments import ArrayFileSegment
 
 
@@ -194,3 +194,81 @@ def test_transform_keeps_plain_link_as_text() -> None:
 
     assert text == "Link: https://dify.ai\n"
     assert files.value == []
+
+
+def _text(content: str) -> ToolInvokeMessage:
+    return ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.TEXT,
+        message=ToolInvokeMessage.TextMessage(text=content),
+    )
+
+
+def _log(*, message_id: str = "log-1", label: str = "ROUND 1") -> ToolInvokeMessage:
+    return ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LOG,
+        message=ToolInvokeMessage.LogMessage(
+            id=message_id,
+            label=label,
+            status=ToolInvokeMessage.LogMessage.LogStatus.START,
+            data={},
+        ),
+    )
+
+
+def test_transform_closes_think_tag_before_nested_open() -> None:
+    text, _ = _run_transform(
+        [
+            _text("<think>first pass\n"),
+            _text("<think>second pass"),
+        ]
+    )
+
+    assert text == "<think>first pass\n</think><think>second pass</think>"
+
+
+def test_transform_closes_think_tag_when_tool_log_interrupts() -> None:
+    text, _ = _run_transform(
+        [
+            _text("<think>need to search"),
+            _log(label="CALL search"),
+            _text("search result summary"),
+        ]
+    )
+
+    assert text == "<think>need to search</think>search result summary"
+
+
+def test_transform_streams_close_tag_before_post_tool_text() -> None:
+    events = list(
+        AgentMessageTransformer().transform(
+            messages=_message_stream(
+                [
+                    _text("<think>need to search"),
+                    _log(label="CALL search"),
+                    _text("visible reply"),
+                ]
+            ),
+            tool_info={},
+            parameters_for_log={},
+            user_id="user-id",
+            tenant_id="tenant-id",
+            conversation_id=None,
+            node_type=BuiltinNodeTypes.AGENT,
+            node_id="node-id",
+            node_execution_id="execution-id",
+        )
+    )
+    text_chunks = [
+        event.chunk for event in events if isinstance(event, StreamChunkEvent) and event.selector == ["node-id", "text"]
+    ]
+
+    assert text_chunks == ["<think>need to search", "</think>", "visible reply", ""]
+
+
+def test_close_unclosed_think_tags_helper() -> None:
+    from core.workflow.nodes.agent.think_tags import close_unclosed_think_tags, has_unclosed_think
+
+    assert has_unclosed_think("<think>open")
+    assert not has_unclosed_think("<think>open</think>done")
+    assert close_unclosed_think_tags("<think>a\n<think>b") == "<think>a\n</think><think>b</think>"
+

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -271,4 +271,3 @@ def test_close_unclosed_think_tags_helper() -> None:
     assert has_unclosed_think("<think>open")
     assert not has_unclosed_think("<think>open</think>done")
     assert close_unclosed_think_tags("<think>a\n<think>b") == "<think>a\n</think><think>b</think>"
-

--- a/web/app/components/base/markdown/__tests__/markdown-utils.spec.ts
+++ b/web/app/components/base/markdown/__tests__/markdown-utils.spec.ts
@@ -105,6 +105,24 @@ describe('preprocessThinkTag', () => {
     expect((out.match(/<details data-think=true>/g) || []).length).toBe(1)
     expect((out.match(/\[ENDTHINKFLAG\]<\/details>/g) || []).length).toBe(1)
   })
+
+  it('closes a dangling <think> so the details block is well-formed', () => {
+    const input = '<think>planning the tool call'
+    const out = mod.preprocessThinkTag(input)
+
+    expect((out.match(/<details data-think=true>/g) || []).length).toBe(1)
+    expect((out.match(/\[ENDTHINKFLAG\]<\/details>/g) || []).length).toBe(1)
+    expect(out).toContain('planning the tool call')
+  })
+
+  it('closes the previous think before a second unclosed <think>', () => {
+    const input = '<think>first pass\n<think>second pass\nreply'
+    const out = mod.preprocessThinkTag(input)
+
+    expect((out.match(/<details data-think=true>/g) || []).length).toBe(2)
+    expect((out.match(/\[ENDTHINKFLAG\]<\/details>/g) || []).length).toBe(2)
+    expect(out.indexOf('first pass')).toBeLessThan(out.indexOf('[ENDTHINKFLAG]'))
+  })
 })
 
 describe('customUrlTransform', () => {

--- a/web/app/components/base/markdown/markdown-utils.ts
+++ b/web/app/components/base/markdown/markdown-utils.ts
@@ -31,10 +31,57 @@ export const preprocessLaTeX = (content: string) => {
   return processedContent
 }
 
+/**
+ * Insert missing </think> before a nested <think> and at end of content.
+ * Tool-call interruptions often drop the close tag, which nests the reply
+ * inside the thinking HTML (github.com/langgenius/dify/issues/41558).
+ */
+export const closeUnclosedThinkTags = (content: string) => {
+  if (typeof content !== 'string' || !content.includes('<think>')) return content
+
+  const open = '<think>'
+  const close = '</think>'
+  let result = ''
+  let inside = false
+  let contentSinceOpen = false
+  let i = 0
+
+  while (i < content.length) {
+    if (content.startsWith(open, i)) {
+      if (inside && contentSinceOpen) result += close
+      else if (inside) {
+        i += open.length
+        continue
+      }
+      result += open
+      inside = true
+      contentSinceOpen = false
+      i += open.length
+      continue
+    }
+    if (content.startsWith(close, i)) {
+      result += close
+      inside = false
+      contentSinceOpen = false
+      i += close.length
+      continue
+    }
+    const ch = content.charAt(i)
+    result += ch
+    if (inside && ch.trim() !== '') contentSinceOpen = true
+    i += 1
+  }
+
+  if (inside) result += close
+
+  return result
+}
+
 export const preprocessThinkTag = (content: string) => {
   const thinkOpenTagRegex = /(<think>\s*)+/g
   const thinkCloseTagRegex = /(\s*<\/think>)+/g
   return flow([
+    closeUnclosedThinkTags,
     (str: string) => str.replace(thinkOpenTagRegex, '<details data-think=true>\n'),
     (str: string) => str.replace(thinkCloseTagRegex, '\n[ENDTHINKFLAG]</details>'),
     (str: string) => str.replace(/(<\/details>)(?![^\S\r\n]*[\r\n])(?![^\S\r\n]*$)/g, '$1\n'),


### PR DESCRIPTION
Fixes #41558

## Summary

Reasoning models (GLM-5.3 and similar) wrap chain-of-thought in `<think>` tags. A tool call often interrupts generation before `</think>` is emitted, so a later `<think>` block or the answer stays nested in the still-open tag. Markdown then turns that into an unclosed `<details data-think>`, and the reply is rendered as thinking.

This PR adds a fallback that inserts the missing close tag:

- Workflow Agent node: close dangling `<think>` when a tool log (or link) interrupts the stream, when a new `<think>` starts after real content, and at stream end.
- Markdown preprocessor: the same nested-open / trailing-close repair so already stored or LLM tagged output still renders as valid think blocks.

## Screenshots

| Before | After |
| ------ | ----- |
| Reply nested in an unclosed thinking block when `</think>` is dropped around a tool call | Think blocks close at the tool-call / nested-open boundary so the answer renders outside thinking |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods