### PR TITLE
fix(api): correct Service API segments has_more pagination

### DIFF
--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -281,7 +281,7 @@ class SegmentApi(DatasetApiResource):
             use_defaults_for_malformed_ints=True,
         )
         page = args.page
-        limit = args.limit
+        limit = min(args.limit, 100)
         dataset_id_str = str(dataset_id)
         dataset = session.scalar(
             select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == dataset_id_str).limit(1)
@@ -331,7 +331,7 @@ class SegmentApi(DatasetApiResource):
             "data": segment_responses_with_summaries(segments, summaries, session=session),
             "doc_form": document.doc_form,
             "total": total,
-            "has_more": len(segments) == limit,
+            "has_more": page * limit < total,
             "limit": limit,
             "page": page,
         }

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -969,21 +969,27 @@ class TestSegmentPagination:
         assert limit >= 1
         assert limit <= 100
 
-    def test_has_more_calculation(self):
-        """Test has_more pagination flag calculation."""
-        segments_count = 20
+    def test_has_more_false_on_last_page_exact_limit(self):
+        """Last page that fills the limit exactly must not claim more rows."""
+        page = 1
         limit = 20
+        total = 20
+        effective_limit = min(limit, 100)
 
-        has_more = segments_count == limit
-        assert has_more is True
-
-    def test_no_more_when_incomplete_page(self):
-        """Test has_more is False for incomplete page."""
-        segments_count = 15
-        limit = 20
-
-        has_more = segments_count == limit
+        has_more = page * effective_limit < total
+        assert effective_limit == 20
         assert has_more is False
+
+    def test_has_more_true_when_limit_exceeds_cap_with_remaining_rows(self):
+        """Capped pages must still report remaining rows after the first 100."""
+        page = 1
+        limit = 200
+        total = 150
+        effective_limit = min(limit, 100)
+
+        has_more = page * effective_limit < total
+        assert effective_limit == 100
+        assert has_more is True
 
 
 # =============================================================================
@@ -1069,6 +1075,91 @@ class TestSegmentApiGet(SQLiteEndpointTest):
         assert response["page"] == 1
         mock_dump_segments.assert_called_once_with([mock_segment], {}, session=ANY)
         assert isinstance(mock_dump_segments.call_args.kwargs["session"], Session)
+
+    @patch("controllers.service_api.dataset.segment.segment_responses_with_summaries")
+    @patch("controllers.service_api.dataset.segment.SummaryIndexService.get_segments_summaries")
+    @patch("controllers.service_api.dataset.segment.SegmentService")
+    @patch("controllers.service_api.dataset.segment.DocumentService")
+    @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
+    def test_list_segments_has_more_false_on_last_page_exact_limit(
+        self,
+        mock_account_fn,
+        mock_doc_svc,
+        mock_seg_svc,
+        mock_get_summaries,
+        mock_dump_segments,
+        app: Flask,
+        mock_tenant,
+        mock_dataset,
+        mock_segment,
+    ):
+        """A full last page must set has_more false instead of forcing another fetch."""
+        mock_account_fn.return_value = (_account(), mock_tenant.id)
+        self._persist_dataset(mock_dataset, mock_tenant.id)
+        mock_doc_svc.get_document.return_value = _document_for_dataset(
+            mock_dataset, doc_form=IndexStructureType.PARAGRAPH_INDEX
+        )
+        page_size = 20
+        segments = [mock_segment] * page_size
+        mock_seg_svc.get_segments.return_value = (segments, page_size)
+        mock_get_summaries.return_value = {}
+        mock_dump_segments.return_value = [_segment_response_dict() for _ in range(page_size)]
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/doc-id/segments?page=1&limit={page_size}",
+            method="GET",
+        ):
+            api = SegmentApi()
+            response, status = api.get(tenant_id=mock_tenant.id, dataset_id=mock_dataset.id, document_id="doc-id")
+
+        assert status == 200
+        assert response["has_more"] is False
+        assert response["limit"] == page_size
+        assert response["total"] == page_size
+        assert response["page"] == 1
+
+    @patch("controllers.service_api.dataset.segment.segment_responses_with_summaries")
+    @patch("controllers.service_api.dataset.segment.SummaryIndexService.get_segments_summaries")
+    @patch("controllers.service_api.dataset.segment.SegmentService")
+    @patch("controllers.service_api.dataset.segment.DocumentService")
+    @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
+    def test_list_segments_has_more_true_when_limit_exceeds_cap(
+        self,
+        mock_account_fn,
+        mock_doc_svc,
+        mock_seg_svc,
+        mock_get_summaries,
+        mock_dump_segments,
+        app: Flask,
+        mock_tenant,
+        mock_dataset,
+        mock_segment,
+    ):
+        """limit>100 still reports remaining rows after the server cap of 100."""
+        mock_account_fn.return_value = (_account(), mock_tenant.id)
+        self._persist_dataset(mock_dataset, mock_tenant.id)
+        mock_doc_svc.get_document.return_value = _document_for_dataset(
+            mock_dataset, doc_form=IndexStructureType.PARAGRAPH_INDEX
+        )
+        returned_count = 100
+        total = 150
+        segments = [mock_segment] * returned_count
+        mock_seg_svc.get_segments.return_value = (segments, total)
+        mock_get_summaries.return_value = {}
+        mock_dump_segments.return_value = [_segment_response_dict() for _ in range(returned_count)]
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/doc-id/segments?page=1&limit=200",
+            method="GET",
+        ):
+            api = SegmentApi()
+            response, status = api.get(tenant_id=mock_tenant.id, dataset_id=mock_dataset.id, document_id="doc-id")
+
+        assert status == 200
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert response["total"] == total
+        assert response["page"] == 1
 
     @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
     def test_list_segments_dataset_not_found(self, mock_account_fn, app, mock_tenant, mock_dataset):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41775

Service API `GET .../segments` computed `has_more` as `len(segments) == limit`. Segment listing is capped at `max_per_page=100`, so a client that requests `limit=200` with `total=150` receives 100 rows and incorrectly gets `has_more=false` while 50 segments remain.

This change uses an effective limit of `min(limit, 100)`, sets `has_more` from `page * effective_limit < total`, and returns the effective limit in the response.

## Testing

- Unit tests in `TestSegmentPagination` / `TestSegmentApiGet` (8 passed), including:
  - last page with exactly `limit` rows → `has_more=false`
  - `limit>100` with remaining rows → `has_more=true` and response `limit=100`