### PR TITLE
feat(dify-builder): add live progress and conversation streaming

### DIFF
--- a/api/tasks/dify_builder_advance_task.py
+++ b/api/tasks/dify_builder_advance_task.py
@@ -16,6 +16,10 @@ than reusing the Flask-request-scoped ``db.session``, since this runs in a
 Celery worker, not a Flask request. The ``FlaskTask`` base
 (``extensions.ext_celery.init_app``) already wraps the task body in
 ``app.app_context()``, so this module must NOT push its own context.
+
+Once a message's user half is durable, a failed assistant half remains at
+the current waiting gate. The client can then retry with the same
+``client_turn_id`` without duplicating the user bubble.
 """
 
 import logging
@@ -111,6 +115,7 @@ def advance_session(session_id: str, action_dict: dict, actor_dict: dict, token:
     env: Env | None = None
     loaded_session: Session | None = None
     last_progress: ProgressEventData | None = None
+    action: Action | None = None
     try:
         repo = _build_repo()
         dify = WorkflowServiceDifyPort()
@@ -256,7 +261,24 @@ def advance_session(session_id: str, action_dict: dict, actor_dict: dict, token:
                 )
             except Exception:
                 logger.exception("dify_builder failed progress publish failed for session %s", session_id)
-        if runner is not None:
+        retryable_message_failure = False
+        failed_action_kind = action.kind if action is not None else action_dict.get("kind")
+        failed_action_payload = action.payload if action is not None else action_dict.get("payload")
+        if repo is not None and failed_action_kind == "message" and isinstance(failed_action_payload, dict):
+            client_turn_id = failed_action_payload.get("client_turn_id")
+            if isinstance(client_turn_id, str) and client_turn_id:
+                try:
+                    turn_kinds = repo.get_conversation_turn_kinds(session_id, client_turn_id)
+                    retryable_message_failure = "user" in turn_kinds and "assistant_turn" not in turn_kinds
+                except Exception:
+                    logger.exception(
+                        "dify_builder could not inspect failed message turn for session %s",
+                        session_id,
+                    )
+
+        if retryable_message_failure:
+            terminal_error = {"kind": "error", "error": "step failed", "recoverable": True}
+        elif runner is not None:
             try:
                 runner.fail(session_id)
                 assert repo is not None

--- a/api/tests/unit_tests/services/dify_builder/test_advance_task.py
+++ b/api/tests/unit_tests/services/dify_builder/test_advance_task.py
@@ -311,6 +311,87 @@ def test_message_advance_publishes_assistant_delta_before_durable_reply(
     assert released == [(session.id, "tok-message")]
 
 
+def test_message_failure_keeps_the_durable_user_half_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+    repo: SqlDifyBuilderRepository,
+) -> None:
+    monkeypatch.setattr(mod, "_build_repo", lambda: repo)
+    monkeypatch.setattr(mod, "WorkflowServiceDifyPort", FakeDifyPort)
+
+    class FailingAgent(StubAgent):
+        def respond_to_message(self, _state, _context, _history, _graph, _text, _on_delta=None):
+            raise RuntimeError("model unavailable")
+
+    monkeypatch.setattr(mod, "build_dify_builder_agent", lambda **_kwargs: FailingAgent())
+    events: list[tuple[str, dict]] = []
+    released: list[tuple[str, str]] = []
+    monkeypatch.setattr(mod.progress_bus, "publish", lambda sid, event: events.append((sid, event)))
+    monkeypatch.setattr(mod.session_lock, "release", lambda sid, token: released.append((sid, token)))
+    session = Session(
+        app_id=APP_ID,
+        tenant_id=TENANT_ID,
+        owner_account_id=ACCOUNT_ID,
+        entry_mode=EntryMode.FIX,
+        current_state=PcState.FIX_AWAIT_APPROVAL,
+    )
+    repo.create_session(session, DifyBuilderContext(), [])
+
+    mod.advance_session(
+        session.id,
+        _act("message", 1, text="Retry me", client_turn_id="turn-retry"),
+        _ACTOR_DICT,
+        "tok-message-failed",
+    )
+
+    stored, _context = repo.get_session(session.id)
+    items = repo.list_conversation(session.id)
+    assert stored.current_state == PcState.FIX_AWAIT_APPROVAL
+    assert stored.version == 2
+    assert [(item.kind, item.payload.get("turn_id")) for item in items] == [("user", "turn-retry")]
+    assert events[-1][1] == {"kind": "error", "error": "step failed", "recoverable": True}
+    assert released == [(session.id, "tok-message-failed")]
+
+    events.clear()
+    monkeypatch.setattr(
+        mod,
+        "build_dify_builder_agent",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("model setup unavailable")),
+    )
+    mod.advance_session(
+        session.id,
+        _act("message", 2, text="Retry me", client_turn_id="turn-retry"),
+        _ACTOR_DICT,
+        "tok-message-setup-failed",
+    )
+
+    still_waiting, _context = repo.get_session(session.id)
+    assert still_waiting.current_state == PcState.FIX_AWAIT_APPROVAL
+    assert still_waiting.version == 2
+    assert [item.kind for item in repo.list_conversation(session.id)] == ["user"]
+    assert events[-1][1] == {"kind": "error", "error": "step failed", "recoverable": True}
+    assert released[-1] == (session.id, "tok-message-setup-failed")
+
+    events.clear()
+    monkeypatch.setattr(mod, "build_dify_builder_agent", lambda **_kwargs: StubAgent())
+    mod.advance_session(
+        session.id,
+        _act("message", 2, text="Retry me", client_turn_id="turn-retry"),
+        _ACTOR_DICT,
+        "tok-message-retry",
+    )
+
+    retried, _context = repo.get_session(session.id)
+    retried_items = repo.list_conversation(session.id)
+    assert retried.current_state == PcState.FIX_AWAIT_APPROVAL
+    assert [item.kind for item in retried_items] == ["user", "assistant_turn"]
+    assert [item.payload.get("turn_id") for item in retried_items] == [
+        "turn-retry",
+        "turn-retry",
+    ]
+    assert events[-1][1]["kind"] == "state"
+    assert released[-1] == (session.id, "tok-message-retry")
+
+
 def test_advance_session_generic_exception_publishes_generic_error_and_releases_lock(monkeypatch) -> None:
     # A fresh, isolated engine/repo/session so the FakeDifyPort.read_graph
     # monkeypatch below cannot bleed into any other test.

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -196,7 +196,7 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
             }
           />
         </div>
-        <div className="max-h-105 overflow-y-auto">
+        <div className="relative max-h-105 overflow-x-hidden overflow-y-auto">
           {trigger && (
             <div className="px-4 pt-2 pb-4">
               <ModelSelector

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/parameter-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/parameter-item.tsx
@@ -294,21 +294,21 @@ function ParameterItem({
           <Fieldset
             render={
               <RadioGroup<boolean>
-                className="w-37.5 gap-3"
+                className="w-full gap-3"
                 value={booleanValue}
                 onValueChange={handleRadioChange}
               />
             }
           >
             <FieldsetLegend className="sr-only">{translatedLabel}</FieldsetLegend>
-            <FieldItem>
-              <FieldLabel className="flex w-17.5 items-center gap-1.5 system-sm-regular text-text-secondary">
+            <FieldItem className="min-w-0 flex-1">
+              <FieldLabel className="flex w-full items-center gap-1.5 system-sm-regular text-text-secondary">
                 <Radio<boolean> value={true} />
                 True
               </FieldLabel>
             </FieldItem>
-            <FieldItem>
-              <FieldLabel className="flex w-17.5 items-center gap-1.5 system-sm-regular text-text-secondary">
+            <FieldItem className="min-w-0 flex-1">
+              <FieldLabel className="flex w-full items-center gap-1.5 system-sm-regular text-text-secondary">
                 <Radio<boolean> value={false} />
                 False
               </FieldLabel>

--- a/web/app/components/workflow-app/components/dify-builder/__tests__/conversation.spec.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/__tests__/conversation.spec.tsx
@@ -1,6 +1,7 @@
 import type { ConversationItem, FormField } from '../types'
 import type { FileUpload } from '@/app/components/base/features/types'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
+import type { MarkdownProps } from '@/app/components/base/markdown'
 import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createStore, Provider } from 'jotai'
@@ -12,7 +13,18 @@ import {
 } from '../session/state'
 
 const mocks = vi.hoisted(() => ({
+  copy: vi.fn(() => true),
   fileUploader: vi.fn(),
+  markdown: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('copy-to-clipboard', () => ({
+  default: mocks.copy,
+}))
+
+vi.mock('@langgenius/dify-ui/toast', () => ({
+  toast: { success: mocks.toastSuccess },
 }))
 
 vi.mock('@/app/components/workflow/store', () => ({
@@ -25,7 +37,10 @@ vi.mock('@/app/components/workflow/store', () => ({
 }))
 
 vi.mock('@/app/components/base/markdown', () => ({
-  Markdown: ({ content }: { content: string }) => <p>{content}</p>,
+  Markdown: (props: MarkdownProps) => {
+    mocks.markdown(props)
+    return <p>{props.content}</p>
+  },
 }))
 
 vi.mock('@/app/components/base/file-uploader', () => ({
@@ -347,6 +362,94 @@ describe('DifyBuilderConversation test data form', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Check test inputs')
     expect(screen.getByText('Inspecting the supplied test data.')).toBeInTheDocument()
     expect(screen.getByText('Checking the workflow')).toBeInTheDocument()
+  })
+
+  it('renders assistant reply text through the shared Markdown renderer', () => {
+    const replyText = '**The plan is ready.**'
+
+    render(
+      <DifyBuilderConversation
+        busy={false}
+        activeInteraction={null}
+        changesExpanded={false}
+        interrupted={false}
+        items={[
+          {
+            seq: 0,
+            at_version: 1,
+            kind: 'assistant_turn',
+            payload: {
+              turn_id: 'turn-assistant-1',
+              stage_id: 'build.plan',
+              execution: { status: 'completed' },
+              reply_text: replyText,
+            },
+          },
+        ]}
+        onActionPayloadChange={vi.fn()}
+      />,
+    )
+
+    expect(mocks.markdown).toHaveBeenCalledTimes(1)
+    expect(mocks.markdown).toHaveBeenCalledWith(expect.objectContaining({ content: replyText }))
+  })
+
+  it('copies user and assistant text with copy before retry', async () => {
+    const user = userEvent.setup()
+    const onRetryMessage = vi.fn()
+
+    render(
+      <DifyBuilderConversation
+        busy={false}
+        activeInteraction={null}
+        changesExpanded={false}
+        interrupted={false}
+        items={[
+          {
+            seq: 0,
+            at_version: 1,
+            kind: 'user',
+            payload: { text: 'Refine the workflow', turn_id: 'turn-1' },
+          },
+          {
+            seq: 1,
+            at_version: 2,
+            kind: 'assistant_turn',
+            payload: {
+              turn_id: 'turn-1',
+              stage_id: 'build.plan',
+              execution: { status: 'completed' },
+              reply_text: '**Updated plan**',
+            },
+          },
+        ]}
+        onActionPayloadChange={vi.fn()}
+        onRetryMessage={onRetryMessage}
+        retryableTurnId="turn-1"
+      />,
+    )
+
+    const userArticle = screen.getByText('Refine the workflow').closest('article')
+    const assistantArticle = screen.getByText('**Updated plan**').closest('article')
+    expect(userArticle).not.toBeNull()
+    expect(assistantArticle).not.toBeNull()
+
+    const userActions = within(userArticle!).getAllByRole('button')
+    expect(userActions).toHaveLength(2)
+    expect(userActions[0]).toHaveAccessibleName('common.operation.copy')
+    expect(userActions[1]).toHaveAccessibleName('common.operation.retry')
+    const assistantCopy = within(assistantArticle!).getByRole('button', {
+      name: 'common.operation.copy',
+    })
+
+    await user.click(userActions[0]!)
+    await user.click(assistantCopy)
+
+    expect(mocks.copy).toHaveBeenNthCalledWith(1, 'Refine the workflow')
+    expect(mocks.copy).toHaveBeenNthCalledWith(2, '**Updated plan**')
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(2)
+    expect(mocks.toastSuccess).toHaveBeenLastCalledWith('common.actionMsg.copySuccessfully')
+    expect(onRetryMessage).not.toHaveBeenCalled()
   })
 
   it('announces committed messages as a labelled log without putting streaming tokens in it', () => {

--- a/web/app/components/workflow-app/components/dify-builder/__tests__/conversation.spec.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/__tests__/conversation.spec.tsx
@@ -349,6 +349,138 @@ describe('DifyBuilderConversation test data form', () => {
     expect(screen.getByText('Checking the workflow')).toBeInTheDocument()
   })
 
+  it('announces committed messages as a labelled log without putting streaming tokens in it', () => {
+    const store = createStore()
+    store.set(difyBuilderStreamingTurnAtom, {
+      sessionId: 'session-1',
+      operationId: 'operation-1',
+      turnId: 'turn-streaming',
+      sequence: 1,
+      atVersion: 2,
+      revision: 1,
+      stageId: 'build.test',
+      replyText: 'Streaming reply',
+    })
+
+    render(
+      <Provider store={store}>
+        <DifyBuilderConversation
+          busy
+          activeInteraction={null}
+          changesExpanded={false}
+          interrupted={false}
+          items={[
+            {
+              seq: 0,
+              at_version: 1,
+              kind: 'user',
+              payload: { text: 'Build a support workflow', turn_id: 'turn-user-1' },
+            },
+            {
+              seq: 1,
+              at_version: 1,
+              kind: 'assistant_turn',
+              payload: {
+                turn_id: 'turn-assistant-1',
+                stage_id: 'build.plan',
+                execution: { status: 'completed' },
+                reply_text: 'The plan is ready.',
+              },
+            },
+          ]}
+          onActionPayloadChange={vi.fn()}
+        />
+      </Provider>,
+    )
+
+    const log = screen.getByRole('log', { name: 'workflow.difyBuilder.panelTitle' })
+    expect(log).toHaveAttribute('aria-live', 'polite')
+    expect(log).toHaveAttribute('aria-relevant', 'additions')
+    expect(within(log).getByRole('heading', { name: 'common.you' })).toBeInTheDocument()
+    expect(
+      within(log).getByRole('heading', { name: 'workflow.difyBuilder.panelTitle' }),
+    ).toBeInTheDocument()
+    expect(log).toContainElement(screen.getByText('The plan is ready.'))
+    expect(log).not.toContainElement(screen.getByText('Streaming reply'))
+  })
+
+  it('keeps a stable status while an assistant reply streams without execution steps', () => {
+    const store = createStore()
+    store.set(difyBuilderStreamingTurnAtom, {
+      sessionId: 'session-1',
+      operationId: 'operation-1',
+      turnId: 'turn-streaming',
+      sequence: 1,
+      atVersion: 2,
+      revision: 1,
+      stageId: 'build.test',
+      replyText: 'Streaming reply',
+    })
+
+    render(
+      <Provider store={store}>
+        <DifyBuilderConversation
+          busy
+          activeInteraction={null}
+          changesExpanded={false}
+          interrupted={false}
+          items={[]}
+          onActionPayloadChange={vi.fn()}
+        />
+      </Provider>,
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('workflow.common.running')
+  })
+
+  it('lets the visible resource label toggle its checkbox and describes it with metadata', async () => {
+    const user = userEvent.setup()
+    const onActionPayloadChange = vi.fn()
+    const resourceCard: Extract<ConversationItem, { kind: 'resource_select' }> = {
+      seq: 0,
+      at_version: 1,
+      kind: 'resource_select',
+      payload: {
+        recommended: [
+          {
+            id: 'knowledge-base-1',
+            kind: 'dataset',
+            label: 'Support knowledge base',
+            meta: '12 documents',
+            readiness: 'ready',
+          },
+        ],
+      },
+    }
+
+    render(
+      <DifyBuilderConversation
+        busy={false}
+        activeInteraction={{
+          action_id: 'confirm_resources',
+          card: resourceCard,
+          valid_at_version: 1,
+        }}
+        changesExpanded={false}
+        interrupted={false}
+        items={[resourceCard]}
+        onActionPayloadChange={onActionPayloadChange}
+      />,
+    )
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Support knowledge base' })
+    expect(checkbox).toBeChecked()
+    expect(checkbox).toHaveAccessibleDescription('12 documents')
+
+    await user.click(screen.getByText('Support knowledge base'))
+
+    expect(checkbox).not.toBeChecked()
+    expect(onActionPayloadChange).toHaveBeenLastCalledWith('confirm_resources', {
+      resource_ids: [],
+      conflict_policy: 'ask',
+    })
+  })
+
   it('restores the current interaction separately and freezes historical forms', async () => {
     const user = userEvent.setup()
     const oldCard: Extract<ConversationItem, { kind: 'form' }> = {
@@ -679,6 +811,7 @@ describe('DifyBuilderConversation test data form', () => {
     const card = heading.closest('article')
     expect(card).toHaveTextContent('workflow.difyBuilder.cardCategory.test')
     expect(card).toHaveTextContent('One node returned an error.')
+    expect(card).toHaveTextContent('common.api.actionFailed')
     expect(card?.querySelector('[data-card-status="failed"]')).toBeInTheDocument()
   })
 })

--- a/web/app/components/workflow-app/components/dify-builder/__tests__/model-selector.spec.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/__tests__/model-selector.spec.tsx
@@ -1,0 +1,39 @@
+import type { ReactElement } from 'react'
+import { render, screen } from '@testing-library/react'
+import { createStore, Provider } from 'jotai'
+import DifyBuilderModelSelector from '../model-selector'
+import { difyBuilderSelectedModelAtom } from '../store'
+
+vi.mock('@/app/components/header/account-setting/model-provider-page/hooks', () => ({
+  useDefaultModel: () => ({ data: null }),
+  useTextGenerationCurrentProviderAndModelAndModelList: () => ({
+    activeTextGenerationModelList: [],
+  }),
+}))
+
+vi.mock(
+  '@/app/components/header/account-setting/model-provider-page/model-parameter-modal',
+  () => ({
+    default: ({ trigger }: { trigger: ReactElement }) => trigger,
+  }),
+)
+
+describe('DifyBuilderModelSelector', () => {
+  it('uses the visible model name as the trigger accessible name', () => {
+    const store = createStore()
+    store.set(difyBuilderSelectedModelAtom, {
+      provider: 'openai',
+      name: 'gpt-4o',
+      mode: 'chat',
+      completion_params: {},
+    })
+
+    render(
+      <Provider store={store}>
+        <DifyBuilderModelSelector />
+      </Provider>,
+    )
+
+    expect(screen.getByRole('button', { name: 'gpt-4o' })).toBeInTheDocument()
+  })
+})

--- a/web/app/components/workflow-app/components/dify-builder/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/__tests__/panel.spec.tsx
@@ -124,8 +124,13 @@ describe('DifyBuilderPanel', () => {
     expect(screen.queryByRole('button', { name: /attach/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /voice|microphone/i })).not.toBeInTheDocument()
     expect(composer).toBeEnabled()
+    const sendButton = screen.getByRole('button', {
+      name: 'workflow.difyBuilder.messageSend',
+    })
+    expect(sendButton).toHaveAttribute('type', 'submit')
+    expect(sendButton.closest('form')).toBe(composer.closest('form'))
     await user.type(composer, 'Make the repair smaller')
-    await user.click(screen.getByRole('button', { name: 'workflow.difyBuilder.messageSend' }))
+    await user.click(sendButton)
     expect(mocks.sendMessage).toHaveBeenCalledWith('Make the repair smaller')
     await waitFor(() => expect(composer).toHaveValue(''))
   })
@@ -237,8 +242,15 @@ describe('DifyBuilderPanel', () => {
       [card],
     )
 
-    await user.type(screen.getByRole('textbox', { name: 'Topic' }), 'AI agents')
-    await user.click(screen.getByRole('button', { name: 'Provide test data' }))
+    const input = screen.getByRole('textbox', { name: 'Topic' })
+    const action = screen.getByRole('button', { name: 'Provide test data' })
+    const form = input.closest('form')
+    expect(form).not.toBeNull()
+    expect(action).toHaveAttribute('type', 'submit')
+    expect(action).toHaveAttribute('form', form?.id)
+
+    await user.type(input, 'AI agents')
+    await user.click(action)
 
     expect(mocks.runAction).toHaveBeenCalledWith('provide_testdata', {
       mode: 'provide',
@@ -328,13 +340,14 @@ describe('DifyBuilderPanel', () => {
     await user.paste('{"name":')
 
     expect(await screen.findByRole('alert')).toBeInTheDocument()
-    expect(action).toBeDisabled()
+    expect(action).toBeEnabled()
     await user.click(action)
     expect(mocks.runAction).not.toHaveBeenCalled()
+    expect(input).toHaveFocus()
 
     await user.clear(input)
     await user.paste('{"name":"Ada"}')
-    await waitFor(() => expect(action).toBeEnabled())
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument())
     await user.click(action)
 
     expect(mocks.runAction).toHaveBeenCalledWith('provide_testdata', {

--- a/web/app/components/workflow-app/components/dify-builder/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/__tests__/panel.spec.tsx
@@ -1,9 +1,13 @@
 import type { ConversationItem, SessionView } from '../types'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createStore, Provider } from 'jotai'
 import DifyBuilderPanel from '../panel'
-import { difyBuilderConversationAtom, difyBuilderSessionViewAtom } from '../session/state'
+import {
+  difyBuilderConversationAtom,
+  difyBuilderRetryableMessageAtom,
+  difyBuilderSessionViewAtom,
+} from '../session/state'
 import {
   difyBuilderCanvasRefreshFailedAtom,
   difyBuilderCanvasRefreshingAtom,
@@ -133,6 +137,64 @@ describe('DifyBuilderPanel', () => {
     await user.click(sendButton)
     expect(mocks.sendMessage).toHaveBeenCalledWith('Make the repair smaller')
     await waitFor(() => expect(composer).toHaveValue(''))
+  })
+
+  it('clears the composer immediately when Enter submits a pending message', async () => {
+    const user = userEvent.setup()
+    let finishSending!: (sent: boolean) => void
+    const sending = new Promise<boolean>((resolve) => {
+      finishSending = resolve
+    })
+    mocks.sendMessage.mockReturnValueOnce(sending)
+    renderPanel()
+
+    const composer = screen.getByRole('textbox', {
+      name: 'workflow.difyBuilder.messagePlaceholder',
+    })
+    await user.type(composer, 'Make the repair smaller')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(mocks.sendMessage).toHaveBeenCalledWith('Make the repair smaller')
+    })
+    try {
+      expect(composer).toHaveValue('')
+    } finally {
+      await act(async () => {
+        finishSending(true)
+        await sending
+      })
+    }
+  })
+
+  it('shows retry below the failed user bubble and resends the same turn', async () => {
+    const user = userEvent.setup()
+    let finishRetry!: (sent: boolean) => void
+    const retrying = new Promise<boolean>((resolve) => {
+      finishRetry = resolve
+    })
+    mocks.sendMessage.mockReturnValueOnce(retrying)
+    renderPanel(sessionView, (store) => {
+      store.set(difyBuilderRetryableMessageAtom, {
+        sessionId: 'session-1',
+        text: 'Fix the workflow',
+        turnId: 'turn-user-1',
+      })
+    })
+
+    const message = screen.getByText('Fix the workflow')
+    const userBubble = message.closest('article')
+    expect(userBubble).not.toBeNull()
+    const retry = within(userBubble!).getByRole('button', { name: 'common.operation.retry' })
+    expect(retry).not.toHaveTextContent('common.operation.retry')
+    expect(message.compareDocumentPosition(retry) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    await user.click(retry)
+
+    expect(mocks.sendMessage).toHaveBeenCalledWith('Fix the workflow', 'turn-user-1')
+    await waitFor(() => expect(retry).toBeDisabled())
+    act(() => finishRetry(true))
+    await waitFor(() => expect(retry).not.toBeInTheDocument())
   })
 
   it('does not submit while Enter confirms an IME composition', async () => {

--- a/web/app/components/workflow-app/components/dify-builder/__tests__/store.spec.ts
+++ b/web/app/components/workflow-app/components/dify-builder/__tests__/store.spec.ts
@@ -3,6 +3,7 @@ import type { SessionView } from '../types'
 import { createStore } from 'jotai'
 import {
   difyBuilderConversationAtom,
+  difyBuilderRetryableMessageAtom,
   difyBuilderSessionBusyAtom,
   difyBuilderSessionViewAtom,
 } from '../session/state'
@@ -19,6 +20,7 @@ import {
   difyBuilderRecheckReadyAtom,
   difyBuilderRegisterChecklistErrorsAtom,
   difyBuilderResetAtom,
+  difyBuilderRetryMessageAtom,
   difyBuilderRunActiveAtom,
   difyBuilderRuntimeAtom,
   difyBuilderSendDraftAtom,
@@ -224,7 +226,7 @@ describe('Dify Builder store', () => {
     expect(runtime.session.sendMessage).toHaveBeenCalledWith('Make the change smaller')
   })
 
-  it('preserves a newer draft while the submitted draft is still sending', async () => {
+  it('clears the submitted draft immediately and preserves a newer draft while sending', async () => {
     const store = createStore()
     const runtime = createRuntime(vi.fn(async () => true))
     let finishSending!: (sent: boolean) => void
@@ -242,6 +244,7 @@ describe('Dify Builder store', () => {
     store.set(difyBuilderDraftAtom, 'First draft')
 
     const sending = store.set(difyBuilderSendDraftAtom)
+    expect(store.get(difyBuilderDraftAtom)).toBe('')
     await vi.waitFor(() => {
       expect(runtime.session.sendMessage).toHaveBeenCalledWith('First draft')
     })
@@ -250,6 +253,40 @@ describe('Dify Builder store', () => {
 
     expect(await sending).toBe(true)
     expect(store.get(difyBuilderDraftAtom)).toBe('Newer draft')
+  })
+
+  it('keeps the submitted draft cleared when sending fails', async () => {
+    const store = createStore()
+    const runtime = createRuntime(vi.fn(async () => true))
+    runtime.session.sendMessage = vi.fn(async () => false)
+    store.set(difyBuilderRuntimeAtom, runtime)
+    store.set(
+      difyBuilderSessionViewAtom,
+      createSessionView({ run_status: 'waiting_input', state: 'fix.await_approval' }),
+    )
+    store.set(difyBuilderDraftAtom, 'Retry this message')
+
+    expect(await store.set(difyBuilderSendDraftAtom)).toBe(false)
+    expect(store.get(difyBuilderDraftAtom)).toBe('')
+  })
+
+  it('retries a failed message with its original turn id', async () => {
+    const store = createStore()
+    const runtime = createRuntime(vi.fn(async () => true))
+    store.set(difyBuilderRuntimeAtom, runtime)
+    store.set(
+      difyBuilderSessionViewAtom,
+      createSessionView({ run_status: 'waiting_input', state: 'fix.await_approval' }),
+    )
+    store.set(difyBuilderRetryableMessageAtom, {
+      sessionId: 'session-1',
+      text: 'Retry this message',
+      turnId: 'turn-retry-1',
+    })
+
+    expect(await store.set(difyBuilderRetryMessageAtom, 'turn-retry-1')).toBe(true)
+    expect(runtime.session.sendMessage).toHaveBeenCalledWith('Retry this message', 'turn-retry-1')
+    expect(store.get(difyBuilderRetryableMessageAtom)).toBeNull()
   })
 
   it('clears the composer draft when resetting the session', () => {

--- a/web/app/components/workflow-app/components/dify-builder/composer.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/composer.tsx
@@ -15,7 +15,6 @@ const DifyBuilderPromptInput = () => {
   const { t } = useTranslation()
   const [draft, setDraft] = useAtom(difyBuilderDraftAtom)
   const canCompose = useAtomValue(difyBuilderCanComposeAtom)
-  const sendDraft = useSetAtom(difyBuilderSendDraftAtom)
   const isComposingRef = useRef(false)
   const compositionEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -52,7 +51,7 @@ const DifyBuilderPromptInput = () => {
         if (event.key !== 'Enter' || event.shiftKey || !draft.trim()) return
         if (event.nativeEvent.isComposing || isComposingRef.current) return
         event.preventDefault()
-        void sendDraft()
+        event.currentTarget.form?.requestSubmit()
       }}
     />
   )
@@ -61,15 +60,13 @@ const DifyBuilderPromptInput = () => {
 const DifyBuilderSendButton = () => {
   const { t } = useTranslation()
   const canSend = useAtomValue(difyBuilderCanSendDraftAtom)
-  const sendDraft = useSetAtom(difyBuilderSendDraftAtom)
 
   return (
     <button
-      type="button"
+      type="submit"
       disabled={!canSend}
       aria-label={t(($) => $['difyBuilder.messageSend'], { ns: 'workflow' })}
       className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border-[0.5px] border-components-button-primary-border bg-components-button-primary-bg text-components-button-primary-text outline-hidden hover:border-components-button-primary-border-hover hover:bg-components-button-primary-bg-hover focus-visible:ring-1 focus-visible:ring-state-accent-solid disabled:cursor-not-allowed disabled:border-components-button-primary-border-disabled disabled:bg-components-button-primary-bg-disabled disabled:text-components-button-primary-text-disabled"
-      onClick={() => void sendDraft()}
     >
       <span aria-hidden className="i-ri-send-plane-2-fill size-4" />
     </button>
@@ -77,8 +74,18 @@ const DifyBuilderSendButton = () => {
 }
 
 const DifyBuilderComposer = () => {
+  const { t } = useTranslation()
+  const sendDraft = useSetAtom(difyBuilderSendDraftAtom)
+
   return (
-    <div className="mx-4 h-21 overflow-hidden rounded-xl border border-components-chat-input-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px] focus-within:border-components-input-border-active-prompt-1">
+    <form
+      aria-label={t(($) => $['difyBuilder.messagePlaceholder'], { ns: 'workflow' })}
+      className="mx-4 h-21 overflow-hidden rounded-xl border border-components-chat-input-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px] focus-within:border-components-input-border-active-prompt-1"
+      onSubmit={(event) => {
+        event.preventDefault()
+        void sendDraft()
+      }}
+    >
       <div className="flex h-full flex-col items-end justify-end p-1.5">
         <DifyBuilderPromptInput />
         <div className="flex h-8 w-full shrink-0 items-center justify-between gap-2 pl-1">
@@ -86,7 +93,7 @@ const DifyBuilderComposer = () => {
           <DifyBuilderSendButton />
         </div>
       </div>
-    </div>
+    </form>
   )
 }
 

--- a/web/app/components/workflow-app/components/dify-builder/conversation/conversation-card.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/conversation/conversation-card.tsx
@@ -3,8 +3,13 @@ import type {
   DifyBuilderActionPayloadChange,
   DifyBuilderActionValidityChange,
 } from '../types'
+import { cn } from '@langgenius/dify-ui/cn'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
+import { toast } from '@langgenius/dify-ui/toast'
+import copy from 'copy-to-clipboard'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Markdown } from '@/app/components/base/markdown'
 import { DifyBuilderCard } from '../cards/card-shell'
 import { ExecutionProgress } from './execution-progress'
 import { FormCard } from './form-card'
@@ -12,10 +17,25 @@ import { ResourceCard } from './resource-card'
 import { Thinking } from './thinking'
 
 export const AssistantReply = ({ text }: { text: string }) => (
-  <div className="px-1 text-sm leading-5 tracking-[-0.07px] whitespace-pre-wrap text-text-primary">
-    {text}
-  </div>
+  <Markdown content={text} className="px-1 text-sm! leading-5! tracking-[-0.07px]" />
 )
+
+const CopyMessageButton = ({ className, text }: { className?: string; text: string }) => {
+  const { t } = useTranslation()
+
+  return (
+    <IconButton
+      aria-label={t(($) => $['operation.copy'], { ns: 'common' })}
+      className={className}
+      onClick={() => {
+        copy(text)
+        toast.success(t(($) => $['actionMsg.copySuccessfully'], { ns: 'common' }))
+      }}
+    >
+      <span aria-hidden="true" className="i-ri-clipboard-line size-4" />
+    </IconButton>
+  )
+}
 
 export const ConversationCard = memo(
   ({
@@ -27,6 +47,9 @@ export const ConversationCard = memo(
     onActionPayloadChange,
     onActionValidityChange,
     onFormSubmit,
+    onRetryMessage,
+    retryableTurnId,
+    retryingTurnId,
   }: {
     item: ConversationItem
     busy: boolean
@@ -37,13 +60,52 @@ export const ConversationCard = memo(
     onActionPayloadChange: DifyBuilderActionPayloadChange
     onActionValidityChange?: DifyBuilderActionValidityChange
     onFormSubmit?: () => void
+    onRetryMessage?: (turnId: string) => void
+    retryableTurnId?: string
+    retryingTurnId?: string | null
   }) => {
     const { t } = useTranslation()
 
     if (item.kind === 'challenge' || item.kind === 'change_set' || item.kind === 'checkpoint')
       return null
 
-    if (item.kind === 'user' || item.kind === 'decision') {
+    if (item.kind === 'user') {
+      const retryable = item.payload.turn_id === retryableTurnId
+      const retrying = item.payload.turn_id === retryingTurnId
+      return (
+        <article className="flex justify-end">
+          <div className="group/user-message flex flex-col items-end gap-1">
+            <h3 className="sr-only">{t(($) => $.you, { ns: 'common' })}</h3>
+            <div className="max-w-[316px] rounded-2xl bg-background-default-dimmed px-4 py-3 text-[13px] leading-4 whitespace-pre-wrap text-text-primary">
+              {item.payload.text}
+            </div>
+            <div className="flex h-6 items-center gap-0.5">
+              <CopyMessageButton
+                className="pointer-events-none opacity-0 transition-opacity group-focus-within/user-message:pointer-events-auto group-focus-within/user-message:opacity-100 group-hover/user-message:pointer-events-auto group-hover/user-message:opacity-100 motion-reduce:transition-none [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100"
+                text={item.payload.text}
+              />
+              {retryable && onRetryMessage && (
+                <IconButton
+                  aria-label={t(($) => $['operation.retry'], { ns: 'common' })}
+                  disabled={busy || retrying}
+                  onClick={() => onRetryMessage(item.payload.turn_id)}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'i-ri-reset-left-line size-4',
+                      retrying && 'animate-spin motion-reduce:animate-none',
+                    )}
+                  />
+                </IconButton>
+              )}
+            </div>
+          </div>
+        </article>
+      )
+    }
+
+    if (item.kind === 'decision') {
       return (
         <article className="flex justify-end">
           <h3 className="sr-only">{t(($) => $.you, { ns: 'common' })}</h3>
@@ -64,7 +126,12 @@ export const ConversationCard = memo(
           <h3 className="sr-only">{t(($) => $['difyBuilder.panelTitle'], { ns: 'workflow' })}</h3>
           {hasExecution ? <ExecutionProgress execution={item.payload.execution} /> : null}
           <Thinking text={item.payload.reasoning_text} />
-          {item.payload.reply_text ? <AssistantReply text={item.payload.reply_text} /> : null}
+          {item.payload.reply_text ? (
+            <div className="flex w-full flex-col items-start gap-1">
+              <AssistantReply text={item.payload.reply_text} />
+              <CopyMessageButton text={item.payload.reply_text} />
+            </div>
+          ) : null}
         </article>
       )
     }

--- a/web/app/components/workflow-app/components/dify-builder/conversation/conversation-card.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/conversation/conversation-card.tsx
@@ -23,16 +23,20 @@ export const ConversationCard = memo(
     busy,
     interactive,
     invalidated,
+    formId,
     onActionPayloadChange,
     onActionValidityChange,
+    onFormSubmit,
   }: {
     item: ConversationItem
     busy: boolean
     interactive: boolean
     changesExpanded: boolean
     invalidated: boolean
+    formId?: string
     onActionPayloadChange: DifyBuilderActionPayloadChange
     onActionValidityChange?: DifyBuilderActionValidityChange
+    onFormSubmit?: () => void
   }) => {
     const { t } = useTranslation()
 
@@ -41,11 +45,12 @@ export const ConversationCard = memo(
 
     if (item.kind === 'user' || item.kind === 'decision') {
       return (
-        <div className="flex justify-end">
+        <article className="flex justify-end">
+          <h3 className="sr-only">{t(($) => $.you, { ns: 'common' })}</h3>
           <div className="max-w-[316px] rounded-2xl bg-background-default-dimmed px-4 py-3 text-[13px] leading-4 whitespace-pre-wrap text-text-primary">
             {item.payload.text}
           </div>
-        </div>
+        </article>
       )
     }
 
@@ -55,11 +60,12 @@ export const ConversationCard = memo(
       const hasReply = Boolean(item.payload.reply_text)
       if (!hasExecution && !hasReasoning && !hasReply) return null
       return (
-        <div className="flex flex-col gap-2">
+        <article className="flex flex-col gap-2">
+          <h3 className="sr-only">{t(($) => $['difyBuilder.panelTitle'], { ns: 'workflow' })}</h3>
           {hasExecution ? <ExecutionProgress execution={item.payload.execution} /> : null}
           <Thinking text={item.payload.reasoning_text} />
           {item.payload.reply_text ? <AssistantReply text={item.payload.reply_text} /> : null}
-        </div>
+        </article>
       )
     }
 
@@ -76,10 +82,12 @@ export const ConversationCard = memo(
         <FormCard
           item={item}
           busy={busy}
+          formId={formId}
           interactive={interactive}
           invalidated={invalidated}
           onActionPayloadChange={onActionPayloadChange}
           onActionValidityChange={onActionValidityChange}
+          onSubmit={onFormSubmit}
         />
       )
     }
@@ -195,9 +203,9 @@ export const ConversationCard = memo(
           invalidated={invalidated}
           status={
             item.payload.tone === 'success'
-              ? { state: 'done' }
+              ? { label: t(($) => $['api.success'], { ns: 'common' }), state: 'done' }
               : item.payload.tone === 'error'
-                ? { state: 'failed' }
+                ? { label: t(($) => $['api.actionFailed'], { ns: 'common' }), state: 'failed' }
                 : undefined
           }
           subheadline={item.payload.subtitle}

--- a/web/app/components/workflow-app/components/dify-builder/conversation/form-card.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/conversation/form-card.tsx
@@ -47,15 +47,19 @@ export const FormCard = memo(
     busy,
     interactive,
     invalidated,
+    formId,
     onActionPayloadChange,
     onActionValidityChange,
+    onSubmit,
   }: {
     item: Extract<ConversationItem, { kind: 'form' }>
     busy: boolean
     interactive: boolean
     invalidated: boolean
+    formId?: string
     onActionPayloadChange: DifyBuilderActionPayloadChange
     onActionValidityChange?: DifyBuilderActionValidityChange
+    onSubmit?: () => void
   }) => {
     const { t } = useTranslation()
     const fileUploadConfig = useStore((state) => state.fileUploadConfig)
@@ -71,6 +75,7 @@ export const FormCard = memo(
           ? 'submit_edit_rules'
           : 'provide_testdata'
     const frozen = busy || !interactive || invalidated || item.payload.frozen === true
+    const category = t(($) => $['difyBuilder.cardCategory.form'], { ns: 'workflow' })
     const prepared = useMemo(() => prepareFormValues(fields, values), [fields, values])
     const actionPayloadChangeRef = useRef(onActionPayloadChange)
     const actionValidityChangeRef = useRef(onActionValidityChange)
@@ -116,11 +121,28 @@ export const FormCard = memo(
     }
 
     return (
-      <DifyBuilderCard
-        category={t(($) => $['difyBuilder.cardCategory.form'], { ns: 'workflow' })}
-        invalidated={invalidated}
-      >
-        <div className="flex flex-col gap-3">
+      <DifyBuilderCard category={category} invalidated={invalidated}>
+        <form
+          id={formId}
+          aria-label={category}
+          className="flex flex-col gap-3"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (!prepared.valid) {
+              const invalidField =
+                event.currentTarget.querySelector<HTMLElement>('[aria-invalid="true"]')
+              const focusableSelector =
+                'input:not(:disabled), textarea:not(:disabled), select:not(:disabled), button:not(:disabled), [tabindex]:not([tabindex="-1"])'
+              const focusTarget = invalidField?.matches(focusableSelector)
+                ? invalidField
+                : invalidField?.querySelector<HTMLElement>(focusableSelector)
+              focusTarget?.focus()
+              return
+            }
+            onSubmit?.()
+          }}
+        >
           {fields.map((field, index) => {
             const validationError = prepared.errors[field.key]
             const fieldErrorId = `${errorId}-${index}-error`
@@ -145,6 +167,8 @@ export const FormCard = memo(
                       checked={values[field.key] === true}
                       disabled={frozen}
                       required={field.required}
+                      aria-invalid={validationError ? true : undefined}
+                      aria-describedby={validationError ? fieldErrorId : undefined}
                       onCheckedChange={(checked) => updateValues(field.key, checked)}
                     />
                     <span>{labelContent}</span>
@@ -338,7 +362,7 @@ export const FormCard = memo(
               </Field>
             )
           })}
-        </div>
+        </form>
       </DifyBuilderCard>
     )
   },

--- a/web/app/components/workflow-app/components/dify-builder/conversation/index.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/conversation/index.tsx
@@ -15,20 +15,24 @@ export const DifyBuilderConversation = memo(
   ({
     busy,
     activeInteraction,
+    activeFormId,
     changesExpanded,
     interrupted,
     items,
     onActionPayloadChange,
     onActionValidityChange,
+    onActiveFormSubmit,
     onStreamingContentChange,
   }: {
     busy: boolean
     activeInteraction: SessionView['active_interaction']
+    activeFormId?: string
     changesExpanded: boolean
     interrupted: boolean
     items: ConversationItem[]
     onActionPayloadChange: DifyBuilderActionPayloadChange
     onActionValidityChange?: DifyBuilderActionValidityChange
+    onActiveFormSubmit?: () => void
     onStreamingContentChange?: () => void
   }) => {
     const { t } = useTranslation()
@@ -45,70 +49,80 @@ export const DifyBuilderConversation = memo(
             {t(($) => $['difyBuilder.interrupted'], { ns: 'workflow' })}
           </div>
         )}
-        {groups.map((group) => {
-          if (group.type === 'standalone') {
-            if (group.item.seq === activeCard?.seq) return null
-            return (
-              <ConversationCard
-                key={`${group.item.seq}-${group.item.kind}`}
-                item={group.item}
-                busy={busy}
-                interactive={group.item.seq === activeInteraction?.card.seq}
-                changesExpanded={changesExpanded}
-                invalidated={false}
-                onActionPayloadChange={onActionPayloadChange}
-                onActionValidityChange={onActionValidityChange}
-              />
-            )
-          }
+        <div
+          role="log"
+          aria-label={t(($) => $['difyBuilder.panelTitle'], { ns: 'workflow' })}
+          aria-live="polite"
+          aria-relevant="additions"
+          className="flex flex-col gap-3"
+        >
+          {groups.map((group) => {
+            if (group.type === 'standalone') {
+              if (group.item.seq === activeCard?.seq) return null
+              return (
+                <ConversationCard
+                  key={`${group.item.seq}-${group.item.kind}`}
+                  item={group.item}
+                  busy={busy}
+                  interactive={group.item.seq === activeInteraction?.card.seq}
+                  changesExpanded={changesExpanded}
+                  invalidated={false}
+                  onActionPayloadChange={onActionPayloadChange}
+                  onActionValidityChange={onActionValidityChange}
+                />
+              )
+            }
 
-          return (
-            <div
-              key={`${group.turn.seq}-${group.turn.kind}`}
-              className={cn('flex flex-col gap-3', group.invalidated && 'opacity-70')}
-            >
-              {group.invalidated && (
-                <div className="flex items-center gap-1.5 px-1 system-2xs-medium-uppercase text-text-tertiary">
-                  <span aria-hidden className="i-ri-history-line size-3.5" />
-                  <span>{t(($) => $['difyBuilder.invalidated'], { ns: 'workflow' })}</span>
-                </div>
-              )}
-              <ConversationCard
-                item={group.turn}
-                busy={busy}
-                interactive={group.turn.seq === activeInteraction?.card.seq}
-                changesExpanded={changesExpanded}
-                invalidated={group.invalidated}
-                onActionPayloadChange={onActionPayloadChange}
-                onActionValidityChange={onActionValidityChange}
-              />
-              {group.cards
-                .filter((item) => item.seq !== activeCard?.seq)
-                .map((item) => (
-                  <ConversationCard
-                    key={`${item.seq}-${item.kind}`}
-                    item={item}
-                    busy={busy}
-                    interactive={item.seq === activeInteraction?.card.seq}
-                    changesExpanded={changesExpanded}
-                    invalidated={group.invalidated}
-                    onActionPayloadChange={onActionPayloadChange}
-                    onActionValidityChange={onActionValidityChange}
-                  />
-                ))}
-            </div>
-          )
-        })}
+            return (
+              <div
+                key={`${group.turn.seq}-${group.turn.kind}`}
+                className={cn('flex flex-col gap-3', group.invalidated && 'opacity-70')}
+              >
+                {group.invalidated && (
+                  <div className="flex items-center gap-1.5 px-1 system-2xs-medium-uppercase text-text-tertiary">
+                    <span aria-hidden className="i-ri-history-line size-3.5" />
+                    <span>{t(($) => $['difyBuilder.invalidated'], { ns: 'workflow' })}</span>
+                  </div>
+                )}
+                <ConversationCard
+                  item={group.turn}
+                  busy={busy}
+                  interactive={group.turn.seq === activeInteraction?.card.seq}
+                  changesExpanded={changesExpanded}
+                  invalidated={group.invalidated}
+                  onActionPayloadChange={onActionPayloadChange}
+                  onActionValidityChange={onActionValidityChange}
+                />
+                {group.cards
+                  .filter((item) => item.seq !== activeCard?.seq)
+                  .map((item) => (
+                    <ConversationCard
+                      key={`${item.seq}-${item.kind}`}
+                      item={item}
+                      busy={busy}
+                      interactive={item.seq === activeInteraction?.card.seq}
+                      changesExpanded={changesExpanded}
+                      invalidated={group.invalidated}
+                      onActionPayloadChange={onActionPayloadChange}
+                      onActionValidityChange={onActionValidityChange}
+                    />
+                  ))}
+              </div>
+            )
+          })}
+        </div>
         {activeCard && (
           <ConversationCard
             key={`active-${activeCard.seq}-${activeCard.kind}`}
             item={activeCard}
             busy={busy}
+            formId={activeFormId}
             interactive
             changesExpanded={changesExpanded}
             invalidated={false}
             onActionPayloadChange={onActionPayloadChange}
             onActionValidityChange={onActionValidityChange}
+            onFormSubmit={onActiveFormSubmit}
           />
         )}
         <StreamingAssistantTurn busy={busy} onContentChange={onStreamingContentChange} />

--- a/web/app/components/workflow-app/components/dify-builder/conversation/index.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/conversation/index.tsx
@@ -22,7 +22,10 @@ export const DifyBuilderConversation = memo(
     onActionPayloadChange,
     onActionValidityChange,
     onActiveFormSubmit,
+    onRetryMessage,
     onStreamingContentChange,
+    retryableTurnId,
+    retryingTurnId,
   }: {
     busy: boolean
     activeInteraction: SessionView['active_interaction']
@@ -33,7 +36,10 @@ export const DifyBuilderConversation = memo(
     onActionPayloadChange: DifyBuilderActionPayloadChange
     onActionValidityChange?: DifyBuilderActionValidityChange
     onActiveFormSubmit?: () => void
+    onRetryMessage?: (turnId: string) => void
     onStreamingContentChange?: () => void
+    retryableTurnId?: string
+    retryingTurnId?: string | null
   }) => {
     const { t } = useTranslation()
     const groups = useMemo(() => groupConversationItems(items), [items])
@@ -69,6 +75,9 @@ export const DifyBuilderConversation = memo(
                   invalidated={false}
                   onActionPayloadChange={onActionPayloadChange}
                   onActionValidityChange={onActionValidityChange}
+                  onRetryMessage={onRetryMessage}
+                  retryableTurnId={retryableTurnId}
+                  retryingTurnId={retryingTurnId}
                 />
               )
             }
@@ -92,6 +101,9 @@ export const DifyBuilderConversation = memo(
                   invalidated={group.invalidated}
                   onActionPayloadChange={onActionPayloadChange}
                   onActionValidityChange={onActionValidityChange}
+                  onRetryMessage={onRetryMessage}
+                  retryableTurnId={retryableTurnId}
+                  retryingTurnId={retryingTurnId}
                 />
                 {group.cards
                   .filter((item) => item.seq !== activeCard?.seq)
@@ -105,6 +117,9 @@ export const DifyBuilderConversation = memo(
                       invalidated={group.invalidated}
                       onActionPayloadChange={onActionPayloadChange}
                       onActionValidityChange={onActionValidityChange}
+                      onRetryMessage={onRetryMessage}
+                      retryableTurnId={retryableTurnId}
+                      retryingTurnId={retryingTurnId}
                     />
                   ))}
               </div>
@@ -123,6 +138,9 @@ export const DifyBuilderConversation = memo(
             onActionPayloadChange={onActionPayloadChange}
             onActionValidityChange={onActionValidityChange}
             onFormSubmit={onActiveFormSubmit}
+            onRetryMessage={onRetryMessage}
+            retryableTurnId={retryableTurnId}
+            retryingTurnId={retryingTurnId}
           />
         )}
         <StreamingAssistantTurn busy={busy} onContentChange={onStreamingContentChange} />

--- a/web/app/components/workflow-app/components/dify-builder/conversation/resource-card.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/conversation/resource-card.tsx
@@ -1,5 +1,5 @@
 import type { ConversationItem, DifyBuilderActionPayloadChange } from '../types'
-import { memo, useState } from 'react'
+import { memo, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DifyBuilderCard } from '../cards/card-shell'
 
@@ -20,6 +20,7 @@ export const ResourceCard = memo(
     const { t } = useTranslation()
     const resources = item.payload.recommended ?? []
     const policies = item.payload.conflict_policy_options ?? []
+    const resourceListId = useId()
     const [selected, setSelected] = useState(() => resources.map((resource) => resource.id))
     const [policy, setPolicy] = useState(
       () => policies.find((option) => option.recommended)?.id ?? 'ask',
@@ -39,32 +40,42 @@ export const ResourceCard = memo(
         invalidated={invalidated}
       >
         <div className="flex flex-col gap-2">
-          {resources.map((resource) => (
-            <div
-              key={resource.id}
-              className="flex items-start gap-2 rounded-lg bg-background-section p-2"
-            >
-              <input
-                type="checkbox"
-                aria-label={resource.label}
-                checked={selected.includes(resource.id)}
-                disabled={frozen}
-                onChange={(event) => {
-                  const next = event.target.checked
-                    ? [...selected, resource.id]
-                    : selected.filter((id) => id !== resource.id)
-                  setSelected(next)
-                  emitPayload(next, policy)
-                }}
-              />
-              <span className="min-w-0">
-                <span className="block system-xs-medium text-text-primary">{resource.label}</span>
-                <span className="block truncate system-2xs-regular text-text-tertiary">
-                  {resource.meta}
+          {resources.map((resource, index) => {
+            const labelId = `${resourceListId}-${index}-label`
+            const descriptionId = `${resourceListId}-${index}-description`
+            return (
+              <label
+                key={resource.id}
+                className="flex items-start gap-2 rounded-lg bg-background-section p-2"
+              >
+                <input
+                  type="checkbox"
+                  aria-labelledby={labelId}
+                  aria-describedby={resource.meta ? descriptionId : undefined}
+                  checked={selected.includes(resource.id)}
+                  disabled={frozen}
+                  onChange={(event) => {
+                    const next = event.target.checked
+                      ? [...selected, resource.id]
+                      : selected.filter((id) => id !== resource.id)
+                    setSelected(next)
+                    emitPayload(next, policy)
+                  }}
+                />
+                <span className="min-w-0">
+                  <span id={labelId} className="block system-xs-medium text-text-primary">
+                    {resource.label}
+                  </span>
+                  <span
+                    id={descriptionId}
+                    className="block truncate system-2xs-regular text-text-tertiary"
+                  >
+                    {resource.meta}
+                  </span>
                 </span>
-              </span>
-            </div>
-          ))}
+              </label>
+            )
+          })}
           {policies.length > 0 && (
             <label className="flex flex-col gap-1 system-xs-medium text-text-secondary">
               <span>{t(($) => $['difyBuilder.conflictPolicy'], { ns: 'workflow' })}</span>

--- a/web/app/components/workflow-app/components/dify-builder/conversation/streaming-assistant-turn.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/conversation/streaming-assistant-turn.tsx
@@ -32,23 +32,32 @@ export const StreamingAssistantTurn = ({
   if (activityCount === 0 && !reasoningText && !replyText) {
     if (!busy) return null
     return (
-      <div role="status" aria-live="polite" className="flex h-8 items-center gap-2 px-1">
-        <span
-          aria-hidden
-          className="i-ri-loader-4-line size-4 animate-spin text-text-tertiary motion-reduce:animate-none"
-        />
-        <span className="text-[13px] font-medium text-text-tertiary">
-          {t(($) => $['common.running'], { ns: 'workflow' })}
-        </span>
-      </div>
+      <article>
+        <h3 className="sr-only">{t(($) => $['difyBuilder.panelTitle'], { ns: 'workflow' })}</h3>
+        <div role="status" aria-live="polite" className="flex h-8 items-center gap-2 px-1">
+          <span
+            aria-hidden
+            className="i-ri-loader-4-line size-4 animate-spin text-text-tertiary motion-reduce:animate-none"
+          />
+          <span className="text-[13px] font-medium text-text-tertiary">
+            {t(($) => $['common.running'], { ns: 'workflow' })}
+          </span>
+        </div>
+      </article>
     )
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <article className="flex flex-col gap-2">
+      <h3 className="sr-only">{t(($) => $['difyBuilder.panelTitle'], { ns: 'workflow' })}</h3>
+      {activityCount === 0 && busy && (
+        <span role="status" aria-live="polite" className="sr-only">
+          {t(($) => $['common.running'], { ns: 'workflow' })}
+        </span>
+      )}
       {activityCount > 0 ? <ExecutionProgress execution={liveExecution?.execution} /> : null}
       <Thinking text={reasoningText} isStreaming />
       {replyText ? <AssistantReply text={replyText} /> : null}
-    </div>
+    </article>
   )
 }

--- a/web/app/components/workflow-app/components/dify-builder/model-selector.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/model-selector.tsx
@@ -77,7 +77,6 @@ const DifyBuilderModelSelector = () => {
         <button
           type="button"
           disabled={readonly}
-          aria-label={t(($) => $['modelProvider.model'], { ns: 'common' })}
           className="flex min-w-0 items-center gap-0.5 rounded-md p-1 text-left system-xs-regular text-text-tertiary outline-hidden hover:bg-state-base-hover focus-visible:ring-1 focus-visible:ring-state-accent-solid disabled:cursor-not-allowed disabled:opacity-50"
         >
           <span className="max-w-36 truncate">

--- a/web/app/components/workflow-app/components/dify-builder/model-selector.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/model-selector.tsx
@@ -53,6 +53,7 @@ const DifyBuilderModelSelector = () => {
       popupClassName="w-[340px]! max-w-[340px]!"
       placement="top-start"
       isAdvancedMode
+      isInWorkflow
       readonly={readonly}
       modelSelectorReadonly={readonly}
       setModel={({ provider, modelId, mode }) => {

--- a/web/app/components/workflow-app/components/dify-builder/panel.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/panel.tsx
@@ -12,6 +12,7 @@ import {
   difyBuilderConversationAtom,
   difyBuilderConversationHasMoreAtom,
   difyBuilderConversationLoadingAtom,
+  difyBuilderRetryableMessageAtom,
 } from './session/state'
 import {
   difyBuilderActionsAtom,
@@ -27,6 +28,7 @@ import {
   difyBuilderRecoveryAtom,
   difyBuilderResetAtom,
   difyBuilderRetryCanvasRefreshAtom,
+  difyBuilderRetryMessageAtom,
   difyBuilderSubmitActionAtom,
   difyBuilderViewVersionAtom,
 } from './store'
@@ -122,13 +124,16 @@ const DifyBuilderPanel = () => {
   const interrupted = useAtomValue(difyBuilderInterruptedAtom)
   const recheckReady = useAtomValue(difyBuilderRecheckReadyAtom)
   const recovery = useAtomValue(difyBuilderRecoveryAtom)
+  const retryableMessage = useAtomValue(difyBuilderRetryableMessageAtom)
   const viewVersion = useAtomValue(difyBuilderViewVersionAtom)
   const reset = useSetAtom(difyBuilderResetAtom)
   const loadOlderConversation = useSetAtom(difyBuilderLoadOlderConversationAtom)
   const retryCanvasRefresh = useSetAtom(difyBuilderRetryCanvasRefreshAtom)
+  const retryMessage = useSetAtom(difyBuilderRetryMessageAtom)
   const submitAction = useSetAtom(difyBuilderSubmitActionAtom)
   const interactionFormId = useId()
   const [pendingActionId, setPendingActionId] = useState<string | null>(null)
+  const [retryingTurnId, setRetryingTurnId] = useState<string | null>(null)
   const [changesExpanded, setChangesExpanded] = useState(false)
   const [actionInteractionState, setActionInteractionState] = useState(
     EMPTY_ACTION_INTERACTION_STATE,
@@ -250,10 +255,24 @@ const DifyBuilderPanel = () => {
     if (action) void handleAction(action)
   }, [actions, activeFormActionId, handleAction])
 
+  const handleRetryMessage = useCallback(
+    async (turnId: string) => {
+      if (interactionBusy || retryingTurnId !== null) return
+      setRetryingTurnId(turnId)
+      try {
+        await retryMessage(turnId)
+      } finally {
+        setRetryingTurnId((current) => (current === turnId ? null : current))
+      }
+    },
+    [interactionBusy, retryMessage, retryingTurnId],
+  )
+
   const handleReset = () => {
     reset()
     pinnedToBottomRef.current = true
     setPendingActionId(null)
+    setRetryingTurnId(null)
     setChangesExpanded(false)
     setActionInteractionState(EMPTY_ACTION_INTERACTION_STATE)
   }
@@ -326,7 +345,10 @@ const DifyBuilderPanel = () => {
                 onActionPayloadChange={handleActionPayloadChange}
                 onActionValidityChange={handleActionValidityChange}
                 onActiveFormSubmit={handleActiveFormSubmit}
+                onRetryMessage={(turnId) => void handleRetryMessage(turnId)}
                 onStreamingContentChange={scrollToBottomIfPinned}
+                retryableTurnId={retryableMessage?.turnId}
+                retryingTurnId={retryingTurnId}
               />
             </>
           ) : (
@@ -335,7 +357,7 @@ const DifyBuilderPanel = () => {
               <h3 className="system-sm-semibold text-text-primary">
                 {t(($) => $['difyBuilder.emptyBuildTitle'], { ns: 'workflow' })}
               </h3>
-              <p className="mt-1 max-w-[284px] text-sm leading-5 tracking-[-0.07px] text-text-tertiary">
+              <p className="mt-1 max-w-71 text-sm leading-5 tracking-[-0.07px] text-text-tertiary">
                 {t(($) => $['difyBuilder.emptyDescription'], { ns: 'workflow' })}
               </p>
             </div>

--- a/web/app/components/workflow-app/components/dify-builder/panel.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/panel.tsx
@@ -1,7 +1,7 @@
 import type { Action } from './types'
 import { Button } from '@langgenius/dify-ui/button'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '@/app/components/workflow/store'
 import { AgentBuildGridTexture } from '@/features/agent-v2/agent-detail/configure/components/build-grid-texture'
@@ -53,6 +53,8 @@ const DifyBuilderActionBar = ({
   actions,
   busy,
   changesExpanded,
+  formActionId,
+  formId,
   pendingActionId,
   recheckReady,
   onAction,
@@ -61,6 +63,8 @@ const DifyBuilderActionBar = ({
   actions: Action[]
   busy: boolean
   changesExpanded: boolean
+  formActionId?: string
+  formId?: string
   pendingActionId: string | null
   recheckReady: boolean
   onAction: (action: Action) => void
@@ -73,6 +77,7 @@ const DifyBuilderActionBar = ({
       {visibleActions.map((action) => {
         const loading = pendingActionId === action.id
         const awaitingChecklist = action.id === 'recheck' && !recheckReady
+        const submitsForm = action.id === formActionId && formId !== undefined
         const invalid = FORM_ACTION_IDS.has(action.id)
           ? actionValidity[action.id] !== true
           : actionValidity[action.id] === false
@@ -82,12 +87,16 @@ const DifyBuilderActionBar = ({
             size="small"
             variant={action.kind === 'primary' ? 'primary' : 'secondary'}
             tone={action.kind === 'destructive' ? 'destructive' : 'default'}
+            type={submitsForm ? 'submit' : 'button'}
+            form={submitsForm ? formId : undefined}
             loading={loading}
             disabled={
-              loading ? false : busy || pendingActionId !== null || awaitingChecklist || invalid
+              loading
+                ? false
+                : busy || pendingActionId !== null || awaitingChecklist || (!submitsForm && invalid)
             }
             aria-expanded={action.id === 'view_changes' ? changesExpanded : undefined}
-            onClick={() => onAction(action)}
+            onClick={submitsForm ? undefined : () => onAction(action)}
           >
             {action.label}
           </Button>
@@ -118,6 +127,7 @@ const DifyBuilderPanel = () => {
   const loadOlderConversation = useSetAtom(difyBuilderLoadOlderConversationAtom)
   const retryCanvasRefresh = useSetAtom(difyBuilderRetryCanvasRefreshAtom)
   const submitAction = useSetAtom(difyBuilderSubmitActionAtom)
+  const interactionFormId = useId()
   const [pendingActionId, setPendingActionId] = useState<string | null>(null)
   const [changesExpanded, setChangesExpanded] = useState(false)
   const [actionInteractionState, setActionInteractionState] = useState(
@@ -128,6 +138,11 @@ const DifyBuilderPanel = () => {
   const activeInteractionKey = activeInteraction
     ? `${activeInteraction.action_id}:${activeInteraction.card.seq}`
     : ''
+  const activeFormActionId =
+    activeInteraction?.card.kind === 'form' && FORM_ACTION_IDS.has(activeInteraction.action_id)
+      ? activeInteraction.action_id
+      : undefined
+  const activeFormId = activeFormActionId ? `${interactionFormId}-interaction` : undefined
   const currentActionInteractionState =
     actionInteractionState.key === activeInteractionKey
       ? actionInteractionState
@@ -229,6 +244,12 @@ const DifyBuilderPanel = () => {
     ],
   )
 
+  const handleActiveFormSubmit = useCallback(() => {
+    if (!activeFormActionId) return
+    const action = actions.find((action) => action.id === activeFormActionId)
+    if (action) void handleAction(action)
+  }, [actions, activeFormActionId, handleAction])
+
   const handleReset = () => {
     reset()
     pinnedToBottomRef.current = true
@@ -301,8 +322,10 @@ const DifyBuilderPanel = () => {
                 busy={interactionBusy}
                 changesExpanded={changesExpanded}
                 interrupted={interrupted}
+                activeFormId={activeFormId}
                 onActionPayloadChange={handleActionPayloadChange}
                 onActionValidityChange={handleActionValidityChange}
+                onActiveFormSubmit={handleActiveFormSubmit}
                 onStreamingContentChange={scrollToBottomIfPinned}
               />
             </>
@@ -354,6 +377,8 @@ const DifyBuilderPanel = () => {
             actions={actions}
             busy={interactionBusy}
             changesExpanded={changesExpanded}
+            formActionId={activeFormActionId}
+            formId={activeFormId}
             pendingActionId={pendingActionId}
             recheckReady={recheckReady}
             onAction={(action) => void handleAction(action)}

--- a/web/app/components/workflow-app/components/dify-builder/session/__tests__/use-session-controller.streaming.spec.tsx
+++ b/web/app/components/workflow-app/components/dify-builder/session/__tests__/use-session-controller.streaming.spec.tsx
@@ -5,6 +5,7 @@ import {
   difyBuilderConversationAtom,
   difyBuilderExecutionProgressAtom,
   difyBuilderReasoningAtom,
+  difyBuilderRetryableMessageAtom,
   difyBuilderSessionBusyAtom,
   difyBuilderSessionLastCanvasEventAtom,
   difyBuilderSessionLastErrorAtom,
@@ -169,6 +170,98 @@ describe('useDifyBuilderSessionController streaming', () => {
       },
       { signal: expect.any(AbortSignal) },
     )
+  })
+
+  it('marks a failed user turn as retryable and reuses its client turn id', async () => {
+    const waiting = createSessionView({
+      conversation_last_seq: -1,
+      version: 2,
+      state: 'fix.await_approval',
+      run_status: 'waiting_input',
+    })
+    const reconciled = createSessionView({
+      ...waiting,
+      conversation_last_seq: 0,
+      version: 3,
+    })
+    const stream = createControlledEventStream()
+    clientMocks.message.mockResolvedValueOnce(stream.iterable)
+    clientMocks.get.mockResolvedValue(reconciled)
+    const { result, store } = renderSessionHook()
+    act(() => {
+      store.set(difyBuilderSessionViewAtom, waiting)
+      store.set(difyBuilderActiveSessionIdAtom, waiting.session_id)
+    })
+
+    let messagePromise!: Promise<boolean>
+    act(() => {
+      messagePromise = result.current.sendMessage('Retry me')
+    })
+    await waitFor(() => expect(clientMocks.message).toHaveBeenCalledOnce())
+    const firstRequest = clientMocks.message.mock.calls[0]?.[0] as {
+      body: { client_turn_id: string }
+    }
+    const clientTurnId = firstRequest.body.client_turn_id
+    const userItem: ConversationItem = {
+      seq: 0,
+      at_version: 3,
+      kind: 'user',
+      payload: { text: 'Retry me', turn_id: clientTurnId },
+    }
+
+    act(() => {
+      stream.push(commandStartedEvent(waiting))
+      stream.push({
+        event: 'commit',
+        data: {
+          kind: 'commit',
+          session_id: 'session-1',
+          operation_id: 'operation-1',
+          stage_id: 'fix.await_approval',
+          at_version: 3,
+          version: 3,
+          state: 'fix.await_approval',
+          settled: false,
+          items: [userItem],
+        },
+      })
+    })
+    await waitFor(() => expect(store.get(difyBuilderConversationAtom)).toEqual([userItem]))
+
+    await act(async () => {
+      stream.push({ event: 'error', data: { kind: 'error', error: 'message failed' } })
+      expect(await messagePromise).toBe(false)
+    })
+    expect(store.get(difyBuilderRetryableMessageAtom)).toEqual({
+      sessionId: 'session-1',
+      text: 'Retry me',
+      turnId: clientTurnId,
+    })
+
+    const retryTerminal = createSessionView({
+      ...reconciled,
+      version: 4,
+    })
+    clientMocks.message.mockResolvedValueOnce(
+      streamOf(commandStartedEvent(reconciled), stateEvent(retryTerminal)),
+    )
+
+    await act(async () => {
+      expect(await result.current.sendMessage('Retry me', clientTurnId)).toBe(true)
+    })
+    expect(clientMocks.message).toHaveBeenNthCalledWith(
+      2,
+      {
+        params: { session_id: 'session-1' },
+        body: {
+          text: 'Retry me',
+          base_version: 3,
+          client_turn_id: clientTurnId,
+        },
+      },
+      { signal: expect.any(AbortSignal) },
+    )
+    expect(store.get(difyBuilderRetryableMessageAtom)).toBeNull()
   })
 
   it('repairs a dropped commit through conversation JSON before merging a later commit', async () => {

--- a/web/app/components/workflow-app/components/dify-builder/session/state.ts
+++ b/web/app/components/workflow-app/components/dify-builder/session/state.ts
@@ -8,6 +8,12 @@ import type {
 } from '../types'
 import { atom } from 'jotai'
 
+export type DifyBuilderRetryableMessage = {
+  sessionId: string
+  text: string
+  turnId: string
+}
+
 export const difyBuilderSessionViewAtom = atom<SessionView | null>(null)
 // The only session lifecycle value persisted by the browser. SessionView is
 // an in-memory server projection rebuilt from GET on restore and updated by
@@ -18,6 +24,7 @@ export const difyBuilderConversationHasMoreAtom = atom(false)
 export const difyBuilderConversationLoadingAtom = atom(false)
 export const difyBuilderSessionBusyAtom = atom(false)
 export const difyBuilderSessionLastErrorAtom = atom('')
+export const difyBuilderRetryableMessageAtom = atom<DifyBuilderRetryableMessage | null>(null)
 export const difyBuilderExecutionProgressAtom = atom<DifyBuilderExecutionProgress | null>(null)
 export const difyBuilderReasoningAtom = atom<DifyBuilderReasoning | null>(null)
 export const difyBuilderStreamingTurnAtom = atom<DifyBuilderStreamingTurn | null>(null)
@@ -34,6 +41,7 @@ export const difyBuilderSessionScopedAtoms = [
   difyBuilderConversationLoadingAtom,
   difyBuilderSessionBusyAtom,
   difyBuilderSessionLastErrorAtom,
+  difyBuilderRetryableMessageAtom,
   difyBuilderExecutionProgressAtom,
   difyBuilderReasoningAtom,
   difyBuilderStreamingTurnAtom,

--- a/web/app/components/workflow-app/components/dify-builder/session/use-session-controller.ts
+++ b/web/app/components/workflow-app/components/dify-builder/session/use-session-controller.ts
@@ -37,6 +37,7 @@ import {
   difyBuilderConversationAtom,
   difyBuilderConversationHasMoreAtom,
   difyBuilderConversationLoadingAtom,
+  difyBuilderRetryableMessageAtom,
   difyBuilderSessionBusyAtom,
   difyBuilderSessionLastCanvasEventAtom,
   difyBuilderSessionLastErrorAtom,
@@ -62,6 +63,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
   const setConversation = useSetAtom(difyBuilderConversationAtom)
   const setConversationHasMore = useSetAtom(difyBuilderConversationHasMoreAtom)
   const setConversationLoading = useSetAtom(difyBuilderConversationLoadingAtom)
+  const setRetryableMessage = useSetAtom(difyBuilderRetryableMessageAtom)
   const setView = useSetAtom(difyBuilderSessionViewAtom)
   const setLastError = useSetAtom(difyBuilderSessionLastErrorAtom)
   const setLastCanvasEvent = useSetAtom(difyBuilderSessionLastCanvasEventAtom)
@@ -199,6 +201,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
       setView((current) => (current?.session_id === sessionId ? null : current))
       setConversation([])
       setConversationHasMore(false)
+      setRetryableMessage(null)
       executionProgress.clear()
       reasoningBuffer.clear()
       streamingTurnBuffer.clear()
@@ -209,6 +212,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
       setActiveSessionId,
       setConversation,
       setConversationHasMore,
+      setRetryableMessage,
       setView,
       streamingTurnBuffer,
     ],
@@ -442,6 +446,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
         setActiveSessionId(null)
         setConversation([])
         setConversationHasMore(false)
+        setRetryableMessage(null)
         setLastCanvasEvent(null)
         canvasCursorRef.current = undefined
         pendingMessageRef.current = null
@@ -550,6 +555,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
       setIsBusy,
       setLastCanvasEvent,
       setLastError,
+      setRetryableMessage,
       store,
       streamingTurnBuffer,
     ],
@@ -606,6 +612,8 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
       reasoningBuffer.clear()
       streamingTurnBuffer.clear()
       setConversationLoading(false)
+      setRetryableMessage(null)
+      pendingMessageRef.current = null
       const controller = new AbortController()
       abortRef.current = controller
       setActiveSessionId(normalizedSessionId)
@@ -645,6 +653,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
       setActiveSessionId,
       setIsBusy,
       setLastError,
+      setRetryableMessage,
       setConversationLoading,
       store,
       streamingTurnBuffer,
@@ -718,16 +727,21 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
   )
 
   const sendMessage = useCallback(
-    async (text: string) => {
+    async (text: string, requestedTurnId?: string) => {
       const view = store.get(difyBuilderSessionViewAtom)
       if (!view || store.get(difyBuilderSessionBusyAtom)) return false
       const normalizedText = text.trim()
       if (!normalizedText) return false
       const pending = pendingMessageRef.current
       const clientTurnId =
-        pending?.sessionId === view.session_id && pending.text === normalizedText
+        requestedTurnId?.trim() ||
+        (pending?.sessionId === view.session_id && pending.text === normalizedText
           ? pending.turnId
-          : globalThis.crypto.randomUUID()
+          : globalThis.crypto.randomUUID())
+      const retryableMessage = store.get(difyBuilderRetryableMessageAtom)
+      const retrying =
+        retryableMessage?.sessionId === view.session_id && retryableMessage.turnId === clientTurnId
+      if (!retrying) setRetryableMessage(null)
       pendingMessageRef.current = {
         sessionId: view.session_id,
         text: normalizedText,
@@ -739,11 +753,21 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
         openStream: (signal) =>
           sendSessionMessage(view.session_id, normalizedText, view.version, clientTurnId, signal),
       })
-      if (sent && pendingMessageRef.current?.turnId === clientTurnId)
-        pendingMessageRef.current = null
+      if (pendingMessageRef.current?.turnId === clientTurnId) {
+        if (sent) {
+          pendingMessageRef.current = null
+          setRetryableMessage((current) => (current?.turnId === clientTurnId ? null : current))
+        } else {
+          setRetryableMessage({
+            sessionId: view.session_id,
+            text: normalizedText,
+            turnId: clientTurnId,
+          })
+        }
+      }
       return sent
     },
-    [runCommand, store],
+    [runCommand, setRetryableMessage, store],
   )
 
   const updateModel = useCallback(
@@ -758,6 +782,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
     reasoningBuffer.clear()
     streamingTurnBuffer.clear()
     pendingMessageRef.current = null
+    setRetryableMessage(null)
     setActiveSessionId(null)
     setConversation([])
     setConversationHasMore(false)
@@ -777,6 +802,7 @@ export function useDifyBuilderSessionController(): DifyBuilderSessionController 
     setIsBusy,
     setLastCanvasEvent,
     setLastError,
+    setRetryableMessage,
     setView,
     streamingTurnBuffer,
   ])

--- a/web/app/components/workflow-app/components/dify-builder/store.ts
+++ b/web/app/components/workflow-app/components/dify-builder/store.ts
@@ -7,6 +7,7 @@ import type {
 import type { DifyBuilderCanvasNode } from './utils'
 import { atom } from 'jotai'
 import {
+  difyBuilderRetryableMessageAtom,
   difyBuilderSessionBusyAtom,
   difyBuilderSessionLastErrorAtom,
   difyBuilderSessionViewAtom,
@@ -190,8 +191,28 @@ export const difyBuilderSendDraftAtom = atom(null, async (get, set) => {
   const prompt = draft.trim()
   if (!prompt || !get(difyBuilderCanComposeAtom)) return false
 
-  const sent = await set(difyBuilderStartPromptAtom, prompt)
-  if (sent && get(difyBuilderDraftAtom) === draft) set(difyBuilderDraftAtom, '')
+  set(difyBuilderDraftAtom, '')
+  return set(difyBuilderStartPromptAtom, prompt)
+})
+
+export const difyBuilderRetryMessageAtom = atom(null, async (get, set, turnId: string) => {
+  const runtime = get(difyBuilderRuntimeAtom)
+  const retryableMessage = get(difyBuilderRetryableMessageAtom)
+  const view = get(difyBuilderSessionViewAtom)
+  if (
+    !runtime?.enabled ||
+    !runtime.canEdit ||
+    !retryableMessage ||
+    retryableMessage.turnId !== turnId ||
+    retryableMessage.sessionId !== view?.session_id ||
+    get(difyBuilderInteractionBusyAtom)
+  )
+    return false
+
+  set(difyBuilderLocalErrorAtom, '')
+  const sent = await runtime.session.sendMessage(retryableMessage.text, retryableMessage.turnId)
+  if (sent && get(difyBuilderRetryableMessageAtom)?.turnId === retryableMessage.turnId)
+    set(difyBuilderRetryableMessageAtom, null)
   return sent
 })
 
@@ -285,6 +306,7 @@ export const difyBuilderResetAtom = atom(null, (get, set) => {
   get(difyBuilderRuntimeAtom)?.session.reset()
   set(difyBuilderSelectedModelAtom, null)
   set(difyBuilderDraftAtom, '')
+  set(difyBuilderRetryableMessageAtom, null)
   set(difyBuilderLocalErrorAtom, '')
   set(difyBuilderChecklistErrorsAtom, [])
   set(difyBuilderCanvasRefreshGenerationAtom, 0)

--- a/web/app/components/workflow-app/components/dify-builder/types.ts
+++ b/web/app/components/workflow-app/components/dify-builder/types.ts
@@ -63,7 +63,7 @@ export type DifyBuilderSessionController = {
   refresh: () => Promise<boolean>
   restore: (sessionId: string) => Promise<boolean>
   runAction: (actionId: string, payload?: Record<string, unknown>) => Promise<boolean>
-  sendMessage: (text: string) => Promise<boolean>
+  sendMessage: (text: string, clientTurnId?: string) => Promise<boolean>
   updateModel: (modelConfig: SessionModel) => Promise<boolean>
   reset: () => void
 }


### PR DESCRIPTION
## Summary

- add durable progress, node, assistant-message, canvas, and commit events to Dify Builder command streams
- split bounded session projections from paginated conversation history, including reconnect gap repair and snapshot-consistent reads
- preserve active interaction drafts across version updates and make message retries idempotent with bounded recent-history reads
- update generated console contracts and frontend/backend regression coverage

## Testing

- Frontend Dify Builder unit suite: 69 passed
- Backend Dify Builder unit suite: 718 passed
- Frontend targeted Vite+ check
- Backend Ruff, formatting, and Pyrefly checks