### PR TITLE
fix(api): preserve schedule next_run_at when cron unchanged

### DIFF
--- a/api/services/trigger/schedule_service.py
+++ b/api/services/trigger/schedule_service.py
@@ -79,17 +79,17 @@ class ScheduleService:
         if not schedule:
             raise ScheduleNotFoundError(f"Schedule not found: {schedule_id}")
 
-        # If time-related fields are updated, synchronously update the next_run_at.
+        # If time-related fields actually change, synchronously update the next_run_at.
         time_fields_updated = False
 
         if updates.node_id is not None:
             schedule.node_id = updates.node_id
 
-        if updates.cron_expression is not None:
+        if updates.cron_expression is not None and updates.cron_expression != schedule.cron_expression:
             schedule.cron_expression = updates.cron_expression
             time_fields_updated = True
 
-        if updates.timezone is not None:
+        if updates.timezone is not None and updates.timezone != schedule.timezone:
             schedule.timezone = updates.timezone
             time_fields_updated = True
 

--- a/api/tests/unit_tests/services/test_schedule_service.py
+++ b/api/tests/unit_tests/services/test_schedule_service.py
@@ -1,13 +1,14 @@
 import json
 import unittest
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from core.trigger.constants import TRIGGER_SCHEDULE_NODE_TYPE
-from core.workflow.nodes.trigger_schedule.entities import VisualConfig
+from core.workflow.nodes.trigger_schedule.entities import SchedulePlanUpdate, VisualConfig
 from core.workflow.nodes.trigger_schedule.exc import ScheduleConfigError
 from libs.schedule_utils import calculate_next_run_at, convert_12h_to_24h
 from models.workflow import Workflow, WorkflowType
@@ -607,6 +608,74 @@ def test_extract_schedule_config_should_raise_when_mode_invalid() -> None:
     # Act / Assert
     with pytest.raises(ScheduleConfigError, match="Invalid schedule mode: invalid"):
         ScheduleService.extract_schedule_config(workflow=workflow)
+
+
+def _schedule_plan(
+    *,
+    cron_expression: str = "*/10 * * * *",
+    timezone: str = "UTC",
+    next_run_at: datetime | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="schedule-1",
+        node_id="start",
+        cron_expression=cron_expression,
+        timezone=timezone,
+        next_run_at=next_run_at,
+    )
+
+
+def test_update_schedule_preserves_next_run_at_when_cron_and_timezone_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored_next_run = datetime(2026, 9, 4, 12, 0, 0)
+    schedule = _schedule_plan(next_run_at=stored_next_run)
+    session = MagicMock()
+    session.get.return_value = schedule
+
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("next_run_at must not be recalculated when cron and timezone are unchanged")
+
+    monkeypatch.setattr("services.trigger.schedule_service.calculate_next_run_at", _fail_if_called)
+
+    updated = ScheduleService.update_schedule(
+        schedule_id="schedule-1",
+        updates=SchedulePlanUpdate(
+            cron_expression="*/10 * * * *",
+            timezone="UTC",
+        ),
+        session=session,
+    )
+
+    assert updated.next_run_at == stored_next_run
+    assert updated.cron_expression == "*/10 * * * *"
+    assert updated.timezone == "UTC"
+
+
+def test_update_schedule_recomputes_next_run_at_when_cron_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    stored_next_run = datetime(2026, 9, 4, 12, 0, 0)
+    recomputed_next_run = datetime(2026, 9, 4, 13, 0, 0)
+    schedule = _schedule_plan(next_run_at=stored_next_run)
+    session = MagicMock()
+    session.get.return_value = schedule
+    monkeypatch.setattr(
+        "services.trigger.schedule_service.calculate_next_run_at",
+        lambda *_args, **_kwargs: recomputed_next_run,
+    )
+
+    updated = ScheduleService.update_schedule(
+        schedule_id="schedule-1",
+        updates=SchedulePlanUpdate(
+            cron_expression="0 * * * *",
+            timezone="UTC",
+        ),
+        session=session,
+    )
+
+    assert updated.cron_expression == "0 * * * *"
+    assert updated.timezone == "UTC"
+    assert updated.next_run_at == recomputed_next_run
+    assert updated.next_run_at != stored_next_run
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Publishing / updating a schedule with the same cron and timezone no longer rewrites `next_run_at`.
- Root cause: `update_schedule` treated any non-null cron/timezone payload as a time-field change, so an unchanged publish recomputed `next_run_at` and could skip an imminent due run.

## Changes
- `api/services/trigger/schedule_service.py`: only mark time fields updated when cron or timezone actually differ from stored values.
- Unit tests: preserve `next_run_at` when unchanged; recompute when cron changes.

## Test plan
- [x] `test_update_schedule_preserves_next_run_at_when_cron_and_timezone_unchanged`
- [x] `test_update_schedule_recomputes_next_run_at_when_cron_changes`

Fixes #41782