### PR TITLE
fix(schedule): preserve next_run_at when republishing an unchanged schedule

### DIFF
--- a/api/services/trigger/schedule_service.py
+++ b/api/services/trigger/schedule_service.py
@@ -85,11 +85,17 @@ class ScheduleService:
         if updates.node_id is not None:
             schedule.node_id = updates.node_id
 
-        if updates.cron_expression is not None:
+        # Only mark time fields as updated when the new value differs from
+        # the stored value. The previous behavior always set
+        # `time_fields_updated = True` whenever the field was non-None,
+        # which caused republishing an unchanged schedule to reset
+        # `next_run_at` from "now" and skip a pending fire that was about
+        # to run. See #41782.
+        if updates.cron_expression is not None and updates.cron_expression != schedule.cron_expression:
             schedule.cron_expression = updates.cron_expression
             time_fields_updated = True
 
-        if updates.timezone is not None:
+        if updates.timezone is not None and updates.timezone != schedule.timezone:
             schedule.timezone = updates.timezone
             time_fields_updated = True
 

--- a/api/tests/unit_tests/services/test_schedule_service.py
+++ b/api/tests/unit_tests/services/test_schedule_service.py
@@ -609,5 +609,94 @@ def test_extract_schedule_config_should_raise_when_mode_invalid() -> None:
         ScheduleService.extract_schedule_config(workflow=workflow)
 
 
+def test_update_schedule_preserves_next_run_at_when_schedule_unchanged() -> None:
+    """Regression for #41782: republishing a workflow whose schedule
+    trigger config is unchanged must NOT reset ``next_run_at`` from
+    "now". Pre-fix, ``update_schedule`` treated any non-None
+    ``cron_expression`` / ``timezone`` as a change and re-derived
+    ``next_run_at`` even when the new value equalled the stored one.
+    """
+    from unittest.mock import MagicMock
+
+    from core.workflow.nodes.trigger_schedule.entities import SchedulePlanUpdate
+    from libs.schedule_utils import calculate_next_run_at
+    from services.trigger.schedule_service import ScheduleService
+
+    base_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    expected_next = calculate_next_run_at("*/10 * * * *", "UTC", base_now)
+    assert expected_next is not None
+
+    schedule = MagicMock()
+    schedule.cron_expression = "*/10 * * * *"
+    schedule.timezone = "UTC"
+    schedule.next_run_at = expected_next
+    # `MagicMock` returns a MagicMock for attribute access; the next two
+    # attributes should be the schedule's pre-update values, returned
+    # verbatim when the new value equals the old one.
+    schedule.cron_expression = "*/10 * * * *"
+    schedule.timezone = "UTC"
+
+    session = MagicMock()
+    session.get.return_value = schedule
+
+    updates = SchedulePlanUpdate(
+        node_id="schedule-1",
+        cron_expression="*/10 * * * *",
+        timezone="UTC",
+    )
+    ScheduleService.update_schedule(
+        schedule_id="schedule-1",
+        updates=updates,
+        session=session,
+    )
+
+    # The pre-existing next_run_at must be preserved when nothing changed.
+    assert schedule.next_run_at == expected_next
+
+
+def test_update_schedule_recomputes_next_run_at_when_cron_changes() -> None:
+    """Companion to #41782: the cron-change path must still recompute
+    ``next_run_at`` so a real schedule change is honored.
+    """
+    from unittest.mock import MagicMock
+
+    from core.workflow.nodes.trigger_schedule.entities import SchedulePlanUpdate
+    from libs.schedule_utils import calculate_next_run_at
+    from services.trigger.schedule_service import ScheduleService
+
+    base_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    expected_next = calculate_next_run_at("0 10 * * *", "UTC", base_now)
+    assert expected_next is not None
+
+    schedule = MagicMock()
+    schedule.cron_expression = "*/10 * * * *"
+    schedule.timezone = "UTC"
+    # Pre-existing next_run_at set to a sentinel value the test will assert
+    # is overwritten with the value computed from the current real time
+    # (calculate_next_run_at does not accept a base_time kwarg in this
+    # service's call path).
+    schedule.next_run_at = "PRE-EXISTING"
+
+    session = MagicMock()
+    session.get.return_value = schedule
+
+    updates = SchedulePlanUpdate(
+        node_id="schedule-1",
+        cron_expression="0 10 * * *",
+        timezone="UTC",
+    )
+    ScheduleService.update_schedule(
+        schedule_id="schedule-1",
+        updates=updates,
+        session=session,
+    )
+
+    assert schedule.cron_expression == "0 10 * * *"
+    # The cron change triggers a recompute; the new value must be a
+    # non-sentinel datetime, not the pre-existing sentinel.
+    assert schedule.next_run_at != "PRE-EXISTING"
+    assert isinstance(schedule.next_run_at, datetime)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #41782.

`ScheduleService.update_schedule` always set `time_fields_updated = True` whenever `cron_expression` or `timezone` was non-None in the update payload, even if the new value equalled the stored one. The subsequent `calculate_next_run_at(...)` call then reset `next_run_at` from "now", which skipped a pending fire that was about to run when an operator republished a workflow without changing the schedule config.

Concrete repro from the issue: a workflow with a `*/10 * * * *` cron has `next_run_at` set to 2 minutes from now. Publishing the same graph with no schedule changes resets `next_run_at` to "10 minutes from the current time" — skipping the pending fire.

## Fix

`api/services/trigger/schedule_service.py` — only mark time fields as updated when the new value differs from the stored value. Re-publishing an identical schedule is now a no-op for `next_run_at`.

```python
# before
if updates.cron_expression is not None:
    schedule.cron_expression = updates.cron_expression
    time_fields_updated = True
if updates.timezone is not None:
    schedule.timezone = updates.timezone
    time_fields_updated = True

# after
if updates.cron_expression is not None and updates.cron_expression != schedule.cron_expression:
    schedule.cron_expression = updates.cron_expression
    time_fields_updated = True
if updates.timezone is not None and updates.timezone != schedule.timezone:
    schedule.timezone = updates.timezone
    time_fields_updated = True
```

The issue body lists the suggested fix as either "only mark time fields updated when the new value differs from the stored value" or "skip `update_schedule` entirely when nothing changed". The first option is the more localized fix and keeps `update_schedule`'s contract (always touch the schedule row) intact.

## Tests

Two new regression tests in `api/tests/unit_tests/services/test_schedule_service.py`:

- `test_update_schedule_preserves_next_run_at_when_schedule_unchanged` — pins the fix. Pre-fix the pre-existing `next_run_at` is overwritten with the current-real-time-based recompute; post-fix the pre-existing value is preserved.
- `test_update_schedule_recomputes_next_run_at_when_cron_changes` — companion test that pins the cron-change path. When the new `cron_expression` differs from the stored one, the function must recompute `next_run_at`.

All 50 pre-existing tests in this file still pass. Pre-fix the new test fails at the missing-comparison site, confirming the test pins the bug.

## Scope

1 source file (one method, two `if` blocks). No new abstractions, no behavior change for the cron-change / timezone-change paths.

## Out of scope (called out for transparency)

- Skipping `update_schedule` entirely when nothing changed. The first option in the issue body's suggested-fix list. Rejected as a wider change — keeping the unconditional call means callers don't need to reason about whether the schedule was updated, and the local change is sufficient to fix the bug.
- Bumping `next_run_at` on cron change. The issue is specifically about resetting `next_run_at` when nothing changed; the cron-change path is correctly handled by the existing `calculate_next_run_at` call.
- Adding a `git log` audit of historical schema changes. The fix is a one-method code change, not a data migration.

## Verification

- `uv run ruff check` on changed files: All checks passed.
- `uv run ruff format --check` on changed files: already formatted.
- Targeted pytest on `test_schedule_service.py`: 52/52 pass (50 pre-existing + 2 new).
- Pre-fix regression check: the new "preserves" test fails at the missing-comparison site, confirming the test pins the new function behavior.

Fixes #41782
