### PR TITLE
fix(api): correct Service API has_more pagination when limit > 100

### DIFF
--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -414,10 +414,11 @@ class DatasetListApi(DatasetApiResource):
             query_params["tag_ids"] = request.args.getlist("tag_ids")
         query = DatasetListQuery.model_validate(query_params)
         # provider = request.args.get("provider", default="vendor")
+        effective_limit = min(query.limit, 100)
 
         datasets, total = DatasetService.get_datasets(
             query.page,
-            query.limit,
+            effective_limit,
             session,
             tenant_id,
             current_user,
@@ -451,8 +452,8 @@ class DatasetListApi(DatasetApiResource):
                 item["embedding_available"] = True
         response = {
             "data": data,
-            "has_more": len(datasets) == query.limit,
-            "limit": query.limit,
+            "has_more": query.page * effective_limit < total,
+            "limit": effective_limit,
             "total": total,
             "page": query.page,
         }

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -1010,8 +1010,9 @@ class DocumentListApi(DatasetApiResource):
 
         query = query.order_by(desc(Document.created_at), desc(Document.position))
 
+        effective_limit = min(query_params.limit, 100)
         paginated_documents = paginate_query(
-            query, session=session, page=query_params.page, per_page=query_params.limit, max_per_page=100
+            query, session=session, page=query_params.page, per_page=effective_limit, max_per_page=100
         )
         documents = paginated_documents.items
 
@@ -1024,8 +1025,8 @@ class DocumentListApi(DatasetApiResource):
 
         response = {
             "data": document_responses(documents, session=session),
-            "has_more": len(documents) == query_params.limit,
-            "limit": query_params.limit,
+            "has_more": query_params.page * effective_limit < paginated_documents.total,
+            "limit": effective_limit,
             "total": paginated_documents.total,
             "page": query_params.page,
         }

--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -279,7 +279,7 @@ class SegmentApi(DatasetApiResource):
             use_defaults_for_malformed_ints=True,
         )
         page = args.page
-        limit = args.limit
+        limit = min(args.limit, 100)
         dataset_id_str = str(dataset_id)
         dataset = session.scalar(
             select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == dataset_id_str).limit(1)
@@ -329,7 +329,7 @@ class SegmentApi(DatasetApiResource):
             "data": segment_responses_with_summaries(segments, summaries, session=session),
             "doc_form": document.doc_form,
             "total": total,
-            "has_more": len(segments) == limit,
+            "has_more": page * limit < total,
             "limit": limit,
             "page": page,
         }

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
@@ -266,6 +266,66 @@ class TestDatasetListApiGet:
             False,
         )
 
+    @patch("controllers.service_api.dataset.dataset.create_plugin_provider_manager")
+    @patch("controllers.service_api.dataset.dataset.DatasetService")
+    def test_list_datasets_has_more_false_on_last_page_exact_limit(
+        self,
+        mock_dataset_svc: MagicMock,
+        mock_provider_mgr: MagicMock,
+        app: Flask,
+        account: Account,
+        tenant: Tenant,
+        controller_session: Session,
+    ) -> None:
+        """A full last page must set has_more false instead of forcing another fetch."""
+        from controllers.service_api.dataset.dataset import DatasetListApi
+
+        page_size = 20
+        dataset = make_dataset(controller_session, tenant, account)
+        mock_dataset_svc.get_datasets.return_value = ([dataset] * page_size, page_size)
+        mock_provider_mgr.return_value.get_configurations.return_value.get_models.return_value = list[object]()
+
+        with app.test_request_context(f"/datasets?page=1&limit={page_size}", method="GET"):
+            api = DatasetListApi()
+            response, status = unwrap(api.get)(api, controller_session, tenant_id=tenant.id)
+
+        assert status == 200
+        assert response["has_more"] is False
+        assert response["limit"] == page_size
+        assert response["total"] == page_size
+        assert response["page"] == 1
+
+    @patch("controllers.service_api.dataset.dataset.create_plugin_provider_manager")
+    @patch("controllers.service_api.dataset.dataset.DatasetService")
+    def test_list_datasets_has_more_true_when_limit_exceeds_cap(
+        self,
+        mock_dataset_svc: MagicMock,
+        mock_provider_mgr: MagicMock,
+        app: Flask,
+        account: Account,
+        tenant: Tenant,
+        controller_session: Session,
+    ) -> None:
+        """limit>100 still reports remaining rows after the server cap of 100."""
+        from controllers.service_api.dataset.dataset import DatasetListApi
+
+        returned_count = 100
+        total = 150
+        dataset = make_dataset(controller_session, tenant, account)
+        mock_dataset_svc.get_datasets.return_value = ([dataset] * returned_count, total)
+        mock_provider_mgr.return_value.get_configurations.return_value.get_models.return_value = list[object]()
+
+        with app.test_request_context("/datasets?page=1&limit=200", method="GET"):
+            api = DatasetListApi()
+            response, status = unwrap(api.get)(api, controller_session, tenant_id=tenant.id)
+
+        assert status == 200
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert response["total"] == total
+        assert response["page"] == 1
+        assert mock_dataset_svc.get_datasets.call_args.args[1] == 100
+
 
 class TestDatasetListApiPost:
     """Test suite for DatasetListApi.post() endpoint."""

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -941,21 +941,27 @@ class TestSegmentPagination:
         assert limit >= 1
         assert limit <= 100
 
-    def test_has_more_calculation(self):
-        """Test has_more pagination flag calculation."""
-        segments_count = 20
+    def test_has_more_false_on_last_page_exact_limit(self):
+        """Last page that fills the limit exactly must not claim more rows."""
+        page = 1
         limit = 20
+        total = 20
+        effective_limit = min(limit, 100)
 
-        has_more = segments_count == limit
-        assert has_more is True
-
-    def test_no_more_when_incomplete_page(self):
-        """Test has_more is False for incomplete page."""
-        segments_count = 15
-        limit = 20
-
-        has_more = segments_count == limit
+        has_more = page * effective_limit < total
+        assert effective_limit == 20
         assert has_more is False
+
+    def test_has_more_true_when_limit_exceeds_cap_with_remaining_rows(self):
+        """Capped pages must still report remaining rows after the first 100."""
+        page = 1
+        limit = 200
+        total = 150
+        effective_limit = min(limit, 100)
+
+        has_more = page * effective_limit < total
+        assert effective_limit == 100
+        assert has_more is True
 
 
 # =============================================================================
@@ -1028,6 +1034,95 @@ class TestSegmentApiGet:
         assert "total" in response
         assert response["page"] == 1
         mock_dump_segments.assert_called_once_with([mock_segment], {}, session=session_factory.session)
+
+    @patch("controllers.service_api.dataset.segment.segment_responses_with_summaries")
+    @patch("controllers.service_api.dataset.segment.SummaryIndexService.get_segments_summaries")
+    @patch("controllers.service_api.dataset.segment.SegmentService")
+    @patch("controllers.service_api.dataset.segment.DocumentService")
+    @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
+    @patch("controllers.common.session.session_factory", new_callable=_session_factory_mock)
+    def test_list_segments_has_more_false_on_last_page_exact_limit(
+        self,
+        session_factory,
+        mock_account_fn,
+        mock_doc_svc,
+        mock_seg_svc,
+        mock_get_summaries,
+        mock_dump_segments,
+        app: Flask,
+        mock_tenant,
+        mock_dataset,
+        mock_segment,
+    ):
+        """A full last page must set has_more false instead of forcing another fetch."""
+        mock_account_fn.return_value = (Mock(), mock_tenant.id)
+        session_factory.session.scalar.return_value = mock_dataset
+        mock_doc_svc.get_document.return_value = _document_for_dataset(
+            mock_dataset, doc_form=IndexStructureType.PARAGRAPH_INDEX
+        )
+        page_size = 20
+        segments = [mock_segment] * page_size
+        mock_seg_svc.get_segments.return_value = (segments, page_size)
+        mock_get_summaries.return_value = {}
+        mock_dump_segments.return_value = [_segment_response_dict() for _ in range(page_size)]
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/doc-id/segments?page=1&limit={page_size}",
+            method="GET",
+        ):
+            api = SegmentApi()
+            response, status = api.get(tenant_id=mock_tenant.id, dataset_id=mock_dataset.id, document_id="doc-id")
+
+        assert status == 200
+        assert response["has_more"] is False
+        assert response["limit"] == page_size
+        assert response["total"] == page_size
+        assert response["page"] == 1
+
+    @patch("controllers.service_api.dataset.segment.segment_responses_with_summaries")
+    @patch("controllers.service_api.dataset.segment.SummaryIndexService.get_segments_summaries")
+    @patch("controllers.service_api.dataset.segment.SegmentService")
+    @patch("controllers.service_api.dataset.segment.DocumentService")
+    @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
+    @patch("controllers.common.session.session_factory", new_callable=_session_factory_mock)
+    def test_list_segments_has_more_true_when_limit_exceeds_cap(
+        self,
+        session_factory,
+        mock_account_fn,
+        mock_doc_svc,
+        mock_seg_svc,
+        mock_get_summaries,
+        mock_dump_segments,
+        app: Flask,
+        mock_tenant,
+        mock_dataset,
+        mock_segment,
+    ):
+        """limit>100 still reports remaining rows after the server cap of 100."""
+        mock_account_fn.return_value = (Mock(), mock_tenant.id)
+        session_factory.session.scalar.return_value = mock_dataset
+        mock_doc_svc.get_document.return_value = _document_for_dataset(
+            mock_dataset, doc_form=IndexStructureType.PARAGRAPH_INDEX
+        )
+        returned_count = 100
+        total = 150
+        segments = [mock_segment] * returned_count
+        mock_seg_svc.get_segments.return_value = (segments, total)
+        mock_get_summaries.return_value = {}
+        mock_dump_segments.return_value = [_segment_response_dict() for _ in range(returned_count)]
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/doc-id/segments?page=1&limit=200",
+            method="GET",
+        ):
+            api = SegmentApi()
+            response, status = api.get(tenant_id=mock_tenant.id, dataset_id=mock_dataset.id, document_id="doc-id")
+
+        assert status == 200
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert response["total"] == total
+        assert response["page"] == 1
 
     @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
     @patch("controllers.common.session.session_factory", new_callable=_session_factory_mock)

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
@@ -1093,6 +1093,78 @@ class TestDocumentListApi:
         assert "data_source_info_dict" not in response["data"][0]
         assert "doc_metadata_details" not in response["data"][0]
 
+    @patch("controllers.service_api.dataset.document.paginate_query")
+    @patch("controllers.service_api.dataset.document.DocumentService")
+    @patch("controllers.service_api.dataset.document.db")
+    def test_list_documents_has_more_false_on_last_page_exact_limit(
+        self, mock_db, mock_doc_svc, mock_paginate, app: Flask, mock_tenant, mock_dataset
+    ):
+        """A full last page must set has_more false instead of forcing another fetch."""
+        page_size = 20
+        mock_db.session.scalar.side_effect = [mock_dataset] + [0] * page_size
+        documents = [
+            make_serializable_document(
+                id=f"doc-{index}",
+                name=f"Document {index}",
+                tenant_id=mock_tenant,
+                dataset_id=mock_dataset.id,
+            )
+            for index in range(page_size)
+        ]
+        mock_paginate.return_value = _PaginationRecord(items=documents, total=page_size)
+        mock_doc_svc.enrich_documents_with_summary_index_status.return_value = None
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents?page=1&limit={page_size}",
+            method="GET",
+        ):
+            api = DocumentListApi()
+            response = inspect.unwrap(type(api).get)(
+                api, mock_db.session, tenant_id=mock_tenant, dataset_id=mock_dataset.id
+            )
+
+        assert response["has_more"] is False
+        assert response["limit"] == page_size
+        assert response["total"] == page_size
+        assert response["page"] == 1
+
+    @patch("controllers.service_api.dataset.document.paginate_query")
+    @patch("controllers.service_api.dataset.document.DocumentService")
+    @patch("controllers.service_api.dataset.document.db")
+    def test_list_documents_has_more_true_when_limit_exceeds_cap(
+        self, mock_db, mock_doc_svc, mock_paginate, app: Flask, mock_tenant, mock_dataset
+    ):
+        """limit>100 still reports remaining rows after the server cap of 100."""
+        returned_count = 100
+        total = 150
+        mock_db.session.scalar.side_effect = [mock_dataset] + [0] * returned_count
+        documents = [
+            make_serializable_document(
+                id=f"doc-{index}",
+                name=f"Document {index}",
+                tenant_id=mock_tenant,
+                dataset_id=mock_dataset.id,
+            )
+            for index in range(returned_count)
+        ]
+        mock_paginate.return_value = _PaginationRecord(items=documents, total=total)
+        mock_doc_svc.enrich_documents_with_summary_index_status.return_value = None
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents?page=1&limit=200",
+            method="GET",
+        ):
+            api = DocumentListApi()
+            response = inspect.unwrap(type(api).get)(
+                api, mock_db.session, tenant_id=mock_tenant, dataset_id=mock_dataset.id
+            )
+
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert response["total"] == total
+        assert response["page"] == 1
+        assert mock_paginate.call_args.kwargs["per_page"] == 100
+
     @patch("controllers.service_api.dataset.document.db")
     def test_list_documents_dataset_not_found(self, mock_db, app: Flask, mock_tenant, mock_dataset):
         """Test 404 when dataset not found."""


### PR DESCRIPTION
Fixes #41775
Fixes #41780

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Service API list endpoints for datasets, documents, and segments compute `has_more` with `len(items) == limit`, but the query layer caps page size at 100 via `paginate_query(..., max_per_page=100)`.

When a client requests `limit=200` and 150 rows exist, the server returns 100 items but reports `has_more=false`, so pagination stops early. The same comparison can also set `has_more=true` on a full last page and force an extra empty fetch.

This PR aligns those endpoints with the existing `ChildChunkApi` pattern:

- clamp the requested limit: `effective_limit = min(limit, 100)`
- compute pagination with `has_more = page * effective_limit < total`
- return the effective `limit` in the response

### Affected endpoints

- `GET /v1/datasets`
- `GET /v1/datasets/{dataset_id}/documents`
- `GET /v1/datasets/{dataset_id}/documents/{document_id}/segments`

## Test plan

- [x] Added unit tests for dataset, document, and segment list endpoints covering:
  - last page that exactly fills the limit reports `has_more=false`
  - `limit > 100` with remaining rows reports `has_more=true` and returns `limit=100`
- [x] `uv run pytest --no-cov` on the new/updated controller tests (9 passed)
- [x] `make lint && make type-check` (backend)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend). No frontend files changed, so `vp staged` is not applicable.