### PR TITLE
fix(ci): avoid npm bootstrap in web setup

### DIFF
--- a/.github/actions/setup-web/action.yml
+++ b/.github/actions/setup-web/action.yml
@@ -4,13 +4,13 @@ description: Set up Node.js, Vite+, pnpm, and web dependencies
 runs:
   using: composite
   steps:
-    - name: Setup pnpm
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+    - name: Setup pnpm and Node.js
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        run_install: false
+        install: false
     - name: Setup Vite+
       uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
       with:
-        node-version-file: package.json
+        node-manager: false
         cache: true
         run-install: true

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -87,10 +87,9 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          package_json_field: packageManager
-          run_install: false
+          install: false
 
       - name: Install CLI dependencies
         working-directory: cli
@@ -131,11 +130,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          package_json_field: packageManager
-          run_install: false
-      - run: pnpm install --frozen-lockfile
       - run: pnpm tree:gen
 
       - name: Run framework + output + error-handling
@@ -181,11 +175,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          package_json_field: packageManager
-          run_install: false
-      - run: pnpm install --frozen-lockfile
       - run: pnpm tree:gen
 
       - name: Run discovery suite
@@ -247,11 +236,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          package_json_field: packageManager
-          run_install: false
-      - run: pnpm install --frozen-lockfile
       - run: pnpm tree:gen
 
       - name: 'Run run/${{ matrix.name }}'
@@ -312,11 +296,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          package_json_field: packageManager
-          run_install: false
-      - run: pnpm install --frozen-lockfile
       - run: pnpm tree:gen
 
       - name: Run auth/login + status + whoami
@@ -371,11 +350,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          package_json_field: packageManager
-          run_install: false
-      - run: pnpm install --frozen-lockfile
       - run: pnpm tree:gen
 
       - name: Run use / devices / logout / agent (serial)


### PR DESCRIPTION
## Summary

- replace the legacy pnpm v11 bootstrap in the shared Web setup with the SHA-pinned `pnpm/setup@v2.1.0`
- make `pnpm/setup` own pnpm and the manifest-declared Node.js runtime while `setup-vp` reuses that runtime and continues to own dependency caching and installation
- remove redundant pnpm setup and dependency installation from CLI E2E suite jobs, and migrate the standalone provision job to the same pnpm setup path

The previous `pnpm/action-setup@v6.0.10` path runs an internal `npm ci` before self-updating pnpm. Recent jobs spent up to seven minutes installing that single bootstrap package, while the subsequent Vite+ setup and workspace install completed in under a minute. The replacement uses pnpm's verified standalone package and avoids the npm CLI bootstrap path.

A broader Web CI review found separate opportunities around the multi-gigabyte pnpm store cache and per-shard installs. Those require measured cold/warm comparisons and are intentionally excluded from this fix.

Fixes SNP-756

From Codex
