### PR TITLE
refactor(web): migrate runtime app inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2624,9 +2624,6 @@
     }
   },
   "web/app/components/plugins/plugin-detail-panel/app-selector/app-inputs-form.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 8
     }
@@ -3003,9 +3000,6 @@
   },
   "web/app/components/share/text-generation/run-once/index.tsx": {
     "eslint-react/set-state-in-effect": {
-      "count": 1
-    },
-    "no-restricted-imports": {
       "count": 1
     },
     "typescript/no-explicit-any": {

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/__tests__/app-inputs-form.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/__tests__/app-inputs-form.spec.tsx
@@ -1,5 +1,7 @@
+import type { ComponentProps } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useRef, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { InputVarType } from '@/app/components/workflow/types'
 import AppInputsForm from '../app-inputs-form'
@@ -27,6 +29,40 @@ vi.mock('@/app/components/base/file-uploader', () => ({
   ),
 }))
 
+type AppInputsFormProps = ComponentProps<typeof AppInputsForm>
+
+const renderControlledForm = ({
+  inputsForms,
+  initialInputs,
+  onFormChange,
+}: {
+  inputsForms: AppInputsFormProps['inputsForms']
+  initialInputs: AppInputsFormProps['inputs']
+  onFormChange: AppInputsFormProps['onFormChange']
+}) => {
+  const Wrapper = () => {
+    const [inputs, setInputs] = useState(initialInputs)
+    const inputsRef = useRef(initialInputs)
+
+    const handleFormChange = (nextInputs: Record<string, unknown>) => {
+      inputsRef.current = nextInputs
+      setInputs(nextInputs)
+      onFormChange(nextInputs)
+    }
+
+    return (
+      <AppInputsForm
+        inputsForms={inputsForms}
+        inputs={inputs}
+        inputsRef={inputsRef}
+        onFormChange={handleFormChange}
+      />
+    )
+  }
+
+  return render(<Wrapper />)
+}
+
 describe('AppInputsForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -45,51 +81,41 @@ describe('AppInputsForm', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('should update text input values', () => {
+  it('should update text input values', async () => {
+    const user = userEvent.setup()
     const onFormChange = vi.fn()
-    const inputsRef = { current: { question: '' } }
 
-    render(
-      <AppInputsForm
-        inputsForms={[
-          {
-            variable: 'question',
-            label: 'Question',
-            type: InputVarType.textInput,
-            required: false,
-          },
-        ]}
-        inputs={{ question: '' }}
-        inputsRef={inputsRef}
-        onFormChange={onFormChange}
-      />,
-    )
-
-    fireEvent.change(screen.getByPlaceholderText('Question'), {
-      target: { value: 'hello' },
+    renderControlledForm({
+      inputsForms: [
+        {
+          variable: 'question',
+          label: 'Question',
+          type: InputVarType.textInput,
+          required: false,
+        },
+      ],
+      initialInputs: { question: '' },
+      onFormChange,
     })
+
+    await user.type(screen.getByRole('textbox', { name: 'Question' }), 'hello')
 
     expect(onFormChange).toHaveBeenCalledWith({ question: 'hello' })
   })
 
-  it('should update number input values', () => {
+  it('should update number input values', async () => {
+    const user = userEvent.setup()
     const onFormChange = vi.fn()
-    const inputsRef = { current: { count: '' } }
 
-    render(
-      <AppInputsForm
-        inputsForms={[
-          { variable: 'count', label: 'Count', type: InputVarType.number, required: false },
-        ]}
-        inputs={{ count: '' }}
-        inputsRef={inputsRef}
-        onFormChange={onFormChange}
-      />,
-    )
-
-    fireEvent.change(screen.getByPlaceholderText('Count'), {
-      target: { value: '42' },
+    renderControlledForm({
+      inputsForms: [
+        { variable: 'count', label: 'Count', type: InputVarType.number, required: false },
+      ],
+      initialInputs: { count: '' },
+      onFormChange,
     })
+
+    await user.type(screen.getByRole('spinbutton', { name: 'Count' }), '42')
 
     expect(onFormChange).toHaveBeenCalledWith({ count: '42' })
   })
@@ -116,7 +142,7 @@ describe('AppInputsForm', () => {
       />,
     )
 
-    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByRole('combobox', { name: 'Tone' }))
     await user.click(await screen.findByRole('option', { name: 'formal' }))
 
     expect(onFormChange).toHaveBeenCalledWith({ tone: 'formal' })
@@ -152,29 +178,24 @@ describe('AppInputsForm', () => {
     })
   })
 
-  it('should update paragraph fields and preserve sibling input values', () => {
+  it('should update paragraph fields and preserve sibling input values', async () => {
+    const user = userEvent.setup()
     const onFormChange = vi.fn()
-    const inputsRef = { current: { description: 'old', topic: 'existing' } }
 
-    render(
-      <AppInputsForm
-        inputsForms={[
-          {
-            variable: 'description',
-            label: 'Description',
-            type: InputVarType.paragraph,
-            required: false,
-          },
-        ]}
-        inputs={{ description: '' }}
-        inputsRef={inputsRef}
-        onFormChange={onFormChange}
-      />,
-    )
-
-    fireEvent.change(screen.getByPlaceholderText('Description'), {
-      target: { value: 'updated paragraph' },
+    renderControlledForm({
+      inputsForms: [
+        {
+          variable: 'description',
+          label: 'Description',
+          type: InputVarType.paragraph,
+          required: false,
+        },
+      ],
+      initialInputs: { description: '', topic: 'existing' },
+      onFormChange,
     })
+
+    await user.type(screen.getByRole('textbox', { name: 'Description' }), 'updated paragraph')
 
     expect(onFormChange).toHaveBeenCalledWith({
       description: 'updated paragraph',

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/app-inputs-form.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/app-inputs-form.tsx
@@ -1,3 +1,4 @@
+import { Input } from '@langgenius/dify-ui/input'
 import {
   Select,
   SelectContent,
@@ -7,10 +8,9 @@ import {
   SelectTrigger,
 } from '@langgenius/dify-ui/select'
 import { Textarea } from '@langgenius/dify-ui/textarea'
-import { useCallback } from 'react'
+import { useCallback, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FileUploaderInAttachmentWrapper } from '@/app/components/base/file-uploader'
-import Input from '@/app/components/base/input'
 import { InputVarType } from '@/app/components/workflow/types'
 
 type Props = Readonly<{
@@ -21,6 +21,7 @@ type Props = Readonly<{
 }>
 const AppInputsForm = ({ inputsForms, inputs, inputsRef, onFormChange }: Props) => {
   const { t } = useTranslation()
+  const baseId = useId()
 
   const handleFormChange = useCallback(
     (variable: string, value: any) => {
@@ -32,13 +33,14 @@ const AppInputsForm = ({ inputsForms, inputs, inputsRef, onFormChange }: Props) 
     [onFormChange, inputsRef],
   )
 
-  const renderField = (form: any) => {
+  const renderField = (form: any, labelId: string) => {
     const { label, variable, options } = form
     if (form.type === InputVarType.textInput) {
       return (
         <Input
+          aria-labelledby={labelId}
           value={inputs[variable] || ''}
-          onChange={(e) => handleFormChange(variable, e.target.value)}
+          onValueChange={(value) => handleFormChange(variable, value)}
           placeholder={label}
         />
       )
@@ -46,9 +48,10 @@ const AppInputsForm = ({ inputsForms, inputs, inputsRef, onFormChange }: Props) 
     if (form.type === InputVarType.number) {
       return (
         <Input
+          aria-labelledby={labelId}
           type="number"
           value={inputs[variable] || ''}
-          onChange={(e) => handleFormChange(variable, e.target.value)}
+          onValueChange={(value) => handleFormChange(variable, value)}
           placeholder={label}
         />
       )
@@ -56,7 +59,7 @@ const AppInputsForm = ({ inputsForms, inputs, inputsRef, onFormChange }: Props) 
     if (form.type === InputVarType.paragraph) {
       return (
         <Textarea
-          aria-label={label}
+          aria-labelledby={labelId}
           value={inputs[variable] || ''}
           onValueChange={(value) => handleFormChange(variable, value)}
           placeholder={label}
@@ -75,7 +78,9 @@ const AppInputsForm = ({ inputsForms, inputs, inputsRef, onFormChange }: Props) 
           value={selectedOption?.value ?? null}
           onValueChange={(value) => value && handleFormChange(variable, value)}
         >
-          <SelectTrigger className="w-full">{selectedOption?.name ?? label}</SelectTrigger>
+          <SelectTrigger aria-labelledby={labelId} className="w-full">
+            {selectedOption?.name ?? label}
+          </SelectTrigger>
           <SelectContent>
             {selectOptions.map((option) => (
               <SelectItem key={option.value} value={option.value}>
@@ -123,19 +128,25 @@ const AppInputsForm = ({ inputsForms, inputs, inputsRef, onFormChange }: Props) 
 
   return (
     <div className="flex flex-col gap-4 px-4 py-2">
-      {inputsForms.map((form) => (
-        <div key={form.variable}>
-          <div className="mb-1 flex h-6 items-center gap-1 system-sm-semibold text-text-secondary">
-            <div className="truncate">{form.label}</div>
-            {!form.required && (
-              <span className="system-xs-regular text-text-tertiary">
-                {t(($) => $['panel.optional'], { ns: 'workflow' })}
-              </span>
-            )}
+      {inputsForms.map((form) => {
+        const labelId = `${baseId}-${form.variable}-label`
+
+        return (
+          <div key={form.variable}>
+            <div className="mb-1 flex h-6 items-center gap-1 system-sm-semibold text-text-secondary">
+              <div id={labelId} className="truncate">
+                {form.label}
+              </div>
+              {!form.required && (
+                <span className="system-xs-regular text-text-tertiary">
+                  {t(($) => $['panel.optional'], { ns: 'workflow' })}
+                </span>
+              )}
+            </div>
+            {renderField(form, labelId)}
           </div>
-          {renderField(form)}
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
+++ b/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
@@ -3,6 +3,7 @@ import type { PromptConfig, PromptVariable } from '@/models/debug'
 import type { SiteInfo } from '@/models/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { Resolution, TransferMethod } from '@/types/app'
@@ -177,6 +178,7 @@ describe('RunOnce', () => {
   })
 
   it('should update inputs when user edits fields', async () => {
+    const user = userEvent.setup()
     const { onInputsChange, getInputsRef } = setup()
 
     await waitFor(() => {
@@ -184,15 +186,17 @@ describe('RunOnce', () => {
     })
     onInputsChange.mockClear()
 
-    fireEvent.change(screen.getByPlaceholderText('Text Input'), {
-      target: { value: 'new text' },
-    })
-    fireEvent.change(screen.getByPlaceholderText('Paragraph Input'), {
-      target: { value: 'paragraph value' },
-    })
-    fireEvent.change(screen.getByPlaceholderText('Number Input'), {
-      target: { value: '99' },
-    })
+    const textInput = screen.getByRole('textbox', { name: 'Text Input' })
+    await user.clear(textInput)
+    await user.type(textInput, 'new text')
+
+    const paragraphInput = screen.getByRole('textbox', { name: 'Paragraph Input' })
+    await user.clear(paragraphInput)
+    await user.type(paragraphInput, 'paragraph value')
+
+    const numberInput = screen.getByRole('spinbutton', { name: 'Number Input' })
+    await user.clear(numberInput)
+    await user.type(numberInput, '99')
 
     const label = screen.getByText('Checkbox Input')
     const checkbox = label.closest('div')?.parentElement?.querySelector('div')
@@ -290,7 +294,7 @@ describe('RunOnce', () => {
           selectInput: 'Option A',
         })
       })
-      expect(screen.getByText('Select Input'))!.toBeInTheDocument()
+      expect(screen.getByRole('combobox', { name: 'Select Input' })).toBeInTheDocument()
     })
   })
 
@@ -512,7 +516,7 @@ describe('RunOnce', () => {
       await waitFor(() => {
         expect(onInputsChange).toHaveBeenCalled()
       })
-      const input = screen.getByPlaceholderText('Text Input')
+      const input = screen.getByRole('textbox', { name: 'Text Input' })
       expect(input).not.toHaveAttribute('maxLength')
     })
 
@@ -535,7 +539,7 @@ describe('RunOnce', () => {
       await waitFor(() => {
         expect(onInputsChange).toHaveBeenCalled()
       })
-      const input = screen.getByPlaceholderText('Text Input')
+      const input = screen.getByRole('textbox', { name: 'Text Input' })
       expect(input)!.toHaveAttribute('maxLength', '100')
     })
   })

--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, FC, FormEvent } from 'react'
+import type { FC, FormEvent } from 'react'
 import type { InputValueTypes } from '../types'
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import type { PromptConfig } from '@/models/debug'
@@ -6,6 +6,7 @@ import type { SiteInfo } from '@/models/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Input } from '@langgenius/dify-ui/input'
 import {
   Select,
   SelectContent,
@@ -18,12 +19,11 @@ import {
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { RiLoader2Line, RiPlayLargeLine } from '@remixicon/react'
 import * as React from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FileUploaderInAttachmentWrapper } from '@/app/components/base/file-uploader'
 import { StopCircle } from '@/app/components/base/icons/src/vender/solid/mediaAndDevices'
 import TextGenerationImageUploader from '@/app/components/base/image-uploader/text-generation-image-uploader'
-import Input from '@/app/components/base/input'
 import BoolInput from '@/app/components/workflow/nodes/_base/components/before-run-form/bool-input'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
@@ -55,6 +55,7 @@ const RunOnce: FC<IRunOnceProps> = ({
   runControl,
 }) => {
   const { t } = useTranslation()
+  const baseId = useId()
   const media = useBreakpoints()
   const isPC = media === MediaType.pc
   const [isInitialized, setIsInitialized] = useState(false)
@@ -133,7 +134,9 @@ const RunOnce: FC<IRunOnceProps> = ({
                     <div className="mt-4 w-full" key={item.key}>
                       {item.type !== 'checkbox' && (
                         <div className="flex h-6 items-center gap-1 system-md-semibold text-text-secondary">
-                          <div className="truncate">{item.name}</div>
+                          <div id={`${baseId}-${item.key}-label`} className="truncate">
+                            {item.name}
+                          </div>
                           {!item.required && (
                             <span className="system-xs-regular text-text-tertiary">
                               {t(($) => $['panel.optional'], { ns: 'workflow' })}
@@ -150,7 +153,10 @@ const RunOnce: FC<IRunOnceProps> = ({
                               handleInputsChange({ ...inputsRef.current, [item.key]: nextValue })
                             }}
                           >
-                            <SelectTrigger className="w-full">
+                            <SelectTrigger
+                              aria-labelledby={`${baseId}-${item.key}-label`}
+                              className="w-full"
+                            >
                               <SelectValue
                                 placeholder={t(($) => $['placeholder.select'], { ns: 'common' })}
                               />
@@ -167,13 +173,14 @@ const RunOnce: FC<IRunOnceProps> = ({
                         )}
                         {item.type === 'string' && (
                           <Input
+                            aria-labelledby={`${baseId}-${item.key}-label`}
                             type="text"
                             placeholder={item.name}
                             value={inputs[item.key] as string}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                            onValueChange={(value) => {
                               handleInputsChange({
                                 ...inputsRef.current,
-                                [item.key]: e.target.value,
+                                [item.key]: value,
                               })
                             }}
                             maxLength={item.max_length || undefined}
@@ -181,7 +188,7 @@ const RunOnce: FC<IRunOnceProps> = ({
                         )}
                         {item.type === 'paragraph' && (
                           <Textarea
-                            aria-label={item.name}
+                            aria-labelledby={`${baseId}-${item.key}-label`}
                             className="h-26 sm:text-xs"
                             placeholder={item.name}
                             value={inputs[item.key] as string}
@@ -192,13 +199,14 @@ const RunOnce: FC<IRunOnceProps> = ({
                         )}
                         {item.type === 'number' && (
                           <Input
+                            aria-labelledby={`${baseId}-${item.key}-label`}
                             type="number"
                             placeholder={item.name}
                             value={inputs[item.key] as number}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                            onValueChange={(value) => {
                               handleInputsChange({
                                 ...inputsRef.current,
-                                [item.key]: e.target.value,
+                                [item.key]: value,
                               })
                             }}
                           />


### PR DESCRIPTION
## Summary

- migrate shared and plugin runtime variable fields to Dify UI Input
- use each visible variable label as the accessible name for text, number, paragraph, and select controls
- verify controlled updates through semantic user interactions

## Validation

- `pnpm check`
- `pnpm --dir web lint:a11y app/components/share/text-generation/run-once/index.tsx app/components/plugins/plugin-detail-panel/app-selector/app-inputs-form.tsx`
- `vp test run --project unit app/components/plugins/plugin-detail-panel/app-selector/__tests__ app/components/share/text-generation/run-once/__tests__` (38 tests)
- visually verified the Run Once form at `http://localhost:3000`

`pnpm --dir web type-check` remains blocked by existing generated `.next` route validator errors unrelated to these files.
