### PR TITLE
fix(web): guard LLM node model_selector against persisted null (#41707)

### DIFF
--- a/web/app/components/workflow/nodes/llm/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/llm/__tests__/utils.spec.ts
@@ -1,4 +1,8 @@
-import type { EnvironmentVariable, ModelConfig } from '@/app/components/workflow/types'
+import type {
+  EnvironmentVariable,
+  ModelConfig,
+  ValueSelector,
+} from '@/app/components/workflow/types'
 import { AppModeEnum } from '@/types/app'
 import {
   getLLMEnvironmentModel,
@@ -156,6 +160,15 @@ describe('llm utils', () => {
 
     it('keeps the static model for a legacy non-environment selector', () => {
       const selector = ['start', 'MODEL_NAME']
+
+      expect(isEnvironmentModelSource(selector)).toBe(false)
+      expect(resolveLLMNodeModel(model, selector, environmentVariables)).toBe(model)
+    })
+
+    it('keeps the static model when the persisted selector is null', () => {
+      // A DSL exported from an older/AI-generated workflow can persist `model_selector: null`
+      // instead of omitting the key; this must not crash the same way `undefined` doesn't.
+      const selector = null as unknown as ValueSelector
 
       expect(isEnvironmentModelSource(selector)).toBe(false)
       expect(resolveLLMNodeModel(model, selector, environmentVariables)).toBe(model)

--- a/web/app/components/workflow/nodes/llm/utils.ts
+++ b/web/app/components/workflow/nodes/llm/utils.ts
@@ -24,7 +24,7 @@ const isLLMEnvironmentVariableValue = (value: unknown): value is LLMEnvironmentV
 }
 
 export const isEnvironmentModelSource = (modelSelector: ValueSelector | undefined) =>
-  modelSelector !== undefined && (modelSelector.length === 0 || modelSelector[0] === 'env')
+  modelSelector != null && (modelSelector.length === 0 || modelSelector[0] === 'env')
 
 export const getLLMEnvironmentModel = (
   modelSelector: ValueSelector | undefined,


### PR DESCRIPTION
(cherry picked from commit 8f7cca3ae280d169a51dae195d05eb38b483fba6)

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
