### PR TITLE
fix: reset cleared optional file tool inputs

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -1085,8 +1085,10 @@ class ToolManager:
         allow_file_parameters: bool = False,
         use_default_for_missing_form_parameters: bool = False,
     ) -> dict[str, Any]:
-        """
-        Convert tool parameters type
+        """Convert persisted form inputs to runtime values.
+
+        Optional parameters with stale variable selectors of ``""`` or ``[]`` are treated as unset.
+        Required and non-empty malformed selectors retain normal validation.
         """
         from graphon.nodes.tool.entities import ToolNodeData
         from graphon.nodes.tool.exc import ToolParameterError
@@ -1116,6 +1118,13 @@ class ToolManager:
                         runtime_parameters[parameter.name] = selector_value
                         continue
 
+                    if (
+                        not parameter.required
+                        and isinstance(config, dict)
+                        and config.get("type") == "variable"
+                        and config.get("value") in ("", [])
+                    ):
+                        continue
                     if not (config and isinstance(config, dict) and config.get("value") is not None):
                         continue
                     tool_input = ToolNodeData.ToolInput.model_validate(tool_configurations.get(parameter.name, {}))

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -28,6 +28,7 @@ from core.tools.entities.tool_entities import (
 from core.tools.errors import ToolProviderCredentialValidationError, ToolProviderNotFoundError
 from core.tools.plugin_tool.provider import PluginToolProviderController
 from core.tools.tool_manager import ToolManager
+from graphon.nodes.tool.exc import ToolParameterError
 from models.base import TypeBase
 from models.tools import ApiToolProvider, BuiltinToolProvider, WorkflowToolProvider
 
@@ -1200,6 +1201,83 @@ def test_convert_tool_parameters_type_constant_branch():
     )
 
     assert constant == {"text": "fixed"}
+
+
+@pytest.mark.parametrize(
+    "parameter_type",
+    [ToolParameter.ToolParameterType.FILE, ToolParameter.ToolParameterType.FILES],
+)
+@pytest.mark.parametrize("selector_value", ["", []])
+def test_convert_tool_parameters_type_skips_empty_optional_file_variable_selector(
+    parameter_type: ToolParameter.ToolParameterType, selector_value: str | list[str]
+):
+    file_param = ToolParameter.get_simple_instance(
+        name="image",
+        llm_description="optional image",
+        typ=parameter_type,
+        required=False,
+    )
+    file_param.form = ToolParameter.ToolParameterForm.FORM
+    variable_pool = Mock()
+    variable_pool.get.return_value = None
+
+    runtime_parameters = ToolManager._convert_tool_parameters_type(
+        parameters=[file_param],
+        variable_pool=variable_pool,
+        tool_configurations={"image": {"type": "variable", "value": selector_value}},
+        typ="workflow",
+    )
+
+    assert runtime_parameters == {}
+    variable_pool.get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("selector_value", "error_type", "error_match"),
+    [
+        ("", ValueError, "value must be a list"),
+        ([], ToolParameterError, r"Variable \[\] does not exist"),
+    ],
+)
+def test_convert_tool_parameters_type_does_not_skip_empty_required_file_variable_selector(
+    selector_value: str | list[str], error_type: type[Exception], error_match: str
+):
+    file_param = ToolParameter.get_simple_instance(
+        name="image",
+        llm_description="required image",
+        typ=ToolParameter.ToolParameterType.FILE,
+        required=True,
+    )
+    file_param.form = ToolParameter.ToolParameterForm.FORM
+    variable_pool = Mock()
+    variable_pool.get.return_value = None
+
+    with pytest.raises(error_type, match=error_match):
+        ToolManager._convert_tool_parameters_type(
+            parameters=[file_param],
+            variable_pool=variable_pool,
+            tool_configurations={"image": {"type": "variable", "value": selector_value}},
+            typ="workflow",
+        )
+
+
+def test_convert_tool_parameters_type_rejects_nonempty_malformed_optional_variable_selector():
+    file_param = ToolParameter.get_simple_instance(
+        name="image",
+        llm_description="optional image",
+        typ=ToolParameter.ToolParameterType.FILE,
+        required=False,
+    )
+    file_param.form = ToolParameter.ToolParameterForm.FORM
+    variable_pool = Mock()
+
+    with pytest.raises(ValueError, match="value must be a list"):
+        ToolManager._convert_tool_parameters_type(
+            parameters=[file_param],
+            variable_pool=variable_pool,
+            tool_configurations={"image": {"type": "variable", "value": "not-a-selector"}},
+            typ="workflow",
+        )
 
 
 def test_convert_tool_parameters_type_model_selector_from_legacy_top_level_config():

--- a/web/app/components/workflow/nodes/_base/components/__tests__/form-input-item.branches.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/form-input-item.branches.spec.tsx
@@ -90,8 +90,12 @@ vi.mock('@/app/components/workflow/nodes/_base/components/editor/code-editor', (
 }))
 
 vi.mock('@/app/components/workflow/nodes/_base/components/variable/var-reference-picker', () => ({
-  default: ({ onChange }: { onChange: (value: string[]) => void }) => (
-    <button onClick={() => onChange(['node-2', 'asset'])}>variable-picker</button>
+  default: ({ onChange }: { onChange: (value: string[] | string) => void }) => (
+    <>
+      <button onClick={() => onChange(['node-2', 'asset'])}>select-variable</button>
+      <button onClick={() => onChange('')}>clear-variable-empty-string</button>
+      <button onClick={() => onChange([])}>clear-variable-empty-selector</button>
+    </>
   ),
 }))
 
@@ -414,7 +418,7 @@ describe('FormInputItem branches', () => {
       },
     })
 
-    fireEvent.click(screen.getByText('variable-picker'))
+    fireEvent.click(screen.getByText('select-variable'))
     expect(picker.onChange).toHaveBeenCalledWith({
       field: {
         type: VarKindType.variable,
@@ -437,12 +441,82 @@ describe('FormInputItem branches', () => {
       },
     })
 
-    fireEvent.click(screen.getByText('variable-picker'))
+    fireEvent.click(screen.getByText('select-variable'))
 
     expect(onChange).toHaveBeenCalledWith({
       field: {
         type: VarKindType.variable,
         value: ['node-2', 'asset'],
+      },
+    })
+  })
+
+  it.each([
+    [FormTypeEnum.file, 'clear-variable-empty-string'],
+    [FormTypeEnum.files, 'clear-variable-empty-selector'],
+  ])('should reset a cleared optional %s selector to an unset value', (type, clearAction) => {
+    const { onChange } = renderFormInputItem({
+      schema: createSchema({ required: false, type }),
+      value: {
+        field: {
+          type: VarKindType.variable,
+          value: ['node-2', 'asset'],
+        },
+      },
+    })
+
+    fireEvent.click(screen.getByText(clearAction))
+
+    expect(onChange).toHaveBeenCalledWith({
+      field: {
+        type: VarKindType.constant,
+        value: null,
+      },
+    })
+  })
+
+  it('should preserve variable mode when a required file selector is cleared', () => {
+    const { onChange } = renderFormInputItem({
+      schema: createSchema({ required: true, type: FormTypeEnum.file }),
+      value: {
+        field: {
+          type: VarKindType.variable,
+          value: ['node-2', 'asset'],
+        },
+      },
+    })
+
+    fireEvent.click(screen.getByText('clear-variable-empty-string'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      field: {
+        type: VarKindType.variable,
+        value: '',
+      },
+    })
+  })
+
+  it('should preserve variable mode when an unrelated selector is cleared', () => {
+    const { onChange } = renderFormInputItem({
+      schema: createSchema({
+        _type: FormTypeEnum.boolean,
+        required: false,
+        type: FormTypeEnum.textInput,
+      }),
+      value: {
+        field: {
+          type: VarKindType.variable,
+          value: ['node-3', 'flag'],
+        },
+      },
+    })
+
+    fireEvent.click(screen.getByText('clear-variable-empty-selector'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      field: {
+        type: VarKindType.variable,
+        value: [],
       },
     })
   })

--- a/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
+++ b/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
@@ -262,13 +262,19 @@ const FormInputItem: FC<Props> = ({
   }
 
   const handleVariableSelectorChange = (newValue: ValueSelector | string, variable: string) => {
+    const isClearedOptionalFile = formState.isFile && !schema.required && newValue.length === 0
     onChange({
       ...value,
-      [variable]: {
-        ...varInput,
-        type: VarKindType.variable,
-        value: normalizeVariableSelectorValue(newValue),
-      },
+      [variable]: isClearedOptionalFile
+        ? {
+            type: VarKindType.constant,
+            value: null,
+          }
+        : {
+            ...varInput,
+            type: VarKindType.variable,
+            value: normalizeVariableSelectorValue(newValue),
+          },
     })
   }
 


### PR DESCRIPTION
## Summary

- Reset cleared optional `file` and `files` selectors to the canonical `{type: "constant", value: null}` state in the workflow editor.
- Treat persisted empty optional variable selectors (`""` and `[]`) as unset at runtime.
- Preserve existing validation for required parameters and non-empty malformed selectors.
- Add frontend and backend regression coverage for the affected states.

Fixes #41809

## Screenshots

Not applicable. This changes serialized state and runtime handling without changing the visual UI.

## Verification

- `uv run --project api --group dev pytest api/tests/unit_tests/core/tools/test_tool_manager.py -q` (54 passed)
- `pnpm exec vp test run app/components/workflow/nodes/_base/components/__tests__/form-input-item.branches.spec.tsx app/components/workflow/nodes/_base/components/__tests__/form-input-item.spec.tsx` (17 passed)
- `pnpm --dir web type-check`
- Targeted Ruff format and lint checks for the changed backend files
- Targeted Pyrefly and Mypy checks for `api/core/tools/tool_manager.py`
- `pnpm exec vp staged --cwd .. --diff 0d8ad27b14d1efc19613b20018e5483fa93f8e5c...HEAD --fail-on-changes`
- `git diff --check`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods. Targeted backend checks and `vp staged` are listed above.
