### PR TITLE
fix(web): allow CookieYes consent logging

### DIFF
--- a/web/__tests__/proxy-frame-options.spec.ts
+++ b/web/__tests__/proxy-frame-options.spec.ts
@@ -88,6 +88,25 @@ describe('proxy frame options', () => {
   })
 })
 
+describe('proxy CookieYes consent logging', () => {
+  it('should allow CookieYes logging requests only through connect-src', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const response = proxy(createRequest('https://cloud.dify.ai/signin'))
+    const contentSecurityPolicy = response.headers.get('content-security-policy')!
+    const directives = Object.fromEntries(
+      contentSecurityPolicy
+        .split(';')
+        .map((directive) => directive.trim().split(/\s+/))
+        .filter(([name]) => name)
+        .map(([name, ...sources]) => [name, sources]),
+    )
+
+    expect(directives['connect-src']).toContain('https://log.cookieyes.com')
+    for (const directive of ['default-src', 'script-src', 'style-src', 'worker-src', 'media-src'])
+      expect(directives[directive]).not.toContain('https://log.cookieyes.com')
+  })
+})
+
 describe('proxy education entry normalization', () => {
   it('redirects the legacy education action without leaking it into the canonical URL', () => {
     const response = proxy(

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -7,6 +7,7 @@ import { env } from '@/env'
 
 const NECESSARY_DOMAIN =
   '*.sentry.io http://localhost:* http://127.0.0.1:* https://analytics.google.com googletagmanager.com *.googletagmanager.com https://www.google-analytics.com https://cdn-cookieyes.com https://ungh.cc https://api2.amplitude.com *.amplitude.com'
+const COOKIEYES_LOGGING_ORIGIN = 'https://log.cookieyes.com'
 const CURRENT_PATHNAME_HEADER = 'x-dify-pathname'
 const CURRENT_SEARCH_HEADER = 'x-dify-search'
 const EMBEDDABLE_PATH_SEGMENTS = [
@@ -87,7 +88,7 @@ export function proxy(request: NextRequest) {
 
   const cspHeader = `
     default-src 'self' ${scheme_source} ${csp} ${whiteList};
-    connect-src 'self' ${scheme_source} ${csp} ${whiteList};
+    connect-src 'self' ${scheme_source} ${csp} ${whiteList} ${COOKIEYES_LOGGING_ORIGIN};
     script-src 'self' 'wasm-unsafe-eval' ${scheme_source} ${csp} ${whiteList};
     style-src 'self' 'unsafe-inline' ${scheme_source} ${whiteList};
     worker-src 'self' ${scheme_source} ${csp} ${whiteList};


### PR DESCRIPTION
## Summary

- allow CookieYes logging requests only through the CSP `connect-src` directive
- keep the logging origin out of script, style, worker, media, and default source permissions
- add regression coverage for the least-privilege CSP boundary

## Test plan

- `vp test run --project unit __tests__/proxy-frame-options.spec.ts`
- `vp check web/proxy.ts web/__tests__/proxy-frame-options.spec.ts`
- `pnpm check`

Fixes SNP-757
