### PR TITLE
perf(agent-v2): flatten build draft request waterfalls

### DIFF
--- a/web/app/components/workflow/nodes/agent-v2/components/__tests__/agent-orchestrate-panel-content.spec.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/__tests__/agent-orchestrate-panel-content.spec.tsx
@@ -568,6 +568,40 @@ describe('WorkflowInlineAgentConfigureWorkspace', () => {
     )
   }
 
+  it('should load the build draft while the inline composer is pending', async () => {
+    render(
+      <WorkflowInlineAgentConfigureWorkspace
+        agentId="agent-1"
+        flowId="app-1"
+        flowType={FlowType.appFlow}
+        nodeId="node-1"
+        open
+      />,
+    )
+
+    expect(screen.getByRole('status', { name: 'appApi.loading' })).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'orchestrate-panel' })).not.toBeInTheDocument()
+    await waitFor(() => expect(mocks.loadBuildDraft).toHaveBeenCalledTimes(1))
+  })
+
+  it('should not load the build draft while the inline agent panel is closed', async () => {
+    render(
+      <WorkflowInlineAgentConfigureWorkspace
+        agentId="agent-1"
+        flowId="app-1"
+        flowType={FlowType.appFlow}
+        inlineComposerState={createInlineComposerState()}
+        nodeId="node-1"
+        open={false}
+      />,
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mocks.loadBuildDraft).not.toHaveBeenCalled()
+  })
+
   async function restartCurrentChat() {
     fireEvent.click(
       screen.getByRole('button', {

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-orchestrate-panel-content.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-orchestrate-panel-content.tsx
@@ -193,7 +193,7 @@ export function WorkflowInlineAgentConfigureWorkspace(
           | undefined)
       : undefined
 
-  if (!agentId || !agentSoulConfig) {
+  if (!agentId) {
     return (
       <div className="flex h-full min-h-80 items-center justify-center bg-components-panel-bg">
         <Loading type="app" />
@@ -227,7 +227,7 @@ function WorkflowInlineAgentConfigureWorkspaceComposerScope({
 }: Omit<WorkflowInlineAgentConfigureWorkspaceProps, 'agentId'> & {
   activeConfigSnapshot?: AgentConfigSnapshotSummaryResponse | null
   agentId: string
-  agentSoulConfig: AgentSoulConfig
+  agentSoulConfig?: AgentSoulConfig
 }) {
   const soulSourceOverride = useAtomValue(agentConfigureSoulSourceOverrideAtom)
   const rightPanelMode = useAtomValue(agentConfigureRightPanelModeAtom)
@@ -236,7 +236,7 @@ function WorkflowInlineAgentConfigureWorkspaceComposerScope({
     agentId,
     activeVersionId: activeConfigSnapshot?.id,
     composerAgentSoulConfig: agentSoulConfig,
-    isBuildMode: rightPanelMode === 'build',
+    isBuildMode: props.open && rightPanelMode === 'build',
     isViewingVersion: false,
     normalAgentSoulConfig: agentSoulConfig,
     setSoulSourceOverride,
@@ -244,7 +244,7 @@ function WorkflowInlineAgentConfigureWorkspaceComposerScope({
   })
   const composerSessionKey = `${props.nodeId}:${agentId}`
 
-  if (buildDraft.isPending) {
+  if (!agentSoulConfig || buildDraft.isPending) {
     return (
       <div className="flex h-full min-h-80 items-center justify-center bg-components-panel-bg">
         <Loading type="app" />

--- a/web/features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx
@@ -604,7 +604,7 @@ describe('AgentConfigurePage', () => {
   })
 
   describe('Loading state', () => {
-    it('should show the page loading indicator instead of skeleton panels while composer data is pending', () => {
+    it('should load the build draft while keeping the page pending with composer data', () => {
       const queryClient = new QueryClient()
 
       render(
@@ -620,6 +620,13 @@ describe('AgentConfigurePage', () => {
       expect(configureSection).toHaveClass('bg-background-body')
       expect(screen.getByRole('status', { name: 'appApi.loading' })).toBeInTheDocument()
       expect(screen.queryByRole('region', { name: 'orchestrate-panel' })).not.toBeInTheDocument()
+      expect(
+        vi
+          .mocked(useQuery)
+          .mock.calls.find(
+            ([options]) => Array.isArray(options.queryKey) && options.queryKey[0] === 'build-draft',
+          )?.[0],
+      ).toMatchObject({ enabled: true })
     })
 
     it('should initialize the composer from the active build draft after its pending check', () => {
@@ -781,6 +788,13 @@ describe('AgentConfigurePage', () => {
 
       expect(screen.getByRole('region', { name: 'preview-chat' })).toHaveTextContent('preview:none')
       expect(screen.queryByRole('region', { name: 'build-chat' })).not.toBeInTheDocument()
+      expect(
+        vi
+          .mocked(useQuery)
+          .mock.calls.find(
+            ([options]) => Array.isArray(options.queryKey) && options.queryKey[0] === 'build-draft',
+          )?.[0],
+      ).toMatchObject({ enabled: false })
     })
 
     it('should switch modes without confirmation before Build chat starts', async () => {

--- a/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
@@ -89,20 +89,14 @@ export function AgentConfigureComposerScope({
     setSoulSourceOverride,
     soulSourceOverride,
   })
-  const sessionController = useAgentConfigureSessionController({
-    buildDraftAgentSoulConfig: buildDraft.buildDraftAgentSoulConfig,
-    hasActiveBuildDraft: buildDraft.hasActiveBuildDraft,
-    isBuildDraftActive: buildDraft.isActive,
-    mode: rightPanelMode,
-    normalAgentSoulConfig: agentSoulConfig,
-    onModeChange: onRightPanelModeChange,
-  })
-
   useEffect(() => {
     if (!buildDraft.isPending) initializedComposerAgentIdRef.current = agentId
   }, [agentId, buildDraft.isPending])
 
-  if (buildDraft.isPending && initializedComposerAgentIdRef.current !== agentId) {
+  if (
+    configureData.isPending ||
+    (buildDraft.isPending && initializedComposerAgentIdRef.current !== agentId)
+  ) {
     return <AgentConfigurePageLoading label={t(($) => $['agentDetail.sections.configure'])} />
   }
 
@@ -118,8 +112,8 @@ export function AgentConfigureComposerScope({
       isViewingVersion={isViewingVersion}
       previewEnabled={previewEnabled}
       rightPanelMode={rightPanelMode}
-      sessionController={sessionController}
       onComposerRebase={onComposerRebase}
+      onRightPanelModeChange={onRightPanelModeChange}
       onSelectVersion={onSelectVersion}
     />
   )
@@ -133,8 +127,8 @@ function AgentConfigurePageComposerSession({
   isViewingVersion,
   previewEnabled,
   rightPanelMode,
-  sessionController,
   onComposerRebase,
+  onRightPanelModeChange,
   onSelectVersion,
 }: {
   agentId: string
@@ -144,12 +138,20 @@ function AgentConfigurePageComposerSession({
   isViewingVersion: boolean
   previewEnabled: boolean
   rightPanelMode: AgentConfigureRightPanelMode
-  sessionController: ReturnType<typeof useAgentConfigureSessionController>
   onComposerRebase: () => void
+  onRightPanelModeChange: (mode: AgentConfigureRightPanelMode) => void | Promise<unknown>
   onSelectVersion: (versionId: string | null) => void
 }) {
-  const { agentQuery } = configureData
+  const { agentQuery, agentSoulConfig } = configureData
   const queryClient = useQueryClient()
+  const sessionController = useAgentConfigureSessionController({
+    buildDraftAgentSoulConfig: buildDraft.buildDraftAgentSoulConfig,
+    hasActiveBuildDraft: buildDraft.hasActiveBuildDraft,
+    isBuildDraftActive: buildDraft.isActive,
+    mode: rightPanelMode,
+    normalAgentSoulConfig: agentSoulConfig,
+    onModeChange: onRightPanelModeChange,
+  })
   const agentIconType = agentQuery.data?.icon_type as AgentIconType | null | undefined
   const refreshDebugConversationMutation = useMutation(
     consoleQuery.agent.byAgentId.debugConversation.refresh.post.mutationOptions({

--- a/web/features/agent-v2/agent-detail/configure/page.tsx
+++ b/web/features/agent-v2/agent-detail/configure/page.tsx
@@ -6,10 +6,8 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { ScopeProvider } from 'jotai-scope'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { AgentConfigureComposerScope } from './components/composer-session'
-import { AgentConfigurePageLoading } from './components/page-loading'
 import { useAgentConfigureData } from './hooks'
 import {
   AGENT_CONFIGURE_RIGHT_PANEL_MODES,
@@ -37,7 +35,6 @@ export function AgentConfigurePage({ agentId }: AgentConfigurePageProps) {
 }
 
 function AgentConfigurePageContent({ agentId }: AgentConfigurePageProps) {
-  const { t } = useTranslation('agentV2')
   const [requestedMode, setRequestedMode] = useQueryState('mode', agentConfigureModeQueryParser)
   const selectedVersionId = useAtomValue(agentConfigureSelectedVersionIdAtom)
   const composerRebaseRevision = useAtomValue(agentConfigureComposerRebaseRevisionAtom)
@@ -58,10 +55,6 @@ function AgentConfigurePageContent({ agentId }: AgentConfigurePageProps) {
     },
     [previewEnabled, setRequestedMode],
   )
-
-  if (configureData.isPending) {
-    return <AgentConfigurePageLoading label={t(($) => $['agentDetail.sections.configure'])} />
-  }
 
   return (
     <AgentConfigureComposerScope


### PR DESCRIPTION
## What changed

This PR removes two artificial client-side request waterfalls around the Agent V2 build draft check.

Previously, both surfaces returned their loading UI before the component owning `useAgentConfigureBuildDraftData` was mounted. Even though the build draft endpoint only needs `agentId`, the browser could not start that request until the unrelated composer request had completed.

## Agent Configure

### Before

```mermaid
sequenceDiagram
    actor User
    participant Page as Configure page
    participant ConfigAPI as Agent / composer API
    participant DraftOwner as Build draft owner
    participant DraftAPI as Build draft API

    User->>Page: Open Configure in Build mode
    Page->>ConfigAPI: Load agent and composer
    Note over Page,DraftOwner: Loading return prevents DraftOwner from mounting
    ConfigAPI-->>Page: Configuration data ready
    Page->>DraftOwner: Mount composer scope
    DraftOwner->>DraftAPI: Load build draft
    DraftAPI-->>DraftOwner: Build draft or 404
    DraftOwner-->>User: Render configure workspace
```

### After

```mermaid
sequenceDiagram
    actor User
    participant Page as Configure page
    participant ConfigAPI as Agent / composer API
    participant DraftOwner as Build draft owner
    participant DraftAPI as Build draft API

    User->>Page: Open Configure in Build mode
    par Load configuration
        Page->>ConfigAPI: Load agent and composer
    and Load build draft
        Page->>DraftOwner: Mount composer scope immediately
        DraftOwner->>DraftAPI: Load build draft
    end
    ConfigAPI-->>Page: Configuration data ready
    DraftAPI-->>DraftOwner: Build draft or 404
    DraftOwner-->>User: Render configure workspace when both are ready
```

The existing loading surface remains visible until all required data is ready. A published version request remains dependent on composer data when its version ID comes from the composer response; this PR does not change that real dependency.

## Workflow inline Agent

### Before

```mermaid
sequenceDiagram
    actor User
    participant Panel as Workflow Agent panel
    participant ComposerAPI as Inline composer API
    participant DraftOwner as Build draft owner
    participant DraftAPI as Build draft API

    User->>Panel: Open inline Agent panel
    Panel->>ComposerAPI: Load inline composer
    Note over Panel,DraftOwner: Missing agent soul keeps DraftOwner unmounted
    ComposerAPI-->>Panel: Composer data ready
    Panel->>DraftOwner: Mount inline composer scope
    DraftOwner->>DraftAPI: Load build draft
    DraftAPI-->>DraftOwner: Build draft or 404
    DraftOwner-->>User: Render Agent configuration panel
```

### After

```mermaid
sequenceDiagram
    actor User
    participant Panel as Workflow Agent panel
    participant ComposerAPI as Inline composer API
    participant DraftOwner as Build draft owner
    participant DraftAPI as Build draft API

    User->>Panel: Open inline Agent panel
    par Load composer
        Panel->>ComposerAPI: Load inline composer
    and Load build draft
        Panel->>DraftOwner: Mount scope once agentId is available
        DraftOwner->>DraftAPI: Load build draft
    end
    ComposerAPI-->>Panel: Composer data ready
    DraftAPI-->>DraftOwner: Build draft or 404
    DraftOwner-->>User: Render Agent configuration panel when both are ready
```

## User impact

On a cold cache, Configure and the Workflow inline-Agent panel remove one serialized network round trip from their blocking path. The expected blocking time changes from `upstream + buildDraft` to `max(upstream, buildDraft)`. UI structure, loading states, and error handling are unchanged.

Build draft remains disabled in Preview mode, while viewing a version, when the Workflow panel is closed, or when no agent ID is available.

## Implementation choices

- keep `useAgentConfigureBuildDraftData` as the single query and error-handling owner
- mount that existing owner at the earliest component boundary with a usable `agentId`
- keep the session controller below the readiness gate so loading transitions still reset session-only state
- do not add `usePrefetchQuery`, imperative cache warming, shared query-options files, or prefetch wrappers

This follows TanStack Query guidance for flattening nested component waterfalls by starting an independent descendant query before the parent loading gate resolves:

- https://tanstack.com/query/latest/docs/framework/react/guides/prefetching#prefetch-in-components
- https://tanstack.com/query/latest/docs/framework/react/guides/request-waterfalls

## Verification

- `pnpm exec vp test run --project unit features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx app/components/workflow/nodes/agent-v2/components/__tests__/agent-orchestrate-panel-content.spec.tsx`
- 73 focused tests passed
- `pnpm check` completed with 0 errors; existing repository warnings remain
- Chrome at `localhost:3000`: verified Agent Configure Build -> Preview -> Build rendering and interactions