### PR TITLE
fix(web): append /api/v1 when SSR reads MARKETPLACE_API_URL

### DIFF
--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -14,14 +14,20 @@ const getStringConfig = (envVar: string | undefined, defaultValue: string) => {
 const isLocalMarketplaceApiUrl = (url: string | undefined) =>
   /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::|\/)/i.test(url ?? '')
 
-// NEXT_PUBLIC_* is inlined at build. The standalone marketplace image sets
-// MARKETPLACE_API_URL at runtime instead, so SSR must read that here or it
-// falls through to localhost:5002 and creator pages throw.
+// Docker entrypoint sets NEXT_PUBLIC_MARKETPLACE_API_PREFIX=${MARKETPLACE_API_URL}/api/v1.
+// MARKETPLACE_API_URL itself is the site origin (no /api/v1). Standalone marketplace
+// images may set MARKETPLACE_API_URL at runtime for SSR; normalize the same way
+// entrypoint does so console SSR does not call the HTML origin and fail Templates.
+const marketplaceApiPrefixFromUrl = (url: string) => {
+  const trimmed = url.replace(/\/$/, '')
+  return trimmed.endsWith('/api/v1') ? trimmed : `${trimmed}/api/v1`
+}
+
 const runtimeMarketplaceApiUrl =
   typeof globalThis.window === 'undefined' &&
   process.env.MARKETPLACE_API_URL &&
   !isLocalMarketplaceApiUrl(process.env.MARKETPLACE_API_URL)
-    ? process.env.MARKETPLACE_API_URL
+    ? marketplaceApiPrefixFromUrl(process.env.MARKETPLACE_API_URL)
     : undefined
 
 export const API_PREFIX = getStringConfig(


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Cherry-pick of #41824 onto `hotfix/1.17.0-fix.14`.

Follow-up to #41538. Standalone marketplace images set `MARKETPLACE_API_URL` at runtime to the site origin (no `/api/v1`). Docker entrypoint already maps that to `NEXT_PUBLIC_MARKETPLACE_API_PREFIX=${MARKETPLACE_API_URL}/api/v1`, but SSR reads `MARKETPLACE_API_URL` directly and was calling the HTML origin, which breaks Templates.

Normalize the runtime URL the same way entrypoint does: if it does not already end with `/api/v1`, append it.

## Screenshots

N/A — SSR config change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Grok