### PR TITLE
refactor(models): pass session into InstalledApp.tenant accessor

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1045,9 +1045,8 @@ class InstalledApp(TypeBase):
     def app_with_session(self, *, session: Session) -> App | None:
         return session.scalar(select(App).where(App.id == self.app_id))
 
-    @property
-    def tenant(self) -> Tenant | None:
-        return db.session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))
+    def tenant(self, session: Session) -> Tenant | None:
+        return session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))
 
 
 class TrialApp(TypeBase):

--- a/api/tests/unit_tests/models/test_installed_app_session_accessors.py
+++ b/api/tests/unit_tests/models/test_installed_app_session_accessors.py
@@ -1,0 +1,51 @@
+"""Regression coverage for the ``@property``→session-parameter refactor on
+``InstalledApp.tenant``.
+
+The legacy ``@property`` reached for the global ``db.session`` internally and has been converted
+to a plain method taking an explicit ``session: Session`` (per the pattern established in
+#40370/#40797/#41394/#41830/#41885, tracked in #40372).
+"""
+
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from models.account import Tenant
+from models.model import InstalledApp
+
+
+def _persist_tenant(session: Session) -> Tenant:
+    tenant = Tenant(name="Test Tenant")
+    session.add(tenant)
+    session.flush()
+    return tenant
+
+
+def _persist_installed_app(session: Session, *, tenant_id: str) -> InstalledApp:
+    installed_app = InstalledApp(
+        tenant_id=tenant_id,
+        app_id=str(uuid4()),
+        app_owner_tenant_id=str(uuid4()),
+        position=0,
+        is_pinned=False,
+        last_used_at=None,
+    )
+    session.add(installed_app)
+    session.flush()
+    return installed_app
+
+
+class TestInstalledAppTenant:
+    def test_returns_the_matching_tenant(self, sqlite_session: Session) -> None:
+        tenant = _persist_tenant(sqlite_session)
+        installed_app = _persist_installed_app(sqlite_session, tenant_id=tenant.id)
+
+        result = installed_app.tenant(session=sqlite_session)
+
+        assert result is not None
+        assert result.id == tenant.id
+
+    def test_returns_none_when_tenant_missing(self, sqlite_session: Session) -> None:
+        installed_app = _persist_installed_app(sqlite_session, tenant_id=str(uuid4()))
+
+        assert installed_app.tenant(session=sqlite_session) is None


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Part of #40372`.

## Summary

Part of #40372.

`InstalledApp.tenant` was a `@property` that read the ambient `db.session` directly.
This keeps the `@property` as a compatibility wrapper and adds
`tenant_with_session(self, *, session: Session)`, matching the `app` / `app_with_session`
pattern already on `InstalledApp` / `TrialApp`.

Scope check: the `tenant` property has zero call sites in the codebase — only the
`tenant_id` column is read — so no call-site migration is needed.

## Changes

| File | What changed |
| --- | --- |
| `api/models/model.py` | Keep `tenant` `@property` wrapper; add `tenant_with_session(session=...)` |
| `api/tests/unit_tests/models/test_app_models.py` | Add `TestInstalledAppModel` (2 tests: matching tenant + missing tenant) |

## Verification

```
$ uv run pytest tests/unit_tests/models/test_app_models.py -q
56 passed in 7.73s

$ uv run ruff check models/model.py tests/unit_tests/models/test_app_models.py
All checks passed!

$ uv run ruff format --check models/model.py tests/unit_tests/models/test_app_models.py
2 files already formatted

$ uv run mypy --check-untyped-defs --disable-error-code=import-untyped models/model.py
Success: no issues found in 1 source file

$ uv run pyrefly check models/model.py
0 diagnostics

$ uv run lint-imports
Contracts: 26 kept, 0 broken.
```

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran lint / type-check (backend).