### PR TITLE
refactor(models): pass session into AppAnnotationHitHistory accessors

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -2123,17 +2123,15 @@ class AppAnnotationHitHistory(TypeBase):
     annotation_question: Mapped[str] = mapped_column(LongText, nullable=False)
     annotation_content: Mapped[str] = mapped_column(LongText, nullable=False)
 
-    @property
-    def account(self):
-        return db.session.scalar(
+    def account(self, session: Session) -> Account | None:
+        return session.scalar(
             select(Account)
             .join(MessageAnnotation, MessageAnnotation.account_id == Account.id)
             .where(MessageAnnotation.id == self.annotation_id)
         )
 
-    @property
-    def annotation_create_account(self):
-        return db.session.scalar(select(Account).where(Account.id == self.account_id))
+    def annotation_create_account(self, session: Session) -> Account | None:
+        return session.scalar(select(Account).where(Account.id == self.account_id))
 
 
 class AppAnnotationSetting(TypeBase):

--- a/api/tests/unit_tests/models/test_annotation_hit_history_session_accessors.py
+++ b/api/tests/unit_tests/models/test_annotation_hit_history_session_accessors.py
@@ -1,0 +1,93 @@
+"""Regression coverage for the ``@property``→session-parameter refactor on
+``AppAnnotationHitHistory`` accessors.
+
+Covers two of `api/models/model.py`'s legacy `@property` accessors that reached for the global
+``db.session`` internally and have been converted to plain methods taking an explicit
+``session: Session`` (per the pattern established in #40370/#40797/#41394/#41830, tracked in
+#40372):
+
+- ``AppAnnotationHitHistory.account`` (joins through ``MessageAnnotation.account_id``)
+- ``AppAnnotationHitHistory.annotation_create_account`` (looks up ``self.account_id`` directly)
+
+Each accessor is exercised against the real ``sqlite_session`` fixture (a genuine SQLAlchemy
+``Session`` bound to a pristine full-schema SQLite database) so the assertions cover actual
+query behaviour rather than a mock's recorded call.
+"""
+
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from models.account import Account
+from models.model import AppAnnotationHitHistory, MessageAnnotation
+
+
+def _persist_account(session: Session) -> Account:
+    account = Account(name="Test Account", email="test@example.com")
+    session.add(account)
+    session.flush()
+    return account
+
+
+def _persist_annotation(session: Session, *, app_id: str, account_id: str) -> MessageAnnotation:
+    annotation = MessageAnnotation(
+        app_id=app_id,
+        conversation_id=None,
+        message_id=None,
+        question="What is AI?",
+        content="AI stands for Artificial Intelligence.",
+        account_id=account_id,
+    )
+    session.add(annotation)
+    session.flush()
+    return annotation
+
+
+def _hit_history(*, app_id: str, annotation_id: str, account_id: str) -> AppAnnotationHitHistory:
+    return AppAnnotationHitHistory(
+        app_id=app_id,
+        annotation_id=annotation_id,
+        source="api",
+        question="What is AI?",
+        account_id=account_id,
+        score=0.95,
+        message_id=str(uuid4()),
+        annotation_question="What is AI?",
+        annotation_content="AI stands for Artificial Intelligence.",
+    )
+
+
+class TestAppAnnotationHitHistoryAccount:
+    def test_returns_the_annotation_creator(self, sqlite_session: Session) -> None:
+        app_id = str(uuid4())
+        creator = _persist_account(sqlite_session)
+        annotation = _persist_annotation(sqlite_session, app_id=app_id, account_id=creator.id)
+        history = _hit_history(app_id=app_id, annotation_id=annotation.id, account_id=str(uuid4()))
+
+        result = history.account(session=sqlite_session)
+
+        assert result is not None
+        assert result.id == creator.id
+
+    def test_returns_none_when_annotation_missing(self, sqlite_session: Session) -> None:
+        history = _hit_history(app_id=str(uuid4()), annotation_id=str(uuid4()), account_id=str(uuid4()))
+
+        assert history.account(session=sqlite_session) is None
+
+
+class TestAppAnnotationHitHistoryAnnotationCreateAccount:
+    def test_returns_the_hit_requester(self, sqlite_session: Session) -> None:
+        app_id = str(uuid4())
+        requester = _persist_account(sqlite_session)
+        annotation = _persist_annotation(sqlite_session, app_id=app_id, account_id=str(uuid4()))
+        history = _hit_history(app_id=app_id, annotation_id=annotation.id, account_id=requester.id)
+
+        result = history.annotation_create_account(session=sqlite_session)
+
+        assert result is not None
+        assert result.id == requester.id
+
+    def test_returns_none_when_account_missing(self, sqlite_session: Session) -> None:
+        history = _hit_history(app_id=str(uuid4()), annotation_id=str(uuid4()), account_id=str(uuid4()))
+
+        assert history.annotation_create_account(session=sqlite_session) is None


### PR DESCRIPTION
## Summary

Follow-up to #40370 / #40797 / #41394 / #41830, continuing the `@property` → explicit `session: Session` refactor tracked in #40372.

Converts the remaining two legacy `@property` accessors on `AppAnnotationHitHistory` (`api/models/model.py`) that internally read from the Flask-global `db.session`:

- `AppAnnotationHitHistory.account` → `account(self, session: Session) -> Account | None`
- `AppAnnotationHitHistory.annotation_create_account` → `annotation_create_account(self, session: Session) -> Account | None`

Both are now plain methods; the query bodies are unchanged (`db.session.scalar(...)` → `session.scalar(...)`).

### Why this slice is safe as a simple "replace `@property` with a method" change

I verified there are **zero call sites outside `api/models/model.py` itself** (repo-wide search across `api/`, excluding tests):

- The only files that touch `AppAnnotationHitHistory` instances at all are `api/services/annotation_service.py` (construction/deletion), `api/tasks/remove_app_and_related_data_task.py`, `api/schedule/clean_workflow_runlogs_precise.py`, `api/services/clear_free_plan_tenant_expired_logs.py`, and `api/services/retention/conversation/messages_clean_service.py` — all of them only do class-level `select(...)`/`delete(...)` queries or bulk deletes, never `.account`/`.annotation_create_account` attribute access.
- `api/controllers/console/app/annotation.py`'s `AnnotationHitHistoryListApi.get()` serializes `AppAnnotationHitHistory` rows via `TypeAdapter(list[AnnotationHitHistory]).validate_python(..., from_attributes=True)`, but the `AnnotationHitHistory` Pydantic model (`api/fields/annotation_fields.py`) declares only `id`, `source`, `score`, `question`, `created_at`, `match`, `response` — neither `account` nor `annotation_create_account` — so this path never reads either accessor.
- I double-checked a name-collision risk: `api/fields/conversation_fields.py`'s `MessageResponseSource.annotation_hit_history` / `_AnnotationResponseSource.account` / `.annotation_create_account` look related at a glance, but they wrap `Message.annotation_hit_history_with_session()`, which returns a `MessageAnnotation`, not an `AppAnnotationHitHistory`. That call chain was already converted under #38559 and is untouched by this PR.
- A GraphQL code search for `AppAnnotationHitHistory` across PR titles/bodies on this repo turned up only unrelated, already-merged historical PRs (#40504, #34049, #30922, #28549) — no competing or duplicate work in flight.

## Testing

- Added `api/tests/unit_tests/models/test_annotation_hit_history_session_accessors.py` — 4 new tests exercising both accessors against the real `sqlite_session` fixture (genuine SQLAlchemy `Session` on a pristine full-schema SQLite DB), covering both the "found" and "not found" paths for each accessor.
- `uv run --project api pytest api/tests/unit_tests/models/test_annotation_hit_history_session_accessors.py -v` → 4 passed.
- `uv run --project api pytest api/tests/unit_tests/models/ -q` → 402 passed (no regressions in the models package).
- Full local suite: `uv run --project api pytest api/tests/unit_tests/ -q --timeout=300` → `18454 passed, 6 skipped, 0 failed` (all warnings are pre-existing deprecation notices unrelated to this change — billing service, external dataset service, feature service, workflow comment service `SAWarning`, deprecated `ToolConversationVariables` class).
- `make lint` → clean (ruff format/check, response-contract lint, import-linter, dotenv-linter).
- `make type-check-core` → clean (pyrefly + mypy, 1776 source files).

## Screenshots

N/A — backend-only model refactor, no UI change.

## Checklist

- [x] This change follows a well-established pattern from prior merged PRs on the same tracking issue (#40370, #40797, #41394, #41830).
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

From Claude Code
