### PR TITLE
fix(api): exclude soft-deleted conversations from direct console detail and chat-message reads

### DIFF
--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -395,7 +395,13 @@ class ChatConversationDetailApi(Resource):
 
 def _get_conversation(session: Session, current_user: Account, app_model, conversation_id):
     conversation = session.scalar(
-        sa.select(Conversation).where(Conversation.id == conversation_id, Conversation.app_id == app_model.id).limit(1)
+        sa.select(Conversation)
+        .where(
+            Conversation.id == conversation_id,
+            Conversation.app_id == app_model.id,
+            Conversation.is_deleted.is_(False),
+        )
+        .limit(1)
     )
 
     if not conversation:

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -402,7 +402,11 @@ def _list_chat_messages(*, session: Session, app_model: App, current_user: Accou
     else:
         conversation = session.scalar(
             select(Conversation)
-            .where(Conversation.id == args.conversation_id, Conversation.app_id == app_model.id)
+            .where(
+                Conversation.id == args.conversation_id,
+                Conversation.app_id == app_model.id,
+                Conversation.is_deleted.is_(False),
+            )
             .limit(1)
         )
 

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
@@ -162,6 +162,16 @@ def test_get_conversation_missing_raises_not_found(sqlite_session: Session) -> N
         conversation_module._get_conversation(session, _make_account(), _app(), "missing")
 
 
+def test_get_conversation_soft_deleted_raises_not_found(sqlite_session: Session) -> None:
+    conversation = _conversation()
+    conversation.is_deleted = True
+    sqlite_session.add(conversation)
+    sqlite_session.flush()
+    session = sqlite_session
+    with pytest.raises(NotFound):
+        conversation_module._get_conversation(session, _make_account(), _app(), "c1")
+
+
 def test_conversation_response_source_uses_caller_session(sqlite_session: Session) -> None:
     account = _make_account()
     end_user = EndUser(

--- a/api/tests/unit_tests/controllers/console/app/test_message_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_message_api.py
@@ -9,6 +9,7 @@ import pytest
 from flask import Flask
 from sqlalchemy import event
 from sqlalchemy.orm import Session
+from werkzeug.exceptions import NotFound
 
 from controllers.console.app import message as message_module
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -141,6 +142,27 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
 
     assert result is response_source
     response_source_factory.assert_called_once_with(message, session=session)
+
+
+def test_list_chat_messages_soft_deleted_conversation_raises_not_found(app: Flask, sqlite_session: Session) -> None:
+    _persist_message(sqlite_session, message_id="m-1")
+    conversation = sqlite_session.get(Conversation, "conversation-1")
+    assert conversation is not None
+    conversation.id = "550e8400-e29b-41d4-a716-446655440000"
+    conversation.is_deleted = True
+    sqlite_session.flush()
+
+    with app.test_request_context(
+        "/console/api/apps/app-1/chat-messages",
+        method="GET",
+        query_string={"conversation_id": "550e8400-e29b-41d4-a716-446655440000"},
+    ):
+        with pytest.raises(NotFound):
+            message_module._list_chat_messages(
+                session=sqlite_session,
+                app_model=SimpleNamespace(id="app-1", mode=AppMode.CHAT),
+                current_user=SimpleNamespace(id="account-1"),
+            )
 
 
 def test_message_response_source_uses_caller_session_for_nested_fields(unbound_session: Session) -> None:


### PR DESCRIPTION
## Summary

Closes a privacy window in the console conversation read paths: the list endpoints already filter `Conversation.is_deleted.is_(False)`, but the direct-GET detail and chat-message endpoints in `_get_conversation` and the non-AGENT branch of `_list_chat_messages` did not. After a soft delete (`Conversation.is_deleted = True` + scheduled physical cleanup), the affected endpoints still returned the soft-deleted row until the cleanup worker ran.

Fix: add the missing `is_deleted` predicate to both reads so they behave the same as the list endpoint. The non-AGENT `_list_chat_messages` branch is the one that bypassed `ConversationService.get_conversation`; the AGENT branch goes through that helper, which already filters.

Fixes #40976

## Why this is a bug, not a feature

- The list endpoint hides the row as soon as the user clicks delete.
- The detail and chat-message endpoints kept returning it for as long as the async cleanup worker is delayed.
- A deleted conversation should be unreachable through *any* console read path, not just the list.

## Changes

`api/controllers/console/app/conversation.py::_get_conversation`
- Add `Conversation.is_deleted.is_(False)` to the read predicate used by both `CompletionConversationDetailApi` and `ChatConversationDetailApi`.
`api/controllers/console/app/message.py::_list_chat_messages`
- Add `Conversation.is_deleted.is_(False)` to the read predicate in the non-AGENT branch. The AGENT branch (lines 392-401) already goes through `ConversationService.get_conversation`, which filters, so it is left untouched.
## Tests

Two regression tests in `api/tests/unit_tests/controllers/console/app/`:

- `test_get_conversation_soft_deleted_raises_not_found` — exercises `_get_conversation` and asserts NotFound when the matched row has `is_deleted = True`.
- `test_list_chat_messages_soft_deleted_conversation_raises_not_found` — exercises the non-AGENT `_list_chat_messages` branch and asserts NotFound for the same condition.
Both tests:
- Pass with the source change.
- Fail with the unpatched predicate (`DID NOT RAISE NotFound`) — verified by stashing only the source files and re-running.

Full file suites: 29/29 pass (`test_conversation_api.py` + `test_message_api.py`).
ruff check + format clean on all four files.
## Diff scope

4 files, 44 insertions / 2 deletions, all in `api/`. No API/DTO/serializer/protocol changes; only read-side SQL predicates.

## Risk

Low. The fix tightens two reads to match the existing list-endpoint behavior. The AGENT-mode path was already correct. No migration, no new index, no API surface change.

## Future work (out of scope here)

A separate audit pass over the other console message/annotation endpoints to confirm none of them bypass the soft-delete predicate similarly. (None surfaced in the grep for `Conversation.id ==` in `controllers/`, but the broader read paths in the message detail and annotation layers are worth a follow-up sweep.)