### PR TITLE
fix: preserve generated API contracts during local development

### DIFF
--- a/packages/contracts/openapi-ts.api.config.ts
+++ b/packages/contracts/openapi-ts.api.config.ts
@@ -40,7 +40,6 @@ type ApiSpec = {
 }
 
 type ApiJob = {
-  clean?: boolean
   document: SwaggerDocument
   outputPath: string
   plugins?: UserConfig['plugins']
@@ -527,7 +526,6 @@ const writeConsoleRouterContract = (segments: string[]) => {
 
 const createConsoleContractEntryJob = (document: SwaggerDocument, segments: string[]): ApiJob => {
   return {
-    clean: false,
     document,
     outputPath: 'generated/api/console',
     plugins: [],
@@ -587,7 +585,7 @@ const createApiConfig = (job: ApiJob): UserConfig => ({
     file: false,
   },
   output: {
-    ...(job.clean === undefined ? {} : { clean: job.clean }),
+    clean: false,
     entryFile: false,
     fileName: {
       suffix: '.gen',

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -30,7 +30,7 @@
     }
   },
   "scripts": {
-    "gen-api-contract": "uv run --project ../../api ../../api/dev/generate_swagger_specs.py --output-dir openapi && uv run --project ../../api ../../api/dev/generate_fastopenapi_specs.py --output-dir openapi && node -e \"fs.rmSync('generated/api', { recursive: true, force: true })\" && openapi-ts -f openapi-ts.api.config.ts && vp fmt generated/api",
+    "gen-api-contract": "uv run --project ../../api ../../api/dev/generate_swagger_specs.py --output-dir openapi && uv run --project ../../api ../../api/dev/generate_fastopenapi_specs.py --output-dir openapi && node -e \"if (process.env.CI) fs.rmSync('generated/api', { recursive: true, force: true })\" && openapi-ts -f openapi-ts.api.config.ts && vp fmt generated/api",
     "gen-enterprise-contract": "openapi-ts -f openapi-ts.enterprise.config.ts",
     "gen-enterprise-app-deploy-contract": "openapi-ts -f openapi-ts.enterprise-app-deploy.config.ts",
     "gen-knowledge-fs-contract": "node scripts/generate-knowledge-fs-contract.mjs",


### PR DESCRIPTION
## Summary

- preserve generated API output directories during local code generation so Vinext and Vite watchers keep tracking contract files
- keep the full generated API cleanup in CI so stale generated endpoints are still removed
- configure every OpenAPI generation job with `clean: false` so local generation updates files in place

Related issue: none found.

## Reproduction

Running `pnpm --dir packages/contracts gen-api-contract` while Vinext was active removed and recreated `generated/api`. Vite then failed to resolve `./account/orpc.gen` from the generated console entry, and reloading the page did not recover the dev server.

## Screenshots

Not applicable; this changes the contract generation workflow.

## Testing

- `pnpm --dir packages/contracts test`
- `pnpm --dir packages/contracts type-check`
- `vp staged`
- local contract generation while Vinext was active: generated directory and file inodes remained stable, the page stayed healthy, and no browser errors were emitted
- `CI=1 pnpm --dir packages/contracts gen-api-contract`: the generated API directory was recreated and a stale generated segment was removed

## Checklist

- [x] No documentation update is required
- [x] Existing focused tests pass
- [x] Formatting and lint checks pass

From Codex