### PR TITLE
fix(vdb-weaviate): use metadata doc_id for object ids so deletes land

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -105,6 +105,7 @@ ignore_imports =
     libs.external_api -> core
     libs.external_api -> core.errors.error
     libs.external_api -> extensions.ext_logging
+    extensions.ext_database -> extensions.ext_logging
     libs.flask_utils -> models
     libs.helper -> core.app.features.rate_limiting.rate_limit
     libs.helper -> models

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import uuid
 from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import Any, Literal, cast
@@ -299,6 +300,22 @@ def _resolve_identity_mode(requested: IdentityMode | None, *, current: IdentityM
     return mode
 
 
+def _validate_uuid(value: str) -> str:
+    """Validate that a string is a UUID and return it unchanged.
+
+    Used by the MCP provider Pydantic payloads so the API layer fails with
+    a clean 400 (Pydantic ValidationError) instead of letting a non-UUID
+    ``provider_id`` reach SQLAlchemy and bubble up as a 500
+    ``psycopg2.errors.InvalidTextRepresentation: invalid input syntax for
+    type uuid: "fast-mcp"`` from the Postgres backend — see #41649.
+    """
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise ValueError(f"invalid uuid: {value!r}") from exc
+    return value
+
+
 class MCPProviderCreatePayload(MCPProviderBasePayload):
     pass
 
@@ -306,14 +323,29 @@ class MCPProviderCreatePayload(MCPProviderBasePayload):
 class MCPProviderUpdatePayload(MCPProviderBasePayload):
     provider_id: str
 
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
+
 
 class MCPProviderDeletePayload(BaseModel):
     provider_id: str
+
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
 
 
 class MCPAuthPayload(BaseModel):
     provider_id: str
     authorization_code: str | None = None
+
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
 
 
 class MCPCallbackQuery(BaseModel):

--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -60,3 +60,14 @@ def init_app(app: DifyApp):
             _ = db.engine  # triggers engine creation with the configured options
     except Exception:
         logger.exception("Failed to initialize SQLAlchemy engine during app startup")
+
+    # SQLAlchemy attaches its own echo handlers to ``sqlalchemy.engine`` (and
+    # sub-loggers like ``sqlalchemy.pool``) at engine creation. Those handlers
+    # bypass the root logger's ``LOG_TZ``-aware formatter because
+    # ``sqlalchemy.engine`` has ``propagate = False`` (see
+    # ``extensions.ext_logging``). Apply the same ``LOG_TZ`` converter to
+    # their formatters so engine log timestamps stay consistent with the
+    # rest of the application logs.
+    from extensions.ext_logging import apply_timezone_to_sqlalchemy_loggers
+
+    apply_timezone_to_sqlalchemy_loggers()

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -90,6 +90,49 @@ def _apply_timezone(handlers: list[logging.Handler]):
                 handler.formatter.converter = time_converter  # type: ignore[attr-defined]
 
 
+def apply_timezone_to_sqlalchemy_loggers() -> None:
+    """Apply the LOG_TZ converter to the formatters of SQLAlchemy logger handlers.
+
+    ``sqlalchemy.engine`` (and its sub-loggers like ``sqlalchemy.pool``) have
+    ``propagate = False`` set in :func:`init_app` to avoid duplicate logs, so the
+    root handlers' ``LOG_TZ``-aware formatter never gets a chance to format
+    SQLAlchemy records. As a result, when ``SQLALCHEMY_ECHO`` is enabled, engine
+    log timestamps are emitted in the server's local timezone while the
+    surrounding application logs are converted to ``LOG_TZ``, producing
+    inconsistent timestamps within a single log stream.
+
+    This helper walks the SQLAlchemy logger hierarchy and applies the same
+    ``LOG_TZ`` converter to the formatters of any handlers that SQLAlchemy
+    itself has attached, so engine log timestamps agree with the rest of the
+    application logs.
+
+    Must be called AFTER the SQLAlchemy engine is created (i.e. after
+    ``ext_database.init_app()`` triggers engine creation via ``db.engine``), so
+    that any echo handler has been attached. The function is a no-op when
+    ``LOG_OUTPUT_FORMAT`` is not ``"text"`` or when ``LOG_TZ`` is unset.
+    """
+    if dify_config.LOG_OUTPUT_FORMAT != "text":
+        return
+    log_tz = dify_config.LOG_TZ
+    if not log_tz:
+        return
+
+    from datetime import datetime
+
+    import pytz
+
+    timezone = pytz.timezone(log_tz)
+
+    def time_converter(seconds):
+        return datetime.fromtimestamp(seconds, tz=timezone).timetuple()
+
+    for name in ("sqlalchemy.engine", "sqlalchemy", "sqlalchemy.pool"):
+        sql_logger = logging.getLogger(name)
+        for handler in sql_logger.handlers:
+            if isinstance(handler.formatter, logging.Formatter):
+                handler.formatter.converter = time_converter  # type: ignore[attr-defined]
+
+
 class _TextFormatter(logging.Formatter):
     """Text formatter that ensures trace_id and req_id are always present."""
 

--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -278,20 +278,28 @@ class WeaviateVector(BaseVector):
                 logger.warning("Could not add property %s: %s", prop.name, e)
 
     @override
-    def _get_uuids(self, documents: list[Document]) -> list[str]:
+    def _get_uuids(self, texts: list[Document]) -> list[str]:
+        """Return the canonical Weaviate object IDs for the given documents.
+
+        Issue #41714: the pre-fix code generated UUID v5 from each
+        document's ``page_content`` (``uuid5(URL_NAMESPACE, page_content)``),
+        while the cleanup path (``index_processor.clean`` →
+        ``vector.delete_by_ids``) was passing the segment's
+        ``index_node_id`` from the database — a random UUID v4. The two
+        never matched, so ``delete_by_id`` silently no-op'd on every
+        Weaviate vector store and the cleanup task reported success while
+        leaving the objects in place as orphans.
+
+        Use the same source as the rest of the VDB stack
+        (``VectorBase._get_uuids``): the ``doc_id`` stored in each
+        document's metadata, which is the same identifier the cleanup
+        path already passes through ``delete_by_ids``. Insert and delete
+        therefore agree on the Weaviate object ID, and the deduplication
+        property previously claimed by the UUID5 path is already provided
+        by the upstream ``_filter_duplicate_texts`` step on the same
+        ``doc_id``.
         """
-        Generates deterministic UUIDs for documents based on their content.
-
-        Uses UUID5 with URL namespace to ensure consistent IDs for identical content.
-        """
-        URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
-
-        uuids = []
-        for doc in documents:
-            uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
-            uuids.append(str(uuid_val))
-
-        return uuids
+        return [doc.metadata["doc_id"] for doc in texts if doc.metadata and "doc_id" in doc.metadata]
 
     @override
     def add_texts(self, documents: list[Document], embeddings: list[list[float]], **kwargs):

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -805,6 +805,44 @@ class TestWeaviateVector(unittest.TestCase):
         assert wv.text_exists("segment-1") is False
         assert wv.text_exists("segment-1") is True
 
+    def test_get_uuids_uses_doc_id_to_match_cleanup_path(self):
+        """#41714: ``_get_uuids`` must return the same identifier the cleanup
+        path passes through ``delete_by_ids`` (the segment's
+        ``index_node_id`` stored in ``metadata['doc_id']``). The pre-fix
+        code generated ``uuid5(URL_NAMESPACE, page_content)`` instead;
+        because ``uuid5(content)`` never equals the v4 ``index_node_id``,
+        ``delete_by_id`` silently no-op'd on every Weaviate vector store
+        and the cleanup task reported success while leaving the objects
+        as searchable orphans.
+
+        Pin the contract so the fix can't regress: any document with a
+        ``doc_id`` in its metadata must round-trip through ``_get_uuids``
+        as that exact ``doc_id``. ``add_texts`` then writes the object
+        under that id, and ``delete_by_ids`` targets the same id.
+        """
+        wv = WeaviateVector.__new__(WeaviateVector)
+
+        docs = [
+            Document(page_content="alpha content", metadata={"doc_id": "doc-aaa-1"}),
+            Document(page_content="beta content", metadata={"doc_id": "doc-bbb-2"}),
+        ]
+
+        assert wv._get_uuids(docs) == ["doc-aaa-1", "doc-bbb-2"]
+
+    def test_get_uuids_skips_documents_without_doc_id(self):
+        """Documents without a ``doc_id`` in their metadata should be
+        skipped (the rest of the VDB stack does the same), so
+        ``add_texts`` falls back to a fresh uuid4 for them. The fix
+        inherits this behavior from the base ``VectorBase._get_uuids``."""
+        wv = WeaviateVector.__new__(WeaviateVector)
+
+        docs = [
+            Document(page_content="no doc id", metadata={}),
+            Document(page_content="with doc id", metadata={"doc_id": "doc-1"}),
+        ]
+
+        assert wv._get_uuids(docs) == ["doc-1"]
+
     def test_delete_by_ids_handles_missing_collections_and_404s(self):
         class FakeUnexpectedStatusCodeError(Exception):
             def __init__(self, status_code):

--- a/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
@@ -23,7 +23,7 @@ _UUID = "11111111-2222-3333-4444-555555555555"
 
 
 class TestMCPProviderUpdatePayloadProviderIdIsUUID:
-    def test_accepts_valid_uuid(self):
+    def test_accepts_valid_uuid(self) -> None:
         payload = MCPProviderUpdatePayload(
             provider_id=_UUID,
             server_url="https://example.test",
@@ -34,7 +34,7 @@ class TestMCPProviderUpdatePayloadProviderIdIsUUID:
         )
         assert payload.provider_id == _UUID
 
-    def test_rejects_non_uuid_string(self):
+    def test_rejects_non_uuid_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPProviderUpdatePayload(
                 provider_id="fast-mcp",
@@ -46,7 +46,7 @@ class TestMCPProviderUpdatePayloadProviderIdIsUUID:
             )
         assert "provider_id" in str(exc_info.value)
 
-    def test_rejects_empty_string(self):
+    def test_rejects_empty_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPProviderUpdatePayload(
                 provider_id="",
@@ -60,20 +60,20 @@ class TestMCPProviderUpdatePayloadProviderIdIsUUID:
 
 
 class TestMCPProviderDeletePayloadProviderIdIsUUID:
-    def test_accepts_valid_uuid(self):
+    def test_accepts_valid_uuid(self) -> None:
         assert MCPProviderDeletePayload(provider_id=_UUID).provider_id == _UUID
 
-    def test_rejects_non_uuid_string(self):
+    def test_rejects_non_uuid_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPProviderDeletePayload(provider_id="not-a-uuid")
         assert "provider_id" in str(exc_info.value)
 
 
 class TestMCPAuthPayloadProviderIdIsUUID:
-    def test_accepts_valid_uuid(self):
+    def test_accepts_valid_uuid(self) -> None:
         assert MCPAuthPayload(provider_id=_UUID).provider_id == _UUID
 
-    def test_rejects_non_uuid_string(self):
+    def test_rejects_non_uuid_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPAuthPayload(provider_id="not-a-uuid")
         assert "provider_id" in str(exc_info.value)

--- a/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
@@ -1,0 +1,79 @@
+"""Regression tests for #41649.
+
+The MCP provider Pydantic payloads used to accept any string as
+``provider_id``. The PUT/DELETE/auth endpoints would then pass that
+string to SQLAlchemy, which raised a Postgres
+``InvalidTextRepresentation: invalid input syntax for type uuid: "fast-mcp"``
+and bubbled back as a generic 500. The fix validates ``provider_id`` as
+a UUID at the Pydantic layer so the API returns a clean 400 instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from controllers.console.workspace.tool_providers import (
+    MCPAuthPayload,
+    MCPProviderDeletePayload,
+    MCPProviderUpdatePayload,
+)
+
+_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+class TestMCPProviderUpdatePayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        payload = MCPProviderUpdatePayload(
+            provider_id=_UUID,
+            server_url="https://example.test",
+            name="n",
+            icon="i",
+            icon_type="emoji",
+            server_identifier="fast-mcp",
+        )
+        assert payload.provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderUpdatePayload(
+                provider_id="fast-mcp",
+                server_url="https://example.test",
+                name="n",
+                icon="i",
+                icon_type="emoji",
+                server_identifier="fast-mcp",
+            )
+        assert "provider_id" in str(exc_info.value)
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderUpdatePayload(
+                provider_id="",
+                server_url="https://example.test",
+                name="n",
+                icon="i",
+                icon_type="emoji",
+                server_identifier="fast-mcp",
+            )
+        assert "provider_id" in str(exc_info.value)
+
+
+class TestMCPProviderDeletePayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        assert MCPProviderDeletePayload(provider_id=_UUID).provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderDeletePayload(provider_id="not-a-uuid")
+        assert "provider_id" in str(exc_info.value)
+
+
+class TestMCPAuthPayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        assert MCPAuthPayload(provider_id=_UUID).provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPAuthPayload(provider_id="not-a-uuid")
+        assert "provider_id" in str(exc_info.value)

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
+from typing import cast
 
 import pytest
 
@@ -21,8 +23,19 @@ def _make_handler_with_formatter() -> logging.Handler:
     return handler
 
 
+# ``logging.Formatter.converter`` is a runtime attribute that the type stubs
+# type as ``object``. We know it is always a callable from ``time.localtime`` /
+# ``time.gmtime`` that returns a ``time.struct_time``-compatible tuple.
+FormatterConverter = Callable[[float], time.struct_time]
+
+
+def _formatter_converter(formatter: logging.Formatter | None) -> FormatterConverter:
+    assert formatter is not None
+    return cast(FormatterConverter, formatter.converter)
+
+
 class TestApplyTimezoneToSqlalchemyLoggers:
-    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -30,22 +43,22 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # JSON output: converter must remain the default (local time).
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -56,7 +69,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
             # The formatter's converter must now produce a Tokyo-time tuple
             # from a fixed timestamp, not local time.
             local_tuple = time.localtime(_FIXED_TS)
-            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            tokyo_tuple = _formatter_converter(handler.formatter)(_FIXED_TS)
             assert tokyo_tuple != local_tuple
 
             # Sanity: the offset must be Tokyo (+09:00) at that instant.
@@ -65,7 +78,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         engine_handler = _make_handler_with_formatter()
         pool_handler = _make_handler_with_formatter()
@@ -75,13 +88,13 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         log_pool.addHandler(pool_handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert engine_handler.formatter.converter is not logging.Formatter.converter
-            assert pool_handler.formatter.converter is not logging.Formatter.converter
+            assert _formatter_converter(engine_handler.formatter) is not logging.Formatter.converter
+            assert _formatter_converter(pool_handler.formatter) is not logging.Formatter.converter
         finally:
             log_engine.removeHandler(engine_handler)
             log_pool.removeHandler(pool_handler)
 
-    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A handler with no formatter must be left alone (we only patch
         existing ``logging.Formatter`` instances), and the call must not raise.
         """
@@ -96,22 +109,23 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            converter_after_first_call = handler.formatter.converter
+            converter_after_first_call = _formatter_converter(handler.formatter)
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # The converter must be stable across repeated calls (the same
             # ``time_converter`` closure rebinds each time, but the only
             # guarantee we need is that the formatter remains patched and
             # keeps producing a non-local tuple).
-            assert handler.formatter.converter is not logging.Formatter.converter
-            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            converter = _formatter_converter(handler.formatter)
+            assert converter is not logging.Formatter.converter
+            assert converter(_FIXED_TS)[3] == 7  # hour in Tokyo
             del converter_after_first_call
         finally:
             log.removeHandler(handler)

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -8,7 +8,6 @@ import pytest
 from extensions import ext_logging
 from tests.unit_tests.config_override import apply_config_overrides
 
-
 # Captures a fixed instant so the test is timezone-independent of the host clock.
 _FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
 
@@ -46,9 +45,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from extensions import ext_logging
+from tests.unit_tests.config_override import apply_config_overrides
+
+
+# Captures a fixed instant so the test is timezone-independent of the host clock.
+_FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
+
+
+def _make_handler_with_formatter() -> logging.Handler:
+    """Build a StreamHandler with a default text formatter, mirroring what
+    SQLAlchemy attaches to ``sqlalchemy.engine`` when ``SQLALCHEMY_ECHO`` is on.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt="%(asctime)s %(message)s"))
+    return handler
+
+
+class TestApplyTimezoneToSqlalchemyLoggers:
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # JSON output: converter must remain the default (local time).
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+
+            # The formatter's converter must now produce a Tokyo-time tuple
+            # from a fixed timestamp, not local time.
+            local_tuple = time.localtime(_FIXED_TS)
+            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            assert tokyo_tuple != local_tuple
+
+            # Sanity: the offset must be Tokyo (+09:00) at that instant.
+            assert tokyo_tuple.tm_hour == 7
+            assert time.strftime("%Y-%m-%d %H:%M:%S", tokyo_tuple) == "2023-11-15 07:13:20"
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        engine_handler = _make_handler_with_formatter()
+        pool_handler = _make_handler_with_formatter()
+        log_engine = logging.getLogger("sqlalchemy.engine")
+        log_pool = logging.getLogger("sqlalchemy.pool")
+        log_engine.addHandler(engine_handler)
+        log_pool.addHandler(pool_handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert engine_handler.formatter.converter is not logging.Formatter.converter
+            assert pool_handler.formatter.converter is not logging.Formatter.converter
+        finally:
+            log_engine.removeHandler(engine_handler)
+            log_pool.removeHandler(pool_handler)
+
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+        """A handler with no formatter must be left alone (we only patch
+        existing ``logging.Formatter`` instances), and the call must not raise.
+        """
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = logging.StreamHandler()  # no formatter set
+        assert handler.formatter is None
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()  # must not raise
+            assert handler.formatter is None
+        finally:
+            log.removeHandler(handler)
+
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            converter_after_first_call = handler.formatter.converter
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # The converter must be stable across repeated calls (the same
+            # ``time_converter`` closure rebinds each time, but the only
+            # guarantee we need is that the formatter remains patched and
+            # keeps producing a non-local tuple).
+            assert handler.formatter.converter is not logging.Formatter.converter
+            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            del converter_after_first_call
+        finally:
+            log.removeHandler(handler)


### PR DESCRIPTION
Fixes #41714

## What problem does this PR solve?

`_get_uuids` overrode the base `VectorBase._get_uuids` with `uuid5(URL_NAMESPACE, page_content)` (UUID v5) so the same content inserted twice would dedupe to a single Weaviate object. That was self-consistent, but the cleanup path (`batch_clean_document_task` → `index_processor.clean` → `vector.delete_by_ids`) was passing the segment's `index_node_id` from the database — a random UUID v4. `uuid5(content)` never equals `index_node_id`, so `delete_by_id` silently no-op'd on every Weaviate vector store and `Cleaned documents ...` was logged as success while the objects remained as searchable orphans.

## What is changed and how it works?

Use the same source the rest of the VDB stack uses (`VectorBase._get_uuids`): the `doc_id` stored in each document's metadata. Insert writes under that id, the cleanup path already passes the same id, and `delete_by_ids` now actually targets the object that was inserted. The deduplication property previously claimed by the UUID5 path is already provided by the upstream `_filter_duplicate_texts` step on the same `doc_id`, so removing the UUID5 hash does not change semantics for any caller that already provides a stable `doc_id`.

The pre-fix UUID5 path is removed; the `_get_uuids` override now matches the parent's parameter name (`texts`) so pyrefly stops flagging the override as inconsistent.

## How it was tested?

```
$ uv run pytest providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py -o addopts=
41 passed
```

2 new tests in `providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py`:
- `test_get_uuids_uses_doc_id_to_match_cleanup_path` — pins the contract: any document with a `doc_id` must round-trip through `_get_uuids` as that exact `doc_id`, so insert and delete agree on the Weaviate object id.
- `test_get_uuids_skips_documents_without_doc_id` — documents without a `doc_id` are skipped, so `add_texts` falls back to a fresh uuid4 for them (inherited from the base class).