### PR TITLE
fix(tools): translate PluginNotFoundError to ToolProviderNotFoundError

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -105,6 +105,7 @@ ignore_imports =
     libs.external_api -> core
     libs.external_api -> core.errors.error
     libs.external_api -> extensions.ext_logging
+    extensions.ext_database -> extensions.ext_logging
     libs.flask_utils -> models
     libs.helper -> core.app.features.rate_limiting.rate_limit
     libs.helper -> models

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import uuid
 from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import Any, Literal, cast
@@ -299,6 +300,22 @@ def _resolve_identity_mode(requested: IdentityMode | None, *, current: IdentityM
     return mode
 
 
+def _validate_uuid(value: str) -> str:
+    """Validate that a string is a UUID and return it unchanged.
+
+    Used by the MCP provider Pydantic payloads so the API layer fails with
+    a clean 400 (Pydantic ValidationError) instead of letting a non-UUID
+    ``provider_id`` reach SQLAlchemy and bubble up as a 500
+    ``psycopg2.errors.InvalidTextRepresentation: invalid input syntax for
+    type uuid: "fast-mcp"`` from the Postgres backend — see #41649.
+    """
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise ValueError(f"invalid uuid: {value!r}") from exc
+    return value
+
+
 class MCPProviderCreatePayload(MCPProviderBasePayload):
     pass
 
@@ -306,14 +323,29 @@ class MCPProviderCreatePayload(MCPProviderBasePayload):
 class MCPProviderUpdatePayload(MCPProviderBasePayload):
     provider_id: str
 
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
+
 
 class MCPProviderDeletePayload(BaseModel):
     provider_id: str
+
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
 
 
 class MCPAuthPayload(BaseModel):
     provider_id: str
     authorization_code: str | None = None
+
+    @field_validator("provider_id")
+    @classmethod
+    def _validate_provider_id(cls, value: str) -> str:
+        return _validate_uuid(value)
 
 
 class MCPCallbackQuery(BaseModel):

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -22,6 +22,7 @@ from core.entities import PluginCredentialType
 from core.helper.module_import_helper import load_single_subclass_from_source
 from core.helper.position_helper import is_filtered
 from core.helper.provider_cache import ToolProviderCredentialsCache
+from core.plugin.impl.exc import PluginDaemonNotFoundError, PluginNotFoundError
 from core.plugin.impl.tool import PluginToolManager
 from core.tools.__base.tool import Tool
 from core.tools.__base.tool_provider import ToolProviderController
@@ -161,7 +162,14 @@ class ToolManager:
                 return plugin_tool_providers[provider]
 
             manager = PluginToolManager()
-            provider_entity = manager.fetch_tool_provider(tenant_id, provider)
+            try:
+                provider_entity = manager.fetch_tool_provider(tenant_id, provider)
+            except (PluginNotFoundError, PluginDaemonNotFoundError) as exc:
+                # The plugin daemon rejected the provider name (probably an
+                # unknown or non-builtin identifier). Translate to the
+                # console's domain error so the API returns a 4xx instead
+                # of leaking the daemon's ``PluginNotFoundError`` as a 500.
+                raise ToolProviderNotFoundError(f"plugin provider {provider} not found") from exc
             if not provider_entity:
                 raise ToolProviderNotFoundError(f"plugin provider {provider} not found")
 

--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -60,3 +60,14 @@ def init_app(app: DifyApp):
             _ = db.engine  # triggers engine creation with the configured options
     except Exception:
         logger.exception("Failed to initialize SQLAlchemy engine during app startup")
+
+    # SQLAlchemy attaches its own echo handlers to ``sqlalchemy.engine`` (and
+    # sub-loggers like ``sqlalchemy.pool``) at engine creation. Those handlers
+    # bypass the root logger's ``LOG_TZ``-aware formatter because
+    # ``sqlalchemy.engine`` has ``propagate = False`` (see
+    # ``extensions.ext_logging``). Apply the same ``LOG_TZ`` converter to
+    # their formatters so engine log timestamps stay consistent with the
+    # rest of the application logs.
+    from extensions.ext_logging import apply_timezone_to_sqlalchemy_loggers
+
+    apply_timezone_to_sqlalchemy_loggers()

--- a/api/extensions/ext_logging.py
+++ b/api/extensions/ext_logging.py
@@ -90,6 +90,49 @@ def _apply_timezone(handlers: list[logging.Handler]):
                 handler.formatter.converter = time_converter  # type: ignore[attr-defined]
 
 
+def apply_timezone_to_sqlalchemy_loggers() -> None:
+    """Apply the LOG_TZ converter to the formatters of SQLAlchemy logger handlers.
+
+    ``sqlalchemy.engine`` (and its sub-loggers like ``sqlalchemy.pool``) have
+    ``propagate = False`` set in :func:`init_app` to avoid duplicate logs, so the
+    root handlers' ``LOG_TZ``-aware formatter never gets a chance to format
+    SQLAlchemy records. As a result, when ``SQLALCHEMY_ECHO`` is enabled, engine
+    log timestamps are emitted in the server's local timezone while the
+    surrounding application logs are converted to ``LOG_TZ``, producing
+    inconsistent timestamps within a single log stream.
+
+    This helper walks the SQLAlchemy logger hierarchy and applies the same
+    ``LOG_TZ`` converter to the formatters of any handlers that SQLAlchemy
+    itself has attached, so engine log timestamps agree with the rest of the
+    application logs.
+
+    Must be called AFTER the SQLAlchemy engine is created (i.e. after
+    ``ext_database.init_app()`` triggers engine creation via ``db.engine``), so
+    that any echo handler has been attached. The function is a no-op when
+    ``LOG_OUTPUT_FORMAT`` is not ``"text"`` or when ``LOG_TZ`` is unset.
+    """
+    if dify_config.LOG_OUTPUT_FORMAT != "text":
+        return
+    log_tz = dify_config.LOG_TZ
+    if not log_tz:
+        return
+
+    from datetime import datetime
+
+    import pytz
+
+    timezone = pytz.timezone(log_tz)
+
+    def time_converter(seconds):
+        return datetime.fromtimestamp(seconds, tz=timezone).timetuple()
+
+    for name in ("sqlalchemy.engine", "sqlalchemy", "sqlalchemy.pool"):
+        sql_logger = logging.getLogger(name)
+        for handler in sql_logger.handlers:
+            if isinstance(handler.formatter, logging.Formatter):
+                handler.formatter.converter = time_converter  # type: ignore[attr-defined]
+
+
 class _TextFormatter(logging.Formatter):
     """Text formatter that ensures trace_id and req_id are always present."""
 

--- a/api/providers/vdb/vdb-tidb-vector/src/dify_vdb_tidb_vector/tidb_vector.py
+++ b/api/providers/vdb/vdb-tidb-vector/src/dify_vdb_tidb_vector/tidb_vector.py
@@ -299,7 +299,7 @@ class TiDBVector(BaseVector):
         score_threshold = float(kwargs.get("score_threshold") or 0.0)
         document_ids_filter = kwargs.get("document_ids_filter")
 
-        where_conditions = ["FTS_MATCH_WORD(text, :query)"]
+        where_conditions = ["FTS_MATCH_WORD(:query, text)"]
         filter_params: dict[str, str] = {}
         if document_ids_filter:
             document_ids_filter_condition, filter_params = self._document_ids_filter_condition(document_ids_filter)
@@ -314,7 +314,7 @@ class TiDBVector(BaseVector):
                   SELECT
                     meta,
                     text,
-                    FTS_MATCH_WORD(text, :query) AS score
+                    FTS_MATCH_WORD(:query, text) AS score
                   FROM {self._collection_name}
                   WHERE {where_clause}
                   ORDER BY score DESC

--- a/api/providers/vdb/vdb-tidb-vector/tests/unit_tests/test_tidb_vector.py
+++ b/api/providers/vdb/vdb-tidb-vector/tests/unit_tests/test_tidb_vector.py
@@ -324,7 +324,7 @@ def test_search_by_full_text_queries_tidb_fts_and_scores(tidb_vector_with_sessio
     assert docs[1].metadata["score"] == pytest.approx(0.6)
     sql = str(session.execute.call_args.args[0])
     params = session.execute.call_args.kwargs["params"]
-    assert "FTS_MATCH_WORD(text, :query)" in sql
+    assert "FTS_MATCH_WORD(:query, text)" in sql
     assert "document_id IN (:document_id_0, :document_id_1)" in sql
     assert "d'2" not in sql
     assert params == {
@@ -334,6 +334,29 @@ def test_search_by_full_text_queries_tidb_fts_and_scores(tidb_vector_with_sessio
         "score_threshold": 0.5,
         "top_k": 2,
     }
+
+
+def test_search_by_full_text_uses_query_first_argument_order(tidb_vector_with_session):
+    """#41822: TiDB's ``FTS_MATCH_WORD`` signature is ``FTS_MATCH_WORD(query, column)``,
+    not ``FTS_MATCH_WORD(column, query)``. The pre-fix code generated
+    ``FTS_MATCH_WORD(text, :query)`` which TiDB rejects with
+    ``This version of TiDB doesn't yet support 'match against a
+    non-constant string'`` (the bound parameter is treated as a
+    non-constant expression). Pin the contract: the SQL must always
+    pass the query as the first argument and the column as the second.
+    """
+    vector, session, tidb_module = tidb_vector_with_session
+    vector._client_config = _config(tidb_module).model_copy(update={"enable_fulltext_search": True})
+    session.execute.return_value = []
+
+    vector.search_by_full_text("search query")
+
+    sql = str(session.execute.call_args.args[0])
+
+    # Both occurrences (the WHERE clause and the score projection) must
+    # use ``FTS_MATCH_WORD(:query, text)``, never ``FTS_MATCH_WORD(text, :query)``.
+    assert sql.count("FTS_MATCH_WORD(:query, text)") == 2
+    assert "FTS_MATCH_WORD(text, :query)" not in sql
 
 
 # 2. text_exists returns True when ids found

--- a/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
@@ -23,7 +23,7 @@ _UUID = "11111111-2222-3333-4444-555555555555"
 
 
 class TestMCPProviderUpdatePayloadProviderIdIsUUID:
-    def test_accepts_valid_uuid(self):
+    def test_accepts_valid_uuid(self) -> None:
         payload = MCPProviderUpdatePayload(
             provider_id=_UUID,
             server_url="https://example.test",
@@ -34,7 +34,7 @@ class TestMCPProviderUpdatePayloadProviderIdIsUUID:
         )
         assert payload.provider_id == _UUID
 
-    def test_rejects_non_uuid_string(self):
+    def test_rejects_non_uuid_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPProviderUpdatePayload(
                 provider_id="fast-mcp",
@@ -46,7 +46,7 @@ class TestMCPProviderUpdatePayloadProviderIdIsUUID:
             )
         assert "provider_id" in str(exc_info.value)
 
-    def test_rejects_empty_string(self):
+    def test_rejects_empty_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPProviderUpdatePayload(
                 provider_id="",
@@ -60,20 +60,20 @@ class TestMCPProviderUpdatePayloadProviderIdIsUUID:
 
 
 class TestMCPProviderDeletePayloadProviderIdIsUUID:
-    def test_accepts_valid_uuid(self):
+    def test_accepts_valid_uuid(self) -> None:
         assert MCPProviderDeletePayload(provider_id=_UUID).provider_id == _UUID
 
-    def test_rejects_non_uuid_string(self):
+    def test_rejects_non_uuid_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPProviderDeletePayload(provider_id="not-a-uuid")
         assert "provider_id" in str(exc_info.value)
 
 
 class TestMCPAuthPayloadProviderIdIsUUID:
-    def test_accepts_valid_uuid(self):
+    def test_accepts_valid_uuid(self) -> None:
         assert MCPAuthPayload(provider_id=_UUID).provider_id == _UUID
 
-    def test_rejects_non_uuid_string(self):
+    def test_rejects_non_uuid_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             MCPAuthPayload(provider_id="not-a-uuid")
         assert "provider_id" in str(exc_info.value)

--- a/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_mcp_provider_id_uuid.py
@@ -1,0 +1,79 @@
+"""Regression tests for #41649.
+
+The MCP provider Pydantic payloads used to accept any string as
+``provider_id``. The PUT/DELETE/auth endpoints would then pass that
+string to SQLAlchemy, which raised a Postgres
+``InvalidTextRepresentation: invalid input syntax for type uuid: "fast-mcp"``
+and bubbled back as a generic 500. The fix validates ``provider_id`` as
+a UUID at the Pydantic layer so the API returns a clean 400 instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from controllers.console.workspace.tool_providers import (
+    MCPAuthPayload,
+    MCPProviderDeletePayload,
+    MCPProviderUpdatePayload,
+)
+
+_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+class TestMCPProviderUpdatePayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        payload = MCPProviderUpdatePayload(
+            provider_id=_UUID,
+            server_url="https://example.test",
+            name="n",
+            icon="i",
+            icon_type="emoji",
+            server_identifier="fast-mcp",
+        )
+        assert payload.provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderUpdatePayload(
+                provider_id="fast-mcp",
+                server_url="https://example.test",
+                name="n",
+                icon="i",
+                icon_type="emoji",
+                server_identifier="fast-mcp",
+            )
+        assert "provider_id" in str(exc_info.value)
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderUpdatePayload(
+                provider_id="",
+                server_url="https://example.test",
+                name="n",
+                icon="i",
+                icon_type="emoji",
+                server_identifier="fast-mcp",
+            )
+        assert "provider_id" in str(exc_info.value)
+
+
+class TestMCPProviderDeletePayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        assert MCPProviderDeletePayload(provider_id=_UUID).provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPProviderDeletePayload(provider_id="not-a-uuid")
+        assert "provider_id" in str(exc_info.value)
+
+
+class TestMCPAuthPayloadProviderIdIsUUID:
+    def test_accepts_valid_uuid(self):
+        assert MCPAuthPayload(provider_id=_UUID).provider_id == _UUID
+
+    def test_rejects_non_uuid_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MCPAuthPayload(provider_id="not-a-uuid")
+        assert "provider_id" in str(exc_info.value)

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.plugin.entities.plugin_daemon import CredentialType
+from core.plugin.impl.exc import PluginDaemonNotFoundError, PluginNotFoundError
 from core.tools.__base.tool_runtime import ToolRuntime
 from core.tools.entities.tool_entities import (
     ApiProviderAuthType,
@@ -296,6 +297,39 @@ def test_get_plugin_provider_raises_when_provider_missing():
         with patch("core.tools.tool_manager.contexts.plugin_tool_providers_lock", lock_context):
             with patch("core.tools.tool_manager.PluginToolManager") as mock_manager_cls:
                 mock_manager_cls.return_value.fetch_tool_provider.return_value = None
+                with pytest.raises(ToolProviderNotFoundError, match="plugin provider provider-a not found"):
+                    ToolManager.get_plugin_provider("provider-a", "tenant-1")
+
+
+@pytest.mark.parametrize(
+    "daemon_error",
+    [
+        # The plugin daemon's typed "plugin not found" — happens when the
+        # builtin credential endpoint is hit with a provider name that
+        # neither the builtin nor the plugin manager owns.
+        PluginNotFoundError("plugin not found"),
+        # The lower-level daemon unreachable variant.
+        PluginDaemonNotFoundError("daemon not reachable"),
+    ],
+)
+def test_get_plugin_provider_translates_plugin_not_found_to_domain_error(daemon_error):
+    """#41805: ``ToolManager.get_builtin_provider`` falls back to
+    ``PluginToolManager.fetch_tool_provider``. The pre-fix code let the
+    plugin daemon's ``PluginNotFoundError`` bubble up to the console API
+    generic exception handler as a 500. Translate it to
+    ``ToolProviderNotFoundError`` at this boundary so the API returns a
+    controlled 4xx, consistent with the missing-provider path the
+    existing ``test_get_plugin_provider_raises_when_provider_missing``
+    test already covers.
+    """
+    provider_context = _SimpleContextVar()
+    lock_context = _SimpleContextVar()
+    lock_context.set(threading.Lock())
+
+    with patch("core.tools.tool_manager.contexts.plugin_tool_providers", provider_context):
+        with patch("core.tools.tool_manager.contexts.plugin_tool_providers_lock", lock_context):
+            with patch("core.tools.tool_manager.PluginToolManager") as mock_manager_cls:
+                mock_manager_cls.return_value.fetch_tool_provider.side_effect = daemon_error
                 with pytest.raises(ToolProviderNotFoundError, match="plugin provider provider-a not found"):
                     ToolManager.get_plugin_provider("provider-a", "tenant-1")
 

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
+from typing import cast
 
 import pytest
 
@@ -21,8 +23,19 @@ def _make_handler_with_formatter() -> logging.Handler:
     return handler
 
 
+# ``logging.Formatter.converter`` is a runtime attribute that the type stubs
+# type as ``object``. We know it is always a callable from ``time.localtime`` /
+# ``time.gmtime`` that returns a ``time.struct_time``-compatible tuple.
+FormatterConverter = Callable[[float], time.struct_time]
+
+
+def _formatter_converter(formatter: logging.Formatter | None) -> FormatterConverter:
+    assert formatter is not None
+    return cast(FormatterConverter, formatter.converter)
+
+
 class TestApplyTimezoneToSqlalchemyLoggers:
-    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -30,22 +43,22 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # JSON output: converter must remain the default (local time).
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert handler.formatter.converter is logging.Formatter.converter
+            assert _formatter_converter(handler.formatter) is logging.Formatter.converter
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
@@ -56,7 +69,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
             # The formatter's converter must now produce a Tokyo-time tuple
             # from a fixed timestamp, not local time.
             local_tuple = time.localtime(_FIXED_TS)
-            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            tokyo_tuple = _formatter_converter(handler.formatter)(_FIXED_TS)
             assert tokyo_tuple != local_tuple
 
             # Sanity: the offset must be Tokyo (+09:00) at that instant.
@@ -65,7 +78,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         engine_handler = _make_handler_with_formatter()
         pool_handler = _make_handler_with_formatter()
@@ -75,13 +88,13 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         log_pool.addHandler(pool_handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            assert engine_handler.formatter.converter is not logging.Formatter.converter
-            assert pool_handler.formatter.converter is not logging.Formatter.converter
+            assert _formatter_converter(engine_handler.formatter) is not logging.Formatter.converter
+            assert _formatter_converter(pool_handler.formatter) is not logging.Formatter.converter
         finally:
             log_engine.removeHandler(engine_handler)
             log_pool.removeHandler(pool_handler)
 
-    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A handler with no formatter must be left alone (we only patch
         existing ``logging.Formatter`` instances), and the call must not raise.
         """
@@ -96,22 +109,23 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")
         log.addHandler(handler)
         try:
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
-            converter_after_first_call = handler.formatter.converter
+            converter_after_first_call = _formatter_converter(handler.formatter)
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             ext_logging.apply_timezone_to_sqlalchemy_loggers()
             # The converter must be stable across repeated calls (the same
             # ``time_converter`` closure rebinds each time, but the only
             # guarantee we need is that the formatter remains patched and
             # keeps producing a non-local tuple).
-            assert handler.formatter.converter is not logging.Formatter.converter
-            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            converter = _formatter_converter(handler.formatter)
+            assert converter is not logging.Formatter.converter
+            assert converter(_FIXED_TS)[3] == 7  # hour in Tokyo
             del converter_after_first_call
         finally:
             log.removeHandler(handler)

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -8,7 +8,6 @@ import pytest
 from extensions import ext_logging
 from tests.unit_tests.config_override import apply_config_overrides
 
-
 # Captures a fixed instant so the test is timezone-independent of the host clock.
 _FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
 
@@ -46,9 +45,7 @@ class TestApplyTimezoneToSqlalchemyLoggers:
         finally:
             log.removeHandler(handler)
 
-    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(self, monkeypatch: pytest.MonkeyPatch):
         apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
         handler = _make_handler_with_formatter()
         log = logging.getLogger("sqlalchemy.engine")

--- a/api/tests/unit_tests/extensions/test_ext_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_logging.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from extensions import ext_logging
+from tests.unit_tests.config_override import apply_config_overrides
+
+
+# Captures a fixed instant so the test is timezone-independent of the host clock.
+_FIXED_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
+
+
+def _make_handler_with_formatter() -> logging.Handler:
+    """Build a StreamHandler with a default text formatter, mirroring what
+    SQLAlchemy attaches to ``sqlalchemy.engine`` when ``SQLALCHEMY_ECHO`` is on.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt="%(asctime)s %(message)s"))
+    return handler
+
+
+class TestApplyTimezoneToSqlalchemyLoggers:
+    def test_no_op_when_output_format_is_json(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="json", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # JSON output: converter must remain the default (local time).
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_no_op_when_log_tz_is_unset(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert handler.formatter.converter is logging.Formatter.converter
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_converter_to_sqlalchemy_engine_handler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+
+            # The formatter's converter must now produce a Tokyo-time tuple
+            # from a fixed timestamp, not local time.
+            local_tuple = time.localtime(_FIXED_TS)
+            tokyo_tuple = handler.formatter.converter(_FIXED_TS)
+            assert tokyo_tuple != local_tuple
+
+            # Sanity: the offset must be Tokyo (+09:00) at that instant.
+            assert tokyo_tuple.tm_hour == 7
+            assert time.strftime("%Y-%m-%d %H:%M:%S", tokyo_tuple) == "2023-11-15 07:13:20"
+        finally:
+            log.removeHandler(handler)
+
+    def test_applies_timezone_to_subloggers(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        engine_handler = _make_handler_with_formatter()
+        pool_handler = _make_handler_with_formatter()
+        log_engine = logging.getLogger("sqlalchemy.engine")
+        log_pool = logging.getLogger("sqlalchemy.pool")
+        log_engine.addHandler(engine_handler)
+        log_pool.addHandler(pool_handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            assert engine_handler.formatter.converter is not logging.Formatter.converter
+            assert pool_handler.formatter.converter is not logging.Formatter.converter
+        finally:
+            log_engine.removeHandler(engine_handler)
+            log_pool.removeHandler(pool_handler)
+
+    def test_handles_handler_without_formatter(self, monkeypatch: pytest.MonkeyPatch):
+        """A handler with no formatter must be left alone (we only patch
+        existing ``logging.Formatter`` instances), and the call must not raise.
+        """
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = logging.StreamHandler()  # no formatter set
+        assert handler.formatter is None
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()  # must not raise
+            assert handler.formatter is None
+        finally:
+            log.removeHandler(handler)
+
+    def test_is_idempotent(self, monkeypatch: pytest.MonkeyPatch):
+        apply_config_overrides(monkeypatch, LOG_OUTPUT_FORMAT="text", LOG_TZ="Asia/Tokyo")
+        handler = _make_handler_with_formatter()
+        log = logging.getLogger("sqlalchemy.engine")
+        log.addHandler(handler)
+        try:
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            converter_after_first_call = handler.formatter.converter
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            ext_logging.apply_timezone_to_sqlalchemy_loggers()
+            # The converter must be stable across repeated calls (the same
+            # ``time_converter`` closure rebinds each time, but the only
+            # guarantee we need is that the formatter remains patched and
+            # keeps producing a non-local tuple).
+            assert handler.formatter.converter is not logging.Formatter.converter
+            assert handler.formatter.converter(_FIXED_TS)[3] == 7  # hour in Tokyo
+            del converter_after_first_call
+        finally:
+            log.removeHandler(handler)


### PR DESCRIPTION
Fixes #41805

## What problem does this PR solve?

`ToolManager.get_builtin_provider` falls back to `PluginToolManager.fetch_tool_provider` when the requested identifier isn't in the builtin cache. The plugin daemon raises `PluginNotFoundError` (and the lower-level `PluginDaemonNotFoundError`) when the provider is unknown to it, and neither was caught at the boundary. The error bubbled up to the console API generic exception handler as a 500.

## What is changed and how it works?

Translate both to `ToolProviderNotFoundError` at the `get_plugin_provider` boundary so the API returns a controlled 4xx (response matches the existing "missing provider" path that already returns `ToolProviderNotFoundError`). This is defense in depth behind the frontend fixes in #40686 and #41088 — the Agent V2 MCP-server-id path referenced in the report is no longer exercised, but any other caller hitting the builtin credential endpoints with a non-builtin identifier now gets a clean 4xx instead of a 500.

## How it was tested?

```
$ uv run pytest tests/unit_tests/core/tools/test_tool_manager.py -o addopts=
46 passed
```

1 new test (parameterized over both daemon error types):
- `test_get_plugin_provider_translates_plugin_not_found_to_domain_error[daemon_error0]` — `PluginNotFoundError`
- `test_get_plugin_provider_translates_plugin_not_found_to_domain_error[daemon_error1]` — `PluginDaemonNotFoundError`

Both confirm the exception is wrapped to `ToolProviderNotFoundError` matching the "plugin provider <name> not found" message. The existing `test_get_plugin_provider_raises_when_provider_missing` test unchanged (covers the `None`-from-fetch path).