### PR TITLE
test(api): cover disabled sensitive-word avoidance extras

### DIFF
--- a/api/tests/unit_tests/core/app/app_config/common/test_sensitive_word_avoidance_manager.py
+++ b/api/tests/unit_tests/core/app/app_config/common/test_sensitive_word_avoidance_manager.py
@@ -95,6 +95,8 @@ class TestSensitiveWordAvoidanceConfigManagerValidateAndSetDefaults:
         "config",
         [
             {"sensitive_word_avoidance": {"enabled": False}},
+            {"sensitive_word_avoidance": {"enabled": False, "type": "", "config": {}}},
+            {"sensitive_word_avoidance": {"enabled": False, "type": "keywords", "config": {"k": "v"}}},
             {"sensitive_word_avoidance": {"enabled": None}},
             {"sensitive_word_avoidance": {}},
         ],
@@ -106,7 +108,7 @@ class TestSensitiveWordAvoidanceConfigManagerValidateAndSetDefaults:
         )
 
         # Assert
-        assert result_config["sensitive_word_avoidance"]["enabled"] is False
+        assert result_config["sensitive_word_avoidance"] == {"enabled": False}
 
     def test_validate_raises_when_enabled_true_without_type(self):
         config = {"sensitive_word_avoidance": {"enabled": True}}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Add regression coverage for disabled `sensitive_word_avoidance` payloads that include legacy `type` and `config` fields. The cases verify that empty and populated extras normalize to `{"enabled": false}` without a validation error.

Fixes #38409

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods