### PR TITLE
refactor(web): dep-inject the passport query with @model_validate

### DIFF
--- a/api/controllers/web/passport.py
+++ b/api/controllers/web/passport.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import NotFound, Unauthorized
 
 from constants import HEADER_NAME_APP_CODE
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
+from controllers.console.wraps import model_validate
 from controllers.web import web_ns
 from controllers.web.error import WebAppAuthRequiredError
 from extensions.ext_application_services import application_services
@@ -48,12 +49,12 @@ class PassportResource(Resource):
         }
     )
     @web_ns.response(200, "Passport retrieved successfully", web_ns.models[PassportAccessTokenResponse.__name__])
-    def get(self):
+    @model_validate(PassportQuery)
+    def get(self, query: PassportQuery):
         app_code = request.headers.get(HEADER_NAME_APP_CODE)
         if app_code is None:
             raise Unauthorized("X-App-Code header is missing.")
 
-        query = PassportQuery.model_validate(request.args.to_dict(flat=True))
         passport_request = WebPassportRequest(
             app_code=app_code,
             user_session_id=query.user_id,

--- a/api/tests/unit_tests/controllers/web/test_web_passport.py
+++ b/api/tests/unit_tests/controllers/web/test_web_passport.py
@@ -1,6 +1,5 @@
 """Unit tests for the thin web-passport Flask adapter."""
 
-from inspect import unwrap
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -31,7 +30,7 @@ def test_passport_resource_parses_input_and_serializes_result(app: Flask) -> Non
         patch("controllers.web.passport.application_services", return_value=services),
         patch("controllers.web.passport.extract_webapp_access_token", return_value="login-token"),
     ):
-        result = unwrap(PassportResource.get)(PassportResource())
+        result = PassportResource().get()
 
     assert result == {"access_token": "issued-token"}
     service.issue.assert_called_once_with(
@@ -41,7 +40,7 @@ def test_passport_resource_parses_input_and_serializes_result(app: Flask) -> Non
 
 def test_passport_resource_requires_app_code(app: Flask) -> None:
     with app.test_request_context("/passport"), pytest.raises(Unauthorized, match="X-App-Code"):
-        unwrap(PassportResource.get)(PassportResource())
+        PassportResource().get()
 
 
 @pytest.mark.parametrize(
@@ -66,4 +65,4 @@ def test_passport_resource_translates_application_errors(
         patch("controllers.web.passport.application_services", return_value=services),
         pytest.raises(http_error),
     ):
-        unwrap(PassportResource.get)(PassportResource())
+        PassportResource().get()


### PR DESCRIPTION
## Summary

Part of #36659. Converts `PassportResource.get`'s query parse to the `@model_validate` decorator.

| File | Handler | Model |
|---|---|---|
| `api/controllers/web/passport.py` | `PassportResource.get` | `PassportQuery` |

The old call is `PassportQuery.model_validate(request.args.to_dict(flat=True))`, which is byte-for-byte what the decorator's GET branch does.

Claimed in https://github.com/langgenius/dify/issues/36659#issuecomment-5549807073.

## Why the guard reorder is safe here

The decorator runs before the handler's `X-App-Code` check, which would normally be a behaviour change — a bad query string on a request with no app code would return 422 instead of 401. It cannot happen in this handler:

```python
class PassportQuery(BaseModel):
    user_id: str | None = Field(default=None, description="End user session ID")
```

One optional `str` field, and the input is always `dict[str, str]` from `request.args`. No query string can make `model_validate` raise — I checked `{}`, `{"user_id": "x"}`, `{"user_id": ""}`, an unknown key, and a mix, and all validate. `test_passport_resource_requires_app_code` sends no query string and still gets its `Unauthorized`, which is the case that would have regressed.

## Test coverage

`test_web_passport.py` called the handler through `inspect.unwrap` at three sites, which strips every decorator — a straight conversion would have shipped the new layer completely unexercised. They are now bound calls, so the decorator is what supplies `query`. Verified by mutation: deleting the decorator fails all 5 tests.

No test was added or removed; the count is unchanged at 247 for the directory.

## Verification

Run locally against the changed surface; CI is the authority for the rest of the suite.

- `pytest tests/unit_tests/controllers/web/` — **247 passed**, identical to the `main` baseline (pure conversion, no test added)
- Mutation-checked: deleting the decorator fails 5 tests
- `ruff check` / `ruff format --check` — clean
- `pyrefly check controllers/web/passport.py` — 0 diagnostics
- `pyrefly --config tests/unit_tests/pyrefly.toml tests/unit_tests/controllers/web/` — 131 diagnostics, identical to the `main` baseline (**0 new**)
- `mypy --check-untyped-defs --disable-error-code=import-untyped` — no issues
- `lint-imports` 26 kept / 0 broken; `dev/lint_response_contracts.py --fail-on-mismatch` 0 mismatch
- `tests/unit_tests/test_config_overrides.py` AST guard — no violations
- no net-new `getattr(` in the diff

---
This PR was written with AI assistance.
