### PR TITLE
fix(agent): allow a conversation to continue after a cancelled tool call

### DIFF
--- a/dify-agent/docs/dify-agent/user-manual/history-layer/index.md
+++ b/dify-agent/docs/dify-agent/user-manual/history-layer/index.md
@@ -54,7 +54,9 @@ cancelled runs. A failure or cancellation before the capture contains any
 messages preserves the previously restored history. An interrupted capture can
 include a partial response or tool-return request marked `state="interrupted"`;
 pydantic-ai repairs that state when the snapshot is used by a later independent
-run. Without this layer, compaction and interrupted messages affect only the
+run. A run cancelled after the model returned tool calls but before any of them
+ran is also stored with that marker, so the calls it never executed do not block
+the next user prompt. Without this layer, compaction and interrupted messages affect only the
 current run.
 
 ## Resume a conversation
@@ -101,7 +103,10 @@ Dify Agent handles memory conservatively:
    the previously restored history remains unchanged.
 6. Run-level system instructions are removed before history is persisted.
 7. Interrupted partial messages retain pydantic-ai's `state="interrupted"` marker
-   so a later independent run can repair and continue from the checkpoint.
+   so a later independent run can repair and continue from the checkpoint. A
+   trailing response whose tool calls the interrupted run never executed is
+   stored with the same marker; a run that ends in a deferred tool request keeps
+   its open call so the next run can answer it.
 8. Failed and cancelled runs keep their terminal status; their snapshot is a
    checkpoint, not a successful continuation of the interrupted run.
 

--- a/dify-agent/src/dify_agent/runtime/history.py
+++ b/dify-agent/src/dify_agent/runtime/history.py
@@ -5,7 +5,10 @@ named ``history``. Current system instructions belong to each run and are never
 stored. Once Pydantic AI binds and builds messages in the run capture, its
 complete captured history replaces the layer for every terminal outcome,
 including interrupted runs. A failure or cancellation before the capture
-contains messages preserves the previously restored history.
+contains messages preserves the previously restored history. When a run is
+interrupted with tool calls the model returned but the run never executed, the
+stored history records that the response was cut short so the next run can close
+those calls out instead of refusing a new user prompt.
 """
 
 from __future__ import annotations
@@ -14,7 +17,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 from typing import Protocol
 
-from pydantic_ai.messages import ModelMessage, ModelRequest
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse
 
 from agenton_collections.layers.pydantic_ai import PYDANTIC_AI_HISTORY_LAYER_TYPE_ID, PydanticAIHistoryLayer
 from dify_agent.protocol import DIFY_AGENT_HISTORY_LAYER_ID
@@ -68,14 +71,42 @@ def get_history_layer(run: SupportsHistoryLayerLookup) -> PydanticAIHistoryLayer
 def replace_run_history(
     history_layer: PydanticAIHistoryLayer | None,
     messages: Sequence[ModelMessage],
+    *,
+    interrupted: bool = False,
 ) -> None:
-    """Persist a run's captured history without transient instructions."""
+    """Persist a run's captured history without transient instructions.
+
+    Set ``interrupted`` when the run did not reach a terminal result, so tool calls the run
+    never got to execute are marked as such for the next run.
+    """
     if history_layer is None:
         return
-    persistent_messages = [
+    persistent_messages: list[ModelMessage] = [
         replace(message, instructions=None) if isinstance(message, ModelRequest) else message for message in messages
     ]
+    if interrupted:
+        persistent_messages = _mark_trailing_tool_calls_interrupted(persistent_messages)
     history_layer.replace_messages(persistent_messages)
+
+
+def _mark_trailing_tool_calls_interrupted(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Record that a final response's tool calls were never executed.
+
+    A run cancelled between the model returning tool calls and the first tool result leaves a
+    ``'complete'`` response whose calls have no matching result. Pydantic AI closes such calls
+    out with synthesized returns on the next run only when that tail is marked
+    ``'interrupted'``; otherwise it rejects the next user prompt and the conversation cannot
+    continue. A run that ends in ``DeferredToolRequests`` keeps its open calls, which is why
+    this is applied to interrupted runs only.
+    """
+    if not messages:
+        return messages
+    last_message = messages[-1]
+    if not isinstance(last_message, ModelResponse) or last_message.state != "complete":
+        return messages
+    if not last_message.tool_calls:
+        return messages
+    return [*messages[:-1], replace(last_message, state="interrupted")]
 
 
 __all__ = [

--- a/dify-agent/src/dify_agent/runtime/runner.py
+++ b/dify-agent/src/dify_agent/runtime/runner.py
@@ -16,6 +16,8 @@ message history only through session state. Once pydantic-ai binds and builds
 messages in the run capture, every terminal outcome replaces that state with the
 captured messages after transient instructions are cleared; a failure or
 cancellation before the capture contains messages preserves the restored state.
+An interrupted run also records that its trailing response was cut short, so tool
+calls it never executed do not block the next user prompt.
 This preserves compaction rewrites and interrupted partial messages without
 saving current system prompts. An optional structured output layer named by
 ``DIFY_AGENT_OUTPUT_LAYER_ID`` is read after entry and resolved into an output
@@ -391,6 +393,7 @@ class AgentRunRunner:
                 run_timeout = asyncio.timeout(self.run_timeout_seconds)
                 try:
                     with capture_run_messages() as captured_messages:
+                        agent_run_finished = False
                         try:
                             async with run_timeout:
                                 result = await agent.run(
@@ -402,9 +405,12 @@ class AgentRunRunner:
                                     capabilities=[compaction] if compaction is not None else None,
                                     usage_limits=UsageLimits(request_limit=_MAX_AGENT_STEPS_PER_RUN),
                                 )
+                            agent_run_finished = True
                         finally:
                             if captured_messages:
-                                replace_run_history(history_layer, captured_messages)
+                                replace_run_history(
+                                    history_layer, captured_messages, interrupted=not agent_run_finished
+                                )
                 except TimeoutError as exc:
                     if not run_timeout.expired():
                         raise

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -21,7 +21,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.function import DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults
 from pydantic_ai.usage import UsageLimits
@@ -3269,3 +3269,149 @@ def test_runner_treats_invalid_shell_snapshot_offsets_as_validation_error() -> N
 
     assert [event.type for event in sink.events["run-invalid-shell-offset"]] == ["run_started", "run_failed"]
     assert sink.statuses["run-invalid-shell-offset"] == "failed"
+
+
+def _request_with_tool_layer(user: str) -> CreateRunRequest:
+    request = _request(user, include_history=True)
+    request.composition.layers.append(
+        RunLayerSpec(
+            name="tools",
+            type=DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID,
+            deps={"execution_context": "execution_context"},
+            config=DifyPluginToolsLayerConfig(
+                tools=[
+                    DifyPluginToolConfig(
+                        plugin_id="langgenius/tools",
+                        provider="search",
+                        tool_name="web_search",
+                        credential_type="api-key",
+                        parameters=_prepared_plugin_tool_parameters(),
+                        parameters_json_schema=_prepared_plugin_tool_schema(),
+                    )
+                ]
+            ),
+        )
+    )
+    return request
+
+
+def _install_tool_calling_model_and_blocking_tool(monkeypatch: pytest.MonkeyPatch, tool_started: asyncio.Event) -> None:
+    async def blocking_tool(query: str) -> str:
+        del query
+        _ = tool_started.set()
+        await asyncio.Event().wait()
+        return "unreachable"
+
+    async def call_web_search(_messages: list[ModelMessage], _info: object) -> AsyncIterator[DeltaToolCalls]:
+        yield {
+            0: DeltaToolCall(
+                name="web_search",
+                json_args='{"query": "dify"}',
+                tool_call_id="call-1",
+            )
+        }
+
+    async def fake_get_tools(
+        _self: DifyPluginToolsLayer,
+        *,
+        http_client: httpx.AsyncClient,
+        dify_api_http_client: httpx.AsyncClient,
+    ) -> list[Tool[object]]:
+        del http_client, dify_api_http_client
+        return [Tool(blocking_tool, name="web_search")]
+
+    def fake_get_model(_self: DifyPluginLLMLayer, *, http_client: httpx.AsyncClient, agent_run_id: str):
+        del http_client, agent_run_id
+        return FunctionModel(stream_function=call_web_search)
+
+    monkeypatch.setattr(DifyPluginLLMLayer, "get_model", fake_get_model)
+    monkeypatch.setattr(DifyPluginToolsLayer, "get_tools", fake_get_tools)
+
+
+def test_runner_marks_unexecuted_tool_calls_when_run_is_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool_started = asyncio.Event()
+    _install_tool_calling_model_and_blocking_tool(monkeypatch, tool_started)
+    sink = InMemoryRunEventSink()
+
+    async def scenario() -> AgentRunRunner:
+        async with httpx.AsyncClient() as client:
+            runner = AgentRunRunner(
+                sink=sink,
+                request=_request_with_tool_layer("find something"),
+                run_id="run-cancel-tool-call",
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+            )
+            task = asyncio.create_task(runner.run())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            _ = task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            return runner
+
+    runner = asyncio.run(scenario())
+
+    assert runner.terminal_session_snapshot is not None
+    saved_history = _history_messages_from_snapshot(runner.terminal_session_snapshot)
+    pending_response = saved_history[-1]
+    assert isinstance(pending_response, ModelResponse)
+    assert pending_response.state == "interrupted"
+    assert [part.tool_call_id for part in pending_response.tool_calls] == ["call-1"]
+
+
+def test_runner_continues_conversation_after_a_cancelled_tool_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool_started = asyncio.Event()
+    _install_tool_calling_model_and_blocking_tool(monkeypatch, tool_started)
+    sink = InMemoryRunEventSink()
+
+    async def scenario() -> AgentRunRunner:
+        async with httpx.AsyncClient() as client:
+            cancelled_runner = AgentRunRunner(
+                sink=sink,
+                request=_request_with_tool_layer("find something"),
+                run_id="run-cancel-first",
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+            )
+            task = asyncio.create_task(cancelled_runner.run())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            _ = task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert cancelled_runner.terminal_session_snapshot is not None
+
+            async def answer(_messages: list[ModelMessage], _info: object) -> AsyncIterator[str]:
+                yield "second answer"
+
+            def fake_get_model(_self: DifyPluginLLMLayer, *, http_client: httpx.AsyncClient, agent_run_id: str):
+                del http_client, agent_run_id
+                return FunctionModel(stream_function=answer)
+
+            monkeypatch.setattr(DifyPluginLLMLayer, "get_model", fake_get_model)
+            follow_up = _request_with_tool_layer("what happened?")
+            follow_up.session_snapshot = cancelled_runner.terminal_session_snapshot
+            follow_up_runner = AgentRunRunner(
+                sink=sink,
+                request=follow_up,
+                run_id="run-continue",
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+            )
+            await follow_up_runner.run()
+            return follow_up_runner
+
+    follow_up_runner = asyncio.run(scenario())
+
+    terminal = sink.events["run-continue"][-1]
+    assert isinstance(terminal, RunSucceededEvent)
+    assert terminal.data.output == "second answer"
+    assert follow_up_runner.terminal_session_snapshot is not None
+    saved_history = _history_messages_from_snapshot(follow_up_runner.terminal_session_snapshot)
+    interrupted_returns = [
+        part
+        for part in _flatten_message_parts(saved_history)
+        if isinstance(part, ToolReturnPart) and part.tool_call_id == "call-1"
+    ]
+    assert len(interrupted_returns) == 1
+    assert interrupted_returns[0].outcome == "interrupted"

--- a/dify-agent/tests/local/dify_agent/runtime/test_runtime_history.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runtime_history.py
@@ -1,7 +1,14 @@
 import asyncio
 
 import pytest
-from pydantic_ai.messages import ModelRequest, ModelResponse, SystemPromptPart, TextPart, UserPromptPart
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    UserPromptPart,
+)
 
 from agenton.compositor import Compositor, LayerNode
 from agenton_collections.layers.pydantic_ai import (
@@ -112,3 +119,51 @@ def test_replace_run_history_persists_full_history_without_instructions() -> Non
     source_request = messages[0]
     assert isinstance(source_request, ModelRequest)
     assert source_request.instructions == "current instructions"
+
+
+def test_replace_run_history_marks_unexecuted_tool_calls_of_an_interrupted_run() -> None:
+    history_layer = PydanticAIHistoryLayer()
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="run a search")]),
+        ModelResponse(parts=[ToolCallPart(tool_name="search", args={}, tool_call_id="call-1")]),
+    ]
+
+    replace_run_history(history_layer, messages, interrupted=True)
+
+    persisted = history_layer.message_history
+    assert len(persisted) == 2
+    persisted_response = persisted[-1]
+    assert isinstance(persisted_response, ModelResponse)
+    assert persisted_response.state == "interrupted"
+    assert persisted_response.parts == messages[1].parts
+    source_response = messages[1]
+    assert isinstance(source_response, ModelResponse)
+    assert source_response.state == "complete"
+
+
+def test_replace_run_history_keeps_open_tool_calls_of_a_finished_run() -> None:
+    history_layer = PydanticAIHistoryLayer()
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="ask me something")]),
+        ModelResponse(parts=[ToolCallPart(tool_name="ask_human", args={}, tool_call_id="call-1")]),
+    ]
+
+    replace_run_history(history_layer, messages)
+
+    persisted_response = history_layer.message_history[-1]
+    assert isinstance(persisted_response, ModelResponse)
+    assert persisted_response.state == "complete"
+
+
+def test_replace_run_history_leaves_an_interrupted_run_without_tool_calls_alone() -> None:
+    history_layer = PydanticAIHistoryLayer()
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="hello")]),
+        ModelResponse(parts=[TextPart(content="partial")]),
+    ]
+
+    replace_run_history(history_layer, messages, interrupted=True)
+
+    persisted_response = history_layer.message_history[-1]
+    assert isinstance(persisted_response, ModelResponse)
+    assert persisted_response.state == "complete"


### PR DESCRIPTION
## Summary

Fixes #41616

Stopping an Agent run while a tool call is still in flight leaves the conversation stuck. The next message in the same conversation fails with:

```
Cannot provide a new user prompt when the message history contains unprocessed tool calls
```

and the only way forward is to start a new conversation.

Pydantic AI already repairs dangling tool calls, but only when the tail of the stored history is marked `state="interrupted"`. It sets that marker in two situations: a streamed response cancelled mid-generation, and `CallToolsNode` appending an interrupted `ModelRequest` when it has already collected some tool returns. Neither one covers the window the issue describes, where the run is cancelled after the model has returned its tool calls and before the first tool produced a result. Nothing gets appended, and the trailing `ModelResponse` is still `state="complete"`. `replace_run_history` stores it as is, so the next run sees open tool calls it is not allowed to repair and refuses the new prompt.

So the gap is on the persistence side. `AgentRunRunner` now tells `replace_run_history` whether the agent run actually finished, and a run that did not finish stores its trailing response as `state="interrupted"` when that response carries tool calls. The next run closes those calls out with synthesized interrupted tool returns, which is the history shape the issue asks for:

```
user -> assistant -> tool_call -> tool_result (interrupted) -> new user prompt
```

Runs that finish are left alone. That part matters for the `ask_human` flow: it ends successfully with an open tool call that `deferred_tool_results` has to answer on resume, and marking that one interrupted would break resumption.

## Tests

Three unit tests on `replace_run_history` cover the interrupted case, the finished-with-open-call case, and an interrupted run with no tool calls.

Two runner tests drive the real pydantic-ai agent through the reported scenario: a model that streams a tool call, a tool that blocks, and a cancelled run. One asserts the persisted response is marked interrupted, the other sends a follow-up prompt on the resulting snapshot and asserts the run succeeds with an interrupted tool return for the abandoned call. Both fail on `main` with the exact error from the issue.

Ran from `dify-agent/`: `ruff check .`, `ruff format --check`, `basedpyright --level error src examples tests`, and `pytest tests/local` (824 passed; the 4 remaining failures are pre-existing on `main` in this Windows checkout and are unrelated to this change).

## Screenshots

Not applicable, this is a backend runtime change.

## Checklist

- [x] This change requires a documentation update, included: the history-layer page under `dify-agent/docs` is updated in this PR. No change needed in [Dify Document](https://github.com/langgenius/dify-docs).
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran the `dify-agent` equivalents of the lint gates (`make check`, `make typecheck`, `make test`). No frontend files are touched, so `vp staged` does not apply.
