### PR TITLE
refactor(models): remove legacy db.session properties from Conversation

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1333,10 +1333,6 @@ class Conversation(Base):
 
         return model_config
 
-    @property
-    def summary_or_query(self):
-        return self.summary_or_query_with_session(session=db.session())
-
     def summary_or_query_with_session(self, *, session: Session) -> str:
         if self.summary:
             return self.summary
@@ -1347,40 +1343,20 @@ class Conversation(Base):
             else:
                 return ""
 
-    @property
-    def annotated(self) -> bool:
-        return self.annotated_with_session(session=db.session())
-
     def annotated_with_session(self, *, session: Session) -> bool:
         return (
             session.scalar(select(func.count(MessageAnnotation.id)).where(MessageAnnotation.conversation_id == self.id))
             or 0
         ) > 0
 
-    @property
-    def annotation(self) -> MessageAnnotation | None:
-        return self.annotation_with_session(session=db.session())
-
     def annotation_with_session(self, *, session: Session) -> MessageAnnotation | None:
         return session.scalar(select(MessageAnnotation).where(MessageAnnotation.conversation_id == self.id).limit(1))
-
-    @property
-    def message_count(self) -> int:
-        return self.message_count_with_session(session=db.session())
 
     def message_count_with_session(self, *, session: Session) -> int:
         return session.scalar(select(func.count(Message.id)).where(Message.conversation_id == self.id)) or 0
 
-    @property
-    def user_feedback_stats(self) -> dict[str, int]:
-        return self.user_feedback_stats_with_session(session=db.session())
-
     def user_feedback_stats_with_session(self, *, session: Session) -> dict[str, int]:
         return self._feedback_stats_with_session(session=session, from_source=FeedbackFromSource.USER)
-
-    @property
-    def admin_feedback_stats(self) -> dict[str, int]:
-        return self.admin_feedback_stats_with_session(session=db.session())
 
     def admin_feedback_stats_with_session(self, *, session: Session) -> dict[str, int]:
         return self._feedback_stats_with_session(session=session, from_source=FeedbackFromSource.ADMIN)
@@ -1409,10 +1385,6 @@ class Conversation(Base):
         )
 
         return {"like": like, "dislike": dislike}
-
-    @property
-    def status_count(self):
-        return self.status_count_with_session(session=db.session())
 
     def status_count_with_session(self, *, session: Session) -> dict[str, int] | None:
         from models.workflow import WorkflowRun
@@ -1468,10 +1440,6 @@ class Conversation(Base):
             "paused": status_counts[WorkflowExecutionStatus.PAUSED],
         }
 
-    @property
-    def first_message(self) -> Message | None:
-        return self.first_message_with_session(session=db.session())
-
     def first_message_with_session(self, *, session: Session) -> Message | None:
         return session.scalar(
             select(Message).where(Message.conversation_id == self.id).order_by(Message.created_at.asc())
@@ -1482,10 +1450,6 @@ class Conversation(Base):
         with Session(db.engine, expire_on_commit=False) as session:
             return session.scalar(select(App).where(App.id == self.app_id))
 
-    @property
-    def from_end_user_session_id(self) -> str | None:
-        return self.from_end_user_session_id_with_session(session=db.session())
-
     def from_end_user_session_id_with_session(self, *, session: Session) -> str | None:
         if self.from_end_user_id:
             end_user = session.scalar(select(EndUser).where(EndUser.id == self.from_end_user_id))
@@ -1493,10 +1457,6 @@ class Conversation(Base):
                 return end_user.session_id
 
         return None
-
-    @property
-    def from_account_name(self) -> str | None:
-        return self.from_account_name_with_session(session=db.session())
 
     def from_account_name_with_session(self, *, session: Session) -> str | None:
         if self.from_account_id:

--- a/api/tests/test_containers_integration_tests/models/test_conversation_status_count.py
+++ b/api/tests/test_containers_integration_tests/models/test_conversation_status_count.py
@@ -1,5 +1,5 @@
 """
-Integration tests for Conversation.status_count and Site.generate_code model properties.
+Integration tests for Conversation.status_count_with_session and Site.generate_code.
 
 Migrated from unit_tests/models/test_app_models.py TestConversationStatusCount and
 test_site_generate_code, replacing db.session.scalars mocks with real PostgreSQL queries.
@@ -18,7 +18,7 @@ from models.workflow import Workflow, WorkflowRun, WorkflowRunTriggeredFrom, Wor
 
 
 class TestConversationStatusCount:
-    """Integration tests for Conversation.status_count property."""
+    """Integration tests for Conversation.status_count_with_session."""
 
     @pytest.fixture(autouse=True)
     def _auto_rollback(self, db_session_with_containers: Session) -> Generator[None, None, None]:
@@ -130,7 +130,7 @@ class TestConversationStatusCount:
         app = self._create_app(db_session_with_containers, tenant_id, created_by)
         conversation = self._create_conversation(db_session_with_containers, app)
 
-        result = conversation.status_count
+        result = conversation.status_count_with_session(session=db_session_with_containers)
 
         assert result is None
 
@@ -145,7 +145,7 @@ class TestConversationStatusCount:
         conversation = self._create_conversation(db_session_with_containers, app)
         self._create_message(db_session_with_containers, app, conversation, workflow_run_id=None)
 
-        result = conversation.status_count
+        result = conversation.status_count_with_session(session=db_session_with_containers)
 
         assert result is None
 
@@ -162,7 +162,7 @@ class TestConversationStatusCount:
         )
         self._create_message(db_session_with_containers, app, conversation, workflow_run_id=run.id)
 
-        result = conversation.status_count
+        result = conversation.status_count_with_session(session=db_session_with_containers)
 
         assert result is not None
         assert result["success"] == 1
@@ -183,7 +183,7 @@ class TestConversationStatusCount:
         )
         self._create_message(db_session_with_containers, app, conversation, workflow_run_id=run.id)
 
-        result = conversation.status_count
+        result = conversation.status_count_with_session(session=db_session_with_containers)
 
         assert result is not None
         assert result["success"] == 0
@@ -204,7 +204,7 @@ class TestConversationStatusCount:
         )
         self._create_message(db_session_with_containers, app, conversation, workflow_run_id=run.id)
 
-        result = conversation.status_count
+        result = conversation.status_count_with_session(session=db_session_with_containers)
 
         assert result is not None
         assert result["success"] == 0
@@ -230,7 +230,7 @@ class TestConversationStatusCount:
             run = self._create_workflow_run(db_session_with_containers, app, workflow, status, created_by)
             self._create_message(db_session_with_containers, app, conversation, workflow_run_id=run.id)
 
-        result = conversation.status_count
+        result = conversation.status_count_with_session(session=db_session_with_containers)
 
         assert result is not None
         assert result["success"] == 1
@@ -255,7 +255,7 @@ class TestConversationStatusCount:
         # Message references that run but is in a conversation under app
         self._create_message(db_session_with_containers, app, conversation, workflow_run_id=other_run.id)
 
-        result = conversation.status_count
+        result = conversation.status_count_with_session(session=db_session_with_containers)
 
         # The run should be excluded because app_id filter doesn't match
         assert result is not None

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -541,8 +541,9 @@ class TestConversationModel:
         # Assert
         assert conversation._inputs == inputs
 
-    def test_conversation_summary_or_query_with_summary(self):
-        """Test summary_or_query property when summary exists."""
+    @pytest.mark.parametrize("sqlite_session", [(Conversation, Message)], indirect=True)
+    def test_conversation_summary_or_query_with_summary(self, sqlite_session: Session):
+        """Test summary_or_query_with_session when summary exists."""
         # Arrange
         conversation = Conversation(
             app_id=str(uuid4()),
@@ -555,14 +556,14 @@ class TestConversationModel:
         )
 
         # Act
-        result = conversation.summary_or_query
+        result = conversation.summary_or_query_with_session(session=sqlite_session)
 
         # Assert
         assert result == "Test summary"
 
     @pytest.mark.parametrize("sqlite_session", [(Conversation, Message)], indirect=True)
     def test_conversation_summary_or_query_without_summary(self, sqlite_session: Session):
-        """Test summary_or_query property when summary is empty."""
+        """Test summary_or_query_with_session when summary is empty."""
         # Arrange
         conversation = Conversation(
             app_id=str(uuid4()),


### PR DESCRIPTION
## Summary

Part of #40372, following the established model cleanup pattern from #40370, #41569, and #41721.

Removes ten legacy @property accessors on Conversation in api/models/model.py that implicitly reach for the global db.session():

- summary_or_query
- annotated
- annotation
- message_count
- user_feedback_stats
- admin_feedback_stats
- status_count
- first_message
- from_end_user_session_id
- from_account_name

All production response reads already go through ConversationResponseSource and the existing *_with_session methods. The direct model and container-test reads were updated to pass the caller-owned session explicitly.

This intentionally leaves inputs, model_config, and app untouched because they still have active property consumers or setter behavior and require a separate migration.

Claimed this slice in https://github.com/langgenius/dify/issues/40372#issuecomment-5550590304.

## Tests

- pytest -q api/tests/unit_tests/models/test_app_models.py api/tests/unit_tests/controllers/console/app/test_conversation_api.py — 61 passed
- Ruff check passed
- Ruff format check passed
- Pyrefly passed for api/models/model.py
- Mypy passed for api/models/model.py

## Screenshots

N/A (backend-only refactor).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran make lint && make type-check (backend) and vp staged (frontend) to appease the lint gods