### PR TITLE
fix(agent): memoize + fail-open the Agent LOG icon-enrichment lookups

### DIFF
--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator, Mapping
 from typing import Any, cast
 
@@ -28,7 +29,42 @@ from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 from .events import AgentLogEvent
 from .exceptions import AgentNodeError, AgentVariableTypeError, ToolFileNotFoundError
 
+logger = logging.getLogger(__name__)
+
 _file_access_controller = DatabaseFileAccessController()
+
+
+def _build_plugin_icon_lookup(tenant_id: str) -> dict[str, str]:
+    """Return ``{qualified_name: icon}`` for every plugin visible to ``tenant_id``.
+
+    The Agent message transformer only needs the icon for a single
+    provider name per message. Building the full map once per
+    ``transform()`` call keeps the per-message cost at a dictionary
+    lookup instead of a fresh ``list_plugins`` round trip to the
+    plugin daemon (up to 256 entries) and a linear scan.
+    """
+    from core.plugin.impl.plugin import PluginInstaller
+
+    manager = PluginInstaller()
+    return {f"{plugin.plugin_id}/{plugin.name}": plugin.declaration.icon for plugin in manager.list_plugins(tenant_id)}
+
+
+def _build_builtin_icon_lookup(user_id: str, tenant_id: str) -> dict[str, tuple[str, str | None]]:
+    """Return ``{provider_name: (icon, icon_dark)}`` for every built-in provider.
+
+    Mirrors ``_build_plugin_icon_lookup`` for the ``BuiltinToolManageService``
+    side of the Agent log enrichment. Avoids the per-message
+    re-enumeration of every built-in controller, default-config reload,
+    and credential decryption that the pre-fix code paid for every
+    matching log message.
+    """
+    return cast(
+        dict[str, tuple[str, str | None]],
+        {
+            provider.name: (provider.icon, provider.icon_dark)
+            for provider in BuiltinToolManageService.list_builtin_tools(user_id, tenant_id)
+        },
+    )
 
 
 class AgentMessageTransformer:
@@ -45,7 +81,14 @@ class AgentMessageTransformer:
         node_id: str,
         node_execution_id: str,
     ) -> Generator[NodeEventBase, None, None]:
-        from core.plugin.impl.plugin import PluginInstaller
+
+        # #41143: per-execution cache for the icon-enrichment lookups in
+        # the LOG-message branch below. Repeated log messages for the
+        # same provider now reuse the same ``PluginInstaller.list_plugins``
+        # / ``BuiltinToolManageService.list_builtin_tools`` result
+        # instead of paying for the full scan every time.
+        _plugin_icon_cache: dict[str, dict[str, str]] = {}
+        _builtin_icon_cache: dict[tuple[str, str], dict[str, tuple[str, str | None]]] = {}
 
         message_stream = ToolFileMessageTransformer.transform_tool_invoke_messages(
             messages=messages,
@@ -195,33 +238,58 @@ class AgentMessageTransformer:
                 assert isinstance(message.message, ToolInvokeMessage.LogMessage)
                 if message.message.metadata:
                     icon = tool_info.get("icon", "")
+                    icon_dark: str | None = None
                     dict_metadata = dict(message.message.metadata)
                     if dict_metadata.get("provider"):
-                        manager = PluginInstaller()
-                        plugins = manager.list_plugins(tenant_id)
+                        # #41143: every LOG message with a `provider`
+                        # value used to synchronously hit
+                        # ``PluginInstaller.list_plugins`` (up to 256 entries
+                        # over the plugin daemon) and enumerate every
+                        # built-in provider + tool — only to populate two
+                        # decoration fields (``icon``, ``icon_dark``). The
+                        # work repeated across matching log messages
+                        # within one execution and, worse, an error in
+                        # either call path was treated as an Agent message
+                        # transformation failure in
+                        # ``AgentNode._run()`` — slowing or failing an
+                        # Agent run over decorative metadata.
+                        #
+                        # Memoize both lookups per ``transform()``
+                        # invocation so repeated log messages reuse the
+                        # same data, and wrap the enrichment in a
+                        # ``try/except`` so a slow / unreachable plugin
+                        # daemon or a credential-decryption failure can't
+                        # stall or fail the run.
                         try:
-                            current_plugin = next(
-                                plugin
-                                for plugin in plugins
-                                if f"{plugin.plugin_id}/{plugin.name}" == dict_metadata["provider"]
+                            # ``dict.setdefault(key, default)`` evaluates
+                            # ``default`` unconditionally, so the cache
+                            # needs an explicit membership check to actually
+                            # save the plugin-daemon / built-in call on
+                            # subsequent log messages.
+                            if tenant_id not in _plugin_icon_cache:
+                                _plugin_icon_cache[tenant_id] = _build_plugin_icon_lookup(tenant_id)
+                            plugin_icon_by_provider = _plugin_icon_cache[tenant_id]
+                            icon = plugin_icon_by_provider.get(dict_metadata["provider"], icon)
+                        except Exception:
+                            logger.exception(
+                                "Agent log icon enrichment failed (plugin lookup) for provider=%s",
+                                dict_metadata.get("provider"),
                             )
-                            icon = current_plugin.declaration.icon
-                        except StopIteration:
-                            pass
-                        icon_dark = None
+
                         try:
-                            builtin_tool = next(
-                                provider
-                                for provider in BuiltinToolManageService.list_builtin_tools(
-                                    user_id,
-                                    tenant_id,
-                                )
-                                if provider.name == dict_metadata["provider"]
+                            cache_key = (user_id, tenant_id)
+                            if cache_key not in _builtin_icon_cache:
+                                _builtin_icon_cache[cache_key] = _build_builtin_icon_lookup(user_id, tenant_id)
+                            builtin_icon_by_provider = _builtin_icon_cache[cache_key]
+                            entry = builtin_icon_by_provider.get(dict_metadata["provider"])
+                            if entry is not None:
+                                icon = entry[0]
+                                icon_dark = entry[1]
+                        except Exception:
+                            logger.exception(
+                                "Agent log icon enrichment failed (builtin lookup) for provider=%s",
+                                dict_metadata.get("provider"),
                             )
-                            icon = builtin_tool.icon
-                            icon_dark = builtin_tool.icon_dark
-                        except StopIteration:
-                            pass
 
                         dict_metadata["icon"] = icon
                         dict_metadata["icon_dark"] = icon_dark

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -13,6 +13,7 @@ from graphon.enums import BuiltinNodeTypes
 from graphon.file import File, FileTransferMethod, FileType
 from graphon.node_events import StreamCompletedEvent
 from graphon.variables.segments import ArrayFileSegment
+from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 
 
 def _file() -> File:
@@ -194,3 +195,132 @@ def test_transform_keeps_plain_link_as_text() -> None:
 
     assert text == "Link: https://dify.ai\n"
     assert files.value == []
+
+
+# --- #41143: Agent LOG icon enrichment caching ---------------------------
+
+
+def _log_message(provider: str | None = None) -> ToolInvokeMessage:
+    """Build a minimal ``LOG``-typed ``ToolInvokeMessage`` for icon enrichment tests."""
+    metadata: dict[str, str] | None = None
+    if provider is not None:
+        metadata = {"provider": provider}
+    return ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LOG,
+        message=ToolInvokeMessage.LogMessage(
+            id="log-1",
+            parent_id=None,
+            label="log",
+            error=None,
+            status=ToolInvokeMessage.LogMessage.LogStatus.START,
+            data={},
+            metadata=metadata,
+        ),
+    )
+
+
+class TestLogMessageIconEnrichment:
+    """Regression tests for #41143: Agent ``LOG`` messages with a
+    ``provider`` used to synchronously hit the plugin daemon and walk
+    every built-in provider on every message. The fix memoizes both
+    lookups per ``transform()`` call and makes the enrichment
+    best-effort so a plugin-daemon / credential error can no longer
+    stall or fail an Agent run.
+    """
+
+    def test_plugin_daemon_called_once_for_multiple_log_messages(self) -> None:
+        """#41143: ``PluginInstaller.list_plugins`` and
+        ``BuiltinToolManageService.list_builtin_tools`` must each be
+        called exactly once per ``transform()`` invocation, regardless
+        of how many LOG messages share the same provider name.
+        """
+        log_messages = [_log_message(provider="anthropic/claude-sonnet-4") for _ in range(5)]
+        with (
+            patch(
+                "core.plugin.impl.plugin.PluginInstaller.list_plugins",
+                return_value=[],
+            ) as mock_list_plugins,
+            patch.object(
+                BuiltinToolManageService,
+                "list_builtin_tools",
+                return_value=[],
+            ) as mock_list_builtins,
+        ):
+            list(
+                AgentMessageTransformer().transform(
+                    messages=_message_stream(log_messages),
+                    tool_info={},
+                    parameters_for_log={},
+                    user_id="user-id",
+                    tenant_id="tenant-id",
+                    conversation_id=None,
+                    node_type=BuiltinNodeTypes.AGENT,
+                    node_id="node-id",
+                    node_execution_id="execution-id",
+                )
+            )
+
+        assert mock_list_plugins.call_count == 1, (
+            "PluginInstaller.list_plugins must be called once per transform(), not once per LOG message."
+        )
+        assert mock_list_builtins.call_count == 1, (
+            "BuiltinToolManageService.list_builtin_tools must be called once per transform()."
+        )
+
+    def test_icon_enrichment_is_best_effort(self) -> None:
+        """#41143: a plugin-daemon error must NOT propagate as an
+        Agent message-transformation failure. The Agent run must
+        continue even when icon enrichment can't reach the daemon.
+        """
+        log_message = _log_message(provider="anthropic/claude-sonnet-4")
+        with patch(
+            "core.plugin.impl.plugin.PluginInstaller.list_plugins",
+            side_effect=RuntimeError("plugin daemon down"),
+        ):
+            # No exception should escape the transform generator.
+            events = list(
+                AgentMessageTransformer().transform(
+                    messages=_message_stream([log_message]),
+                    tool_info={},
+                    parameters_for_log={},
+                    user_id="user-id",
+                    tenant_id="tenant-id",
+                    conversation_id=None,
+                    node_type=BuiltinNodeTypes.AGENT,
+                    node_id="node-id",
+                    node_execution_id="execution-id",
+                )
+            )
+
+        # The log event must still be emitted (run completed).
+        assert any(isinstance(event, StreamCompletedEvent) for event in events)
+
+    def test_builtin_icon_lookup_is_safe_on_failure(self) -> None:
+        """#41143: the built-in-tool enumeration must also fail open."""
+        log_message = _log_message(provider="google/google")
+        with (
+            patch(
+                "core.plugin.impl.plugin.PluginInstaller.list_plugins",
+                return_value=[],
+            ),
+            patch.object(
+                BuiltinToolManageService,
+                "list_builtin_tools",
+                side_effect=RuntimeError("decrypt failure"),
+            ),
+        ):
+            events = list(
+                AgentMessageTransformer().transform(
+                    messages=_message_stream([log_message]),
+                    tool_info={},
+                    parameters_for_log={},
+                    user_id="user-id",
+                    tenant_id="tenant-id",
+                    conversation_id=None,
+                    node_type=BuiltinNodeTypes.AGENT,
+                    node_id="node-id",
+                    node_execution_id="execution-id",
+                )
+            )
+
+        assert any(isinstance(event, StreamCompletedEvent) for event in events)


### PR DESCRIPTION
Fixes #41143

## What problem does this PR solve?

`AgentMessageTransformer.transform` enriched every LOG message's `metadata.icon` / `metadata.icon_dark` by:

1. Issuing a synchronous `PluginInstaller.list_plugins(tenant_id)` call (up to 256 plugins over the plugin daemon), then linearly scanning the result for the message's provider.
2. Enumerating every built-in provider via `BuiltinToolManageService.list_builtin_tools(user_id, tenant_id)`, which loads default provider configurations, decrypts credentials, and converts every tool schema.

Both calls ran *for every matching LOG message* in a single execution, used only to populate two decoration fields, and — worse — an exception in either call path was treated as an Agent message-transformation failure by `AgentNode._run()`, slowing or failing an Agent run over decorative metadata.

## What is changed and how it works?

Three focused changes:

1. Move the lookup payloads into module-level `_build_plugin_icon_lookup` / `_build_builtin_icon_lookup` helpers, called *once* per `transform()` invocation and cached in per-call dicts.
2. Look up cached values from the dict on every subsequent LOG message so repeated messages for the same provider reuse the same data instead of paying for the full scan again.
3. Wrap both enrichment paths in `try/except` so a slow / unreachable plugin daemon or a credential-decryption failure can't stall or fail the Agent run — the icon fields just stay at their default (`""` / `None`).

## How it was tested?

```
$ uv run pytest tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py -o addopts=
11 passed in 0.32s
```

3 new tests in `tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py`:

- `test_plugin_daemon_called_once_for_multiple_log_messages` — pins the memoization: `PluginInstaller.list_plugins` and `BuiltinToolManageService.list_builtin_tools` must each be called exactly once per `transform()` invocation.
- `test_icon_enrichment_is_best_effort` — a plugin-daemon error must NOT propagate as an Agent message-transformation failure.
- `test_builtin_icon_lookup_is_safe_on_failure` — the built-in-tool enumeration also fails open.

All 8 existing tests in the file still pass. `ruff check` / `ruff format --check` clean, `pyrefly` 0 diagnostics, `importlinter` 25 kept / 0 broken.