### PR TITLE
fix(api): resolve MCP provider detail route by either id or server_identifier

### DIFF
--- a/api/services/tools/mcp_tools_manage_service.py
+++ b/api/services/tools/mcp_tools_manage_service.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import uuid
 from collections.abc import Mapping
 from datetime import datetime
 from enum import StrEnum
@@ -26,6 +27,18 @@ from models.tools import MCPToolProvider
 from services.tools.tools_transform_service import ToolTransformService
 
 logger = logging.getLogger(__name__)
+
+
+def _is_uuid(value: str | None) -> bool:
+    """Return True when `value` parses as a UUID, False for anything else."""
+    if not value:
+        return False
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
 
 # Constants
 UNCHANGED_SERVER_URL_PLACEHOLDER = "[__HIDDEN__]"
@@ -90,8 +103,9 @@ class MCPToolManageService:
         Get MCP provider by ID or server identifier.
 
         Args:
-            provider_id: Provider ID (UUID)
-            server_identifier: Server identifier
+            provider_id: Provider ID (UUID) or human-readable server identifier
+                when the path segment is not a valid UUID
+            server_identifier: Server identifier (overrides `provider_id` when set)
             tenant_id: Tenant ID
 
         Returns:
@@ -99,10 +113,21 @@ class MCPToolManageService:
 
         Raises:
             ValueError: If provider not found
+
+        Notes:
+            The console front-end may pass either the entity UUID or the
+            human-readable `server_identifier` in path segments such as
+            `/tool-provider/mcp/tools/<id>`. A non-UUID value falls back to
+            the `server_identifier` lookup so PostgreSQL does not raise
+            `invalid input syntax for type uuid`.
         """
         if server_identifier:
             stmt = select(MCPToolProvider).where(
                 MCPToolProvider.tenant_id == tenant_id, MCPToolProvider.server_identifier == server_identifier
+            )
+        elif not _is_uuid(provider_id):
+            stmt = select(MCPToolProvider).where(
+                MCPToolProvider.tenant_id == tenant_id, MCPToolProvider.server_identifier == provider_id
             )
         else:
             stmt = select(MCPToolProvider).where(

--- a/api/tests/unit_tests/services/tools/test_mcp_tools_manage_service.py
+++ b/api/tests/unit_tests/services/tools/test_mcp_tools_manage_service.py
@@ -1,0 +1,118 @@
+"""Unit tests for MCPToolManageService.get_provider dual-form dispatch.
+
+The fix in https://github.com/langgenius/dify/issues/41512 lets callers pass
+either a provider UUID or the human-readable `server_identifier` as
+`provider_id`. PostgreSQL would otherwise reject a non-UUID path segment with
+`invalid input syntax for type uuid` and surface as HTTP 500 from
+`ToolMCPDetailApi` and sibling console routes.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from models.tools import MCPToolProvider
+from services.tools.mcp_tools_manage_service import MCPToolManageService
+
+
+def _persist_provider(
+    session: Session,
+    *,
+    server_identifier: str = "my-mcp-tools",
+    name: str = "My MCP Tools",
+    tenant_id: str = "tenant-1",
+) -> MCPToolProvider:
+    provider = MCPToolProvider(
+        name=name,
+        server_identifier=server_identifier,
+        server_url="https://example.com",
+        server_url_hash=f"hash-{server_identifier}",
+        icon="icon",
+        tenant_id=tenant_id,
+        user_id="user-1",
+    )
+    session.add(provider)
+    session.flush()
+    return provider
+
+
+def test_get_provider_resolves_uuid(sqlite_session: Session) -> None:
+    provider = _persist_provider(sqlite_session, server_identifier="my-mcp-tools", name="MCP A")
+    service = MCPToolManageService(session=sqlite_session)
+
+    result = service.get_provider(provider_id=provider.id, tenant_id="tenant-1")
+
+    assert result.id == provider.id
+    assert result.server_identifier == "my-mcp-tools"
+
+
+def test_get_provider_resolves_server_identifier_via_provider_id(sqlite_session: Session) -> None:
+    """A non-UUID `provider_id` must dispatch to the server_identifier branch."""
+    _persist_provider(sqlite_session, server_identifier="my-mcp-tools", name="MCP A")
+    service = MCPToolManageService(session=sqlite_session)
+
+    result = service.get_provider(provider_id="my-mcp-tools", tenant_id="tenant-1")
+
+    assert result.server_identifier == "my-mcp-tools"
+
+
+def test_get_provider_explicit_server_identifier_takes_precedence(sqlite_session: Session) -> None:
+    """When both args are passed, the explicit `server_identifier` is honored."""
+    provider_uuid = str(uuid4())
+    other = _persist_provider(sqlite_session, server_identifier="real-identifier", name="MCP B")
+    _persist_provider(
+        sqlite_session,
+        server_identifier="other-identifier",
+        name="MCP C",
+    )
+    service = MCPToolManageService(session=sqlite_session)
+
+    result = service.get_provider(
+        provider_id=provider_uuid,
+        server_identifier="real-identifier",
+        tenant_id="tenant-1",
+    )
+
+    assert result.id == other.id
+    assert result.server_identifier == "real-identifier"
+
+
+def test_get_provider_missing_server_identifier_raises(sqlite_session: Session) -> None:
+    service = MCPToolManageService(session=sqlite_session)
+
+    with pytest.raises(ValueError, match="MCP tool not found"):
+        service.get_provider(provider_id="does-not-exist", tenant_id="tenant-1")
+
+
+def test_get_provider_missing_uuid_raises(sqlite_session: Session) -> None:
+    service = MCPToolManageService(session=sqlite_session)
+
+    with pytest.raises(ValueError, match="MCP tool not found"):
+        service.get_provider(provider_id=str(uuid4()), tenant_id="tenant-1")
+
+
+def test_get_provider_cross_tenant_isolation_on_server_identifier(sqlite_session: Session) -> None:
+    """A server_identifier match in another tenant must not leak across tenants."""
+    _persist_provider(
+        sqlite_session,
+        server_identifier="shared-id",
+        tenant_id="tenant-a",
+        name="Tenant A",
+    )
+    _persist_provider(
+        sqlite_session,
+        server_identifier="shared-id",
+        tenant_id="tenant-b",
+        name="Tenant B",
+    )
+    service = MCPToolManageService(session=sqlite_session)
+
+    result_a = service.get_provider(provider_id="shared-id", tenant_id="tenant-a")
+    result_b = service.get_provider(provider_id="shared-id", tenant_id="tenant-b")
+
+    assert result_a.tenant_id == "tenant-a"
+    assert result_b.tenant_id == "tenant-b"
+    assert result_a.id != result_b.id


### PR DESCRIPTION
## Summary

Closes a 1.17.0 regression in the console MCP provider detail/update/auth/delete routes. The front-end (`web/service/use-tools.ts` → `useMCPTools`) passes the human-readable `server_identifier` (e.g. `my-mcp-tools`) as the path segment for `GET /console/api/workspaces/current/tool-provider/mcp/tools/<id>`. The endpoint then routed that value into `MCPToolManageService.get_provider(provider_id=...)`, which queries the `StringUUID` `id` column. PostgreSQL rejected the non-UUID input with `invalid input syntax for type uuid` and the request returned HTTP 500.

Centralize the dual-form dispatch in `get_provider` so a non-UUID `provider_id` falls back to the `server_identifier` branch (the tenant_id filter is preserved). The four console call sites — `ToolMCPDetailApi`, `ToolMCPUpdateApi`, the OAuth callback consumer, and the delete handler — all pick it up without per-endpoint changes.

Fixes #41512

## Why this is a regression, not a feature

- The path was always defined as `<path:provider_id>`; the URL is opaque to the back-end.
- The list endpoint at `/console/api/workspaces/current/tools/mcp` returns the entity's `id` (the UUID) as `for_list=True` exposes `db_provider.id`, but the detail endpoint's response shape (`mcp_provider_to_user_provider(..., for_list=True)`) and the front-end's existing round-tripping mean the value the front-end replays is the `server_identifier`.
- The sibling `get_provider_entity(by_server_id=...)` already implements the intended dual-form dispatch on the `tool_manager.py` / `mcp_tool/tool.py` / `dify_tools_builder.py` paths; this brings the console routes in line with that contract.

## Changes

`api/services/tools/mcp_tools_manage_service.py`
- Add `import uuid` and a private `_is_uuid(value)` helper.
- In `MCPToolManageService.get_provider`, when `server_identifier` is not provided and `provider_id` is not a valid UUID, dispatch to the `server_identifier` lookup. UUID inputs continue to hit the `id` branch unchanged.

`api/services/tools/mcp_tools_manage_service.py` (call sites, unchanged)
- `ToolMCPDetailApi.get` (`tool_providers.py:1589`) — covered
- `ToolMCPUpdateApi.get` (`tool_providers.py:1625` via `list_provider_tools`) — covered
- `ToolMCPCallbackApi` consumer (`tool_providers.py:1646` via `save_oauth_data`) — covered (uses the same `get_provider` path)
- Delete handler (`tool_providers.py:1496` via `delete_provider`) — covered

## Tests

Six new unit tests in `api/tests/unit_tests/services/tools/test_mcp_tools_manage_service.py`:

- `test_get_provider_resolves_uuid` — UUID inputs still hit the `id` branch.
- `test_get_provider_resolves_server_identifier_via_provider_id` — a non-UUID `provider_id` (e.g. `my-mcp-tools`) falls back to the `server_identifier` branch.
- `test_get_provider_explicit_server_identifier_takes_precedence` — when both args are passed, the explicit `server_identifier` wins.
- `test_get_provider_missing_server_identifier_raises` / `test_get_provider_missing_uuid_raises` — `ValueError` for either form when the row is absent.
- `test_get_provider_cross_tenant_isolation_on_server_identifier` — a shared `server_identifier` in two tenants resolves to the right row per tenant when the lookup is exercised via the new non-UUID `provider_id` branch.

The two non-UUID tests (`..._via_provider_id` and `..._cross_tenant_isolation_on_server_identifier`) fail with `ValueError: 'MCP tool not found'` on the unpatched dispatch. Verified by stashing only `api/services/tools/mcp_tools_manage_service.py` and re-running the new tests, then restoring the source change.

## Verification

- `pytest tests/unit_tests/services/tools/test_mcp_tools_manage_service.py` — 6/6 pass.
- `ruff check` — clean.
- `ruff format --check` — clean.

## Risk

Low. The fix narrows the read-side query dispatch and preserves the existing `tenant_id` filter on both branches. No schema change, no API change, no protocol change. The four affected endpoints already had a tenant-scoped lookup; the fix simply allows the second lookup column.

## Future work (out of scope here)

A small audit over the other console read paths to confirm no other service-layer `get_*` methods are called with a non-UUID path segment. The grep for `service.get_provider` in `api/controllers/console/` only surfaced the four sites listed above, but the broader pattern (round-tripping `server_identifier` as the entity `id`) is worth a follow-up sweep to confirm no siblings hide the same regression.
