### PR TITLE
fix(tools,api): handle unknown tool provider lookups and normalize message list fields

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -131,9 +131,17 @@ class ToolManager:
 
         if provider not in cls._hardcoded_providers:
             # get plugin provider
-            plugin_provider = cls.get_plugin_provider(provider, tenant_id)
-            if plugin_provider:
-                return plugin_provider
+            try:
+                plugin_provider = cls.get_plugin_provider(provider, tenant_id)
+                if plugin_provider:
+                    return plugin_provider
+            except ToolProviderNotFoundError:
+                raise
+            except Exception as e:
+                raise ToolProviderNotFoundError(f"builtin or plugin provider {provider} not found: {e}")
+
+        if provider not in cls._hardcoded_providers:
+            raise ToolProviderNotFoundError(f"builtin provider {provider} not found")
 
         return cls._hardcoded_providers[provider]
 
@@ -161,7 +169,10 @@ class ToolManager:
                 return plugin_tool_providers[provider]
 
             manager = PluginToolManager()
-            provider_entity = manager.fetch_tool_provider(tenant_id, provider)
+            try:
+                provider_entity = manager.fetch_tool_provider(tenant_id, provider)
+            except Exception as e:
+                raise ToolProviderNotFoundError(f"plugin provider {provider} not found: {e}")
             if not provider_entity:
                 raise ToolProviderNotFoundError(f"plugin provider {provider} not found")
 

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -56,10 +56,10 @@ class MessageListItem(ResponseModel):
     query: str
     answer: str = Field(validation_alias="re_sign_file_url_answer")
     feedback: SimpleFeedback | None = Field(default=None, validation_alias="user_feedback")
-    retriever_resources: list[RetrieverResource]
+    retriever_resources: list[RetrieverResource] = Field(default_factory=list)
     created_at: Int64 | None = None
-    agent_thoughts: list[AgentThought]
-    message_files: list[MessageFile]
+    agent_thoughts: list[AgentThought] = Field(default_factory=list)
+    message_files: list[MessageFile] = Field(default_factory=list)
     message_tokens: int = 0
     answer_tokens: int = 0
     provider_response_latency: FloatNumber = 0
@@ -67,11 +67,18 @@ class MessageListItem(ResponseModel):
     currency: str | None = None
     status: str
     error: str | None = None
-    extra_contents: list[ExecutionExtraContentDomainModel]
+    extra_contents: list[ExecutionExtraContentDomainModel] = Field(default_factory=list)
 
     @computed_field
     def total_tokens(self) -> int:
         return self.message_tokens + self.answer_tokens
+
+    @field_validator("retriever_resources", "agent_thoughts", "message_files", "extra_contents", mode="before")
+    @classmethod
+    def _normalize_lists(cls, value: object) -> list:
+        if value is None:
+            return []
+        return value if isinstance(value, list) else list(value)
 
     @field_validator("inputs", mode="before")
     @classmethod

--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -447,6 +447,8 @@ class BuiltinToolManageService:
         get builtin tool provider credential info
         """
         provider_controller = ToolManager.get_builtin_provider(provider, tenant_id)
+        if not provider_controller:
+            raise ToolProviderNotFoundError(f"Provider {provider} not found")
         supported_credential_types = provider_controller.get_supported_credential_types()
         credentials = BuiltinToolManageService.get_builtin_tool_provider_credentials(
             tenant_id,

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -1275,3 +1275,11 @@ def test_convert_tool_parameters_type_model_selector_from_constant_value_config(
             "voice": "Cherry",
         }
     }
+
+
+def test_get_builtin_provider_unknown_raises_tool_provider_not_found():
+    ToolManager._hardcoded_providers = {"time": Mock()}
+
+    with patch.object(ToolManager, "get_plugin_provider", side_effect=ToolProviderNotFoundError("not found")):
+        with pytest.raises(ToolProviderNotFoundError, match="not found"):
+            ToolManager.get_builtin_provider("unknown_provider", "tenant-1")

--- a/api/tests/unit_tests/fields/test_message_fields.py
+++ b/api/tests/unit_tests/fields/test_message_fields.py
@@ -66,3 +66,24 @@ class TestExploreMessageListItem:
         assert payload["message_tokens"] == 7
         assert payload["answer_tokens"] == 11
         assert payload["total_tokens"] == 18
+
+    def test_message_list_item_handles_none_and_omitted_lists(self):
+        # When retriever_resources, agent_thoughts, etc. are None or omitted, it defaults to []
+        kwargs = {
+            "id": "m1",
+            "conversation_id": "c1",
+            "inputs": {},
+            "query": "hi",
+            "answer": "answer",
+            "status": "normal",
+            "retriever_resources": None,
+            "agent_thoughts": None,
+            "message_files": None,
+            "extra_contents": None,
+        }
+        item = MessageListItem(**kwargs)
+        payload = item.model_dump(mode="json")
+        assert payload["retriever_resources"] == []
+        assert payload["agent_thoughts"] == []
+        assert payload["message_files"] == []
+        assert payload["extra_contents"] == []


### PR DESCRIPTION
### Summary
This PR resolves two related API robustness issues:
1. **Tool Provider Lookup Error Handling** (Fixes #41805): When fetching credentials or information for a builtin/plugin tool provider that does not exist or whose plugin provider lookup fails, the API previously threw unhandled exceptions or returned HTTP 500. `ToolManager.get_builtin_provider` and `BuiltinToolManageService` now properly catch missing provider exceptions and wrap them into `ToolProviderNotFoundError`, returning a clean HTTP 404 response.
2. **Empty Message History Response Validation** (Fixes #41688): In message listing responses (`MessageListItem`), fields such as `retriever_resources`, `agent_thoughts`, `message_files`, and `extra_contents` could be `None` or absent in legacy records or empty history responses, resulting in a Pydantic validation error (`Input should be a valid list`). Added default factories (`default_factory=list`) and pre-validators to normalize `None`/absent values to empty lists (`[]`).

### Changes
- **`api/core/tools/tool_manager.py`**: Added explicit error trapping around plugin tool provider retrieval and raised `ToolProviderNotFoundError` if the provider cannot be resolved.
- **`api/services/tools/builtin_tools_manage_service.py`**: Added explicit validation ensuring `provider_controller` is not null before accessing its supported credential types.
- **`api/fields/message_fields.py`**: Added `default_factory=list` and a `@field_validator` `_normalize_lists` to gracefully handle `None` values for list fields in `MessageListItem`.
- **`api/tests/unit_tests/core/tools/test_tool_manager.py`**: Added unit test `test_get_builtin_provider_unknown_raises_tool_provider_not_found`.
- **`api/tests/unit_tests/fields/test_message_fields.py`**: Added unit test `test_message_list_item_handles_none_and_omitted_lists`.

### Verification
- Tested provider lookup raising `ToolProviderNotFoundError` when provider is unknown.
- Tested `MessageListItem` instantiation with `None` values for list fields, confirming default empty list serialization.
