### PR TITLE
style(api): remove unnecessary type conversions in services, repositories and tests

### DIFF
--- a/api/events/event_handlers/update_provider_when_message_created.py
+++ b/api/events/event_handlers/update_provider_when_message_created.py
@@ -142,7 +142,7 @@ def handle(sender: Message, **kwargs):
         "created_by": get_credit_usage_created_by(app_mode),
     }
     credit_deduction_context: _CreditDeductionContext = {
-        "request_id": str(message.id) if message.id else None,
+        "request_id": message.id or None,
         "metadata": credit_deduction_metadata,
     }
     agent_gateway_metered = (

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -536,7 +536,7 @@ def build_application_services(
                 passwords=passwords,
                 tokens=RedisForgotPasswordTokenGateway(
                     redis=redis,
-                    expiry_seconds=int(dify_config.RESET_PASSWORD_TOKEN_EXPIRY_MINUTES * 60),
+                    expiry_seconds=dify_config.RESET_PASSWORD_TOKEN_EXPIRY_MINUTES * 60,
                 ),
                 codes=SecureForgotPasswordCodeGenerator(),
                 notifications=CeleryForgotPasswordNotificationGateway(),

--- a/api/repositories/oauth_access_token_repository.py
+++ b/api/repositories/oauth_access_token_repository.py
@@ -44,7 +44,7 @@ class SQLAlchemyOAuthAccessTokenRepository(AccountSessionRepository):
                 .offset(offset)
                 .limit(limit)
             ).all()
-            return int(total), tuple(self._to_snapshot(row) for row in rows)
+            return total, tuple(self._to_snapshot(row) for row in rows)
 
     @override
     def revoke(
@@ -79,7 +79,7 @@ class SQLAlchemyOAuthAccessTokenRepository(AccountSessionRepository):
     @staticmethod
     def _to_snapshot(row: OAuthAccessToken) -> AccountSessionSnapshot:
         return AccountSessionSnapshot(
-            id=str(row.id),
+            id=row.id,
             prefix=row.prefix,
             client_id=row.client_id,
             device_label=row.device_label,

--- a/api/repositories/webapp_access_query_repository.py
+++ b/api/repositories/webapp_access_query_repository.py
@@ -19,6 +19,6 @@ class WebAppAccessQueryRepository(WebAppAccessQuery):
         try:
             with self._session_factory() as session:
                 app_id = session.scalar(select(Site.app_id).where(Site.code == app_code).limit(1))
-                return str(app_id) if app_id is not None else None
+                return app_id if app_id is not None else None
         except (DBAPIError, TimeoutError) as e:
             raise WebAppAccessUnavailableError from e

--- a/api/services/account_adapters.py
+++ b/api/services/account_adapters.py
@@ -151,8 +151,8 @@ class RBACWorkspaceMemberAccessSync(WorkspaceMemberAccessSync):
         from tasks.initialize_created_app_rbac_access_task import sync_joined_workspace_member_rbac_access_task
 
         sync_joined_workspace_member_rbac_access_task.delay(
-            str(workspace_id),
-            str(account_id),
+            workspace_id,
+            account_id,
             operator_account_id=None,
         )
 
@@ -221,8 +221,8 @@ class TokenManagerChangeEmailTokenGateway(ChangeEmailTokenGateway):
             return None
         token_kwargs = {
             "account_id": token_data.account_id,
-            "email": str(token_data.email),
-            "old_email": str(token_data.old_email),
+            "email": token_data.email,
+            "old_email": token_data.old_email,
             "code": token_data.code,
         }
         if isinstance(token_data, ChangeEmailOldEmailToken):

--- a/api/services/account_login_adapters.py
+++ b/api/services/account_login_adapters.py
@@ -447,7 +447,7 @@ class SQLAlchemyConsoleAuthProvisioningGateway(AccountProvisioningGateway, Works
         ).data
         for role in roles:
             if role.is_builtin and role.category == "global_system_default" and role.role_tag == "owner":
-                return str(role.id)
+                return role.id
         raise ValueError(f"Builtin RBAC owner role not found in tenant {tenant_id}")
 
 

--- a/api/services/skill_management_service.py
+++ b/api/services/skill_management_service.py
@@ -3623,7 +3623,7 @@ class SkillManagementService:
         except yaml.YAMLError as exc:
             line = None
             if isinstance(exc, MarkedYAMLError) and exc.problem_mark is not None:
-                line = int(exc.problem_mark.line) + 2
+                line = exc.problem_mark.line + 2
             raise SkillManagementServiceError(
                 "invalid_skill_md",
                 f"SKILL.md frontmatter YAML is invalid: {exc}",

--- a/api/tests/test_containers_integration_tests/controllers/console/test_apikey.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/test_apikey.py
@@ -219,12 +219,11 @@ class TestDatasetApiKeyListResource:
     """
 
     def _bound_dataset_ids(self, session: Session, api_token_id: str) -> set[str]:
-        return {
-            str(dataset_id)
-            for dataset_id in session.scalars(
+        return set(
+            session.scalars(
                 select(DatasetApiTokenBinding.dataset_id).where(DatasetApiTokenBinding.api_token_id == api_token_id)
             ).all()
-        }
+        )
 
     def test_create_unbound_key(
         self,
@@ -402,10 +401,9 @@ class TestDatasetDeleteCascadesToScopedKeys:
         assert resp.status_code == 204
         # The key survives, still scoped to the remaining dataset only.
         assert db_session_with_containers.scalar(select(ApiToken).where(ApiToken.id == api_key_id)) is not None
-        remaining = {
-            str(ds_id)
-            for ds_id in db_session_with_containers.scalars(
+        remaining = set(
+            db_session_with_containers.scalars(
                 select(DatasetApiTokenBinding.dataset_id).where(DatasetApiTokenBinding.api_token_id == api_key_id)
             ).all()
-        }
+        )
         assert remaining == {other_id}

--- a/api/tests/unit_tests/controllers/web/test_pydantic_models.py
+++ b/api/tests/unit_tests/controllers/web/test_pydantic_models.py
@@ -258,7 +258,7 @@ from controllers.web.remote_files import RemoteFileUploadPayload
 class TestRemoteFileUploadPayload:
     def test_valid_url(self) -> None:
         p = RemoteFileUploadPayload(url="https://example.com/file.pdf")
-        assert str(p.url) == "https://example.com/file.pdf"
+        assert p.url == "https://example.com/file.pdf"
 
     def test_url_syntax_is_validated_by_remote_file_service(self) -> None:
         payload = RemoteFileUploadPayload(url="not-a-url")

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_resolve_agent.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_resolve_agent.py
@@ -319,7 +319,7 @@ class TestResolveAgent:
     @pytest.fixture(autouse=True)
     def _publish_visibility(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def is_publish_visible(*, agent: Agent, **_kwargs: object) -> bool:
-            return bool(agent.active_config_is_published)
+            return agent.active_config_is_published
 
         monkeypatch.setattr(
             app_generator,


### PR DESCRIPTION
Part of #39947 (clean away unnecessary-type-conversion).

## Scope

This slice covers the sites **not touched by** the in-flight slices #39950, #41081, #41082, #41083 and #41722. I cross-checked the current `pyrefly check --min-severity info` output against the files changed by each of those PRs, leaving 15 sites in 10 files:

- `api/services/account_adapters.py` (4)
- `api/services/account_login_adapters.py` (1)
- `api/services/skill_management_service.py` (1)
- `api/repositories/oauth_access_token_repository.py` (2)
- `api/repositories/webapp_access_query_repository.py` (1)
- `api/events/event_handlers/update_provider_when_message_created.py` (1)
- `api/extensions/ext_application_services.py` (1)
- `api/tests/test_containers_integration_tests/controllers/console/test_apikey.py` (2)
- `api/tests/unit_tests/controllers/web/test_pydantic_models.py` (1)
- `api/tests/unit_tests/core/app/apps/agent_app/test_resolve_agent.py` (1)

## Changes

- Removed redundant `str()` / `int()` / `bool()` calls whose argument pyrefly proves is already of the target type (behavior-preserving; no `str` subclasses with custom `__str__`, no `bool`-as-`int` sites involved).
- Two set comprehensions in `test_apikey.py` became passthrough after removing `str()`, so they were rewritten as `set(...)` per ruff `unnecessary-comprehension` (which otherwise fires once the redundant call is gone); one ternary became `x or None` per ruff `if-exp-instead-of-or-operator` for the same reason.

## Validation

- `pyrefly check --min-severity info`: 379 → 364 `unnecessary-type-conversion` sites, none remaining in the 10 touched files (the remaining 364 live in files owned by the PRs above).
- `ruff check` / `ruff format --check` clean on all changed files; all changed files byte-compile.
- No runtime behavior change: only statically-identical conversions removed.