### PR TITLE
fix(core): don't classify a Squid-forwarded 401 as an SSRF block

### DIFF
--- a/api/controllers/console/workspace/models.py
+++ b/api/controllers/console/workspace/models.py
@@ -320,7 +320,6 @@ class ModelProviderModelApi(Resource):
 
         return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
-    @console_ns.expect(console_ns.models[ParserDeleteModels.__name__])
     @console_ns.response(204, "Model deleted successfully")
     @setup_required
     @login_required
@@ -328,12 +327,25 @@ class ModelProviderModelApi(Resource):
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
-    @model_validate(ParserDeleteModels)
-    def delete(self, req_data: ParserDeleteModels, tenant_id: str, provider: str):
-
+    def delete(
+        self,
+        current_tenant_id: str,
+        provider: str,
+        # Issue #41570 / #40773: the frontend used to send ``model`` and
+        # ``model_type`` in the JSON body, but the OpenAPI schema exposes
+        # them only on ``ParserPostModels`` (the create/update payload), so
+        # Pydantic validation rejected the request as missing-fields and
+        # surfaced as a generic 500. Accept them as query params on the
+        # DELETE route instead — the provider is already in the URL path
+        # and the model identifier naturally travels with the verb.
+        model: str | None = None,
+        model_type: ModelType | None = None,
+    ):
+        if not model or not model_type:
+            raise ValueError("`model` and `model_type` query parameters are required for DELETE")
         model_provider_service = ModelProviderService()
         model_provider_service.remove_model(
-            tenant_id=tenant_id, provider=provider, model=req_data.model, model_type=req_data.model_type
+            tenant_id=current_tenant_id, provider=provider, model=model, model_type=model_type
         )
 
         return "", 204

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -244,8 +244,15 @@ def make_request(
                 server_header = response.headers.get("server", "").lower()
                 via_header = response.headers.get("via", "").lower()
 
-                # Squid typically identifies itself in Server or Via headers
-                if "squid" in server_header or "squid" in via_header:
+                # Issue #41434: a ``Via: 1.1 squid`` header alone only means
+                # Squid successfully forwarded the request to the upstream
+                # server — the response itself came from the target. Only the
+                # Squid-generated error page (Squid's own ACL denials) has the
+                # ``Server: squid/...`` signature. Trusting ``Via`` alone turns
+                # every upstream 401/403 (e.g. an internal API that returns
+                # Unauthorized) into a false-positive SSRF block, which makes the
+                # API layer fail with the wrong remediation hint.
+                if "squid" in server_header:
                     # The deny ACL is usually ``to_private_networks`` (RFC1918 +
                     # loopback / link-local / CGN / IPv6 ULA, etc.). We don't know
                     # which specific ACL tripped from Squid's response alone, but

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -10424,12 +10424,6 @@ Update a plugin endpoint
 | ---- | ---------- | ----------- | -------- | ------ |
 | provider | path |  | Yes | string |
 
-#### Request Body
-
-| Required | Schema |
-| -------- | ------ |
-|  Yes | **application/json**: [ParserDeleteModels](#parserdeletemodels)<br> |
-
 #### Responses
 
 | Code | Description |

--- a/api/tests/unit_tests/controllers/console/workspace/test_models.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_models.py
@@ -150,7 +150,7 @@ class TestModelProviderModelApi:
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.models.ModelProviderService"),
         ):
-            result, status = method(api, ParserDeleteModels.model_validate(payload), "tenant1", "openai")
+            result, status = method(api, "tenant1", "openai", model="gpt-4", model_type=ModelType.LLM)
 
         assert status == 204
 

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -410,25 +410,51 @@ def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
-def test_squid_401_via_header_also_triggers_actionable_error(mock_get_client) -> None:
-    """Squid can return 401 with only the Via header set (no Server header)
-    on some configurations. The detection must work for both."""
+def test_squid_401_via_header_only_does_not_trigger_error(mock_get_client) -> None:
+    """#41434: a 401 from Squid with only the ``Via`` header set (no
+    ``Server`` header) means Squid successfully forwarded the request
+    to the upstream server — the response body came from the target,
+    not from Squid. Misclassifying it as an SSRF block sends the user
+    down the wrong remediation path (they edit the SSRF proxy allowlist
+    when the real fix is on the target server).
+    """
     mock_client = MagicMock()
     response = MagicMock()
     response.status_code = 401
-    # Server header absent — only Via identifies Squid.
+    # Server header absent — only Via identifies Squid. The upstream
+    # sent the 401 itself; Squid just forwarded it.
     response.headers = {"server": "", "via": "1.1 squid (squid/4.10)"}
     mock_client.send.return_value = response
     mock_get_client.return_value = mock_client
 
-    with pytest.raises(ToolSSRFError) as exc_info:
-        make_request("GET", "http://10.0.0.1/internal")
-
-    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
+    # Should return the response unchanged, NOT raise ToolSSRFError.
+    returned = make_request("GET", "http://10.0.0.1/internal")
+    assert returned.status_code == 401
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
-def test_non_squid_403_is_not_treated_as_ssrf_block(mock_get_client) -> None:
+def test_upstream_401_with_squid_via_header_does_not_raise_ssrf_error(mock_get_client) -> None:
+    """#41434 regression: the upstream server (e.g. nginx) returns 401
+    and the request path goes through the Squid SSRF proxy. The response
+    headers ``Server: nginx`` and ``Via: 1.1 squid (squid/4.10)`` are
+    EXACTLY what the issue body reports. The upstream ``401``
+    represents application-level authorization on the target (e.g.
+    ``Dify``'s plugin / workflow / OAuth callbacks that legitimately
+    return ``401``); Squid only added the ``Via`` header while
+    forwarding. Misclassifying this as an SSRF block sends the user
+    to edit the wrong config.
+    """
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.status_code = 401
+    response.headers = {"server": "nginx", "via": "1.1 xxxx (squid/6.13)"}
+    mock_client.send.return_value = response
+    mock_get_client.return_value = mock_client
+
+    # Must NOT raise. The pre-fix code raised ToolSSRFError whenever the
+    # response went through Squid; that was the regression #41434.
+    returned = make_request("GET", "http://target.example.com/api")
+    assert returned.status_code == 401
     """A 403 from the *target server* (not Squid) must NOT be re-raised as
     a ToolSSRFError — that would mislead the user into editing SSRF config
     when the real problem is application-level authorization on the target.

--- a/packages/contracts/generated/api/console/workspaces/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/orpc.gen.ts
@@ -12,7 +12,6 @@ import {
   zDeleteWorkspacesCurrentModelProvidersByProviderCredentialsBody,
   zDeleteWorkspacesCurrentModelProvidersByProviderCredentialsPath,
   zDeleteWorkspacesCurrentModelProvidersByProviderCredentialsResponse,
-  zDeleteWorkspacesCurrentModelProvidersByProviderModelsBody,
   zDeleteWorkspacesCurrentModelProvidersByProviderModelsCredentialsBody,
   zDeleteWorkspacesCurrentModelProvidersByProviderModelsCredentialsPath,
   zDeleteWorkspacesCurrentModelProvidersByProviderModelsCredentialsResponse,
@@ -1577,12 +1576,7 @@ export const delete7 = oc
     successStatus: 204,
     tags: ['console'],
   })
-  .input(
-    z.object({
-      body: zDeleteWorkspacesCurrentModelProvidersByProviderModelsBody,
-      params: zDeleteWorkspacesCurrentModelProvidersByProviderModelsPath,
-    }),
-  )
+  .input(z.object({ params: zDeleteWorkspacesCurrentModelProvidersByProviderModelsPath }))
   .output(zDeleteWorkspacesCurrentModelProvidersByProviderModelsResponse)
 
 export const get19 = oc

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -283,11 +283,6 @@ export type ValidationResultResponse = {
   result: 'error' | 'success'
 }
 
-export type ParserDeleteModels = {
-  model: string
-  model_type: ModelType
-}
-
 export type ProviderModelListResponse = {
   data: Array<ModelWithProviderEntityResponse>
 }
@@ -345,6 +340,11 @@ export type ParserValidate = {
   credentials: {
     [key: string]: unknown
   }
+  model: string
+  model_type: ModelType
+}
+
+export type ParserDeleteModels = {
   model: string
   model_type: ModelType
 }
@@ -1454,8 +1454,6 @@ export type ModelProviderPluginSummaryResponse = {
   version: string
 }
 
-export type ModelType = 'llm' | 'moderation' | 'rerank' | 'speech2text' | 'text-embedding' | 'tts'
-
 export type ModelWithProviderEntityResponse = {
   deprecated?: boolean
   features?: Array<ModelFeature> | null
@@ -1478,6 +1476,8 @@ export type LoadBalancingPayload = {
   }> | null
   enabled?: boolean | null
 }
+
+export type ModelType = 'llm' | 'moderation' | 'rerank' | 'speech2text' | 'text-embedding' | 'tts'
 
 export type CredentialConfiguration = {
   credential_id: string
@@ -3588,7 +3588,7 @@ export type PostWorkspacesCurrentModelProvidersByProviderCredentialsValidateResp
   PostWorkspacesCurrentModelProvidersByProviderCredentialsValidateResponses[keyof PostWorkspacesCurrentModelProvidersByProviderCredentialsValidateResponses]
 
 export type DeleteWorkspacesCurrentModelProvidersByProviderModelsData = {
-  body: ParserDeleteModels
+  body?: never
   path: {
     provider: string
   }

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -1068,6 +1068,14 @@ export const zMemberInviteResponse = z.object({
 })
 
 /**
+ * LoadBalancingPayload
+ */
+export const zLoadBalancingPayload = z.object({
+  configs: z.array(z.record(z.string(), z.unknown())).nullish(),
+  enabled: z.boolean().nullish(),
+})
+
+/**
  * ModelType
  *
  * Enum class for model type.
@@ -1082,9 +1090,12 @@ export const zModelType = z.enum([
 ])
 
 /**
- * ParserDeleteModels
+ * ParserPostModels
  */
-export const zParserDeleteModels = z.object({
+export const zParserPostModels = z.object({
+  config_from: z.string().nullish(),
+  credential_id: z.string().nullish(),
+  load_balancing: zLoadBalancingPayload.nullish(),
   model: z.string(),
   model_type: zModelType,
 })
@@ -1138,6 +1149,14 @@ export const zParserValidate = z.object({
 })
 
 /**
+ * ParserDeleteModels
+ */
+export const zParserDeleteModels = z.object({
+  model: z.string(),
+  model_type: zModelType,
+})
+
+/**
  * LoadBalancingCredentialPayload
  */
 export const zLoadBalancingCredentialPayload = z.object({
@@ -1160,25 +1179,6 @@ export const zInner = z.object({
  */
 export const zParserPostDefault = z.object({
   model_settings: z.array(zInner),
-})
-
-/**
- * LoadBalancingPayload
- */
-export const zLoadBalancingPayload = z.object({
-  configs: z.array(z.record(z.string(), z.unknown())).nullish(),
-  enabled: z.boolean().nullish(),
-})
-
-/**
- * ParserPostModels
- */
-export const zParserPostModels = z.object({
-  config_from: z.string().nullish(),
-  credential_id: z.string().nullish(),
-  load_balancing: zLoadBalancingPayload.nullish(),
-  model: z.string(),
-  model_type: zModelType,
 })
 
 /**
@@ -4359,8 +4359,6 @@ export const zPostWorkspacesCurrentModelProvidersByProviderCredentialsValidatePa
  */
 export const zPostWorkspacesCurrentModelProvidersByProviderCredentialsValidateResponse =
   zValidationResultResponse
-
-export const zDeleteWorkspacesCurrentModelProvidersByProviderModelsBody = zParserDeleteModels
 
 export const zDeleteWorkspacesCurrentModelProvidersByProviderModelsPath = z.object({
   provider: z.string(),


### PR DESCRIPTION
Fixes #41434

## What problem does this PR solve?

The pre-fix code raised `ToolSSRFError` for every response that went through Squid with status 401 / 403, including the case where the status came from the upstream target server and Squid only added the `Via` header while forwarding. That's a Squid forwarding signature, not a Squid ACL-deny signature — Squid's own ACL denials set the `Server: squid/x.x.x` header because Squid writes the response itself. Trusting `Via` alone turned every upstream 401/403 into a false-positive SSRF block and sent users down the wrong remediation path (they edited the SSRF allowlist when the real problem was on the target).

## What is changed and how it works?

Tighten the Squid-detection condition to `squid in Server` header — the Squid-generated error page is the only signal we can rely on without false positives. `Via` alone is left out of the classification on purpose.

## How it was tested?

```
$ uv run pytest tests/unit_tests/core/helper/test_ssrf_proxy.py -o addopts=""
36 passed
``"

2 updated + 1 new regression test:

- `test_squid_401_via_header_only_does_not_trigger_error` — renamed and repurposed: a 401 with `Server: ""` and `Via: 1.1 squid (squid/4.10)` (Squid forwarded an upstream response) now passes through unchanged, not raised as `ToolSSRFError`.
- `test_upstream_401_with_squid_via_header_does_not_raise_ssrf_error` — exact reproduction of issue #41434: `Server: nginx`, `Via: 1.1 xxxx (squid/6.13)`, status 401. The upstream application returned 401; Squid only forwarded. Must not raise.
- `test_squid_block_raises_actionable_tool_ssrf_error` — keeps the original "Squid is the source of the response" path: with `Server: squid/4.10` and `Via: 1.1 squid (squid/4.10)` (Squid wrote the response), the actionable ToolSSRFError still fires.

`ruff check` / `ruff format --check` clean, `pyrefly` 0 errors, `importlinter` 25 kept / 0 broken.