### PR TITLE
fix(api): translate PluginNotFoundError / PluginDaemonNotFoundError at the ToolManager boundary

### DIFF
--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -22,6 +22,7 @@ from core.entities import PluginCredentialType
 from core.helper.module_import_helper import load_single_subclass_from_source
 from core.helper.position_helper import is_filtered
 from core.helper.provider_cache import ToolProviderCredentialsCache
+from core.plugin.impl.exc import PluginDaemonNotFoundError, PluginNotFoundError
 from core.plugin.impl.tool import PluginToolManager
 from core.tools.__base.tool import Tool
 from core.tools.__base.tool_provider import ToolProviderController
@@ -161,7 +162,19 @@ class ToolManager:
                 return plugin_tool_providers[provider]
 
             manager = PluginToolManager()
-            provider_entity = manager.fetch_tool_provider(tenant_id, provider)
+            try:
+                provider_entity = manager.fetch_tool_provider(tenant_id, provider)
+            except (PluginNotFoundError, PluginDaemonNotFoundError) as exc:
+                # Issue #41805: ``fetch_tool_provider`` raises
+                # ``PluginNotFoundError`` (provider unknown to the plugin
+                # daemon) or ``PluginDaemonNotFoundError`` (the daemon itself
+                # is unreachable) instead of returning ``None``. The
+                # boundary contract of ``ToolManager.get_plugin_provider`` is
+                # ``ToolProviderNotFoundError`` — translate here so callers
+                # (e.g. the builtin credential endpoints, which fall back
+                # to this method for unknown providers) get a controlled
+                # 4xx instead of leaking the daemon error as an HTTP 500.
+                raise ToolProviderNotFoundError(f"plugin provider {provider} not found") from exc
             if not provider_entity:
                 raise ToolProviderNotFoundError(f"plugin provider {provider} not found")
 

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.plugin.entities.plugin_daemon import CredentialType
+from core.plugin.impl.exc import PluginDaemonNotFoundError, PluginNotFoundError
 from core.tools.__base.tool_runtime import ToolRuntime
 from core.tools.entities.tool_entities import (
     ApiProviderAuthType,
@@ -262,6 +263,35 @@ def test_get_plugin_provider_raises_when_provider_missing():
         with patch("core.tools.tool_manager.contexts.plugin_tool_providers_lock", lock_context):
             with patch("core.tools.tool_manager.PluginToolManager") as mock_manager_cls:
                 mock_manager_cls.return_value.fetch_tool_provider.return_value = None
+                with pytest.raises(ToolProviderNotFoundError, match="plugin provider provider-a not found"):
+                    ToolManager.get_plugin_provider("provider-a", "tenant-1")
+
+
+@pytest.mark.parametrize(
+    "daemon_error",
+    [
+        PluginNotFoundError("plugin not found"),
+        PluginDaemonNotFoundError("daemon unreachable"),
+    ],
+)
+def test_get_plugin_provider_translates_plugin_daemon_errors_to_domain_error(daemon_error):
+    """#41805: ``PluginToolManager.fetch_tool_provider`` raises
+    ``PluginNotFoundError`` (the provider is unknown to the plugin
+    daemon) or ``PluginDaemonNotFoundError`` (the daemon itself is
+    unreachable) instead of returning ``None``. Without the boundary
+    translation at ``ToolManager.get_plugin_provider`` those errors
+    leak out as HTTP 500 from the builtin credential endpoints; with the
+    fix they surface as the existing ``ToolProviderNotFoundError``
+    domain error, which the controller layer maps to HTTP 400/404.
+    """
+    provider_context = _SimpleContextVar()
+    lock_context = _SimpleContextVar()
+    lock_context.set(threading.Lock())
+
+    with patch("core.tools.tool_manager.contexts.plugin_tool_providers", provider_context):
+        with patch("core.tools.tool_manager.contexts.plugin_tool_providers_lock", lock_context):
+            with patch("core.tools.tool_manager.PluginToolManager") as mock_manager_cls:
+                mock_manager_cls.return_value.fetch_tool_provider.side_effect = daemon_error
                 with pytest.raises(ToolProviderNotFoundError, match="plugin provider provider-a not found"):
                     ToolManager.get_plugin_provider("provider-a", "tenant-1")
 


### PR DESCRIPTION
Fixes #41805

## What problem does this PR solve?

The builtin-tool credential endpoints (and other paths that fall back to `ToolManager.get_plugin_provider` for unknown providers) used to leak the plugin daemon's `PluginNotFoundError` (and the lower-level `PluginDaemonNotFoundError`) as an HTTP 500. The boundary contract of `ToolManager.get_plugin_provider` is `ToolProviderNotFoundError` (controller maps to 400 / 404) but `PluginToolManager.fetch_tool_provider` raises — it never returns `None` — so the existing `if not provider_entity` check never fires. The Agent V2 frontend bug in #40686 / #41088 already fixed the source of the bad identifier, but this is defense in depth for every other caller of these endpoints.

## What is changed and how it works?

Catch `PluginNotFoundError` / `PluginDaemonNotFoundError` at the boundary and translate to `ToolProviderNotFoundError` with the existing `"plugin provider <name> not found"` message so callers get the controlled 4xx response they were already getting for the known-unknown case.

## How it was tested?

```
$ uv run pytest tests/unit_tests/core/tools/test_tool_manager.py -o addopts=
46 passed
``"

1 new, parameterized over both daemon error types:

- `test_get_plugin_provider_translates_plugin_daemon_errors_to_domain_error` — when `fetch_tool_provider` raises either `PluginNotFoundError` or `PluginDaemonNotFoundError`, `ToolManager.get_plugin_provider` must raise the existing `ToolProviderNotFoundError("plugin provider provider-a not found")` so callers see the controlled 4xx path.

All 46 tests in the suite still pass. `ruff check` / `ruff format --check` clean, `pyrefly` 0 errors, `importlinter` 25 kept / 0 broken.