### PR TITLE
fix(web): make isPrivateOrLocalAddress handle bracketed IPv6 and loopback ranges

### DIFF
--- a/web/utils/__tests__/urlValidation.spec.ts
+++ b/web/utils/__tests__/urlValidation.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { isPrivateOrLocalAddress } from '../urlValidation'
+
+describe('isPrivateOrLocalAddress', () => {
+  it('keeps treating public hosts as public', () => {
+    expect(isPrivateOrLocalAddress('https://dify.ai')).toBe(false)
+    expect(isPrivateOrLocalAddress('http://example.com')).toBe(false)
+    expect(isPrivateOrLocalAddress('http://8.8.8.8')).toBe(false)
+    expect(isPrivateOrLocalAddress('http://[2001:db8::1]')).toBe(false)
+  })
+
+  it('treats localhost, the whole 127.0.0.0/8 range and 0.0.0.0 as private', () => {
+    expect(isPrivateOrLocalAddress('http://localhost:8080/x')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://127.0.0.1')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://127.0.0.2')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://0.0.0.0')).toBe(true)
+  })
+
+  it('recognizes bracketed IPv6 literals', () => {
+    expect(isPrivateOrLocalAddress('http://[::1]:8080/x')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://[fd00::1]')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://[fc00::1]')).toBe(true)
+  })
+
+  it('keeps the existing IPv4 range and .local behavior', () => {
+    expect(isPrivateOrLocalAddress('http://10.0.0.1')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://172.16.0.1')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://192.168.1.1')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://169.254.1.1')).toBe(true)
+    expect(isPrivateOrLocalAddress('http://nas.local')).toBe(true)
+  })
+})

--- a/web/utils/urlValidation.ts
+++ b/web/utils/urlValidation.ts
@@ -27,16 +27,22 @@ export function validateRedirectUrl(url: string): void {
 export function isPrivateOrLocalAddress(url: string): boolean {
   try {
     const urlObj = new URL(url)
-    const hostname = urlObj.hostname.toLowerCase()
+    // WHATWG URL keeps the brackets around IPv6 literals in hostname (e.g.
+    // '[::1]'), so strip them before comparing against bare IPv6 addresses.
+    const hostname = urlObj.hostname.toLowerCase().replace(/^\[|\]$/g, '')
 
     // Check for localhost
-    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true
+    if (hostname === 'localhost') return true
 
     // Check for private IP ranges
     const ipv4Regex = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/
     const ipv4Match = ipv4Regex.exec(hostname)
     if (ipv4Match) {
       const [, a, b] = ipv4Match.map(Number)
+      // 127.0.0.0/8 loopback
+      if (a === 127) return true
+      // unspecified address
+      if (hostname === '0.0.0.0') return true
       // 10.0.0.0/8
       if (a === 10) return true
       // 172.16.0.0/12
@@ -46,6 +52,10 @@ export function isPrivateOrLocalAddress(url: string): boolean {
       // 169.254.0.0/16 (link-local)
       if (a === 169 && b === 254) return true
     }
+
+    // Check for IPv6 loopback and unique-local addresses (fc00::/7)
+    if (hostname === '::1') return true
+    if (/^f[cd][0-9a-f]{2}:/.test(hostname)) return true
 
     // Check for .local domains
     return hostname.endsWith('.local')


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41865

`isPrivateOrLocalAddress()` compared `URL.hostname` against the bare string `'::1'`, but the WHATWG URL parser keeps the brackets around IPv6 literals (`new URL('http://[::1]:8080/x').hostname` → `'[::1]'`), so that comparison was unreachable and the private-address advisory never rendered for IPv6 self-hosted URLs.

Changes in `web/utils/urlValidation.ts`:

- strip the surrounding brackets from `hostname` before the checks, so bracketed IPv6 literals are matched;
- extend the IPv4 loopback check from exactly `127.0.0.1` to the whole `127.0.0.0/8` range, and add the unspecified address `0.0.0.0`;
- treat IPv6 unique-local addresses (`fc00::/7`, e.g. `fd00::1`) as private, matching the advisory's intent for self-hosted instances;
- added `web/utils/__tests__/urlValidation.spec.ts` covering the public-host negatives, the loopback/unspecified ranges, bracketed IPv6 literals, and the pre-existing IPv4 range + `.local` behavior.

Not an SSRF fix: the function only drives the client-side advisory label on the Webhook Trigger panel and plugin subscription callback URLs; server-side SSRF protection is separate and untouched.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A — util change; the advisory label this drives is covered by the added unit tests | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods — frontend lint/format applied to the touched files; the new spec and the util were exercised directly (see test plan below)

### Verification

- `npx tsx` harness importing the patched module ran the full behavior table: 17/17 cases pass (public hosts and global IPv6 → `false`; localhost, `127.0.0.2`, `0.0.0.0`, `[::1]`, `[fd00::1]`, `[fc00::1]`, the existing IPv4 ranges and `.local` → `true`).
- On current `main`, the same harness fails on `http://[::1]:8080/x` (returns `false`, the `'::1'` comparison being unreachable), matching the issue's report.

From ZCode
