### PR TITLE
fix(api): compute annotation list has_more with the effective page size

### DIFF
--- a/api/controllers/console/app/annotation.py
+++ b/api/controllers/console/app/annotation.py
@@ -301,13 +301,18 @@ class AnnotationApi(Resource):
         page = req_data.page
         limit = req_data.limit
         keyword = req_data.keyword
+        effective_limit = min(limit, 100)
 
         annotation_list, total = AppAnnotationService.get_annotation_list_by_app_id(
-            str(app_id), page, limit, keyword, session
+            str(app_id), page, effective_limit, keyword, session
         )
         annotation_models = TypeAdapter(list[Annotation]).validate_python(annotation_list, from_attributes=True)
         return AnnotationList(
-            data=annotation_models, has_more=len(annotation_list) == limit, limit=limit, total=total, page=page
+            data=annotation_models,
+            has_more=page * effective_limit < total,
+            limit=effective_limit,
+            total=total,
+            page=page,
         ).model_dump(mode="json"), 200
 
     @console_ns.doc("create_annotation")
@@ -551,17 +556,18 @@ class AnnotationHitHistoryListApi(Resource):
     def get(self, session: Session, app_id: UUID, annotation_id: UUID):
         page = request.args.get("page", default=1, type=int)
         limit = request.args.get("limit", default=20, type=int)
+        effective_limit = min(limit, 100)
         app_ref = _get_app_ref(session, str(app_id))
         annotation_ref = AppRefService.create_annotation_ref(app_ref, str(annotation_id))
         annotation_hit_history_list, total = AppAnnotationService.get_annotation_hit_histories(
             annotation_ref,
             page,
-            limit,
+            effective_limit,
             session,
         )
         history_models = TypeAdapter(list[AnnotationHitHistory]).validate_python(
             annotation_hit_history_list, from_attributes=True
         )
         return AnnotationHitHistoryList(
-            data=history_models, has_more=len(annotation_hit_history_list) == limit, limit=limit, total=total, page=page
+            data=history_models, has_more=page * effective_limit < total, limit=effective_limit, total=total, page=page
         ).model_dump(mode="json")

--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -210,14 +210,15 @@ class AnnotationListApi(Resource):
     def get(self, query: AnnotationListQuery, session: Session, app_model: App):
         """List annotations for the application."""
 
+        effective_limit = min(query.limit, 100)
         annotation_list, total = AppAnnotationService.get_annotation_list_by_app_id(
-            app_model.id, query.page, query.limit, query.keyword, session
+            app_model.id, query.page, effective_limit, query.keyword, session
         )
         annotation_models = TypeAdapter(list[Annotation]).validate_python(annotation_list, from_attributes=True)
         return AnnotationList(
             data=annotation_models,
-            has_more=len(annotation_list) == query.limit,
-            limit=query.limit,
+            has_more=query.page * effective_limit < total,
+            limit=effective_limit,
             total=total,
             page=query.page,
         ).model_dump(mode="json")

--- a/api/tests/unit_tests/controllers/console/app/test_annotation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_annotation_api.py
@@ -249,7 +249,6 @@ class TestConsoleAnnotationRefBoundaries:
         history = _annotation_hit_history()
         hit_history_mock = Mock(return_value=([history], 1))
         _persist_app(sqlite_session)
-
         with (
             app.test_request_context("/hit-histories?page=2&limit=5", method="GET"),
             patch.object(
@@ -260,8 +259,92 @@ class TestConsoleAnnotationRefBoundaries:
             patch.object(annotation_module.AppAnnotationService, "get_annotation_hit_histories", hit_history_mock),
         ):
             response = handler(api, sqlite_session, "app-1", "ann-1")
-
         assert response["total"] == 1
         hit_history_mock.assert_called_once_with(
             AnnotationRef(AppRef("tenant-1", "app-1"), "ann-1"), 2, 5, sqlite_session
         )
+
+
+class TestAnnotationListHasMore:
+    def test_list_annotations_has_more_false_on_last_page_exact_limit(
+        self, app: Flask, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A full last page must set has_more false instead of forcing another fetch."""
+        page_size = 20
+        annotation = _annotation_model()
+        get_mock = Mock(return_value=([annotation] * page_size, page_size))
+        monkeypatch.setattr(annotation_module.AppAnnotationService, "get_annotation_list_by_app_id", get_mock)
+        api = annotation_module.AnnotationApi()
+        handler = unwrap(api.get)
+        with app.test_request_context(f"/apps/app-1/annotations?page=1&limit={page_size}", method="GET"):
+            response, status = handler(
+                api, annotation_module.AnnotationListQuery(page=1, limit=page_size), Mock(), "app-1"
+            )
+        assert status == 200
+        assert response["has_more"] is False
+        assert response["limit"] == page_size
+        assert response["total"] == page_size
+        assert response["page"] == 1
+
+    def test_list_annotations_has_more_true_when_limit_exceeds_cap(
+        self, app: Flask, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """limit>100 still reports remaining rows after the server cap of 100."""
+        annotation = _annotation_model()
+        get_mock = Mock(return_value=([annotation] * 100, 150))
+        monkeypatch.setattr(annotation_module.AppAnnotationService, "get_annotation_list_by_app_id", get_mock)
+        api = annotation_module.AnnotationApi()
+        handler = unwrap(api.get)
+        with app.test_request_context("/apps/app-1/annotations?page=1&limit=200", method="GET"):
+            response, status = handler(api, annotation_module.AnnotationListQuery(page=1, limit=200), Mock(), "app-1")
+        assert status == 200
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert response["total"] == 150
+        assert response["page"] == 1
+
+    def test_hit_histories_has_more_false_on_last_page_exact_limit(self, app: Flask, sqlite_session: Session):
+        api = annotation_module.AnnotationHitHistoryListApi()
+        handler = unwrap(api.get)
+        history = _annotation_hit_history()
+        hit_history_mock = Mock(return_value=([history] * 20, 20))
+        _persist_app(sqlite_session)
+
+        with (
+            app.test_request_context("/hit-histories?page=1&limit=20", method="GET"),
+            patch.object(
+                annotation_module,
+                "current_account_with_tenant",
+                return_value=(_account(), "tenant-1"),
+            ),
+            patch.object(annotation_module.AppAnnotationService, "get_annotation_hit_histories", hit_history_mock),
+        ):
+            response = handler(api, sqlite_session, "app-1", "ann-1")
+
+        assert response["has_more"] is False
+        assert response["limit"] == 20
+        assert response["total"] == 20
+        assert response["page"] == 1
+
+    def test_hit_histories_has_more_true_when_limit_exceeds_cap(self, app: Flask, sqlite_session: Session):
+        api = annotation_module.AnnotationHitHistoryListApi()
+        handler = unwrap(api.get)
+        history = _annotation_hit_history()
+        hit_history_mock = Mock(return_value=([history] * 100, 150))
+        _persist_app(sqlite_session)
+
+        with (
+            app.test_request_context("/hit-histories?page=1&limit=200", method="GET"),
+            patch.object(
+                annotation_module,
+                "current_account_with_tenant",
+                return_value=(_account(), "tenant-1"),
+            ),
+            patch.object(annotation_module.AppAnnotationService, "get_annotation_hit_histories", hit_history_mock),
+        ):
+            response = handler(api, sqlite_session, "app-1", "ann-1")
+
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert response["total"] == 150
+        assert response["page"] == 1

--- a/api/tests/unit_tests/controllers/service_api/app/test_annotation.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_annotation.py
@@ -269,6 +269,41 @@ class TestAnnotationListApi:
         assert unwrap(api.get) is not api.get
         get_mock.assert_not_called()
 
+    def test_has_more_false_on_last_page_exact_limit(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A full last page must set has_more false instead of forcing another fetch."""
+        page_size = 20
+        annotation = SimpleNamespace(id="a1", question="q", content="a", created_at=0)
+        get_mock = Mock(return_value=([annotation] * page_size, page_size))
+        monkeypatch.setattr(AppAnnotationService, "get_annotation_list_by_app_id", get_mock)
+        api = AnnotationListApi()
+        handler = unwrap(api.get)
+        app_model = SimpleNamespace(id="app")
+        with app.test_request_context(f"/apps/annotations?page=1&limit={page_size}", method="GET"):
+            query = AnnotationListQuery.model_validate(request.args.to_dict(flat=True))
+            response = handler(api, query, MagicMock(), app_model=app_model)
+        assert response["has_more"] is False
+        assert response["limit"] == page_size
+        assert response["total"] == page_size
+        assert response["page"] == 1
+
+    def test_has_more_true_when_limit_exceeds_cap(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        """limit>100 still reports remaining rows after the server cap of 100."""
+        returned_count = 100
+        total = 150
+        annotation = SimpleNamespace(id="a1", question="q", content="a", created_at=0)
+        get_mock = Mock(return_value=([annotation] * returned_count, total))
+        monkeypatch.setattr(AppAnnotationService, "get_annotation_list_by_app_id", get_mock)
+        api = AnnotationListApi()
+        handler = unwrap(api.get)
+        app_model = SimpleNamespace(id="app")
+        with app.test_request_context("/apps/annotations?page=1&limit=200", method="GET"):
+            query = AnnotationListQuery.model_validate(request.args.to_dict(flat=True))
+            response = handler(api, query, MagicMock(), app_model=app_model)
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert response["total"] == total
+        assert response["page"] == 1
+
     def test_create(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
         annotation = SimpleNamespace(id="a1", question="q", content="a", created_at=0)
         monkeypatch.setattr(


### PR DESCRIPTION
Fixes #41875

## Summary

The annotation list and hit-history endpoints computed `has_more` as `len(items) == limit`, while the query is served through `paginate_query(..., max_per_page=100)` which caps the page size at 100. Two wrong behaviours, both user-visible:

- **Last page exactly full** → `has_more=true` (phantom extra fetch / "loading more" spinner that returns nothing).
- **`limit` above the 100 cap with remaining rows** → `has_more=false` (pagination silently stops, remaining rows never fetched), and the response echoes the uncapped `limit` instead of the 100 actually used.

This is the same bug class already fixed for the dataset / document / segment Service API lists in #41784 / #41776; the annotation endpoints were missed.

### Changes

- `api/controllers/service_api/app/annotation.py` — Service API `GET /apps/annotations`
- `api/controllers/console/app/annotation.py` — Console `GET /apps/{app_id}/annotations` and `GET /apps/{app_id}/annotations/{annotation_id}/hit-histories`

Each now caps the page size (`effective_limit = min(limit, 100)`) and computes `has_more = page * effective_limit < total`, mirroring the accepted #41784/#41776 fix.

### Tests

6 regression tests added (2 per endpoint family), covering both the exact-full-last-page case and the `limit > 100` case. Before the fix all 6 fail; after, they pass.

- `tests/unit_tests/controllers/service_api/app/test_annotation.py` (2 new)
- `tests/unit_tests/controllers/console/app/test_annotation_api.py` (4 new)

Verification (local, dify `api` on `main`):
- Red: `test_has_more_*` → 6 failed
- Green after fix: `pytest tests/unit_tests/controllers/service_api/app/test_annotation.py` → 40 passed; `pytest .../console/app/test_annotation_api.py::TestAnnotationListHasMore TestConsoleAnnotationRefBoundaries` → 8 passed
- `ruff check` and `ruff format --check` clean on all changed files

### Follow-up (not in this PR)

The same `len(...) == limit` pattern remains on the console **datasets** controllers (`controllers/console/datasets/datasets.py`, `datasets_document.py`, `external.py`) and `controllers/console/explore/trial.py`; those are a separate service path and can be handled as a follow-up.

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` locally on the changed files (`ruff check` + `ruff format --check`) to appease the lint gods

From opencode.