### PR TITLE
chore: remove unnecessary str() calls in annotation tasks

### DIFF
--- a/api/tasks/annotation/batch_import_annotations_task.py
+++ b/api/tasks/annotation/batch_import_annotations_task.py
@@ -31,7 +31,7 @@ def batch_import_annotations_task(job_id: str, content_list: list[dict], app_id:
     """
     logger.info(click.style(f"Start batch import annotation: {job_id}", fg="green"))
     start_at = time.perf_counter()
-    indexing_cache_key = f"app_annotation_batch_import_{str(job_id)}"
+    indexing_cache_key = f"app_annotation_batch_import_{job_id}"
     active_jobs_key = f"annotation_import_active:{tenant_id}"
 
     with session_factory.create_session() as session:
@@ -94,7 +94,7 @@ def batch_import_annotations_task(job_id: str, content_list: list[dict], app_id:
             except Exception as e:
                 session.rollback()
                 redis_client.setex(indexing_cache_key, 600, "error")
-                indexing_error_msg_key = f"app_annotation_batch_import_error_msg_{str(job_id)}"
+                indexing_error_msg_key = f"app_annotation_batch_import_error_msg_{job_id}"
                 redis_client.setex(indexing_error_msg_key, 600, str(e))
                 logger.exception("Build index for batch import annotations failed")
             finally:

--- a/api/tasks/annotation/disable_annotation_reply_task.py
+++ b/api/tasks/annotation/disable_annotation_reply_task.py
@@ -40,8 +40,8 @@ def disable_annotation_reply_task(job_id: str, app_id: str, tenant_id: str):
             logger.info(click.style(f"App annotation setting not found: {app_id}", fg="red"))
             return
 
-        disable_app_annotation_key = f"disable_app_annotation_{str(app_id)}"
-        disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
+        disable_app_annotation_key = f"disable_app_annotation_{app_id}"
+        disable_app_annotation_job_key = f"disable_app_annotation_job_{job_id}"
 
         try:
             dataset = Dataset(
@@ -73,7 +73,7 @@ def disable_annotation_reply_task(job_id: str, app_id: str, tenant_id: str):
         except Exception as e:
             logger.exception("Annotation batch deleted index failed")
             redis_client.setex(disable_app_annotation_job_key, 600, "error")
-            disable_app_annotation_error_key = f"disable_app_annotation_error_{str(job_id)}"
+            disable_app_annotation_error_key = f"disable_app_annotation_error_{job_id}"
             redis_client.setex(disable_app_annotation_error_key, 600, str(e))
         finally:
             redis_client.delete(disable_app_annotation_key)

--- a/api/tasks/annotation/enable_annotation_reply_task.py
+++ b/api/tasks/annotation/enable_annotation_reply_task.py
@@ -45,8 +45,8 @@ def enable_annotation_reply_task(
             return
 
         annotations = session.scalars(select(MessageAnnotation).where(MessageAnnotation.app_id == app_id)).all()
-        enable_app_annotation_key = f"enable_app_annotation_{str(app_id)}"
-        enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
+        enable_app_annotation_key = f"enable_app_annotation_{app_id}"
+        enable_app_annotation_job_key = f"enable_app_annotation_job_{job_id}"
 
         try:
             documents = []
@@ -131,7 +131,7 @@ def enable_annotation_reply_task(
         except Exception as e:
             logger.exception("Annotation batch created index failed")
             redis_client.setex(enable_app_annotation_job_key, 600, "error")
-            enable_app_annotation_error_key = f"enable_app_annotation_error_{str(job_id)}"
+            enable_app_annotation_error_key = f"enable_app_annotation_error_{job_id}"
             redis_client.setex(enable_app_annotation_error_key, 600, str(e))
             session.rollback()
         finally:


### PR DESCRIPTION
## Summary

Part of #39947 

Removes 8 no-op `str()` wrappers in `api/tasks/annotation/*`. The `job_id` / `app_id` arguments are already typed as `str`, and inside an f-string the `str()` call is a no-op regardless, so pyrefly flags each of them as `unnecessary-type-conversion`.

Verified locally: with `unnecessary-type-conversion` raised to `warn`, pyrefly reports 0 remaining findings under `tasks/annotation/`; `ruff check` and `ruff format --check` pass. No behaviour change.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (no behaviour change; existing annotation service tests cover these tasks)
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods