### PR TITLE
fix(api): default Message.retriever_resources to [] when metadata lacks the key

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1817,7 +1817,7 @@ class Message(Base):
 
     @property
     def retriever_resources(self) -> Any:
-        return self.message_metadata_dict.get("retriever_resources") if self.message_metadata else []
+        return self.message_metadata_dict.get("retriever_resources", []) if self.message_metadata else []
 
     @property
     def message_files(self) -> list[MessageFileInfo]:

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -857,6 +857,77 @@ class TestMessageModel:
         # Assert
         assert result == {}
 
+    def test_retriever_resources_default_when_key_missing(self):
+        """Regression for langgenius/dify#41688: when message_metadata is set
+        but does not contain the 'retriever_resources' key, the property must
+        return [] (not None) so MessageListItem.retriever_resources
+        (a required list[...] field) does not fail Pydantic validation.
+        """
+        # Arrange — message_metadata exists but has no retriever_resources key
+        message = Message(
+            app_id=str(uuid4()),
+            conversation_id=str(uuid4()),
+            query="Test query",
+            message={"role": "user", "content": "Test"},
+            answer="Test answer",
+            message_unit_price=Decimal("0.0001"),
+            answer_unit_price=Decimal("0.0002"),
+            currency="USD",
+            from_source=ConversationFromSource.API,
+            message_metadata=json.dumps({"usage": {"tokens": 100}}),
+        )
+
+        # Act
+        result = message.retriever_resources
+
+        # Assert — must default to empty list, not None
+        assert result == []
+
+    def test_retriever_resources_none_when_message_metadata_none(self):
+        """When message_metadata is None, the property returns [] (the else branch)."""
+        # Arrange
+        message = Message(
+            app_id=str(uuid4()),
+            conversation_id=str(uuid4()),
+            query="Test query",
+            message={"role": "user", "content": "Test"},
+            answer="Test answer",
+            message_unit_price=Decimal("0.0001"),
+            answer_unit_price=Decimal("0.0002"),
+            currency="USD",
+            from_source=ConversationFromSource.API,
+            message_metadata=None,
+        )
+
+        # Act
+        result = message.retriever_resources
+
+        # Assert
+        assert result == []
+
+    def test_retriever_resources_returns_existing_value(self):
+        """When retriever_resources is set in metadata, the property returns it."""
+        # Arrange
+        resources = [{"document_id": "doc-1", "score": 0.9}]
+        message = Message(
+            app_id=str(uuid4()),
+            conversation_id=str(uuid4()),
+            query="Test query",
+            message={"role": "user", "content": "Test"},
+            answer="Test answer",
+            message_unit_price=Decimal("0.0001"),
+            answer_unit_price=Decimal("0.0002"),
+            currency="USD",
+            from_source=ConversationFromSource.API,
+            message_metadata=json.dumps({"retriever_resources": resources}),
+        )
+
+        # Act
+        result = message.retriever_resources
+
+        # Assert
+        assert result == resources
+
     def test_message_to_dict_serialization(self):
         """Test message to_dict method."""
         # Arrange


### PR DESCRIPTION
## Summary

Closes a 1.17.0 regression in the web-app embedded conversation history. When a chatflow or agent message has `message_metadata` set but does not include the `retriever_resources` key, the embedded page throws:

```
1 validation error for WebMessageListItem
retriever_resources
  Input should be a valid list
  [type=list_type, input_value=None, input_type=NoneType]
```

and the history fails to render.

Root cause: `Message.retriever_resources` does `self.message_metadata_dict.get("retriever_resources")` when `message_metadata` is set. `dict.get` without a default returns `None` for a missing key, and `None` then fails Pydantic validation on the required `list[RetrieverResource]` field declared by `MessageListItem.retriever_resources`.

Fix: add the missing default to `dict.get` so a metadata blob that does not carry the `retriever_resources` key resolves to `[]`.

Fixes #41688

## Why this is a regression, not a feature

- The `MessageListItem` Pydantic field is a required `list[RetrieverResource]` with no default; the contract is "always a list, possibly empty".
- The property already had the right contract for the `message_metadata is None` branch (`else []`). The `message_metadata is not None but key missing` branch was an oversight.
- The sibling `service_api` path was already fixed in PR #17304 (issue #14650) on a different serializer; this brings the web path in line with the same default-empty contract.

## Changes

`api/models/model.py::Message.retriever_resources`

```python
@property
def retriever_resources(self) -> Any:
-    return self.message_metadata_dict.get("retriever_resources") if self.message_metadata else []
+    return self.message_metadata_dict.get("retriever_resources", []) if self.message_metadata else []
```

No other call sites need to change; the property is the single source of truth for `retriever_resources` on the model.

## Tests

Three new unit tests in `api/tests/unit_tests/models/test_app_models.py` (`TestMessageModel`):

- `test_retriever_resources_default_when_key_missing` — a Message whose `message_metadata` JSON does not contain `retriever_resources` returns `[]` from the property. **This test fails on the unpatched property with `assert None == []`**; verified by stashing only the source file and re-running, then restoring.
- `test_retriever_resources_none_when_message_metadata_none` — a Message with `message_metadata=None` still returns `[]` (the existing `else` branch).
- `test_retriever_resources_returns_existing_value` — a Message whose metadata does carry `retriever_resources` returns the stored value unchanged.

3/3 pass on the new tests. 57/57 pass on the full `test_app_models.py` file. ruff check + format clean on both touched files.

## Verification

- `pytest tests/unit_tests/models/test_app_models.py` — 57/57 pass.
- `ruff check` — clean.
- `ruff format --check` — clean.

## Risk

Very low. The change is a 1-character default on a `dict.get` call. The two other branches (key present, metadata None) are unchanged. No schema, API, or protocol change. The web `MessageListItem.retriever_resources` field already required a list, so the contract is preserved.

## Future work (out of scope here)

A small audit of other `message_metadata_dict.get(...)` call sites in the model layer to confirm no other property has the same missing-key shape mismatch with its serializer. Grep for `message_metadata_dict.get` in `api/models/` would surface them. None were reported as broken in #41688, but a sweep would harden the contract.
