### PR TITLE
fix: suggested questions empty for reasoning models

### DIFF
--- a/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
+++ b/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
@@ -24,10 +24,13 @@ class SuggestedQuestionsAfterAnswerOutputParser:
 
     def parse(self, text: str) -> Sequence[str]:
         stripped_text = text.strip()
-        # Reasoning models may prepend a <think>...</think> block before the payload. Any
-        # bracket pair inside it would otherwise be matched first (and either fail to parse
-        # or parse as non-strings), leaving the suggested questions empty.
-        stripped_text = re.sub(r"<think>.*?</think>", "", stripped_text, flags=re.DOTALL).strip()
+        # Reasoning models may prepend a <think>...</think> or <thought>...</thought> block
+        # before the payload. Unclosed blocks (e.g. truncated responses) are discarded through
+        # end-of-input. Any bracket pair inside reasoning would otherwise be matched first
+        # (and either fail to parse or parse as non-strings), leaving the suggested questions empty.
+        stripped_text = re.sub(
+            r"<(think|thought)>.*?(?:</\1>|$)", "", stripped_text, flags=re.DOTALL | re.IGNORECASE
+        ).strip()
         action_match = re.search(r"\[.*?\]", stripped_text, re.DOTALL)
         questions: list[str] = []
         if action_match is not None:

--- a/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
+++ b/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
@@ -24,6 +24,10 @@ class SuggestedQuestionsAfterAnswerOutputParser:
 
     def parse(self, text: str) -> Sequence[str]:
         stripped_text = text.strip()
+        # Reasoning models may prepend a <think>...</think> block before the payload. Any
+        # bracket pair inside it would otherwise be matched first (and either fail to parse
+        # or parse as non-strings), leaving the suggested questions empty.
+        stripped_text = re.sub(r"<think>.*?</think>", "", stripped_text, flags=re.DOTALL).strip()
         action_match = re.search(r"\[.*?\]", stripped_text, re.DOTALL)
         questions: list[str] = []
         if action_match is not None:

--- a/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
+++ b/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
@@ -1,0 +1,51 @@
+from core.llm_generator.output_parser.suggested_questions_after_answer import (
+    SuggestedQuestionsAfterAnswerOutputParser,
+)
+
+
+class TestSuggestedQuestionsAfterAnswerOutputParser:
+    def test_parse_plain_array(self):
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = 'questions:\n["What is Dify?", "How to build an app?"]'
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?", "How to build an app?"]
+
+    def test_parse_strips_think_block_before_matching(self):
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = (
+            "<think>\n"
+            "The user asked about Dify. Relevant tokens are [CLS] and probabilities [0.2, 0.8].\n"
+            "</think>\n"
+            '["What is Dify?", "How to build an app?"]'
+        )
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?", "How to build an app?"]
+
+    def test_parse_ignores_numeric_array_inside_think_block(self):
+        # Regression for #41854: a numeric array inside <think> used to be matched first and
+        # parsed successfully, but was then filtered out as non-strings, yielding [].
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = '<think>score vector: [0.2, 0.8]</think>\n["What is Dify?"]'
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?"]
+
+    def test_parse_ignores_invalid_array_inside_think_block(self):
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = '<think>masked token: [MASK]</think>\n["What is Dify?"]'
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?"]
+
+    def test_parse_empty_without_payload(self):
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+
+        result = parser.parse("no questions here")
+
+        assert list(result) == []

--- a/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
+++ b/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
@@ -49,3 +49,45 @@ class TestSuggestedQuestionsAfterAnswerOutputParser:
         result = parser.parse("no questions here")
 
         assert list(result) == []
+
+    def test_parse_discards_unclosed_think_block(self) -> None:
+        # Truncated response leaving an unclosed <think> tag with bracket tokens inside
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = "<think>Analyzing user query: score vector [0.1, 0.9]"
+
+        result = parser.parse(text)
+
+        assert list(result) == []
+
+    def test_parse_discards_unclosed_thought_block(self) -> None:
+        # Truncated response with an unclosed <thought> tag
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = "<thought>Analyzing user query: tokens [MASK]"
+
+        result = parser.parse(text)
+
+        assert list(result) == []
+
+    def test_parse_case_insensitive_closed_think_block(self) -> None:
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = '<Think>\nThinking with [0.1, 0.9]\n</THINK>\n["What is Dify?"]'
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?"]
+
+    def test_parse_case_insensitive_unclosed_think_block(self) -> None:
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = "<THINK>Thinking with [0.1, 0.9] truncated"
+
+        result = parser.parse(text)
+
+        assert list(result) == []
+
+    def test_parse_closed_thought_block(self) -> None:
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = '<thought>\nInternal thought with [MASK]\n</thought>\n["What is Dify?"]'
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?"]

--- a/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
+++ b/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
@@ -4,7 +4,7 @@ from core.llm_generator.output_parser.suggested_questions_after_answer import (
 
 
 class TestSuggestedQuestionsAfterAnswerOutputParser:
-    def test_parse_plain_array(self):
+    def test_parse_plain_array(self) -> None:
         parser = SuggestedQuestionsAfterAnswerOutputParser()
         text = 'questions:\n["What is Dify?", "How to build an app?"]'
 
@@ -12,7 +12,7 @@ class TestSuggestedQuestionsAfterAnswerOutputParser:
 
         assert list(result) == ["What is Dify?", "How to build an app?"]
 
-    def test_parse_strips_think_block_before_matching(self):
+    def test_parse_strips_think_block_before_matching(self) -> None:
         parser = SuggestedQuestionsAfterAnswerOutputParser()
         text = (
             "<think>\n"
@@ -25,7 +25,7 @@ class TestSuggestedQuestionsAfterAnswerOutputParser:
 
         assert list(result) == ["What is Dify?", "How to build an app?"]
 
-    def test_parse_ignores_numeric_array_inside_think_block(self):
+    def test_parse_ignores_numeric_array_inside_think_block(self) -> None:
         # Regression for #41854: a numeric array inside <think> used to be matched first and
         # parsed successfully, but was then filtered out as non-strings, yielding [].
         parser = SuggestedQuestionsAfterAnswerOutputParser()
@@ -35,7 +35,7 @@ class TestSuggestedQuestionsAfterAnswerOutputParser:
 
         assert list(result) == ["What is Dify?"]
 
-    def test_parse_ignores_invalid_array_inside_think_block(self):
+    def test_parse_ignores_invalid_array_inside_think_block(self) -> None:
         parser = SuggestedQuestionsAfterAnswerOutputParser()
         text = '<think>masked token: [MASK]</think>\n["What is Dify?"]'
 
@@ -43,7 +43,7 @@ class TestSuggestedQuestionsAfterAnswerOutputParser:
 
         assert list(result) == ["What is Dify?"]
 
-    def test_parse_empty_without_payload(self):
+    def test_parse_empty_without_payload(self) -> None:
         parser = SuggestedQuestionsAfterAnswerOutputParser()
 
         result = parser.parse("no questions here")


### PR DESCRIPTION
## Summary

Fixes #41854

When the suggested-questions-after-answer generator falls back to the workspace default LLM and that model is a reasoning model, the completion can contain a `<think>...</think>` block before the JSON payload. `SuggestedQuestionsAfterAnswerOutputParser` searched the raw text for the first `[...]` pair, so a bracket pair inside the reasoning block (e.g. a probability vector `[0.2, 0.8]` or a token like `[MASK]`) was matched first: it either failed to decode (logged warning + empty list) or decoded into non-string values that were filtered away — both leaving the API returning `[]` even though the model answered fine.

This change strips `<think>...</think>` blocks (DOTALL) before searching for the payload array. Output from non-reasoning models is unaffected, as is the behavior when no reasoning block is present.

## Screenshots

N/A — behavior is covered by unit tests.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From ZCode