### PR TITLE
refactor(models): pass session into ApiToolProvider.user accessor

### DIFF
--- a/api/core/tools/custom_tool/provider.py
+++ b/api/core/tools/custom_tool/provider.py
@@ -4,6 +4,7 @@ from typing import override
 
 from pydantic import Field
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from core.entities.provider_entities import ProviderConfig, ProviderConfigType
 from core.tools.__base.tool_provider import ToolProviderController
@@ -36,7 +37,9 @@ class ApiToolProviderController(ToolProviderController[ToolProviderEntity, ApiTo
         self.tools = []
 
     @classmethod
-    def from_db(cls, db_provider: ApiToolProvider, auth_type: ApiProviderAuthType) -> ApiToolProviderController:
+    def from_db(
+        cls, db_provider: ApiToolProvider, auth_type: ApiProviderAuthType, *, session: Session
+    ) -> ApiToolProviderController:
         credentials_schema = [
             ProviderConfig(
                 name="auth_type",
@@ -104,7 +107,7 @@ class ApiToolProviderController(ToolProviderController[ToolProviderEntity, ApiTo
         elif auth_type == ApiProviderAuthType.NONE:
             pass
 
-        user = db_provider.user
+        user = db_provider.user(session=session)
         user_name = user.name if user else ""
 
         return ApiToolProviderController(

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -781,6 +781,7 @@ class ToolManager:
                             db_provider=db_provider,
                             decrypt_credentials=False,
                             labels=provider_labels,
+                            session=db.session(),
                         )
                         result_providers[f"api_provider.{user_provider.name}"] = user_provider
 
@@ -858,6 +859,7 @@ class ToolManager:
         controller = ApiToolProviderController.from_db(
             provider,
             auth_type,
+            session=db.session(),
         )
         controller.load_bundled_tools(provider.tools)
 
@@ -918,6 +920,7 @@ class ToolManager:
         controller = ApiToolProviderController.from_db(
             provider_obj,
             auth_type,
+            session=db.session(),
         )
         # init tool configuration
         encrypter, _ = create_tool_provider_encrypter(

--- a/api/models/tools.py
+++ b/api/models/tools.py
@@ -197,11 +197,10 @@ class ApiToolProvider(TypeBase):
     def credentials(self) -> dict[str, Any]:
         return dict[str, Any](json.loads(self.credentials_str))
 
-    @property
-    def user(self) -> Account | None:
+    def user(self, session: Session) -> Account | None:
         if not self.user_id:
             return None
-        return db.session.scalar(select(Account).where(Account.id == self.user_id))
+        return session.scalar(select(Account).where(Account.id == self.user_id))
 
     def tenant(self, session: Session) -> Tenant | None:
         return session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -201,7 +201,7 @@ class ApiToolManageService:
             auth_type = ApiProviderAuthType.value_of(credentials["auth_type"])
 
             # create provider entity
-            provider_controller = ApiToolProviderController.from_db(api_tool_provider, auth_type)
+            provider_controller = ApiToolProviderController.from_db(api_tool_provider, auth_type, session=db.session())
             # load tools into provider entity
             provider_controller.load_bundled_tools(tool_bundles)
 
@@ -352,7 +352,7 @@ class ApiToolManageService:
             auth_type = ApiProviderAuthType.value_of(credentials["auth_type"])
 
             # create provider entity
-            provider_controller = ApiToolProviderController.from_db(provider, auth_type)
+            provider_controller = ApiToolProviderController.from_db(provider, auth_type, session=db.session())
             # load tools into provider entity
             provider_controller.load_bundled_tools(tool_bundles)
 
@@ -494,7 +494,7 @@ class ApiToolManageService:
         auth_type = ApiProviderAuthType.value_of(credentials["auth_type"])
 
         # create provider entity
-        provider_controller = ApiToolProviderController.from_db(provider, auth_type)
+        provider_controller = ApiToolProviderController.from_db(provider, auth_type, session=db.session())
         # load tools into provider entity
         provider_controller.load_bundled_tools(tool_bundles)
 
@@ -549,7 +549,7 @@ class ApiToolManageService:
             provider_controller = ToolTransformService.api_provider_to_controller(db_provider=provider)
             labels = ToolLabelManager.get_tool_labels(provider_controller)
             user_provider = ToolTransformService.api_provider_to_user_provider(
-                provider_controller, db_provider=provider, decrypt_credentials=True
+                provider_controller, db_provider=provider, decrypt_credentials=True, session=db.session()
             )
             user_provider.labels = labels
 

--- a/api/services/tools/tools_transform_service.py
+++ b/api/services/tools/tools_transform_service.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from pydantic import TypeAdapter, ValidationError
+from sqlalchemy.orm import Session
 from yarl import URL
 
 from configs import dify_config
@@ -27,6 +28,7 @@ from core.tools.plugin_tool.provider import PluginToolProviderController
 from core.tools.utils.encryption import create_provider_encrypter, create_tool_provider_encrypter
 from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
 from core.tools.workflow_as_tool.tool import WorkflowTool
+from extensions.ext_database import db
 from models.tools import ApiToolProvider, BuiltinToolProvider, MCPToolProvider, WorkflowToolProvider
 
 logger = logging.getLogger(__name__)
@@ -202,6 +204,7 @@ class ToolTransformService:
         controller = ApiToolProviderController.from_db(
             db_provider=db_provider,
             auth_type=auth_type,
+            session=db.session(),
         )
 
         return controller
@@ -305,15 +308,17 @@ class ToolTransformService:
         db_provider: ApiToolProvider,
         decrypt_credentials: bool = True,
         labels: list[str] | None = None,
+        *,
+        session: Session,
     ) -> ToolProviderApiEntity:
         """
         convert provider controller to user provider
         """
         username = "Anonymous"
-        if db_provider.user is None:
+        user = db_provider.user(session=session)
+        if user is None:
             raise ValueError(f"user is None for api provider {db_provider.id}")
         try:
-            user = db_provider.user
             if not user:
                 raise ValueError("user not found")
 

--- a/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
+++ b/api/tests/unit_tests/core/tools/test_custom_tool_provider.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -43,7 +44,7 @@ def _db_provider() -> ApiToolProvider:
             name="provider-a",
             description="desc",
             icon="icon.svg",
-            user=SimpleNamespace(name="Alice"),
+            user=MagicMock(return_value=SimpleNamespace(name="Alice")),
             tools=[bundle],
         ),
     )
@@ -68,7 +69,9 @@ def _persist_provider(session: Session, *, tenant_id: str, name: str = "provider
 
 
 def test_api_tool_provider_from_db_and_parse_tool_bundle() -> None:
-    controller = ApiToolProviderController.from_db(_db_provider(), ApiProviderAuthType.API_KEY_HEADER)
+    controller = ApiToolProviderController.from_db(
+        _db_provider(), ApiProviderAuthType.API_KEY_HEADER, session=MagicMock()
+    )
     assert controller.provider_type == ToolProviderType.API
     assert any(c.name == "api_key_value" for c in controller.entity.credentials_schema)
 
@@ -78,17 +81,19 @@ def test_api_tool_provider_from_db_and_parse_tool_bundle() -> None:
 
 
 def test_api_tool_provider_from_db_query_auth_and_none_auth() -> None:
-    query_controller = ApiToolProviderController.from_db(_db_provider(), ApiProviderAuthType.API_KEY_QUERY)
+    query_controller = ApiToolProviderController.from_db(
+        _db_provider(), ApiProviderAuthType.API_KEY_QUERY, session=MagicMock()
+    )
     assert any(c.name == "api_key_query_param" for c in query_controller.entity.credentials_schema)
 
-    none_controller = ApiToolProviderController.from_db(_db_provider(), ApiProviderAuthType.NONE)
+    none_controller = ApiToolProviderController.from_db(_db_provider(), ApiProviderAuthType.NONE, session=MagicMock())
     assert [c.name for c in none_controller.entity.credentials_schema] == ["auth_type"]
 
 
 def test_api_tool_provider_load_get_tools_and_get_tool(
     monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
 ) -> None:
-    controller = ApiToolProviderController.from_db(_db_provider(), ApiProviderAuthType.NONE)
+    controller = ApiToolProviderController.from_db(_db_provider(), ApiProviderAuthType.NONE, session=MagicMock())
     loaded = controller.load_bundled_tools(_db_provider().tools)
     assert len(loaded) == 1
 

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -41,9 +41,6 @@ class _CallableSessionProxy:
     def __call__(self) -> Session:
         return self._session
 
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._session, name)
-
     def add(self, instance: object) -> None:
         self._session.add(instance)
 

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -41,6 +41,9 @@ class _CallableSessionProxy:
     def __call__(self) -> Session:
         return self._session
 
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
     def add(self, instance: object) -> None:
         self._session.add(instance)
 
@@ -55,6 +58,15 @@ class _CallableSessionProxy:
 
     def get(self, entity: type[object], ident: object) -> object | None:
         return self._session.get(entity, ident)
+
+    def scalar(self, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        return self._session.scalar(statement, *args, **kwargs)
+
+    def scalars(self, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        return self._session.scalars(statement, *args, **kwargs)
+
+    def execute(self, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        return self._session.execute(statement, *args, **kwargs)
 
 
 @dataclass(frozen=True)

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -33,7 +33,7 @@ from models.tools import ApiToolProvider, BuiltinToolProvider, WorkflowToolProvi
 
 
 class _CallableSessionProxy:
-    """Lets ``db.session`` support both attribute access and ``db.session()`` calls in tests."""
+    """Lets test code use a session directly while production obtains it from ``db.session()``."""
 
     def __init__(self, session: Session) -> None:
         self._session = session
@@ -41,8 +41,20 @@ class _CallableSessionProxy:
     def __call__(self) -> Session:
         return self._session
 
-    def __getattr__(self, name: str):
-        return getattr(self._session, name)
+    def add(self, instance: object) -> None:
+        self._session.add(instance)
+
+    def add_all(self, instances: list[object]) -> None:
+        self._session.add_all(instances)
+
+    def commit(self) -> None:
+        self._session.commit()
+
+    def expire_all(self) -> None:
+        self._session.expire_all()
+
+    def get(self, entity: type[object], ident: object) -> object | None:
+        return self._session.get(entity, ident)
 
 
 @dataclass(frozen=True)

--- a/api/tests/unit_tests/core/tools/test_tool_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_manager.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 from sqlalchemy import event
@@ -32,10 +32,23 @@ from models.base import TypeBase
 from models.tools import ApiToolProvider, BuiltinToolProvider, WorkflowToolProvider
 
 
+class _CallableSessionProxy:
+    """Lets ``db.session`` support both attribute access and ``db.session()`` calls in tests."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def __call__(self) -> Session:
+        return self._session
+
+    def __getattr__(self, name: str):
+        return getattr(self._session, name)
+
+
 @dataclass(frozen=True)
 class _ToolDatabase:
     engine: Engine
-    session: Session
+    session: _CallableSessionProxy
 
 
 @pytest.fixture
@@ -48,7 +61,7 @@ def tool_database(sqlite_engine: Engine) -> Iterator[_ToolDatabase]:
     ]
     TypeBase.metadata.create_all(sqlite_engine, tables=tables)
     with Session(sqlite_engine, expire_on_commit=False) as session:
-        yield _ToolDatabase(engine=sqlite_engine, session=session)
+        yield _ToolDatabase(engine=sqlite_engine, session=_CallableSessionProxy(session))
 
 
 def _builtin_provider(
@@ -962,7 +975,7 @@ def test_get_api_provider_controller_returns_controller_and_credentials(
 
     assert built_controller is controller
     assert credentials == provider.credentials
-    mock_from_db.assert_called_with(provider, ApiProviderAuthType.API_KEY_QUERY)
+    mock_from_db.assert_called_with(provider, ApiProviderAuthType.API_KEY_QUERY, session=ANY)
     controller.load_bundled_tools.assert_called_once_with(provider.tools)
 
 

--- a/api/tests/unit_tests/models/test_tool_provider_session_accessors.py
+++ b/api/tests/unit_tests/models/test_tool_provider_session_accessors.py
@@ -5,6 +5,7 @@ Covers four of `api/models/tools.py`'s legacy `@property` accessors that reached
 ``session: Session`` (per the pattern established in #40370/#40797/#41394, tracked in #40372):
 
 - ``ApiToolProvider.tenant``
+- ``ApiToolProvider.user``
 - ``WorkflowToolProvider.user``
 - ``WorkflowToolProvider.tenant``
 - ``WorkflowToolProvider.app``
@@ -93,6 +94,25 @@ class TestApiToolProviderTenant:
         provider = _api_tool_provider(tenant_id=str(uuid4()))
 
         assert provider.tenant(session=sqlite_session) is None
+
+
+class TestApiToolProviderUser:
+    def test_returns_persisted_user(self, sqlite_session: Session) -> None:
+        account = _persist_account(sqlite_session)
+        provider = _api_tool_provider(tenant_id=str(uuid4()))
+        provider.user_id = account.id
+        sqlite_session.add(provider)
+        sqlite_session.flush()
+
+        result = provider.user(session=sqlite_session)
+
+        assert result is not None
+        assert result.id == account.id
+
+    def test_returns_none_when_user_missing(self, sqlite_session: Session) -> None:
+        provider = _api_tool_provider(tenant_id=str(uuid4()))
+
+        assert provider.user(session=sqlite_session) is None
 
 
 class TestWorkflowToolProviderUser:

--- a/api/tests/unit_tests/services/tools/test_tools_transform_service.py
+++ b/api/tests/unit_tests/services/tools/test_tools_transform_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 from core.tools.__base.tool import Tool
 from core.tools.entities.api_entities import ToolApiEntity, ToolProviderApiEntity
@@ -512,31 +512,39 @@ class TestApiProviderToController:
     def test_api_key_header_auth(self):
         db_provider = MagicMock()
         db_provider.credentials = {"auth_type": "api_key_header"}
-        with patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
+        with patch(f"{MODULE}.db.session"), patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
             ctrl_cls.from_db.return_value = MagicMock()
             ToolTransformService.api_provider_to_controller(db_provider)
-        ctrl_cls.from_db.assert_called_once_with(db_provider=db_provider, auth_type=ApiProviderAuthType.API_KEY_HEADER)
+        ctrl_cls.from_db.assert_called_once_with(
+            db_provider=db_provider, auth_type=ApiProviderAuthType.API_KEY_HEADER, session=ANY
+        )
 
     def test_api_key_query_auth(self):
         db_provider = MagicMock()
         db_provider.credentials = {"auth_type": "api_key_query"}
-        with patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
+        with patch(f"{MODULE}.db.session"), patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
             ctrl_cls.from_db.return_value = MagicMock()
             ToolTransformService.api_provider_to_controller(db_provider)
-        ctrl_cls.from_db.assert_called_once_with(db_provider=db_provider, auth_type=ApiProviderAuthType.API_KEY_QUERY)
+        ctrl_cls.from_db.assert_called_once_with(
+            db_provider=db_provider, auth_type=ApiProviderAuthType.API_KEY_QUERY, session=ANY
+        )
 
     def test_legacy_api_key_maps_to_header(self):
         db_provider = MagicMock()
         db_provider.credentials = {"auth_type": "api_key"}
-        with patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
+        with patch(f"{MODULE}.db.session"), patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
             ctrl_cls.from_db.return_value = MagicMock()
             ToolTransformService.api_provider_to_controller(db_provider)
-        ctrl_cls.from_db.assert_called_once_with(db_provider=db_provider, auth_type=ApiProviderAuthType.API_KEY_HEADER)
+        ctrl_cls.from_db.assert_called_once_with(
+            db_provider=db_provider, auth_type=ApiProviderAuthType.API_KEY_HEADER, session=ANY
+        )
 
     def test_unknown_auth_defaults_to_none(self):
         db_provider = MagicMock()
         db_provider.credentials = {"auth_type": "something_else"}
-        with patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
+        with patch(f"{MODULE}.db.session"), patch(f"{MODULE}.ApiToolProviderController") as ctrl_cls:
             ctrl_cls.from_db.return_value = MagicMock()
             ToolTransformService.api_provider_to_controller(db_provider)
-        ctrl_cls.from_db.assert_called_once_with(db_provider=db_provider, auth_type=ApiProviderAuthType.NONE)
+        ctrl_cls.from_db.assert_called_once_with(
+            db_provider=db_provider, auth_type=ApiProviderAuthType.NONE, session=ANY
+        )


### PR DESCRIPTION
## Summary

Part of #40372.

Converts `ApiToolProvider.user` from a `@property` that reached for the global `db.session` into a plain method taking an explicit caller-provided `session: Session` (matching the `tenant(session)` accessor converted earlier in the same model). The session is threaded through `ApiToolProviderController.from_db` and its production call sites (`ToolManager`, `ToolsTransformService`, `ApiToolsManageService`) via `session=db.session()`, keeping the request-scoped behavior unchanged.

## Screenshots

N/A — behavior is covered by unit tests.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From ZCode