### PR TITLE
refactor(models): remove legacy db.session wrappers on Message accessors

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -1212,7 +1212,7 @@ class TraceTask:
         tool_parameters = {}
         created_time = message_data.created_at
         end_time = message_data.updated_at
-        agent_thoughts = message_data.agent_thoughts
+        agent_thoughts = message_data.agent_thoughts_with_session(session=db.session())
         for agent_thought in agent_thoughts:
             if tool_name in agent_thought.tools:
                 created_time = agent_thought.created_at

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1740,10 +1740,6 @@ class Message(Base):
 
         return re_sign_file_url_answer
 
-    @property
-    def user_feedback(self) -> MessageFeedback | None:
-        return self.user_feedback_with_session(session=db.session())
-
     def user_feedback_with_session(self, *, session: Session) -> MessageFeedback | None:
         return session.scalar(
             select(MessageFeedback).where(MessageFeedback.message_id == self.id, MessageFeedback.from_source == "user")
@@ -1757,23 +1753,11 @@ class Message(Base):
             select(MessageFeedback).where(MessageFeedback.message_id == self.id, MessageFeedback.from_source == "admin")
         )
 
-    @property
-    def feedbacks(self) -> Sequence[MessageFeedback]:
-        return self.feedbacks_with_session(session=db.session())
-
     def feedbacks_with_session(self, *, session: Session) -> Sequence[MessageFeedback]:
         return session.scalars(select(MessageFeedback).where(MessageFeedback.message_id == self.id)).all()
 
-    @property
-    def annotation(self) -> MessageAnnotation | None:
-        return self.annotation_with_session(session=db.session())
-
     def annotation_with_session(self, *, session: Session) -> MessageAnnotation | None:
         return session.scalar(select(MessageAnnotation).where(MessageAnnotation.message_id == self.id))
-
-    @property
-    def annotation_hit_history(self) -> MessageAnnotation | None:
-        return self.annotation_hit_history_with_session(session=db.session())
 
     def annotation_hit_history_with_session(self, *, session: Session) -> MessageAnnotation | None:
         annotation_history = session.scalar(
@@ -1784,10 +1768,6 @@ class Message(Base):
                 select(MessageAnnotation).where(MessageAnnotation.id == annotation_history.annotation_id)
             )
         return None
-
-    @property
-    def app_model_config(self) -> AppModelConfig | None:
-        return self.app_model_config_with_session(session=db.session())
 
     def app_model_config_with_session(self, *, session: Session) -> AppModelConfig | None:
         conversation = session.scalar(select(Conversation).where(Conversation.id == self.conversation_id))
@@ -1804,10 +1784,6 @@ class Message(Base):
     def message_metadata_dict(self) -> dict[str, Any]:
         return json.loads(self.message_metadata) if self.message_metadata else {}
 
-    @property
-    def agent_thoughts(self) -> Sequence[MessageAgentThought]:
-        return self.agent_thoughts_with_session(session=db.session())
-
     def agent_thoughts_with_session(self, *, session: Session) -> Sequence[MessageAgentThought]:
         return session.scalars(
             select(MessageAgentThought)
@@ -1818,10 +1794,6 @@ class Message(Base):
     @property
     def retriever_resources(self) -> Any:
         return self.message_metadata_dict.get("retriever_resources") if self.message_metadata else []
-
-    @property
-    def message_files(self) -> list[MessageFileInfo]:
-        return self.message_files_with_session(session=db.session())
 
     def message_files_with_session(self, *, session: Session) -> list[MessageFileInfo]:
         from factories import file_factory

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -14,7 +14,7 @@ from uuid import UUID
 import pytest
 from flask import Flask
 from sqlalchemy import Engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 import core.ops.ops_trace_manager as module
 from core.ops.ops_trace_manager import OpsTraceManager, TraceQueueManager, TraceTask, TraceTaskName
@@ -144,8 +144,9 @@ class RecordingDispatcher:
 
 @pytest.fixture
 def database(sqlite_engine: Engine, sqlite_session: Session) -> Iterator[Session]:
+    session_proxy = scoped_session(lambda: sqlite_session)
     with (
-        patch.object(module.db, "session", sqlite_session),
+        patch.object(module.db, "session", session_proxy),
         patch.object(type(module.db), "engine", new_callable=PropertyMock, return_value=sqlite_engine),
     ):
         yield sqlite_session

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -289,7 +289,11 @@ def _message_data(**overrides):
         "inputs": "inputs",
     }
     data.update(overrides)
-    return SimpleNamespace(**data, to_dict=lambda: data)
+    return SimpleNamespace(
+        **data,
+        agent_thoughts_with_session=lambda *, session: data["agent_thoughts"],
+        to_dict=lambda: data,
+    )
 
 
 def test_encrypt_decrypt_obfuscate_and_cache(


### PR DESCRIPTION
## Summary

Part of #40372.

Removes seven thin `Message` `@property` wrappers that only built a session from the global `db.session` and delegated to their existing `*_with_session` variants:

`user_feedback`, `feedbacks`, `annotation`, `annotation_hit_history`, `app_model_config`, `agent_thoughts`, `message_files`

The `MessageResponseSource` layer (`fields/conversation_fields.py`) already routes through the `*_with_session` methods. The one direct caller (`ops_trace_manager.tool_trace` reading `agent_thoughts`) now passes the request-scoped session explicitly via `agent_thoughts_with_session(session=db.session())`.

`Message.inputs` is intentionally left in place: it carries a setter with File payload normalization and is not a plain session wrapper.

## Screenshots

N/A — no behavior change; the unit suite (models + controllers) passes.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From ZCode