### PR TITLE
fix(web): strip IPv6 brackets and recognize IPv6 local/private ranges in isPrivateOrLocalAddress

### DIFF
--- a/web/utils/urlValidation.spec.ts
+++ b/web/utils/urlValidation.spec.ts
@@ -1,4 +1,4 @@
-import { validateRedirectUrl } from './urlValidation'
+import { isPrivateOrLocalAddress, validateRedirectUrl } from './urlValidation'
 
 describe('URL Validation', () => {
   describe('validateRedirectUrl', () => {
@@ -54,6 +54,44 @@ describe('URL Validation', () => {
 
     it('should reject protocol-relative URLs', () => {
       expect(() => validateRedirectUrl('//example.com')).toThrow('Invalid URL')
+    })
+  })
+
+  describe('isPrivateOrLocalAddress', () => {
+    it('should identify localhost and loopback IPv4', () => {
+      expect(isPrivateOrLocalAddress('http://localhost')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://localhost:3000')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://127.0.0.1')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://127.0.0.1:8080/api')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://app.localhost')).toBe(true)
+    })
+
+    it('should identify IPv6 loopback and private ranges with and without brackets', () => {
+      expect(isPrivateOrLocalAddress('http://[::1]')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://[::1]:8080/api')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://[0:0:0:0:0:0:0:1]:3000')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://[fe80::1ff:fe23:4567:890a]')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://[fc00::1]')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://[fd12:3456:789a:1::1]')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://[::ffff:127.0.0.1]')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://[::ffff:192.168.1.100]')).toBe(true)
+    })
+
+    it('should identify private IPv4 ranges', () => {
+      expect(isPrivateOrLocalAddress('http://10.0.0.1')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://172.16.0.1')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://172.31.255.255')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://192.168.1.1')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://169.254.169.254')).toBe(true)
+      expect(isPrivateOrLocalAddress('http://service.local')).toBe(true)
+    })
+
+    it('should return false for public addresses', () => {
+      expect(isPrivateOrLocalAddress('https://google.com')).toBe(false)
+      expect(isPrivateOrLocalAddress('https://api.github.com/events')).toBe(false)
+      expect(isPrivateOrLocalAddress('http://8.8.8.8')).toBe(false)
+      expect(isPrivateOrLocalAddress('http://1.1.1.1:53')).toBe(false)
+      expect(isPrivateOrLocalAddress('http://[2001:4860:4860::8888]')).toBe(false)
     })
   })
 })

--- a/web/utils/urlValidation.ts
+++ b/web/utils/urlValidation.ts
@@ -27,10 +27,36 @@ export function validateRedirectUrl(url: string): void {
 export function isPrivateOrLocalAddress(url: string): boolean {
   try {
     const urlObj = new URL(url)
-    const hostname = urlObj.hostname.toLowerCase()
+    let hostname = urlObj.hostname.toLowerCase()
 
-    // Check for localhost
-    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true
+    // Strip IPv6 square brackets from hostname if present (e.g. "[::1]" -> "::1")
+    if (hostname.startsWith('[') && hostname.endsWith(']'))
+      hostname = hostname.slice(1, -1)
+
+    // Check for localhost and loopback addresses
+    if (
+      hostname === 'localhost'
+      || hostname === '127.0.0.1'
+      || hostname === '::1'
+      || hostname === '0:0:0:0:0:0:0:1'
+      || hostname === '0:0:0:0:0:0:0:0'
+      || hostname === '::'
+    )
+      return true
+
+    // Check for IPv6 link-local (fe80::/10), unique local (fc00::/7, fd00::/8)
+    if (
+      hostname.startsWith('fe80:')
+      || hostname.startsWith('fc')
+      || hostname.startsWith('fd')
+    )
+      return true
+
+    // Check for IPv4-mapped IPv6 addresses (e.g., ::ffff:127.0.0.1)
+    if (hostname.startsWith('::ffff:')) {
+      const mappedIpv4 = hostname.slice(7)
+      return isPrivateOrLocalAddress(`http://${mappedIpv4}`)
+    }
 
     // Check for private IP ranges
     const ipv4Regex = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/
@@ -39,6 +65,10 @@ export function isPrivateOrLocalAddress(url: string): boolean {
       const [, a, b] = ipv4Match.map(Number)
       // 10.0.0.0/8
       if (a === 10) return true
+      // 127.0.0.0/8 (loopback)
+      if (a === 127) return true
+      // 0.0.0.0/8
+      if (a === 0) return true
       // 172.16.0.0/12
       if (a === 172 && b! >= 16 && b! <= 31) return true
       // 192.168.0.0/16
@@ -47,8 +77,8 @@ export function isPrivateOrLocalAddress(url: string): boolean {
       if (a === 169 && b === 254) return true
     }
 
-    // Check for .local domains
-    return hostname.endsWith('.local')
+    // Check for .local domains and localhost subdomains
+    return hostname.endsWith('.local') || hostname.endsWith('.localhost')
   } catch {
     return false
   }


### PR DESCRIPTION
## Problem
When checking URLs containing IPv6 addresses (such as \http://[::1]:8080\ or \http://[fe80::1]\), \URL.hostname\ returns the address enclosed in square brackets (e.g. \[::1]\). \isPrivateOrLocalAddress()\ compared against unbracketed \::1\, causing all bracketed IPv6 loopback and private addresses to bypass local/private network detection.

## Solution
- Normalize hostname by stripping square brackets if present before performing address classification.
- Add support for IPv6 loopback (\::1\, \