### PR TITLE
fix(api): cap raw limit before computing has_more in annotation endpoints (#41875)

### DIFF
--- a/api/controllers/console/app/annotation.py
+++ b/api/controllers/console/app/annotation.py
@@ -299,15 +299,19 @@ class AnnotationApi(Resource):
     @model_validate(AnnotationListQuery)
     def get(self, req_data: AnnotationListQuery, session: Session, app_id: UUID):
         page = req_data.page
-        limit = req_data.limit
+        effective_limit = min(req_data.limit, 100)
         keyword = req_data.keyword
 
         annotation_list, total = AppAnnotationService.get_annotation_list_by_app_id(
-            str(app_id), page, limit, keyword, session
+            str(app_id), page, effective_limit, keyword, session
         )
         annotation_models = TypeAdapter(list[Annotation]).validate_python(annotation_list, from_attributes=True)
         return AnnotationList(
-            data=annotation_models, has_more=len(annotation_list) == limit, limit=limit, total=total, page=page
+            data=annotation_models,
+            has_more=page * effective_limit < total,
+            limit=effective_limit,
+            total=total,
+            page=page,
         ).model_dump(mode="json"), 200
 
     @console_ns.doc("create_annotation")
@@ -550,18 +554,22 @@ class AnnotationHitHistoryListApi(Resource):
     @with_session(write=False)
     def get(self, session: Session, app_id: UUID, annotation_id: UUID):
         page = request.args.get("page", default=1, type=int)
-        limit = request.args.get("limit", default=20, type=int)
+        effective_limit = min(request.args.get("limit", default=20, type=int), 100)
         app_ref = _get_app_ref(session, str(app_id))
         annotation_ref = AppRefService.create_annotation_ref(app_ref, str(annotation_id))
         annotation_hit_history_list, total = AppAnnotationService.get_annotation_hit_histories(
             annotation_ref,
             page,
-            limit,
+            effective_limit,
             session,
         )
         history_models = TypeAdapter(list[AnnotationHitHistory]).validate_python(
             annotation_hit_history_list, from_attributes=True
         )
         return AnnotationHitHistoryList(
-            data=history_models, has_more=len(annotation_hit_history_list) == limit, limit=limit, total=total, page=page
+            data=history_models,
+            has_more=page * effective_limit < total,
+            limit=effective_limit,
+            total=total,
+            page=page,
         ).model_dump(mode="json")

--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -210,14 +210,15 @@ class AnnotationListApi(Resource):
     def get(self, query: AnnotationListQuery, session: Session, app_model: App):
         """List annotations for the application."""
 
+        effective_limit = min(query.limit, 100)
         annotation_list, total = AppAnnotationService.get_annotation_list_by_app_id(
-            app_model.id, query.page, query.limit, query.keyword, session
+            app_model.id, query.page, effective_limit, query.keyword, session
         )
         annotation_models = TypeAdapter(list[Annotation]).validate_python(annotation_list, from_attributes=True)
         return AnnotationList(
             data=annotation_models,
-            has_more=len(annotation_list) == query.limit,
-            limit=query.limit,
+            has_more=query.page * effective_limit < total,
+            limit=effective_limit,
             total=total,
             page=query.page,
         ).model_dump(mode="json")

--- a/api/tests/unit_tests/controllers/console/app/test_annotation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_annotation_api.py
@@ -171,6 +171,40 @@ def test_get_app_ref_raises_not_found_when_app_is_not_in_current_tenant(sqlite_s
 
 
 class TestConsoleAnnotationRefBoundaries:
+    @pytest.mark.parametrize(
+        ("requested_limit", "item_count", "total", "expected_limit", "expected_has_more"),
+        [(20, 20, 20, 20, False), (200, 100, 150, 100, True)],
+    )
+    def test_list_annotations_uses_effective_limit_for_pagination(
+        self,
+        app: Flask,
+        sqlite_session: Session,
+        requested_limit: int,
+        item_count: int,
+        total: int,
+        expected_limit: int,
+        expected_has_more: bool,
+    ):
+        api = annotation_module.AnnotationApi()
+        handler = unwrap(api.get)
+        annotation = _annotation_model()
+        annotation_list_mock = Mock(return_value=([annotation] * item_count, total))
+
+        with patch.object(
+            annotation_module.AppAnnotationService, "get_annotation_list_by_app_id", annotation_list_mock
+        ):
+            response, status = handler(
+                api,
+                annotation_module.AnnotationListQuery(page=1, limit=requested_limit),
+                sqlite_session,
+                "app-1",
+            )
+
+        assert status == 200
+        assert response["limit"] == expected_limit
+        assert response["has_more"] is expected_has_more
+        assert annotation_list_mock.call_args.args[2] == expected_limit
+
     def test_batch_delete_uses_app_ref(self, app: Flask, sqlite_session: Session):
         api = annotation_module.AnnotationApi()
         handler = unwrap(api.delete)
@@ -265,3 +299,38 @@ class TestConsoleAnnotationRefBoundaries:
         hit_history_mock.assert_called_once_with(
             AnnotationRef(AppRef("tenant-1", "app-1"), "ann-1"), 2, 5, sqlite_session
         )
+
+    @pytest.mark.parametrize(
+        ("requested_limit", "item_count", "total", "expected_limit", "expected_has_more"),
+        [(20, 20, 20, 20, False), (200, 100, 150, 100, True)],
+    )
+    def test_hit_history_uses_effective_limit_for_pagination(
+        self,
+        app: Flask,
+        sqlite_session: Session,
+        requested_limit: int,
+        item_count: int,
+        total: int,
+        expected_limit: int,
+        expected_has_more: bool,
+    ):
+        api = annotation_module.AnnotationHitHistoryListApi()
+        handler = unwrap(api.get)
+        history = _annotation_hit_history()
+        hit_history_mock = Mock(return_value=([history] * item_count, total))
+        _persist_app(sqlite_session)
+
+        with (
+            app.test_request_context(f"/hit-histories?page=1&limit={requested_limit}", method="GET"),
+            patch.object(
+                annotation_module,
+                "current_account_with_tenant",
+                return_value=(_account(), "tenant-1"),
+            ),
+            patch.object(annotation_module.AppAnnotationService, "get_annotation_hit_histories", hit_history_mock),
+        ):
+            response = handler(api, sqlite_session, "app-1", "ann-1")
+
+        assert response["limit"] == expected_limit
+        assert response["has_more"] is expected_has_more
+        assert hit_history_mock.call_args.args[2] == expected_limit

--- a/api/tests/unit_tests/controllers/service_api/app/test_annotation.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_annotation.py
@@ -254,6 +254,34 @@ class TestAnnotationListApi:
         assert isinstance(session, MagicMock)
         assert get_mock.call_args.args == ("app", 2, 5, "refund", session)
 
+    @pytest.mark.parametrize(
+        ("requested_limit", "item_count", "total", "expected_limit", "expected_has_more"),
+        [(20, 20, 20, 20, False), (200, 100, 150, 100, True)],
+    )
+    def test_get_uses_effective_limit_for_pagination(
+        self,
+        app: Flask,
+        monkeypatch: pytest.MonkeyPatch,
+        requested_limit: int,
+        item_count: int,
+        total: int,
+        expected_limit: int,
+        expected_has_more: bool,
+    ) -> None:
+        annotation = SimpleNamespace(id="a1", question="q", content="a", created_at=0)
+        get_mock = Mock(return_value=([annotation] * item_count, total))
+        monkeypatch.setattr(AppAnnotationService, "get_annotation_list_by_app_id", get_mock)
+        api = AnnotationListApi()
+        handler = unwrap(api.get)
+        app_model = SimpleNamespace(id="app")
+        query = AnnotationListQuery(page=1, limit=requested_limit)
+
+        response = handler(api, query, MagicMock(), app_model=app_model)
+
+        assert response["limit"] == expected_limit
+        assert response["has_more"] is expected_has_more
+        assert get_mock.call_args.args[2] == expected_limit
+
     @pytest.mark.parametrize("query_string", ["page=abc&limit=5", "page=1&limit=abc", "page=&limit=5", "limit=0"])
     def test_get_rejects_invalid_explicit_pagination_value(
         self, app: Flask, monkeypatch: pytest.MonkeyPatch, query_string: str


### PR DESCRIPTION
### Description
Fixes #41875 (sibling of #41780 and #41776).

When fetching annotation lists / hit history with a query parameter `limit > 100`, the query capped results to 100 while `has_more` still evaluated against the raw incoming `limit`. This caused incorrect pagination state (`has_more: false`).

### Changes
- Capped limit before evaluating pagination and `has_more` in:
  - `api/controllers/console/app/annotation.py`
  - `api/controllers/service_api/app/annotation.py`
- Added unit tests for `limit > 100` edge cases in `test_annotation.py` and `test_annotation_api.py`.

### Checklist
- [x] Unit tests pass locally
- [x] Ruff lint/format checks pass