### PR TITLE
refactor(web): migrate loop variable constant inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4001,11 +4001,8 @@
     }
   },
   "web/app/components/workflow/nodes/loop/components/loop-variables/form-item.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
-      "count": 3
+      "count": 2
     }
   },
   "web/app/components/workflow/nodes/loop/components/loop-variables/item.tsx": {

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3260,14 +3260,6 @@
       "count": 1
     }
   },
-  "web/app/components/workflow/nodes/_base/components/error-handle/default-value.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "typescript/no-explicit-any": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/_base/components/error-handle/types.ts": {
     "erasable-syntax-only/enums": {
       "count": 1

--- a/web/app/components/workflow/nodes/_base/components/error-handle/__tests__/index.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/error-handle/__tests__/index.spec.tsx
@@ -123,7 +123,8 @@ describe('error-handle path', () => {
       )
     })
 
-    it('should render string forms and surface array forms in the default value editor', () => {
+    it('should edit a labeled string default and preserve the array editor', async () => {
+      const user = userEvent.setup()
       const onFormChange = vi.fn()
       render(
         <DefaultValue
@@ -135,14 +136,36 @@ describe('error-handle path', () => {
         />,
       )
 
-      fireEvent.change(screen.getByDisplayValue('hello'), { target: { value: 'updated' } })
+      const input = screen.getByRole('textbox', { name: 'message' })
+      await user.click(screen.getByText('message'))
+      expect(input).toHaveFocus()
+      await user.type(input, '!')
 
       expect(onFormChange).toHaveBeenCalledWith({
         key: 'message',
         type: VarType.string,
-        value: 'updated',
+        value: 'hello!',
       })
       expect(screen.getByText('items')).toBeInTheDocument()
+    })
+
+    it('should report a numeric default as a string to the workflow owner', async () => {
+      const user = userEvent.setup()
+      const onFormChange = vi.fn()
+      render(
+        <DefaultValue
+          forms={[{ key: 'count', type: VarType.number, value: 12 }]}
+          onFormChange={onFormChange}
+        />,
+      )
+
+      await user.type(screen.getByRole('spinbutton', { name: 'count' }), '3')
+
+      expect(onFormChange).toHaveBeenLastCalledWith({
+        key: 'count',
+        type: VarType.number,
+        value: '123',
+      })
     })
 
     it('should toggle the selector popup and report the selected strategy', async () => {

--- a/web/app/components/workflow/nodes/_base/components/error-handle/default-value.tsx
+++ b/web/app/components/workflow/nodes/_base/components/error-handle/default-value.tsx
@@ -1,7 +1,7 @@
 import type { DefaultValueForm } from './types'
-import { useCallback } from 'react'
+import { Input } from '@langgenius/dify-ui/input'
+import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import { VarType } from '@/app/components/workflow/types'
@@ -12,27 +12,7 @@ type DefaultValueProps = {
 }
 const DefaultValue = ({ forms, onFormChange }: DefaultValueProps) => {
   const { t } = useTranslation()
-  const getFormChangeHandler = useCallback(
-    ({ key, type }: DefaultValueForm) => {
-      return (payload: any) => {
-        let value
-        if (type === VarType.string || type === VarType.number) value = payload.target.value
-
-        if (
-          type === VarType.array ||
-          type === VarType.arrayNumber ||
-          type === VarType.arrayString ||
-          type === VarType.arrayObject ||
-          type === VarType.arrayFile ||
-          type === VarType.object
-        )
-          value = payload
-
-        onFormChange({ key, type, value })
-      }
-    },
-    [onFormChange],
-  )
+  const id = useId()
 
   return (
     <div className="px-4 pt-2">
@@ -42,17 +22,27 @@ const DefaultValue = ({ forms, onFormChange }: DefaultValueProps) => {
       </div>
       <div className="space-y-1">
         {forms.map((form, index) => {
+          const isInput = form.type === VarType.string || form.type === VarType.number
+          const inputId = `${id}-${index}`
           return (
             <div key={index} className="py-1">
               <div className="mb-1 flex items-center">
-                <div className="mr-1 system-sm-medium text-text-primary">{form.key}</div>
+                {isInput ? (
+                  <label htmlFor={inputId} className="mr-1 system-sm-medium text-text-primary">
+                    {form.key}
+                  </label>
+                ) : (
+                  <div className="mr-1 system-sm-medium text-text-primary">{form.key}</div>
+                )}
                 <div className="system-xs-regular text-text-tertiary">{form.type}</div>
               </div>
-              {(form.type === VarType.string || form.type === VarType.number) && (
+              {isInput && (
                 <Input
-                  type={form.type}
+                  id={inputId}
+                  type={form.type === VarType.number ? 'number' : 'text'}
+                  placeholder={t(($) => $['placeholder.input'], { ns: 'common' })}
                   value={form.value || (form.type === VarType.string ? '' : 0)}
-                  onChange={getFormChangeHandler({ key: form.key, type: form.type })}
+                  onValueChange={(value) => onFormChange({ key: form.key, type: form.type, value })}
                 />
               )}
               {(form.type === VarType.array ||
@@ -63,7 +53,7 @@ const DefaultValue = ({ forms, onFormChange }: DefaultValueProps) => {
                 <CodeEditor
                   language={CodeLanguage.json}
                   value={form.value}
-                  onChange={getFormChangeHandler({ key: form.key, type: form.type })}
+                  onChange={(value) => onFormChange({ key: form.key, type: form.type, value })}
                 />
               )}
             </div>

--- a/web/app/components/workflow/nodes/loop/components/loop-variables/__tests__/form-item.spec.tsx
+++ b/web/app/components/workflow/nodes/loop/components/loop-variables/__tests__/form-item.spec.tsx
@@ -1,0 +1,62 @@
+import type { LoopVariable } from '@/app/components/workflow/nodes/loop/types'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { ValueType, VarType } from '@/app/components/workflow/types'
+import FormItem from '../form-item'
+
+describe('Loop variable constant input', () => {
+  it('reports numeric edits and clearing as strings to the loop draft', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    function LoopDraft() {
+      const [value, setValue] = useState('12')
+      return (
+        <FormItem
+          nodeId="loop-node"
+          item={{
+            id: 'count',
+            label: 'count',
+            var_type: VarType.number,
+            value_type: ValueType.constant,
+            value,
+          }}
+          onChange={(nextValue) => {
+            setValue(nextValue)
+            onChange(nextValue)
+          }}
+        />
+      )
+    }
+    render(<LoopDraft />)
+
+    const input = screen.getByRole('spinbutton', { name: 'count' })
+    await user.clear(input)
+    expect(onChange).toHaveBeenLastCalledWith('')
+    await user.type(input, '-3.5')
+    expect(input).toHaveValue(-3.5)
+    expect(onChange).toHaveBeenLastCalledWith('-3.5')
+  })
+
+  it.each([
+    [VarType.number, 'spinbutton'],
+    [VarType.string, 'textbox'],
+  ] as const)('names an unnamed %s constant until its variable is named', (varType, role) => {
+    const item: LoopVariable = {
+      id: 'new-variable',
+      label: '',
+      var_type: varType,
+      value_type: ValueType.constant,
+      value: '',
+    }
+    const { rerender } = render(<FormItem nodeId="loop-node" item={item} onChange={vi.fn()} />)
+    expect(
+      screen.getByRole(role, { name: 'workflow.errorMsg.fields.variableValue' }),
+    ).toBeInTheDocument()
+
+    rerender(
+      <FormItem nodeId="loop-node" item={{ ...item, label: 'counter' }} onChange={vi.fn()} />,
+    )
+    expect(screen.getByRole(role, { name: 'counter' })).toBeInTheDocument()
+  })
+})

--- a/web/app/components/workflow/nodes/loop/components/loop-variables/form-item.tsx
+++ b/web/app/components/workflow/nodes/loop/components/loop-variables/form-item.tsx
@@ -1,9 +1,9 @@
 import type { LoopVariable } from '@/app/components/workflow/nodes/loop/types'
 import type { Var } from '@/app/components/workflow/types'
+import { Input } from '@langgenius/dify-ui/input'
 import { Textarea } from '@langgenius/dify-ui/textarea'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
 import VarReferencePicker from '@/app/components/workflow/nodes/_base/components/variable/var-reference-picker'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
@@ -26,16 +26,10 @@ type FormItemProps = {
 const FormItem = ({ nodeId, item, onChange }: FormItemProps) => {
   const { t } = useTranslation()
   const { value_type, var_type, value } = item
+  const valueLabel = item.label || t(($) => $['errorMsg.fields.variableValue'], { ns: 'workflow' })
   const normalizedVarValue = useMemo(() => {
     return Array.isArray(value) ? value : []
   }, [value])
-
-  const handleInputChange = useCallback(
-    (e: any) => {
-      onChange(e.target.value)
-    },
-    [onChange],
-  )
 
   const handleValueChange = useCallback(
     (value: string) => {
@@ -85,14 +79,21 @@ const FormItem = ({ nodeId, item, onChange }: FormItemProps) => {
       )}
       {value_type === ValueType.constant && var_type === VarType.string && (
         <Textarea
-          aria-label={item.label}
+          aria-label={valueLabel}
           value={value}
           onValueChange={handleValueChange}
           className="min-h-12 w-full"
         />
       )}
       {value_type === ValueType.constant && var_type === VarType.number && (
-        <Input type="number" value={value} onChange={handleInputChange} className="w-full" />
+        <Input
+          aria-label={valueLabel}
+          type="number"
+          value={value}
+          onValueChange={handleValueChange}
+          placeholder={t(($) => $['placeholder.input'], { ns: 'common' })}
+          className="w-full"
+        />
       )}
       {value_type === ValueType.constant && var_type === VarType.boolean && (
         <BoolValue value={value} onChange={handleChange} />


### PR DESCRIPTION
Replace the legacy Loop numeric constant input with Dify UI Input while preserving string-valued draft updates and empty values. Name the numeric control from its variable name and keep both numeric and text constants named while a new variable is unnamed.

Preserves the existing placeholder and layout. Numeric inputs now use native input behavior instead of the legacy wrapper's extra leading-zero normalization on blur.

Validation: 5 Loop variable tests, targeted accessibility lint, and `pnpm check` passed. Compared the same live Loop input against main: width, height, padding, radius, background, and focused shadow match.
