### PR TITLE
fix(web): resolve infinite signin redirect loop caused by dead token …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,13 @@
 *.md
 !web/README.md
 !api/README.md
+
+# Local env files must never reach an image build. Next.js resolves NEXT_PUBLIC_* at build
+# time, so a developer's web/.env.local bakes the host dev API origin
+# (http://localhost:5001) into the served bundle. The browser then talks to the dev API
+# while the container's server-side render talks to api:5001 -- different databases and
+# SECRET_KEYs, so every session the browser establishes is rejected server-side.
+**/.env.local
+**/.env.*.local
+**/.env.development
+**/.env.test

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -213,7 +213,7 @@ services:
       - "${EXPOSE_PLUGIN_DAEMON_PORT:-5002}:${PLUGIN_DAEMON_PORT:-5002}"
       - "${EXPOSE_PLUGIN_DEBUGGING_PORT:-5003}:${PLUGIN_DEBUGGING_PORT:-5003}"
     volumes:
-      - ./volumes/plugin_daemon:/app/storage
+      - ${PLUGIN_DAEMON_HOST_VOLUME:-./volumes/plugin_daemon}:/app/storage
 
   # ssrf_proxy server
   # for more information, please refer to

--- a/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
     throw new Error(`NEXT_REDIRECT:${url}`)
   }),
   headers: vi.fn(),
+  cookies: vi.fn(),
   resolveServerConsoleApiUrl: vi.fn(),
   basePath: '',
 }))
@@ -28,6 +29,11 @@ vi.mock('@/app/get-query-client', () => {
 
 vi.mock('@/next/headers', () => ({
   headers: () => mocks.headers(),
+  cookies: () => mocks.cookies(),
+}))
+
+vi.mock('@/config', () => ({
+  REFRESH_TOKEN_COOKIE_NAME: () => 'refresh_token',
 }))
 
 vi.mock('@/next/navigation', () => ({
@@ -82,6 +88,12 @@ describe('CommonLayoutHydrationBoundary', () => {
         'x-dify-search': '?tag=workflow',
       }),
     )
+    // Default to holding a refresh token, so the existing 401 cases still expect the
+    // /auth/refresh hop. The no-token shortcut is covered by its own case below.
+    mocks.cookies.mockResolvedValue({
+      get: (name: string) =>
+        name === 'refresh_token' ? { name, value: 'a-refresh-token' } : undefined,
+    })
     mocks.resolveServerConsoleApiUrl.mockReturnValue(
       'https://console.example.com/console/api/account/profile',
     )
@@ -215,6 +227,21 @@ describe('CommonLayoutHydrationBoundary', () => {
     expect(mocks.redirect).toHaveBeenCalledWith(
       '/auth/refresh?redirect_url=%2Fapps%3Ftag%3Dworkflow',
     )
+  })
+
+  it('should redirect straight to signin on 401 when no refresh token is present', async () => {
+    // /auth/refresh is a Route Handler and can only answer with a bare 3xx, which an RSC
+    // navigation cannot settle on — the client router then retries forever. With nothing
+    // to exchange there is no reason to go there, so go to the sign-in page directly.
+    mocks.cookies.mockResolvedValue({ get: () => undefined })
+    mocks.profileQueryFn.mockRejectedValue(
+      new Response(JSON.stringify({ code: 'unauthorized' }), { status: 401 }),
+    )
+    const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
+
+    await expect(CommonLayoutHydrationBoundary({ children: null })).rejects.toThrow('NEXT_REDIRECT')
+
+    expect(mocks.redirect).toHaveBeenCalledWith('/signin?redirect_url=%2Fapps%3Ftag%3Dworkflow')
   })
 
   it('should use the internal home path when the pathname header is missing', async () => {

--- a/web/app/(commonLayout)/hydration-boundary.tsx
+++ b/web/app/(commonLayout)/hydration-boundary.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { dehydrate, HydrationBoundary, noop } from '@tanstack/react-query'
 import { getQueryClient } from '@/app/get-query-client'
 import { serverUserProfileQueryOptions } from '@/features/account-profile/server'
+import { REFRESH_TOKEN_COOKIE_NAME } from '@/config'
 import { headers } from '@/next/headers'
 import { redirect } from '@/next/navigation'
 import {
@@ -14,6 +15,7 @@ const CURRENT_PATHNAME_HEADER = 'x-dify-pathname'
 const CURRENT_SEARCH_HEADER = 'x-dify-search'
 const ACCOUNT_PROFILE_PATH = '/account/profile'
 const AUTH_REFRESH_PATH = '/auth/refresh'
+const SIGNIN_PATH = '/signin'
 
 type ConsoleErrorPayload = {
   code?: string
@@ -38,9 +40,21 @@ const getCurrentPath = async () => {
   return `${pathname}${search}`
 }
 
+// `/auth/refresh` is a Route Handler, so it can only answer with a bare 3xx. During an
+// RSC navigation the client router cannot settle on that, and it retries this request
+// forever (the flashing sign-in loop). Only go there when a refresh token actually
+// exists to be exchanged; otherwise redirect straight to the sign-in *page*, which
+// returns an RSC payload the router can commit.
 const redirectToAuthRefresh = async () => {
   const currentPath = await getCurrentPath()
-  redirect(`${AUTH_REFRESH_PATH}?redirect_url=${encodeURIComponent(currentPath)}`)
+  const target = encodeURIComponent(currentPath)
+  const { cookies } = await import('@/next/headers')
+  const cookieStore = await cookies()
+
+  if (!cookieStore.get(REFRESH_TOKEN_COOKIE_NAME())?.value)
+    redirect(`${SIGNIN_PATH}?redirect_url=${target}`)
+
+  redirect(`${AUTH_REFRESH_PATH}?redirect_url=${target}`)
 }
 
 const handleProfileError = async (error: unknown) => {

--- a/web/app/auth/refresh/__tests__/route.spec.ts
+++ b/web/app/auth/refresh/__tests__/route.spec.ts
@@ -10,6 +10,8 @@ vi.mock('@/config', () => ({
   API_PREFIX: 'http://localhost:5001/console/api',
   CSRF_COOKIE_NAME: () => 'csrf_token',
   CSRF_HEADER_NAME: 'X-CSRF-Token',
+  ACCESS_TOKEN_COOKIE_NAME: () => 'access_token',
+  REFRESH_TOKEN_COOKIE_NAME: () => 'refresh_token',
 }))
 
 vi.mock('server-only', () => ({}))
@@ -103,6 +105,30 @@ describe('auth refresh route', () => {
 
     expect(response.status).toBe(303)
     expect(response.headers.get('location')).toBe('/signin?redirect_url=%2Fapps')
+  })
+
+  it('should expire the dead token pair when refresh is rejected', async () => {
+    // Leaving the unusable cookies in place sends the next guarded navigation back through
+    // this handler, which is what sustained the sign-in redirect loop. Clearing them makes
+    // the next attempt take the direct-to-signin path instead.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 401 })))
+    const { GET } = await import('../route')
+
+    const response = await GET(
+      createRequest(
+        'http://localhost:3000/auth/refresh?redirect_url=%2Fapps',
+        'refresh_token=expired',
+      ),
+    )
+
+    const setCookies = response.headers.getSetCookie()
+    expect(setCookies).toHaveLength(2)
+    for (const name of ['refresh_token', 'access_token']) {
+      const cookie = setCookies.find(value => value.startsWith(`${name}=`))
+      expect(cookie).toBeDefined()
+      expect(cookie).toContain('Max-Age=0')
+      expect(cookie).toContain('Path=/')
+    }
   })
 
   it('should ignore cross-origin redirect targets', async () => {

--- a/web/app/auth/refresh/route.ts
+++ b/web/app/auth/refresh/route.ts
@@ -1,6 +1,7 @@
 import type { LoginRedirectTarget } from '@/utils/login-redirect'
 import { resolveServerConsoleApiUrl } from '@/service/server'
 import { getServerLoginFallback, resolveLoginRedirectTarget } from '@/utils/login-redirect'
+import { ACCESS_TOKEN_COOKIE_NAME, API_PREFIX, REFRESH_TOKEN_COOKIE_NAME } from '@/config'
 import { basePath } from '@/utils/var'
 
 const REFRESH_TOKEN_PATH = '/refresh-token'
@@ -82,9 +83,27 @@ const createRedirectResponse = (pathname: string, setCookies: string[] = []) => 
   })
 }
 
+// Expire the unusable pair so the next request to a guarded page skips this handler
+// entirely and goes straight to /signin. Without this the caller keeps arriving here
+// with the same dead cookies, which is what sustained the sign-in redirect loop.
+const buildExpiredAuthCookies = () => {
+  // Must mirror the attributes the backend sets in api/libs/token.py: Path is always "/"
+  // (not basePath), and Secure tracks the scheme. A `__Host-`prefixed cookie is rejected
+  // outright by browsers unless it carries Secure and Path=/, so the pair has to match.
+  const attrs = ['Path=/', 'Max-Age=0', 'HttpOnly', 'SameSite=Lax']
+  if (API_PREFIX.startsWith('https://')) attrs.push('Secure')
+  const suffix = attrs.join('; ')
+
+  return [
+    `${REFRESH_TOKEN_COOKIE_NAME()}=; ${suffix}`,
+    `${ACCESS_TOKEN_COOKIE_NAME()}=; ${suffix}`,
+  ]
+}
+
 const createSigninRedirectResponse = (redirectTarget: LoginRedirectTarget) =>
   createRedirectResponse(
     `${basePath}/signin?redirect_url=${encodeURIComponent(redirectTarget.href)}`,
+    buildExpiredAuthCookies(),
   )
 
 export async function GET(request: Request) {

--- a/web/app/signin/__tests__/normal-form.spec.tsx
+++ b/web/app/signin/__tests__/normal-form.spec.tsx
@@ -77,7 +77,17 @@ const mockQueryResults = (
 ) => {
   mockUseQuery.mockImplementation((options) => {
     const queryKey = options.queryKey as readonly unknown[]
-    return (queryKey[0] === 'account' ? profileResult : inviteResult) as ReturnType<typeof useQuery>
+    if (queryKey[0] !== 'account') return inviteResult as ReturnType<typeof useQuery>
+    // The component only trusts a probe that settled during the current mount, so stamp
+    // the timestamps real useQuery always reports. Evaluated at call time, which is inside
+    // render and therefore at or after the component's own mount timestamp. Fixtures that
+    // set these explicitly (e.g. replaying a stale cache) keep their own values.
+    const settledAt = Date.now()
+    return {
+      ...profileResult,
+      dataUpdatedAt: profileResult.data ? settledAt : 0,
+      errorUpdatedAt: profileResult.error ? settledAt : 0,
+    } as ReturnType<typeof useQuery>
   })
 }
 
@@ -100,6 +110,30 @@ describe('NormalForm', () => {
   })
 
   describe('Default Redirects', () => {
+    // Regression: a guarded page's server component rejects the session and bounces here.
+    // That soft navigation replays the cached profile synchronously, and redirecting on it
+    // unmounts us before the revalidation lands, so the cache is never corrected and
+    // / <-> /signin ping-pongs indefinitely.
+    it('should not redirect on a cached probe that has not settled during this mount', async () => {
+      mockUseSearchParams.mockReturnValue(new URLSearchParams())
+      mockQueryResults(
+        {
+          ...loggedInQueryResult,
+          // Cached before this mount, and the revalidation is still in flight.
+          dataUpdatedAt: Date.now() - 60_000,
+          errorUpdatedAt: 0,
+          isFetching: true,
+        } as unknown as ReturnType<typeof useQuery>,
+        nonInviteQueryResult as unknown as ReturnType<typeof useQuery>,
+      )
+
+      render(<NormalForm />)
+
+      await waitFor(() => {
+        expect(mockReplace).not.toHaveBeenCalled()
+      })
+    })
+
     it('should send logged-in visitors without a redirect target to the console home', async () => {
       const searchParams = new URLSearchParams()
       mockUseSearchParams.mockReturnValue(searchParams)

--- a/web/app/signin/normal-form.tsx
+++ b/web/app/signin/normal-form.tsx
@@ -29,6 +29,9 @@ function NormalForm() {
   const searchParams = useSearchParams()
   const queryString = searchParams.toString()
   const signupHref = queryString ? `/signup?${queryString}` : '/signup'
+  // Read before the probe below so any timestamp the probe reports from this render is
+  // ordered at or after it. See isProbeConfirmed.
+  const [mountedAt] = useState(() => Date.now())
   // Login probe: 401 stays as `error` (legitimate "not logged in" state on /signin),
   // other errors throw to error.tsx. jumpTo same-pathname guard in service/base.ts
   // prevents the redirect loop on 401.
@@ -36,12 +39,21 @@ function NormalForm() {
     isPending: isCheckLoading,
     data: userResp,
     error: probeError,
+    isFetching: isProbeFetching,
+    dataUpdatedAt: probeUpdatedAt,
+    errorUpdatedAt: probeErrorUpdatedAt,
   } = useQuery({
     ...userProfileQueryOptions(),
     throwOnError: (err) => !isLegacyBase401(err),
     refetchOnWindowFocus: false,
   })
-  const isLoggedIn = !!userResp && !probeError
+  // A soft navigation into /signin (a guarded page's server component bounced us here)
+  // replays the cached probe synchronously: `data` is set, `error` is not, and the redirect
+  // below unmounts us before the revalidation can land, so the in-flight query is cancelled
+  // and never corrects the cache. A session the server already rejected then looks live
+  // forever and / <-> /signin ping-pongs. Only act on a probe that settled in this mount.
+  const isProbeConfirmed = Math.max(probeUpdatedAt ?? 0, probeErrorUpdatedAt ?? 0) >= mountedAt
+  const isLoggedIn = isProbeConfirmed && !!userResp && !probeError
   const message = decodeURIComponent(searchParams.get('message') || '')
   const inviteToken = decodeURIComponent(searchParams.get('invite_token') || '')
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
@@ -93,7 +105,13 @@ function NormalForm() {
   const allMethodsAreDisabled = noLoginMethodsConfigured || isInviteCheckError
   const shouldRedirectLoggedInUser = isLoggedIn && (!isInviteLink || isInvitationForCurrentAccount)
   const isLoading =
-    isCheckLoading || shouldRedirectLoggedInUser || (isInviteLink && isInviteCheckLoading)
+    isCheckLoading
+    // Keep the spinner up while the revalidation that will confirm (or refute) a cached
+    // probe is still in flight, so a live session never flashes the login form. Gated on
+    // isProbeFetching so an idle unconfirmed probe renders the form instead of hanging.
+    || (!isProbeConfirmed && isProbeFetching)
+    || shouldRedirectLoggedInUser
+    || (isInviteLink && isInviteCheckLoading)
 
   useEffect(() => {
     if (!isLoggedIn) return

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -119,6 +119,17 @@ export const CSRF_COOKIE_NAME = () => {
   const isSecure = API_PREFIX.startsWith('https://')
   return isSecure ? '__Host-csrf_token' : 'csrf_token'
 }
+// Mirrors the backend's `_real_cookie_name` in api/libs/token.py.
+export const REFRESH_TOKEN_COOKIE_NAME = () => {
+  if (COOKIE_DOMAIN) return 'refresh_token'
+  const isSecure = API_PREFIX.startsWith('https://')
+  return isSecure ? '__Host-refresh_token' : 'refresh_token'
+}
+export const ACCESS_TOKEN_COOKIE_NAME = () => {
+  if (COOKIE_DOMAIN) return 'access_token'
+  const isSecure = API_PREFIX.startsWith('https://')
+  return isSecure ? '__Host-access_token' : 'access_token'
+}
 export const CSRF_HEADER_NAME = 'X-CSRF-Token'
 export const ACCESS_TOKEN_LOCAL_STORAGE_NAME = 'access_token'
 export const PASSPORT_LOCAL_STORAGE_NAME = (appCode: string) => `passport-${appCode}`


### PR DESCRIPTION
…pair

- hydration-boundary: skip /auth/refresh hop when no refresh token exists
- auth/refresh: expire invalid token pair on 401 to break the loop
- signin/normal-form: require probe to settle in current mount before redirecting

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
