### PR TITLE
fix(vdb-weaviate): backward-compatible cleanup + preserve positional alignment

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -431,9 +431,7 @@ class WeaviateVector(BaseVector):
         #    metadata so a delete pass never leaves orphans behind.
         if ids:
             try:
-                col.data.delete_many(
-                    where=Filter.by_property("doc_id").contains_any(ids)
-                )
+                col.data.delete_many(where=Filter.by_property("doc_id").contains_any(ids))
             except UnexpectedStatusCodeError as e:
                 if getattr(e, "status_code", None) != 404:
                     raise

--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -280,16 +280,36 @@ class WeaviateVector(BaseVector):
     @override
     def _get_uuids(self, documents: list[Document]) -> list[str]:
         """
-        Generates deterministic UUIDs for documents based on their content.
+        Generate canonical Weaviate object ids for each document.
 
-        Uses UUID5 with URL namespace to ensure consistent IDs for identical content.
+        Issue #41714: insert and the cleanup path
+        (``batch_clean_document_task`` → ``index_processor.clean`` →
+        ``vector.delete_by_ids``) must agree on the object id, otherwise
+        ``delete_by_id`` silently no-ops and the cleanup task reports
+        success while the objects stay behind as orphans.
+
+        Use the same source the rest of the VDB stack uses
+        (``VectorBase._get_uuids``): the ``doc_id`` stored in each
+        document's metadata. ``doc_id`` is the segment's
+        ``index_node_id`` that ``delete_by_ids`` already passes in.
+
+        Preserve the parent caller's positional alignment: a missing
+        ``doc_id`` is replaced with a freshly generated ``uuid4`` rather
+        than dropping the slot, so the parallel ``objs`` list in
+        ``add_texts`` keeps matching the input documents one-for-one.
         """
-        URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
-
-        uuids = []
+        uuids: list[str] = []
         for doc in documents:
-            uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
-            uuids.append(str(uuid_val))
+            doc_id = (doc.metadata or {}).get("doc_id")
+            if isinstance(doc_id, str) and doc_id:
+                uuids.append(doc_id)
+            else:
+                # Fallback only when the caller didn't supply a doc_id.
+                # Random uuid4 keeps the object uniquely addressable; the
+                # cleanup path can't find it without doc_id, but that's
+                # only acceptable for tests / fixtures that don't exercise
+                # cleanup.
+                uuids.append(str(_uuid.uuid4()))
 
         return uuids
 
@@ -380,15 +400,40 @@ class WeaviateVector(BaseVector):
         Deletes objects by their UUID identifiers.
 
         Silently ignores 404 errors for non-existent IDs.
+
+        Issue #41714: cleanup task (and any other caller) passes
+        ``index_node_id`` (a UUID) here. New objects inserted after this
+        fix use the segment's ``index_node_id`` as their Weaviate UUID, so
+        the call lands cleanly. **Pre-existing** objects written by the
+        old UUID5 path still don't match — fall through to a
+        backward-compatible ``doc_id``-metadata filter so they are
+        cleaned up too, and a legacy object whose Weaviate UUID differs
+        from its ``doc_id`` is still reaped.
         """
         if not self._client.collections.exists(self._collection_name):
             return
 
         col = self._client.collections.use(self._collection_name)
 
+        # 1. Best-effort direct delete by UUID for the fresh-write path.
+        #    404s mean the object was never written (or was written under
+        #    a different UUID), which is expected for legacy rows.
         for uid in ids:
             try:
                 col.data.delete_by_id(uid)
+            except UnexpectedStatusCodeError as e:
+                if getattr(e, "status_code", None) != 404:
+                    raise
+
+        # 2. Backward-compatible catch-up: the legacy UUID5 path (or any
+        #    other source) wrote rows whose Weaviate UUID no longer
+        #    matches ``index_node_id``. Reap them by the ``doc_id``
+        #    metadata so a delete pass never leaves orphans behind.
+        if ids:
+            try:
+                col.data.delete_many(
+                    where=Filter.by_property("doc_id").contains_any(ids)
+                )
             except UnexpectedStatusCodeError as e:
                 if getattr(e, "status_code", None) != 404:
                     raise

--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -422,7 +422,7 @@ class WeaviateVector(BaseVector):
             try:
                 col.data.delete_by_id(uid)
             except UnexpectedStatusCodeError as e:
-                if getattr(e, "status_code", None) != 404:
+                if e.status_code != 404:
                     raise
 
         # 2. Backward-compatible catch-up: the legacy UUID5 path (or any
@@ -433,7 +433,7 @@ class WeaviateVector(BaseVector):
             try:
                 col.data.delete_many(where=Filter.by_property("doc_id").contains_any(ids))
             except UnexpectedStatusCodeError as e:
-                if getattr(e, "status_code", None) != 404:
+                if e.status_code != 404:
                     raise
 
     @override

--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -278,7 +278,7 @@ class WeaviateVector(BaseVector):
                 logger.warning("Could not add property %s: %s", prop.name, e)
 
     @override
-    def _get_uuids(self, documents: list[Document]) -> list[str]:
+    def _get_uuids(self, texts: list[Document]) -> list[str]:
         """
         Generate canonical Weaviate object ids for each document.
 
@@ -299,7 +299,7 @@ class WeaviateVector(BaseVector):
         ``add_texts`` keeps matching the input documents one-for-one.
         """
         uuids: list[str] = []
-        for doc in documents:
+        for doc in texts:
             doc_id = (doc.metadata or {}).get("doc_id")
             if isinstance(doc_id, str) and doc_id:
                 uuids.append(doc_id)

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
@@ -1,0 +1,213 @@
+"""Regression tests for issue #41714.
+
+The pre-fix code generated Weaviate object ids via
+``uuid5(URL_NAMESPACE, page_content)`` (UUID v5 from content). The
+cleanup path (``batch_clean_document_task`` → ``index_processor.clean``
+→ ``vector.delete_by_ids``) passes the segment's ``index_node_id``
+(random UUID v4 from the database), so the two never agreed and
+``delete_by_id`` silently no-op'd on every cleanup pass.
+
+The fix:
+
+1. ``_get_uuids`` now uses the segment's ``doc_id`` (== ``index_node_id``)
+   from each document's metadata. New objects line up with the
+   cleanup path one-for-one.
+2. Documents without a ``doc_id`` keep a stable slot via a freshly
+   generated ``uuid4`` so the parallel ``objs`` list in ``add_texts``
+   never goes out of alignment with the input documents.
+3. ``delete_by_ids`` keeps the best-effort direct-UUID delete (the
+   fresh-write path), then falls through to a ``doc_id``-metadata
+   ``contains_any`` filter so the legacy UUID5 objects are reaped
+   too — backwards-compatible with the rows already in production.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from core.rag.models.document import Document
+from dify_vdb_weaviate import weaviate_vector as weaviate_vector_module
+from dify_vdb_weaviate.weaviate_vector import WeaviateConfig, WeaviateVector
+
+
+def _unexpected_response(status_code: int) -> "weaviate_vector_module.UnexpectedStatusCodeError":
+    """Patch ``WeaviateVector.delete_by_ids`` to raise an ``UnexpectedStatusCodeError``.
+
+    The constructor of the real exception class reaches into
+    ``response.code()`` and ``response.details()`` (different members
+    of the gRPC / HTTP / httpx response union types) and would need
+    per-shape stubs. Use ``side_effect`` on the patch instead so the
+    test does not have to instantiate the real class.
+    """
+    response = MagicMock()
+    response.status_code = status_code
+    response.details.return_value = ""
+    err = weaviate_vector_module.UnexpectedStatusCodeError(f"status {status_code}", response)
+    err.status_code = status_code  # ensure the property we read in production
+    return err
+
+
+def _make_raising_404_response():
+    """Stand-in for the gRPC / HTTP / httpx response shape that
+    ``UnexpectedStatusCodeError.__init__`` probes for ``code()`` and
+    ``details()``. The constructor reads ``code().value[0]`` for the
+    status and ``code().value[1]`` for the canonical name, plus
+    ``details()`` for the body. Set all three.
+    """
+    from types import SimpleNamespace
+
+    code = SimpleNamespace()
+    # 404 lands in the first element of the value tuple, the canonical
+    # name (``"Not Found"``) in the second.
+    code.value = (404, "Not Found")
+    response = MagicMock()
+    response.code.return_value = code
+    response.details.return_value = ""
+    err = weaviate_vector_module.UnexpectedStatusCodeError("status 404", response)
+    err.status_code = 404
+    return err
+
+
+def _make_vector(**overrides) -> WeaviateVector:
+    config = WeaviateConfig(
+        endpoint="http://localhost:8080",
+        api_key="test-key",
+        batch_size=100,
+    )
+    v = WeaviateVector.__new__(WeaviateVector)
+    v._config = config
+    v._collection_name = "Test_Collection"
+    v._attributes = ["doc_id", "dataset_id"]
+    v._client = MagicMock()
+    for k, val in overrides.items():
+        setattr(v, f"_{k}", val)
+    return v
+
+
+class TestGetUuidsUsesDocId:
+    """_get_uuids must return one id per input document, positionally aligned."""
+
+    def test_doc_id_passes_through(self):
+        v = _make_vector()
+        docs = [Document(page_content="x", metadata={"doc_id": "doc-aaa-1"})]
+
+        uuids = v._get_uuids(docs)
+
+        assert uuids == ["doc-aaa-1"]
+
+    def test_missing_doc_id_falls_back_to_fresh_uuid4(self):
+        """A document without ``doc_id`` still needs a slot in the
+        returned list so the parallel ``objs`` list in ``add_texts``
+        never goes out of alignment with the input documents.
+        """
+        v = _make_vector()
+        docs = [
+            Document(page_content="x", metadata={"doc_id": "doc-aaa-1"}),
+            Document(page_content="y", metadata={}),
+            Document(page_content="z", metadata={"doc_id": "doc-ccc-3"}),
+        ]
+
+        uuids = v._get_uuids(docs)
+
+        assert uuids[0] == "doc-aaa-1"
+        assert uuids[2] == "doc-ccc-3"
+        # The middle slot is filled, not dropped.
+        assert len(uuids) == 3
+        assert uuids[1] != ""
+        # And the fallback is a valid UUID4.
+        import uuid as _uuid
+
+        parsed = _uuid.UUID(uuids[1])
+        assert parsed.version == 4
+
+    def test_all_doc_ids_present(self):
+        v = _make_vector()
+        docs = [
+            Document(page_content="x", metadata={"doc_id": "a"}),
+            Document(page_content="y", metadata={"doc_id": "b"}),
+            Document(page_content="z", metadata={"doc_id": "c"}),
+        ]
+
+        assert v._get_uuids(docs) == ["a", "b", "c"]
+
+
+class TestDeleteByIdsBackwardCompatible:
+    """#41714 backwards-compatibility: legacy UUID5 objects whose Weaviate
+    UUID no longer matches ``index_node_id`` are reaped via the
+    ``doc_id``-metadata filter."""
+
+    def test_legacy_object_with_matching_doc_id_is_reaped(self):
+        """A legacy object whose ``doc_id`` matches the supplied
+        ``index_node_id`` must be reaped even though its Weaviate UUID
+        no longer matches.
+        """
+        v = _make_vector()
+        col = v._client.collections.use.return_value
+        # The production code only reads ``.status_code`` from the
+        # raised exception; use a plain Mock with that attribute instead
+        # of instantiating the real ``UnexpectedStatusCodeError`` (which
+        # probes gRPC / httpx response members and breaks the test).
+        not_found = MagicMock()
+        not_found.status_code = 404
+        col.data.delete_by_id.side_effect = not_found
+
+        v.delete_by_ids(["doc-aaa-1"])
+
+        # Best-effort direct delete ran for each id.
+        assert col.data.delete_by_id.call_count == 1
+        # And the metadata catch-up filter ran with the same ids.
+        col.data.delete_many.assert_called_once()
+        kwargs = col.data.delete_many.call_args.kwargs
+        where = kwargs["where"]
+        # Filter.by_property("doc_id").contains_any(["doc-aaa-1"])
+        assert "doc_id" in str(where)
+        assert "doc-aaa-1" in str(where)
+
+    def test_fresh_object_is_reaped_by_direct_delete(self):
+        """A fresh object whose Weaviate UUID equals the supplied
+        ``index_node_id`` is reaped by the direct delete, and the
+        metadata-filter pass is a redundant no-op (no rows match).
+        """
+        v = _make_vector()
+        col = v._client.collections.use.return_value
+
+        v.delete_by_ids(["doc-aaa-1"])
+
+        col.data.delete_by_id.assert_called_once_with("doc-aaa-1")
+        # The metadata filter always runs, but it's a no-op when the row
+        # is already gone (Weaviate's ``delete_many`` returns an empty
+        # result set against the cleared UUID).
+        col.data.delete_many.assert_called_once()
+        where = col.data.delete_many.call_args.kwargs["where"]
+        assert "doc_id" in str(where)
+        assert "doc-aaa-1" in str(where)
+
+    def test_non_404_error_propagates(self):
+        """A non-404 (e.g. 500) error on direct delete must propagate,
+        not be swallowed as if it were a 404.
+        """
+
+        class _ServerError(Exception):
+            status_code = 500
+
+        v = _make_vector()
+        col = v._client.collections.use.return_value
+        col.data.delete_by_id.side_effect = _ServerError()
+
+        with pytest.raises(_ServerError):
+            v.delete_by_ids(["doc-aaa-1"])
+
+    def test_delete_many_404_is_swallowed(self):
+        """The metadata-filter 404 (column doesn't exist) is also
+        swallowed — the schema may not have been migrated yet.
+        """
+        v = _make_vector()
+        col = v._client.collections.use.return_value
+        not_found_a = MagicMock()
+        not_found_a.status_code = 404
+        not_found_b = MagicMock()
+        not_found_b.status_code = 404
+        col.data.delete_by_id.side_effect = not_found_a
+        col.data.delete_many.side_effect = not_found_b
+
+        # Neither path raises.
+        v.delete_by_ids(["doc-aaa-1"])

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
@@ -21,12 +21,13 @@ The fix:
    too — backwards-compatible with the rows already in production.
 """
 
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from core.rag.models.document import Document
+import pytest
 from dify_vdb_weaviate import weaviate_vector as weaviate_vector_module
 from dify_vdb_weaviate.weaviate_vector import WeaviateConfig, WeaviateVector
+
+from core.rag.models.document import Document
 
 
 def _unexpected_response(status_code: int) -> "weaviate_vector_module.UnexpectedStatusCodeError":

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
@@ -2,8 +2,8 @@
 
 The pre-fix code generated Weaviate object ids via
 ``uuid5(URL_NAMESPACE, page_content)`` (UUID v5 from content). The
-cleanup path (``batch_clean_document_task`` → ``index_processor.clean``
-→ ``vector.delete_by_ids``) passes the segment's ``index_node_id``
+cleanup path (``batch_clean_document_task`` -> ``index_processor.clean``
+-> ``vector.delete_by_ids``) passes the segment's ``index_node_id``
 (random UUID v4 from the database), so the two never agreed and
 ``delete_by_id`` silently no-op'd on every cleanup pass.
 
@@ -18,69 +18,43 @@ The fix:
 3. ``delete_by_ids`` keeps the best-effort direct-UUID delete (the
    fresh-write path), then falls through to a ``doc_id``-metadata
    ``contains_any`` filter so the legacy UUID5 objects are reaped
-   too — backwards-compatible with the rows already in production.
+   too -- backwards-compatible with the rows already in production.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-import pytest
 from dify_vdb_weaviate import weaviate_vector as weaviate_vector_module
-from dify_vdb_weaviate.weaviate_vector import WeaviateConfig, WeaviateVector
+from dify_vdb_weaviate.weaviate_vector import WeaviateVector
 
 from core.rag.models.document import Document
 
 
-def _unexpected_response(status_code: int) -> "weaviate_vector_module.UnexpectedStatusCodeError":
-    """Patch ``WeaviateVector.delete_by_ids`` to raise an ``UnexpectedStatusCodeError``.
+class _FakeUnexpectedStatusCodeError(Exception):
+    """Stand-in for ``weaviate.exceptions.UnexpectedStatusCodeError``.
 
-    The constructor of the real exception class reaches into
-    ``response.code()`` and ``response.details()`` (different members
-    of the gRPC / HTTP / httpx response union types) and would need
-    per-shape stubs. Use ``side_effect`` on the patch instead so the
-    test does not have to instantiate the real class.
+    The real class has a read-only ``status_code`` property; the
+    production code only reads ``.status_code`` off the exception, so
+    a plain attribute is enough. We patch the module-level reference
+    in the production module so the ``except`` clause catches ours.
     """
-    response = MagicMock()
-    response.status_code = status_code
-    response.details.return_value = ""
-    err = weaviate_vector_module.UnexpectedStatusCodeError(f"status {status_code}", response)
-    err.status_code = status_code  # ensure the property we read in production
-    return err
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"status={status_code}")
+        self.status_code = status_code
 
 
-def _make_raising_404_response():
-    """Stand-in for the gRPC / HTTP / httpx response shape that
-    ``UnexpectedStatusCodeError.__init__`` probes for ``code()`` and
-    ``details()``. The constructor reads ``code().value[0]`` for the
-    status and ``code().value[1]`` for the canonical name, plus
-    ``details()`` for the body. Set all three.
+def _make_vector() -> WeaviateVector:
+    """Build a ``WeaviateVector`` without invoking ``__init__`` so we
+    never reach ``_init_client`` (which would try to connect).
+
+    Only ``_client`` and ``_collection_name`` are touched by the
+    production code paths exercised here (``_get_uuids`` and
+    ``delete_by_ids``), so the rest of the instance dict is left bare.
     """
-    from types import SimpleNamespace
-
-    code = SimpleNamespace()
-    # 404 lands in the first element of the value tuple, the canonical
-    # name (``"Not Found"``) in the second.
-    code.value = (404, "Not Found")
-    response = MagicMock()
-    response.code.return_value = code
-    response.details.return_value = ""
-    err = weaviate_vector_module.UnexpectedStatusCodeError("status 404", response)
-    err.status_code = 404
-    return err
-
-
-def _make_vector(**overrides) -> WeaviateVector:
-    config = WeaviateConfig(
-        endpoint="http://localhost:8080",
-        api_key="test-key",
-        batch_size=100,
-    )
     v = WeaviateVector.__new__(WeaviateVector)
-    v._config = config
     v._collection_name = "Test_Collection"
-    v._attributes = ["doc_id", "dataset_id"]
     v._client = MagicMock()
-    for k, val in overrides.items():
-        setattr(v, f"_{k}", val)
+    v._client.collections.exists.return_value = True
     return v
 
 
@@ -143,15 +117,10 @@ class TestDeleteByIdsBackwardCompatible:
         """
         v = _make_vector()
         col = v._client.collections.use.return_value
-        # The production code only reads ``.status_code`` from the
-        # raised exception; use a plain Mock with that attribute instead
-        # of instantiating the real ``UnexpectedStatusCodeError`` (which
-        # probes gRPC / httpx response members and breaks the test).
-        not_found = MagicMock()
-        not_found.status_code = 404
-        col.data.delete_by_id.side_effect = not_found
+        col.data.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
 
-        v.delete_by_ids(["doc-aaa-1"])
+        with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", _FakeUnexpectedStatusCodeError):
+            v.delete_by_ids(["doc-aaa-1"])
 
         # Best-effort direct delete ran for each id.
         assert col.data.delete_by_id.call_count == 1
@@ -186,29 +155,27 @@ class TestDeleteByIdsBackwardCompatible:
         """A non-404 (e.g. 500) error on direct delete must propagate,
         not be swallowed as if it were a 404.
         """
-
-        class _ServerError(Exception):
-            status_code = 500
+        import pytest
 
         v = _make_vector()
         col = v._client.collections.use.return_value
-        col.data.delete_by_id.side_effect = _ServerError()
+        col.data.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(500)
 
-        with pytest.raises(_ServerError):
+        with (
+            patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", _FakeUnexpectedStatusCodeError),
+            pytest.raises(_FakeUnexpectedStatusCodeError),
+        ):
             v.delete_by_ids(["doc-aaa-1"])
 
     def test_delete_many_404_is_swallowed(self) -> None:
         """The metadata-filter 404 (column doesn't exist) is also
-        swallowed — the schema may not have been migrated yet.
+        swallowed -- the schema may not have been migrated yet.
         """
         v = _make_vector()
         col = v._client.collections.use.return_value
-        not_found_a = MagicMock()
-        not_found_a.status_code = 404
-        not_found_b = MagicMock()
-        not_found_b.status_code = 404
-        col.data.delete_by_id.side_effect = not_found_a
-        col.data.delete_many.side_effect = not_found_b
+        col.data.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
+        col.data.delete_many.side_effect = _FakeUnexpectedStatusCodeError(404)
 
         # Neither path raises.
-        v.delete_by_ids(["doc-aaa-1"])
+        with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", _FakeUnexpectedStatusCodeError):
+            v.delete_by_ids(["doc-aaa-1"])

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
@@ -43,13 +43,19 @@ class _FakeUnexpectedStatusCodeError(Exception):
         self.status_code = status_code
 
 
-def _make_vector() -> WeaviateVector:
+def _make_vector() -> tuple[WeaviateVector, MagicMock]:
     """Build a ``WeaviateVector`` without invoking ``__init__`` so we
     never reach ``_init_client`` (which would try to connect).
 
     Only ``_client`` and ``_collection_name`` are touched by the
     production code paths exercised here (``_get_uuids`` and
     ``delete_by_ids``), so the rest of the instance dict is left bare.
+
+    Returns the ``WeaviateVector`` together with its mocked client so
+    tests can reach ``client.collections.use(...).data`` (the same
+    path the production code walks) without pyrefly tripping over
+    chained ``.return_value`` access through the dynamic ``_client``
+    instance attribute.
     """
     # pyrefly cannot resolve chained ``.return_value`` access through
     # dynamically-attached attributes (it infers ``v._client`` as the
@@ -63,11 +69,11 @@ def _make_vector() -> WeaviateVector:
     v = WeaviateVector.__new__(WeaviateVector)
     v._collection_name = "Test_Collection"
     v._client = client
-    return v
+    return v, client
 
 
-def _collection(v: WeaviateVector) -> MagicMock:
-    """Resolve ``v._client.collections.use().data`` as a typed MagicMock.
+def _collection(client: MagicMock) -> MagicMock:
+    """Resolve ``client.collections.use().data`` as a typed MagicMock.
 
     Centralised so the same ``client.data`` instance is reused -- the
     production code reaches the Weaviate collection's ``data`` object
@@ -75,7 +81,7 @@ def _collection(v: WeaviateVector) -> MagicMock:
     so ``delete_by_id`` / ``delete_many`` side effects wired on the
     returned mock are observed by the production calls.
     """
-    col: MagicMock = v._client.collections.use.return_value
+    col: MagicMock = client.collections.use.return_value
     return col.data
 
 
@@ -83,7 +89,7 @@ class TestGetUuidsUsesDocId:
     """_get_uuids must return one id per input document, positionally aligned."""
 
     def test_doc_id_passes_through(self) -> None:
-        v = _make_vector()
+        v, _client = _make_vector()
         docs = [Document(page_content="x", metadata={"doc_id": "doc-aaa-1"})]
 
         uuids = v._get_uuids(docs)
@@ -95,7 +101,7 @@ class TestGetUuidsUsesDocId:
         returned list so the parallel ``objs`` list in ``add_texts``
         never goes out of alignment with the input documents.
         """
-        v = _make_vector()
+        v, _client = _make_vector()
         docs = [
             Document(page_content="x", metadata={"doc_id": "doc-aaa-1"}),
             Document(page_content="y", metadata={}),
@@ -116,7 +122,7 @@ class TestGetUuidsUsesDocId:
         assert parsed.version == 4
 
     def test_all_doc_ids_present(self) -> None:
-        v = _make_vector()
+        v, _client = _make_vector()
         docs = [
             Document(page_content="x", metadata={"doc_id": "a"}),
             Document(page_content="y", metadata={"doc_id": "b"}),
@@ -136,8 +142,8 @@ class TestDeleteByIdsBackwardCompatible:
         ``index_node_id`` must be reaped even though its Weaviate UUID
         no longer matches.
         """
-        v = _make_vector()
-        col = _collection(v)
+        v, client = _make_vector()
+        col = _collection(client)
         col.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
 
         with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", _FakeUnexpectedStatusCodeError):
@@ -158,8 +164,8 @@ class TestDeleteByIdsBackwardCompatible:
         ``index_node_id`` is reaped by the direct delete, and the
         metadata-filter pass is a redundant no-op (no rows match).
         """
-        v = _make_vector()
-        col = _collection(v)
+        v, client = _make_vector()
+        col = _collection(client)
 
         v.delete_by_ids(["doc-aaa-1"])
 
@@ -178,8 +184,8 @@ class TestDeleteByIdsBackwardCompatible:
         """
         import pytest
 
-        v = _make_vector()
-        col = _collection(v)
+        v, client = _make_vector()
+        col = _collection(client)
         col.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(500)
 
         with (
@@ -192,8 +198,8 @@ class TestDeleteByIdsBackwardCompatible:
         """The metadata-filter 404 (column doesn't exist) is also
         swallowed -- the schema may not have been migrated yet.
         """
-        v = _make_vector()
-        col = _collection(v)
+        v, client = _make_vector()
+        col = _collection(client)
         col.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
         col.delete_many.side_effect = _FakeUnexpectedStatusCodeError(404)
 

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
@@ -87,7 +87,7 @@ def _make_vector(**overrides) -> WeaviateVector:
 class TestGetUuidsUsesDocId:
     """_get_uuids must return one id per input document, positionally aligned."""
 
-    def test_doc_id_passes_through(self):
+    def test_doc_id_passes_through(self) -> None:
         v = _make_vector()
         docs = [Document(page_content="x", metadata={"doc_id": "doc-aaa-1"})]
 
@@ -95,7 +95,7 @@ class TestGetUuidsUsesDocId:
 
         assert uuids == ["doc-aaa-1"]
 
-    def test_missing_doc_id_falls_back_to_fresh_uuid4(self):
+    def test_missing_doc_id_falls_back_to_fresh_uuid4(self) -> None:
         """A document without ``doc_id`` still needs a slot in the
         returned list so the parallel ``objs`` list in ``add_texts``
         never goes out of alignment with the input documents.
@@ -120,7 +120,7 @@ class TestGetUuidsUsesDocId:
         parsed = _uuid.UUID(uuids[1])
         assert parsed.version == 4
 
-    def test_all_doc_ids_present(self):
+    def test_all_doc_ids_present(self) -> None:
         v = _make_vector()
         docs = [
             Document(page_content="x", metadata={"doc_id": "a"}),
@@ -136,7 +136,7 @@ class TestDeleteByIdsBackwardCompatible:
     UUID no longer matches ``index_node_id`` are reaped via the
     ``doc_id``-metadata filter."""
 
-    def test_legacy_object_with_matching_doc_id_is_reaped(self):
+    def test_legacy_object_with_matching_doc_id_is_reaped(self) -> None:
         """A legacy object whose ``doc_id`` matches the supplied
         ``index_node_id`` must be reaped even though its Weaviate UUID
         no longer matches.
@@ -163,7 +163,7 @@ class TestDeleteByIdsBackwardCompatible:
         assert "doc_id" in str(where)
         assert "doc-aaa-1" in str(where)
 
-    def test_fresh_object_is_reaped_by_direct_delete(self):
+    def test_fresh_object_is_reaped_by_direct_delete(self) -> None:
         """A fresh object whose Weaviate UUID equals the supplied
         ``index_node_id`` is reaped by the direct delete, and the
         metadata-filter pass is a redundant no-op (no rows match).
@@ -182,7 +182,7 @@ class TestDeleteByIdsBackwardCompatible:
         assert "doc_id" in str(where)
         assert "doc-aaa-1" in str(where)
 
-    def test_non_404_error_propagates(self):
+    def test_non_404_error_propagates(self) -> None:
         """A non-404 (e.g. 500) error on direct delete must propagate,
         not be swallowed as if it were a 404.
         """
@@ -197,7 +197,7 @@ class TestDeleteByIdsBackwardCompatible:
         with pytest.raises(_ServerError):
             v.delete_by_ids(["doc-aaa-1"])
 
-    def test_delete_many_404_is_swallowed(self):
+    def test_delete_many_404_is_swallowed(self) -> None:
         """The metadata-filter 404 (column doesn't exist) is also
         swallowed — the schema may not have been migrated yet.
         """

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
@@ -51,13 +51,32 @@ def _make_vector() -> WeaviateVector:
     production code paths exercised here (``_get_uuids`` and
     ``delete_by_ids``), so the rest of the instance dict is left bare.
     """
-    client = MagicMock()
+    # pyrefly cannot resolve chained ``.return_value`` access through
+    # dynamically-attached attributes (it infers ``v._client`` as the
+    # missing-on-class attribute and falls through to the stdlib
+    # ``collections`` module), so keep the mocked client in a local
+    # variable whose type pyrefly can see.
+    client: MagicMock = MagicMock()
     client.collections.exists.return_value = True
+    client.collections.use.return_value = client.data
 
     v = WeaviateVector.__new__(WeaviateVector)
     v._collection_name = "Test_Collection"
     v._client = client
     return v
+
+
+def _collection(v: WeaviateVector) -> MagicMock:
+    """Resolve ``v._client.collections.use().data`` as a typed MagicMock.
+
+    Centralised so the same ``client.data`` instance is reused -- the
+    production code reaches the Weaviate collection's ``data`` object
+    via ``v._client.collections.use(name).data``; we mirror that path
+    so ``delete_by_id`` / ``delete_many`` side effects wired on the
+    returned mock are observed by the production calls.
+    """
+    col: MagicMock = v._client.collections.use.return_value
+    return col.data
 
 
 class TestGetUuidsUsesDocId:
@@ -118,17 +137,17 @@ class TestDeleteByIdsBackwardCompatible:
         no longer matches.
         """
         v = _make_vector()
-        col = v._client.collections.use.return_value
-        col.data.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
+        col = _collection(v)
+        col.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
 
         with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", _FakeUnexpectedStatusCodeError):
             v.delete_by_ids(["doc-aaa-1"])
 
         # Best-effort direct delete ran for each id.
-        assert col.data.delete_by_id.call_count == 1
+        assert col.delete_by_id.call_count == 1
         # And the metadata catch-up filter ran with the same ids.
-        col.data.delete_many.assert_called_once()
-        kwargs = col.data.delete_many.call_args.kwargs
+        col.delete_many.assert_called_once()
+        kwargs = col.delete_many.call_args.kwargs
         where = kwargs["where"]
         # Filter.by_property("doc_id").contains_any(["doc-aaa-1"])
         assert "doc_id" in str(where)
@@ -140,16 +159,16 @@ class TestDeleteByIdsBackwardCompatible:
         metadata-filter pass is a redundant no-op (no rows match).
         """
         v = _make_vector()
-        col = v._client.collections.use.return_value
+        col = _collection(v)
 
         v.delete_by_ids(["doc-aaa-1"])
 
-        col.data.delete_by_id.assert_called_once_with("doc-aaa-1")
+        col.delete_by_id.assert_called_once_with("doc-aaa-1")
         # The metadata filter always runs, but it's a no-op when the row
         # is already gone (Weaviate's ``delete_many`` returns an empty
         # result set against the cleared UUID).
-        col.data.delete_many.assert_called_once()
-        where = col.data.delete_many.call_args.kwargs["where"]
+        col.delete_many.assert_called_once()
+        where = col.delete_many.call_args.kwargs["where"]
         assert "doc_id" in str(where)
         assert "doc-aaa-1" in str(where)
 
@@ -160,8 +179,8 @@ class TestDeleteByIdsBackwardCompatible:
         import pytest
 
         v = _make_vector()
-        col = v._client.collections.use.return_value
-        col.data.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(500)
+        col = _collection(v)
+        col.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(500)
 
         with (
             patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", _FakeUnexpectedStatusCodeError),
@@ -174,9 +193,9 @@ class TestDeleteByIdsBackwardCompatible:
         swallowed -- the schema may not have been migrated yet.
         """
         v = _make_vector()
-        col = v._client.collections.use.return_value
-        col.data.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
-        col.data.delete_many.side_effect = _FakeUnexpectedStatusCodeError(404)
+        col = _collection(v)
+        col.delete_by_id.side_effect = _FakeUnexpectedStatusCodeError(404)
+        col.delete_many.side_effect = _FakeUnexpectedStatusCodeError(404)
 
         # Neither path raises.
         with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", _FakeUnexpectedStatusCodeError):

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py
@@ -51,10 +51,12 @@ def _make_vector() -> WeaviateVector:
     production code paths exercised here (``_get_uuids`` and
     ``delete_by_ids``), so the rest of the instance dict is left bare.
     """
+    client = MagicMock()
+    client.collections.exists.return_value = True
+
     v = WeaviateVector.__new__(WeaviateVector)
     v._collection_name = "Test_Collection"
-    v._client = MagicMock()
-    v._client.collections.exists.return_value = True
+    v._client = client
     return v
 
 


### PR DESCRIPTION
Follow-ups from the #41714 review of the prior PR (#41835). Two issues were raised:

1. **Backward-compatible cleanup** — pre-existing objects written by the old UUID5 path still don't match the segment's index_node_id; the direct-delete-by-UUID would miss them and the orphans would persist. After the direct delete, fall through to a doc_id-metadata contains_any filter that reaps any legacy object whose doc_id matches the supplied id. 404s (column doesn't exist yet, race) are swallowed, just like the direct-delete path.

2. **Preserve positional alignment** — the prior _get_uuids override dropped documents without doc_id from the returned list; add_texts then zipped the objs against the original input list positionally and either raised IndexError or, in the best case, gave a UUID4 to the wrong row. Replace the drop with a fresh uuid4 so the parallel objs list always matches the input documents one-for-one.

Tests (7 new, in
`providers/vdb/vdb-weaviate/tests/unit_tests/test_doc_id_cleanup_41714.py`):

- `test_doc_id_passes_through`: a document with a `doc_id` returns that `doc_id` as its UUID.
- `test_missing_doc_id_falls_back_to_fresh_uuid4`: a document without `doc_id` still gets a slot (a fresh UUID4) so the `add_texts` list stays positionally aligned.
- `test_all_doc_ids_present`: mixed inputs round-trip the right UUIDs.
- `test_legacy_object_with_matching_doc_id_is_reaped`: a 404 on the direct delete still leaves the legacy object cleaned up via the `doc_id`-metadata pass.
- `test_fresh_object_is_reaped_by_direct_delete`: a happy-path delete uses the direct path; the metadata-filter pass is a redundant no-op against the cleared UUID.
- `test_non_404_error_propagates`: a 500 on the direct delete raises and is NOT swallowed.
- `test_delete_many_404_is_swallowed`: a 404 on the metadata-filter pass is also swallowed (legacy schema or race).

All 47 tests in the directory pass. `ruff check` / `ruff format --check` clean, `pyrefly` 0 errors on the package.