### PR TITLE
fix(api): fix tencent summary vector deadlock (#41916)

### DIFF
--- a/api/core/rag/datasource/vdb/tencent/tencent_vector.py
+++ b/api/core/rag/datasource/vdb/tencent/tencent_vector.py
@@ -181,6 +181,11 @@ class TencentVector(BaseVector):
                 if metadatas is None:
                     continue
                 metadata = metadatas[i] or {}
+                if metadata.get("is_summary") is True:
+                    # Tencent VectorDB JSON fields do not support boolean values.
+                    # Use an integer only for the summary marker so other metadata
+                    # and other vector backends keep their existing types.
+                    metadata = {**metadata, "is_summary": 1}
                 doc = document.Document(
                     id=metadata.get("doc_id"),
                     vector=embeddings[i],

--- a/api/services/summary_index_service.py
+++ b/api/services/summary_index_service.py
@@ -465,8 +465,16 @@ class SummaryIndexService:
                         summary_record_id,
                         original_session is not None,
                     )
-                    # Always create a new session for error handling to avoid issues with closed sessions
-                    # Even if original_session was provided, we create a new one for safety
+                    if original_session is not None:
+                        # Keep the error update in the caller-owned transaction. Opening another
+                        # session here can deadlock when the caller has already flushed this row.
+                        summary_record.status = SummaryStatus.ERROR
+                        summary_record.error = f"Vectorization failed: {str(e)}"
+                        summary_record.updated_at = datetime.now(UTC).replace(tzinfo=None)
+                        original_session.add(summary_record)
+                        raise
+
+                    # Standalone callers still need this method to persist the error itself.
                     with session_factory.create_session() as error_session:
                         # Try to find the record by id first
                         # Note: Using assignment only (no type annotation) to avoid redeclaration error

--- a/api/tests/unit_tests/core/rag/datasource/vdb/tencent/test_tencent_vector.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/tencent/test_tencent_vector.py
@@ -279,7 +279,24 @@ def test_create_add_delete_and_search_behaviour(tencent_module):
     vector._client.drop_collection.assert_called_once()
 
 
-def test_tencent_factory_existing_and_generated_collection(tencent_module, monkeypatch):
+def test_add_texts_converts_only_true_summary_marker(tencent_module):
+    vector = tencent_module.TencentVector("collection_1", _config(tencent_module))
+    summary_metadata = {"doc_id": "summary", "is_summary": True, "published": False}
+    regular_metadata = {"doc_id": "regular", "published": False}
+    docs = [
+        Document(page_content="summary", metadata=summary_metadata),
+        Document(page_content="regular", metadata=regular_metadata),
+    ]
+
+    vector.add_texts(docs, [[0.1], [0.2]])
+
+    upserted = vector._client.upsert.call_args.kwargs["documents"]
+    assert upserted[0].metadata == {"doc_id": "summary", "is_summary": 1, "published": False}
+    assert upserted[1].metadata == regular_metadata
+    assert summary_metadata["is_summary"] is True
+
+
+def test_tencent_factory_existing_and_generated_collection(tencent_module, monkeypatch: pytest.MonkeyPatch):
     factory = tencent_module.TencentVectorFactory()
     dataset_with_index = SimpleNamespace(
         id="dataset-1",

--- a/api/tests/unit_tests/services/test_summary_index_service.py
+++ b/api/tests/unit_tests/services/test_summary_index_service.py
@@ -283,6 +283,45 @@ def test_vectorize_summary_final_failure_updates_error_status(monkeypatch: pytes
     error_session.commit.assert_called_once()
 
 
+def test_vectorize_summary_failure_with_provided_session_does_not_open_error_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id=None)
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="uuid-1"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(
+        summary_module,
+        "Vector",
+        MagicMock(return_value=MagicMock(add_texts=MagicMock(side_effect=RuntimeError("boom")))),
+    )
+    monkeypatch.setattr(
+        summary_module,
+        "ModelManager",
+        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
+    )
+
+    session = MagicMock(name="provided_session")
+    create_session_mock = MagicMock()
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=create_session_mock),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        SummaryIndexService.vectorize_summary(summary, segment, dataset, session=session)
+
+    create_session_mock.assert_not_called()
+    session.add.assert_called_once_with(summary)
+    session.commit.assert_not_called()
+    session.flush.assert_not_called()
+    assert summary.status == SummaryStatus.ERROR
+    assert summary.error == "Vectorization failed: boom"
+
+
 def test_batch_create_summary_records_no_segments_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     create_session_mock = MagicMock()
     monkeypatch.setattr(summary_module, "session_factory", SimpleNamespace(create_session=create_session_mock))


### PR DESCRIPTION
(cherry picked from commit 60656a60cf397bb80e57051875f976589b476b71)

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Backports #41916 to `lts/1.13.x`.

Tencent VectorDB rejects boolean values in JSON metadata. Automatic summary generation writes summary vectors with `is_summary: true`, causing the Tencent VectorDB upsert to fail after summary generation and embedding have completed.

The failure path can then open a second database session to update the same summary record while the caller-owned session still holds its row lock. This creates a circular lock wait that leaves the Celery task running and occupies a worker slot. A worker configured with concurrency 1 can consequently stop consuming additional tasks.

This backport:

- converts only the Tencent VectorDB `is_summary` marker from boolean `true` to integer `1`;
- keeps other metadata and other vector backends unchanged;
- records vectorization failures in the caller-owned session when one is provided, avoiding the cross-session lock wait;
- preserves the existing self-managed error-session behavior for standalone calls;
- includes regression tests for both fixes.

No new dependencies are introduced.

Refs #41918

### Testing

- Regression tests for Tencent summary-marker conversion are included.
- Regression tests verify that provided-session failures do not open a second error session.
- PR CI is running against `lts/1.13.x`.

## Screenshots

Not applicable; this is a backend-only fix with no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — Not required for this backend bug fix.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. — No documentation changes are required.
- [ ] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods — PR CI is still running.

From Codex

