### PR TITLE
fix(rag): preserve CSV cell text during knowledge import

### DIFF
--- a/api/core/rag/extractor/csv_extractor.py
+++ b/api/core/rag/extractor/csv_extractor.py
@@ -31,7 +31,8 @@ class CSVExtractor(BaseExtractor):
         self._encoding = encoding
         self._autodetect_encoding = autodetect_encoding
         self.source_column = source_column
-        self.csv_args = csv_args or {}
+        # Preserve source text for indexing unless the caller requests type or NA conversion.
+        self.csv_args: dict[str, Any] = {"dtype": str, "keep_default_na": False, **(csv_args or {})}
 
     @override
     def extract(self) -> list[Document]:

--- a/api/tests/unit_tests/core/rag/extractor/test_csv_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_csv_extractor.py
@@ -22,6 +22,27 @@ class _ManagedStringIO(io.StringIO):
 
 
 class TestCSVExtractor:
+    @pytest.mark.parametrize("value", ["00123", "1.00", "1e3", "NA", "NULL", "N/A", "", "hello"])
+    def test_extract_preserves_cell_text(self, tmp_path: Path, value: str) -> None:
+        file_path = tmp_path / "data.csv"
+        file_path.write_text(f"value,body\n{value},reference\n", encoding="utf-8")
+
+        docs = CSVExtractor(str(file_path), encoding="utf-8", source_column="value").extract()
+
+        assert len(docs) == 1
+        assert docs[0].page_content == f"value: {value};body: reference"
+        assert docs[0].metadata["source"] == value
+
+    def test_extract_honors_explicit_csv_args(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "data.csv"
+        file_path.write_text("value;body\n00123;NA\n", encoding="utf-8")
+        csv_args = {"sep": ";", "dtype": {"value": int}, "keep_default_na": True}
+
+        docs = CSVExtractor(str(file_path), encoding="utf-8", csv_args=csv_args).extract()
+
+        assert docs[0].page_content == "value: 123.0;body: nan"
+        assert csv_args == {"sep": ";", "dtype": {"value": int}, "keep_default_na": True}
+
     def test_extract_success_with_source_column(self, tmp_path: Path):
         file_path = tmp_path / "data.csv"
         file_path.write_text("id,body\nsource-1,hello\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

- Default `CSVExtractor` to `dtype=str` and `keep_default_na=False` so pandas does not coerce leading-zero codes, literal `NA`/`NULL` strings, or empty cells before knowledge indexing
- Explicit `csv_args` still override these defaults for callers that want typed parsing
- Add unit tests covering preserved cell text, source metadata, and explicit parsing overrides

Fixes #41910

## Problem

The built-in CSV extractor passed cells through pandas' default number and missing-value inference before building indexed document text:

```text
# Before
code: 123.0;region: nan;price: 1.0
code: 456.0;region: nan;price: 2.5
```

## Solution

```text
# After
code: 00123;region: NA;price: 1.00
code: 00456;region: NULL;price: 2.50
```

## Test plan

- [x] `pytest tests/unit_tests/core/rag/extractor/test_csv_extractor.py -v --no-cov` (15 passed)
- [x] Manual repro from #41910
- [x] Ruff lint/format on changed files