### PR TITLE
Fixes #41399.

### DIFF
--- a/api/tasks/delete_segment_from_index_task.py
+++ b/api/tasks/delete_segment_from_index_task.py
@@ -7,6 +7,7 @@ from sqlalchemy import delete, select
 
 from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
+from extensions.ext_storage import storage
 from models.dataset import Dataset, Document, SegmentAttachmentBinding
 from models.model import UploadFile
 
@@ -70,6 +71,16 @@ def delete_segment_from_index_task(
                     index_processor.clean(
                         session=session, dataset=dataset, node_ids=attachment_ids, with_keywords=False
                     )
+                    # collect the storage keys of the attachment files before
+                    # removing their DB rows, so we can clean up the physical
+                    # objects even after the upload_files are gone
+                    attachment_file_keys = [
+                        upload_file.key
+                        for upload_file in session.scalars(
+                            select(UploadFile).where(UploadFile.id.in_(attachment_ids))
+                        ).all()
+                    ]
+
                     segment_attachment_bind_ids = [i.id for i in segment_attachment_bindings]
 
                     for i in range(0, len(segment_attachment_bind_ids), 1000):
@@ -81,6 +92,15 @@ def delete_segment_from_index_task(
                     # delete upload file
                     session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
                     session.commit()
+
+                    # delete the physical attachment files from storage; a
+                    # backend failure should only be logged, not undo the
+                    # database cleanup already committed above
+                    for attachment_file_key in attachment_file_keys:
+                        try:
+                            storage.delete(attachment_file_key)
+                        except Exception:
+                            logger.exception("Delete attachment_file failed for key: %s", attachment_file_key)
 
             end_at = time.perf_counter()
             logger.info(click.style(f"Segment deleted from index latency: {end_at - start_at}", fg="green"))


### PR DESCRIPTION
When deleting a multimodal segment, `delete_segment_from_index_task` removed the `SegmentAttachmentBinding` and `UploadFile` DB rows but never deleted the physical files from the storage backend, leaving orphaned attachment objects behind.

This PR mirrors the existing document/batch-document cleanup pattern:
1. Collect the storage keys of the attachment files **before** removing their DB rows.
2. Delete the physical files via `storage.delete()` after the DB cleanup is committed.

A storage backend failure is logged but does not undo the already-committed DB cleanup.

## Changes

- `api/tasks/delete_segment_from_index_task.py`: collect attachment storage keys, then delete each physical file after the DB rows are removed, logging (not re-raising) backend failures.

Fixes #41399