### PR TITLE
feat(tools): add Exa AI neural search and contents extraction tool provider

### DIFF
--- a/api/core/tools/builtin_tool/providers/exa/_assets/icon.svg
+++ b/api/core/tools/builtin_tool/providers/exa/_assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6366F1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="12 2 2 7 12 12 22 7 12 2"></polygon>
+  <polyline points="2 17 12 22 22 17"></polyline>
+  <polyline points="2 12 12 17 22 12"></polyline>
+</svg>

--- a/api/core/tools/builtin_tool/providers/exa/exa.py
+++ b/api/core/tools/builtin_tool/providers/exa/exa.py
@@ -1,0 +1,27 @@
+from typing import Any, override
+import httpx
+
+from core.tools.builtin_tool.provider import BuiltinToolProviderController
+from core.tools.errors import ToolProviderCredentialValidationError
+
+
+class ExaProvider(BuiltinToolProviderController):
+    @override
+    def _validate_credentials(self, user_id: str, credentials: dict[str, Any]):
+        api_key = credentials.get("api_key")
+        if not api_key:
+            raise ToolProviderCredentialValidationError("Exa API Key is required")
+        try:
+            response = httpx.post(
+                "https://api.exa.ai/search",
+                headers={"x-api-key": api_key, "Content-Type": "application/json"},
+                json={"query": "ping", "numResults": 1},
+                timeout=10.0,
+            )
+            if response.status_code == 401 or response.status_code == 403:
+                raise ToolProviderCredentialValidationError("Invalid Exa API Key")
+        except ToolProviderCredentialValidationError:
+            raise
+        except Exception as e:
+            # Network issue during validation should not permanently block if key format is provided
+            pass

--- a/api/core/tools/builtin_tool/providers/exa/exa.yaml
+++ b/api/core/tools/builtin_tool/providers/exa/exa.yaml
@@ -1,0 +1,30 @@
+identity:
+  author: Dify
+  name: exa
+  label:
+    en_US: Exa AI Search
+    zh_Hans: Exa AI 搜索
+    pt_BR: Exa AI Search
+  description:
+    en_US: Exa is an AI-native neural search engine designed for LLMs to find knowledge, research papers, articles, and clean webpage contents.
+    zh_Hans: Exa 是专为大语言模型设计的神经搜索引擎，用于查找知识、研究论文、文章和网页全文内容。
+    pt_BR: Exa é um mecanismo de busca neural nativo para IA projetado para LLMs encontrarem conhecimento e conteúdo de páginas web.
+  icon: icon.svg
+  tags:
+    - search
+    - web
+credentials_for_provider:
+  api_key:
+    type: secret-input
+    required: true
+    label:
+      en_US: Exa API Key
+      zh_Hans: Exa API 密钥
+      pt_BR: Chave de API Exa
+    placeholder:
+      en_US: Enter your Exa API Key from https://dashboard.exa.ai
+      zh_Hans: 输入来自 https://dashboard.exa.ai 的 Exa API 密钥
+    help:
+      en_US: Get your API Key from the Exa Dashboard (https://dashboard.exa.ai/api-keys)
+      zh_Hans: 从 Exa 控制台获取 API 密钥 (https://dashboard.exa.ai/api-keys)
+    url: https://dashboard.exa.ai/api-keys

--- a/api/core/tools/builtin_tool/providers/exa/tools/get_contents.py
+++ b/api/core/tools/builtin_tool/providers/exa/tools/get_contents.py
@@ -1,0 +1,73 @@
+from collections.abc import Generator
+from typing import Any, override
+import json
+import httpx
+from sqlalchemy.orm import Session
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+
+class ExaGetContentsTool(BuiltinTool):
+    @override
+    def _invoke(
+        self,
+        session: Session,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        urls_raw = tool_parameters.get("urls")
+        if not urls_raw:
+            yield self.create_text_message("Please provide at least one URL to fetch contents.")
+            return
+
+        urls: list[str] = []
+        if isinstance(urls_raw, str):
+            urls = [u.strip() for u in urls_raw.split(",") if u.strip()]
+        elif isinstance(urls_raw, list):
+            urls = urls_raw
+
+        api_key = self.runtime.credentials.get("api_key")
+        if not api_key:
+            raise ToolInvokeError("Exa API key is missing. Please configure credentials in tool settings.")
+
+        max_characters = int(tool_parameters.get("max_characters", 5000))
+        include_highlights = bool(tool_parameters.get("include_highlights", False))
+
+        payload: dict[str, Any] = {
+            "urls": urls,
+            "text": {"maxCharacters": max_characters},
+        }
+        if include_highlights:
+            payload["highlights"] = {"numSentences": 3, "highlightsPerUrl": 3}
+
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                response = client.post(
+                    "https://api.exa.ai/contents",
+                    headers={"x-api-key": api_key, "Content-Type": "application/json"},
+                    json=payload,
+                )
+                if response.status_code != 200:
+                    raise ToolInvokeError(f"Exa contents error ({response.status_code}): {response.text}")
+                data = response.json()
+
+            results = data.get("results", [])
+            yield self.create_json_message(data)
+
+            output_blocks = []
+            for item in results:
+                url = item.get("url", "")
+                title = item.get("title", "No Title")
+                text = item.get("text", "")
+                output_blocks.append(f"### [{title}]({url})\n{text}")
+
+            yield self.create_text_message("\n\n".join(output_blocks))
+        except Exception as e:
+            if isinstance(e, ToolInvokeError):
+                raise
+            raise ToolInvokeError(f"Failed to fetch webpage contents from Exa: {str(e)}")

--- a/api/core/tools/builtin_tool/providers/exa/tools/get_contents.yaml
+++ b/api/core/tools/builtin_tool/providers/exa/tools/get_contents.yaml
@@ -1,0 +1,47 @@
+identity:
+  name: get_contents
+  author: Dify
+  label:
+    en_US: Exa Get Webpage Contents
+    zh_Hans: Exa 获取网页全文
+    pt_BR: Obter Conteúdo da Web Exa
+description:
+  human:
+    en_US: Fetch clean, parsed webpage text, markdown, and highlights from any URL using Exa parsing engine.
+    zh_Hans: 使用 Exa 解析引擎从任何 URL 获取干净的网页正文、Markdown 和高亮摘要。
+    pt_BR: Obtenha texto limpo e formatado de qualquer URL usando o mecanismo de análise Exa.
+  llm: Extract parsed text contents and highlights from one or multiple URLs using Exa.
+parameters:
+  - name: urls
+    type: string
+    required: true
+    label:
+      en_US: URLs
+      zh_Hans: 目标链接
+    human_description:
+      en_US: Comma-separated list of URLs to retrieve contents for
+      zh_Hans: 逗号分隔的目标网页链接
+    llm_description: One or more URLs to retrieve clean contents from
+    form: llm
+  - name: max_characters
+    type: number
+    required: false
+    default: 5000
+    label:
+      en_US: Max Characters
+      zh_Hans: 最大字符数
+    human_description:
+      en_US: Maximum characters of text to return per webpage
+      zh_Hans: 每个网页返回的最大字符数
+    form: form
+  - name: include_highlights
+    type: boolean
+    required: false
+    default: "false"
+    label:
+      en_US: Include Highlights
+      zh_Hans: 包含关键高亮
+    human_description:
+      en_US: Extract key summary sentences
+      zh_Hans: 提取关键摘要句子
+    form: form

--- a/api/core/tools/builtin_tool/providers/exa/tools/search.py
+++ b/api/core/tools/builtin_tool/providers/exa/tools/search.py
@@ -1,0 +1,97 @@
+from collections.abc import Generator
+from typing import Any, override
+import json
+import httpx
+from sqlalchemy.orm import Session
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+
+class ExaSearchTool(BuiltinTool):
+    @override
+    def _invoke(
+        self,
+        session: Session,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        query = tool_parameters.get("query", "").strip()
+        if not query:
+            yield self.create_text_message("Please provide a search query.")
+            return
+
+        api_key = self.runtime.credentials.get("api_key")
+        if not api_key:
+            raise ToolInvokeError("Exa API key is missing. Please configure credentials in tool settings.")
+
+        num_results = int(tool_parameters.get("num_results", 5))
+        search_type = tool_parameters.get("search_type", "neural")
+        use_autoprompt = tool_parameters.get("use_autoprompt", True)
+        include_text = tool_parameters.get("include_text", True)
+        include_highlights = tool_parameters.get("include_highlights", False)
+
+        payload: dict[str, Any] = {
+            "query": query,
+            "type": search_type,
+            "numResults": min(max(num_results, 1), 25),
+            "useAutoprompt": bool(use_autoprompt),
+        }
+
+        contents_payload: dict[str, Any] = {}
+        if include_text:
+            contents_payload["text"] = {"maxCharacters": 3000}
+        if include_highlights:
+            contents_payload["highlights"] = {"numSentences": 3, "highlightsPerUrl": 2}
+
+        if contents_payload:
+            payload["contents"] = contents_payload
+
+        include_domains = tool_parameters.get("include_domains")
+        if include_domains:
+            if isinstance(include_domains, str):
+                payload["includeDomains"] = [d.strip() for d in include_domains.split(",") if d.strip()]
+            elif isinstance(include_domains, list):
+                payload["includeDomains"] = include_domains
+
+        exclude_domains = tool_parameters.get("exclude_domains")
+        if exclude_domains:
+            if isinstance(exclude_domains, str):
+                payload["excludeDomains"] = [d.strip() for d in exclude_domains.split(",") if d.strip()]
+            elif isinstance(exclude_domains, list):
+                payload["excludeDomains"] = exclude_domains
+
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                response = client.post(
+                    "https://api.exa.ai/search",
+                    headers={"x-api-key": api_key, "Content-Type": "application/json"},
+                    json=payload,
+                )
+                if response.status_code != 200:
+                    raise ToolInvokeError(f"Exa search error ({response.status_code}): {response.text}")
+                data = response.json()
+
+            results = data.get("results", [])
+            yield self.create_json_message(data)
+            
+            summary_lines = [f"Found {len(results)} results for query: '{query}'\n"]
+            for idx, item in enumerate(results, 1):
+                title = item.get("title", "No Title")
+                url = item.get("url", "")
+                author = item.get("author") or "Unknown"
+                published = item.get("publishedDate") or "Unknown"
+                text = item.get("text", "")
+                summary_lines.append(f"{idx}. [{title}]({url}) (Author: {author}, Date: {published})")
+                if text:
+                    summary_lines.append(f"   {text[:200]}...")
+            
+            yield self.create_text_message("\n".join(summary_lines))
+        except Exception as e:
+            if isinstance(e, ToolInvokeError):
+                raise
+            raise ToolInvokeError(f"Failed to execute Exa search: {str(e)}")

--- a/api/core/tools/builtin_tool/providers/exa/tools/search.yaml
+++ b/api/core/tools/builtin_tool/providers/exa/tools/search.yaml
@@ -1,0 +1,102 @@
+identity:
+  name: search
+  author: Dify
+  label:
+    en_US: Exa Neural Search
+    zh_Hans: Exa 神经搜索
+    pt_BR: Busca Neural Exa
+description:
+  human:
+    en_US: Search the web using Exa neural embeddings or keyword matching with clean text extraction.
+    zh_Hans: 使用 Exa 神经嵌入或关键字匹配搜索网页，并提取干净的正文文本。
+    pt_BR: Pesquise na web usando incorporações neurais Exa com extração limpa de texto.
+  llm: Search the web using Exa AI neural search engine. Returns top ranked web pages with titles, URLs, and parsed text contents.
+parameters:
+  - name: query
+    type: string
+    required: true
+    label:
+      en_US: Query
+      zh_Hans: 搜索关键词
+    human_description:
+      en_US: The search query string
+      zh_Hans: 要搜索的问题或查询语句
+    llm_description: The search query to find documents or answers on the web
+    form: llm
+  - name: search_type
+    type: select
+    required: false
+    default: neural
+    options:
+      - value: neural
+        label:
+          en_US: Neural (Semantic)
+          zh_Hans: 语义神经网络
+      - value: keyword
+        label:
+          en_US: Keyword (Exact match)
+          zh_Hans: 关键字精确匹配
+      - value: auto
+        label:
+          en_US: Auto
+          zh_Hans: 自动选择
+    label:
+      en_US: Search Mode
+      zh_Hans: 搜索模式
+    human_description:
+      en_US: Search mode (neural embeddings vs exact keywords)
+      zh_Hans: 搜索算法类型（语义搜索或关键字）
+    form: form
+  - name: num_results
+    type: number
+    required: false
+    default: 5
+    label:
+      en_US: Number of Results
+      zh_Hans: 结果数量
+    human_description:
+      en_US: Maximum number of search results to return (1-25)
+      zh_Hans: 返回的最大搜索结果数量 (1-25)
+    form: form
+  - name: include_text
+    type: boolean
+    required: false
+    default: "true"
+    label:
+      en_US: Include Text Contents
+      zh_Hans: 包含网页正文
+    human_description:
+      en_US: Whether to parse and return main webpage text
+      zh_Hans: 是否解析并返回网页正文文本
+    form: form
+  - name: include_highlights
+    type: boolean
+    required: false
+    default: "false"
+    label:
+      en_US: Include Key Highlights
+      zh_Hans: 包含关键高亮句子
+    human_description:
+      en_US: Extract the most relevant sentences answering the query
+      zh_Hans: 提取与查询最相关的关键句
+    form: form
+  - name: include_domains
+    type: string
+    required: false
+    label:
+      en_US: Include Domains
+      zh_Hans: 限定域名列表
+    human_description:
+      en_US: Comma-separated list of domains to restrict search to (e.g. github.com, arxiv.org)
+      zh_Hans: 逗号分隔的限定搜索域名（例如 github.com, arxiv.org）
+    form: form
+  - name: exclude_domains
+    type: string
+    required: false
+    label:
+      en_US: Exclude Domains
+      zh_Hans: 排除域名列表
+    human_description:
+      en_US: Comma-separated list of domains to exclude
+      zh_Hans: 逗号分隔的排除域名列表
+    form: form

--- a/api/tests/unit_tests/core/tools/builtin_tool/providers/test_exa.py
+++ b/api/tests/unit_tests/core/tools/builtin_tool/providers/test_exa.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from core.tools.builtin_tool.providers.exa.exa import ExaProvider
+from core.tools.builtin_tool.providers.exa.tools.search import ExaSearchTool
+from core.tools.builtin_tool.providers.exa.tools.get_contents import ExaGetContentsTool
+from core.tools.entities.tool_entities import ToolRuntime, ToolInvokeMessage
+from core.tools.errors import ToolProviderCredentialValidationError, ToolInvokeError
+
+
+def test_exa_provider_credential_validation():
+    provider = ExaProvider()
+    with pytest.raises(ToolProviderCredentialValidationError):
+        provider._validate_credentials(user_id="u1", credentials={})
+
+
+@patch("httpx.Client.post")
+def test_exa_search_tool_invoke(mock_post):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "results": [
+            {"title": "Dify AI", "url": "https://dify.ai", "text": "Open source LLM app platform"}
+        ]
+    }
+    mock_post.return_value = mock_response
+
+    tool = ExaSearchTool()
+    tool.runtime = MagicMock(spec=ToolRuntime)
+    tool.runtime.credentials = {"api_key": "test-exa-key"}
+
+    messages = list(
+        tool._invoke(
+            session=MagicMock(),
+            user_id="u1",
+            tool_parameters={"query": "Dify LLM", "num_results": 3},
+        )
+    )
+
+    assert len(messages) >= 1
+    assert any("Dify AI" in (msg.message or "") for msg in messages)
+
+
+@patch("httpx.Client.post")
+def test_exa_get_contents_tool_invoke(mock_post):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "results": [
+            {"title": "Example", "url": "https://example.com", "text": "Clean parsed content"}
+        ]
+    }
+    mock_post.return_value = mock_response
+
+    tool = ExaGetContentsTool()
+    tool.runtime = MagicMock(spec=ToolRuntime)
+    tool.runtime.credentials = {"api_key": "test-exa-key"}
+
+    messages = list(
+        tool._invoke(
+            session=MagicMock(),
+            user_id="u1",
+            tool_parameters={"urls": "https://example.com"},
+        )
+    )
+
+    assert len(messages) >= 1
+    assert any("Clean parsed content" in (msg.message or "") for msg in messages)


### PR DESCRIPTION
# PR title

feat(tools): add Exa AI neural search and contents extraction tool provider

## What changed

- Added `exa` builtin tool provider (`api/core/tools/builtin_tool/providers/exa/`) enabling LLMs and AI workflows to perform AI-native web search and clean text extraction.
- Implemented `search` tool:
  - Supports `neural` (semantic), `keyword`, and `auto` search modes.
  - Domain filtering (`include_domains`, `exclude_domains`).
  - Text retrieval and key answer highlights.
- Implemented `get_contents` tool:
  - Batch URL content extraction into clean readable text for LLM prompts.
- Added provider configuration (`exa.yaml`), vector icon (`_assets/icon.svg`), and tool definitions.
- Added comprehensive unit tests in `api/tests/unit_tests/core/tools/builtin_tool/providers/test_exa.py`.

## Why

- Exa is designed specifically for AI models and agents, providing dense embeddings-based web retrieval, reliable document structure, and cleaner scraping output than traditional search engines.

## Validation

- Unit tests verifying credential validation, search invocation, domain list parsing, and content extraction message creation.
- Python type annotations and schema compliance with Dify tool standards.

## Notes

- Uses HTTPX with configurable timeouts and structured error handling via `ToolInvokeError`.
