### PR TITLE
fix(vdb-weaviate): align insert UUID with the cleanup path's index_node_id

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -280,14 +280,24 @@ class WeaviateVector(BaseVector):
     @override
     def _get_uuids(self, documents: list[Document]) -> list[str]:
         """
-        Generates deterministic UUIDs for documents based on their content.
+        Resolves the object UUID for each document.
 
-        Uses UUID5 with URL namespace to ensure consistent IDs for identical content.
+        When a document's metadata carries a caller-supplied ``doc_id`` (the same
+        identifier persisted on ``DocumentSegment.index_node_id`` and passed back
+        to ``delete_by_ids`` by the cleanup path), that value is used as the
+        Weaviate object UUID. Otherwise the UUID falls back to UUID5 of the
+        page content, which keeps re-indexing identical content idempotent
+        (overwriting the same object).
         """
         URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
 
         uuids = []
         for doc in documents:
+            meta = doc.metadata or {}
+            caller_uuid = meta.get("doc_id")
+            if isinstance(caller_uuid, str) and caller_uuid:
+                uuids.append(caller_uuid)
+                continue
             uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
             uuids.append(str(uuid_val))
 

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -932,5 +932,109 @@ class TestWeaviateVectorFactory(unittest.TestCase):
         }
 
 
+class TestGetUuids(unittest.TestCase):
+    """_get_uuids must align the insert path with the delete path.
+
+    The cleanup path persists ``DocumentSegment.index_node_id`` and later passes
+    it back to ``delete_by_ids``. The insert path receives the same identifier
+    in ``Document.metadata["doc_id"]`` (see qa_index_processor.py:87, which
+    generates ``doc_id = str(uuid.uuid4())`` and stores it both in the
+    segment row and in the document metadata before the vector insert).
+    The Weaviate adapter must use that identifier as the Weaviate object UUID
+    so the delete path actually targets the right object.
+    """
+
+    @override
+    def test_prefers_caller_doc_id_when_present(self) -> None:
+        from dify_vdb_weaviate.weaviate_vector import WeaviateVector
+
+        wv = WeaviateVector.__new__(WeaviateVector)  # bypass __init__
+        caller_uuid = "6390eac9-9441-4deb-9b1e-1c4d2e0a6f55"
+        documents = [
+            Document(
+                page_content="segment content",
+                metadata={"doc_id": caller_uuid, "doc_hash": "h"},
+            )
+        ]
+
+        uuids = wv._get_uuids(documents)
+
+        assert uuids == [caller_uuid]
+
+    @override
+    def test_falls_back_to_uuid5_when_doc_id_missing(self) -> None:
+        from dify_vdb_weaviate.weaviate_vector import WeaviateVector
+
+        wv = WeaviateVector.__new__(WeaviateVector)  # bypass __init__
+        documents = [
+            Document(
+                page_content="segment content",
+                metadata={"doc_hash": "h"},
+            )
+        ]
+
+        uuids = wv._get_uuids(documents)
+
+        # UUID5(namespace, "segment content") is deterministic; assert shape, not value
+        import uuid as _uuid
+
+        assert len(uuids) == 1
+        _uuid.UUID(uuids[0])  # parses as UUID
+        assert uuids[0] != "6390eac9-9441-4deb-9b1e-1c4d2e0a6f55"  # not the v4 fallback
+
+    @override
+    def test_falls_back_to_uuid5_when_doc_id_empty(self) -> None:
+        from dify_vdb_weaviate.weaviate_vector import WeaviateVector
+
+        wv = WeaviateVector.__new__(WeaviateVector)  # bypass __init__
+        documents = [
+            Document(
+                page_content="segment content",
+                metadata={"doc_id": ""},
+            )
+        ]
+
+        uuids = wv._get_uuids(documents)
+
+        import uuid as _uuid
+
+        assert len(uuids) == 1
+        _uuid.UUID(uuids[0])
+
+    @override
+    def test_handles_metadata_none(self) -> None:
+        from dify_vdb_weaviate.weaviate_vector import WeaviateVector
+
+        wv = WeaviateVector.__new__(WeaviateVector)  # bypass __init__
+        documents = [Document(page_content="segment content", metadata={})]
+
+        uuids = wv._get_uuids(documents)
+
+        import uuid as _uuid
+
+        assert len(uuids) == 1
+        _uuid.UUID(uuids[0])
+
+    @override
+    def test_handles_non_string_doc_id(self) -> None:
+        from dify_vdb_weaviate.weaviate_vector import WeaviateVector
+
+        wv = WeaviateVector.__new__(WeaviateVector)  # bypass __init__
+        # Some legacy callers may pass a non-string value; fall back to UUID5(content)
+        documents = [
+            Document(
+                page_content="segment content",
+                metadata={"doc_id": 12345},
+            )
+        ]
+
+        uuids = wv._get_uuids(documents)
+
+        import uuid as _uuid
+
+        assert len(uuids) == 1
+        _uuid.UUID(uuids[0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes a 1.17.0 data leak in the Weaviate vector adapter. The cleanup path (`batch_clean_document_task` → `index_processor.clean()` → `vector.delete_by_ids(node_ids)`) reports success while leaving orphan vectors searchable in Weaviate. The bug is a UUID v5 / v4 mismatch between the insert and delete paths.

Root cause:
- Insert: `WeaviateVector._get_uuids` computed `uuid5(URL_NAMESPACE, page_content)` and used that as the Weaviate object UUID.
- Delete: the cleanup path persists `DocumentSegment.index_node_id` (a random UUID v4) and passes it to `delete_by_ids(node_ids)`.

Since `uuid5(content) != index_node_id` in general, the delete targets a non-existent object. Weaviate's client treats the 404 as success, so the task reports "Cleaned successfully" while the vectors remain as searchable orphans that pollute retrieval results (verified in the issue report: 652 of 687 vectors belonged to 6 already-deleted documents).

The index processor already generates a `doc_id` at insert time (`qa_index_processor.py:87`: `doc_id = str(uuid.uuid4())`) and stores it in **both** `DocumentSegment.index_node_id` and `Document.metadata["doc_id"]` before the vector insert. The Weaviate adapter was ignoring that metadata.

Fix: in `WeaviateVector._get_uuids`, prefer `Document.metadata["doc_id"]` when present, falling back to `uuid5(content)` only when it is not. This keeps the re-index-identical-content idempotency contract (uuid5 collisions overwrite the same object) while aligning the insert and delete paths for the common case where the caller already provides the identifier.

Fixes #41714

## Changes

`api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py::WeaviateVector._get_uuids`

- Read `doc.metadata.get("doc_id")` and use it as the Weaviate object UUID when it is a non-empty string.
- Fall back to `uuid5(namespace, page_content)` for the existing behavior (idempotent overwrites of identical content) when the metadata does not carry a usable `doc_id`.
- Skip non-string values (e.g. legacy callers that passed a non-string `doc_id`).

The downstream `add_texts` already accepts a candidate UUID and uses it when valid (it routes through `_is_uuid`); the change is upstream of that path, so no other call sites need to change.

## Tests

Five new unit tests in a new `TestGetUuids` class in `providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py`:

- `test_prefers_caller_doc_id_when_present` — the caller-supplied `doc_id` from `Document.metadata` is used as the Weaviate object UUID. **On the unpatched helper this test fails** because `_get_uuids` returned `uuid5(namespace, page_content)` instead of the caller's v4 `doc_id`, so the Weaviate UUID never matched `index_node_id` and `delete_by_ids` targeted a non-existent object. Verified by stashing only `weaviate_vector.py` and re-running, then restoring.
- `test_falls_back_to_uuid5_when_doc_id_missing` — documents without a `doc_id` still get a UUID5 derivation (keeps the re-index-identical-content idempotency contract).
- `test_falls_back_to_uuid5_when_doc_id_empty` — an empty-string `doc_id` is treated as missing.
- `test_handles_metadata_none` — an empty metadata dict falls back to UUID5(content).
- `test_handles_non_string_doc_id` — a non-string `doc_id` (legacy callers) falls back to UUID5(content).

44/44 pass on the full `test_weaviate_vector.py`. ruff check + format clean on both touched files.

## Verification

- `pytest providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py` — 44/44 pass.
- `ruff check` — clean.
- `ruff format --check` — clean.

## Risk

Low. The change is additive: a usable caller-supplied `doc_id` now wins; the UUID5(content) path remains for callers that don't supply one (the historical contract). No existing caller passes `doc_id` in metadata that would conflict with this new preference — the index processor is the only producer and uses a v4 UUID, which is what the delete path round-trips.

## Future work (out of scope here)

A small audit of the other VDB adapters to confirm the same insert/delete ID contract holds (or doesn't). Some adapters may use a similar UUID5-from-content pattern; if so, they have the same orphan-vector leak. The grep for `uuid5(` in `api/providers/vdb/` would surface the candidates.
