### PR TITLE
fix(api): share the request session when uploading text/file rows in dataset document APIs

### DIFF
--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -410,7 +410,11 @@ def _create_document_by_text(session: Session, tenant_id: str, dataset_id: UUID)
         raise ValueError("current_user is required")
 
     upload_file = FileService(db.engine).upload_text(
-        text=payload.text, text_name=payload.name, user_id=current_user.id, tenant_id=tenant_id_str
+        text=payload.text,
+        text_name=payload.name,
+        user_id=current_user.id,
+        tenant_id=tenant_id_str,
+        session=session,
     )
     data_source = {
         "type": "upload_file",
@@ -475,7 +479,11 @@ def _update_document_by_text(
         if not current_user:
             raise ValueError("current_user is required")
         upload_file = FileService(db.engine).upload_text(
-            text=str(text), text_name=str(name), user_id=current_user.id, tenant_id=tenant_id
+            text=str(text),
+            text_name=str(name),
+            user_id=current_user.id,
+            tenant_id=tenant_id,
+            session=session,
         )
         data_source = {
             "type": "upload_file",
@@ -793,6 +801,7 @@ class DocumentAddByFileApi(DatasetApiResource):
                 user=current_user,
                 source="datasets",
                 default_file_size_limit=FeatureService.get_knowledge_file_size_limit(tenant_id),
+                session=session,
             )
         except services.errors.file.FileTooLargeError as file_too_large_error:
             raise FileTooLargeError(file_too_large_error.description)
@@ -871,6 +880,7 @@ def _update_document_by_file(
                 user=current_user,
                 source="datasets",
                 default_file_size_limit=FeatureService.get_knowledge_file_size_limit(tenant_id),
+                session=session,
             )
         except services.errors.file.FileTooLargeError as file_too_large_error:
             raise FileTooLargeError(file_too_large_error.description)

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -58,6 +58,7 @@ class FileService:
         source: Literal["datasets"] | None = None,
         source_url: str = "",
         default_file_size_limit: int | None = None,
+        session: Session | None = None,
     ) -> UploadFile:
         # get file extension
         extension = os.path.splitext(filename)[1].lstrip(".").lower()
@@ -115,9 +116,17 @@ class FileService:
             source_url=source_url,
         )
 
-        with self._session_maker(expire_on_commit=False) as session:
+        if session is not None:
+            # Use the caller's session so the just-added row is visible to the
+            # same transaction's follow-up queries (matters under MySQL
+            # REPEATABLE-READ, which freezes the snapshot at the first read
+            # of the request session).
             session.add(upload_file)
-            session.commit()
+            session.flush()
+        else:
+            with self._session_maker(expire_on_commit=False) as own_session:
+                own_session.add(upload_file)
+                own_session.commit()
 
         if not upload_file.source_url:
             upload_file.source_url = file_helpers.get_signed_file_url(upload_file_id=upload_file.id)
@@ -198,7 +207,15 @@ class FileService:
             return self.get_file_presigned_url(file_id=file_id, tenant_id=tenant_id)
         return file_helpers.get_signed_file_url(upload_file_id=file_id)
 
-    def upload_text(self, text: str, text_name: str, user_id: str, tenant_id: str) -> UploadFile:
+    def upload_text(
+        self,
+        text: str,
+        text_name: str,
+        user_id: str,
+        tenant_id: str,
+        *,
+        session: Session | None = None,
+    ) -> UploadFile:
         if len(text_name) > 200:
             text_name = text_name[:200]
         # user uuid as file name
@@ -226,9 +243,17 @@ class FileService:
             used_at=naive_utc_now(),
         )
 
-        with self._session_maker(expire_on_commit=False) as session:
+        if session is not None:
+            # Use the caller's session so the just-added row is visible to the
+            # same transaction's follow-up queries (matters under MySQL
+            # REPEATABLE-READ, which freezes the snapshot at the first read
+            # of the request session).
             session.add(upload_file)
-            session.commit()
+            session.flush()
+        else:
+            with self._session_maker(expire_on_commit=False) as own_session:
+                own_session.add(upload_file)
+                own_session.commit()
 
         return upload_file
 

--- a/api/tests/unit_tests/services/test_file_service.py
+++ b/api/tests/unit_tests/services/test_file_service.py
@@ -549,3 +549,64 @@ class TestFileService:
                 assert os.path.exists(tmp_path)
 
             mock_remove.assert_called_once()
+
+    @patch("services.file_service.naive_utc_now")
+    @patch("services.file_service.storage")
+    @patch("services.file_service.file_helpers.get_signed_file_url")
+    def test_upload_text_uses_caller_session_without_autocommit(
+        self, mock_get_url, mock_storage, mock_now, file_service: FileService, db_session: Session
+    ):
+        """Regression for langgenius/dify#41735: when a caller session is
+        provided, the row must be added to that session (not committed
+        independently) so the follow-up query in the same request can
+        see it under MySQL REPEATABLE-READ.
+        """
+        mock_now.return_value = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_get_url.return_value = ""
+
+        user = Account(name="u", email="u@example.com")
+        user.id = "user_id"
+
+        result = file_service.upload_text(
+            text="hello world",
+            text_name="test.txt",
+            user_id="user_id",
+            tenant_id="tenant_id",
+            session=db_session,
+        )
+
+        assert isinstance(result, UploadFile)
+        assert result.tenant_id == "tenant_id"
+        # Caller session must see the just-added row, no separate commit
+        assert db_session.get(UploadFile, result.id) is result
+        mock_storage.save.assert_called_once()
+
+    @patch("services.file_service.extract_tenant_id")
+    @patch("services.file_service.storage")
+    @patch("services.file_service.file_helpers.get_signed_file_url")
+    def test_upload_file_uses_caller_session_without_autocommit(
+        self, mock_get_url, mock_storage, mock_tenant_id, file_service: FileService, db_session: Session
+    ):
+        """Regression for langgenius/dify#41735: when a caller session is
+        provided, the row must be added to that session (not committed
+        independently) so the follow-up query in the same request can
+        see it under MySQL REPEATABLE-READ.
+        """
+        mock_tenant_id.return_value = "tenant_id"
+        mock_get_url.return_value = ""
+
+        user = Account(name="u", email="u@example.com")
+        user.id = "user_id"
+
+        result = file_service.upload_file(
+            filename="test.jpg",
+            content=b"content",
+            mimetype="image/jpeg",
+            user=user,
+            session=db_session,
+        )
+
+        assert isinstance(result, UploadFile)
+        # Caller session must see the just-added row
+        assert db_session.get(UploadFile, result.id) is result
+        mock_storage.save.assert_called_once()


### PR DESCRIPTION
## Summary

Closes a MySQL-specific regression in the dataset document service APIs (`create-by-text`, `create-by-file`, and the corresponding update endpoints). On MySQL 8.0 (default isolation `REPEATABLE-READ`), the request session's snapshot is established at the first read, so a row written by a different session/connection after that point is invisible to follow-up queries in the same request.

Root cause: `FileService.upload_text` (and `upload_file`) open their own session via `self._session_maker`, commit, and return. The dataset document controller then calls `DocumentService.save_document_with_dataset_id(..., session=request_session)`, which queries `UploadFile` using the request's `@with_session` session. The request session cannot see the just-committed row, so the API returns:

```json
{"code": "invalid_param", "message": "One or more files not found.", "status": 400}
```

PostgreSQL is unaffected because its default isolation is `READ COMMITTED`.

Add an optional keyword-only `session` parameter to `FileService.upload_text` and `FileService.upload_file`. When provided, the row is added to that session and `flush()`-ed (no independent commit); the request's `@with_session` decorator then commits both the upload and the follow-up document inserts in the same transaction. When `session` is `None`, the existing behaviour (open own session, commit) is preserved for callers that don't have a request session to share.

Update the four dataset document API call sites to pass their existing request session.

Fixes #41735

## Changes

`api/services/file_service.py`

- `FileService.upload_text` gains a keyword-only `session: Session | None = None` parameter. When provided, the new row is added to that session with `session.flush()`; otherwise the original `with self._session_maker(...): own_session.add(...); own_session.commit()` path runs unchanged.
- `FileService.upload_file` gets the same optional `session` parameter with the same branch behavior.

`api/controllers/service_api/dataset/document.py`

- `_create_document_by_text` passes `session=session` to `FileService.upload_text`.
- `_update_document_by_text` does the same.
- `_create_document_by_file` and `_update_document_by_file` pass `session=session` to `FileService.upload_file`.

The `dataset` and `knowledge_config` arguments are unchanged; only the upload path is rewired to share the request session.

## Tests

Two new unit tests in `api/tests/unit_tests/services/test_file_service.py`:

- `test_upload_text_uses_caller_session_without_autocommit` — when the caller passes a session, the new `UploadFile` row is added to that session and is visible immediately (no independent commit). Regression for #41735.
- `test_upload_file_uses_caller_session_without_autocommit` — same coverage for the `upload_file` path.

Both tests fail on the unpatched `FileService` (`TypeError: unexpected keyword argument 'session'`), verified by stashing only `api/services/file_service.py` against the new tests, then restoring. 48/48 pass on the full `test_file_service.py`.

## Verification

- `pytest tests/unit_tests/services/test_file_service.py` — 48/48 pass.
- `ruff check` — clean.
- `ruff format --check` — clean.

## Risk

Low. The new `session` parameter is keyword-only and defaults to `None`, so existing callers are unaffected. When the caller passes a session, the behaviour change is "use the caller's session" instead of "open own session and commit" — strictly more correct for the cross-session visibility case, and harmless for any caller that already had its own session.

## Future work (out of scope here)

A small audit of the other call sites in `api/services/rag_pipeline/rag_pipeline_task_proxy.py` (which also calls `FileService(db.engine).upload_text` and `upload_file` without a session argument) to confirm they are not in the same cross-session visibility scenario. None surfaced in the issue body, but the grep for `FileService(db.engine)` in `api/controllers/` and `api/services/rag_pipeline/` would surface the candidates.
