### PR TITLE
refactor(models): remove the legacy db.session wrappers on App

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -575,19 +575,11 @@ class App(Base):
             return True
         return False
 
-    @property
-    def mode_compatible_with_agent(self) -> str:
-        return self.mode_compatible_with_agent_with_session(session=db.session())
-
     def mode_compatible_with_agent_with_session(self, *, session: Session) -> str:
         if self.mode == AppMode.CHAT and self.is_agent_with_session(session=session):
             return AppMode.AGENT_CHAT
 
         return str(self.mode)
-
-    @property
-    def deleted_tools(self) -> list[DeletedToolInfo]:
-        return self.deleted_tools_with_session(session=db.session())
 
     def deleted_tools_with_session(self, *, session: Session) -> list[DeletedToolInfo]:
         from core.plugin.plugin_service import PluginService

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -242,6 +242,35 @@ class TestAppModelValidation:
         assert result == AppMode.CHAT
 
     @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
+    def test_app_mode_compatible_with_agent_reports_agent_chat(self, sqlite_session: Session):
+        """A CHAT app whose own config enables agent mode reports AGENT_CHAT."""
+        # Arrange
+        app = App(
+            tenant_id=str(uuid4()),
+            name="Test App",
+            mode=AppMode.CHAT,
+            enable_site=True,
+            enable_api=False,
+            created_by=str(uuid4()),
+        )
+        sqlite_session.add(app)
+        sqlite_session.flush()
+        app.app_model_config_id = str(uuid4())
+        config = AppModelConfig(
+            app_id=app.id,
+            agent_mode=json.dumps({"enabled": True, "strategy": "react"}),
+        )
+        config.id = app.app_model_config_id
+        sqlite_session.add(config)
+        sqlite_session.flush()
+
+        # Act
+        result = app.mode_compatible_with_agent_with_session(session=sqlite_session)
+
+        # Assert
+        assert result == AppMode.AGENT_CHAT
+
+    @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
     def test_deleted_tools_checks_plugin_builtin_providers_through_core_plugin_service(self, sqlite_session: Session):
         """Plugin-backed built-in tools are checked through core PluginService."""
         # Arrange


### PR DESCRIPTION
## Summary

Part of #40372. Removes two legacy `@property` wrappers on `App` in `api/models/model.py`:

| Removed | Kept (unchanged) |
|---|---|
| `App.mode_compatible_with_agent` | `mode_compatible_with_agent_with_session(self, *, session: Session)` |
| `App.deleted_tools` | `deleted_tools_with_session(self, *, session: Session)` |

Each wrapper's whole body was `return self.<name>_with_session(session=db.session())`.

Claimed in https://github.com/langgenius/dify/issues/40372#issuecomment-5578808249.

## Why no call site changes

Every caller already uses the twins:

- `services/app_service.py:214,218` — `AppResponseView`
- `controllers/console/datasets/datasets.py:276` — `_RelatedAppResponseSource`
- `repositories/app_definition_query_repository.py:203`

The four response fields that carry `validation_alias="mode_compatible_with_agent"` / `deleted_tools` never see the raw attribute. `AppResponseModel._use_request_session` (`controllers/console/app/app.py:365-372`) is a `mode="before"` validator: it converts any `App` into `AppResponseView`, and raises `ValueError` when no session is in the validation context. Both `model_validate` sites pass `context={"session": session}` (`app.py:720`, `:1129`).

`grep` over `api/` finds no remaining reader of either raw property.

## Test

Added the `AGENT_CHAT` case for `mode_compatible_with_agent_with_session`, which nothing covered — the existing `test_app_mode_compatible_with_agent` only exercises the `CHAT` path against a decoy config whose `app_id` deliberately does not match. The new case wires a real `AppModelConfig` to the app and asserts `AGENT_CHAT`.

Mutation-checked: stubbing out the `AGENT_CHAT` branch fails the new test (55 passed -> 1 failed).

## Verification

- `pytest tests/unit_tests/models/test_app_models.py` — **55 passed** (54 on `main`, +1 new)
- `pytest tests/unit_tests/models/` — 422 passed, identical to the `main` baseline including two pre-existing failures unrelated to this change
- `ruff check` / `ruff format --check` — clean
- `pyrefly check models/model.py` — 0 diagnostics
- `mypy --check-untyped-defs --disable-error-code=import-untyped models/model.py` — no issues
- `lint-imports` — 29 contracts kept, 0 broken
- `dev/lint_response_contracts.py --fail-on-mismatch` — 0 mismatch
- no net-new `getattr(` in the diff

One gap I should flag: `tests/unit_tests/controllers/console/app/test_app_response_models.py` covers the `AppResponseView` path, but it segfaults on my Windows box **on clean `main`** (`Windows fatal exception: access violation`), so I could not run it locally either before or after this change. I'm relying on CI for that file.

---
This PR was written with AI assistance.
