### PR TITLE
fix(api): handle string and missing params in weekday time tool

### DIFF
--- a/api/core/tools/builtin_tool/providers/time/tools/weekday.py
+++ b/api/core/tools/builtin_tool/providers/time/tools/weekday.py
@@ -35,20 +35,23 @@ class WeekdayTool(BuiltinTool):
             return
 
         weekday_name = calendar.day_name[date_obj.weekday()]
-        month_name = calendar.month_name[month]
+        month_name = calendar.month_name[date_obj.month]
         readable_date = f"{month_name} {date_obj.day}, {date_obj.year}"
         yield self.create_text_message(f"{readable_date} is {weekday_name}.")
 
     @staticmethod
     def convert_datetime(year, month, day) -> datetime | None:
         try:
-            # allowed range in datetime module
-            if not (year >= 1 and 1 <= month <= 12 and 1 <= day <= 31):
+            if year is None or month is None or day is None:
                 return None
 
             year = int(year)
             month = int(month)
             day = int(day)
+            # allowed range in datetime module
+            if not (year >= 1 and 1 <= month <= 12 and 1 <= day <= 31):
+                return None
+
             return datetime(year, month, day)
-        except ValueError:
+        except (TypeError, ValueError):
             return None

--- a/api/tests/unit_tests/core/tools/test_builtin_tools_extra.py
+++ b/api/tests/unit_tests/core/tools/test_builtin_tools_extra.py
@@ -143,6 +143,23 @@ def test_weekday_tool(sqlite_session: Session):
     with pytest.raises(ValueError, match="Month is required"):
         list(weekday_tool.invoke(session=sqlite_session, user_id="u", tool_parameters={"year": 2024, "day": 1}))
 
+    # LLMs often send numeric parameters as strings; these must be accepted.
+    string_params = list(
+        weekday_tool.invoke(
+            session=sqlite_session, user_id="u", tool_parameters={"year": "2024", "month": "3", "day": "5"}
+        )
+    )[0].message.text
+    expected_date = date(2024, 3, 5)
+    assert string_params == (
+        f"{calendar.month_name[expected_date.month]} "
+        f"{expected_date.day}, {expected_date.year} "
+        f"is {calendar.day_name[expected_date.weekday()]}."
+    )
+    # Missing or non-numeric values must yield an "Invalid date" message, not crash.
+    for params in ({"year": 2024, "month": 3}, {"year": "abc", "month": 3, "day": 5}):
+        result = list(weekday_tool.invoke(session=sqlite_session, user_id="u", tool_parameters=params))[0].message.text
+        assert "Invalid date" in result
+
 
 def test_simple_code_valid_execution(monkeypatch: pytest.MonkeyPatch, sqlite_session: Session):
     simple_code = _build_builtin_tool(SimpleCode)


### PR DESCRIPTION
## Summary

Fixes #41951

The built-in weekday tool crashed with an uncaught `TypeError` instead of returning its "Invalid date" message when:

1. Parameters arrive as strings (LLMs commonly send numbers as strings, e.g. `"2024"`): `convert_datetime` compared raw values (`year >= 1`) before calling `int()`.
2. `day` is omitted: only `month` was None-checked, so `1 <= day <= 31` raised `TypeError` on `None`.

`_invoke` also indexed `calendar.month_name` with the raw `month` parameter, which fails when it's a string.

## Changes

- `api/core/tools/builtin_tool/providers/time/tools/weekday.py`: convert parameters to `int` before range checks, return `None` for missing (`None`) values, catch `TypeError` alongside `ValueError`, and derive the month name from the parsed `date_obj` instead of the raw parameter.
- Regression coverage in `test_weekday_tool`: string parameters now produce the correct weekday message; missing `day` and non-numeric `year` produce "Invalid date" instead of raising. Verified the new assertions fail before the fix and pass after.

## Test results

- `tests/unit_tests/core/tools/`: 353 passed
- `ruff check` on touched files: clean

Environment note: tests run in a local Python 3.12 venv (`uv sync --frozen --no-dev` plus pytest/pytest-mock); no Docker/services needed for these unit suites.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
- [x] There is an associated issue and the PR uses the correct syntax to link it