### PR TITLE
fix(api): flatten readabilipy plain_text items in web reader tool

### DIFF
--- a/api/core/tools/utils/web_reader_tool.py
+++ b/api/core/tools/utils/web_reader_tool.py
@@ -1,6 +1,5 @@
 import mimetypes
 import re
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import unquote
@@ -101,15 +100,24 @@ def get_url(url: str, user_agent: str | None = None) -> str:
 class Article:
     title: str
     author: str
-    text: Sequence[dict]
+    text: str
 
 
 def extract_using_readabilipy(html: str):
     json_article: dict[str, Any] = simple_json_from_html_string(html, use_readability=False)
+    # readabilipy returns plain_text as a list of dicts whose "text" values
+    # contain the (possibly HTML-tagged) paragraph content; flatten them into
+    # a single clean text block.
+    plain_text = json_article.get("plain_text") or []
+    text = "\n".join(
+        stripped
+        for item in plain_text
+        if isinstance(item, dict) and (stripped := re.sub(r"<[^>]+>", "", str(item.get("text") or "")).strip())
+    )
     article = Article(
         title=json_article.get("title") or "",
         author=json_article.get("byline") or "",
-        text=json_article.get("plain_text") or [],
+        text=text,
     )
 
     return article

--- a/api/tests/unit_tests/core/tools/utils/test_web_reader_tool.py
+++ b/api/tests/unit_tests/core/tools/utils/test_web_reader_tool.py
@@ -286,9 +286,31 @@ def test_extract_using_readabilipy_field_mapping_and_defaults(monkeypatch: pytes
     article = extract_using_readabilipy("<html>...</html>")
     assert article.title == "Hello"
     assert article.author == "Alice"
-    assert isinstance(article.text, list)
-    assert article.text
-    assert article.text[0]["text"] == "world"
+    assert article.text == "world"
+
+
+def test_extract_using_readabilipy_flattens_plain_text_items(monkeypatch: pytest.MonkeyPatch):
+    """readabilipy returns plain_text as a list of dicts; the article text must be clean joined text,
+    not the Python repr of that list, and HTML tags inside items must be stripped."""
+
+    def fake_simple_json_from_html_string(html, use_readability=True):
+        return {
+            "title": "T",
+            "byline": "A",
+            "plain_text": [
+                {"type": "text", "text": "<p>First paragraph.</p>"},
+                {"type": "text", "text": "Second paragraph."},
+                {"type": "text", "text": ""},
+                "not-a-dict",
+            ],
+        }
+
+    import core.tools.utils.web_reader_tool as mod
+
+    monkeypatch.setattr(mod, "simple_json_from_html_string", fake_simple_json_from_html_string)
+
+    article = extract_using_readabilipy("<html>...</html>")
+    assert article.text == "First paragraph.\nSecond paragraph."
 
 
 def test_extract_using_readabilipy_defaults_when_missing(monkeypatch: pytest.MonkeyPatch):
@@ -302,7 +324,7 @@ def test_extract_using_readabilipy_defaults_when_missing(monkeypatch: pytest.Mon
     article = extract_using_readabilipy("<html>...</html>")
     assert article.title == ""
     assert article.author == ""
-    assert article.text == []
+    assert article.text == ""
 
 
 # ---------------------------


### PR DESCRIPTION
## Summary

Fixes #41953

readabilipy's `simple_json_from_html_string` returns `plain_text` as a list of dicts (`[{'text': '<p>paragraph</p>'}, ...]`), but `get_url` passed that list straight into `FULL_TEMPLATE`, so the built-in webscraper tool returned the Python repr of the list (dicts, quotes, and HTML tags included) instead of readable page text for every scraped page.

## Changes

- `api/core/tools/utils/web_reader_tool.py`: `extract_using_readabilipy` now flattens the `plain_text` items into a single string - each item's `text` value, HTML tags stripped, non-empty entries joined with newlines. The `Article.text` field type is corrected from `Sequence[dict]` to `str`.
- `tests/unit_tests/core/tools/utils/test_web_reader_tool.py`: updated the two `extract_using_readabilipy` tests to assert the string contract (they previously asserted the buggy list shape), and added `test_extract_using_readabilipy_flattens_plain_text_items` covering tag stripping, empty entries, and non-dict items. Verified the updated/new assertions fail before the fix and pass after.

## Test results

- `tests/unit_tests/core/tools/`: 354 passed
- `tests/unit_tests/tasks/` (clean-document tasks, which consume this module's image-id extraction): 25 passed
- `ruff check` on touched files: clean

Environment note: tests run in a local Python 3.12 venv (`uv sync --frozen --no-dev` plus pytest/pytest-mock); no Docker/services needed for these unit suites.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
- [x] There is an associated issue and the PR uses the correct syntax to link it