### PR TITLE
refactor(api): isolate installed app management

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -213,6 +213,20 @@ forbidden_modules =
     sqlalchemy
     werkzeug
 
+[importlinter:contract:installed-app-management-boundary]
+name = Installed app management service is framework and persistence neutral
+type = forbidden
+source_modules =
+    services.installed_app_service
+forbidden_modules =
+    controllers
+    extensions
+    flask
+    models
+    repositories
+    sqlalchemy
+    werkzeug
+
 [importlinter:contract:installed-app-generation-boundary]
 name = Installed app generation service is framework and persistence neutral
 type = forbidden

--- a/api/controllers/console/explore/error.py
+++ b/api/controllers/console/explore/error.py
@@ -1,4 +1,44 @@
+from core.logging.context import get_request_id
 from libs.exception import BaseHTTPException
+
+
+class InstalledAppHTTPError(BaseHTTPException):
+    """A Console error with safe details and a request ID for troubleshooting."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        details: dict[str, object] = {"request_id": get_request_id()}
+        self.data = {"code": self.error_code, "message": self.description, "status": self.code, "details": details}
+
+
+class InstalledAppNotFoundHTTPError(InstalledAppHTTPError):
+    error_code = "installed_app_not_found"
+    description = "The app was not found in this workspace."
+    code = 404
+
+
+class InstalledAppUnavailableHTTPError(InstalledAppHTTPError):
+    error_code = "installed_app_unavailable"
+    description = "The app is not available in this app library."
+    code = 404
+
+
+class InstalledAppUninstallForbiddenError(InstalledAppHTTPError):
+    error_code = "installed_app_uninstall_forbidden"
+    description = "An app owned by this workspace cannot be removed from its app library."
+    code = 403
+
+
+class InstalledAppInvalidCursorError(InstalledAppHTTPError):
+    error_code = "invalid_cursor"
+    description = "The app list cursor is invalid. Refresh the list and try again."
+    code = 400
+
+
+class WebAppAccessUnavailableHTTPError(InstalledAppHTTPError):
+    error_code = "web_app_access_unavailable"
+    description = "The app access service is unavailable. Try again later."
+    code = 503
 
 
 class NotCompletionAppError(BaseHTTPException):

--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -2,14 +2,19 @@ import base64
 import binascii
 import logging
 
-from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field, computed_field
-from werkzeug.exceptions import BadRequest, NotFound
 
 from controllers.common.fields import SimpleResultMessageResponse
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
+from controllers.console.explore.error import (
+    InstalledAppInvalidCursorError,
+    InstalledAppNotFoundHTTPError,
+    InstalledAppUnavailableHTTPError,
+    InstalledAppUninstallForbiddenError,
+    WebAppAccessUnavailableHTTPError,
+)
 from controllers.console.explore.installed_app_admission import get_installed_app
 from controllers.console.flask_admission import console_account_admission
 from controllers.console.wraps import model_validate
@@ -24,7 +29,9 @@ from services.installed_app_service import (
     InstalledAppCursor,
     InstalledAppOwnedByWorkspaceError,
     InstalledAppRecord,
+    InstalledAppUnavailableError,
 )
+from services.webapp_access_query_service import WebAppAccessUnavailableError
 
 
 class InstalledAppUpdatePayload(BaseModel):
@@ -67,8 +74,8 @@ def _decode_installed_app_cursor(cursor: str | None) -> InstalledAppCursor | Non
         padded_cursor = cursor + "=" * (-len(cursor) % 4)
         payload = base64.b64decode(padded_cursor, altchars=b"-_", validate=True)
         return InstalledAppCursor.model_validate_json(payload)
-    except (binascii.Error, UnicodeDecodeError, ValueError):
-        raise BadRequest("Invalid cursor") from None
+    except (binascii.Error, UnicodeDecodeError, ValueError) as error:
+        raise InstalledAppInvalidCursorError() from error
 
 
 class InstalledAppInfoResponse(ResponseModel):
@@ -139,17 +146,26 @@ class InstalledAppsListApi(Resource):
     @console_ns.doc(params=query_params_from_model(InstalledAppsListQuery))
     @console_ns.response(200, "Success", console_ns.models[InstalledAppListResponse.__name__])
     @console_account_admission()
-    def get(self, request_context: RequestContext) -> dict[str, object]:
-        query = InstalledAppsListQuery.model_validate(request.args.to_dict())
+    @model_validate(InstalledAppsListQuery)
+    def get(self, query: InstalledAppsListQuery, request_context: RequestContext) -> dict[str, object]:
         cursor = _decode_installed_app_cursor(query.cursor)
-        page = application_services().installed_apps.get_visible_page(
-            tenant_id=request_context.active_workspace_id,
-            user_id=request_context.account_id,
-            cursor=cursor,
-            limit=query.limit,
-            app_id=query.app_id,
-            name=query.name,
-        )
+        try:
+            page = application_services().installed_apps.get_visible_page(
+                tenant_id=request_context.active_workspace_id,
+                user_id=request_context.account_id,
+                cursor=cursor,
+                limit=query.limit,
+                app_id=query.app_id,
+                name=query.name,
+            )
+        except WebAppAccessUnavailableError as error:
+            logger.exception(
+                "Installed app list access check failed: workspace_id=%s account_id=%s request_id=%s",
+                request_context.active_workspace_id,
+                request_context.account_id,
+                request_context.request_id,
+            )
+            raise WebAppAccessUnavailableHTTPError() from error
         installed_app_list = [
             _installed_app_response_data(
                 installed_app,
@@ -186,8 +202,10 @@ class InstalledAppApi(Resource):
             detail = application_services().installed_apps.get_detail(
                 installed_app=installed_app, account_id=request_context.account_id
             )
-        except InstalledAppNotFoundError:
-            raise NotFound("Installed app not found") from None
+        except InstalledAppUnavailableError as error:
+            raise InstalledAppUnavailableHTTPError() from error
+        except InstalledAppNotFoundError as error:
+            raise InstalledAppNotFoundHTTPError() from error
         return dump_response(
             InstalledAppResponse,
             _installed_app_response_data(
@@ -203,10 +221,10 @@ class InstalledAppApi(Resource):
     def delete(self, request_context: RequestContext, installed_app: InstalledAppRef) -> tuple[str, int]:
         try:
             application_services().installed_apps.uninstall(installed_app=installed_app)
-        except InstalledAppOwnedByWorkspaceError:
-            raise BadRequest("You can't uninstall an app owned by the current tenant") from None
-        except InstalledAppNotFoundError:
-            raise NotFound("Installed app not found") from None
+        except InstalledAppOwnedByWorkspaceError as error:
+            raise InstalledAppUninstallForbiddenError() from error
+        except InstalledAppNotFoundError as error:
+            raise InstalledAppNotFoundHTTPError() from error
 
         return "", 204
 
@@ -220,7 +238,7 @@ class InstalledAppApi(Resource):
     ) -> dict[str, str]:
         try:
             application_services().installed_apps.set_pinned(installed_app=installed_app, is_pinned=req_data.is_pinned)
-        except InstalledAppNotFoundError:
-            raise NotFound("Installed app not found") from None
+        except InstalledAppNotFoundError as error:
+            raise InstalledAppNotFoundHTTPError() from error
 
         return {"result": "success", "message": "App info updated successfully"}

--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -5,34 +5,26 @@ import logging
 from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field, computed_field
-from sqlalchemy import and_, select
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+from werkzeug.exceptions import BadRequest, NotFound
 
-from controllers.common.fields import SimpleMessageResponse, SimpleResultMessageResponse
+from controllers.common.fields import SimpleResultMessageResponse
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
-from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.wraps import (
-    account_initialization_required,
-    cloud_edition_billing_resource_check,
-    model_validate,
-    with_current_tenant_id,
-    with_current_user,
-)
-from extensions.ext_database import db
+from controllers.console.explore.installed_app_admission import get_installed_app
+from controllers.console.flask_admission import console_account_admission
+from controllers.console.wraps import model_validate
+from extensions.ext_application_services import application_services
 from fields.base import ResponseModel
 from graphon.file import helpers as file_helpers
-from libs.datetime_utils import naive_utc_now
 from libs.helper import dump_response, to_timestamp
-from libs.login import login_required
-from models import Account, App, InstalledApp, RecommendedApp
+from machinery.context import RequestContext
 from models.model import AppMode, IconType
-from services.account_service import TenantService
-from services.installed_app_service import InstalledAppCursor, InstalledAppService
-
-
-class InstalledAppCreatePayload(BaseModel):
-    app_id: str
+from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
+from services.installed_app_service import (
+    InstalledAppCursor,
+    InstalledAppOwnedByWorkspaceError,
+    InstalledAppRecord,
+)
 
 
 class InstalledAppUpdatePayload(BaseModel):
@@ -112,26 +104,24 @@ class InstalledAppListResponse(ResponseModel):
 
 
 def _installed_app_response_data(
-    installed_app: InstalledApp,
-    app_model: App,
+    installed_app: InstalledAppRecord,
     *,
     current_tenant_id: str,
-    current_user: Account,
+    editable: bool,
 ) -> InstalledAppResponse:
     return InstalledAppResponse(
         id=installed_app.id,
-        app=InstalledAppInfoResponse.model_validate(app_model),
+        app=InstalledAppInfoResponse.model_validate(installed_app.app, from_attributes=True),
         app_owner_tenant_id=installed_app.app_owner_tenant_id,
         is_pinned=installed_app.is_pinned,
         last_used_at=to_timestamp(installed_app.last_used_at),
-        editable=current_user.role in {"owner", "admin"},
+        editable=editable,
         uninstallable=current_tenant_id == installed_app.app_owner_tenant_id,
     )
 
 
 register_schema_models(
     console_ns,
-    InstalledAppCreatePayload,
     InstalledAppUpdatePayload,
     InstalledAppsListQuery,
 )
@@ -140,155 +130,97 @@ register_response_schema_models(
     InstalledAppInfoResponse,
     InstalledAppResponse,
     InstalledAppListResponse,
-    SimpleMessageResponse,
     SimpleResultMessageResponse,
 )
 
 
 @console_ns.route("/installed-apps")
 class InstalledAppsListApi(Resource):
-    @login_required
-    @account_initialization_required
     @console_ns.doc(params=query_params_from_model(InstalledAppsListQuery))
     @console_ns.response(200, "Success", console_ns.models[InstalledAppListResponse.__name__])
-    @with_current_user
-    @with_current_tenant_id
-    def get(self, current_tenant_id: str, current_user: Account):
+    @console_account_admission()
+    def get(self, request_context: RequestContext) -> dict[str, object]:
         query = InstalledAppsListQuery.model_validate(request.args.to_dict())
         cursor = _decode_installed_app_cursor(query.cursor)
-        if current_user.current_tenant is None:
-            raise ValueError("current_user.current_tenant must not be None")
-
-        installed_apps, has_more, next_cursor = InstalledAppService.get_visible_page(
-            tenant_id=current_tenant_id,
-            user_id=str(current_user.id),
+        page = application_services().installed_apps.get_visible_page(
+            tenant_id=request_context.active_workspace_id,
+            user_id=request_context.account_id,
             cursor=cursor,
             limit=query.limit,
             app_id=query.app_id,
             name=query.name,
-            session=db.session,
         )
-
-        current_user.role = TenantService.get_user_role(current_user, current_user.current_tenant, session=db.session())
         installed_app_list = [
             _installed_app_response_data(
                 installed_app,
-                app_model,
-                current_tenant_id=current_tenant_id,
-                current_user=current_user,
+                current_tenant_id=request_context.active_workspace_id,
+                editable=page.editable,
             )
-            for installed_app, app_model in installed_apps
+            for installed_app in page.data
         ]
 
-        logger.debug("installed_app_list: %s, user_id: %s", installed_app_list, current_user.id)
+        logger.debug("installed_app_list: %s, user_id: %s", installed_app_list, request_context.account_id)
         return dump_response(
             InstalledAppListResponse,
             {
                 "installed_apps": installed_app_list,
-                "has_more": has_more,
-                "next_cursor": _encode_installed_app_cursor(next_cursor) if next_cursor else None,
+                "has_more": page.has_more,
+                "next_cursor": _encode_installed_app_cursor(page.next_cursor) if page.next_cursor else None,
             },
         )
 
-    @login_required
-    @account_initialization_required
-    @cloud_edition_billing_resource_check("apps")
-    @console_ns.expect(console_ns.models[InstalledAppCreatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[SimpleMessageResponse.__name__])
-    @with_current_tenant_id
-    @model_validate(InstalledAppCreatePayload)
-    def post(self, req_data: InstalledAppCreatePayload, current_tenant_id: str):
-        recommended_app = db.session.scalar(
-            select(RecommendedApp).where(RecommendedApp.app_id == req_data.app_id).limit(1)
-        )
-        if recommended_app is None:
-            raise NotFound("Recommended app not found")
-
-        app = db.session.get(App, req_data.app_id)
-
-        if app is None:
-            raise NotFound("App entity not found")
-
-        if not app.is_public:
-            raise Forbidden("You can't install a non-public app")
-
-        installed_app = db.session.scalar(
-            select(InstalledApp)
-            .where(and_(InstalledApp.app_id == req_data.app_id, InstalledApp.tenant_id == current_tenant_id))
-            .limit(1)
-        )
-
-        if installed_app is None:
-            # todo: position
-            recommended_app.install_count += 1
-
-            new_installed_app = InstalledApp(
-                app_id=req_data.app_id,
-                tenant_id=current_tenant_id,
-                app_owner_tenant_id=app.tenant_id,
-                is_pinned=False,
-                last_used_at=naive_utc_now(),
-            )
-            db.session.add(new_installed_app)
-            db.session.commit()
-
-        return {"message": "App installed successfully"}
-
 
 @console_ns.route("/installed-apps/<uuid:installed_app_id>")
-class InstalledAppApi(InstalledAppResource):
-    """
-    get, update, and delete an installed app
-    use InstalledAppResource to apply default decorators and get installed_app
-    """
+class InstalledAppApi(Resource):
+    """Read, update, or uninstall an admitted workspace installation."""
 
     @console_ns.response(200, "Success", console_ns.models[InstalledAppResponse.__name__])
-    @with_current_user
-    @with_current_tenant_id
+    @console_account_admission()
+    @get_installed_app
     def get(
         self,
-        current_tenant_id: str,
-        current_user: Account,
-        installed_app: InstalledApp,
-    ):
-        app_model = InstalledAppService.get_published_app(installed_app.app_id, session=db.session)
-        if app_model is None:
-            raise NotFound("Installed app not found")
-        if current_user.current_tenant is None:
-            raise ValueError("current_user.current_tenant must not be None")
-
-        current_user.role = TenantService.get_user_role(current_user, current_user.current_tenant, session=db.session())
+        request_context: RequestContext,
+        installed_app: InstalledAppRef,
+    ) -> dict[str, object]:
+        try:
+            detail = application_services().installed_apps.get_detail(
+                installed_app=installed_app, account_id=request_context.account_id
+            )
+        except InstalledAppNotFoundError:
+            raise NotFound("Installed app not found") from None
         return dump_response(
             InstalledAppResponse,
             _installed_app_response_data(
-                installed_app,
-                app_model,
-                current_tenant_id=current_tenant_id,
-                current_user=current_user,
+                detail.installation,
+                current_tenant_id=request_context.active_workspace_id,
+                editable=detail.editable,
             ),
         )
 
     @console_ns.response(204, "App uninstalled successfully")
-    @with_current_tenant_id
-    def delete(self, current_tenant_id: str, installed_app: InstalledApp):
-        if installed_app.app_owner_tenant_id == current_tenant_id:
-            raise BadRequest("You can't uninstall an app owned by the current tenant")
-
-        db.session.delete(installed_app)
-        db.session.commit()
+    @console_account_admission()
+    @get_installed_app
+    def delete(self, request_context: RequestContext, installed_app: InstalledAppRef) -> tuple[str, int]:
+        try:
+            application_services().installed_apps.uninstall(installed_app=installed_app)
+        except InstalledAppOwnedByWorkspaceError:
+            raise BadRequest("You can't uninstall an app owned by the current tenant") from None
+        except InstalledAppNotFoundError:
+            raise NotFound("Installed app not found") from None
 
         return "", 204
 
     @console_ns.response(200, "Success", console_ns.models[SimpleResultMessageResponse.__name__])
     @console_ns.expect(console_ns.models[InstalledAppUpdatePayload.__name__])
+    @console_account_admission()
+    @get_installed_app
     @model_validate(InstalledAppUpdatePayload)
-    def patch(self, req_data: InstalledAppUpdatePayload, installed_app: InstalledApp):
-        commit_args = False
-        if req_data.is_pinned is not None:
-            installed_app.is_pinned = req_data.is_pinned
-            commit_args = True
-
-        if commit_args:
-            db.session.commit()
+    def patch(
+        self, req_data: InstalledAppUpdatePayload, request_context: RequestContext, installed_app: InstalledAppRef
+    ) -> dict[str, str]:
+        try:
+            application_services().installed_apps.set_pinned(installed_app=installed_app, is_pinned=req_data.is_pinned)
+        except InstalledAppNotFoundError:
+            raise NotFound("Installed app not found") from None
 
         return {"result": "success", "message": "App info updated successfully"}

--- a/api/controllers/console/explore/installed_app_admission.py
+++ b/api/controllers/console/explore/installed_app_admission.py
@@ -1,13 +1,15 @@
 """Installed-app admission for handlers using a pure installation reference."""
 
+import logging
 from collections.abc import Callable
 from functools import wraps
 from typing import Concatenate
 
-from werkzeug.exceptions import NotFound
-
-from controllers.console.explore.error import AppAccessDeniedError
-from controllers.web.error import WebAppAccessServiceUnavailableError
+from controllers.console.explore.error import (
+    AppAccessDeniedError,
+    InstalledAppNotFoundHTTPError,
+    WebAppAccessUnavailableHTTPError,
+)
 from extensions.ext_application_services import application_services
 from machinery.context import RequestContext
 from services.installed_app_access_service import (
@@ -16,6 +18,8 @@ from services.installed_app_access_service import (
     InstalledAppRef,
 )
 from services.webapp_access_query_service import WebAppAccessUnavailableError
+
+logger = logging.getLogger(__name__)
 
 
 def get_installed_app[T, **P, R](
@@ -27,19 +31,27 @@ def get_installed_app[T, **P, R](
     def decorated(self: T, request_context: RequestContext, /, *args: P.args, **kwargs: P.kwargs) -> R:
         installed_app_id = kwargs.pop("installed_app_id", None)
         if installed_app_id is None:
-            raise ValueError("installed_app_id is required")
+            raise RuntimeError("The installed-app admission route must provide installed_app_id")
         try:
             installed_app = application_services().installed_app_access.get_access(
                 installed_app_id=str(installed_app_id),
                 tenant_id=request_context.active_workspace_id,
                 account_id=request_context.account_id,
             )
-        except InstalledAppNotFoundError:
-            raise NotFound("Installed app not found") from None
-        except InstalledAppAccessDeniedError:
-            raise AppAccessDeniedError() from None
-        except WebAppAccessUnavailableError:
-            raise WebAppAccessServiceUnavailableError() from None
+        except InstalledAppNotFoundError as error:
+            raise InstalledAppNotFoundHTTPError() from error
+        except InstalledAppAccessDeniedError as error:
+            raise AppAccessDeniedError() from error
+        except WebAppAccessUnavailableError as error:
+            logger.exception(
+                "Installed app admission access check failed: installed_app_id=%s workspace_id=%s "
+                "account_id=%s request_id=%s",
+                installed_app_id,
+                request_context.active_workspace_id,
+                request_context.account_id,
+                request_context.request_id,
+            )
+            raise WebAppAccessUnavailableHTTPError() from error
         return view(self, request_context, installed_app, *args, **kwargs)
 
     return decorated

--- a/api/controllers/console/wraps.py
+++ b/api/controllers/console/wraps.py
@@ -659,6 +659,10 @@ def with_current_user_id[T, **P, R](
 def validate_request[M: BaseModel](model: type[M]) -> M:
     """Parse and validate the current request without exposing submitted values."""
 
+    # TODO: Standardize request parsing and structured validation errors after
+    # auditing callers. Malformed or falsy JSON currently becomes {}, allowing
+    # optional payloads to succeed as no-ops; validation details currently travel
+    # as a JSON string in the error message.
     if request.method == "GET":
         raw = request.args.to_dict(flat=True)
     elif request.method == "DELETE":

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -194,10 +194,7 @@ from services.web_passport_gateways import (
     PassportTokenGateway,
 )
 from services.web_passport_service import WebPassportService
-from services.webapp_access_query_service import (
-    WebAppAccessQueryService,
-    WebAppAccessUnavailableError,
-)
+from services.webapp_access_query_service import WebAppAccessQueryService, WebAppAccessUnavailableError
 from services.workflow_app_log_query_service import WorkflowAppLogQueryService
 from services.workflow_run_service import WorkflowRunService
 from services.workflow_statistic_query_service import WorkflowStatisticQueryService
@@ -212,9 +209,15 @@ logger = logging.getLogger(__name__)
 _EXTENSION_KEY = "application_services"
 
 
-# TODO: Move response normalization and error translation into EnterpriseService.WebAppAuth
-# after migrating its callers to typed result/error contracts, then inject its methods
-# directly and remove these adapters.
+# TODO: Normalize EnterpriseService.WebAppAuth result/error contracts in the SDK,
+# migrate its callers, then inject its methods directly and remove these adapters.
+# Define SDK errors for timeouts, transport failures, upstream status and invalid
+# responses before adding finer HTTP mappings; these adapters report unavailability.
+# Validate required fields and real booleans there, replacing legacy permission
+# truthiness conversion. Missing fields currently become False, {} or a default mode.
+# Replace response-shape ValueError/KeyError/AttributeError with typed SDK errors;
+# ordinary ValueError can still reach the global 400 invalid_param handler. The
+# lost field information cannot be recovered by translating exceptions here.
 def _get_enterprise_webapp_access_mode(app_id: str) -> WebAppAccessMode:
     try:
         settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id)
@@ -234,7 +237,10 @@ def _is_enterprise_webapp_user_allowed(user_id: str, app_id: str) -> bool:
 
 
 def _batch_get_enterprise_webapp_access_modes(*, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
-    settings = EnterpriseService.WebAppAuth.batch_get_app_access_mode_by_id(list(app_ids))
+    try:
+        settings = EnterpriseService.WebAppAuth.batch_get_app_access_mode_by_id(list(app_ids))
+    except (EnterpriseServiceError, httpx.RequestError, json.JSONDecodeError, UnicodeDecodeError, ValidationError) as e:
+        raise WebAppAccessUnavailableError from e
     access_modes: dict[str, WebAppAccessMode] = {}
     for app_id, setting in settings.items():
         try:
@@ -247,9 +253,12 @@ def _batch_get_enterprise_webapp_access_modes(*, app_ids: Sequence[str]) -> Mapp
 
 
 def _batch_get_enterprise_webapp_user_permissions(*, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
-    permissions = EnterpriseService.WebAppAuth.batch_is_user_allowed_to_access_webapps(
-        user_id=user_id, app_ids=list(app_ids)
-    )
+    try:
+        permissions = EnterpriseService.WebAppAuth.batch_is_user_allowed_to_access_webapps(
+            user_id=user_id, app_ids=list(app_ids)
+        )
+    except (EnterpriseServiceError, httpx.RequestError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise WebAppAccessUnavailableError from e
     return {app_id: bool(allowed) for app_id, allowed in permissions.items()}
 
 

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -1,8 +1,9 @@
 """Composition root for application services used by transport adapters."""
 
 import json
+import logging
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
@@ -160,6 +161,7 @@ from services.inner_mail_service import InnerMailService
 from services.installed_app_access_service import InstalledAppAccessService
 from services.installed_app_generation_adapters import AppGenerateServiceRuntime
 from services.installed_app_generation_service import InstalledAppGenerationService
+from services.installed_app_service import InstalledAppService
 from services.notification_gateway import BillingNotificationGateway
 from services.notification_service import NotificationService
 from services.notion_data_source_gateway import NotionDataSourceGateway
@@ -205,9 +207,14 @@ from services.workspace_plan_gateway import DeploymentWorkspacePlanGateway
 from services.workspace_query_service import WorkspaceQueryService
 from tasks.mail_inner_task import enqueue_inner_mail
 
+logger = logging.getLogger(__name__)
+
 _EXTENSION_KEY = "application_services"
 
 
+# TODO: Move response normalization and error translation into EnterpriseService.WebAppAuth
+# after migrating its callers to typed result/error contracts, then inject its methods
+# directly and remove these adapters.
 def _get_enterprise_webapp_access_mode(app_id: str) -> WebAppAccessMode:
     try:
         settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id)
@@ -219,11 +226,31 @@ def _get_enterprise_webapp_access_mode(app_id: str) -> WebAppAccessMode:
         raise WebAppAccessUnavailableError from e
 
 
-def _is_user_allowed_to_access_webapp(user_id: str, app_id: str) -> bool:
+def _is_enterprise_webapp_user_allowed(user_id: str, app_id: str) -> bool:
     try:
         return EnterpriseService.WebAppAuth.is_user_allowed_to_access_webapp(user_id, app_id)
     except (EnterpriseServiceError, httpx.RequestError, json.JSONDecodeError, UnicodeDecodeError) as e:
         raise WebAppAccessUnavailableError from e
+
+
+def _batch_get_enterprise_webapp_access_modes(*, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+    settings = EnterpriseService.WebAppAuth.batch_get_app_access_mode_by_id(list(app_ids))
+    access_modes: dict[str, WebAppAccessMode] = {}
+    for app_id, setting in settings.items():
+        try:
+            access_mode = WebAppAccessMode(setting.access_mode)
+        except ValueError:
+            logger.warning("Skipping invalid web app access mode %r for app %s", setting.access_mode, app_id)
+            continue
+        access_modes[app_id] = access_mode
+    return access_modes
+
+
+def _batch_get_enterprise_webapp_user_permissions(*, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+    permissions = EnterpriseService.WebAppAuth.batch_is_user_allowed_to_access_webapps(
+        user_id=user_id, app_ids=list(app_ids)
+    )
+    return {app_id: bool(allowed) for app_id, allowed in permissions.items()}
 
 
 @dataclass(frozen=True, slots=True)
@@ -268,6 +295,7 @@ class ApplicationServices:
     init_validation: InitValidationService
     installed_app_access: InstalledAppAccessService
     installed_app_generation: InstalledAppGenerationService
+    installed_apps: InstalledAppService
     notifications: NotificationService
     step_by_step_tour: StepByStepTourService
     partner_tenant_bindings: PartnerTenantBindingService
@@ -423,11 +451,20 @@ def build_application_services(
             dify_config.CONSOLE_API_URL + "/console/api/workspaces/current/tool-provider/builtin/"
         ),
     )
+    webapp_auth_enabled = SystemFeatureService.is_webapp_auth_enabled(deployment_edition=deployment_edition)
     webapp_access = WebAppAccessQueryService(
         access=WebAppAccessQueryRepository(session_factory=database_client),
-        webapp_auth_enabled=SystemFeatureService.is_webapp_auth_enabled(deployment_edition=deployment_edition),
+        webapp_auth_enabled=webapp_auth_enabled,
         access_mode_for_app=_get_enterprise_webapp_access_mode,
-        is_user_allowed_for_app=_is_user_allowed_to_access_webapp,
+        is_user_allowed_for_app=_is_enterprise_webapp_user_allowed,
+        get_access_modes=_batch_get_enterprise_webapp_access_modes,
+        get_user_permissions=_batch_get_enterprise_webapp_user_permissions,
+    )
+    installed_app_access = InstalledAppAccessService(
+        installed_apps=installed_apps,
+        is_user_allowed=webapp_access.is_user_allowed,
+        get_access_modes=webapp_access.batch_get_access_modes,
+        get_user_permissions=webapp_access.batch_get_user_permissions,
     )
     feature_gateway = FeatureServiceGateway()
     accounts = SQLAlchemyAccountRepository(session_factory=database_client)
@@ -633,14 +670,16 @@ def build_application_services(
         ),
         data_source_oauth=_build_data_source_oauth_services(database_client=database_client),
         webapp_access=webapp_access,
-        installed_app_access=InstalledAppAccessService(
-            installed_apps=installed_apps,
-            is_user_allowed=webapp_access.is_user_allowed,
-        ),
+        installed_app_access=installed_app_access,
         installed_app_generation=InstalledAppGenerationService(
             app_definitions=app_definitions,
             usage=installed_apps,
             runtime=AppGenerateServiceRuntime(session_factory=database_client),
+        ),
+        installed_apps=InstalledAppService(
+            installed_apps=installed_apps,
+            get_workspace_role=workspace_query_repository.get_account_role,
+            get_visible_app_ids=installed_app_access.get_visible_app_ids if webapp_auth_enabled else None,
         ),
         web_app_runtime=WebAppRuntimeQueryService(
             runtime=app_definition_repository,

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -6712,19 +6712,6 @@ Request body:
 | ---- | ----------- | ------ |
 | 200 | Success | **application/json**: [InstalledAppListResponse](#installedapplistresponse)<br> |
 
-### [POST] /installed-apps
-#### Request Body
-
-| Required | Schema |
-| -------- | ------ |
-|  Yes | **application/json**: [InstalledAppCreatePayload](#installedappcreatepayload)<br> |
-
-#### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SimpleMessageResponse](#simplemessageresponse)<br> |
-
 ### [DELETE] /installed-apps/{installed_app_id}
 #### Parameters
 
@@ -18797,12 +18784,6 @@ Input field definition for snippet parameters.
 | required | boolean |  | No |
 | type | string |  | No |
 
-#### InstalledAppCreatePayload
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| app_id | string |  | Yes |
-
 #### InstalledAppInfoResponse
 
 | Name | Type | Description | Required |
@@ -21818,12 +21799,6 @@ Model class for provider quota configuration.
 | inputs | object |  | Yes |
 | message | string |  | Yes |
 | query | string |  | Yes |
-
-#### SimpleMessageResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| message | string |  | Yes |
 
 #### SimpleModelConfig
 

--- a/api/repositories/installed_app_repository.py
+++ b/api/repositories/installed_app_repository.py
@@ -1,18 +1,94 @@
 """Persist workspace installations with independently scoped operations."""
 
 from datetime import datetime
+from itertools import starmap
 from typing import cast, override
 
-from sqlalchemy import select, update
+from sqlalchemy import ColumnElement, UnaryExpression, and_, exists, or_, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import Session, sessionmaker
 
-from models.model import App, InstalledApp
+from libs.helper import escape_like_pattern
+from models.model import App, AppMode, AppModelConfig, InstalledApp
+from models.workflow import Workflow
 from services.installed_app_access_service import InstalledAppAccessStore, InstalledAppNotFoundError, InstalledAppRef
 from services.installed_app_generation_service import InstalledAppUsageRecorder
+from services.installed_app_service import (
+    InstalledAppCursor,
+    InstalledAppInfo,
+    InstalledAppOwnedByWorkspaceError,
+    InstalledAppRecord,
+    InstalledAppStore,
+)
 
 
-class SQLAlchemyInstalledAppRepository(InstalledAppAccessStore, InstalledAppUsageRecorder):
+def _published_app_filter() -> ColumnElement[bool]:
+    """Match the model configuration used by installed-app parameters.
+
+    Keep the existing publication reference policy: workflow version, public
+    visibility and site settings do not decide whether an installation is listed.
+    """
+    workflow_app_modes = (AppMode.ADVANCED_CHAT, AppMode.WORKFLOW)
+    has_published_workflow = exists(select(Workflow.id).where(Workflow.id == App.workflow_id))
+    has_published_model_config = exists(select(AppModelConfig.id).where(AppModelConfig.id == App.app_model_config_id))
+    return and_(
+        App.mode != AppMode.AGENT,
+        or_(
+            and_(App.mode.in_(workflow_app_modes), App.workflow_id.isnot(None), has_published_workflow),
+            and_(~App.mode.in_(workflow_app_modes), App.app_model_config_id.isnot(None), has_published_model_config),
+        ),
+    )
+
+
+def _installed_app_cursor_filter(cursor: InstalledAppCursor) -> ColumnElement[bool]:
+    same_pin_group = InstalledApp.is_pinned == cursor.is_pinned
+    if cursor.last_used_at is None:
+        later_in_pin_group = and_(
+            InstalledApp.last_used_at.is_(None),
+            InstalledApp.id > cursor.installed_app_id,
+        )
+    else:
+        later_in_pin_group = or_(
+            InstalledApp.last_used_at < cursor.last_used_at,
+            InstalledApp.last_used_at.is_(None),
+            and_(
+                InstalledApp.last_used_at == cursor.last_used_at,
+                InstalledApp.id > cursor.installed_app_id,
+            ),
+        )
+    if cursor.is_pinned:
+        return or_(InstalledApp.is_pinned.is_(False), and_(same_pin_group, later_in_pin_group))
+    return and_(same_pin_group, later_in_pin_group)
+
+
+def _installed_app_order_by() -> tuple[UnaryExpression[bool], UnaryExpression[datetime | None], UnaryExpression[str]]:
+    return (
+        InstalledApp.is_pinned.desc(),
+        InstalledApp.last_used_at.desc().nulls_last(),
+        InstalledApp.id.asc(),
+    )
+
+
+def _to_record(installed_app: InstalledApp, app: App) -> InstalledAppRecord:
+    return InstalledAppRecord(
+        id=installed_app.id,
+        app=InstalledAppInfo(
+            id=app.id,
+            name=app.name,
+            description=app.description,
+            mode=app.mode,
+            icon_type=app.icon_type,
+            icon=app.icon,
+            icon_background=app.icon_background,
+            use_icon_as_answer_icon=app.use_icon_as_answer_icon,
+        ),
+        app_owner_tenant_id=installed_app.app_owner_tenant_id,
+        is_pinned=installed_app.is_pinned,
+        last_used_at=installed_app.last_used_at,
+    )
+
+
+class SQLAlchemyInstalledAppRepository(InstalledAppAccessStore, InstalledAppUsageRecorder, InstalledAppStore):
     def __init__(self, *, session_factory: sessionmaker[Session]) -> None:
         self._session_factory: sessionmaker[Session] = session_factory
 
@@ -49,6 +125,79 @@ class SQLAlchemyInstalledAppRepository(InstalledAppAccessStore, InstalledAppUsag
                     InstalledApp.app_id == installed_app.app_id,
                 )
                 .values(last_used_at=used_at)
+            )
+            if cast(CursorResult, result).rowcount == 0:
+                raise InstalledAppNotFoundError(f"Installed app {installed_app.id} no longer exists")
+
+    @override
+    def get_candidates(
+        self,
+        *,
+        tenant_id: str,
+        cursor: InstalledAppCursor | None,
+        limit: int,
+        app_id: str | None,
+        name: str | None,
+    ) -> tuple[InstalledAppRecord, ...]:
+        statement = (
+            select(InstalledApp, App)
+            .join(App, App.id == InstalledApp.app_id)
+            .where(InstalledApp.tenant_id == tenant_id, _published_app_filter())
+        )
+        if app_id:
+            statement = statement.where(InstalledApp.app_id == app_id)
+        if name and (normalized_name := name.strip()):
+            escaped_name = escape_like_pattern(normalized_name)
+            statement = statement.where(App.name.ilike(f"%{escaped_name}%", escape="\\"))
+        if cursor is not None:
+            statement = statement.where(_installed_app_cursor_filter(cursor))
+        with self._session_factory() as session:
+            rows = session.execute(statement.order_by(*_installed_app_order_by()).limit(limit))
+            return tuple(starmap(_to_record, rows))
+
+    @override
+    def get_published(self, *, installed_app: InstalledAppRef) -> InstalledAppRecord | None:
+        with self._session_factory() as session:
+            row = session.execute(
+                select(InstalledApp, App)
+                .join(App, App.id == InstalledApp.app_id)
+                .where(
+                    InstalledApp.id == installed_app.id,
+                    InstalledApp.tenant_id == installed_app.tenant_id,
+                    InstalledApp.app_id == installed_app.app_id,
+                    _published_app_filter(),
+                )
+                .limit(1)
+            ).first()
+            return None if row is None else _to_record(row[0], row[1])
+
+    @override
+    def uninstall(self, *, installed_app: InstalledAppRef) -> None:
+        with self._session_factory.begin() as session:
+            installation = session.scalar(
+                select(InstalledApp).where(
+                    InstalledApp.id == installed_app.id,
+                    InstalledApp.tenant_id == installed_app.tenant_id,
+                    InstalledApp.app_id == installed_app.app_id,
+                )
+            )
+            if installation is None:
+                raise InstalledAppNotFoundError(f"Installed app {installed_app.id} no longer exists")
+            if installation.app_owner_tenant_id == installed_app.tenant_id:
+                raise InstalledAppOwnedByWorkspaceError(f"Installed app {installed_app.id} is owned by this workspace")
+            session.delete(installation)
+
+    @override
+    def set_pinned(self, *, installed_app: InstalledAppRef, is_pinned: bool) -> None:
+        with self._session_factory.begin() as session:
+            result = session.execute(
+                update(InstalledApp)
+                .where(
+                    InstalledApp.id == installed_app.id,
+                    InstalledApp.tenant_id == installed_app.tenant_id,
+                    InstalledApp.app_id == installed_app.app_id,
+                )
+                .values(is_pinned=is_pinned)
             )
             if cast(CursorResult, result).rowcount == 0:
                 raise InstalledAppNotFoundError(f"Installed app {installed_app.id} no longer exists")

--- a/api/repositories/workspace_query_repository.py
+++ b/api/repositories/workspace_query_repository.py
@@ -21,6 +21,17 @@ class WorkspaceQueryRepository(
     def __init__(self, session_factory: sessionmaker[Session]) -> None:
         self._session_factory = session_factory
 
+    def get_account_role(self, *, account_id: str, tenant_id: str) -> str | None:
+        """Read the current membership role without loading or mutating an Account."""
+        stmt = (
+            select(TenantAccountJoin.role)
+            .where(TenantAccountJoin.account_id == account_id, TenantAccountJoin.tenant_id == tenant_id)
+            .limit(1)
+        )
+        with self._session_factory() as session:
+            role = session.scalar(stmt)
+            return role.value if role is not None else None
+
     @override
     def list_for_account(self, account_id: str) -> tuple[WorkspaceRecord, ...]:
         stmt = (

--- a/api/services/installed_app_access_service.py
+++ b/api/services/installed_app_access_service.py
@@ -1,7 +1,11 @@
-"""Application admission for an app installed in a workspace."""
+"""Resolve installed-app admission and account-specific list visibility."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
+
+from enums import WebAppAccessMode
+from services.webapp_access_query_service import WebAppAccessModesQuery, WebAppUserPermissionsQuery
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,9 +37,13 @@ class InstalledAppAccessService:
         *,
         installed_apps: InstalledAppAccessStore,
         is_user_allowed: WebAppUserAccessCheck,
+        get_access_modes: WebAppAccessModesQuery,
+        get_user_permissions: WebAppUserPermissionsQuery,
     ) -> None:
-        self._installed_apps = installed_apps
-        self._is_user_allowed = is_user_allowed
+        self._installed_apps: InstalledAppAccessStore = installed_apps
+        self._is_user_allowed: WebAppUserAccessCheck = is_user_allowed
+        self._get_access_modes: WebAppAccessModesQuery = get_access_modes
+        self._get_user_permissions: WebAppUserPermissionsQuery = get_user_permissions
 
     def get_access(self, *, installed_app_id: str, tenant_id: str, account_id: str) -> InstalledAppRef:
         installed_app = self._installed_apps.resolve(installed_app_id=installed_app_id, tenant_id=tenant_id)
@@ -44,3 +52,24 @@ class InstalledAppAccessService:
         if not self._is_user_allowed(user_id=account_id, app_id=installed_app.app_id):
             raise InstalledAppAccessDeniedError("Access to installed app denied")
         return installed_app
+
+    def get_visible_app_ids(self, *, user_id: str, app_ids: Sequence[str]) -> frozenset[str]:
+        """Apply list visibility rules without changing single-app admission.
+
+        Missing access settings and SSO-only apps are omitted from the list.
+        Preserve candidate order for the subsequent batch permission query.
+        """
+        if not app_ids:
+            return frozenset(app_ids)
+
+        access_modes = self._get_access_modes(app_ids=app_ids)
+        candidates = [
+            app_id
+            for app_id in app_ids
+            if app_id in access_modes and access_modes[app_id] != WebAppAccessMode.SSO_VERIFIED
+        ]
+        if not candidates:
+            return frozenset()
+
+        permissions = self._get_user_permissions(user_id=user_id, app_ids=candidates)
+        return frozenset(app_id for app_id in candidates if permissions.get(app_id))

--- a/api/services/installed_app_service.py
+++ b/api/services/installed_app_service.py
@@ -7,7 +7,7 @@ from typing import Protocol
 
 from pydantic import BaseModel
 
-from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
+from services.installed_app_access_service import InstalledAppRef
 
 
 class InstalledAppCursor(BaseModel):
@@ -58,7 +58,11 @@ class InstalledAppDetail:
     editable: bool
 
 
-class InstalledAppOwnedByWorkspaceError(ValueError):
+class InstalledAppUnavailableError(RuntimeError):
+    """The admitted installation cannot be returned as a published library app."""
+
+
+class InstalledAppOwnedByWorkspaceError(PermissionError):
     """A workspace cannot uninstall an app it owns."""
 
 
@@ -161,7 +165,7 @@ class InstalledAppService:
     def get_detail(self, *, installed_app: InstalledAppRef, account_id: str) -> InstalledAppDetail:
         installation = self._installed_apps.get_published(installed_app=installed_app)
         if installation is None:
-            raise InstalledAppNotFoundError(f"Installed app {installed_app.id} is not published or no longer exists")
+            raise InstalledAppUnavailableError(f"Installed app {installed_app.id} is not available as a published app")
         role = self._get_workspace_role(account_id=account_id, tenant_id=installed_app.tenant_id)
         return InstalledAppDetail(installation=installation, editable=role in {"owner", "admin"})
 

--- a/api/services/installed_app_service.py
+++ b/api/services/installed_app_service.py
@@ -1,14 +1,13 @@
+"""Manage workspace installations and paginate apps visible to an account."""
+
+from collections.abc import Sequence, Set
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Protocol
 
 from pydantic import BaseModel
-from sqlalchemy import and_, exists, or_, select
-from sqlalchemy.orm import Session, scoped_session
 
-from libs.helper import escape_like_pattern
-from models import App, AppModelConfig, InstalledApp, Workflow
-from models.model import AppMode
-from services.enterprise.enterprise_service import EnterpriseService
-from services.system_feature_service import SystemFeatureService
+from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
 
 
 class InstalledAppCursor(BaseModel):
@@ -17,86 +16,92 @@ class InstalledAppCursor(BaseModel):
     installed_app_id: str
 
 
-def _published_app_filter():
-    """Return the SQL predicate for installed-app web API availability.
-
-    The installed-app parameters endpoint reads the published workflow for
-    workflow-style apps and the published app model config for easy UI apps.
-    Keep the list endpoint aligned in SQL so it does not return entries that
-    will immediately fail with app_unavailable when opened.
-    """
-    workflow_app_modes = (AppMode.ADVANCED_CHAT, AppMode.WORKFLOW)
-    has_published_workflow = exists(select(Workflow.id).where(Workflow.id == App.workflow_id))
-    has_published_model_config = exists(select(AppModelConfig.id).where(AppModelConfig.id == App.app_model_config_id))
-
-    return and_(
-        App.mode != AppMode.AGENT,
-        or_(
-            and_(App.mode.in_(workflow_app_modes), App.workflow_id.isnot(None), has_published_workflow),
-            and_(~App.mode.in_(workflow_app_modes), App.app_model_config_id.isnot(None), has_published_model_config),
-        ),
-    )
+@dataclass(frozen=True, slots=True)
+class InstalledAppInfo:
+    id: str
+    name: str
+    description: str
+    mode: str
+    icon_type: str | None
+    icon: str | None
+    icon_background: str | None
+    use_icon_as_answer_icon: bool
 
 
-def _installed_app_cursor_filter(cursor: InstalledAppCursor):
-    same_pin_group = InstalledApp.is_pinned == cursor.is_pinned
-    if cursor.last_used_at is None:
-        later_in_pin_group = and_(
-            InstalledApp.last_used_at.is_(None),
-            InstalledApp.id > cursor.installed_app_id,
-        )
-    else:
-        later_in_pin_group = or_(
-            InstalledApp.last_used_at < cursor.last_used_at,
-            InstalledApp.last_used_at.is_(None),
-            and_(
-                InstalledApp.last_used_at == cursor.last_used_at,
-                InstalledApp.id > cursor.installed_app_id,
-            ),
+@dataclass(frozen=True, slots=True)
+class InstalledAppRecord:
+    id: str
+    app: InstalledAppInfo
+    app_owner_tenant_id: str
+    is_pinned: bool
+    last_used_at: datetime | None
+
+    def cursor(self) -> InstalledAppCursor:
+        return InstalledAppCursor(
+            is_pinned=self.is_pinned,
+            last_used_at=self.last_used_at,
+            installed_app_id=self.id,
         )
 
-    if cursor.is_pinned:
-        return or_(
-            InstalledApp.is_pinned.is_(False),
-            and_(same_pin_group, later_in_pin_group),
-        )
-    return and_(same_pin_group, later_in_pin_group)
+
+@dataclass(frozen=True, slots=True)
+class InstalledAppPage:
+    data: tuple[InstalledAppRecord, ...]
+    has_more: bool
+    next_cursor: InstalledAppCursor | None
+    editable: bool
 
 
-def _installed_app_order_by():
-    return (
-        InstalledApp.is_pinned.desc(),
-        InstalledApp.last_used_at.desc().nulls_last(),
-        InstalledApp.id.asc(),
-    )
+@dataclass(frozen=True, slots=True)
+class InstalledAppDetail:
+    installation: InstalledAppRecord
+    editable: bool
 
 
-def _filter_rows_by_webapp_auth(
-    rows: list[tuple[InstalledApp, App]],
-    *,
-    user_id: str,
-) -> list[tuple[InstalledApp, App]]:
-    if not rows:
-        return []
+class InstalledAppOwnedByWorkspaceError(ValueError):
+    """A workspace cannot uninstall an app it owns."""
 
-    app_ids = [app.id for _, app in rows]
-    webapp_settings = EnterpriseService.WebAppAuth.batch_get_app_access_mode_by_id(app_ids)
-    candidates = [
-        (installed_app, app)
-        for installed_app, app in rows
-        if (setting := webapp_settings.get(app.id)) is not None and setting.access_mode != "sso_verified"
-    ]
-    permissions = EnterpriseService.WebAppAuth.batch_is_user_allowed_to_access_webapps(
-        user_id=user_id,
-        app_ids=[app.id for _, app in candidates],
-    )
-    return [(installed_app, app) for installed_app, app in candidates if permissions.get(app.id)]
+
+class InstalledAppStore(Protocol):
+    def get_candidates(
+        self,
+        *,
+        tenant_id: str,
+        cursor: InstalledAppCursor | None,
+        limit: int,
+        app_id: str | None,
+        name: str | None,
+    ) -> tuple[InstalledAppRecord, ...]: ...
+
+    def get_published(self, *, installed_app: InstalledAppRef) -> InstalledAppRecord | None: ...
+
+    def uninstall(self, *, installed_app: InstalledAppRef) -> None: ...
+
+    def set_pinned(self, *, installed_app: InstalledAppRef, is_pinned: bool) -> None: ...
+
+
+class InstalledAppVisibilityQuery(Protocol):
+    def __call__(self, *, user_id: str, app_ids: Sequence[str]) -> Set[str]: ...
+
+
+class WorkspaceRoleLookup(Protocol):
+    def __call__(self, *, account_id: str, tenant_id: str) -> str | None: ...
 
 
 class InstalledAppService:
-    @classmethod
+    def __init__(
+        self,
+        *,
+        installed_apps: InstalledAppStore,
+        get_workspace_role: WorkspaceRoleLookup,
+        get_visible_app_ids: InstalledAppVisibilityQuery | None,
+    ) -> None:
+        self._installed_apps: InstalledAppStore = installed_apps
+        self._get_workspace_role: WorkspaceRoleLookup = get_workspace_role
+        self._get_visible_app_ids: InstalledAppVisibilityQuery | None = get_visible_app_ids
+
     def get_visible_page(
-        cls,
+        self,
         *,
         tenant_id: str,
         user_id: str,
@@ -104,74 +109,65 @@ class InstalledAppService:
         limit: int,
         app_id: str | None,
         name: str | None,
-        session: Session | scoped_session,
-    ) -> tuple[list[tuple[InstalledApp, App]], bool, InstalledAppCursor | None]:
+    ) -> InstalledAppPage:
         """Scan ordered candidates until one page of authorized apps is complete."""
-        stmt = (
-            select(InstalledApp, App)
-            .join(App, App.id == InstalledApp.app_id)
-            .where(InstalledApp.tenant_id == tenant_id, _published_app_filter())
-        )
-        if app_id:
-            stmt = stmt.where(InstalledApp.app_id == app_id)
-        if name and (normalized_name := name.strip()):
-            escaped_name = escape_like_pattern(normalized_name)
-            stmt = stmt.where(App.name.ilike(f"%{escaped_name}%", escape="\\"))
-
-        webapp_auth_enabled = SystemFeatureService.is_webapp_auth_enabled()
-        scan_size = limit * 2 if webapp_auth_enabled else limit + 1
-        visible_rows: list[tuple[InstalledApp, App]] = []
+        scan_size = limit * 2 if self._get_visible_app_ids is not None else limit + 1
+        visible_rows: list[InstalledAppRecord] = []
         scan_cursor = cursor
         has_more = False
-        last_consumed_app: InstalledApp | None = None
+        last_consumed_app: InstalledAppRecord | None = None
 
         while True:
-            page_stmt = stmt
-            if scan_cursor is not None:
-                page_stmt = page_stmt.where(_installed_app_cursor_filter(scan_cursor))
-            candidate_result = session.execute(page_stmt.order_by(*_installed_app_order_by()).limit(scan_size)).all()
-            candidate_rows = [(installed_app, app) for installed_app, app in candidate_result]
+            # Candidate records are detached and the repository Session is closed
+            # before the optional Enterprise request.
+            candidate_rows = self._installed_apps.get_candidates(
+                tenant_id=tenant_id,
+                cursor=scan_cursor,
+                limit=scan_size,
+                app_id=app_id,
+                name=name,
+            )
             if not candidate_rows:
                 break
 
-            authorized_rows = candidate_rows
-            if webapp_auth_enabled:
-                authorized_rows = _filter_rows_by_webapp_auth(candidate_rows, user_id=user_id)
+            authorized_app_ids: Set[str] = {row.app.id for row in candidate_rows}
+            if self._get_visible_app_ids is not None:
+                authorized_app_ids = self._get_visible_app_ids(
+                    user_id=user_id, app_ids=[row.app.id for row in candidate_rows]
+                )
 
-            authorized_installed_app_ids = {installed_app.id for installed_app, _ in authorized_rows}
             for row in candidate_rows:
-                installed_app = row[0]
-                if installed_app.id not in authorized_installed_app_ids:
-                    last_consumed_app = installed_app
+                if row.app.id not in authorized_app_ids:
+                    last_consumed_app = row
                     continue
                 if len(visible_rows) == limit:
                     has_more = True
                     break
                 visible_rows.append(row)
-                last_consumed_app = installed_app
+                last_consumed_app = row
             if has_more:
                 break
 
             if len(candidate_rows) < scan_size:
                 break
-            last_scanned_app = candidate_rows[-1][0]
-            scan_cursor = InstalledAppCursor(
-                is_pinned=last_scanned_app.is_pinned,
-                last_used_at=last_scanned_app.last_used_at,
-                installed_app_id=last_scanned_app.id,
-            )
+            scan_cursor = candidate_rows[-1].cursor()
 
-        next_cursor = (
-            InstalledAppCursor(
-                is_pinned=last_consumed_app.is_pinned,
-                last_used_at=last_consumed_app.last_used_at,
-                installed_app_id=last_consumed_app.id,
-            )
-            if has_more and last_consumed_app
-            else None
+        next_cursor = last_consumed_app.cursor() if has_more and last_consumed_app is not None else None
+        role = self._get_workspace_role(account_id=user_id, tenant_id=tenant_id)
+        return InstalledAppPage(
+            data=tuple(visible_rows), has_more=has_more, next_cursor=next_cursor, editable=role in {"owner", "admin"}
         )
-        return visible_rows, has_more, next_cursor
 
-    @staticmethod
-    def get_published_app(app_id: str, *, session: Session | scoped_session) -> App | None:
-        return session.scalar(select(App).where(App.id == app_id, _published_app_filter()).limit(1))
+    def get_detail(self, *, installed_app: InstalledAppRef, account_id: str) -> InstalledAppDetail:
+        installation = self._installed_apps.get_published(installed_app=installed_app)
+        if installation is None:
+            raise InstalledAppNotFoundError(f"Installed app {installed_app.id} is not published or no longer exists")
+        role = self._get_workspace_role(account_id=account_id, tenant_id=installed_app.tenant_id)
+        return InstalledAppDetail(installation=installation, editable=role in {"owner", "admin"})
+
+    def uninstall(self, *, installed_app: InstalledAppRef) -> None:
+        self._installed_apps.uninstall(installed_app=installed_app)
+
+    def set_pinned(self, *, installed_app: InstalledAppRef, is_pinned: bool | None) -> None:
+        if is_pinned is not None:
+            self._installed_apps.set_pinned(installed_app=installed_app, is_pinned=is_pinned)

--- a/api/services/webapp_access_query_service.py
+++ b/api/services/webapp_access_query_service.py
@@ -1,6 +1,6 @@
 """Application service for resolving web-app access."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from typing import Protocol
 
 from enums import WebAppAccessMode
@@ -10,6 +10,14 @@ _PERMISSION_CHECK_MODES = frozenset({WebAppAccessMode.PRIVATE, WebAppAccessMode.
 
 class WebAppAccessQuery(Protocol):
     def find_app_id_by_code(self, app_code: str) -> str | None: ...
+
+
+class WebAppAccessModesQuery(Protocol):
+    def __call__(self, *, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]: ...
+
+
+class WebAppUserPermissionsQuery(Protocol):
+    def __call__(self, *, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]: ...
 
 
 class WebAppAccessReferenceRequiredError(ValueError):
@@ -32,11 +40,15 @@ class WebAppAccessQueryService:
         webapp_auth_enabled: bool,
         access_mode_for_app: Callable[[str], WebAppAccessMode],
         is_user_allowed_for_app: Callable[[str, str], bool],
+        get_access_modes: WebAppAccessModesQuery,
+        get_user_permissions: WebAppUserPermissionsQuery,
     ) -> None:
-        self._access = access
-        self._webapp_auth_enabled = webapp_auth_enabled
-        self._access_mode_for_app = access_mode_for_app
-        self._is_user_allowed_for_app = is_user_allowed_for_app
+        self._access: WebAppAccessQuery = access
+        self._webapp_auth_enabled: bool = webapp_auth_enabled
+        self._access_mode_for_app: Callable[[str], WebAppAccessMode] = access_mode_for_app
+        self._is_user_allowed_for_app: Callable[[str, str], bool] = is_user_allowed_for_app
+        self._get_access_modes: WebAppAccessModesQuery = get_access_modes
+        self._get_user_permissions: WebAppUserPermissionsQuery = get_user_permissions
 
     def get_access_mode(self, *, app_id: str | None, app_code: str | None) -> WebAppAccessMode:
         if not self._webapp_auth_enabled:
@@ -60,3 +72,16 @@ class WebAppAccessQueryService:
             return True
 
         return self._is_user_allowed_for_app(user_id, app_id)
+
+    def batch_get_access_modes(self, *, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+        """Return successfully parsed modes; missing IDs do not grant access."""
+        if not self._webapp_auth_enabled or not app_ids:
+            return dict.fromkeys(app_ids, WebAppAccessMode.PUBLIC)
+
+        return self._get_access_modes(app_ids=app_ids)
+
+    def batch_get_user_permissions(self, *, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+        if not self._webapp_auth_enabled or not app_ids:
+            return dict.fromkeys(app_ids, True)
+
+        return self._get_user_permissions(user_id=user_id, app_ids=app_ids)

--- a/api/tests/unit_tests/controllers/console/explore/test_completion.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_completion.py
@@ -301,7 +301,14 @@ def test_chat_enforces_admission_before_payload_validation(
         )
     else:
         _assert_json_response(
-            response, status=404, body={"code": "not_found", "message": "Installed app not found", "status": 404}
+            response,
+            status=404,
+            body={
+                "code": "installed_app_not_found",
+                "message": "The app was not found in this workspace.",
+                "status": 404,
+                "details": {"request_id": "request-1"},
+            },
         )
     assert chat_runtime.calls == []
     assert _last_used_at(harness, sqlite_session_factory) is None

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -1,11 +1,13 @@
 """HTTP contracts for InstalledApp management with real admission and persistence."""
 
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from uuid import UUID, uuid4
 
 import pytest
+from flask import Flask, got_request_exception
 from flask.testing import FlaskClient
 from sqlalchemy import Connection, delete, event, select
 from sqlalchemy.orm import Session, SessionTransaction, sessionmaker
@@ -20,6 +22,7 @@ from repositories.installed_app_repository import SQLAlchemyInstalledAppReposito
 from repositories.workspace_query_repository import WorkspaceQueryRepository
 from services.installed_app_access_service import InstalledAppAccessService
 from services.installed_app_service import InstalledAppService
+from services.webapp_access_query_service import WebAppAccessUnavailableError
 from tests.unit_tests.controllers.console.explore.test_installed_app_admission import (
     _assert_json_response,
     _Harness,
@@ -45,6 +48,7 @@ class _Management:
     denied_app_ids: set[str] = field(default_factory=set)
     visibility_calls: list[tuple[str, tuple[str, ...]]] = field(default_factory=list)
     signed_files: list[str] = field(default_factory=list)
+    visibility_error: WebAppAccessUnavailableError | None = None
 
     @property
     def client(self) -> FlaskClient:
@@ -58,6 +62,8 @@ class _Management:
 
     def get_access_modes(self, *, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
         self.assert_sessions_closed()
+        if self.visibility_error is not None:
+            raise self.visibility_error
         return dict.fromkeys(app_ids, WebAppAccessMode.PUBLIC)
 
     def get_user_permissions(self, *, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
@@ -466,24 +472,148 @@ def test_list_empty_result_has_no_cursor(management: _Management, empty: str) ->
 
 
 @pytest.mark.parametrize("cursor", ["not-a-cursor", "!!!", "e30", ""])
-def test_list_invalid_cursor_preserves_bad_request(management: _Management, cursor: str) -> None:
+def test_list_invalid_cursor_returns_specific_error(management: _Management, cursor: str) -> None:
     response = management.client.get("/installed-apps", query_string={"cursor": cursor})
     _assert_json_response(
-        response, status=400, body={"code": "bad_request", "message": "Invalid cursor", "status": 400}
+        response,
+        status=400,
+        body={
+            "code": "invalid_cursor",
+            "message": "The app list cursor is invalid. Refresh the list and try again.",
+            "status": 400,
+            "details": {"request_id": "request-1"},
+        },
     )
     assert management.sessions == []
 
 
-@pytest.mark.parametrize("mode", [AppMode.CHAT, AppMode.WORKFLOW])
-def test_unpublished_installation_rejects_detail_but_can_be_pinned_and_removed(
-    management: _Management, mode: AppMode
+@pytest.mark.parametrize(
+    ("query", "error"),
+    [
+        (
+            {"limit": "private-input"},
+            {
+                "type": "int_parsing",
+                "loc": ["limit"],
+                "msg": "Input should be a valid integer, unable to parse string as an integer",
+            },
+        ),
+        (
+            {"limit": "0"},
+            {"type": "greater_than_equal", "loc": ["limit"], "msg": "Input should be greater than or equal to 1"},
+        ),
+        (
+            {"limit": "101"},
+            {"type": "less_than_equal", "loc": ["limit"], "msg": "Input should be less than or equal to 100"},
+        ),
+        (
+            {"name": "private-input" * 10},
+            {"type": "string_too_long", "loc": ["name"], "msg": "String should have at most 100 characters"},
+        ),
+    ],
+)
+def test_list_validation_identifies_query_field_without_echoing_input(
+    management: _Management, query: dict[str, str], error: dict[str, object]
 ) -> None:
-    installed, _ = _installation(management, mode=mode, published=False)
+    response = management.client.get("/installed-apps", query_string=query)
+
+    _assert_json_response(
+        response,
+        status=422,
+        body={"code": "unprocessable_entity", "message": json.dumps([error]), "status": 422},
+    )
+    assert "private-input" not in response.get_data(as_text=True)
+    assert management.sessions == []
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (
+            {"is_pinned": "private-input"},
+            {
+                "type": "bool_parsing",
+                "loc": ["is_pinned"],
+                "msg": "Input should be a valid boolean, unable to interpret input",
+            },
+        ),
+        (
+            ["private-input"],
+            {
+                "type": "model_type",
+                "loc": [],
+                "msg": "Input should be a valid dictionary or instance of InstalledAppUpdatePayload",
+            },
+        ),
+    ],
+)
+def test_patch_validation_identifies_body_field_without_echoing_input(
+    management: _Management, payload: object, error: dict[str, object]
+) -> None:
+    response = management.client.patch(management.url(), data=json.dumps(payload), content_type="application/json")
+
+    _assert_json_response(
+        response,
+        status=422,
+        body={"code": "unprocessable_entity", "message": json.dumps([error]), "status": 422},
+    )
+    assert "private-input" not in response.get_data(as_text=True)
+    assert management.sessions == []
+    with management.session_factory() as session:
+        installed = session.get(InstalledApp, management.harness.installed_app.id)
+        assert installed is not None
+        assert installed.is_pinned is False
+
+
+@pytest.mark.parametrize(
+    ("body", "content_type"),
+    [
+        pytest.param('{"is_pinned": private-input}', "application/json", id="malformed-json"),
+        pytest.param("null", "application/json", id="null"),
+        pytest.param("false", "application/json", id="false"),
+        pytest.param("[]", "application/json", id="empty-list"),
+        pytest.param("", "application/json", id="empty-body"),
+        pytest.param('{"is_pinned": false}', "text/plain", id="non-json-media"),
+    ],
+)
+def test_patch_shared_parser_normalizes_empty_or_unreadable_body_to_noop(
+    management: _Management, body: str, content_type: str
+) -> None:
+    installed, _ = _installation(management, pinned=True)
+    management.sessions.clear()
+
+    response = management.client.patch(management.url(installed.id), data=body, content_type=content_type)
+
+    _assert_json_response(
+        response,
+        status=200,
+        body={"result": "success", "message": "App info updated successfully"},
+    )
+    assert management.sessions == []
+    with management.session_factory() as session:
+        persisted = session.get(InstalledApp, installed.id)
+        assert persisted is not None
+        assert persisted.is_pinned is True
+        assert persisted.last_used_at == _USED_AT
+
+
+@pytest.mark.parametrize(
+    ("mode", "published"), [(AppMode.CHAT, False), (AppMode.WORKFLOW, False), (AppMode.AGENT, True)]
+)
+def test_unavailable_installation_rejects_detail_but_can_be_pinned_and_removed(
+    management: _Management, mode: AppMode, published: bool
+) -> None:
+    installed, _ = _installation(management, mode=mode, published=published)
     url = management.url(installed.id)
     _assert_json_response(
         management.client.get(url),
         status=404,
-        body={"code": "not_found", "message": "Installed app not found", "status": 404},
+        body={
+            "code": "installed_app_unavailable",
+            "message": "The app is not available in this app library.",
+            "status": 404,
+            "details": {"request_id": "request-1"},
+        },
     )
     _assert_json_response(
         management.client.patch(url, json={"is_pinned": True}),
@@ -509,11 +639,12 @@ def test_owned_installation_preserves_uninstallable_field_but_rejects_delete(man
     assert response.get_json()["uninstallable"] is True
     _assert_json_response(
         management.client.delete(management.url(installed.id)),
-        status=400,
+        status=403,
         body={
-            "code": "bad_request",
-            "message": "You can't uninstall an app owned by the current tenant",
-            "status": 400,
+            "code": "installed_app_uninstall_forbidden",
+            "message": "An app owned by this workspace cannot be removed from its app library.",
+            "status": 403,
+            "details": {"request_id": "request-1"},
         },
     )
     with management.session_factory() as session:
@@ -557,14 +688,21 @@ def test_item_admission_precedes_management_actions_and_preserves_errors(
                 assert app is not None
                 session.delete(app)
     management.sessions.clear()
-    response = management.client.open(url, method=method, json={"is_pinned": True})
+    response = management.client.open(url, method=method, json={"is_pinned": "invalid"})
     if failure == "permission":
         _assert_json_response(
             response, status=403, body={"code": "access_denied", "message": "App access denied.", "status": 403}
         )
     else:
         _assert_json_response(
-            response, status=404, body={"code": "not_found", "message": "Installed app not found", "status": 404}
+            response,
+            status=404,
+            body={
+                "code": "installed_app_not_found",
+                "message": "The app was not found in this workspace.",
+                "status": 404,
+                "details": {"request_id": "request-1"},
+            },
         )
     assert management.sessions == []
     with management.session_factory() as session:
@@ -572,6 +710,57 @@ def test_item_admission_precedes_management_actions_and_preserves_errors(
         assert (installed is None) is (failure == "orphan")
         if installed is not None:
             assert installed.is_pinned is False
+
+
+@pytest.mark.parametrize(("method", "item"), [("GET", False), ("GET", True), ("PATCH", True), ("DELETE", True)])
+def test_management_dependency_failure_preserves_cause_and_request_context(
+    management: _Management,
+    caplog: pytest.LogCaptureFixture,
+    method: str,
+    item: bool,
+) -> None:
+    failure = WebAppAccessUnavailableError("private upstream response containing credentials")
+    if item:
+        management.harness.state.permission_error = failure
+    else:
+        _enable_visibility(management)
+        management.visibility_error = failure
+    exceptions: list[Exception] = []
+
+    def capture_exception(_sender: Flask, exception: Exception) -> None:
+        exceptions.append(exception)
+
+    with got_request_exception.connected_to(capture_exception):
+        response = management.client.open(
+            management.url() if item else "/installed-apps", method=method, json={"is_pinned": True}
+        )
+
+    _assert_json_response(
+        response,
+        status=503,
+        body={
+            "code": "web_app_access_unavailable",
+            "message": "The app access service is unavailable. Try again later.",
+            "status": 503,
+            "details": {"request_id": "request-1"},
+        },
+    )
+    assert "WWW-Authenticate" not in response.headers
+    assert "private upstream" not in response.get_data(as_text=True)
+    assert len(exceptions) == 1
+    assert exceptions[0].__cause__ is failure
+    management.assert_sessions_closed()
+    records = [record for record in caplog.records if record.name.startswith("controllers.console.explore.")]
+    assert len(records) == 1
+    assert records[0].exc_info is not None
+    assert records[0].exc_info[1] is failure
+    assert management.harness.installed_app.tenant_id in records[0].getMessage()
+    assert management.harness.account.id in records[0].getMessage()
+    assert "request-1" in records[0].getMessage()
+    with management.session_factory() as session:
+        installed = session.get(InstalledApp, management.harness.installed_app.id)
+        assert installed is not None
+        assert installed.is_pinned is False
 
 
 @pytest.mark.parametrize(("method", "item"), [("GET", False), ("GET", True), ("PATCH", True), ("DELETE", True)])

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -1,576 +1,595 @@
-from collections.abc import Generator
-from contextlib import contextmanager
+"""HTTP contracts for InstalledApp management with real admission and persistence."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import datetime
-from inspect import unwrap
-from types import SimpleNamespace
-from unittest.mock import patch
+from uuid import UUID, uuid4
 
 import pytest
-from flask import Flask
-from sqlalchemy import Engine, select
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+from flask.testing import FlaskClient
+from sqlalchemy import Connection, delete, event, select
+from sqlalchemy.orm import Session, SessionTransaction, sessionmaker
 
 import controllers.console.explore.installed_app as module
-import services.installed_app_service as service_module
-from models import Account, Tenant, TenantAccountJoin
-from models.account import AccountStatus, TenantAccountRole
-from models.model import App, AppMode, AppModelConfig, IconType, InstalledApp, RecommendedApp
+from enums import WebAppAccessMode
+from models import Account, App, InstalledApp, Tenant, TenantAccountJoin
+from models.account import TenantAccountRole
+from models.model import AppMode, AppModelConfig, IconType
 from models.workflow import Workflow, WorkflowKind, WorkflowType
+from repositories.installed_app_repository import SQLAlchemyInstalledAppRepository
+from repositories.workspace_query_repository import WorkspaceQueryRepository
+from services.installed_app_access_service import InstalledAppAccessService
+from services.installed_app_service import InstalledAppService
+from tests.unit_tests.controllers.console.explore.test_installed_app_admission import (
+    _assert_json_response,
+    _Harness,
+    harness,
+)
+
+__all__ = ["harness"]
+
+_USED_AT = datetime(2024, 1, 1)
+
+
+@dataclass
+class _Services:
+    installed_apps: InstalledAppService
+
+
+@dataclass
+class _Management:
+    harness: _Harness
+    session_factory: sessionmaker[Session]
+    services: _Services
+    sessions: list[Session]
+    denied_app_ids: set[str] = field(default_factory=set)
+    visibility_calls: list[tuple[str, tuple[str, ...]]] = field(default_factory=list)
+    signed_files: list[str] = field(default_factory=list)
+
+    @property
+    def client(self) -> FlaskClient:
+        return self.harness.app.test_client()
+
+    def url(self, installed_app_id: str | None = None) -> str:
+        return f"/installed-apps/{installed_app_id or self.harness.installed_app.id}"
+
+    def assert_sessions_closed(self) -> None:
+        assert all(not session.in_transaction() and not session.identity_map for session in self.sessions)
+
+    def get_access_modes(self, *, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+        self.assert_sessions_closed()
+        return dict.fromkeys(app_ids, WebAppAccessMode.PUBLIC)
+
+    def get_user_permissions(self, *, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+        self.assert_sessions_closed()
+        self.visibility_calls.append((user_id, tuple(app_ids)))
+        return {app_id: app_id not in self.denied_app_ids for app_id in app_ids}
 
 
 @pytest.fixture
-def tenant_id() -> str:
-    return "tenant-1"
+def management(
+    harness: _Harness,
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session_factory: sessionmaker[Session],
+) -> _Management:
+    factory = sessionmaker(bind=sqlite_session_factory.kw["bind"], expire_on_commit=False)
+    tenant = harness.account.current_tenant
+    assert tenant is not None
+    harness.account.role = TenantAccountRole.ADMIN
+    with factory.begin() as session:
+        session.add_all(
+            [
+                harness.account,
+                tenant,
+                TenantAccountJoin(
+                    tenant_id=tenant.id,
+                    account_id=harness.account.id,
+                    current=True,
+                    role=TenantAccountRole.OWNER,
+                ),
+            ]
+        )
+        app = session.get(App, harness.target_app.id)
+        assert app is not None
+        app.description = "Description"
+        app.icon_type = IconType.EMOJI
+        app.icon = "robot"
+        app.icon_background = "#FFFFFF"
+        app.use_icon_as_answer_icon = False
+        _publish(session, app)
+    sessions: list[Session] = []
 
+    @event.listens_for(factory, "after_begin")
+    def track_session(session: Session, _transaction: SessionTransaction, _connection: Connection) -> None:
+        sessions.append(session)
 
-@pytest.fixture
-def database_session(sqlite_engine: Engine) -> Generator[scoped_session[Session]]:
-    session_registry = scoped_session(sessionmaker(bind=sqlite_engine, expire_on_commit=False))
-    try:
-        yield session_registry
-    finally:
-        session_registry.remove()
-
-
-@pytest.fixture
-def current_user(database_session: scoped_session[Session], tenant_id: str) -> Account:
-    tenant = Tenant(name="Current tenant")
-    tenant.id = tenant_id
-    account = Account(name="Current user", email="user@example.com", status=AccountStatus.ACTIVE)
-    account.id = "user-1"
-    membership = TenantAccountJoin(
-        tenant_id=tenant.id,
-        account_id=account.id,
-        current=True,
-        role=TenantAccountRole.OWNER,
+    services = _Services(
+        installed_apps=InstalledAppService(
+            installed_apps=SQLAlchemyInstalledAppRepository(session_factory=factory),
+            get_workspace_role=WorkspaceQueryRepository(factory).get_account_role,
+            get_visible_app_ids=None,
+        )
     )
-    database_session.add_all([tenant, account, membership])
-    database_session.commit()
-    account._current_tenant = tenant
-    account.role = TenantAccountRole.OWNER
-    return account
+    management = _Management(harness, factory, services, sessions)
+
+    def sign_icon(file_id: str) -> str:
+        management.assert_sessions_closed()
+        management.signed_files.append(file_id)
+        return f"/signed-files/{file_id}"
+
+    monkeypatch.setattr(module, "application_services", lambda: services)
+    monkeypatch.setattr(module.file_helpers, "get_signed_file_url", sign_icon)
+    harness.api.add_resource(module.InstalledAppsListApi, "/installed-apps")
+    harness.api.add_resource(module.InstalledAppApi, "/installed-apps/<uuid:installed_app_id>")
+    return management
 
 
-def _persist_app(
-    session: Session | scoped_session[Session],
-    *,
-    app_id: str,
-    tenant_id: str = "owner-tenant",
-    name: str | None = None,
-    mode: AppMode = AppMode.CHAT,
-    public: bool = True,
-    published: bool = True,
-) -> App:
-    app = App(
-        id=app_id,
-        tenant_id=tenant_id,
-        name=name or f"App {app_id}",
-        description="Description",
-        mode=mode,
-        icon_type=IconType.EMOJI,
-        icon="robot",
-        icon_background="#FFFFFF",
-        enable_site=True,
-        enable_api=True,
-        is_public=public,
-        max_active_requests=None,
-    )
-    session.add(app)
-    session.flush()
-    if published and mode in {AppMode.WORKFLOW, AppMode.ADVANCED_CHAT}:
+def _publish(session: Session, app: App) -> None:
+    if app.mode in {AppMode.WORKFLOW, AppMode.ADVANCED_CHAT}:
         workflow = Workflow(
-            id=f"workflow-{app_id}",
-            tenant_id=tenant_id,
-            app_id=app_id,
+            tenant_id=app.tenant_id,
+            app_id=app.id,
             type=WorkflowType.WORKFLOW,
             kind=WorkflowKind.STANDARD,
             version="1",
             graph='{"nodes":[],"edges":[]}',
             features="{}",
-            created_by="user-1",
+            created_by=str(uuid4()),
             environment_variables=[],
             conversation_variables=[],
             rag_pipeline_variables=[],
         )
         session.add(workflow)
-        app.workflow_id = workflow.id
-    elif published:
-        model_config = AppModelConfig(app_id=app_id)
-        session.add(model_config)
         session.flush()
-        app.app_model_config_id = model_config.id
-    session.commit()
-    return app
+        app.workflow_id = workflow.id
+    else:
+        config = AppModelConfig(app_id=app.id)
+        session.add(config)
+        session.flush()
+        app.app_model_config_id = config.id
 
 
-def _persist_installed_app(
-    session: Session | scoped_session[Session],
-    app: App,
+def _installation(
+    management: _Management,
     *,
-    tenant_id: str,
-    installed_app_id: str,
+    name: str = "Another app",
+    mode: AppMode = AppMode.CHAT,
+    published: bool = True,
+    tenant_id: str | None = None,
+    app_owner_tenant_id: str | None = None,
+    installed_app_id: str | None = None,
     pinned: bool = False,
-    last_used_at: datetime | None = datetime(2024, 1, 1),
-) -> InstalledApp:
-    installed_app = InstalledApp(
-        app_id=app.id,
-        tenant_id=tenant_id,
-        app_owner_tenant_id=app.tenant_id,
-        is_pinned=pinned,
-        last_used_at=last_used_at,
+    last_used_at: datetime | None = _USED_AT,
+) -> tuple[InstalledApp, App]:
+    with management.session_factory.begin() as session:
+        app = App(
+            tenant_id=app_owner_tenant_id or str(uuid4()),
+            name=name,
+            description="Description",
+            mode=mode,
+            icon_type=IconType.EMOJI,
+            icon="robot",
+            icon_background="#FFFFFF",
+            enable_site=True,
+            enable_api=True,
+            is_public=True,
+        )
+        session.add(app)
+        session.flush()
+        if published:
+            _publish(session, app)
+        installed = InstalledApp(
+            app_id=app.id,
+            tenant_id=tenant_id or management.harness.installed_app.tenant_id,
+            app_owner_tenant_id=app.tenant_id,
+            is_pinned=pinned,
+            last_used_at=last_used_at,
+        )
+        if installed_app_id is not None:
+            installed.id = installed_app_id
+        session.add(installed)
+    return installed, app
+
+
+def _clear_installations(management: _Management) -> None:
+    with management.session_factory.begin() as session:
+        session.execute(delete(InstalledApp))
+
+
+def _enable_visibility(management: _Management) -> None:
+    def unexpected_single_permission(*, user_id: str, app_id: str) -> bool:
+        pytest.fail(f"Listing should use batch permissions: {user_id=}, {app_id=}")
+
+    repository = SQLAlchemyInstalledAppRepository(session_factory=management.session_factory)
+    access = InstalledAppAccessService(
+        installed_apps=repository,
+        is_user_allowed=unexpected_single_permission,
+        get_access_modes=management.get_access_modes,
+        get_user_permissions=management.get_user_permissions,
     )
-    installed_app.id = installed_app_id
-    session.add(installed_app)
-    session.commit()
-    return installed_app
+    management.services.installed_apps = InstalledAppService(
+        installed_apps=repository,
+        get_workspace_role=WorkspaceQueryRepository(management.session_factory).get_account_role,
+        get_visible_app_ids=access.get_visible_app_ids,
+    )
 
 
-@contextmanager
-def _controller_context(
-    database_session: scoped_session[Session],
-    *,
-    role: TenantAccountRole = TenantAccountRole.OWNER,
-    auth_enabled: bool = False,
-) -> Generator[None]:
-    with (
-        patch.object(module.db, "session", database_session),
-        patch.object(module.TenantService, "get_user_role", return_value=role),
-        patch.object(
-            service_module.SystemFeatureService,
-            "is_webapp_auth_enabled",
-            return_value=auth_enabled,
-        ),
-    ):
-        yield
+def test_response_schema_preserves_domain_types_and_default_page_size() -> None:
+    assert module.InstalledAppsListQuery().limit == 20
+    app_schema = module.InstalledAppInfoResponse.model_json_schema(mode="serialization")
+    assert set(app_schema["properties"]) == {
+        "id",
+        "name",
+        "description",
+        "mode",
+        "icon_type",
+        "icon",
+        "icon_background",
+        "use_icon_as_answer_icon",
+        "icon_url",
+    }
+    assert app_schema["properties"]["mode"]["$ref"].endswith("/AppMode")
+    assert any(item.get("$ref", "").endswith("/IconType") for item in app_schema["properties"]["icon_type"]["anyOf"])
 
 
-class TestInstalledAppsListApi:
-    def test_list_query_defaults_to_20(self) -> None:
-        assert module.InstalledAppsListQuery().limit == 20
+def test_collection_rejects_post_and_keeps_get_available(management: _Management) -> None:
+    response = management.client.post("/installed-apps", json={"app_id": management.harness.target_app.id})
 
-    def test_response_schema_preserves_installed_app_domain_types(self) -> None:
-        app_schema = module.InstalledAppInfoResponse.model_json_schema(mode="serialization")
-        list_schema = module.InstalledAppListResponse.model_json_schema(mode="serialization")
+    _assert_json_response(
+        response,
+        status=405,
+        body={
+            "code": "method_not_allowed",
+            "message": "The method is not allowed for the requested URL.",
+            "status": 405,
+        },
+    )
+    options = management.client.options("/installed-apps")
+    assert options.status_code == 200
+    allowed_methods = {method.strip() for method in options.headers["Allow"].split(",")}
+    assert "POST" not in allowed_methods
+    assert "GET" in allowed_methods
+    assert management.sessions == []
 
-        assert {
-            "id",
-            "name",
-            "description",
-            "mode",
-            "icon_type",
-            "icon",
-            "icon_background",
-            "use_icon_as_answer_icon",
-            "icon_url",
-        } <= set(app_schema["required"])
-        assert set(app_schema["$defs"]["AppMode"]["enum"]) == {mode.value for mode in AppMode}
-        assert set(app_schema["$defs"]["IconType"]["enum"]) == {icon_type.value for icon_type in IconType}
-        assert "next_cursor" in list_schema["required"]
+    response = management.client.get("/installed-apps")
 
-    def test_published_app_filter_checks_publish_targets(self) -> None:
-        compiled_filter = str(service_module._published_app_filter().compile(compile_kwargs={"literal_binds": True}))
-
-        assert "workflows" in compiled_filter
-        assert "app_model_configs" in compiled_filter
-        assert "workflow_id" in compiled_filter
-        assert "app_model_config_id" in compiled_filter
-        assert "apps.mode != 'agent'" in compiled_filter
-
-    def test_get_filters_tenant_publication_mode_and_app_id(
-        self,
-        app: Flask,
-        current_user: Account,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        chat = _persist_app(database_session, app_id="chat")
-        workflow = _persist_app(database_session, app_id="workflow", mode=AppMode.WORKFLOW)
-        unpublished = _persist_app(database_session, app_id="unpublished", published=False)
-        agent = _persist_app(database_session, app_id="agent", mode=AppMode.AGENT)
-        foreign = _persist_app(database_session, app_id="foreign")
-        for index, (app_model, installed_tenant) in enumerate(
-            (
-                (chat, tenant_id),
-                (workflow, tenant_id),
-                (unpublished, tenant_id),
-                (agent, tenant_id),
-                (foreign, "other-tenant"),
-            )
-        ):
-            _persist_installed_app(
-                database_session,
-                app_model,
-                tenant_id=installed_tenant,
-                installed_app_id=f"installed-{index}",
-            )
-
-        api = module.InstalledAppsListApi()
-        method = unwrap(api.get)
-        with app.test_request_context("/"), _controller_context(database_session):
-            result = method(api, tenant_id, current_user)
-
-        assert {item["app"]["id"] for item in result["installed_apps"]} == {"chat", "workflow"}
-        assert all(item["editable"] is True for item in result["installed_apps"])
-        assert all(item["uninstallable"] is False for item in result["installed_apps"])
-        assert result["has_more"] is False
-        assert result["next_cursor"] is None
-
-        with (
-            app.test_request_context("/?app_id=workflow"),
-            _controller_context(database_session, role=TenantAccountRole.NORMAL),
-        ):
-            filtered = method(api, tenant_id, current_user)
-        assert [item["app"]["id"] for item in filtered["installed_apps"]] == ["workflow"]
-        assert filtered["installed_apps"][0]["editable"] is False
-
-    def test_get_name_search_escapes_like_wildcards(
-        self,
-        app: Flask,
-        current_user: Account,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        exact = _persist_app(database_session, app_id="exact", name="Sales%_Q3")
-        wildcard_decoy = _persist_app(database_session, app_id="decoy", name="SalesZZQ3")
-        for index, app_model in enumerate((exact, wildcard_decoy)):
-            _persist_installed_app(
-                database_session,
-                app_model,
-                tenant_id=tenant_id,
-                installed_app_id=f"installed-{index}",
-            )
-
-        with app.test_request_context("/?name=Sales%25_Q3"), _controller_context(database_session):
-            result = unwrap(module.InstalledAppsListApi().get)(module.InstalledAppsListApi(), tenant_id, current_user)
-
-        assert [item["app"]["id"] for item in result["installed_apps"]] == ["exact"]
-
-    def test_get_orders_and_paginates_with_cursor(
-        self,
-        app: Flask,
-        current_user: Account,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        app_models = [_persist_app(database_session, app_id=f"app-{index}") for index in range(4)]
-        rows = (
-            (app_models[0], "installed-0", True, datetime(2024, 1, 1)),
-            (app_models[1], "installed-1", False, datetime(2024, 1, 3)),
-            (app_models[2], "installed-2", False, datetime(2024, 1, 2)),
-            (app_models[3], "installed-3", False, None),
-        )
-        for app_model, installed_id, pinned, last_used_at in rows:
-            _persist_installed_app(
-                database_session,
-                app_model,
-                tenant_id=tenant_id,
-                installed_app_id=installed_id,
-                pinned=pinned,
-                last_used_at=last_used_at,
-            )
-
-        api = module.InstalledAppsListApi()
-        method = unwrap(api.get)
-        with app.test_request_context("/?limit=2"), _controller_context(database_session):
-            first_page = method(api, tenant_id, current_user)
-
-        assert [item["id"] for item in first_page["installed_apps"]] == ["installed-0", "installed-1"]
-        assert first_page["has_more"] is True
-        cursor = module._decode_installed_app_cursor(first_page["next_cursor"])
-        assert cursor is not None
-        assert cursor.installed_app_id == "installed-1"
-
-        with (
-            app.test_request_context(f"/?limit=2&cursor={first_page['next_cursor']}"),
-            _controller_context(database_session),
-        ):
-            second_page = method(api, tenant_id, current_user)
-        assert [item["id"] for item in second_page["installed_apps"]] == ["installed-2", "installed-3"]
-        assert second_page["has_more"] is False
-
-    def test_get_scans_past_denied_candidate_batch(
-        self,
-        app: Flask,
-        current_user: Account,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        allowed_first = _persist_app(database_session, app_id="allowed-first")
-        denied = _persist_app(database_session, app_id="denied")
-        allowed_later = _persist_app(database_session, app_id="allowed-later")
-        _persist_installed_app(
-            database_session,
-            allowed_first,
-            tenant_id=tenant_id,
-            installed_app_id="installed-allowed-first",
-            last_used_at=datetime(2024, 1, 3),
-        )
-        _persist_installed_app(
-            database_session,
-            denied,
-            tenant_id=tenant_id,
-            installed_app_id="installed-denied",
-            last_used_at=datetime(2024, 1, 2),
-        )
-        _persist_installed_app(
-            database_session,
-            allowed_later,
-            tenant_id=tenant_id,
-            installed_app_id="installed-allowed-later",
-            last_used_at=datetime(2024, 1, 1),
-        )
-        settings = {
-            app_id: SimpleNamespace(access_mode="restricted") for app_id in ("allowed-first", "denied", "allowed-later")
-        }
-
-        def permission_state(*, user_id: str, app_ids: list[str]) -> dict[str, bool]:
-            assert user_id == current_user.id
-            return {app_id: app_id != "denied" for app_id in app_ids}
-
-        with (
-            app.test_request_context("/?limit=1"),
-            _controller_context(database_session, role=TenantAccountRole.NORMAL, auth_enabled=True),
-            patch.object(
-                service_module.EnterpriseService.WebAppAuth,
-                "batch_get_app_access_mode_by_id",
-                side_effect=lambda app_ids: {app_id: settings[app_id] for app_id in app_ids},
-            ),
-            patch.object(
-                service_module.EnterpriseService.WebAppAuth,
-                "batch_is_user_allowed_to_access_webapps",
-                side_effect=permission_state,
-            ),
-        ):
-            result = unwrap(module.InstalledAppsListApi().get)(module.InstalledAppsListApi(), tenant_id, current_user)
-
-        assert [item["id"] for item in result["installed_apps"]] == ["installed-allowed-first"]
-        assert result["has_more"] is True
-        cursor = module._decode_installed_app_cursor(result["next_cursor"])
-        assert cursor is not None
-        assert cursor.installed_app_id == "installed-denied"
-
-    def test_get_applies_web_auth_permission_and_sso_state(
-        self,
-        app: Flask,
-        current_user: Account,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        apps = {app_id: _persist_app(database_session, app_id=app_id) for app_id in ("allowed", "denied", "sso")}
-        for index, app_model in enumerate(apps.values()):
-            _persist_installed_app(
-                database_session,
-                app_model,
-                tenant_id=tenant_id,
-                installed_app_id=f"installed-{index}",
-            )
-        settings = {
-            "allowed": SimpleNamespace(access_mode="restricted"),
-            "denied": SimpleNamespace(access_mode="restricted"),
-            "sso": SimpleNamespace(access_mode="sso_verified"),
-        }
-
-        with (
-            app.test_request_context("/"),
-            _controller_context(database_session, auth_enabled=True),
-            patch.object(
-                service_module.EnterpriseService.WebAppAuth,
-                "batch_get_app_access_mode_by_id",
-                return_value=settings,
-            ),
-            patch.object(
-                service_module.EnterpriseService.WebAppAuth,
-                "batch_is_user_allowed_to_access_webapps",
-                return_value={"allowed": True, "denied": False},
-            ),
-        ):
-            result = unwrap(module.InstalledAppsListApi().get)(module.InstalledAppsListApi(), tenant_id, current_user)
-
-        assert [item["app"]["id"] for item in result["installed_apps"]] == ["allowed"]
-
-    def test_get_rejects_invalid_cursor(self, app: Flask, current_user: Account, tenant_id: str) -> None:
-        with app.test_request_context("/?cursor=not-a-cursor"), pytest.raises(BadRequest, match="Invalid cursor"):
-            unwrap(module.InstalledAppsListApi().get)(module.InstalledAppsListApi(), tenant_id, current_user)
-
-    def test_get_rejects_user_without_current_tenant(self, app: Flask, tenant_id: str) -> None:
-        current_user = Account(name="No tenant", email="no-tenant@example.com", status=AccountStatus.ACTIVE)
-        current_user.id = "user-without-tenant"
-
-        with (
-            app.test_request_context("/"),
-            pytest.raises(ValueError, match="current_user.current_tenant must not be None"),
-        ):
-            unwrap(module.InstalledAppsListApi().get)(module.InstalledAppsListApi(), tenant_id, current_user)
+    assert response.status_code == 200
+    assert [item["id"] for item in response.get_json()["installed_apps"]] == [management.harness.installed_app.id]
 
 
-class TestInstalledAppsCreateApi:
-    def test_post_installs_public_recommended_app_once(
-        self,
-        app: Flask,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        app_model = _persist_app(database_session, app_id="recommended", public=True)
-        recommended = RecommendedApp(
-            app_id=app_model.id,
-            description={"en-US": "recommended"},
-            copyright="copyright",
-            privacy_policy="https://example.com/privacy",
-            category="productivity",
-        )
-        database_session.add(recommended)
-        database_session.commit()
-        recommended_id = recommended.id
-        bind = database_session.bind
-        request_data = module.InstalledAppCreatePayload(app_id=app_model.id)
+@pytest.mark.parametrize("endpoint", ["list", "detail"])
+@pytest.mark.parametrize("icon_type", [IconType.EMOJI, IconType.IMAGE, None])
+@pytest.mark.parametrize("last_used_at", [None, _USED_AT])
+def test_read_responses_preserve_exact_fields_types_headers_and_signed_icons(
+    management: _Management, endpoint: str, icon_type: IconType | None, last_used_at: datetime | None
+) -> None:
+    harness = management.harness
+    with management.session_factory.begin() as session:
+        app = session.get(App, harness.target_app.id)
+        assert app is not None
+        app.icon_type = icon_type
+        installed = session.get(InstalledApp, harness.installed_app.id)
+        assert installed is not None
+        installed.last_used_at = last_used_at
+    expected: dict[str, object] = {
+        "id": harness.installed_app.id,
+        "app": {
+            "id": harness.target_app.id,
+            "name": "Shared app",
+            "description": "Description",
+            "mode": "completion",
+            "icon_type": icon_type.value if icon_type is not None else None,
+            "icon": "robot",
+            "icon_background": "#FFFFFF",
+            "use_icon_as_answer_icon": False,
+            "icon_url": "/signed-files/robot" if icon_type == IconType.IMAGE else None,
+        },
+        "app_owner_tenant_id": harness.target_app.tenant_id,
+        "is_pinned": False,
+        "last_used_at": int(last_used_at.timestamp()) if last_used_at is not None else None,
+        "editable": True,
+        "uninstallable": False,
+    }
 
-        for _ in range(2):
-            with (
-                app.test_request_context("/", json={"app_id": app_model.id}),
-                patch.object(module.db, "session", database_session),
-            ):
-                assert unwrap(module.InstalledAppsListApi().post)(
-                    module.InstalledAppsListApi(), request_data, tenant_id
-                ) == {"message": "App installed successfully"}
+    response = management.client.get("/installed-apps" if endpoint == "list" else management.url())
 
-        database_session.remove()
-        with Session(bind) as observer:
-            installed = observer.scalars(select(InstalledApp)).all()
-            assert len(installed) == 1
-            assert installed[0].tenant_id == tenant_id
-            assert installed[0].app_owner_tenant_id == app_model.tenant_id
-            persisted_recommendation = observer.get(RecommendedApp, recommended_id)
-            assert persisted_recommendation is not None
-            assert persisted_recommendation.install_count == 1
+    body: dict[str, object] = (
+        {"installed_apps": [expected], "has_more": False, "next_cursor": None} if endpoint == "list" else expected
+    )
+    _assert_json_response(response, status=200, body=body)
+    assert dict(response.headers) == {"Content-Type": "application/json", "Content-Length": str(len(response.data))}
+    assert management.signed_files == (["robot"] if icon_type == IconType.IMAGE else [])
+    management.assert_sessions_closed()
 
-    def test_post_enforces_recommendation_and_public_state(
-        self,
-        app: Flask,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        api = module.InstalledAppsListApi()
-        with (
-            app.test_request_context("/", json={"app_id": "missing"}),
-            patch.object(module.db, "session", database_session),
-            pytest.raises(NotFound, match="Recommended app not found"),
-        ):
-            unwrap(api.post)(api, module.InstalledAppCreatePayload(app_id="missing"), tenant_id)
 
-        private_app = _persist_app(database_session, app_id="private", public=False)
-        database_session.add(
-            RecommendedApp(
-                app_id=private_app.id,
-                description={},
-                copyright="copyright",
-                privacy_policy="privacy",
-                category="category",
+@pytest.mark.parametrize("role", [TenantAccountRole.OWNER, TenantAccountRole.ADMIN, TenantAccountRole.NORMAL, None])
+@pytest.mark.parametrize("endpoint", ["list", "detail"])
+def test_read_uses_fresh_workspace_role_without_mutating_cached_account(
+    management: _Management, role: TenantAccountRole | None, endpoint: str
+) -> None:
+    harness = management.harness
+    with management.session_factory.begin() as session:
+        membership = session.scalar(select(TenantAccountJoin).where(TenantAccountJoin.account_id == harness.account.id))
+        assert membership is not None
+        if role is None:
+            session.delete(membership)
+        else:
+            membership.role = role
+
+    response = management.client.get("/installed-apps" if endpoint == "list" else management.url())
+
+    assert response.status_code == 200
+    item = response.get_json()["installed_apps"][0] if endpoint == "list" else response.get_json()
+    assert item["editable"] is (role in {TenantAccountRole.OWNER, TenantAccountRole.ADMIN})
+    assert harness.account.role == TenantAccountRole.ADMIN
+
+
+@pytest.mark.parametrize("endpoint", ["list", "detail"])
+@pytest.mark.parametrize("different_owner", ["account", "workspace"])
+def test_read_does_not_use_privileged_membership_from_another_account_or_workspace(
+    management: _Management, endpoint: str, different_owner: str
+) -> None:
+    harness = management.harness
+    account_id = harness.account.id
+    tenant_id = harness.installed_app.tenant_id
+    with management.session_factory.begin() as session:
+        session.execute(
+            delete(TenantAccountJoin).where(
+                TenantAccountJoin.account_id == account_id,
+                TenantAccountJoin.tenant_id == tenant_id,
             )
         )
-        database_session.commit()
-        with (
-            app.test_request_context("/", json={"app_id": private_app.id}),
-            patch.object(module.db, "session", database_session),
-            pytest.raises(Forbidden, match="non-public app"),
-        ):
-            unwrap(api.post)(api, module.InstalledAppCreatePayload(app_id=private_app.id), tenant_id)
+        if different_owner == "account":
+            account = Account(name="Another account", email="other@example.com")
+            session.add(account)
+            session.flush()
+            account_id = account.id
+        else:
+            tenant = Tenant(name="Another workspace")
+            session.add(tenant)
+            session.flush()
+            tenant_id = tenant.id
+        session.add(TenantAccountJoin(account_id=account_id, tenant_id=tenant_id, role=TenantAccountRole.OWNER))
+
+    response = management.client.get("/installed-apps" if endpoint == "list" else management.url())
+
+    assert response.status_code == 200
+    item = response.get_json()["installed_apps"][0] if endpoint == "list" else response.get_json()
+    assert item["editable"] is False
+    assert harness.account.role == TenantAccountRole.ADMIN
 
 
-class TestInstalledAppApi:
-    def test_get_returns_published_app_and_rejects_unpublished_app(
-        self,
-        app: Flask,
-        current_user: Account,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        published = _persist_app(database_session, app_id="published")
-        installed = _persist_installed_app(
-            database_session,
-            published,
-            tenant_id=tenant_id,
-            installed_app_id="installed-published",
+def test_list_filters_tenant_mode_and_actual_publication_targets(management: _Management) -> None:
+    workflow, _ = _installation(management, mode=AppMode.WORKFLOW)
+    advanced, _ = _installation(management, mode=AppMode.ADVANCED_CHAT)
+    _installation(management, mode=AppMode.AGENT)
+    _installation(management, published=False)
+    _installation(management, mode=AppMode.WORKFLOW, published=False)
+    _installation(management, tenant_id=str(uuid4()))
+    missing_config, config_app = _installation(management)
+    missing_workflow, workflow_app = _installation(management, mode=AppMode.WORKFLOW)
+    with management.session_factory.begin() as session:
+        session.execute(delete(AppModelConfig).where(AppModelConfig.id == config_app.app_model_config_id))
+        session.execute(delete(Workflow).where(Workflow.id == workflow_app.workflow_id))
+        # Existing installations remain visible even if their app is private.
+        app = session.get(App, management.harness.target_app.id)
+        assert app is not None
+        app.is_public = False
+
+    response = management.client.get("/installed-apps")
+
+    assert response.status_code == 200
+    ids = {item["id"] for item in response.get_json()["installed_apps"]}
+    assert ids == {management.harness.installed_app.id, workflow.id, advanced.id}
+    assert missing_config.id not in ids
+    assert missing_workflow.id not in ids
+    filtered = management.client.get("/installed-apps", query_string={"app_id": workflow.app_id})
+    assert [item["id"] for item in filtered.get_json()["installed_apps"]] == [workflow.id]
+
+
+def test_list_name_search_trims_and_escapes_wildcards(management: _Management) -> None:
+    exact, _ = _installation(management, name="Literal %_\\ app")
+    _installation(management, name="Literal wildcard app")
+
+    response = management.client.get("/installed-apps", query_string={"name": "  %_\\  "})
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.get_json()["installed_apps"]] == [exact.id]
+    assert len(management.client.get("/installed-apps", query_string={"name": "   "}).get_json()["installed_apps"]) == 3
+
+
+def test_list_pages_pin_time_null_and_id_order_without_duplicates(management: _Management) -> None:
+    _clear_installations(management)
+    expected: list[str] = []
+    for number, pinned, used_at in [
+        (1, True, datetime(2024, 2, 1)),
+        (2, True, _USED_AT),
+        (3, True, _USED_AT),
+        (4, True, None),
+        (5, False, datetime(2024, 3, 1)),
+        (6, False, None),
+        (7, False, None),
+    ]:
+        installed, _ = _installation(
+            management, installed_app_id=str(UUID(int=number)), pinned=pinned, last_used_at=used_at
         )
-        api = module.InstalledAppApi()
-        with app.test_request_context("/"), _controller_context(database_session):
-            result = unwrap(api.get)(api, tenant_id, current_user, installed)
+        expected.append(installed.id)
+    received: list[str] = []
+    cursor: str | None = None
+    for _ in range(4):
+        query = {"limit": "2"}
+        if cursor is not None:
+            query["cursor"] = cursor
+        response = management.client.get("/installed-apps", query_string=query)
+        assert response.status_code == 200
+        page = response.get_json()
+        received.extend(item["id"] for item in page["installed_apps"])
+        cursor = page["next_cursor"]
+        assert page["has_more"] is (cursor is not None)
+    assert received == expected
+    assert cursor is None
 
-        assert result["id"] == installed.id
-        assert result["app"]["id"] == published.id
-        assert result["app"]["mode"] == AppMode.CHAT
-        assert result["app"]["icon_type"] == IconType.EMOJI
-        assert result["editable"] is True
 
-        unpublished = _persist_app(database_session, app_id="unpublished", published=False)
-        unpublished_install = _persist_installed_app(
-            database_session,
-            unpublished,
-            tenant_id=tenant_id,
-            installed_app_id="installed-unpublished",
-        )
-        with (
-            app.test_request_context("/"),
-            patch.object(module.db, "session", database_session),
-            pytest.raises(NotFound, match="Installed app not found"),
-        ):
-            unwrap(api.get)(api, tenant_id, current_user, unpublished_install)
+def test_visible_page_scans_denied_batches_and_cursor_tracks_last_consumed_candidate(management: _Management) -> None:
+    _clear_installations(management)
+    _enable_visibility(management)
+    rows = [_installation(management, installed_app_id=str(UUID(int=index + 1))) for index in range(5)]
+    management.denied_app_ids.update(app.id for _, app in rows[1:4])
 
-    def test_delete_removes_foreign_app_and_rejects_owned_app(
-        self,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        foreign_app = _persist_app(database_session, app_id="foreign")
-        installed = _persist_installed_app(
-            database_session,
-            foreign_app,
-            tenant_id=tenant_id,
-            installed_app_id="installed-foreign",
-        )
-        api = module.InstalledAppApi()
-        with patch.object(module.db, "session", database_session):
-            response, status = unwrap(api.delete)(api, tenant_id, installed)
-        assert (response, status) == ("", 204)
-        database_session.expire_all()
-        assert database_session.get(InstalledApp, installed.id) is None
+    response = management.client.get("/installed-apps", query_string={"limit": 1})
 
-        owned_app = _persist_app(database_session, app_id="owned", tenant_id=tenant_id)
-        owned_install = _persist_installed_app(
-            database_session,
-            owned_app,
-            tenant_id=tenant_id,
-            installed_app_id="installed-owned",
-        )
-        with pytest.raises(BadRequest, match="owned by the current tenant"):
-            unwrap(api.delete)(api, tenant_id, owned_install)
-        assert database_session.get(InstalledApp, owned_install.id) is not None
+    assert response.status_code == 200
+    page = response.get_json()
+    assert [item["id"] for item in page["installed_apps"]] == [rows[0][0].id]
+    assert page["has_more"] is True
+    cursor = module._decode_installed_app_cursor(page["next_cursor"])
+    assert cursor is not None
+    assert cursor.installed_app_id == rows[3][0].id
+    assert management.visibility_calls == [
+        (management.harness.account.id, tuple(app.id for _, app in rows[start : start + 2])) for start in (0, 2, 4)
+    ]
+    response = management.client.get("/installed-apps", query_string={"limit": 1, "cursor": page["next_cursor"]})
+    assert [item["id"] for item in response.get_json()["installed_apps"]] == [rows[4][0].id]
+    assert response.get_json()["has_more"] is False
+    assert response.get_json()["next_cursor"] is None
 
-    def test_patch_persists_pin_and_accepts_noop_payload(
-        self,
-        app: Flask,
-        tenant_id: str,
-        database_session: scoped_session[Session],
-    ) -> None:
-        app_model = _persist_app(database_session, app_id="pin")
-        installed = _persist_installed_app(
-            database_session,
-            app_model,
-            tenant_id=tenant_id,
-            installed_app_id="installed-pin",
-        )
-        api = module.InstalledAppApi()
-        with (
-            app.test_request_context("/", json={"is_pinned": True}),
-            patch.object(module.db, "session", database_session),
-        ):
-            result = unwrap(api.patch)(api, module.InstalledAppUpdatePayload(is_pinned=True), installed)
-        assert result["result"] == "success"
-        database_session.expire_all()
-        persisted = database_session.get(InstalledApp, installed.id)
+
+@pytest.mark.parametrize("empty", ["database", "visibility"])
+def test_list_empty_result_has_no_cursor(management: _Management, empty: str) -> None:
+    if empty == "database":
+        _clear_installations(management)
+    else:
+        _enable_visibility(management)
+        management.denied_app_ids.add(management.harness.target_app.id)
+    response = management.client.get("/installed-apps")
+    _assert_json_response(response, status=200, body={"installed_apps": [], "has_more": False, "next_cursor": None})
+
+
+@pytest.mark.parametrize("cursor", ["not-a-cursor", "!!!", "e30", ""])
+def test_list_invalid_cursor_preserves_bad_request(management: _Management, cursor: str) -> None:
+    response = management.client.get("/installed-apps", query_string={"cursor": cursor})
+    _assert_json_response(
+        response, status=400, body={"code": "bad_request", "message": "Invalid cursor", "status": 400}
+    )
+    assert management.sessions == []
+
+
+@pytest.mark.parametrize("mode", [AppMode.CHAT, AppMode.WORKFLOW])
+def test_unpublished_installation_rejects_detail_but_can_be_pinned_and_removed(
+    management: _Management, mode: AppMode
+) -> None:
+    installed, _ = _installation(management, mode=mode, published=False)
+    url = management.url(installed.id)
+    _assert_json_response(
+        management.client.get(url),
+        status=404,
+        body={"code": "not_found", "message": "Installed app not found", "status": 404},
+    )
+    _assert_json_response(
+        management.client.patch(url, json={"is_pinned": True}),
+        status=200,
+        body={"result": "success", "message": "App info updated successfully"},
+    )
+    with management.session_factory() as session:
+        persisted = session.get(InstalledApp, installed.id)
         assert persisted is not None
         assert persisted.is_pinned is True
+    response = management.client.delete(url)
+    assert response.status_code == 204
+    assert response.data == b""
+    assert dict(response.headers) == {"Content-Type": "application/json"}
+    with management.session_factory() as session:
+        assert session.get(InstalledApp, installed.id) is None
 
-        with app.test_request_context("/", json={}), patch.object(module.db, "session", database_session):
-            result = unwrap(api.patch)(api, module.InstalledAppUpdatePayload(), installed)
-        assert result["result"] == "success"
+
+def test_owned_installation_preserves_uninstallable_field_but_rejects_delete(management: _Management) -> None:
+    installed, _ = _installation(management, app_owner_tenant_id=management.harness.installed_app.tenant_id)
+    response = management.client.get(management.url(installed.id))
+    assert response.status_code == 200
+    assert response.get_json()["uninstallable"] is True
+    _assert_json_response(
+        management.client.delete(management.url(installed.id)),
+        status=400,
+        body={
+            "code": "bad_request",
+            "message": "You can't uninstall an app owned by the current tenant",
+            "status": 400,
+        },
+    )
+    with management.session_factory() as session:
+        assert session.get(InstalledApp, installed.id) is not None
+
+
+@pytest.mark.parametrize("payload", [{}, {"is_pinned": None}, {"is_pinned": False}, {"is_pinned": True}])
+def test_patch_preserves_pin_values_and_noop_payloads(management: _Management, payload: dict[str, object]) -> None:
+    installed, _ = _installation(management, pinned=True)
+    management.sessions.clear()
+    response = management.client.patch(management.url(installed.id), json=payload)
+    _assert_json_response(response, status=200, body={"result": "success", "message": "App info updated successfully"})
+    if payload.get("is_pinned") is None:
+        assert management.sessions == []
+    with management.session_factory() as session:
+        persisted = session.get(InstalledApp, installed.id)
+        assert persisted is not None
+        assert persisted.is_pinned is (payload["is_pinned"] if payload.get("is_pinned") is not None else True)
+        assert persisted.last_used_at == _USED_AT
+
+
+@pytest.mark.parametrize("method", ["GET", "PATCH", "DELETE"])
+@pytest.mark.parametrize("failure", ["tenant", "missing", "orphan", "permission"])
+def test_item_admission_precedes_management_actions_and_preserves_errors(
+    management: _Management, method: str, failure: str
+) -> None:
+    harness = management.harness
+    url = management.url()
+    if failure == "permission":
+        harness.state.allowed = False
+    elif failure == "missing":
+        url = management.url(str(uuid4()))
+    else:
+        with management.session_factory.begin() as session:
+            if failure == "tenant":
+                installed = session.get(InstalledApp, harness.installed_app.id)
+                assert installed is not None
+                installed.tenant_id = str(uuid4())
+            else:
+                app = session.get(App, harness.target_app.id)
+                assert app is not None
+                session.delete(app)
+    management.sessions.clear()
+    response = management.client.open(url, method=method, json={"is_pinned": True})
+    if failure == "permission":
+        _assert_json_response(
+            response, status=403, body={"code": "access_denied", "message": "App access denied.", "status": 403}
+        )
+    else:
+        _assert_json_response(
+            response, status=404, body={"code": "not_found", "message": "Installed app not found", "status": 404}
+        )
+    assert management.sessions == []
+    with management.session_factory() as session:
+        installed = session.get(InstalledApp, harness.installed_app.id)
+        assert (installed is None) is (failure == "orphan")
+        if installed is not None:
+            assert installed.is_pinned is False
+
+
+@pytest.mark.parametrize(("method", "item"), [("GET", False), ("GET", True), ("PATCH", True), ("DELETE", True)])
+def test_all_management_handlers_apply_setup_before_business_operations(
+    management: _Management, method: str, item: bool
+) -> None:
+    management.harness.state.setup_completed = False
+    response = management.client.open(management.url() if item else "/installed-apps", method=method, json={})
+    _assert_json_response(
+        response,
+        status=401,
+        body={
+            "code": "not_setup",
+            "message": "Dify has not been initialized and installed yet. "
+            "Please proceed with the initialization and installation process first.",
+            "status": 401,
+        },
+    )
+    assert response.headers["WWW-Authenticate"] == 'Bearer realm="api"'
+    assert management.sessions == []
+    assert management.harness.state.permission_calls == []

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app_admission.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app_admission.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass, field
 from operator import itemgetter
 from uuid import UUID, uuid4
@@ -25,7 +25,7 @@ import libs.login as login_module
 import services.app_task_service as app_task_module
 from controllers.console.explore.installed_app_admission import get_installed_app
 from controllers.console.flask_admission import console_account_admission
-from enums import DeploymentEdition
+from enums import DeploymentEdition, WebAppAccessMode
 from extensions.ext_login import DifyLoginManager, unauthorized_handler
 from libs.external_api import ExternalApi
 from machinery.context import RequestContext
@@ -124,10 +124,18 @@ def harness(
             state.permission_action()
         return state.allowed
 
+    def unexpected_access_modes(*, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+        pytest.fail(f"Single-app admission should not query batch access modes: {app_ids=}")
+
+    def unexpected_user_permissions(*, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+        pytest.fail(f"Single-app admission should not query batch permissions: {user_id=}, {app_ids=}")
+
     services = _ApplicationServices(
         installed_app_access=InstalledAppAccessService(
             installed_apps=SQLAlchemyInstalledAppRepository(session_factory=repository_factory),
             is_user_allowed=permission_check,
+            get_access_modes=unexpected_access_modes,
+            get_user_permissions=unexpected_user_permissions,
         )
     )
 

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app_admission.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app_admission.py
@@ -14,6 +14,7 @@ from werkzeug.exceptions import Unauthorized
 from werkzeug.test import TestResponse
 
 import controllers.console.explore.completion as completion_module
+import controllers.console.explore.error as explore_error_module
 import controllers.console.explore.installed_app_admission as admission_module
 import controllers.console.explore.parameter as parameter_module
 import controllers.console.explore.saved_message as saved_message_module
@@ -152,6 +153,7 @@ def harness(
     monkeypatch.setattr(login_module, "check_csrf_token", check_csrf)
     monkeypatch.setattr(console_wraps, "_is_setup_completed", setup_completed)
     monkeypatch.setattr(console_admission, "get_request_id", lambda: "request-1")
+    monkeypatch.setattr(explore_error_module, "get_request_id", lambda: "request-1")
     monkeypatch.setattr(console_admission, "get_trace_id", lambda: None)
 
     app = Flask(__name__)
@@ -245,7 +247,12 @@ def test_missing_or_foreign_installation_returns_404_before_permission(
     _assert_json_response(
         response,
         status=404,
-        body={"code": "not_found", "message": "Installed app not found", "status": 404},
+        body={
+            "code": "installed_app_not_found",
+            "message": "The app was not found in this workspace.",
+            "status": 404,
+            "details": {"request_id": "request-1"},
+        },
     )
     assert harness.state.permission_calls == []
     assert harness.state.events == ["setup", "csrf"]
@@ -318,20 +325,42 @@ def test_account_admission_precedes_installed_app_lookup(
         assert response.headers["WWW-Authenticate"] == 'Bearer realm="api"'
 
 
-def test_permission_dependency_unavailable_returns_503_without_calling_handler(harness: _Harness) -> None:
-    harness.state.permission_error = WebAppAccessUnavailableError()
+def test_permission_dependency_failure_preserves_cause_without_leaking_details(
+    harness: _Harness,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    failure = WebAppAccessUnavailableError("private upstream response containing credentials")
+    harness.state.permission_error = failure
+    exceptions: list[Exception] = []
 
-    response = harness.app.test_client().get(harness.url())
+    def capture_exception(_sender: Flask, exception: Exception) -> None:
+        exceptions.append(exception)
+
+    with got_request_exception.connected_to(capture_exception):
+        response = harness.app.test_client().get(harness.url())
 
     _assert_json_response(
         response,
         status=503,
         body={
             "code": "web_app_access_unavailable",
-            "message": "Web app access service is unavailable.",
+            "message": "The app access service is unavailable. Try again later.",
             "status": 503,
+            "details": {"request_id": "request-1"},
         },
     )
+    assert "private upstream" not in response.get_data(as_text=True)
+    assert len(exceptions) == 1
+    assert exceptions[0].__cause__ is failure
+    records = [record for record in caplog.records if record.name == admission_module.__name__]
+    assert len(records) == 1
+    assert records[0].exc_info is not None
+    assert records[0].exc_info[1] is failure
+    assert harness.installed_app.id in records[0].getMessage()
+    assert harness.installed_app.tenant_id in records[0].getMessage()
+    assert harness.account.id in records[0].getMessage()
+    assert "request-1" in records[0].getMessage()
+    assert "WWW-Authenticate" not in response.headers
     assert harness.state.events == ["setup", "csrf", "permission"]
     assert harness.state.permission_calls == [(harness.account.id, harness.target_app.id)]
 

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app_completion.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app_completion.py
@@ -348,7 +348,14 @@ def test_completion_requires_installed_app_admission_before_payload_validation(
         )
     else:
         _assert_json_response(
-            response, status=404, body={"code": "not_found", "message": "Installed app not found", "status": 404}
+            response,
+            status=404,
+            body={
+                "code": "installed_app_not_found",
+                "message": "The app was not found in this workspace.",
+                "status": 404,
+                "details": {"request_id": "request-1"},
+            },
         )
     assert runtime.calls == []
     if rejection != "missing":
@@ -388,6 +395,8 @@ def test_resource_removed_after_admission_does_not_start_runtime(
         assert _last_used_at(harness, sqlite_session_factory) is None
     else:
         _assert_json_response(
-            response, status=404, body={"code": "not_found", "message": "Installed app not found", "status": 404}
+            response,
+            status=404,
+            body={"code": "not_found", "message": "Installed app not found", "status": 404},
         )
     assert runtime.calls == []

--- a/api/tests/unit_tests/controllers/console/explore/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_workflow.py
@@ -342,7 +342,14 @@ def test_workflow_handlers_require_admission_before_payload_or_task_actions(
         )
     else:
         _assert_json_response(
-            response, status=404, body={"code": "not_found", "message": "Installed app not found", "status": 404}
+            response,
+            status=404,
+            body={
+                "code": "installed_app_not_found",
+                "message": "The app was not found in this workspace.",
+                "status": 404,
+                "details": {"request_id": "request-1"},
+            },
         )
     assert runtime.calls == []
     assert stop_redis.operations == []

--- a/api/tests/unit_tests/extensions/test_ext_application_services.py
+++ b/api/tests/unit_tests/extensions/test_ext_application_services.py
@@ -1,6 +1,7 @@
 """Tests for application-service dependency wiring."""
 
 import json
+import logging
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, call, patch
@@ -10,15 +11,15 @@ import httpx
 import pytest
 from flask import Flask
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import event, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from enums import DeploymentEdition, WebAppAccessMode
 from extensions import ext_application_services
 from extensions.ext_redis import RedisClientWrapper
 from machinery.context import RequestContext
-from models.account import Account
-from models.model import AccountTrialAppRecord, App, AppMode, DifySetup, InstalledApp
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.model import AccountTrialAppRecord, App, AppMode, AppModelConfig, DifySetup, InstalledApp
 from repositories.account_activation_repository import SQLAlchemyAccountActivationRepository
 from repositories.account_integration_repository import SQLAlchemyAccountIntegrationRepository
 from repositories.account_oauth_repository import (
@@ -881,7 +882,7 @@ def test_webapp_permission_adapter_maps_connection_failure() -> None:
         ),
         pytest.raises(WebAppAccessUnavailableError) as raised,
     ):
-        ext_application_services._is_user_allowed_to_access_webapp("user-1", "app-1")
+        ext_application_services._is_enterprise_webapp_user_allowed("user-1", "app-1")
 
     assert raised.value.__cause__ is failure
 
@@ -919,3 +920,278 @@ def test_build_application_services_wires_dynamic_recommended_catalog(
         services.recommended_app_queries.list_recommended(
             language="en-US",
         )
+
+
+@pytest.mark.parametrize(
+    ("deployment_edition", "permission_result"),
+    [
+        pytest.param(DeploymentEdition.COMMUNITY, False, id="community-skips-enterprise"),
+        pytest.param(DeploymentEdition.CLOUD, False, id="cloud-skips-enterprise"),
+        pytest.param(DeploymentEdition.ENTERPRISE, True, id="enterprise-allowed"),
+        pytest.param(DeploymentEdition.ENTERPRISE, False, id="enterprise-denied"),
+    ],
+)
+def test_installed_app_management_composition_reads_real_installations_and_current_workspace_role(
+    sqlite_session_factory: sessionmaker[Session],
+    installed_app_ref: InstalledAppRef,
+    deployment_edition: DeploymentEdition,
+    permission_result: bool,
+) -> None:
+    account_id = str(uuid4())
+    with sqlite_session_factory.begin() as session:
+        account = Account(name="Viewer", email="management@example.com")
+        account.id = account_id
+        tenant = Tenant(name="Viewer workspace")
+        tenant.id = installed_app_ref.tenant_id
+        session.add_all([account, tenant])
+        membership = TenantAccountJoin(
+            tenant_id=installed_app_ref.tenant_id, account_id=account_id, role=TenantAccountRole.OWNER
+        )
+        configuration = AppModelConfig(app_id=installed_app_ref.app_id)
+        session.add_all([membership, configuration])
+        session.flush()
+        app = session.get(App, installed_app_ref.app_id)
+        assert app is not None
+        app.app_model_config_id = configuration.id
+        membership_id = membership.id
+
+    active_connections = 0
+    engine = sqlite_session_factory.kw["bind"]
+
+    @event.listens_for(engine, "checkout")
+    def connection_checked_out(_connection: object, _record: object, _proxy: object) -> None:
+        nonlocal active_connections
+        active_connections += 1
+
+    @event.listens_for(engine, "checkin")
+    def connection_checked_in(_connection: object, _record: object) -> None:
+        nonlocal active_connections
+        active_connections -= 1
+
+    def enterprise_response(method: str, path: str, *, json: dict[str, object]) -> dict[str, object]:
+        assert deployment_edition == DeploymentEdition.ENTERPRISE
+        # The candidate read must release its DB connection before either network call.
+        assert active_connections == 0
+        assert method == "POST"
+        if path == "/webapp/access-mode/batch/id":
+            assert json == {"appIds": [installed_app_ref.app_id]}
+            return {"accessModes": {installed_app_ref.app_id: "private"}}
+        assert path == "/webapp/permission/batch"
+        assert json == {"userId": account_id, "appIds": [installed_app_ref.app_id]}
+        return {"permissions": {installed_app_ref.app_id: permission_result}}
+
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseRequest.send_request", side_effect=enterprise_response
+    ) as enterprise_request:
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=deployment_edition,
+            initialization_password="",
+            redis=_StopRedis(),
+        )
+        if deployment_edition != DeploymentEdition.ENTERPRISE:
+            assert services.webapp_access.batch_get_access_modes(app_ids=(installed_app_ref.app_id,)) == {
+                installed_app_ref.app_id: WebAppAccessMode.PUBLIC
+            }
+            assert services.webapp_access.batch_get_user_permissions(
+                user_id=account_id, app_ids=(installed_app_ref.app_id,)
+            ) == {installed_app_ref.app_id: True}
+            assert services.installed_app_access.get_visible_app_ids(
+                user_id=account_id, app_ids=(installed_app_ref.app_id,)
+            ) == frozenset({installed_app_ref.app_id})
+        page = services.installed_apps.get_visible_page(
+            tenant_id=installed_app_ref.tenant_id,
+            user_id=account_id,
+            cursor=None,
+            limit=1,
+            app_id=None,
+            name=None,
+        )
+        assert page.editable is True
+        assert page.has_more is False
+        assert page.next_cursor is None
+        expected_ids: list[str] = (
+            [installed_app_ref.id] if deployment_edition != DeploymentEdition.ENTERPRISE or permission_result else []
+        )
+        assert [installation.id for installation in page.data] == expected_ids
+
+        with sqlite_session_factory.begin() as session:
+            stored_membership = session.get(TenantAccountJoin, membership_id)
+            assert stored_membership is not None
+            stored_membership.role = TenantAccountRole.NORMAL
+        services.installed_apps.set_pinned(installed_app=installed_app_ref, is_pinned=True)
+        detail = services.installed_apps.get_detail(installed_app=installed_app_ref, account_id=account_id)
+        assert detail.editable is False
+        assert detail.installation.is_pinned is True
+        assert detail.installation.id == installed_app_ref.id
+        assert detail.installation.app.id == installed_app_ref.app_id
+        assert active_connections == 0
+
+    if deployment_edition == DeploymentEdition.ENTERPRISE:
+        assert enterprise_request.call_args_list == [
+            call("POST", "/webapp/access-mode/batch/id", json={"appIds": [installed_app_ref.app_id]}),
+            call(
+                "POST",
+                "/webapp/permission/batch",
+                json={"userId": account_id, "appIds": [installed_app_ref.app_id]},
+            ),
+        ]
+    else:
+        enterprise_request.assert_not_called()
+
+
+def test_installed_app_visibility_batches_settings_before_permissions_and_preserves_truthiness_filter(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    app_ids = (
+        "allowed",
+        "truthy-permission",
+        "missing-setting",
+        "sso",
+        "denied",
+        "zero",
+        "empty",
+        "null",
+        "missing-permission",
+    )
+    permission_candidates = ["allowed", "truthy-permission", "denied", "zero", "empty", "null", "missing-permission"]
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseRequest.send_request",
+        side_effect=[
+            {
+                "accessModes": {
+                    "allowed": "private",
+                    "truthy-permission": "private_all",
+                    "sso": "sso_verified",
+                    "denied": "public",
+                    "zero": "private_all",
+                    "empty": "public",
+                    "null": "private",
+                    "missing-permission": "private",
+                }
+            },
+            {
+                "permissions": {
+                    "allowed": True,
+                    "truthy-permission": 1,
+                    "missing-setting": True,
+                    "sso": True,
+                    "denied": False,
+                    "zero": 0,
+                    "empty": "",
+                    "null": None,
+                }
+            },
+        ],
+    ) as enterprise_request:
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.ENTERPRISE,
+            initialization_password="",
+            redis=_StopRedis(),
+        )
+        visible = services.installed_app_access.get_visible_app_ids(user_id="viewer", app_ids=app_ids)
+
+    assert visible == frozenset({"allowed", "truthy-permission"})
+    assert enterprise_request.call_args_list == [
+        call("POST", "/webapp/access-mode/batch/id", json={"appIds": list(app_ids)}),
+        call("POST", "/webapp/permission/batch", json={"userId": "viewer", "appIds": permission_candidates}),
+    ]
+
+
+@pytest.mark.parametrize("include_valid_apps", [True, False], ids=["mixed-modes", "all-invalid"])
+def test_installed_app_visibility_skips_and_logs_each_invalid_access_mode(
+    sqlite_session_factory: sessionmaker[Session], caplog: pytest.LogCaptureFixture, include_valid_apps: bool
+) -> None:
+    modes = {"invalid-empty": "", "invalid-unknown": "future-mode"}
+    valid_ids: list[str] = ["valid-before", "valid-after"] if include_valid_apps else []
+    if include_valid_apps:
+        modes = {"valid-before": "private", **modes, "valid-after": "public"}
+    app_ids = tuple(modes)
+    responses: list[object] = [{"accessModes": modes}]
+    if include_valid_apps:
+        # Even an over-inclusive permission response must not restore invalid apps.
+        responses.append({"permissions": dict.fromkeys(app_ids, True)})
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseRequest.send_request", side_effect=responses
+    ) as enterprise_request:
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.ENTERPRISE,
+            initialization_password="",
+            redis=_StopRedis(),
+        )
+        visible = services.installed_app_access.get_visible_app_ids(user_id="viewer", app_ids=app_ids)
+
+    assert visible == frozenset(valid_ids)
+    expected_calls = [call("POST", "/webapp/access-mode/batch/id", json={"appIds": list(app_ids)})]
+    if include_valid_apps:
+        expected_calls.append(call("POST", "/webapp/permission/batch", json={"userId": "viewer", "appIds": valid_ids}))
+    assert enterprise_request.call_args_list == expected_calls
+    warnings = [
+        message
+        for logger_name, level, message in caplog.record_tuples
+        if logger_name == ext_application_services.__name__ and level == logging.WARNING
+    ]
+    assert len(warnings) == 2
+    assert any("invalid-empty" in message and repr("") in message for message in warnings)
+    assert any("invalid-unknown" in message and repr("future-mode") in message for message in warnings)
+
+
+@pytest.mark.parametrize("app_ids", [(), ("sso", "missing")])
+def test_installed_app_visibility_skips_unnecessary_enterprise_requests(
+    sqlite_session_factory: sessionmaker[Session], app_ids: tuple[str, ...]
+) -> None:
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseRequest.send_request",
+        return_value={"accessModes": {"sso": "sso_verified"}},
+    ) as enterprise_request:
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.ENTERPRISE,
+            initialization_password="",
+            redis=_StopRedis(),
+        )
+        visible = services.installed_app_access.get_visible_app_ids(user_id="viewer", app_ids=app_ids)
+
+    assert visible == frozenset()
+    if app_ids:
+        enterprise_request.assert_called_once_with(
+            "POST", "/webapp/access-mode/batch/id", json={"appIds": list(app_ids)}
+        )
+    else:
+        enterprise_request.assert_not_called()
+
+
+@pytest.mark.parametrize("failure_stage", ["settings", "permissions"])
+@pytest.mark.parametrize(
+    "enterprise_error",
+    [
+        pytest.param(EnterpriseAPINotFoundError(), id="not-found"),
+        pytest.param(EnterpriseAPIError("batch unavailable"), id="api-error"),
+        pytest.param(httpx.ConnectError("connection failed"), id="transport"),
+        pytest.param(json.JSONDecodeError("invalid", "", 0), id="invalid-json"),
+        pytest.param(ValueError("No data found."), id="invalid-response"),
+    ],
+)
+def test_installed_app_visibility_preserves_original_enterprise_error(
+    sqlite_session_factory: sessionmaker[Session], failure_stage: str, enterprise_error: Exception
+) -> None:
+    responses: list[object] = []
+    if failure_stage == "permissions":
+        responses.append({"accessModes": {"app-1": "private"}})
+    responses.append(enterprise_error)
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseRequest.send_request", side_effect=responses
+    ) as enterprise_request:
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.ENTERPRISE,
+            initialization_password="",
+            redis=_StopRedis(),
+        )
+        with pytest.raises(type(enterprise_error)) as caught:
+            services.installed_app_access.get_visible_app_ids(user_id="viewer", app_ids=("app-1",))
+
+    assert caught.value is enterprise_error
+    assert enterprise_request.call_count == (2 if failure_stage == "permissions" else 1)

--- a/api/tests/unit_tests/extensions/test_ext_application_services.py
+++ b/api/tests/unit_tests/extensions/test_ext_application_services.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, call, patch
@@ -10,7 +11,6 @@ from uuid import uuid4
 import httpx
 import pytest
 from flask import Flask
-from pydantic import ValidationError
 from sqlalchemy import event, select
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -63,8 +63,7 @@ from services.auth.data_source_api_key_auth_service import DataSourceApiKeyAuthS
 from services.billing_portal_service import BillingPortalService
 from services.billing_service import BillingService
 from services.compliance_download_service import ComplianceDownloadService
-from services.enterprise.enterprise_service import WebAppSettings
-from services.errors.enterprise import EnterpriseAPIError, EnterpriseAPINotFoundError
+from services.errors.enterprise import EnterpriseAPIError, EnterpriseAPINotFoundError, EnterpriseServiceError
 from services.file_service import FileService
 from services.init_validation_service import InvalidInitializationPasswordError
 from services.installed_app_access_service import InstalledAppAccessDeniedError, InstalledAppRef
@@ -72,7 +71,7 @@ from services.partner_tenant_binding_service import PartnerTenantBindingService
 from services.retention.workflow_run.archive_download_task_cache import WorkflowRunArchiveDownloadTaskCache
 from services.retention.workflow_run.archive_log_service import WorkflowRunArchiveService
 from services.tag_application_service import TagApplicationService
-from services.webapp_access_query_service import WebAppAccessUnavailableError
+from services.webapp_access_query_service import WebAppAccessQueryService, WebAppAccessUnavailableError
 from services.workflow_app_log_query_service import WorkflowAppLogQueryService
 from services.workflow_run_service import WorkflowRunService
 from services.workflow_statistic_query_service import WorkflowStatisticQueryService
@@ -751,87 +750,87 @@ def test_build_application_services_adapts_enterprise_webapp_access_mode(
     get_access_mode.assert_called_once_with("app-1")
 
 
+def _query_webapp_access(
+    service: WebAppAccessQueryService, query_kind: str
+) -> WebAppAccessMode | bool | Mapping[str, WebAppAccessMode] | Mapping[str, bool]:
+    if query_kind == "single-mode":
+        return service.get_access_mode(app_id="app-1", app_code=None)
+    if query_kind == "single-permission":
+        return service.is_user_allowed(user_id="viewer", app_id="app-1")
+    if query_kind == "batch-modes":
+        return service.batch_get_access_modes(app_ids=("app-1",))
+    assert query_kind == "batch-permissions"
+    return service.batch_get_user_permissions(user_id="viewer", app_ids=("app-1",))
+
+
+@pytest.mark.parametrize("query_kind", ["single-mode", "single-permission", "batch-modes", "batch-permissions"])
 @pytest.mark.parametrize(
     "enterprise_error",
     [
-        pytest.param(EnterpriseAPINotFoundError(), id="not-found"),
-        pytest.param(EnterpriseAPIError(), id="api-error"),
-        pytest.param(httpx.ConnectError("connection failed"), id="transport"),
+        pytest.param(httpx.ReadTimeout("Enterprise timed out"), id="timeout"),
+        pytest.param(httpx.ConnectError("connection failed"), id="connection"),
+        pytest.param(EnterpriseServiceError("upstream failure"), id="upstream"),
         pytest.param(json.JSONDecodeError("invalid", "", 0), id="invalid-json"),
         pytest.param(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid"), id="invalid-encoding"),
-        pytest.param(
-            ValidationError.from_exception_data(WebAppSettings.__name__, []),
-            id="invalid-response",
-        ),
     ],
 )
-def test_build_application_services_maps_known_enterprise_errors(
+def test_webapp_access_queries_map_known_enterprise_errors_to_unavailable(
     sqlite_session_factory: sessionmaker[Session],
+    query_kind: str,
     enterprise_error: Exception,
 ) -> None:
-    with (
-        patch("extensions.ext_application_services.SystemFeatureService.is_webapp_auth_enabled", return_value=True),
-        patch(
-            "extensions.ext_application_services.EnterpriseService.WebAppAuth.get_app_access_mode_by_id",
-            side_effect=enterprise_error,
-        ),
-    ):
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseRequest.send_request", side_effect=enterprise_error
+    ) as enterprise_request:
         services = ext_application_services.build_application_services(
             database_client=sqlite_session_factory,
-            deployment_edition=DeploymentEdition.COMMUNITY,
+            deployment_edition=DeploymentEdition.ENTERPRISE,
             initialization_password="",
-            redis=MagicMock(spec=RedisClientWrapper),
+            redis=_StopRedis(),
         )
-
         with pytest.raises(WebAppAccessUnavailableError) as raised:
-            services.webapp_access.get_access_mode(app_id="app-1", app_code=None)
+            _query_webapp_access(services.webapp_access, query_kind)
 
+    assert type(raised.value) is WebAppAccessUnavailableError
     assert raised.value.__cause__ is enterprise_error
+    assert enterprise_request.call_count == 1
 
 
-def test_build_application_services_maps_invalid_access_mode_to_unavailable(
-    sqlite_session_factory: sessionmaker[Session],
+@pytest.mark.parametrize("access_mode", ["invalid", 123])
+def test_single_webapp_mode_maps_invalid_enum_or_field_value_to_unavailable(
+    sqlite_session_factory: sessionmaker[Session], access_mode: str | int
 ) -> None:
-    with (
-        patch("extensions.ext_application_services.SystemFeatureService.is_webapp_auth_enabled", return_value=True),
-        patch(
-            "extensions.ext_application_services.EnterpriseService.WebAppAuth.get_app_access_mode_by_id",
-            return_value=SimpleNamespace(access_mode="invalid"),
-        ),
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseRequest.send_request",
+        return_value={"accessMode": access_mode},
     ):
         services = ext_application_services.build_application_services(
             database_client=sqlite_session_factory,
-            deployment_edition=DeploymentEdition.COMMUNITY,
+            deployment_edition=DeploymentEdition.ENTERPRISE,
             initialization_password="",
-            redis=MagicMock(spec=RedisClientWrapper),
+            redis=_StopRedis(),
         )
-
         with pytest.raises(WebAppAccessUnavailableError) as raised:
             services.webapp_access.get_access_mode(app_id="app-1", app_code=None)
 
+    assert type(raised.value) is WebAppAccessUnavailableError
     assert isinstance(raised.value.__cause__, ValueError)
 
 
-def test_build_application_services_does_not_hide_unknown_enterprise_errors(
-    sqlite_session_factory: sessionmaker[Session],
+@pytest.mark.parametrize("query_kind", ["single-mode", "single-permission", "batch-modes", "batch-permissions"])
+@pytest.mark.parametrize("failure", [TypeError("adapter bug"), ValueError("unexpected programming error")])
+def test_webapp_access_queries_do_not_hide_unknown_programming_errors(
+    sqlite_session_factory: sessionmaker[Session], query_kind: str, failure: Exception
 ) -> None:
-    failure = TypeError("adapter bug")
-    with (
-        patch("extensions.ext_application_services.SystemFeatureService.is_webapp_auth_enabled", return_value=True),
-        patch(
-            "extensions.ext_application_services.EnterpriseService.WebAppAuth.get_app_access_mode_by_id",
-            side_effect=failure,
-        ),
-    ):
+    with patch("services.enterprise.enterprise_service.EnterpriseRequest.send_request", side_effect=failure):
         services = ext_application_services.build_application_services(
             database_client=sqlite_session_factory,
-            deployment_edition=DeploymentEdition.COMMUNITY,
+            deployment_edition=DeploymentEdition.ENTERPRISE,
             initialization_password="",
-            redis=MagicMock(spec=RedisClientWrapper),
+            redis=_StopRedis(),
         )
-
-        with pytest.raises(TypeError) as raised:
-            services.webapp_access.get_access_mode(app_id="app-1", app_code=None)
+        with pytest.raises(type(failure)) as raised:
+            _query_webapp_access(services.webapp_access, query_kind)
 
     assert raised.value is failure
 
@@ -1164,19 +1163,11 @@ def test_installed_app_visibility_skips_unnecessary_enterprise_requests(
 
 
 @pytest.mark.parametrize("failure_stage", ["settings", "permissions"])
-@pytest.mark.parametrize(
-    "enterprise_error",
-    [
-        pytest.param(EnterpriseAPINotFoundError(), id="not-found"),
-        pytest.param(EnterpriseAPIError("batch unavailable"), id="api-error"),
-        pytest.param(httpx.ConnectError("connection failed"), id="transport"),
-        pytest.param(json.JSONDecodeError("invalid", "", 0), id="invalid-json"),
-        pytest.param(ValueError("No data found."), id="invalid-response"),
-    ],
-)
-def test_installed_app_visibility_preserves_original_enterprise_error(
-    sqlite_session_factory: sessionmaker[Session], failure_stage: str, enterprise_error: Exception
+def test_installed_app_visibility_propagates_access_unavailable_with_original_cause(
+    sqlite_session_factory: sessionmaker[Session],
+    failure_stage: str,
 ) -> None:
+    enterprise_error = EnterpriseAPIError("batch unavailable")
     responses: list[object] = []
     if failure_stage == "permissions":
         responses.append({"accessModes": {"app-1": "private"}})
@@ -1190,8 +1181,9 @@ def test_installed_app_visibility_preserves_original_enterprise_error(
             initialization_password="",
             redis=_StopRedis(),
         )
-        with pytest.raises(type(enterprise_error)) as caught:
+        with pytest.raises(WebAppAccessUnavailableError) as caught:
             services.installed_app_access.get_visible_app_ids(user_id="viewer", app_ids=("app-1",))
 
-    assert caught.value is enterprise_error
+    assert type(caught.value) is WebAppAccessUnavailableError
+    assert caught.value.__cause__ is enterprise_error
     assert enterprise_request.call_count == (2 if failure_stage == "permissions" else 1)

--- a/api/tests/unit_tests/repositories/test_installed_app_repository.py
+++ b/api/tests/unit_tests/repositories/test_installed_app_repository.py
@@ -1,14 +1,20 @@
 from dataclasses import replace
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 import pytest
 from sqlalchemy import event, inspect
 from sqlalchemy.orm import Session, sessionmaker
 
-from models.model import App, AppMode, InstalledApp
+from models.model import App, AppMode, AppModelConfig, IconType, InstalledApp, RecommendedApp
+from models.workflow import Workflow, WorkflowKind, WorkflowType
 from repositories.installed_app_repository import SQLAlchemyInstalledAppRepository
 from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
+from services.installed_app_service import (
+    InstalledAppInfo,
+    InstalledAppOwnedByWorkspaceError,
+    InstalledAppRecord,
+)
 
 _USED_AT = datetime(2026, 9, 6, 12, 30, 45)
 _VIEWER_TENANT_ID = "11111111-1111-4111-8111-111111111111"
@@ -199,3 +205,317 @@ def test_record_rolls_back_and_preserves_commit_error(
         stored = session.get(InstalledApp, installed_app.id)
         assert stored is not None
         assert stored.last_used_at is None
+
+
+def _app_with_publication(
+    session: Session,
+    *,
+    name: str = "Shared app",
+    mode: AppMode = AppMode.COMPLETION,
+    published: bool = True,
+) -> App:
+    app = App(
+        tenant_id=_OWNER_TENANT_ID,
+        name=name,
+        description="",
+        mode=mode,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background=None,
+        use_icon_as_answer_icon=False,
+        is_public=False,
+        enable_site=False,
+        enable_api=False,
+    )
+    session.add(app)
+    session.flush()
+    if published and mode in (AppMode.WORKFLOW, AppMode.ADVANCED_CHAT):
+        # Preserve the existing reference-existence check, including draft versions.
+        workflow = Workflow(
+            id=str(uuid4()),
+            tenant_id=app.tenant_id,
+            app_id=app.id,
+            type=WorkflowType.WORKFLOW,
+            kind=WorkflowKind.STANDARD,
+            version="draft",
+            graph='{"nodes":[],"edges":[]}',
+            features="{}",
+            created_by=str(uuid4()),
+            environment_variables=[],
+            conversation_variables=[],
+            rag_pipeline_variables=[],
+        )
+        session.add(workflow)
+        app.workflow_id = workflow.id
+    elif published:
+        configuration = AppModelConfig(app_id=app.id)
+        session.add(configuration)
+        session.flush()
+        app.app_model_config_id = configuration.id
+    return app
+
+
+def _recommend(session: Session, app_id: str) -> RecommendedApp:
+    recommended = RecommendedApp(
+        app_id=app_id,
+        description={"en-US": "recommended"},
+        copyright="copyright",
+        privacy_policy="",
+        category="productivity",
+        install_count=4,
+    )
+    session.add(recommended)
+    session.flush()
+    return recommended
+
+
+@pytest.mark.parametrize("mode", list(AppMode))
+@pytest.mark.parametrize("publication", ["present", "missing", "dangling"])
+def test_candidate_and_detail_publication_filters_preserve_mode_and_reference_rules(
+    sqlite_session_factory: sessionmaker[Session], mode: AppMode, publication: str
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = _app_with_publication(session, mode=mode, published=publication == "present")
+        if publication == "dangling":
+            if mode in (AppMode.ADVANCED_CHAT, AppMode.WORKFLOW):
+                app.workflow_id = str(uuid4())
+            else:
+                app.app_model_config_id = str(uuid4())
+        installation = _installation(app_id=app.id)
+        session.add(installation)
+        session.flush()
+        reference = _reference(installation)
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+
+    candidates = repository.get_candidates(tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=10, app_id=None, name=None)
+    detail = repository.get_published(installed_app=reference)
+
+    if publication == "present" and mode != AppMode.AGENT:
+        assert len(candidates) == 1
+        assert candidates[0] == detail
+        assert candidates[0].app.mode == mode
+    else:
+        assert candidates == ()
+        assert detail is None
+
+
+def test_candidates_return_detached_nested_data_and_stored_installation_owner(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    stored_owner_id = str(uuid4())
+    with sqlite_session_factory.begin() as session:
+        app = _app_with_publication(session)
+        installation = _installation(app_id=app.id)
+        installation.app_owner_tenant_id = stored_owner_id
+        installation.last_used_at = _USED_AT
+        session.add(installation)
+        session.flush()
+        installation_id, app_id = installation.id, app.id
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+
+    result = repository.get_candidates(tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=10, app_id=None, name=None)
+
+    assert result == (
+        InstalledAppRecord(
+            id=installation_id,
+            app=InstalledAppInfo(
+                id=app_id,
+                name="Shared app",
+                description="",
+                mode="completion",
+                icon_type="emoji",
+                icon="robot",
+                icon_background=None,
+                use_icon_as_answer_icon=False,
+            ),
+            app_owner_tenant_id=stored_owner_id,
+            is_pinned=False,
+            last_used_at=_USED_AT,
+        ),
+    )
+    assert inspect(result[0], raiseerr=False) is None
+    assert inspect(result[0].app, raiseerr=False) is None
+
+
+def test_candidates_order_and_cursor_cover_pin_groups_ties_and_null_dates(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    ordered: list[str] = []
+    rows = [
+        (True, _USED_AT),
+        (True, _USED_AT),
+        (True, _USED_AT - timedelta(days=1)),
+        (True, None),
+        (True, None),
+        (False, _USED_AT + timedelta(days=1)),
+        (False, _USED_AT),
+        (False, _USED_AT),
+        (False, None),
+        (False, None),
+    ]
+    with sqlite_session_factory.begin() as session:
+        for number, (is_pinned, last_used_at) in enumerate(rows, start=1):
+            app = _app_with_publication(session)
+            installation = _installation(app_id=app.id)
+            installation.id = f"00000000-0000-4000-8000-{number:012d}"
+            installation.is_pinned = is_pinned
+            installation.last_used_at = last_used_at
+            session.add(installation)
+            ordered.append(installation.id)
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+
+    all_rows = repository.get_candidates(tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=20, app_id=None, name=None)
+
+    assert [row.id for row in all_rows] == ordered
+    for index, row in enumerate(all_rows):
+        after = repository.get_candidates(
+            tenant_id=_VIEWER_TENANT_ID, cursor=row.cursor(), limit=20, app_id=None, name=None
+        )
+        assert [candidate.id for candidate in after] == ordered[index + 1 :]
+    assert repository.get_candidates(tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=0, app_id=None, name=None) == ()
+    assert (
+        repository.get_candidates(tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=2, app_id=None, name=None)
+        == all_rows[:2]
+    )
+
+
+@pytest.mark.parametrize("search", ["  50%_\\  ", "50%_\\", "literal"])
+def test_candidates_filter_literal_case_insensitive_name_and_app_with_workspace_scope(
+    sqlite_session_factory: sessionmaker[Session], search: str
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        matching = _app_with_publication(session, name="LITERAL 50%_\\ suffix")
+        another = _app_with_publication(session, name="Literal 5000 suffix")
+        foreign = _app_with_publication(session, name=matching.name)
+        session.add_all([_installation(app_id=matching.id), _installation(app_id=another.id)])
+        foreign_installation = _installation(app_id=foreign.id)
+        foreign_installation.tenant_id = _OWNER_TENANT_ID
+        session.add(foreign_installation)
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+
+    candidates = repository.get_candidates(
+        tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=10, app_id=matching.id, name=search
+    )
+
+    assert [row.app.id for row in candidates] == [matching.id]
+    if search != "literal":
+        by_name = repository.get_candidates(
+            tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=10, app_id=None, name=search
+        )
+        assert [row.app.id for row in by_name] == [matching.id]
+    assert len(repository.get_candidates(tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=10, app_id="", name="  ")) == 2
+    assert (
+        repository.get_candidates(tenant_id=_VIEWER_TENANT_ID, cursor=None, limit=10, app_id=foreign.id, name=None)
+        == ()
+    )
+
+
+@pytest.mark.parametrize("field", ["id", "tenant_id", "app_id"])
+@pytest.mark.parametrize("operation", ["get_published", "uninstall", "set_pinned"])
+def test_management_operations_require_all_admitted_reference_fields(
+    sqlite_session_factory: sessionmaker[Session], field: str, operation: str
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = _app_with_publication(session)
+        installation = _installation(app_id=app.id)
+        session.add(installation)
+        session.flush()
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+    reference = replace(_reference(installation), **{field: str(uuid4())})
+
+    if operation == "get_published":
+        assert repository.get_published(installed_app=reference) is None
+    elif operation == "uninstall":
+        with pytest.raises(InstalledAppNotFoundError, match=reference.id):
+            repository.uninstall(installed_app=reference)
+    else:
+        with pytest.raises(InstalledAppNotFoundError, match=reference.id):
+            repository.set_pinned(installed_app=reference, is_pinned=True)
+
+    with sqlite_session_factory() as session:
+        stored = session.get(InstalledApp, installation.id)
+        assert stored is not None
+        assert stored.is_pinned is False
+
+
+def test_uninstall_removes_only_foreign_installation_even_when_app_is_unpublished(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = _app_with_publication(session, published=False)
+        recommended = _recommend(session, app.id)
+        installation = _installation(app_id=app.id)
+        session.add(installation)
+        session.flush()
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+
+    repository.uninstall(installed_app=_reference(installation))
+
+    with sqlite_session_factory() as session:
+        assert session.get(InstalledApp, installation.id) is None
+        assert session.get(App, app.id) is not None
+        stored = session.get(RecommendedApp, recommended.id)
+        assert stored is not None
+        assert stored.install_count == 4
+
+
+def test_uninstall_respects_stored_installation_ownership(sqlite_session_factory: sessionmaker[Session]) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = _app_with_publication(session)
+        installation = _installation(app_id=app.id)
+        # The installation's stored owner is the existing policy source.
+        installation.app_owner_tenant_id = _VIEWER_TENANT_ID
+        session.add(installation)
+        session.flush()
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+
+    with pytest.raises(InstalledAppOwnedByWorkspaceError, match=installation.id):
+        repository.uninstall(installed_app=_reference(installation))
+
+    with sqlite_session_factory() as session:
+        assert session.get(InstalledApp, installation.id) is not None
+
+
+@pytest.mark.parametrize("is_pinned", [True, False])
+def test_pin_updates_only_pin_state_including_unpublished_apps(
+    sqlite_session_factory: sessionmaker[Session], installed_app: InstalledApp, is_pinned: bool
+) -> None:
+    repository = SQLAlchemyInstalledAppRepository(session_factory=sqlite_session_factory)
+
+    repository.set_pinned(installed_app=_reference(installed_app), is_pinned=is_pinned)
+    repository.set_pinned(installed_app=_reference(installed_app), is_pinned=is_pinned)
+
+    with sqlite_session_factory() as session:
+        stored = session.get(InstalledApp, installed_app.id)
+        assert stored is not None
+        assert stored.is_pinned is is_pinned
+        assert stored.last_used_at is None
+        assert stored.position == 7
+        assert stored.app_owner_tenant_id == installed_app.app_owner_tenant_id
+
+
+@pytest.mark.parametrize("operation", ["uninstall", "set_pinned"])
+def test_management_mutations_roll_back_and_preserve_database_failure(
+    sqlite_session_factory: sessionmaker[Session], installed_app: InstalledApp, operation: str
+) -> None:
+    failure = RuntimeError("installation commit unavailable")
+    repository_factory = sessionmaker(bind=sqlite_session_factory.kw["bind"], expire_on_commit=False)
+
+    @event.listens_for(repository_factory, "before_commit")
+    def fail_commit(session: Session) -> None:
+        session.flush()
+        raise failure
+
+    repository = SQLAlchemyInstalledAppRepository(session_factory=repository_factory)
+    if operation == "uninstall":
+        with pytest.raises(RuntimeError, match="installation commit unavailable") as caught:
+            repository.uninstall(installed_app=_reference(installed_app))
+    else:
+        with pytest.raises(RuntimeError, match="installation commit unavailable") as caught:
+            repository.set_pinned(installed_app=_reference(installed_app), is_pinned=False)
+
+    assert caught.value is failure
+    with sqlite_session_factory() as session:
+        stored = session.get(InstalledApp, installed_app.id)
+        assert stored is not None
+        assert stored.is_pinned is True

--- a/api/tests/unit_tests/services/test_installed_app_access_service.py
+++ b/api/tests/unit_tests/services/test_installed_app_access_service.py
@@ -1,5 +1,9 @@
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
 import pytest
 
+from enums import WebAppAccessMode
 from services.installed_app_access_service import (
     InstalledAppAccessDeniedError,
     InstalledAppAccessService,
@@ -29,6 +33,39 @@ class _Store:
         return self._result
 
 
+def _unexpected_access_modes(*, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+    pytest.fail(f"Unexpected batch access-mode query: {app_ids=}")
+
+
+def _unexpected_user_permissions(*, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+    pytest.fail(f"Unexpected batch permission query: {user_id=}, {app_ids=}")
+
+
+def _unexpected_single_permission(*, user_id: str, app_id: str) -> bool:
+    pytest.fail(f"Visibility must use batch permission checks: {user_id=}, {app_id=}")
+
+
+@dataclass
+class _BatchAccess:
+    modes: Mapping[str, WebAppAccessMode] = field(default_factory=dict)
+    permissions: Mapping[str, bool] = field(default_factory=dict)
+    events: list[tuple[str, ...]] = field(default_factory=list)
+    modes_error: Exception | None = None
+    permissions_error: Exception | None = None
+
+    def get_access_modes(self, *, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+        self.events.append(("modes", *app_ids))
+        if self.modes_error is not None:
+            raise self.modes_error
+        return self.modes
+
+    def get_user_permissions(self, *, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+        self.events.append(("permissions", user_id, *app_ids))
+        if self.permissions_error is not None:
+            raise self.permissions_error
+        return self.permissions
+
+
 @pytest.mark.parametrize("allowed", [True, False])
 def test_access_resolves_workspace_installation_before_checking_target_app(allowed: bool) -> None:
     events: list[tuple[str, ...]] = []
@@ -40,6 +77,8 @@ def test_access_resolves_workspace_installation_before_checking_target_app(allow
     service = InstalledAppAccessService(
         installed_apps=_Store(result=_REF, events=events),
         is_user_allowed=is_user_allowed,
+        get_access_modes=_unexpected_access_modes,
+        get_user_permissions=_unexpected_user_permissions,
     )
 
     if allowed:
@@ -60,6 +99,8 @@ def test_missing_installation_does_not_check_permission() -> None:
     service = InstalledAppAccessService(
         installed_apps=_Store(result=None, events=events),
         is_user_allowed=unexpected_permission_check,
+        get_access_modes=_unexpected_access_modes,
+        get_user_permissions=_unexpected_user_permissions,
     )
 
     with pytest.raises(InstalledAppNotFoundError, match="^Installed app not found$"):
@@ -80,6 +121,8 @@ def test_dependency_errors_propagate_unchanged(failure_source: str) -> None:
     service = InstalledAppAccessService(
         installed_apps=_Store(result=_REF, events=events, error=failure if failure_source == "store" else None),
         is_user_allowed=is_user_allowed,
+        get_access_modes=_unexpected_access_modes,
+        get_user_permissions=_unexpected_user_permissions,
     )
 
     with pytest.raises(RuntimeError) as raised:
@@ -87,3 +130,136 @@ def test_dependency_errors_propagate_unchanged(failure_source: str) -> None:
 
     assert raised.value is failure
     assert len(events) == (1 if failure_source == "store" else 2)
+
+
+def test_visibility_skips_external_queries_when_empty() -> None:
+    events: list[tuple[str, ...]] = []
+    service = InstalledAppAccessService(
+        installed_apps=_Store(result=_REF, events=events, error=AssertionError("Visibility must not resolve an app")),
+        is_user_allowed=_unexpected_single_permission,
+        get_access_modes=_unexpected_access_modes,
+        get_user_permissions=_unexpected_user_permissions,
+    )
+
+    visible = service.get_visible_app_ids(user_id="account-1", app_ids=[])
+
+    assert visible == frozenset()
+    assert isinstance(visible, frozenset)
+    assert events == []
+
+
+def test_visibility_filters_modes_then_permissions_preserving_batch_order_and_duplicates() -> None:
+    app_ids = ["public", "sso", "missing", "private", "private-all", "public", "also-public", "denied", "no-permission"]
+    batches = _BatchAccess(
+        modes={
+            "public": WebAppAccessMode.PUBLIC,
+            "sso": WebAppAccessMode.SSO_VERIFIED,
+            "private": WebAppAccessMode.PRIVATE,
+            "private-all": WebAppAccessMode.PRIVATE_ALL,
+            "also-public": WebAppAccessMode.PUBLIC,
+            "denied": WebAppAccessMode.PRIVATE,
+            "no-permission": WebAppAccessMode.PUBLIC,
+        },
+        permissions={
+            "public": True,
+            "private": True,
+            "private-all": True,
+            "also-public": True,
+            "denied": False,
+            "sso": True,
+            "missing": True,
+            "not-requested": True,
+        },
+    )
+    events: list[tuple[str, ...]] = []
+    service = InstalledAppAccessService(
+        installed_apps=_Store(result=_REF, events=events, error=AssertionError("Visibility must not resolve an app")),
+        is_user_allowed=_unexpected_single_permission,
+        get_access_modes=batches.get_access_modes,
+        get_user_permissions=batches.get_user_permissions,
+    )
+
+    visible = service.get_visible_app_ids(user_id="account-1", app_ids=app_ids)
+
+    assert visible == frozenset({"public", "private", "private-all", "also-public"})
+    assert isinstance(visible, frozenset)
+    assert batches.events == [
+        ("modes", *app_ids),
+        (
+            "permissions",
+            "account-1",
+            "public",
+            "private",
+            "private-all",
+            "public",
+            "also-public",
+            "denied",
+            "no-permission",
+        ),
+    ]
+    assert events == []
+
+
+@pytest.mark.parametrize("app_ids", [["missing"], ["sso", "missing", "sso"]])
+def test_visibility_skips_permission_query_when_no_mode_is_eligible(app_ids: list[str]) -> None:
+    batches = _BatchAccess(
+        modes={"sso": WebAppAccessMode.SSO_VERIFIED},
+        permissions_error=AssertionError("Empty candidates must not reach the permission provider"),
+    )
+    service = InstalledAppAccessService(
+        installed_apps=_Store(result=_REF, events=[], error=AssertionError("Visibility must not resolve an app")),
+        is_user_allowed=_unexpected_single_permission,
+        get_access_modes=batches.get_access_modes,
+        get_user_permissions=batches.get_user_permissions,
+    )
+
+    assert service.get_visible_app_ids(user_id="account-1", app_ids=app_ids) == frozenset()
+    assert batches.events == [("modes", *app_ids)]
+
+
+@pytest.mark.parametrize("failure_source", ["modes", "permissions"])
+def test_visibility_preserves_dependency_exception_and_query_order(failure_source: str) -> None:
+    failure = RuntimeError("Enterprise request failed")
+    batches = _BatchAccess(modes={"app-1": WebAppAccessMode.PUBLIC})
+    if failure_source == "modes":
+        batches.modes_error = failure
+    else:
+        batches.permissions_error = failure
+    service = InstalledAppAccessService(
+        installed_apps=_Store(result=_REF, events=[], error=AssertionError("Visibility must not resolve an app")),
+        is_user_allowed=_unexpected_single_permission,
+        get_access_modes=batches.get_access_modes,
+        get_user_permissions=batches.get_user_permissions,
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        service.get_visible_app_ids(user_id="account-1", app_ids=["app-1"])
+
+    assert raised.value is failure
+    assert batches.events == (
+        [("modes", "app-1")]
+        if failure_source == "modes"
+        else [("modes", "app-1"), ("permissions", "account-1", "app-1")]
+    )
+
+
+def test_single_app_admission_does_not_apply_list_sso_filter() -> None:
+    events: list[tuple[str, ...]] = []
+    batches = _BatchAccess(modes={_REF.app_id: WebAppAccessMode.SSO_VERIFIED}, permissions={_REF.app_id: False})
+
+    def allowed(*, user_id: str, app_id: str) -> bool:
+        events.append(("authorize", user_id, app_id))
+        return True
+
+    service = InstalledAppAccessService(
+        installed_apps=_Store(result=_REF, events=events),
+        is_user_allowed=allowed,
+        get_access_modes=batches.get_access_modes,
+        get_user_permissions=batches.get_user_permissions,
+    )
+
+    admitted = service.get_access(installed_app_id=_REF.id, tenant_id=_REF.tenant_id, account_id="account-1")
+
+    assert admitted is _REF
+    assert batches.events == []
+    assert events == [("resolve", _REF.id, _REF.tenant_id), ("authorize", "account-1", _REF.app_id)]

--- a/api/tests/unit_tests/services/test_webapp_access_query_service.py
+++ b/api/tests/unit_tests/services/test_webapp_access_query_service.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
@@ -9,6 +11,14 @@ from services.webapp_access_query_service import (
     WebAppAccessQueryService,
     WebAppAccessReferenceRequiredError,
 )
+
+
+def _unexpected_access_modes(*, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+    raise AssertionError(f"Unexpected batch access mode query: {app_ids}")
+
+
+def _unexpected_user_permissions(*, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+    raise AssertionError(f"Unexpected batch permission query: {user_id}, {app_ids}")
 
 
 def _service(
@@ -26,6 +36,8 @@ def _service(
             webapp_auth_enabled=enabled,
             access_mode_for_app=access_mode_for_app,
             is_user_allowed_for_app=is_user_allowed_for_app,
+            get_access_modes=_unexpected_access_modes,
+            get_user_permissions=_unexpected_user_permissions,
         ),
         access_mode_for_app,
         is_user_allowed_for_app,
@@ -148,3 +160,111 @@ def test_enabled_auth_delegates_user_permission() -> None:
 
     assert service.is_user_allowed(user_id="user-1", app_id="app-1") is False
     is_user_allowed_for_app.assert_called_once_with("user-1", "app-1")
+
+
+@dataclass
+class _BatchQueries:
+    access_modes: Mapping[str, WebAppAccessMode] = field(default_factory=dict)
+    user_permissions: Mapping[str, bool] = field(default_factory=dict)
+    mode_requests: list[tuple[str, ...]] = field(default_factory=list)
+    permission_requests: list[tuple[str, tuple[str, ...]]] = field(default_factory=list)
+    mode_error: Exception | None = None
+    permission_error: Exception | None = None
+
+    def get_access_modes(self, *, app_ids: Sequence[str]) -> Mapping[str, WebAppAccessMode]:
+        self.mode_requests.append(tuple(app_ids))
+        if self.mode_error is not None:
+            raise self.mode_error
+        return self.access_modes
+
+    def get_user_permissions(self, *, user_id: str, app_ids: Sequence[str]) -> Mapping[str, bool]:
+        self.permission_requests.append((user_id, tuple(app_ids)))
+        if self.permission_error is not None:
+            raise self.permission_error
+        return self.user_permissions
+
+    def find_app_id_by_code(self, app_code: str) -> str | None:
+        raise AssertionError(f"Batch queries must not resolve app codes: {app_code}")
+
+    def get_access_mode(self, app_id: str) -> WebAppAccessMode:
+        raise AssertionError(f"Batch queries must not use single-app lookups: {app_id}")
+
+    def is_user_allowed(self, user_id: str, app_id: str) -> bool:
+        raise AssertionError(f"Batch queries must not use single-app permissions: {user_id}, {app_id}")
+
+
+def _batch_service(queries: _BatchQueries, *, enabled: bool = True) -> WebAppAccessQueryService:
+    return WebAppAccessQueryService(
+        access=queries,
+        webapp_auth_enabled=enabled,
+        access_mode_for_app=queries.get_access_mode,
+        is_user_allowed_for_app=queries.is_user_allowed,
+        get_access_modes=queries.get_access_modes,
+        get_user_permissions=queries.get_user_permissions,
+    )
+
+
+@pytest.mark.parametrize(
+    ("enabled", "app_ids"),
+    [
+        pytest.param(False, ("app-b", "app-a", "app-b"), id="disabled-auth"),
+        pytest.param(False, (), id="disabled-empty"),
+        pytest.param(True, (), id="enabled-empty"),
+    ],
+)
+def test_disabled_or_empty_batch_queries_return_public_access_without_external_calls(
+    enabled: bool, app_ids: tuple[str, ...]
+) -> None:
+    queries = _BatchQueries(
+        mode_error=AssertionError("Must not query modes"),
+        permission_error=AssertionError("Must not query permissions"),
+    )
+    service = _batch_service(queries, enabled=enabled)
+
+    assert service.batch_get_access_modes(app_ids=app_ids) == dict.fromkeys(app_ids, WebAppAccessMode.PUBLIC)
+    assert service.batch_get_user_permissions(user_id="viewer", app_ids=app_ids) == dict.fromkeys(app_ids, True)
+    assert queries.mode_requests == []
+    assert queries.permission_requests == []
+
+
+def test_enabled_batch_queries_preserve_order_duplicates_missing_results_and_sso_mode() -> None:
+    app_ids = ("private", "sso", "public", "private", "missing")
+    queries = _BatchQueries(
+        access_modes={
+            "private": WebAppAccessMode.PRIVATE,
+            "sso": WebAppAccessMode.SSO_VERIFIED,
+            "public": WebAppAccessMode.PUBLIC,
+        },
+        user_permissions={"private": False, "sso": True, "public": True},
+    )
+    service = _batch_service(queries)
+
+    modes = service.batch_get_access_modes(app_ids=app_ids)
+    permissions = service.batch_get_user_permissions(user_id="viewer", app_ids=app_ids)
+
+    assert modes == queries.access_modes
+    assert modes["sso"] is WebAppAccessMode.SSO_VERIFIED
+    assert "missing" not in modes
+    assert permissions == queries.user_permissions
+    assert "missing" not in permissions
+    assert queries.mode_requests == [app_ids]
+    assert queries.permission_requests == [("viewer", app_ids)]
+
+
+@pytest.mark.parametrize("failure_stage", ["modes", "permissions"])
+@pytest.mark.parametrize("failure", [ConnectionError("batch unavailable"), ValueError("invalid batch response")])
+def test_batch_callback_errors_propagate_without_wrapping(failure_stage: str, failure: Exception) -> None:
+    queries = _BatchQueries(mode_error=failure, permission_error=failure)
+    service = _batch_service(queries)
+
+    if failure_stage == "modes":
+        with pytest.raises(type(failure)) as raised:
+            service.batch_get_access_modes(app_ids=("app-1",))
+        assert queries.mode_requests == [("app-1",)]
+        assert queries.permission_requests == []
+    else:
+        with pytest.raises(type(failure)) as raised:
+            service.batch_get_user_permissions(user_id="viewer", app_ids=("app-1",))
+        assert queries.mode_requests == []
+        assert queries.permission_requests == [("viewer", ("app-1",))]
+    assert raised.value is failure

--- a/packages/contracts/generated/api/console/installed-apps/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/orpc.gen.ts
@@ -38,7 +38,6 @@ import {
   zPatchInstalledAppsByInstalledAppIdConversationsByCIdUnpinResponse,
   zPatchInstalledAppsByInstalledAppIdPath,
   zPatchInstalledAppsByInstalledAppIdResponse,
-  zPostInstalledAppsBody,
   zPostInstalledAppsByInstalledAppIdAudioToTextPath,
   zPostInstalledAppsByInstalledAppIdAudioToTextResponse,
   zPostInstalledAppsByInstalledAppIdChatMessagesBody,
@@ -68,7 +67,6 @@ import {
   zPostInstalledAppsByInstalledAppIdWorkflowsRunResponse,
   zPostInstalledAppsByInstalledAppIdWorkflowsTasksByTaskIdStopPath,
   zPostInstalledAppsByInstalledAppIdWorkflowsTasksByTaskIdStopResponse,
-  zPostInstalledAppsResponse,
 } from './zod.gen'
 
 export const post = oc
@@ -576,20 +574,8 @@ export const get9 = oc
   .input(z.object({ query: zGetInstalledAppsQuery.optional() }))
   .output(zGetInstalledAppsResponse)
 
-export const post12 = oc
-  .route({
-    inputStructure: 'detailed',
-    method: 'POST',
-    operationId: 'postInstalledApps',
-    path: '/installed-apps',
-    tags: ['console'],
-  })
-  .input(z.object({ body: zPostInstalledAppsBody }))
-  .output(zPostInstalledAppsResponse)
-
 export const installedApps = {
   get: get9,
-  post: post12,
   byInstalledAppId,
 }
 

--- a/packages/contracts/generated/api/console/installed-apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/types.gen.ts
@@ -10,14 +10,6 @@ export type InstalledAppListResponse = {
   next_cursor: string | null
 }
 
-export type InstalledAppCreatePayload = {
-  app_id: string
-}
-
-export type SimpleMessageResponse = {
-  message: string
-}
-
 export type InstalledAppResponse = {
   app: InstalledAppInfoResponse
   app_owner_tenant_id: string
@@ -830,19 +822,6 @@ export type GetInstalledAppsResponses = {
 }
 
 export type GetInstalledAppsResponse = GetInstalledAppsResponses[keyof GetInstalledAppsResponses]
-
-export type PostInstalledAppsData = {
-  body: InstalledAppCreatePayload
-  path?: never
-  query?: never
-  url: '/installed-apps'
-}
-
-export type PostInstalledAppsResponses = {
-  200: SimpleMessageResponse
-}
-
-export type PostInstalledAppsResponse = PostInstalledAppsResponses[keyof PostInstalledAppsResponses]
 
 export type DeleteInstalledAppsByInstalledAppIdData = {
   body?: never

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -3,20 +3,6 @@
 import * as z from 'zod'
 
 /**
- * InstalledAppCreatePayload
- */
-export const zInstalledAppCreatePayload = z.object({
-  app_id: z.string(),
-})
-
-/**
- * SimpleMessageResponse
- */
-export const zSimpleMessageResponse = z.object({
-  message: z.string(),
-})
-
-/**
  * InstalledAppUpdatePayload
  */
 export const zInstalledAppUpdatePayload = z.object({
@@ -1002,13 +988,6 @@ export const zGetInstalledAppsQuery = z.object({
  * Success
  */
 export const zGetInstalledAppsResponse = zInstalledAppListResponse
-
-export const zPostInstalledAppsBody = zInstalledAppCreatePayload
-
-/**
- * Success
- */
-export const zPostInstalledAppsResponse = zSimpleMessageResponse
 
 export const zDeleteInstalledAppsByInstalledAppIdPath = z.object({
   installed_app_id: z.uuid(),


### PR DESCRIPTION
## Summary

Part of #39993. Stacked on #41912.

Installed-app management currently mixes request handling, ORM access, and Enterprise visibility checks. Move list/detail queries, pin updates, and removal into an injected `InstalledAppService` and the existing installed-app repository. Repository sessions close before list visibility calls, while pagination, publication filtering, and successful response shapes are preserved.

- Migrate management handlers to Console account admission and typed installed-app references. Centralize batch visibility decisions in `InstalledAppAccessService`, using typed queries from `WebAppAccessQueryService`.
- Remove the unused `POST /installed-apps` endpoint and its generated OpenAPI/TypeScript contracts; retain the frontend-used PATCH and DELETE endpoints.
- Return specific Console error codes for missing/unavailable installations (404), prohibited removal (403), invalid cursors (400), and known access-service failures (503), with request IDs for troubleshooting. Actual permission denial remains 403. The shared installed-app admission change also affects already-migrated Explore handlers, including completion, chat, and workflow.
- Use the shared `model_validate` decorator for list queries and pin payloads. Invalid list queries now receive the standard 422 validation response, and management handlers use the standard setup/account admission checks.

