### PR TITLE
refactor(models): remove four unread legacy db.session wrappers

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -467,10 +467,6 @@ class App(Base):
             else:
                 return ""
 
-    @property
-    def site(self) -> Site | None:
-        return self.site_with_session(session=db.session())
-
     def site_with_session(self, *, session: Session) -> Site | None:
         return session.scalar(select(Site).where(Site.app_id == self.id))
 
@@ -701,10 +697,6 @@ class App(Base):
 
         return deleted_tools
 
-    @property
-    def tags(self) -> Sequence[Tag]:
-        return self.tags_with_session(session=db.session())
-
     def tags_with_session(self, *, session: Session) -> Sequence[Tag]:
         tags = session.scalars(
             select(Tag)
@@ -801,10 +793,6 @@ class AppModelConfig(TypeBase):
     dataset_configs: Mapped[str | None] = mapped_column(LongText, default=None)
     external_data_tools: Mapped[str | None] = mapped_column(LongText, default=None)
     file_upload: Mapped[str | None] = mapped_column(LongText, default=None)
-
-    @property
-    def app(self) -> App | None:
-        return self.app_with_session(session=db.session())
 
     def app_with_session(self, *, session: Session) -> App | None:
         return session.scalar(select(App).where(App.id == self.app_id))
@@ -1067,10 +1055,6 @@ class TrialApp(TypeBase):
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), init=False
     )
     trial_limit: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=3)
-
-    @property
-    def app(self) -> App | None:
-        return self.app_with_session(session=db.session())
 
     def app_with_session(self, *, session: Session) -> App | None:
         return session.scalar(select(App).where(App.id == self.app_id))


### PR DESCRIPTION
## Summary

Part of #40372. Deletes four legacy `@property` wrappers in `api/models/model.py` whose entire body forwarded to a `*_with_session` twin with an implicit `db.session()`:

| Removed | Kept (unchanged) |
|---|---|
| `App.site` | `site_with_session` |
| `App.tags` | `tags_with_session` |
| `AppModelConfig.app` | `app_with_session` |
| `TrialApp.app` | `app_with_session` |

Claimed in https://github.com/langgenius/dify/issues/40372#issuecomment-5580475365.

## Why this is a pure deletion

Nothing reads any of the four raw properties. I grepped every `.site`, `.tags` and `.app` occurrence in `api/` and checked the receiver of each:

- **`App.site`** — `controllers/web/site.py:157` is `bootstrap.site` (a service DTO); `services/web_app_runtime_query_service.py:69,70,74` is a SQL `Row` (it calls `._asdict()`). The serialization path `AppDetailWithSite.site` goes through `AppResponseView.site`, which forwards to the twin.
- **`App.tags`** — every hit is `args.tags`, `payload.tags`, `entity.identity.tags` or a Pydantic field. `repositories/app_definition_query_repository.py:165` already uses `tags_with_session`, and the response side is `AppResponseView.tags`.
- **`AppModelConfig.app`** — no reader anywhere. `AppModelConfigResponse` (`controllers/console/app/app.py:255`) declares no `app` field, so `AppModelConfigResponseView.__getattr__` never resolves this name.
- **`TrialApp.app`** — its only consumer, `controllers/console/explore/wraps.py:87`, already calls `app_with_session(session=session)`.

No `getattr`/`hasattr` on these names, and no `validation_alias` referencing them.

## Deliberately not touched

`model.py` has six properties named `app`. This PR removes two of them. The other four — `RecommendedApp.app`, `InstalledApp.app`, `AccountTrialAppRecord.app`, `Conversation.app` — are left alone. `InstalledApp.app` in particular is still read on a real ORM instance at `tests/unit_tests/controllers/console/explore/test_wraps.py:131`, so it is not a pure deletion.

## Verification

- `pytest tests/unit_tests/models/` — 422 passed, **identical to the `main` baseline**, including two pre-existing failures and two errors unrelated to this change
- `pytest tests/unit_tests/services/test_app_service.py` — 33 passed on both this branch and `main`
- `pytest tests/unit_tests/repositories/test_app_definition_query_repository.py` — 22 passed
- `ruff check` / `ruff format --check` — clean
- `pyrefly check models/model.py` — 0 diagnostics
- `mypy --check-untyped-defs --disable-error-code=import-untyped models/model.py` — no issues
- `lint-imports` — 31 contracts kept, 0 broken
- `dev/lint_response_contracts.py --fail-on-mismatch` — 0 mismatch
- no net-new `getattr(` in the diff

`tests/unit_tests/controllers/console/app/test_app_response_models.py` also exercises the `AppResponseView` path, but it segfaults on my Windows box **on clean `main`**, so I could not run it locally. It builds on `MagicMock` and only asserts that `site_with_session` / `tags_with_session` are called, so this change should not affect it — but I'm relying on CI to confirm.

---
This PR was written with AI assistance.
