### PR TITLE
fix(web): reset goto anything search after dialog closes

### DIFF
--- a/web/app/components/goto-anything/__tests__/index.spec.tsx
+++ b/web/app/components/goto-anything/__tests__/index.spec.tsx
@@ -388,7 +388,7 @@ describe('GotoAnything', () => {
       expect(input).toHaveFocus()
     })
 
-    it('should reset search query when modal opens', async () => {
+    it('should reopen with an empty search after the modal finishes closing', async () => {
       const user = userEvent.setup()
       renderGotoAnything(<GotoAnything />)
 

--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -379,8 +379,8 @@ function GotoAnythingDialog() {
   const dedupedResults = dedupeSearchResults(searchResults)
   const groupedResults = groupSearchResults(dedupedResults)
 
-  function resetSearch() {
-    setSearchQuery('')
+  function handleDialogOpenChangeComplete(open: boolean) {
+    if (!open) setSearchQuery('')
   }
 
   useHotkey(
@@ -500,7 +500,10 @@ function GotoAnythingDialog() {
   return (
     <>
       <SlashCommandProvider />
-      <Dialog handle={gotoAnythingDialogHandle} onOpenChange={resetSearch}>
+      <Dialog
+        handle={gotoAnythingDialogHandle}
+        onOpenChangeComplete={handleDialogOpenChangeComplete}
+      >
         <DialogPortal>
           <DialogBackdrop />
           <DialogPopup

--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -226,7 +226,7 @@ function chunkArray<T>(items: readonly T[], size: number): T[][] {
   return rows
 }
 
-function GotoAnythingDialog() {
+export function GotoAnything() {
   const { t } = useTranslation()
   const pathname = usePathname()
   const router = useRouter()
@@ -432,13 +432,6 @@ function GotoAnythingDialog() {
     }
   }
 
-  function handleAutocompleteOpenChange(
-    nextOpen: boolean,
-    eventDetails: AutocompleteChangeEventDetails,
-  ) {
-    if (!nextOpen && eventDetails.reason === 'escape-key') gotoAnythingDialogHandle.close()
-  }
-
   function handleAutocompleteValueChange(
     nextValue: string,
     eventDetails: AutocompleteChangeEventDetails,
@@ -525,7 +518,6 @@ function GotoAnythingDialog() {
               items={visibleOptions}
               value={searchQuery}
               onValueChange={handleAutocompleteValueChange}
-              onOpenChange={handleAutocompleteOpenChange}
               itemToStringValue={optionToInputValue}
               filter={null}
               grid={isCommandsMode}
@@ -711,8 +703,4 @@ function GotoAnythingDialog() {
       )}
     </>
   )
-}
-
-export function GotoAnything() {
-  return <GotoAnythingDialog />
 }


### PR DESCRIPTION
## Summary

Closing Goto Anything currently clears its controlled search input as soon as the dialog starts closing, which can change the input and derived results during the 150 ms exit transition. Reset the search only in `onOpenChangeComplete(false)` so the exiting content retains its query and the next completed-close session opens empty.

Let the inline Autocomplete's Escape event reach the enclosing Dialog by removing the redundant close-forwarding callback. Keep explicit handle closure for navigation and direct commands; selecting a search scope continues editing the query without dismissing the dialog. Export the behavior-owning component directly instead of retaining a pass-through wrapper.

Dialog Root remains the sole open-state owner, with the detached handle connecting triggers and imperative actions. Search and plugin installation state remain local, and remote search state remains in TanStack Query. Rename the existing close-and-reopen test to describe the observable contract.

## Validation

- `vp test run --project unit app/components/goto-anything`: 19 files, 212 tests passed after removing the Escape forwarding callback, including Escape dismissal, trigger focus restoration, close/reopen reset, command selection, navigation, and plugin installation.
- `vp run -w check`: passed (0 errors; 1952 non-blocking warnings).
- Checked the installed Base UI inline dismissal and close-completion implementations and [Dialog API](https://base-ui.com/react/components/dialog).
- Browser visual verification of the exit animation was not performed; happy-dom tests verify observable interactions and close/reopen behavior, not native focus timing or CSS transitions.

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] Reused existing behavior tests and kept changes within Goto Anything.
- [x] Ran complete repository static checks.

From Codex
