### PR TITLE
fix(api): coerce time-typed metadata filter values to Unix timestamps

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -6,6 +6,7 @@ import threading
 import time
 from collections import Counter, defaultdict
 from collections.abc import Generator, Mapping
+from datetime import datetime
 from typing import Any, Union, cast
 
 from flask import Flask, current_app
@@ -93,7 +94,7 @@ from models.dataset import (
 )
 from models.dataset import Document as DatasetDocument
 from models.dataset import Document as DocumentModel
-from models.enums import CreatorUserRole, DatasetQuerySource
+from models.enums import CreatorUserRole, DatasetMetadataType, DatasetQuerySource
 from services.external_knowledge_service import ExternalDatasetService
 from services.feature_service import FeatureService
 
@@ -106,6 +107,31 @@ default_retrieval_model: DefaultRetrievalModelDict = {
 }
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_metadata_filter_value(value: Any, field_type: str | None) -> Any:
+    """Coerce the LLM-extracted metadata filter value into the form the SQL
+    filter expects.
+
+    The automatic-metadata-filter prompt only knows the bare field names (see
+    `_automatic_metadata_filter_func`), so a `time`-typed field's value is
+    often returned as a date string (e.g. ``"2024-01-01"``). The downstream
+    filter uses ``as_float()`` for ``time``/``number`` columns, so a date
+    string would raise
+    ``psycopg2.errors.InvalidTextRepresentation: invalid input syntax for
+    type double precision``. Convert a parseable date string to a Unix
+    timestamp here so the filter executes. The ``is``/``is not`` conditions
+    are left as strings (time fields are usually compared with ``before``/
+    ``after``/``≤``/``≥``).
+    """
+    if not isinstance(value, str):
+        return value
+    if field_type == DatasetMetadataType.TIME:
+        try:
+            return datetime.fromisoformat(value).timestamp()
+        except ValueError:
+            return value
+    return value
 
 
 class DatasetRetrieval:
@@ -1586,6 +1612,7 @@ class DatasetRetrieval:
         metadata_stmt = select(DatasetMetadata).where(DatasetMetadata.dataset_id.in_(dataset_ids))
         metadata_fields = session.scalars(metadata_stmt).all()
         all_metadata_fields = [metadata_field.name for metadata_field in metadata_fields]
+        metadata_field_types = {mf.name: mf.type for mf in metadata_fields}
         # get metadata model config
         if metadata_model_config is None:
             raise ValueError("metadata_model_config is required")
@@ -1626,7 +1653,10 @@ class DatasetRetrieval:
                         automatic_metadata_filters.append(
                             {
                                 "metadata_name": item.get("metadata_field_name"),
-                                "value": item.get("metadata_field_value"),
+                                "value": _coerce_metadata_filter_value(
+                                    item.get("metadata_field_value"),
+                                    metadata_field_types.get(item.get("metadata_field_name")),
+                                ),
                                 "condition": item.get("comparison_operator"),
                             }
                         )

--- a/api/tests/unit_tests/core/rag/retrieval/test_coerce_metadata_filter_value.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_coerce_metadata_filter_value.py
@@ -1,0 +1,57 @@
+"""Unit tests for `_coerce_metadata_filter_value`.
+
+The automatic metadata filter prompt only knows the bare field names, so a
+`time`-typed field's value is often returned as a date string. The
+downstream SQL filter uses `as_float()` for time/number columns, so a
+date string would raise a `psycopg2.errors.InvalidTextRepresentation`
+error. The helper converts a parseable date string to a Unix timestamp
+before the filter is applied.
+
+Regression for langgenius/dify#41597.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from core.rag.retrieval.dataset_retrieval import _coerce_metadata_filter_value
+from models.enums import DatasetMetadataType
+
+
+class TestCoerceMetadataFilterValue:
+    def test_time_iso_date_string_to_unix_timestamp(self) -> None:
+        # "2024-01-01" is the exact value from the issue body
+        result = _coerce_metadata_filter_value("2024-01-01", DatasetMetadataType.TIME)
+        assert isinstance(result, float)
+        assert result == datetime(2024, 1, 1).timestamp()
+
+    def test_time_iso_datetime_string_to_unix_timestamp(self) -> None:
+        result = _coerce_metadata_filter_value("2024-01-01T12:34:56", DatasetMetadataType.TIME)
+        assert isinstance(result, float)
+        assert result == datetime(2024, 1, 1, 12, 34, 56).timestamp()
+
+    def test_time_unparseable_string_passes_through(self) -> None:
+        # If the LLM emits something we cannot parse, do not raise — let the
+        # downstream filter surface the original error.
+        assert _coerce_metadata_filter_value("not-a-date", DatasetMetadataType.TIME) == "not-a-date"
+
+    def test_string_field_passes_through(self) -> None:
+        assert _coerce_metadata_filter_value("hello", DatasetMetadataType.STRING) == "hello"
+
+    def test_number_field_passes_through(self) -> None:
+        # Number values come from the LLM as strings or numbers already
+        assert _coerce_metadata_filter_value("42", DatasetMetadataType.NUMBER) == "42"
+        assert _coerce_metadata_filter_value(42, DatasetMetadataType.NUMBER) == 42
+
+    def test_none_passes_through(self) -> None:
+        assert _coerce_metadata_filter_value(None, DatasetMetadataType.TIME) is None
+
+    def test_non_string_with_time_field_passes_through(self) -> None:
+        # If the LLM already emitted a number for a time field (unlikely but
+        # possible), do not coerce
+        assert _coerce_metadata_filter_value(1.7e9, DatasetMetadataType.TIME) == 1.7e9
+
+    def test_none_field_type_passes_through(self) -> None:
+        # Defensive: if the field type is unknown (e.g. DatasetMetadata row
+        # missing for an edge case), do not coerce
+        assert _coerce_metadata_filter_value("2024-01-01", None) == "2024-01-01"


### PR DESCRIPTION
## Summary

Closes a 1.16.1 / `main` regression in the automatic-metadata-filter path. The filter prompt in `DatasetRetrieval._automatic_metadata_filter_func` only knows the bare metadata field names (the field `type` is never passed to the LLM), so a `time`-typed field's value is naturally returned as a date string the user mentioned in the query (e.g. `"2024-01-01"`).

`DatasetRetrieval.process_metadata_filter_func` uses `DatasetDocument.doc_metadata[...].as_float()` for `time`/`number` columns (because time metadata is stored/compared as a Unix timestamp). Feeding a date string into the float comparison raises:

```
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type double precision: "2024-01-0"
```

and the retrieval call fails.

Add a small module-level helper `_coerce_metadata_filter_value(value, field_type)` that converts a parseable ISO date string to a Unix timestamp when the field is `DatasetMetadataType.TIME`, and leaves the value unchanged for other field types. The helper runs on each filter value as it is appended to `automatic_metadata_filters`, before `process_metadata_filter_func` is called.

Fixes #41597

## Why this is a Python-side fix (option 2 of the issue body)

The issue body offers two fix options:

1. Pass field `type` to the LLM prompt so it emits a Unix timestamp directly.
2. Convert the extracted value to a Unix timestamp in Python after the LLM call.

Picked option 2 because it does not depend on the LLM following instructions in the prompt — the helper is deterministic, easy to test in isolation, and the user-facing field type is still preserved in the prompt follow-up that the issue body describes as a separate Phase 1. Option 1 is a follow-up (see "Future work").

## Changes

`api/core/rag/retrieval/dataset_retrieval.py`

- Import `datetime` at the top of the module.
- Import `DatasetMetadataType` from `models.enums`.
- Add a new module-level helper `_coerce_metadata_filter_value(value, field_type)`. When the value is a string and the field type is `DatasetMetadataType.TIME`, call `datetime.fromisoformat(value).timestamp()`. On `ValueError` (unparseable date), pass the original string through so the downstream error still surfaces. For all other field types, pass the value through unchanged.
- In `DatasetRetrieval._automatic_metadata_filter_func`, build a `metadata_field_types` map alongside the existing `all_metadata_fields` list, and run each LLM-extracted value through the new helper when appending to `automatic_metadata_filters`. The `process_metadata_filter_func` call site is unchanged (it now receives Unix timestamps for time fields).

No schema, API, or protocol change. The fix is internal to the LLM-extracted value lifetime.

## Tests

Eight new unit tests in a new file `api/tests/unit_tests/core/rag/retrieval/test_coerce_metadata_filter_value.py` (one `TestCoerceMetadataFilterValue` class):

- `test_time_iso_date_string_to_unix_timestamp` — a bare date string (`"2024-01-01"`, the exact value from the issue body) is converted to the matching `datetime(2024, 1, 1).timestamp()` float. **Regression for #41597.**
- `test_time_iso_datetime_string_to_unix_timestamp` — an ISO datetime string is also converted.
- `test_time_unparseable_string_passes_through` — an unparseable string is left as-is so the original downstream `ValueError` still surfaces.
- `test_string_field_passes_through` — string-typed fields are not coerced.
- `test_number_field_passes_through` — number-typed fields accept strings or numbers without coercion.
- `test_none_passes_through` — `None` values are left alone.
- `test_non_string_with_time_field_passes_through` — a number passed for a time field is left as-is.
- `test_none_field_type_passes_through` — defensive pass-through for an unknown/missing field type.

The test module fails to import without the source change (`ImportError: cannot import name '_coerce_metadata_filter_value'`), which is the regression signal. Verified by stashing only `dataset_retrieval.py` against the new tests, then restoring. 8/8 pass on the new test file.

## Verification

- `pytest tests/unit_tests/core/rag/retrieval/test_coerce_metadata_filter_value.py` — 8/8 pass.
- `ruff check` — clean.
- `ruff format --check` — clean.

## Risk

Low. The helper is additive and only converts a string to a float for `TIME`-typed fields. Number-typed fields are intentionally left alone (the LLM is more reliable for numbers and the existing test `test_number_field_passes_through` guards that boundary). Unparseable strings fall through to the existing downstream error path, so no behavior changes for malformed input.

## Future work (out of scope here)

1. Pass the field `type` (and an example value format) to the prompt so the LLM emits a Unix timestamp directly for `time` fields. The issue body lists this as the primary fix option; the Python-side coercion is a defense-in-depth that covers the cases where the LLM still emits a date string.
2. The same `_automatic_metadata_filter_func` passes the field name list to the prompt template. The template could also include a per-field schema line (e.g. `release_date (time, expected value format: Unix timestamp seconds)`) for the LLM's benefit. That is a prompt change, not a code change, and worth a follow-up PR once the schema is stable.
