### PR TITLE
refactor(models): remove the unread App.author_name db.session wrapper

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -703,10 +703,6 @@ class App(Base):
 
         return tags or []
 
-    @property
-    def author_name(self) -> str | None:
-        return self.author_name_with_session(session=db.session())
-
     def author_name_with_session(self, *, session: Session) -> str | None:
         if self.created_by:
             account = session.scalar(select(Account).where(Account.id == self.created_by))


### PR DESCRIPTION
## Summary

Part of #40372. Deletes `App.author_name` in `api/models/model.py`, a legacy `@property` whose entire body was `return self.author_name_with_session(session=db.session())`. The twin `author_name_with_session` is kept unchanged.

Same shape as my merged #41942 and #41964.

Claimed in https://github.com/langgenius/dify/issues/40372#issuecomment-5584206374.

## Why this is a pure deletion

Nothing reads the raw property. Every `.author_name` occurrence in `api/` has a different receiver:

| Site | Receiver |
|---|---|
| `tests/.../console/app/test_app_response_models.py:468` | `AppResponseView` |
| `tests/unit_tests/fields/test_dataset_fields.py:238` | `DatasetDetailResponse` |
| `tests/.../repositories/test_app_definition_query_repository.py:296` | the repository's result object |
| `tests/unit_tests/services/test_app_service.py:500` | `RecentAppListItem` |

`RecentAppListItem` (`services/app_service.py:140`) is a `@dataclass(frozen=True)` that declares `author_name: str | None` as its own field. That test also asserts the recent-apps query issues exactly **one** SELECT — a per-row lazy property would have broken that assertion, so the raw property demonstrably was not in play.

No `getattr`/`hasattr` on the name, and no `validation_alias` referencing it.

`Dataset.author_name` is a different accessor on a different model and is untouched.

## Verification

- `pytest tests/unit_tests/models/` — 423 passed, **identical to the `main` baseline** (2 pre-existing failures, 2 errors, unrelated)
- `pytest tests/unit_tests/services/test_app_service.py` — 33 passed, same on `main`
- `pytest tests/unit_tests/fields/test_dataset_fields.py` — 5 passed, same on `main`
- `pytest tests/unit_tests/repositories/test_app_definition_query_repository.py` — 22 passed, same on `main`
- `ruff check` / `ruff format --check` — clean
- `pyrefly check models/model.py` — 0 diagnostics
- `mypy --check-untyped-defs --disable-error-code=import-untyped models/model.py` — no issues
- `lint-imports` — 31 contracts kept, 0 broken
- `dev/lint_response_contracts.py --fail-on-mismatch` — 0 mismatch
- no net-new `getattr(` in the diff

`test_app_response_models.py` segfaults on my Windows box on clean `main`, so I could not run that one locally — relying on CI, as on my previous two PRs in this campaign.

---
This PR was written with AI assistance.
