### PR TITLE
fix(api): preserve full stem when truncating long upload filenames

### DIFF
--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -68,7 +68,12 @@ class FileService:
             raise ValueError("Filename contains invalid characters")
 
         if len(filename) > 200:
-            filename = filename.split(".")[0][:200] + "." + extension
+            # Truncate the stem (everything before the final extension), not
+            # just the text before the first dot, and don't append a bare
+            # "." when the name has no extension.
+            stem = os.path.splitext(filename)[0]
+            suffix = f".{extension}" if extension else ""
+            filename = stem[:200] + suffix
 
         # check if extension is in blacklist
         if extension and extension in dify_config.UPLOAD_FILE_EXTENSION_BLACKLIST:

--- a/api/tests/unit_tests/services/test_file_service.py
+++ b/api/tests/unit_tests/services/test_file_service.py
@@ -174,6 +174,45 @@ class TestFileService:
             assert result.name.endswith(".txt")
             assert db_session.get(UploadFile, result.id) is not None
 
+    def test_upload_file_long_multidot_filename_preserves_stem(self, file_service: FileService):
+        # A long name with several dots must keep everything up to the final
+        # extension (truncated to 200 chars), not just the text before the
+        # first dot.
+        stem = "quarterly.report." + "x" * 180 + ".final"
+        long_name = stem + ".pdf"
+        user = Account(name="Test Account", email="test@example.com")
+        user.id = "user_id"
+
+        with (
+            patch("services.file_service.storage"),
+            patch("services.file_service.extract_tenant_id") as mock_tenant,
+            patch("services.file_service.file_helpers.get_signed_file_url"),
+        ):
+            mock_tenant.return_value = "tenant"
+            result = file_service.upload_file(
+                filename=long_name, content=b"test", mimetype="application/pdf", user=user
+            )
+            assert result.name == stem[:200] + ".pdf"
+            assert len(result.name) == 204
+
+    def test_upload_file_long_filename_without_extension_has_no_trailing_dot(self, file_service: FileService):
+        # A long name with no extension must not gain a spurious trailing dot.
+        long_name = "y" * 250
+        user = Account(name="Test Account", email="test@example.com")
+        user.id = "user_id"
+
+        with (
+            patch("services.file_service.storage"),
+            patch("services.file_service.extract_tenant_id") as mock_tenant,
+            patch("services.file_service.file_helpers.get_signed_file_url"),
+        ):
+            mock_tenant.return_value = "tenant"
+            result = file_service.upload_file(
+                filename=long_name, content=b"test", mimetype="application/octet-stream", user=user
+            )
+            assert result.name == "y" * 200
+            assert not result.name.endswith(".")
+
     def test_upload_file_blocked_extension(self, file_service, config_overrides: Callable[..., None]):
         config_overrides(inner_UPLOAD_FILE_EXTENSION_BLACKLIST="exe")
         with pytest.raises(BlockedFileExtensionError):


### PR DESCRIPTION
## Summary

Fixes #41984

When an uploaded filename exceeds 200 characters, `FileService.upload_file` truncated it with `filename.split(".")[0][:200]`, which keeps only the text before the **first** dot:

- `quarterly.report.<180 chars>.final.pdf` (207 chars) was stored as `quarterly.pdf` - 194 characters of the user's filename silently discarded.
- A long filename with no extension gained a spurious trailing dot (`"y" * 250` was stored as `"yyy...yyy."`).

The fix truncates the `os.path.splitext` stem instead (everything before the final extension) and appends the extension only when one exists, so multi-dot names keep as much of the original name as fits in 200 stem characters.

This path is hit by every file upload (console, openapi, service API) since the filename comes straight from the multipart request.

## Test plan

- Two new regression tests in `api/tests/unit_tests/services/test_file_service.py`:
  - `test_upload_file_long_multidot_filename_preserves_stem` - fails before the fix (stored `quarterly.pdf`), passes after (stores the 200-char stem + `.pdf`).
  - `test_upload_file_long_filename_without_extension_has_no_trailing_dot` - fails before (trailing dot), passes after.
- Full `tests/unit_tests/services/test_file_service.py` suite: 38 passed (both new tests verified to fail on unfixed code first).
- `ruff check` clean on both touched files.

Environment caveat: tests were run locally with pytest against an in-memory SQLite session; no docker compose stack was started. CI should cover the rest.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes