### PR TITLE
fix(rag): preserve angle brackets in code blocks during markdown extraction

### DIFF
--- a/api/core/rag/extractor/markdown_extractor.py
+++ b/api/core/rag/extractor/markdown_extractor.py
@@ -73,13 +73,13 @@ class MarkdownExtractor(BaseExtractor):
                 current_header = line
                 current_text = ""
             else:
-                current_text += line + "\n"
+                # Strip HTML tags from prose lines only. Fenced code blocks are
+                # accumulated verbatim above, so `<...>` sequences in code (e.g.
+                # comparisons or generics) are preserved.
+                current_text += re.sub(r"<.*?>", "", line) + "\n"
         markdown_tups.append((current_header, current_text))
 
-        markdown_tups = [
-            (re.sub(r"#", "", key).strip() if key else None, re.sub(r"<.*?>", "", value))
-            for key, value in markdown_tups
-        ]
+        markdown_tups = [(re.sub(r"#", "", key).strip() if key else None, value) for key, value in markdown_tups]
 
         return markdown_tups
 

--- a/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
@@ -47,6 +47,36 @@ after
         assert tups[1][0] == "Header"
         assert "# this is not a heading" in tups[1][1]
 
+    def test_markdown_to_tups_preserves_angle_brackets_in_code_blocks(self):
+        markdown = """# Comparison
+before
+```python
+if a < b > c:
+    process(List<String>, Map<String, Integer>)
+```
+after
+"""
+        extractor = MarkdownExtractor(file_path="dummy_path")
+
+        tups = extractor.markdown_to_tups(markdown)
+
+        assert len(tups) == 2
+        assert tups[1][0] == "Comparison"
+        assert "if a < b > c:" in tups[1][1]
+        assert "process(List<String>, Map<String, Integer>)" in tups[1][1]
+
+    def test_markdown_to_tups_still_strips_html_tags_from_prose(self):
+        markdown = """# Header
+Text with <b>bold</b> and <span class="x">inline</span> tags.
+"""
+        extractor = MarkdownExtractor(file_path="dummy_path")
+
+        tups = extractor.markdown_to_tups(markdown)
+
+        assert len(tups) == 2
+        assert tups[1][0] == "Header"
+        assert tups[1][1].strip() == "Text with bold and inline tags."
+
     def test_remove_images_and_hyperlinks(self):
         extractor = MarkdownExtractor(file_path="dummy_path")
 


### PR DESCRIPTION
Fixes #41986

## Summary

`MarkdownExtractor.markdown_to_tups` tracks fenced code blocks so that `#` inside them is not treated as a heading, but the trailing `re.sub(r"<.*?>", "", value)` ran over the whole accumulated section, silently deleting `<...>` sequences inside code blocks. For example, an uploaded Markdown document containing

    if a < b > c:
        process(List<String>, Map<String, Integer>)

was indexed as

    if a  c:
        process(List, Map)

This strips HTML tags per prose line while accumulating (skipping fenced code block lines). Prose behavior is unchanged (the regex cannot match across lines anyway), and code block content is preserved verbatim.

Regression tests added in `tests/unit_tests/core/rag/extractor/test_markdown_extractor.py`:

- `test_markdown_to_tups_preserves_angle_brackets_in_code_blocks` (fails before the fix, passes after)
- `test_markdown_to_tups_still_strips_html_tags_from_prose` (guards the intended prose behavior)

Verified locally: the new code-block test fails on the unpatched code and passes with the fix; the full extractor suite passes (10 passed in `test_markdown_extractor.py`, 229 passed in `tests/unit_tests/core/rag/extractor/`); `ruff check` is clean.

## Screenshots

| Before | After |
|--------|-------|
| `if a  c:` / `process(List, Map)` | `if a < b > c:` / `process(List<String>, Map<String, Integer>)` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

## Environment note

Tests were run with pytest inside a Python 3.12 venv with the project's pinned dependencies (`uv pip install` of the api requirements); no external services were required for this suite.