### PR TITLE
fix(rag): keep embedding-to-text alignment when a NaN vector is skipped

### DIFF
--- a/api/core/rag/embedding/cached_embedding.py
+++ b/api/core/rag/embedding/cached_embedding.py
@@ -62,14 +62,14 @@ class CacheEmbedding(Embeddings):
                     if model_schema and ModelPropertyKey.MAX_CHUNKS in model_schema.model_properties
                     else 1
                 )
-                for i in range(0, len(embedding_queue_texts), max_chunks):
-                    batch_texts = embedding_queue_texts[i : i + max_chunks]
+                for batch_start in range(0, len(embedding_queue_texts), max_chunks):
+                    batch_texts = embedding_queue_texts[batch_start : batch_start + max_chunks]
 
                     embedding_result = self._model_instance.invoke_text_embedding(
                         texts=batch_texts, input_type=EmbeddingInputType.DOCUMENT
                     )
 
-                    for vector in embedding_result.embeddings:
+                    for batch_offset, vector in enumerate(embedding_result.embeddings):
                         try:
                             # FIXME: type ignore for numpy here
                             normalized_embedding = (vector / np.linalg.norm(vector)).tolist()  # type: ignore
@@ -78,14 +78,17 @@ class CacheEmbedding(Embeddings):
                                 # for issue #11827  float values are not json compliant
                                 logger.warning("Normalized embedding is nan: %s", normalized_embedding)
                                 continue
-                            embedding_queue_embeddings.append(normalized_embedding)
+                            # Keep the queue position attached so a skipped NaN vector
+                            # cannot shift later embeddings onto the wrong texts.
+                            embedding_queue_embeddings.append((batch_start + batch_offset, normalized_embedding))
                         except IntegrityError:
                             db.session.rollback()
                         except Exception:
                             logger.exception("Failed transform embedding")
                 cache_embeddings = []
                 try:
-                    for i, n_embedding in zip(embedding_queue_indices, embedding_queue_embeddings):
+                    for queue_position, n_embedding in embedding_queue_embeddings:
+                        i = embedding_queue_indices[queue_position]
                         text_embeddings[i] = n_embedding
                         hash = helper.generate_text_hash(texts[i])
                         if hash not in cache_embeddings:
@@ -144,15 +147,17 @@ class CacheEmbedding(Embeddings):
                     if model_schema and ModelPropertyKey.MAX_CHUNKS in model_schema.model_properties
                     else 1
                 )
-                for i in range(0, len(embedding_queue_multimodel_documents), max_chunks):
-                    batch_multimodel_documents = embedding_queue_multimodel_documents[i : i + max_chunks]
+                for batch_start in range(0, len(embedding_queue_multimodel_documents), max_chunks):
+                    batch_multimodel_documents = embedding_queue_multimodel_documents[
+                        batch_start : batch_start + max_chunks
+                    ]
 
                     embedding_result = self._model_instance.invoke_multimodal_embedding(
                         multimodel_documents=batch_multimodel_documents,
                         input_type=EmbeddingInputType.DOCUMENT,
                     )
 
-                    for vector in embedding_result.embeddings:
+                    for batch_offset, vector in enumerate(embedding_result.embeddings):
                         try:
                             # FIXME: type ignore for numpy here
                             normalized_embedding = (vector / np.linalg.norm(vector)).tolist()  # type: ignore
@@ -161,14 +166,17 @@ class CacheEmbedding(Embeddings):
                                 # for issue #11827  float values are not json compliant
                                 logger.warning("Normalized embedding is nan: %s", normalized_embedding)
                                 continue
-                            embedding_queue_embeddings.append(normalized_embedding)
+                            # Keep the queue position attached so a skipped NaN vector
+                            # cannot shift later embeddings onto the wrong documents.
+                            embedding_queue_embeddings.append((batch_start + batch_offset, normalized_embedding))
                         except IntegrityError:
                             db.session.rollback()
                         except Exception:
                             logger.exception("Failed transform embedding")
                 cache_embeddings = []
                 try:
-                    for i, n_embedding in zip(embedding_queue_indices, embedding_queue_embeddings):
+                    for queue_position, n_embedding in embedding_queue_embeddings:
+                        i = embedding_queue_indices[queue_position]
                         multimodel_embeddings[i] = n_embedding
                         file_id = multimodel_documents[i]["file_id"]
                         if file_id not in cache_embeddings:

--- a/api/tests/unit_tests/core/rag/embedding/test_cached_embedding.py
+++ b/api/tests/unit_tests/core/rag/embedding/test_cached_embedding.py
@@ -263,6 +263,55 @@ class TestCacheEmbeddingMultimodalDocuments:
 
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
+    def test_embed_multimodal_documents_nan_vector_does_not_shift_following_embeddings(
+        self,
+        mock_model_instance,
+        embedding_session: Session,
+    ):
+        """A skipped NaN vector must not shift later embeddings onto the wrong documents."""
+        cache_embedding = CacheEmbedding(mock_model_instance)
+        documents = [{"file_id": "first"}, {"file_id": "nan"}, {"file_id": "third"}]
+
+        first_vector = np.random.randn(1536).tolist()
+        nan_vector = [0.0] * 1536  # zero vector normalizes to NaN
+        third_vector = np.random.randn(1536).tolist()
+
+        usage = EmbeddingUsage(
+            tokens=30,
+            total_tokens=30,
+            unit_price=Decimal("0.0001"),
+            price_unit=Decimal(1000),
+            total_price=Decimal("0.000003"),
+            currency="USD",
+            latency=0.5,
+        )
+
+        embedding_result = EmbeddingResult(
+            model="vision-embedding-model",
+            embeddings=[first_vector, nan_vector, third_vector],
+            usage=usage,
+        )
+
+        mock_model_instance.invoke_multimodal_embedding.return_value = embedding_result
+
+        result = cache_embedding.embed_multimodal_documents(documents)
+
+        expected_first = (np.array(first_vector) / np.linalg.norm(first_vector)).tolist()
+        expected_third = (np.array(third_vector) / np.linalg.norm(third_vector)).tolist()
+        assert result[0] == expected_first
+        assert result[1] is None
+        assert result[2] == expected_third
+
+        # The cache must not persist an embedding under the skipped document's id.
+        assert embedding_session.scalar(select(func.count()).select_from(Embedding)) == 2
+        persisted_first = embedding_session.scalar(select(Embedding).where(Embedding.hash == "first"))
+        persisted_third = embedding_session.scalar(select(Embedding).where(Embedding.hash == "third"))
+        assert persisted_first is not None
+        assert persisted_first.get_embedding() == expected_first
+        assert persisted_third is not None
+        assert persisted_third.get_embedding() == expected_third
+        assert embedding_session.scalar(select(Embedding).where(Embedding.hash == "nan")) is None
+
     def test_embed_multimodal_documents_large_batch(self, mock_model_instance, embedding_session: Session):
         """Test embedding large batch of multimodal documents respecting MAX_CHUNKS."""
         cache_embedding = CacheEmbedding(mock_model_instance)
@@ -351,6 +400,80 @@ class TestCacheEmbeddingMultimodalDocuments:
         assert len(result) == 1
         assert not embedding_session.in_transaction()
         assert embedding_session.scalar(select(func.count()).select_from(Embedding)) == 0
+
+
+class TestCacheEmbeddingDocuments:
+    """Test suite for CacheEmbedding.embed_documents (text path)."""
+
+    @pytest.fixture
+    def mock_model_instance(self):
+        model_instance = Mock()
+        model_instance.model = "text-embedding-model"
+        model_instance.model_name = "text-embedding-model"
+        model_instance.provider = "openai"
+        model_instance.credentials = {"api_key": "test-key"}
+
+        model_type_instance = Mock()
+        model_instance.model_type_instance = model_type_instance
+
+        model_schema = Mock()
+        model_schema.model_properties = {ModelPropertyKey.MAX_CHUNKS: 10}
+        model_type_instance.get_model_schema.return_value = model_schema
+
+        return model_instance
+
+    def test_embed_documents_nan_vector_does_not_shift_following_embeddings(
+        self,
+        mock_model_instance,
+        embedding_session: Session,
+    ):
+        """A skipped NaN vector must not shift later embeddings onto the wrong texts or cache keys."""
+        from libs import helper
+
+        cache_embedding = CacheEmbedding(mock_model_instance)
+        texts = ["alpha", "beta", "gamma"]
+
+        alpha_vector = np.random.randn(1536).tolist()
+        zero_vector = [0.0] * 1536  # zero vector normalizes to NaN
+        gamma_vector = np.random.randn(1536).tolist()
+
+        usage = EmbeddingUsage(
+            tokens=30,
+            total_tokens=30,
+            unit_price=Decimal("0.0001"),
+            price_unit=Decimal(1000),
+            total_price=Decimal("0.000003"),
+            currency="USD",
+            latency=0.5,
+        )
+
+        embedding_result = EmbeddingResult(
+            model="text-embedding-model",
+            embeddings=[alpha_vector, zero_vector, gamma_vector],
+            usage=usage,
+        )
+
+        mock_model_instance.invoke_text_embedding.return_value = embedding_result
+
+        result = cache_embedding.embed_documents(texts)
+
+        expected_alpha = (np.array(alpha_vector) / np.linalg.norm(alpha_vector)).tolist()
+        expected_gamma = (np.array(gamma_vector) / np.linalg.norm(gamma_vector)).tolist()
+        assert result[0] == expected_alpha
+        assert result[1] is None
+        assert result[2] == expected_gamma
+
+        # The cache must not persist gamma's vector under beta's text hash.
+        assert embedding_session.scalar(select(func.count()).select_from(Embedding)) == 2
+        persisted_beta = embedding_session.scalar(
+            select(Embedding).where(Embedding.hash == helper.generate_text_hash("beta"))
+        )
+        assert persisted_beta is None
+        persisted_gamma = embedding_session.scalar(
+            select(Embedding).where(Embedding.hash == helper.generate_text_hash("gamma"))
+        )
+        assert persisted_gamma is not None
+        assert persisted_gamma.get_embedding() == expected_gamma
 
 
 class TestCacheEmbeddingMultimodalQuery:


### PR DESCRIPTION
Fixes #41988

## Summary

`CacheEmbedding.embed_documents` and `embed_multimodal_documents` collect normalized embeddings into a list, skipping vectors that normalize to NaN (the guard added for #11827). The skipped vector shrinks the list, but the later `zip(embedding_queue_indices, embedding_queue_embeddings)` assumes 1:1 alignment, so every embedding after a skipped one is assigned to the previous text/document:

- `["alpha", "beta", "gamma"]` with a zero (NaN-normalizing) vector for `"beta"` returns `[v_alpha, v_gamma, None]` — `"beta"` gets gamma's embedding, `"gamma"` gets `None`
- worse, the embedding cache then persists `hash("beta") -> v_gamma`, permanently serving gamma's vector for the text `"beta"` on all future lookups

The fix attaches the queue position to each collected embedding, so a skipped NaN vector leaves only its own slot empty (`None`) and cannot shift the following embeddings onto the wrong texts or cache keys.

Regression tests added in `tests/unit_tests/core/rag/embedding/test_cached_embedding.py` (both fail before the fix, pass after):

- `test_embed_documents_nan_vector_does_not_shift_following_embeddings` (text path, including cache-key assertions)
- `test_embed_multimodal_documents_nan_vector_does_not_shift_following_embeddings` (multimodal path)

The pre-existing `test_embed_multimodal_documents_nan_handling` (NaN in last position) still passes unchanged.

Verified locally: full embedding suite passes (60 passed in `tests/unit_tests/core/rag/embedding/`); `ruff check` is clean.

## Screenshots

| Before | After |
|--------|-------|
| `[v_alpha, v_gamma, None]`, cache `hash(beta) -> v_gamma` | `[v_alpha, None, v_gamma]`, cache holds only correct mappings |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

## Environment note

Tests were run with pytest inside a Python 3.12 venv with the project's pinned dependencies (`uv pip install` of the api requirements); the SQLite-backed `sqlite_session` fixture is used, no external services required.