### PR TITLE
fix: escape pipe characters in Word extractor table cells

### DIFF
--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -222,7 +222,8 @@ class WordExtractor(BaseExtractor):
                 break
             # get the correct cell
             cell = row.cells[col_index]
-            cell_content = self._parse_cell(cell, image_map).strip()
+            # Escape pipes so cell content cannot break the markdown table structure
+            cell_content = self._parse_cell(cell, image_map).strip().replace("|", "\\|")
             cell_colspan = cell.grid_span or 1
             for i in range(cell_colspan):
                 if col_index + i < total_cols:

--- a/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
@@ -3,6 +3,7 @@
 import io
 import logging
 import os
+import re
 import tempfile
 from collections import UserDict
 from collections.abc import Generator
@@ -820,3 +821,36 @@ def test_parse_cell_paragraph_hyperlink_in_table_cell_mailto():
     finally:
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
+
+
+def _generate_table_with_pipe_cells():
+    doc = Document()
+    table = doc.add_table(rows=2, cols=2)
+    table.style = "Table Grid"
+    table.cell(0, 0).text = "Name"
+    table.cell(0, 1).text = "Formula"
+    table.cell(1, 0).text = "OR gate"
+    table.cell(1, 1).text = "a | b"
+    return doc.tables[0]
+
+
+def test_table_to_markdown_escapes_pipes():
+    table = _generate_table_with_pipe_cells()
+    extractor = object.__new__(WordExtractor)
+    markdown = extractor._table_to_markdown(table, {})
+
+    lines = markdown.splitlines()
+    assert lines[2] == "| OR gate | a \\| b |"
+    # Every row must have the same number of unescaped pipe separators,
+    # otherwise markdown renderers treat the row as a different column count.
+    for line in lines:
+        assert len(re.findall(r"(?<!\\)\|", line)) == 3
+
+
+def test_parse_row_escapes_pipes_in_header():
+    doc = Document()
+    table = doc.add_table(rows=1, cols=1)
+    table.style = "Table Grid"
+    table.cell(0, 0).text = "col | name"
+    extractor = object.__new__(WordExtractor)
+    assert extractor._parse_row(table.rows[0], {}, 1) == ["col \\| name"]


### PR DESCRIPTION
Fixes #41990

## What

`WordExtractor._parse_row` embedded cell text into the generated Markdown table verbatim. A cell containing a literal `|` (for example a formula like `a | b`) added an extra column separator to that row, so the rendered table was corrupted: the row parsed as a different column count than the header and the cell content shifted.

## Fix

Escape pipe characters in cell content (`|` -> `\|`) when building each row in `_parse_row`, which covers both header and data rows.

## Verification

- Reproduced on current `main`: a 2x2 table with cell text `a | b` produced the row `| OR gate | a | b |` (4 separators vs 3 in the header).
- Added two regression tests in `tests/unit_tests/core/rag/extractor/test_word_extractor.py`:
  - `test_table_to_markdown_escapes_pipes`
  - `test_parse_row_escapes_pipes_in_header`
  Both fail before the fix and pass after.
- Full extractor suite: `pytest tests/unit_tests/core/rag/extractor/` - 229 passed.
- `ruff check` clean on both changed files.

## Environment note

Tests were run locally with Python 3.12 against the unit test suite only; no external services are required for this change.