### PR TITLE
refactor(models): remove the App.bound_agent_id and App.is_agent wrappers

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -492,10 +492,6 @@ class App(Base):
 
         return None
 
-    @property
-    def bound_agent_id(self) -> str | None:
-        return self.bound_agent_id_with_session(session=db.session())
-
     def bound_agent_id_with_session(self, *, session: Session) -> str | None:
         """For an Agent App (mode=agent), the roster Agent it is backed by.
 
@@ -549,10 +545,6 @@ class App(Base):
     @property
     def tenant(self) -> Tenant | None:
         return db.session.scalar(select(Tenant).where(Tenant.id == self.tenant_id))
-
-    @property
-    def is_agent(self) -> bool:
-        return self.is_agent_with_session(session=db.session())
 
     def is_agent_with_session(self, *, session: Session) -> bool:
         """Detect legacy agent mode, committing the compatible app mode through the supplied session."""

--- a/api/tests/unit_tests/controllers/console/app/test_model_config_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_model_config_api.py
@@ -25,8 +25,9 @@ def _poison_implicit_app_config_properties(monkeypatch: pytest.MonkeyPatch) -> N
     def fail(_app: App) -> Never:
         raise AssertionError("implicit App model-config property was accessed")
 
+    # `App.is_agent` used to be poisoned here too. It no longer exists as an
+    # implicit property, so its absence enforces the same thing outright.
     monkeypatch.setattr(App, "app_model_config", property(fail))
-    monkeypatch.setattr(App, "is_agent", property(fail))
 
 
 @pytest.mark.parametrize("app_mode", [AppMode.CHAT, AppMode.COMPLETION])

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -16,9 +16,8 @@ from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.orm import Session, scoped_session
+from sqlalchemy.orm import Session
 
-from models import model as model_module
 from models.dataset import DatasetCollectionBinding
 from models.enums import CollectionBindingType, ConversationFromSource, CustomizeTokenStrategy
 from models.model import (
@@ -166,8 +165,8 @@ class TestAppModelValidation:
         assert result == ""
 
     @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
-    def test_app_is_agent_property_false(self, sqlite_session: Session, monkeypatch: pytest.MonkeyPatch):
-        """Test is_agent property returns False when not configured as agent."""
+    def test_app_is_agent_false_when_not_configured_as_agent(self, sqlite_session: Session):
+        """`is_agent_with_session` returns False when the config has no agent mode."""
         # Arrange
         app = App(
             tenant_id=str(uuid4()),
@@ -180,11 +179,9 @@ class TestAppModelValidation:
         )
         sqlite_session.add(app)
         sqlite_session.flush()
-        session_registry = scoped_session(lambda: sqlite_session)
-        monkeypatch.setattr(model_module.db, "session", session_registry)
 
         # Act
-        result = app.is_agent
+        result = app.is_agent_with_session(session=sqlite_session)
 
         # Assert
         assert result is False

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -639,13 +639,15 @@ class TestAgentAppType:
         assert searched_counts.drafts == 1
 
     def test_bound_agent_id_is_none_for_non_agent_app(self):
-        """Non-agent apps short-circuit without touching the DB."""
+        """Non-agent apps short-circuit before the session is used."""
         from models.model import App, AppMode
 
         app = App(
             mode=AppMode.CHAT,
         )
-        assert app.bound_agent_id is None
+        # `agent_app_binding_with_session` returns before touching the session
+        # for a non-agent app, so passing None still exercises that path.
+        assert app.bound_agent_id_with_session(session=None) is None  # type: ignore[arg-type]
 
     def test_update_agent_app_syncs_backing_agent_identity(self, sqlite_session: Session):
         app, backing_agent = _persist_agent_app(sqlite_session)


### PR DESCRIPTION
## Summary

Part of #40372. Deletes two legacy `@property` wrappers on `App` in `api/models/model.py`:

| Removed | Kept (unchanged) |
|---|---|
| `App.bound_agent_id` | `bound_agent_id_with_session(self, *, session: Session)` |
| `App.is_agent` | `is_agent_with_session(self, *, session: Session)` |

Both bodies were `return self.<name>_with_session(session=db.session())`. Same shape as my merged #41942 and #41964.

Claimed in https://github.com/langgenius/dify/issues/40372#issuecomment-5585872421.

## Readers

No production code reads either property. The apparent readers:

| Site | What it actually is |
|---|---|
| `test_app_response_models.py:459,464` | `AppResponseView`, not the model — untouched |
| `test_hitl_service_api.py:403` | sets `is_agent` on a `MagicMock` — untouched |
| `test_app_service.py:648` | real read — updated |
| `test_app_models.py:187` | real read — updated |

## The two test changes

**`test_bound_agent_id_is_none_for_non_agent_app`** asserts a non-agent app short-circuits without a DB round trip. `agent_app_binding_with_session` returns on `self.mode != AppMode.AGENT` before the session is used, so the test now calls the twin with `session=None` and still proves exactly that — arguably more directly than before, since a session that cannot be used is stronger evidence than one that merely isn't.

**`test_app_is_agent_property_false`** had a `monkeypatch.setattr(model_module.db, "session", scoped_session(...))` whose only purpose was to make the wrapper resolve. Calling the twin drops that scaffolding, along with the now-unused `scoped_session` and `model_module` imports. Renamed to `test_app_is_agent_false_when_not_configured_as_agent` to match what it asserts.

## Verification

- `pytest tests/unit_tests/models/` — 428 passed, **identical to the `main` baseline** (2 pre-existing failures, 2 errors, unrelated)
- `pytest tests/unit_tests/services/test_app_service.py` — 33 passed, same on `main`
- `ruff check` / `ruff format --check` — clean
- `pyrefly check models/model.py` — 0 diagnostics
- `mypy --check-untyped-defs --disable-error-code=import-untyped models/model.py` — no issues
- `lint-imports` — 31 contracts kept, 0 broken
- `dev/lint_response_contracts.py --fail-on-mismatch` — 0 mismatch
- no net-new `getattr(` in the diff

`test_hitl_service_api.py` and `test_app_response_models.py` both segfault on my Windows box **on clean `main`**, so I could not run them locally. Neither touches the raw properties — one uses `MagicMock`, the other `AppResponseView` — but I'm relying on CI to confirm.

---
This PR was written with AI assistance.
