### PR TITLE
refactor(api): remove InstalledApp implicit-session accessor

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1018,10 +1018,6 @@ class InstalledApp(TypeBase):
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), init=False
     )
 
-    @property
-    def app(self) -> App | None:
-        return self.app_with_session(session=db.session())
-
     def app_with_session(self, *, session: Session) -> App | None:
         return session.scalar(select(App).where(App.id == self.app_id))
 

--- a/api/tests/unit_tests/controllers/console/explore/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_wraps.py
@@ -128,8 +128,9 @@ def test_installed_app_required_success(
         result = view(installed_app.id)
 
     assert result.id == installed_app.id
-    assert result.app is not None
-    assert result.app.id == app.id
+    app_model = result.app_with_session(session=sqlite_session)
+    assert app_model is not None
+    assert app_model.id == app.id
 
 
 def test_user_allowed_to_access_app_denied():


### PR DESCRIPTION
## Summary

Part of #40372; limited to `InstalledApp.app`. The umbrella issue is unassigned.

Remove the legacy property that obtains `db.session()` implicitly, and update its remaining unit-test reader to pass the existing SQLite session to `app_with_session`. Production readers already use the explicit-session method; its lookup implementation is unchanged.

## Validation

- 12 tests passed in `api/tests/unit_tests/controllers/console/explore/test_wraps.py`.
- Ruff check and format check passed for both changed files; `git diff --check` passed.
- Local Python 3.12.14 environment used locked dependencies, with lock-pinned `pydantic-settings==2.14.2` and `cachetools==6.2.6` installed ephemerally to satisfy test-startup imports. No dependency manifests or lockfiles changed.
- Full backend lint/type-check and integration suites were not run for this two-file change. Existing deprecation and optional-libmagic warnings remain.

## Checklist

- [x] Existing issue linked; this PR addresses only one slice.
- [x] Existing affected unit test updated and focused checks passed.
- [x] I understand this PR may be closed without prior maintainer agreement or assignment.
- [ ] Full `make lint && make type-check` (not run).

From Codex
