### PR TITLE
fix(rag,extractors): resolve markdown table corruption and Content-Type parsing across document extractors

### DIFF
--- a/api/core/rag/extractor/extract_processor.py
+++ b/api/core/rag/extractor/extract_processor.py
@@ -84,7 +84,8 @@ class ExtractProcessor:
             if not suffix and suffix != ".":
                 # get content-type
                 if response.headers.get("Content-Type"):
-                    suffix = "." + response.headers.get("Content-Type").split("/")[-1]
+                    raw_ct = response.headers.get("Content-Type", "").split(";")[0].strip()
+                    suffix = "." + raw_ct.split("/")[-1]
                 else:
                     content_disposition = response.headers.get("Content-Disposition")
                     filename_match = re.search(r'filename="([^"]+)"', content_disposition)

--- a/api/core/rag/extractor/markdown_extractor.py
+++ b/api/core/rag/extractor/markdown_extractor.py
@@ -76,8 +76,22 @@ class MarkdownExtractor(BaseExtractor):
                 current_text += line + "\n"
         markdown_tups.append((current_header, current_text))
 
+        def _clean_markdown_text(text: str) -> str:
+            lines = text.split("\n")
+            cleaned_lines = []
+            in_code = False
+            for line in lines:
+                if line.strip().startswith("```"):
+                    in_code = not in_code
+                    cleaned_lines.append(line)
+                elif in_code:
+                    cleaned_lines.append(line)
+                else:
+                    cleaned_lines.append(re.sub(r"<.*?>", "", line))
+            return "\n".join(cleaned_lines)
+
         markdown_tups = [
-            (re.sub(r"#", "", key).strip() if key else None, re.sub(r"<.*?>", "", value))
+            (re.sub(r"#", "", key).strip() if key else None, _clean_markdown_text(value))
             for key, value in markdown_tups
         ]
 

--- a/api/core/rag/extractor/notion_extractor.py
+++ b/api/core/rag/extractor/notion_extractor.py
@@ -317,9 +317,12 @@ class NotionExtractor(BaseExtractor):
             table_header_cells = data["results"][0]["table_row"]["cells"]
             for table_header_cell in table_header_cells:
                 if table_header_cell:
-                    for table_header_cell_text in table_header_cell:
-                        text = table_header_cell_text["text"]["content"]
-                        table_header_cell_texts.append(text)
+                    cell_text = "".join(
+                        item["text"]["content"]
+                        for item in table_header_cell
+                        if isinstance(item, dict) and "text" in item and "content" in item.get("text", {})
+                    ).replace("|", "\\|")
+                    table_header_cell_texts.append(cell_text)
                 else:
                     table_header_cell_texts.append("")
             # Initialize Markdown table with headers
@@ -333,9 +336,14 @@ class NotionExtractor(BaseExtractor):
                 table_column_cells = data["results"][i + 1]["table_row"]["cells"]
                 for j in range(len(table_column_cells)):
                     if table_column_cells[j]:
-                        for table_column_cell_text in table_column_cells[j]:
-                            column_text = table_column_cell_text["text"]["content"]
-                            column_texts.append(column_text)
+                        cell_text = "".join(
+                            item["text"]["content"]
+                            for item in table_column_cells[j]
+                            if isinstance(item, dict) and "text" in item and "content" in item.get("text", {})
+                        ).replace("|", "\\|")
+                        column_texts.append(cell_text)
+                    else:
+                        column_texts.append("")
                 # Add row to Markdown table
                 markdown_table += "| " + " | ".join(column_texts) + " |\n"
             result_lines_arr.append(markdown_table)

--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -222,7 +222,7 @@ class WordExtractor(BaseExtractor):
                 break
             # get the correct cell
             cell = row.cells[col_index]
-            cell_content = self._parse_cell(cell, image_map).strip()
+            cell_content = self._parse_cell(cell, image_map).strip().replace('|', '\\|')
             cell_colspan = cell.grid_span or 1
             for i in range(cell_colspan):
                 if col_index + i < total_cols:

--- a/api/tests/unit_tests/core/rag/extractor/test_extract_processor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_extract_processor.py
@@ -352,3 +352,10 @@ class TestExtractProcessorDatasourceRouting:
     def test_extract_requires_website_info(self):
         with pytest.raises(AssertionError, match="website_info is required"):
             ExtractProcessor.extract(SimpleNamespace(datasource_type=DatasourceType.WEBSITE, website_info=None))
+
+
+    def test_content_type_with_parameters_parsing(self):
+        raw_ct = "application/pdf; charset=binary"
+        content_type = raw_ct.split(";")[0].strip()
+        suffix = "." + content_type.split("/")[-1]
+        assert suffix == ".pdf"

--- a/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
@@ -128,3 +128,27 @@ after
         docs = extractor.extract()
 
         assert [doc.page_content for doc in docs] == ["plain", "\n\nHeader\nvalue"]
+
+
+    def test_markdown_code_block_angle_brackets_preserved(self):
+        extractor = MarkdownExtractor(file_path="dummy.md")
+        sample_text = """# Header
+Here is some <b>bold</b> text.
+
+```cpp
+#include <iostream>
+#include <vector>
+
+int main() {
+    std::vector<int> nums;
+    return 0;
+}
+```
+"""
+        tups = extractor.markdown_to_tups(sample_text)
+        assert len(tups) == 1
+        header, content = tups[0]
+        assert header == "Header"
+        assert "Here is some bold text." in content
+        assert "#include <iostream>" in content
+        assert "std::vector<int> nums;" in content

--- a/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
@@ -543,3 +543,42 @@ class TestNotionMetadataAndCredentialMethods:
         monkeypatch.setattr(notion_extractor, "DatasourceProviderService", FakeProviderServiceFound)
 
         assert notion_extractor.NotionExtractor._get_access_token("tenant", "cred") == "token-from-credential"
+
+
+def test_notion_read_table_rows_mixed_formatting_and_empty_cells():
+    extractor = object.__new__(NotionExtractor)
+    extractor._notion_access_token = "test_token"
+
+    mock_response_data = {
+        "results": [
+            {
+                "table_row": {
+                    "cells": [
+                        [{"text": {"content": "Header 1"}}],
+                        [{"text": {"content": "Header "}}, {"text": {"content": "2 (Bold)"}}],
+                    ]
+                }
+            },
+            {
+                "table_row": {
+                    "cells": [
+                        [{"text": {"content": "Part A "}}, {"text": {"content": "Part B"}}],
+                        [],
+                    ]
+                }
+            }
+        ],
+        "next_cursor": None
+    }
+
+    mock_res = MagicMock()
+    mock_res.json.return_value = mock_response_data
+
+    with patch("httpx.request", return_value=mock_res):
+        table_md = extractor._read_table_rows("mock_block_id")
+
+    lines = [l.strip() for l in table_md.strip().split("\n")]
+    assert len(lines) == 3
+    assert lines[0] == "| Header 1 | Header 2 (Bold) |"
+    assert lines[1] == "| --- | --- |"
+    assert lines[2] == "| Part A Part B |  |"

--- a/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
@@ -820,3 +820,18 @@ def test_parse_cell_paragraph_hyperlink_in_table_cell_mailto():
     finally:
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
+
+
+def test_word_table_pipe_escaping():
+    extractor = object.__new__(WordExtractor)
+    extractor._parse_cell = lambda cell, image_map: "a | b"
+    
+    mock_row = MagicMock()
+    mock_cell_1 = MagicMock()
+    mock_cell_1.grid_span = 1
+    mock_cell_2 = MagicMock()
+    mock_cell_2.grid_span = 1
+    mock_row.cells = [mock_cell_1, mock_cell_2]
+
+    row_cells = extractor._parse_row(mock_row, {}, 2)
+    assert row_cells == ["a \\| b", "a \\| b"]


### PR DESCRIPTION
### Summary
Fixes multiple table formatting and header parsing issues across RAG document extractors (#41992, #41990, #41986, #41955):
1. **Notion Extractor (#41992)**: Concatenate all rich-text segments within each Notion table cell into a single column string, preserve empty cells (`[]`) without column shifting, and escape pipe characters.
2. **Word Extractor (#41990)**: Escape pipe characters (`|`) in Word table cells to prevent table delimiter breakage in generated Markdown tables.
3. **Markdown Extractor (#41986)**: Preserve angle brackets (`<...>`) in fenced code blocks while cleaning HTML tags outside code blocks.
4. **Extract Processor (#41955)**: Strip Content-Type parameters (e.g. `; charset=binary`) before deriving file extension suffix.

### Files Changed (8 files)
- `api/core/rag/extractor/notion_extractor.py`
- `api/core/rag/extractor/word_extractor.py`
- `api/core/rag/extractor/markdown_extractor.py`
- `api/core/rag/extractor/extract_processor.py`
- `api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py`
- `api/tests/unit_tests/core/rag/extractor/test_word_extractor.py`
- `api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py`
- `api/tests/unit_tests/core/rag/extractor/test_extract_processor.py`
