### PR TITLE
fix: preserve literal hash characters in markdown heading text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,6 +239,7 @@ mise.toml
 # AI Assistant
 .roo/
 /.claude/worktrees/
+/.claude/logs/
 api/.env.backup
 /clickzetta
 

--- a/api/core/rag/extractor/markdown_extractor.py
+++ b/api/core/rag/extractor/markdown_extractor.py
@@ -77,7 +77,7 @@ class MarkdownExtractor(BaseExtractor):
         markdown_tups.append((current_header, current_text))
 
         markdown_tups = [
-            (re.sub(r"#", "", key).strip() if key else None, re.sub(r"<.*?>", "", value))
+            (re.sub(r"^#+\s*", "", key).strip() if key else None, re.sub(r"<.*?>", "", value))
             for key, value in markdown_tups
         ]
 


### PR DESCRIPTION
## What changed
Fixed  to only strip leading  heading markers instead of removing all  characters from heading text.

## Why
The regex  removes every  in the heading, including legitimate characters like  (becomes ) or  (becomes ). Changed to  which only removes the markdown heading prefix.

## How tested
- Verified with 6 test cases including , , , 
- All previously-failing cases now correctly preserve hash characters in heading text

## Linked issue
Fixes #41907