### PR TITLE
fix(api): preserve QA segment answer on partial updates

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3632,11 +3632,15 @@ class SegmentService:
         try:
             word_count_change = segment.word_count
             content = args.content or segment.content
+            # For QA segments, keep the stored answer unless the caller explicitly provides a
+            # replacement. A partial update (e.g. content-only or keywords-only) must not wipe
+            # the existing answer.
+            if document.doc_form == IndexStructureType.QA_INDEX and args.answer is not None:
+                segment.answer = args.answer
             if segment.content == content:
                 segment.word_count = len(content)
                 if document.doc_form == IndexStructureType.QA_INDEX:
-                    segment.answer = args.answer
-                    segment.word_count += len(args.answer) if args.answer else 0
+                    segment.word_count += len(segment.answer) if segment.answer else 0
                 word_count_change = segment.word_count - word_count_change
                 keyword_changed = False
                 if args.keywords:
@@ -3733,8 +3737,9 @@ class SegmentService:
 
                     # calc embedding use tokens
                     if document.doc_form == IndexStructureType.QA_INDEX:
-                        segment.answer = args.answer
-                        tokens = embedding_model.get_text_embedding_num_tokens(texts=[content + segment.answer])[0]  # type: ignore
+                        tokens = embedding_model.get_text_embedding_num_tokens(
+                            texts=[content + (segment.answer or "")]
+                        )[0]
                     else:
                         tokens = embedding_model.get_text_embedding_num_tokens(texts=[content])[0]
                 segment.content = content
@@ -3750,8 +3755,7 @@ class SegmentService:
                 segment.disabled_at = None
                 segment.disabled_by = None
                 if document.doc_form == IndexStructureType.QA_INDEX:
-                    segment.answer = args.answer
-                    segment.word_count += len(args.answer) if args.answer else 0
+                    segment.word_count += len(segment.answer) if segment.answer else 0
                 word_count_change = segment.word_count - word_count_change
                 # update document word count
                 if word_count_change != 0:

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -779,6 +779,73 @@ class TestSegmentServiceMutations:
         vector_update.assert_not_called()
         multimodel_update.assert_not_called()
 
+    def test_update_segment_qa_content_only_preserves_existing_answer(self, sqlite_session: Session) -> None:
+        dataset = _dataset()
+        document = _document(doc_form=IndexStructureType.QA_INDEX, word_count=40)
+        segment = _segment(content="old question")
+        segment.answer = "old answer"
+        segment.word_count = len("old question") + len("old answer")
+        sqlite_session.add_all([dataset, document, segment])
+        sqlite_session.commit()
+        embedding_model = MagicMock()
+        embedding_model.get_text_embedding_num_tokens.return_value = [21]
+
+        with (
+            patch("services.dataset_service.current_user", _account()),
+            patch("services.dataset_service.redis_client.get", return_value=None),
+            patch("services.dataset_service.ModelManager") as manager_cls,
+            patch("services.dataset_service.VectorService.update_segment_vector") as vector_update,
+            patch("services.dataset_service.VectorService.update_multimodel_vector") as multimodel_update,
+        ):
+            manager_cls.for_tenant.return_value.get_model_instance.return_value = embedding_model
+            updated = SegmentService.update_segment(
+                SegmentUpdateArgs(content="new question"),
+                segment,
+                document,
+                dataset,
+                sqlite_session,
+            )
+
+        # A content-only QA update must not wipe the existing answer.
+        assert updated.answer == "old answer"
+        assert updated.content == "new question"
+        embedding_model.get_text_embedding_num_tokens.assert_called_once_with(texts=["new questionold answer"])
+        assert updated.word_count == len("new question") + len("old answer")
+        assert document.word_count == 40 + updated.word_count - len("old question") - len("old answer")
+        vector_update.assert_called_once_with(None, segment, dataset, session=sqlite_session)
+        multimodel_update.assert_not_called()
+
+    def test_update_segment_qa_keywords_only_preserves_existing_answer(self, sqlite_session: Session) -> None:
+        dataset = _dataset()
+        document = _document(doc_form=IndexStructureType.QA_INDEX, word_count=20)
+        segment = _segment(content="question")
+        segment.answer = "answer"
+        segment.word_count = len("question") + len("answer")
+        sqlite_session.add_all([dataset, document, segment])
+        sqlite_session.commit()
+
+        with (
+            patch("services.dataset_service.current_user", _account()),
+            patch("services.dataset_service.redis_client.get", return_value=None),
+            patch("services.dataset_service.VectorService.update_segment_vector") as vector_update,
+            patch("services.dataset_service.VectorService.update_multimodel_vector") as multimodel_update,
+        ):
+            updated = SegmentService.update_segment(
+                SegmentUpdateArgs(keywords=["new-keyword"]),
+                segment,
+                document,
+                dataset,
+                sqlite_session,
+            )
+
+        # A keywords-only QA update must not wipe the existing answer or drift the word counts.
+        assert updated.answer == "answer"
+        assert updated.keywords == ["new-keyword"]
+        assert updated.word_count == len("question") + len("answer")
+        assert document.word_count == 20
+        vector_update.assert_called_once_with(["new-keyword"], segment, dataset, session=sqlite_session)
+        multimodel_update.assert_not_called()
+
     def test_update_segment_changed_qa_content_tokenizes_question_and_answer(self, sqlite_session: Session) -> None:
         dataset = _dataset()
         document = _document(doc_form=IndexStructureType.QA_INDEX, word_count=10)


### PR DESCRIPTION
Fixes #41315

## Summary

Updating a QA-mode segment without sending an `answer` silently wipes the stored answer:

- Content-only update (`{"segment": {"content": "new question"}}`) cleared the existing `answer`.
- Keywords-only update (`{"segment": {"keywords": [...]}}`) also cleared the existing `answer`.

Root cause: in `SegmentService.update_segment` (`api/services/dataset_service.py`), for `doc_form == qa` the code unconditionally executed `segment.answer = args.answer`. Because `SegmentUpdateArgs.answer` defaults to `None` when omitted, a partial update replaced the stored answer with `None` (and drifted segment/document word counts; a QA content change under the high-quality technique could additionally crash while computing embedding tokens via `content + None`).

## Change

Partial updates now preserve the existing answer:

- Only overwrite `segment.answer` when the caller explicitly provides an `answer`.
- Word counts and the embedding-token text are derived from the effective (kept or replaced) answer.
- Explicitly passing `answer` still replaces the stored answer exactly as before.

The console flow is unaffected: it already validates that QA updates carry an `answer`.

## Tests

Added regression tests in `api/tests/unit_tests/services/test_dataset_service_segment.py`:

- `test_update_segment_qa_content_only_preserves_existing_answer`
- `test_update_segment_qa_keywords_only_preserves_existing_answer`

Both fail on the pre-fix code and pass with the fix. All 56 tests in the file pass (`uv run --project api --dev pytest api/tests/unit_tests/services/test_dataset_service_segment.py`).