### PR TITLE
fix: parse first complete unfenced JSON value

### DIFF
--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -21,7 +21,13 @@ def parse_json_markdown(json_string: str):
         # than one JSON value in a row, and slicing to the last bracket hands
         # all of them to json.loads() at once, which fails with "Extra data".
         # Decode only the first complete value instead.
-        if "`" not in json_string:
+        #
+        # A lone backtick is not a reliable "this is fenced" signal: it can
+        # legitimately occur inside a JSON string value (e.g. "use `print`")
+        # or in surrounding prose. Only a real markdown code fence (```) means
+        # the block below - which anchors on the last bracket and therefore
+        # still fails on multiple fenced blocks - should run instead.
+        if "```" not in json_string:
             first_value, _ = json.JSONDecoder().raw_decode(json_string, start_index)
             return first_value
 

--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -15,6 +15,16 @@ def parse_json_markdown(json_string: str):
     start_candidates = [i for i in (json_string.find("{"), json_string.find("[")) if i != -1]
     if start_candidates:
         start_index = min(start_candidates)
+
+        # Without code fences there is no end marker to anchor on, so the last
+        # "}" / "]" may belong to a *later* value. Models sometimes emit more
+        # than one JSON value in a row, and slicing to the last bracket hands
+        # all of them to json.loads() at once, which fails with "Extra data".
+        # Decode only the first complete value instead.
+        if "`" not in json_string:
+            first_value, _ = json.JSONDecoder().raw_decode(json_string, start_index)
+            return first_value
+
         end_index = max(json_string.rfind("}"), json_string.rfind("]"))
         if end_index != -1 and start_index < end_index:
             end_index += 1

--- a/api/tests/unit_tests/libs/test_json_in_md_parser.py
+++ b/api/tests/unit_tests/libs/test_json_in_md_parser.py
@@ -165,3 +165,28 @@ def test_parse_and_check_json_markdown_multiple_unfenced_objects():
     src = '{"keywords": ["a"], "category_id": "1", "category_name": "x"}\n{"category_id": "2"}'
     obj = parse_and_check_json_markdown(src, ["keywords", "category_id", "category_name"])
     assert obj == {"keywords": ["a"], "category_id": "1", "category_name": "x"}
+
+
+def test_parse_json_markdown_backtick_in_string_value_followed_by_second_unfenced_value():
+    """A backtick inside a string value must not disable the first-value-only fix.
+
+    Regression case from PR review: a single stray backtick anywhere in the
+    input previously fell back to anchoring on the *last* bracket, which
+    reintroduces the original "Extra data" bug from #42006 once a second
+    unfenced value follows.
+    """
+    src = '{"code":"use `print` function","n":1}\n{"a": 2}'
+    assert parse_json_markdown(src) == {"code": "use `print` function", "n": 1}
+
+
+def test_parse_json_markdown_multiple_backticks_in_string_value():
+    """Several backtick pairs inside one string value are still just data."""
+    src = '{"code": "`a` and `b` and `c`", "n": 1}\n{"a": 2}'
+    assert parse_json_markdown(src) == {"code": "`a` and `b` and `c`", "n": 1}
+
+
+def test_parse_json_markdown_fenced_block_with_backtick_in_string_value():
+    """A real ``` fence still uses the bracket-anchored fenced path, even
+    when the fenced JSON itself contains a backtick in a string value."""
+    src = '```json\n{"code": "use `print` function", "n": 1}\n```'
+    assert parse_json_markdown(src) == {"code": "use `print` function", "n": 1}

--- a/api/tests/unit_tests/libs/test_json_in_md_parser.py
+++ b/api/tests/unit_tests/libs/test_json_in_md_parser.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from core.llm_generator.output_parser.errors import OutputParserError
@@ -124,3 +126,42 @@ def test_parse_json_markdown_backtick_in_surrounding_prose():
 def test_parse_json_markdown_fenced_scalar_still_supported():
     """Fenced content without brackets still parses via the fence fallback."""
     assert parse_json_markdown('```json\n"hello"\n```') == "hello"
+
+
+def test_parse_json_markdown_returns_first_unfenced_json_object():
+    """Two unfenced objects must not be concatenated into one json.loads() call."""
+    src = '{"a": 1}\n{"a": 2}'
+    assert parse_json_markdown(src) == {"a": 1}
+
+
+def test_parse_json_markdown_returns_first_unfenced_json_array():
+    src = "[1, 2]\n[3, 4]"
+    assert parse_json_markdown(src) == [1, 2]
+
+
+def test_parse_json_markdown_first_unfenced_value_keeps_nested_objects():
+    src = '{"a": {"b": [1, {"c": 2}]}}\n{"a": 2}'
+    assert parse_json_markdown(src) == {"a": {"b": [1, {"c": 2}]}}
+
+
+def test_parse_json_markdown_brackets_inside_string_values():
+    """Brackets inside string values must not terminate the value early."""
+    src = '{"s": "{not json} [nor this]"}\n{"a": 2}'
+    assert parse_json_markdown(src) == {"s": "{not json} [nor this]"}
+
+
+def test_parse_json_markdown_first_value_followed_by_prose():
+    src = '{"a": 1}\nThat is the answer.'
+    assert parse_json_markdown(src) == {"a": 1}
+
+
+def test_parse_json_markdown_malformed_first_value_still_fails():
+    with pytest.raises(json.JSONDecodeError):
+        parse_json_markdown('{"a": }\n{"a": 2}')
+
+
+def test_parse_and_check_json_markdown_multiple_unfenced_objects():
+    """The reported failure mode now resolves to the first value instead of raising."""
+    src = '{"keywords": ["a"], "category_id": "1", "category_name": "x"}\n{"category_id": "2"}'
+    obj = parse_and_check_json_markdown(src, ["keywords", "category_id", "category_name"])
+    assert obj == {"keywords": ["a"], "category_id": "1", "category_name": "x"}


### PR DESCRIPTION
## Summary

Fix `parse_json_markdown()` so multiple unfenced JSON values do not get concatenated into a single `json.loads()` call.

The parser now consumes the first complete unfenced JSON value while preserving the existing fenced-content and scalar behavior.

## Problem

Given:

```text
{"a": 1}
{"a": 2}
```

the current implementation selects the first opening brace and the last closing brace, causing both values to be passed to `json.loads()` and raising `JSONDecodeError: Extra data`.

This surfaces in the Question Classifier node when a model emits more than one JSON value in a row.

## Fix

Use `json.JSONDecoder().raw_decode()` for the unfenced JSON path so parsing stops after the first complete JSON value.

Existing fenced JSON behavior is intentionally preserved — in particular, `test_parse_and_check_json_markdown_multiple_blocks_fails` (multiple fenced blocks still fail) is left unchanged.

## Tests

Added regression coverage for multiple unfenced JSON values and verified the existing JSON-in-Markdown parser tests continue to pass.

New cases: first value is an object / an array / contains nested objects / contains brackets inside string values / is followed by prose, a malformed first value still raises, and the reported `parse_and_check_json_markdown` failure mode now resolves.

`tests/unit_tests/libs/test_json_in_md_parser.py`: **20 passed** (13 existing + 7 new).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — not needed, internal parser behavior only
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly. — N/A
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

> Note on the last item: the full `make` targets need `uv`, which was not available in my environment. I ran the equivalent checks scoped to the two changed files instead: `ruff check` (all checks passed), `ruff format --check` (already formatted), and `mypy --check-untyped-defs` (no issues). Happy to run anything else the full pipeline flags.

Fixes #42006

From Claude Code
