### PR TITLE
fix: keep zero and false property values in Notion database extraction

### DIFF
--- a/api/core/rag/extractor/notion_extractor.py
+++ b/api/core/rag/extractor/notion_extractor.py
@@ -147,7 +147,10 @@ class NotionExtractor(BaseExtractor):
                     else:
                         value = property_value[type]
                     data[property_name] = value
-                row_dict = {k: v for k, v in data.items() if v}
+                # Keep falsy-but-real values (0, 0.0, False); drop only empty
+                # ones (None, "", [], {}). `False == 0` in Python, so `v == 0`
+                # covers booleans too.
+                row_dict = {k: v for k, v in data.items() if v or v == 0}
                 row_content = ""
                 for key, value in sorted(row_dict.items(), key=operator.itemgetter(0)):
                     if isinstance(value, dict):

--- a/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
@@ -208,6 +208,44 @@ class TestNotionDatabase:
         mocker.patch("httpx.post", return_value=_mock_response({"results": None}))
         assert extractor._get_notion_database_data("db-1") == []
 
+    def test_get_notion_database_data_keeps_zero_and_false_values(self, mocker: MockerFixture):
+        extractor = notion_extractor.NotionExtractor(
+            notion_workspace_id="ws",
+            notion_obj_id="obj",
+            notion_page_type="database",
+            tenant_id="tenant",
+            notion_access_token="token",
+        )
+
+        page = {
+            "results": [
+                {
+                    "properties": {
+                        "name": {"type": "title", "title": [{"plain_text": "Gadget"}]},
+                        "price": {"type": "number", "number": 0},
+                        "rating": {"type": "number", "number": 0.0},
+                        "in_stock": {"type": "checkbox", "checkbox": False},
+                        "note": {"type": "rich_text", "rich_text": []},
+                    },
+                    "url": "https://notion.so/page-1",
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        }
+
+        mocker.patch("httpx.post", return_value=_mock_response(page))
+
+        docs = extractor._get_notion_database_data("db-1")
+
+        assert len(docs) == 1
+        content = docs[0].page_content
+        # Falsy but real values must be indexed; empty ones must still be dropped.
+        assert "price:0" in content
+        assert "rating:0.0" in content
+        assert "in_stock:False" in content
+        assert "note:" not in content
+
     def test_requests_use_bounded_timeout(self, mocker: MockerFixture):
         """All outbound Notion API calls must carry a bounded timeout so a hanging endpoint cannot block extraction."""
         extractor = notion_extractor.NotionExtractor(


### PR DESCRIPTION
Fixes #42018

## What

`NotionExtractor._get_notion_database_data` filters row values with `if v`, so legitimate falsy values - a number property of `0`/`0.0` and a checkbox property of `False` - are silently dropped from the content indexed into the knowledge base.

## Fix

Change the filter to keep falsy-but-real values while still skipping empty ones (`None`, `""`, `[]`, `{}`): `if v or v == 0` (in Python `False == 0`, so booleans are covered). Empty titles/selects/rich text continue to be dropped exactly as before.

## Verification

- Reproduced on current `main` with a mocked Notion API response: a row with `price = 0` and `in_stock = false` indexed as `name:Gadget / rating:4.5` with both properties missing.
- Added a regression test `test_get_notion_database_data_keeps_zero_and_false_values` in `tests/unit_tests/core/rag/extractor/test_notion_extractor.py`: fails before the fix, passes after, and also asserts empty properties are still excluded.
- Full extractor suite: `pytest tests/unit_tests/core/rag/extractor/` - 228 passed.
- `ruff check` clean on both changed files.

## Environment note

Tests were run locally with Python 3.12 against the unit test suite only; the Notion API is mocked in the new test, so no external credentials are required.