### PR TITLE
fix: validate declared blob size before allocating buffer in chunk merger

### DIFF
--- a/api/core/plugin/utils/chunk_merger.py
+++ b/api/core/plugin/utils/chunk_merger.py
@@ -61,9 +61,7 @@ def merge_blob_chunks[T: ToolInvokeMessage | AgentInvokeMessage](
                 # (or raise an unhandled MemoryError/OverflowError) before the
                 # size limit below is ever checked.
                 if total_length > max_file_size:
-                    raise ValueError(
-                        f"File is too large which reached the limit of {max_file_size / 1024 / 1024}MB"
-                    )
+                    raise ValueError(f"File is too large which reached the limit of {max_file_size / 1024 / 1024}MB")
                 files[chunk_id] = FileChunk(total_length)
 
             # Check if file is too large (before appending)

--- a/api/core/plugin/utils/chunk_merger.py
+++ b/api/core/plugin/utils/chunk_merger.py
@@ -55,6 +55,15 @@ def merge_blob_chunks[T: ToolInvokeMessage | AgentInvokeMessage](
 
             # Initialize buffer for this file if it doesn't exist
             if chunk_id not in files:
+                # Validate the declared size before allocating the buffer.
+                # total_length comes from the plugin and the whole buffer is
+                # pre-allocated, so an oversized claim would exhaust memory
+                # (or raise an unhandled MemoryError/OverflowError) before the
+                # size limit below is ever checked.
+                if total_length > max_file_size:
+                    raise ValueError(
+                        f"File is too large which reached the limit of {max_file_size / 1024 / 1024}MB"
+                    )
                 files[chunk_id] = FileChunk(total_length)
 
             # Check if file is too large (before appending)

--- a/api/tests/unit_tests/core/plugin/utils/test_chunk_merger.py
+++ b/api/tests/unit_tests/core/plugin/utils/test_chunk_merger.py
@@ -546,3 +546,31 @@ class TestConverter:
         assert converted["empty_list"] == []
         assert converted["mixed_list"] == [file_one, "raw"]
         assert converted["none_value"] is None
+
+    def test_merge_blob_chunks_rejects_declared_size_above_limit(self):
+        """A declared total_length above the limit is rejected before allocation."""
+
+        def mock_generator() -> Generator[ToolInvokeMessage, None, None]:
+            yield ToolInvokeMessage(
+                type=ToolInvokeMessage.MessageType.BLOB_CHUNK,
+                message=ToolInvokeMessage.BlobChunkMessage(
+                    id="file1", sequence=0, total_length=1025, blob=b"x", end=False
+                ),
+            )
+
+        with pytest.raises(ValueError, match="File is too large"):
+            list(merge_blob_chunks(mock_generator(), max_file_size=1024))
+
+    def test_merge_blob_chunks_rejects_absurd_declared_size(self):
+        """An absurd declared total_length raises ValueError, not MemoryError/OverflowError."""
+
+        def mock_generator() -> Generator[ToolInvokeMessage, None, None]:
+            yield ToolInvokeMessage(
+                type=ToolInvokeMessage.MessageType.BLOB_CHUNK,
+                message=ToolInvokeMessage.BlobChunkMessage(
+                    id="file1", sequence=0, total_length=2**62, blob=b"x", end=False
+                ),
+            )
+
+        with pytest.raises(ValueError, match="File is too large"):
+            list(merge_blob_chunks(mock_generator()))


### PR DESCRIPTION
Fixes #42020

## What

`merge_blob_chunks` pre-allocates a `bytearray` of the plugin-declared `total_length` for every new blob-chunk stream, before validating it against `max_file_size`. Since `total_length` is plugin-controlled, a plugin claiming a huge size either exhausts worker memory on the first chunk (the 30MB `PLUGIN_MAX_FILE_SIZE` limit is never consulted first) or crashes with an unhandled `MemoryError`/`OverflowError` instead of the documented `ValueError` size-limit error.

## Fix

Validate `total_length > max_file_size` before creating the `FileChunk` buffer, raising the same `ValueError` message used for oversized actual payloads. Streaming behavior for in-limit files is unchanged; the existing per-chunk and cumulative checks still apply.

## Verification

- Reproduced on current `main`: a chunk declaring `total_length=2**62` raises `MemoryError` before the fix.
- Added two regression tests in `tests/unit_tests/core/plugin/utils/test_chunk_merger.py`:
  - `test_merge_blob_chunks_rejects_declared_size_above_limit` (declared 1025 with limit 1024 and a tiny payload - previously accepted)
  - `test_merge_blob_chunks_rejects_absurd_declared_size` (declared `2**62` - previously `MemoryError`)
  Both fail before the fix and pass after.
- `pytest tests/unit_tests/core/plugin/utils/` - 63 passed. Broader `tests/unit_tests/core/plugin/` - 465 passed; `test_plugin_runtime.py` has 2 failures that also fail on a clean checkout of `main` in my environment (they assert `127.0.0.1` where local resolution yields `localhost`), unrelated to this change.
- `ruff check` clean on both changed files.

## Environment note

Tests were run locally with Python 3.12 against the unit test suite only; no plugin daemon is required.