### PR TITLE
fix(api): accept valid epoch-0 timestamps in localtime conversion tool

### DIFF
--- a/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py
+++ b/api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py
@@ -31,7 +31,7 @@ class LocaltimeToTimestampTool(BuiltinTool):
         time_format = "%Y-%m-%d %H:%M:%S"
 
         timestamp = self.localtime_to_timestamp(localtime, time_format, timezone)  # type: ignore
-        if not timestamp:
+        if timestamp is None:
             yield self.create_text_message(f"Invalid localtime: {localtime}")
             return
 

--- a/api/tests/unit_tests/core/tools/test_builtin_tools_extra.py
+++ b/api/tests/unit_tests/core/tools/test_builtin_tools_extra.py
@@ -392,3 +392,18 @@ def test_provider_classes_and_builtin_sort(monkeypatch: pytest.MonkeyPatch):
     )
     sorted_providers = BuiltinToolProviderSort.sort(providers)
     assert [p.name for p in sorted_providers] == ["a", "b"]
+
+
+def test_localtime_to_timestamp_tool_epoch_zero(sqlite_session: Session):
+    localtime_tool = _build_builtin_tool(LocaltimeToTimestampTool)
+    # 1970-01-01 08:00:00 in Asia/Shanghai is exactly Unix epoch 0. A valid
+    # conversion to timestamp 0 must not be reported as "Invalid localtime"
+    # just because 0 is falsy.
+    epoch_message = list(
+        localtime_tool.invoke(
+            session=sqlite_session,
+            user_id="u",
+            tool_parameters={"localtime": "1970-01-01 08:00:00", "timezone": "Asia/Shanghai"},
+        )
+    )[0].message.text
+    assert epoch_message.strip() == "0"


### PR DESCRIPTION
Fixes #42026

## Summary

`LocaltimeToTimestampTool._invoke` validated the conversion result with `if not timestamp:`. A valid localtime that maps to Unix epoch 0 (for example `1970-01-01 08:00:00` in Asia/Shanghai, or `1970-01-01 00:00:00` UTC) produces timestamp `0`, which is falsy, so the tool incorrectly responded with `Invalid localtime: ...`.

The fix checks `if timestamp is None:` instead. Invalid input continues to raise `ToolInvokeError` from the conversion helper, matching the behavior codified in the existing tests.

## Changes

- `api/core/tools/builtin_tool/providers/time/tools/localtime_to_timestamp.py`: one-line fix, falsy check -> `is None` check.
- `api/tests/unit_tests/core/tools/test_builtin_tools_extra.py`: regression test invoking the tool with a localtime at Unix epoch 0 and asserting the result is `0` (fails before the fix, passes after).

## Testing

- New regression test fails before / passes after the fix.
- Full `api/tests/unit_tests/core/tools/` suite: 355 passed.
- `ruff check` clean.

## Environment note

Tests were run locally with `pytest` against `api/tests/unit_tests/core/tools/` (Python 3.12, no external services required).