### PR TITLE
fix(api): reject trailing newlines in user_input_form variable names

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/variables/manager.py
+++ b/api/core/app/app_config/easy_ui_based_app/variables/manager.py
@@ -139,7 +139,7 @@ class BasicVariablesConfigManager:
                 raise ValueError("variable in user_input_form must be of string type")
 
             pattern = re.compile(r"^(?!\d)[\u4e00-\u9fa5A-Za-z0-9_\U0001F300-\U0001F64F\U0001F680-\U0001F6FF]{1,100}$")
-            if pattern.match(form_item["variable"]) is None:
+            if pattern.fullmatch(form_item["variable"]) is None:
                 raise ValueError("variable in user_input_form must be a string, and cannot start with a number")
 
             variables.append(form_item["variable"])

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_variables_manager.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_variables_manager.py
@@ -285,3 +285,27 @@ class TestValidateAndSetDefaultsIntegration:
         assert "user_input_form" in keys
         assert "external_data_tools" in keys
         assert updated == config
+
+
+class TestBasicVariablesConfigManagerValidateVariables:
+    def test_validate_variables_rejects_trailing_newline(self):
+        # re.match with a "$" anchor still matches just before a trailing
+        # newline, so "name\n" used to pass validation even though "\n" is
+        # not in the allowed character set. fullmatch rejects it.
+        config = {
+            "user_input_form": [
+                {"text-input": {"label": "Name", "variable": "name\n"}},
+            ]
+        }
+        with pytest.raises(ValueError, match="cannot start with a number"):
+            BasicVariablesConfigManager.validate_variables_and_set_defaults(config)
+
+    def test_validate_variables_accepts_valid_name(self):
+        config = {
+            "user_input_form": [
+                {"text-input": {"label": "Name", "variable": "name"}},
+            ]
+        }
+        validated, keys = BasicVariablesConfigManager.validate_variables_and_set_defaults(config)
+        assert keys == ["user_input_form"]
+        assert validated["user_input_form"][0]["text-input"]["required"] is False


### PR DESCRIPTION
Fixes #42028

## Summary

`BasicVariablesConfigManager.validate_variables_and_set_defaults` validated `user_input_form` variable names with `pattern.match` against a `$`-anchored regex. In Python, `$` also matches just before a trailing newline, so a name like `"name\n"` passed validation even though the newline is outside the allowed character set.

The fix uses `pattern.fullmatch`, consistent with the email validator (#39234) and the alphanumeric validator (#39666), which were hardened against the same trailing-newline acceptance.

## Changes

- `api/core/app/app_config/easy_ui_based_app/variables/manager.py`: one-line fix, `pattern.match` -> `pattern.fullmatch`.
- `api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_variables_manager.py`: two regression tests - a variable name with a trailing newline is rejected (fails before the fix), and a valid name still validates with defaults applied.

## Testing

- The newline-rejection test fails before / passes after the fix; the valid-name test passes both before and after (no behavior change for valid input).
- Full `api/tests/unit_tests/core/app/app_config/` suite: 212 passed.
- `ruff check` clean.

## Environment note

Tests were run locally with `pytest` against `api/tests/unit_tests/core/app/app_config/` (Python 3.12, no external services required).