### PR TITLE
fix(api): compute console dataset list has_more with the effective page size

### DIFF
--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -501,6 +501,7 @@ class DatasetListApi(Resource):
                 accessible_dataset_ids = sorted(filtered_dataset_ids)
 
         if query.ids:
+            effective_limit = len(query.ids)
             datasets, total = DatasetService.get_datasets_by_ids(
                 query.ids,
                 current_tenant_id,
@@ -510,9 +511,10 @@ class DatasetListApi(Resource):
                 session=session,
             )
         else:
+            effective_limit = min(query.limit, 100)
             datasets, total = DatasetService.get_datasets(
                 query.page,
-                query.limit,
+                effective_limit,
                 session,
                 current_tenant_id,
                 current_user,
@@ -574,8 +576,8 @@ class DatasetListApi(Resource):
 
         response = {
             "data": data,
-            "has_more": len(datasets) == query.limit,
-            "limit": query.limit,
+            "has_more": query.page * effective_limit < total,
+            "limit": effective_limit,
             "total": total,
             "page": query.page,
         }
@@ -866,15 +868,16 @@ class DatasetQueryApi(Resource):
 
         page = request.args.get("page", default=1, type=int)
         limit = request.args.get("limit", default=20, type=int)
+        effective_limit = min(limit, 100)
 
         dataset_queries, total = DatasetService.get_dataset_queries(
-            dataset_id=dataset.id, page=page, per_page=limit, session=session
+            dataset_id=dataset.id, page=page, per_page=effective_limit, session=session
         )
 
         response = {
             "data": [_DatasetQueryResponseSource(query=query, session=session) for query in dataset_queries],
-            "has_more": len(dataset_queries) == limit,
-            "limit": limit,
+            "has_more": page * effective_limit < total,
+            "limit": effective_limit,
             "total": total,
             "page": page,
         }

--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -414,6 +414,7 @@ class DatasetDocumentListApi(Resource):
         param = DocumentDatasetListParam.model_validate(raw_args)
         page = param.page
         limit = param.limit
+        effective_limit = min(limit, 100)
         search = param.search
         sort = param.sort_by
         status = param.status
@@ -484,7 +485,9 @@ class DatasetDocumentListApi(Resource):
                     desc(Document.position),
                 )
 
-        paginated_documents = paginate_query(query, session=session, page=page, per_page=limit, max_per_page=100)
+        paginated_documents = paginate_query(
+            query, session=session, page=page, per_page=effective_limit, max_per_page=100
+        )
         documents = paginated_documents.items
 
         DocumentService.enrich_documents_with_summary_index_status(
@@ -519,8 +522,8 @@ class DatasetDocumentListApi(Resource):
                 document.total_segments = total_segments
         response = {
             "data": document_with_segments_responses(documents, session=session),
-            "has_more": len(documents) == limit,
-            "limit": limit,
+            "has_more": page * effective_limit < paginated_documents.total,
+            "limit": effective_limit,
             "total": paginated_documents.total,
             "page": page,
         }

--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -168,13 +168,14 @@ class ExternalApiTemplateListApi(Resource):
     @model_validate(ExternalApiTemplateListQuery)
     def get(self, req_data: ExternalApiTemplateListQuery, session: Session, current_tenant_id: str):
 
+        effective_limit = min(req_data.limit, 100)
         external_knowledge_apis, total = ExternalDatasetService.get_external_knowledge_apis(
-            req_data.page, req_data.limit, current_tenant_id, req_data.keyword, session=session
+            req_data.page, effective_limit, current_tenant_id, req_data.keyword, session=session
         )
         return ExternalKnowledgeApiListResponse(
             data=[external_knowledge_api_response(item, session=session) for item in external_knowledge_apis],
-            has_more=len(external_knowledge_apis) == req_data.limit,
-            limit=req_data.limit,
+            has_more=req_data.page * effective_limit < total,
+            limit=effective_limit,
             total=total,
             page=req_data.page,
         ).model_dump(mode="json"), 200

--- a/api/controllers/console/datasets/external.py
+++ b/api/controllers/console/datasets/external.py
@@ -174,7 +174,7 @@ class ExternalApiTemplateListApi(Resource):
         )
         return ExternalKnowledgeApiListResponse(
             data=[external_knowledge_api_response(item, session=session) for item in external_knowledge_apis],
-            has_more=req_data.page * effective_limit < total,
+            has_more=total is not None and req_data.page * effective_limit < total,
             limit=effective_limit,
             total=total,
             page=req_data.page,

--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -906,16 +906,22 @@ class DatasetListApi(Resource):
     @get_previewable_app_model(None)
     def get(self, session: Session, app_model):
         page = request.args.get("page", default=1, type=int)
-        limit = request.args.get("limit", default=20, type=int)
         ids = request.args.getlist("ids")
 
         tenant_id = app_model.tenant_id
         if ids:
+            effective_limit = len(ids)
             datasets, total = DatasetService.get_datasets_by_ids(ids, tenant_id, session=session)
         else:
             raise NeedAddIdsError()
 
-        response = {"data": datasets, "has_more": len(datasets) == limit, "limit": limit, "total": total, "page": page}
+        response = {
+            "data": datasets,
+            "has_more": page * effective_limit < total,
+            "limit": effective_limit,
+            "total": total,
+            "page": page,
+        }
         return dump_response(TrialDatasetListResponse, response)
 
 

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -219,6 +219,38 @@ class TestDatasetList(_UsesSQLiteSession):
             "icon_url": None,
         }
 
+    def test_get_has_more_false_on_last_page_exact_limit(self, app: Flask):
+        api = DatasetListApi()
+        method = unwrap(api.get)
+        current_user = self._mock_user()
+        datasets = [make_dataset() for _ in range(20)]
+        with app.test_request_context("/datasets?page=1&limit=20"):
+            with (
+                patch.object(DatasetService, "get_datasets", return_value=(datasets, 20)),
+                patch.object(ProviderManager, "get_configurations", return_value=MagicMock(get_models=lambda **_: [])),
+            ):
+                resp, status = method(api, self.session, "tenant-1", current_user)
+        assert status == 200
+        assert resp["has_more"] is False
+        assert resp["limit"] == 20
+
+    def test_get_has_more_true_when_limit_exceeds_cap(self, app: Flask):
+        api = DatasetListApi()
+        method = unwrap(api.get)
+        current_user = self._mock_user()
+        datasets = [make_dataset() for _ in range(100)]
+        with app.test_request_context("/datasets?page=1&limit=200"):
+            with (
+                patch.object(DatasetService, "get_datasets", return_value=(datasets, 150)) as get_datasets,
+                patch.object(ProviderManager, "get_configurations", return_value=MagicMock(get_models=lambda **_: [])),
+            ):
+                resp, status = method(api, self.session, "tenant-1", current_user)
+        assert status == 200
+        assert resp["has_more"] is True
+        assert resp["limit"] == 100
+        assert len(resp["data"]) == 100
+        assert get_datasets.call_args.args[1] == 100
+
     def test_get_serializes_database_fields_with_caller_session(self, app: Flask, dataset_model_property_defaults):
         api = DatasetListApi()
         method = unwrap(api.get)
@@ -1066,6 +1098,43 @@ class TestDatasetQueryApi(_UsesSQLiteSession):
         assert status == 200
         assert response["has_more"] is True
         assert len(response["data"]) == 20
+
+    def test_get_queries_has_more_false_on_last_page_exact_limit(self, app: Flask):
+        api = DatasetQueryApi()
+        method = unwrap(api.get)
+        dataset_id = "dataset-id"
+        current_user = make_account()
+        dataset = make_dataset(id=dataset_id)
+        queries = [self._query_record(index) for index in range(1, 21)]
+        with (
+            app.test_request_context("/datasets/queries?page=1&limit=20"),
+            patch.object(DatasetService, "get_dataset", return_value=dataset),
+            patch.object(DatasetService, "check_dataset_permission", return_value=None),
+            patch.object(DatasetService, "get_dataset_queries", return_value=(queries, 20)),
+        ):
+            response, status = method(api, self.session, current_user, dataset_id)
+        assert status == 200
+        assert response["has_more"] is False
+        assert response["limit"] == 20
+
+    def test_get_queries_has_more_true_when_limit_exceeds_cap(self, app: Flask):
+        api = DatasetQueryApi()
+        method = unwrap(api.get)
+        dataset_id = "dataset-id"
+        current_user = make_account()
+        dataset = make_dataset(id=dataset_id)
+        queries = [self._query_record(index % 28 + 1) for index in range(1, 101)]
+        with (
+            app.test_request_context("/datasets/queries?page=1&limit=200"),
+            patch.object(DatasetService, "get_dataset", return_value=dataset),
+            patch.object(DatasetService, "check_dataset_permission", return_value=None),
+            patch.object(DatasetService, "get_dataset_queries", return_value=(queries, 150)),
+        ):
+            response, status = method(api, self.session, current_user, dataset_id)
+        assert status == 200
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert len(response["data"]) == 100
 
 
 class TestDatasetIndexingEstimateApi(_UsesSQLiteSession):

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
@@ -386,6 +386,46 @@ class TestDatasetDocumentListApi(_UsesSQLiteSession):
         assert response["data"][0]["data_source_info"] == {"upload_file_id": "file-1"}
         assert response["data"][0]["doc_metadata"] == []
 
+    def test_get_has_more_false_on_last_page_exact_limit(
+        self, app: Flask, patch_tenant, patch_dataset, patch_permission
+    ):
+        api = DatasetDocumentListApi()
+        method = unwrap(api.get)
+        user, tenant_id = patch_tenant
+        documents = [make_serializable_document() for _ in range(20)]
+        pagination = MagicMock(items=documents, total=20)
+        with (
+            app.test_request_context("/?page=1&limit=20"),
+            patch("controllers.console.datasets.datasets_document.paginate_query", return_value=pagination),
+            patch(
+                "controllers.console.datasets.datasets_document.DocumentService.enrich_documents_with_summary_index_status",
+                return_value=None,
+            ),
+        ):
+            response = method(api, self.session, tenant_id, user, "ds-1")
+        assert response["has_more"] is False
+        assert response["limit"] == 20
+
+    def test_get_has_more_true_when_limit_exceeds_cap(self, app: Flask, patch_tenant, patch_dataset, patch_permission):
+        api = DatasetDocumentListApi()
+        method = unwrap(api.get)
+        user, tenant_id = patch_tenant
+        documents = [make_serializable_document() for _ in range(100)]
+        pagination = MagicMock(items=documents, total=150)
+        with (
+            app.test_request_context("/?page=1&limit=200"),
+            patch("controllers.console.datasets.datasets_document.paginate_query", return_value=pagination) as pg,
+            patch(
+                "controllers.console.datasets.datasets_document.DocumentService.enrich_documents_with_summary_index_status",
+                return_value=None,
+            ),
+        ):
+            response = method(api, self.session, tenant_id, user, "ds-1")
+        assert response["has_more"] is True
+        assert response["limit"] == 100
+        assert len(response["data"]) == 100
+        assert pg.call_args.kwargs["per_page"] == 100
+
     def test_post_success(self, app: Flask, patch_tenant, patch_dataset, patch_permission):
         api = DatasetDocumentListApi()
         method = unwrap(api.post)

--- a/api/tests/unit_tests/controllers/console/datasets/test_external.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_external.py
@@ -199,6 +199,47 @@ class TestExternalApiTemplateListApi(_UsesSQLiteSession):
         api_item.get_dataset_bindings.assert_called_once_with(session=session)
         get_external_knowledge_apis.assert_called_once_with(2, 1, "tenant-1", "vector", session=ANY)
 
+    def test_get_has_more_false_on_last_page_exact_limit(self, app: Flask):
+        api = ExternalApiTemplateListApi()
+        method = inspect.unwrap(api.get)
+
+        api_items = [_external_api_object(str(i)) for i in range(20)]
+        with (
+            app.test_request_context("/?page=1&limit=20"),
+            patch.object(
+                ExternalDatasetService,
+                "get_external_knowledge_apis",
+                return_value=(api_items, 20),
+            ) as get_external_knowledge_apis,
+        ):
+            resp, status = method(api, ExternalApiTemplateListQuery(page=1, limit=20), self.session, "tenant-1")
+
+        assert status == 200
+        assert resp["has_more"] is False
+        assert resp["limit"] == 20
+        get_external_knowledge_apis.assert_called_once_with(1, 20, "tenant-1", None, session=ANY)
+
+    def test_get_has_more_true_when_limit_exceeds_cap(self, app: Flask):
+        api = ExternalApiTemplateListApi()
+        method = inspect.unwrap(api.get)
+
+        api_items = [_external_api_object(str(i)) for i in range(100)]
+        with (
+            app.test_request_context("/?page=1&limit=200"),
+            patch.object(
+                ExternalDatasetService,
+                "get_external_knowledge_apis",
+                return_value=(api_items, 150),
+            ) as get_external_knowledge_apis,
+        ):
+            resp, status = method(api, ExternalApiTemplateListQuery(page=1, limit=200), self.session, "tenant-1")
+
+        assert status == 200
+        assert resp["has_more"] is True
+        assert resp["limit"] == 100
+        assert len(resp["data"]) == 100
+        get_external_knowledge_apis.assert_called_once_with(1, 100, "tenant-1", None, session=ANY)
+
     def test_post_success_uses_validated_payload_and_returns_template(self, app: Flask, current_user: Account):
         api = ExternalApiTemplateListApi()
         method = inspect.unwrap(api.post)

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -188,10 +188,39 @@ def test_trial_dataset_list_preserves_slim_dataset_fields(app: Flask, unbound_se
             }
         ],
         "has_more": False,
-        "limit": 20,
+        "limit": 1,
         "total": 1,
         "page": 1,
     }
+
+
+def test_trial_dataset_list_has_more_tracks_ids_count_not_limit(app: Flask, unbound_session: Session):
+    api = module.DatasetListApi()
+    method = unwrap(api.get)
+    app_model = _app(app_id="app-1", mode=AppMode.CHAT)
+    datasets = [
+        Dataset(
+            id=f"dataset-{i}",
+            tenant_id=app_model.tenant_id,
+            name=f"Dataset {i}",
+            permission="only_me",
+            data_source_type="upload_file",
+            indexing_technique="high_quality",
+            created_by="user-1",
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        for i in range(20)
+    ]
+    with (
+        app.test_request_context("/?page=1&limit=20&ids=" + "&ids=".join(f"dataset-{i}" for i in range(20))),
+        patch.object(module.DatasetService, "get_datasets_by_ids", return_value=(datasets, 20)) as get_datasets,
+    ):
+        result = method(api, unbound_session, app_model)
+
+    get_datasets.assert_called_once_with([f"dataset-{i}" for i in range(20)], "tenant-1", session=unbound_session)
+    assert result["has_more"] is False
+    assert result["limit"] == 20
+    assert result["total"] == 20
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #42024

## Summary

The console **datasets** list endpoints compute `has_more = len(items) == limit` while their queries are served through `paginate_query(..., max_per_page=100)` (or, for the by-ids trial endpoint, `max_per_page=len(ids)`). Two wrong behaviours, both user-visible:

- **`limit` above the server cap with remaining rows** → `has_more=false`: e.g. `GET /datasets?limit=200` with 150 datasets returns 100 rows but `has_more=false`, so pagination silently stops and remaining rows are never fetched.
- **Last page exactly full** → `has_more=true` (phantom): clients render a "load more" spinner that returns nothing.

This is the same bug class already fixed for the Service API dataset / document / segment lists in #41784 / #41776 and the annotation lists in #41875 / #41876; the console datasets controllers were missed.

### Changes

- `api/controllers/console/datasets/datasets.py` — console `GET /datasets` and `GET /datasets/{dataset_id}/queries`
- `api/controllers/console/datasets/datasets_document.py` — console `GET /datasets/{dataset_id}/documents`
- `api/controllers/console/datasets/external.py` — console `GET /datasets/external-knowledge-api`
- `api/controllers/console/explore/trial.py` — explore `GET /explore/datasets` (by-ids)

Each now caps the page size (`effective_limit = min(limit, 100)`; `len(ids)` for the trial endpoint) and computes `has_more = page * effective_limit < total`, mirroring the accepted #41784/#41776 and #41875 fixes.

### Tests

9 regression tests added (2 per endpoint family, 1 for trial), covering both the exact-full-last-page case and the `limit > 100` / ids-count case. Before the fix all 9 fail; after, they pass.

- `tests/unit_tests/controllers/console/datasets/test_datasets.py` (4 new)
- `tests/unit_tests/controllers/console/datasets/test_datasets_document.py` (2 new)
- `tests/unit_tests/controllers/console/datasets/test_external.py` (2 new)
- `tests/unit_tests/controllers/console/explore/test_trial.py` (1 new + 1 expectation updated: trial now echoes `len(ids)` as the effective limit)

Verification (local, dify `api` on `main` @ d60873d):
- Red: new `test_*_has_more_*` tests → 9 failed on unfixed controllers
- Green after fix: `test_datasets.py` + `test_datasets_document.py` + `test_external.py` + `test_trial.py` → 261 passed
- Console datasets + explore suites → 639 passed
- `ruff check` and `ruff format --check` clean on all changed files

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint` locally on the changed files (`ruff check` + `ruff format --check`) to appease the lint gods

From opencode.