### PR TITLE
fix: dataset hitcount deadlock (#41979)

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -10,7 +10,9 @@ from typing import Any, Union, cast
 
 from flask import Flask, current_app
 from sqlalchemy import and_, func, literal, or_, select
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
+from tenacity import before_sleep_log, retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from core.app.app_config.entities import (
     DatasetEntity,
@@ -96,6 +98,18 @@ default_retrieval_model: DefaultRetrievalModelDict = {
 }
 
 logger = logging.getLogger(__name__)
+
+_POSTGRES_DEADLOCK_SQLSTATE = "40P01"
+_HIT_COUNT_UPDATE_MAX_ATTEMPTS = 3
+
+
+def _is_postgres_deadlock_error(exc: BaseException) -> bool:
+    if not isinstance(exc, DBAPIError) or exc.orig is None:
+        return False
+    orig = cast(Any, exc.orig)
+    return (hasattr(orig, "sqlstate") and orig.sqlstate == _POSTGRES_DEADLOCK_SQLSTATE) or (
+        hasattr(orig, "pgcode") and orig.pgcode == _POSTGRES_DEADLOCK_SQLSTATE
+    )
 
 
 class DatasetRetrieval:
@@ -869,6 +883,13 @@ class DatasetRetrieval:
                 retrieval_resource_list.append(document)
         return retrieval_resource_list
 
+    @retry(
+        retry=retry_if_exception(_is_postgres_deadlock_error),
+        stop=stop_after_attempt(_HIT_COUNT_UPDATE_MAX_ATTEMPTS),
+        wait=wait_exponential(multiplier=0.05, min=0.05, max=0.1),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
     def _on_retrieval_end(
         self, flask_app: Flask, documents: list[Document], message_id: str | None = None, timer: dict | None = None
     ):
@@ -966,6 +987,14 @@ class DatasetRetrieval:
 
                 # Batch update hit_count for all segments
                 if segment_ids_to_update:
+                    # PostgreSQL does not guarantee that an IN predicate is visited in parameter order.
+                    # Lock every target row explicitly and consistently before the multi-row update.
+                    session.scalars(
+                        select(DocumentSegment.id)
+                        .where(DocumentSegment.id.in_(segment_ids_to_update))
+                        .order_by(DocumentSegment.id)
+                        .with_for_update()
+                    ).all()
                     session.query(DocumentSegment).where(DocumentSegment.id.in_(segment_ids_to_update)).update(
                         {DocumentSegment.hit_count: DocumentSegment.hit_count + 1},
                         synchronize_session=False,

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -7,7 +7,10 @@ from uuid import uuid4
 import pytest
 from flask import Flask, current_app
 from sqlalchemy import column
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.exc import DBAPIError
 
+import core.rag.retrieval.dataset_retrieval as dataset_retrieval_module
 from core.app.app_config.entities import (
     Condition as AppCondition,
 )
@@ -4818,6 +4821,7 @@ class TestInternalHooksCoverage:
             _scalars(child_chunks),
             _scalars(segments),
             _scalars(bindings),
+            _scalars(["seg-a", "seg-b", "seg-c", "seg-d"]),
         ]
         query = Mock()
         query.where.return_value = query
@@ -4835,7 +4839,114 @@ class TestInternalHooksCoverage:
 
         query.update.assert_called_once()
         session.commit.assert_called_once()
+        lock_statement = session.scalars.call_args_list[-1].args[0]
+        assert "ORDER BY document_segments.id FOR UPDATE" in str(lock_statement.compile(dialect=postgresql.dialect()))
         mock_trace.assert_called_once()
+
+    def test_on_retrieval_end_retries_postgres_deadlock(self, retrieval: DatasetRetrieval) -> None:
+        app = Flask(__name__)
+        deadlock = DBAPIError(
+            "UPDATE document_segments",
+            {},
+            SimpleNamespace(sqlstate="40P01"),
+            connection_invalidated=False,
+        )
+        doc = _doc(provider="dify")
+        retry_session = MagicMock()
+        retry_session.__enter__.return_value.scalars.return_value.all.return_value = []
+        retry_session.__exit__.return_value = False
+
+        with (
+            patch("core.rag.retrieval.dataset_retrieval.db", SimpleNamespace(engine=Mock())),
+            patch("core.rag.retrieval.dataset_retrieval.Session") as mock_session,
+            patch.object(retrieval, "_send_trace_task") as mock_trace,
+        ):
+            mock_session.side_effect = [deadlock, retry_session]
+            retrieval._on_retrieval_end(flask_app=app, documents=[doc], message_id="m1", timer={"cost": 1})
+
+        assert mock_session.call_count == 2
+        mock_trace.assert_called_once_with("m1", [doc], {"cost": 1})
+
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            (RuntimeError("not a database error"), False),
+            (DBAPIError("SELECT 1", {}, None, connection_invalidated=False), False),
+            (
+                DBAPIError(
+                    "UPDATE document_segments",
+                    {},
+                    SimpleNamespace(pgcode="40P01"),
+                    connection_invalidated=False,
+                ),
+                True,
+            ),
+            (
+                DBAPIError(
+                    "UPDATE document_segments",
+                    {},
+                    SimpleNamespace(sqlstate="40001", pgcode="40P01"),
+                    connection_invalidated=False,
+                ),
+                True,
+            ),
+            (
+                DBAPIError(
+                    "UPDATE document_segments",
+                    {},
+                    SimpleNamespace(sqlstate="40001", pgcode="40001"),
+                    connection_invalidated=False,
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_is_postgres_deadlock_error(self, error: BaseException, expected: bool) -> None:
+        assert dataset_retrieval_module._is_postgres_deadlock_error(error) is expected
+
+    def test_on_retrieval_end_reraises_non_deadlock(self, retrieval: DatasetRetrieval) -> None:
+        app = Flask(__name__)
+        error = DBAPIError(
+            "UPDATE document_segments",
+            {},
+            SimpleNamespace(sqlstate="40001"),
+            connection_invalidated=False,
+        )
+        doc = _doc(provider="dify")
+
+        with (
+            patch("core.rag.retrieval.dataset_retrieval.db", SimpleNamespace(engine=Mock())),
+            patch("core.rag.retrieval.dataset_retrieval.Session") as mock_session,
+            patch.object(retrieval, "_send_trace_task") as mock_trace,
+        ):
+            mock_session.side_effect = error
+            with pytest.raises(DBAPIError):
+                retrieval._on_retrieval_end(flask_app=app, documents=[doc])
+
+        assert mock_session.call_count == 1
+        mock_trace.assert_not_called()
+
+    def test_on_retrieval_end_reraises_after_deadlock_retries_are_exhausted(self, retrieval: DatasetRetrieval) -> None:
+        app = Flask(__name__)
+        deadlock = DBAPIError(
+            "UPDATE document_segments",
+            {},
+            SimpleNamespace(sqlstate="40P01"),
+            connection_invalidated=False,
+        )
+        doc = _doc(provider="dify")
+
+        with (
+            patch("core.rag.retrieval.dataset_retrieval.db", SimpleNamespace(engine=Mock())),
+            patch("core.rag.retrieval.dataset_retrieval.Session") as mock_session,
+            patch.object(retrieval, "_send_trace_task") as mock_trace,
+        ):
+            mock_session.side_effect = deadlock
+            with pytest.raises(DBAPIError):
+                retrieval._on_retrieval_end(flask_app=app, documents=[doc])
+
+        assert mock_session.call_count == 3
+        mock_trace.assert_not_called()
 
     def test_retriever_variants(self, retrieval: DatasetRetrieval) -> None:
         flask_app = SimpleNamespace(app_context=lambda: nullcontext())


### PR DESCRIPTION
(cherry picked from commit bb2945a1a3a56f5ba802173344f01bff593e6ce3)

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

Backport of #41979 to `lts/1.13.x`. Related issue: #41981.

## Summary

Concurrent knowledge retrieval requests can update overlapping `document_segments` rows when recording hit counts. PostgreSQL does not guarantee row-lock acquisition in the order of values supplied to an `IN` predicate, so concurrent multi-row updates may acquire locks in different orders and fail with SQLSTATE `40P01` (`deadlock_detected`).

This backport:

- locks all target segment rows with `ORDER BY document_segments.id FOR UPDATE` before incrementing `hit_count`, ensuring a consistent lock order;
- retries the complete retrieval-end transaction up to three times only for PostgreSQL deadlocks, using short 50 ms and 100 ms delays;
- immediately re-raises non-deadlock database errors;
- preserves the existing asynchronous, best-effort retrieval-statistics boundary;
- does not change retrieval results or ranking.

Retrying the complete transaction is important because PostgreSQL aborts the transaction after a deadlock; retrying only the failed statement would not be safe.

## LTS adaptation

The implementation was adapted to the APIs and transaction structure already used by `lts/1.13.x`:

- keeps `Session(db.engine)`;
- keeps the existing ORM `query(...).update(...)` and explicit commit;
- adds only the ordered locking query and deadlock-specific retry behavior.

No unrelated main-branch refactors are included.

## Tests

- Added coverage for the generated `ORDER BY document_segments.id FOR UPDATE` locking query.
- Added coverage for successful retry after SQLSTATE `40P01`.
- Added coverage for both `sqlstate` and legacy `pgcode` detection.
- Added coverage that non-deadlock errors are not retried.
- Added coverage that the error is re-raised after retry exhaustion.
- Full unit test file passed locally:
  - `uv run --project api pytest -q api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py`
  - Result: `128 passed`

A PostgreSQL-backed concurrency/load test was not run locally. Repository-wide pre-commit lint is also not claimed because the LTS branch currently reports unrelated existing lint violations.

## Screenshots

Not applicable; this is a backend-only concurrency fix.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Documentation is not applicable because there is no user-facing behavior or configuration change.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Codex
