### PR TITLE
chore(deps): upgrade jotai to v3 and jotai-scope

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,11 +504,11 @@ catalogs:
       specifier: 11.1.18
       version: 11.1.18
     jotai:
-      specifier: 2.20.3
-      version: 2.20.3
+      specifier: 3.0.0
+      version: 3.0.0
     jotai-scope:
-      specifier: 0.11.0
-      version: 0.11.0
+      specifier: 0.12.2
+      version: 0.12.2
     jotai-tanstack-query:
       specifier: 0.11.0
       version: 0.11.0
@@ -1170,7 +1170,7 @@ importers:
         version: typescript@7.0.2
       jotai:
         specifier: 'catalog:'
-        version: 2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+        version: 3.0.0(@types/react@19.2.18)(react@19.2.8)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -1404,13 +1404,13 @@ importers:
         version: 11.1.18
       jotai:
         specifier: 'catalog:'
-        version: 2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+        version: 3.0.0(@types/react@19.2.18)(react@19.2.8)
       jotai-scope:
         specifier: 'catalog:'
-        version: 0.11.0(jotai@2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+        version: 0.12.2(jotai@3.0.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
       jotai-tanstack-query:
         specifier: 'catalog:'
-        version: 0.11.0(@tanstack/query-core@5.102.8)(@tanstack/react-query@5.102.8(react@19.2.8))(jotai@2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+        version: 0.11.0(@tanstack/query-core@5.102.8)(@tanstack/react-query@5.102.8(react@19.2.8))(jotai@3.0.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
       js-cookie:
         specifier: 'catalog:'
         version: 3.0.8
@@ -6917,11 +6917,11 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jotai-scope@0.11.0:
-    resolution: {integrity: sha512-ofiW0Z0i3lTw509Gx0+T6fqsDPMDxMn+AHmNs9iF9OA8CmK1/0xRprPxuZ89UZdBzt6jcrTYdunNZSF2255zJQ==}
+  jotai-scope@0.12.2:
+    resolution: {integrity: sha512-E8iVkHS6Ox3kF+eBqq6zM32mj3Fxm6Ks2OlrTG/F2G6vOn4qpW/jJHq81/O72r7NwQ14K80wJTa16icuR7ppFg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      jotai: '>=2.20.0'
+      jotai: '>=2.20.0 || >=3.0.0-alpha.0'
       react: '>=16.0.0'
 
   jotai-tanstack-query@0.11.0:
@@ -6937,19 +6937,13 @@ packages:
       react:
         optional: true
 
-  jotai@2.20.3:
-    resolution: {integrity: sha512-N8L9FUbeGDP+0qNJw1FebOxt+5hk+jTOwUA2LlRE4C081jUcY6F1T/FSETp4DT2/INMtiSRZyNm2D+yZdzrSgA==}
-    engines: {node: '>=12.20.0'}
+  jotai@3.0.0:
+    resolution: {integrity: sha512-KxhbmsJUp/tmrv6aZgO+nzB3H9K8C0xmk5i3aGkwy/EANg73DVBkggv3zVHaAi5PlNlQgTgP4uiVepo+JC+wSA==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
-      '@babel/core': ^7.29.1
-      '@babel/template': '>=7.0.0'
-      '@types/react': '>=17.0.0'
-      react: '>=17.0.0'
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
     peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
       '@types/react':
         optional: true
       react:
@@ -14457,23 +14451,21 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jotai-scope@0.11.0(jotai@2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
+  jotai-scope@0.12.2(jotai@3.0.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
     dependencies:
-      jotai: 2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+      jotai: 3.0.0(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
 
-  jotai-tanstack-query@0.11.0(@tanstack/query-core@5.102.8)(@tanstack/react-query@5.102.8(react@19.2.8))(jotai@2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
+  jotai-tanstack-query@0.11.0(@tanstack/query-core@5.102.8)(@tanstack/react-query@5.102.8(react@19.2.8))(jotai@3.0.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
     dependencies:
       '@tanstack/query-core': 5.102.8
-      jotai: 2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+      jotai: 3.0.0(@types/react@19.2.18)(react@19.2.8)
     optionalDependencies:
       '@tanstack/react-query': 5.102.8(react@19.2.8)
       react: 19.2.8
 
-  jotai@2.20.3(@babel/core@7.29.7(supports-color@11.0.0))(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8):
+  jotai@3.0.0(@types/react@19.2.18)(react@19.2.8):
     optionalDependencies:
-      '@babel/core': 7.29.7(supports-color@11.0.0)
-      '@babel/template': 7.29.7
       '@types/react': 19.2.18
       react: 19.2.8
 
@@ -17472,9 +17464,9 @@ time:
   i18next@26.4.0: '2026-08-20T09:25:14.621Z'
   iconify-import-svg@0.2.0: '2026-04-20T06:18:25.132Z'
   immer@11.1.18: '2026-08-19T07:25:22.934Z'
-  jotai-scope@0.11.0: '2026-05-13T18:43:15.331Z'
+  jotai-scope@0.12.2: '2026-08-13T23:49:51.764Z'
   jotai-tanstack-query@0.11.0: '2025-08-01T02:55:49.826Z'
-  jotai@2.20.3: '2026-08-24T07:26:18.202Z'
+  jotai@3.0.0: '2026-09-08T13:51:57.446Z'
   js-cookie@3.0.8: '2026-05-29T10:51:39.065Z'
   js-yaml@5.4.1: '2026-08-26T19:31:37.034Z'
   jsonschema@1.5.0: '2025-01-07T15:09:11.287Z'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -183,8 +183,8 @@ catalog:
   i18next-resources-to-backend: 1.2.3
   iconify-import-svg: 0.2.0
   immer: 11.1.18
-  jotai: 2.20.3
-  jotai-scope: 0.11.0
+  jotai: 3.0.0
+  jotai-scope: 0.12.2
   jotai-tanstack-query: 0.11.0
   js-cookie: 3.0.8
   js-yaml: 5.4.1


### PR DESCRIPTION
## Summary

Upgrade the workspace catalog from Jotai 2.20.3 to 3.0.0 and jotai-scope 0.11.0 to 0.12.2, and refresh the lockfile. Keep jotai-tanstack-query at 0.11.0. Existing consumers use supported public APIs, so no application source changes are required by the checks performed.

## Validation

- Passed `pnpm install`, `pnpm check`, and staged formatting/lint checks.
- Passed 228 focused Web test files (1,734 tests), covering query bootstrap/hydration, Agent scope/session transitions, publishing/deployment state, and onboarding atoms.
- Passed all 9 jotai-tanstack-form tests.
- Local full Web tests and Next production build were stopped intentionally; full unit, browser, and E2E/build validation is delegated to CI.

From Codex
