### PR TITLE
chore(lint): share and tighten JSX accessibility rules

### DIFF
--- a/lint.config.ts
+++ b/lint.config.ts
@@ -22,7 +22,23 @@ const tailwindCanonicalClassesOverride = {
   },
 } satisfies NonNullable<OxlintConfig['overrides']>[number]
 
-export const webJsxA11yRules = {
+// Oxlint's default handler lists omit pointer and touch activation.
+const jsxInteractionHandlers = [
+  'onClick',
+  'onDoubleClick',
+  'onContextMenu',
+  'onMouseDown',
+  'onMouseUp',
+  'onPointerDown',
+  'onPointerUp',
+  'onTouchStart',
+  'onTouchEnd',
+  'onKeyPress',
+  'onKeyDown',
+  'onKeyUp',
+]
+
+export const jsxA11yRules = {
   'jsx-a11y/alt-text': 'error',
   'jsx-a11y/anchor-ambiguous-text': 'off',
   'jsx-a11y/anchor-has-content': 'error',
@@ -34,6 +50,8 @@ export const webJsxA11yRules = {
   'jsx-a11y/aria-unsupported-elements': 'error',
   'jsx-a11y/autocomplete-valid': 'error',
   'jsx-a11y/click-events-have-key-events': 'error',
+  // The native rule cannot resolve names supplied by Base UI render composition.
+  'jsx-a11y/control-has-associated-label': 'off',
   'jsx-a11y/heading-has-content': 'error',
   'jsx-a11y/html-has-lang': 'error',
   'jsx-a11y/iframe-has-title': 'error',
@@ -44,10 +62,15 @@ export const webJsxA11yRules = {
       tabbable: ['button', 'checkbox', 'link', 'searchbox', 'spinbutton', 'switch', 'textbox'],
     },
   ],
-  'jsx-a11y/label-has-associated-control': 'error',
+  'jsx-a11y/label-has-associated-control': [
+    'error',
+    { controlComponents: ['Checkbox', 'Textarea'] },
+  ],
+  'jsx-a11y/lang': 'error',
   'jsx-a11y/media-has-caption': 'error',
   'jsx-a11y/mouse-events-have-key-events': 'error',
   'jsx-a11y/no-access-key': 'error',
+  'jsx-a11y/no-aria-hidden-on-focusable': 'error',
   'jsx-a11y/no-autofocus': 'error',
   'jsx-a11y/no-distracting-elements': 'error',
   'jsx-a11y/no-interactive-element-to-noninteractive-role': [
@@ -60,16 +83,7 @@ export const webJsxA11yRules = {
   'jsx-a11y/no-noninteractive-element-interactions': [
     'error',
     {
-      handlers: [
-        'onClick',
-        'onError',
-        'onLoad',
-        'onMouseDown',
-        'onMouseUp',
-        'onKeyPress',
-        'onKeyDown',
-        'onKeyUp',
-      ],
+      handlers: [...jsxInteractionHandlers, 'onError', 'onLoad'],
       alert: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
       body: ['onError', 'onLoad'],
       dialog: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
@@ -80,8 +94,9 @@ export const webJsxA11yRules = {
   'jsx-a11y/no-noninteractive-element-to-interactive-role': [
     'error',
     {
-      ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
-      ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
+      // ARIA in HTML allows list widgets here, but not treegrid.
+      ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'],
+      ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree'],
       li: ['menuitem', 'menuitemradio', 'menuitemcheckbox', 'option', 'row', 'tab', 'treeitem'],
       table: ['grid'],
       td: ['gridcell'],
@@ -91,7 +106,6 @@ export const webJsxA11yRules = {
   'jsx-a11y/no-noninteractive-tabindex': [
     'error',
     {
-      tags: [],
       roles: ['tabpanel'],
       allowExpressionValues: true,
     },
@@ -101,7 +115,7 @@ export const webJsxA11yRules = {
     'error',
     {
       allowExpressionValues: true,
-      handlers: ['onClick', 'onMouseDown', 'onMouseUp', 'onKeyPress', 'onKeyDown', 'onKeyUp'],
+      handlers: jsxInteractionHandlers,
     },
   ],
   'jsx-a11y/role-has-required-aria-props': 'error',
@@ -788,8 +802,8 @@ export const lintConfig = {
       },
     },
     {
-      files: ['web/**/*.tsx'],
-      rules: webJsxA11yRules,
+      files: ['web/**/*.{jsx,tsx}', 'packages/dify-ui/**/*.{jsx,tsx}'],
+      rules: jsxA11yRules,
     },
     {
       files: ['web/**/*.stories.{js,cjs,mjs,jsx,ts,tsx}', 'web/**/*.story.{js,cjs,mjs,jsx,ts,tsx}'],
@@ -1160,113 +1174,6 @@ export const lintConfig = {
         'react/only-export-components': 'off',
         'eslint-react/no-context-provider': 'off',
         'eslint-react/no-use-context': 'off',
-      },
-    },
-    {
-      files: ['packages/dify-ui/**/*.tsx'],
-      rules: {
-        'jsx-a11y/alt-text': 'error',
-        'jsx-a11y/anchor-ambiguous-text': 'off',
-        'jsx-a11y/anchor-has-content': 'off',
-        'jsx-a11y/anchor-is-valid': 'error',
-        'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
-        'jsx-a11y/aria-props': 'error',
-        'jsx-a11y/aria-proptypes': 'error',
-        'jsx-a11y/aria-role': 'error',
-        'jsx-a11y/aria-unsupported-elements': 'error',
-        'jsx-a11y/autocomplete-valid': 'error',
-        'jsx-a11y/click-events-have-key-events': 'error',
-        'jsx-a11y/control-has-associated-label': 'off',
-        'jsx-a11y/heading-has-content': 'error',
-        'jsx-a11y/html-has-lang': 'error',
-        'jsx-a11y/iframe-has-title': 'error',
-        'jsx-a11y/img-redundant-alt': 'error',
-        'jsx-a11y/interactive-supports-focus': [
-          'error',
-          {
-            tabbable: [
-              'button',
-              'checkbox',
-              'link',
-              'searchbox',
-              'spinbutton',
-              'switch',
-              'textbox',
-            ],
-          },
-        ],
-        'jsx-a11y/label-has-associated-control': 'off',
-        'jsx-a11y/media-has-caption': 'error',
-        'jsx-a11y/mouse-events-have-key-events': 'error',
-        'jsx-a11y/no-access-key': 'error',
-        'jsx-a11y/no-autofocus': 'error',
-        'jsx-a11y/no-distracting-elements': 'error',
-        'jsx-a11y/no-interactive-element-to-noninteractive-role': [
-          'error',
-          {
-            tr: ['none', 'presentation'],
-            canvas: ['img'],
-          },
-        ],
-        'jsx-a11y/no-noninteractive-element-interactions': [
-          'error',
-          {
-            handlers: [
-              'onClick',
-              'onError',
-              'onLoad',
-              'onMouseDown',
-              'onMouseUp',
-              'onKeyPress',
-              'onKeyDown',
-              'onKeyUp',
-            ],
-            alert: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
-            body: ['onError', 'onLoad'],
-            dialog: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
-            iframe: ['onError', 'onLoad'],
-            img: ['onError', 'onLoad'],
-          },
-        ],
-        'jsx-a11y/no-noninteractive-element-to-interactive-role': [
-          'error',
-          {
-            ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
-            ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
-            li: [
-              'menuitem',
-              'menuitemradio',
-              'menuitemcheckbox',
-              'option',
-              'row',
-              'tab',
-              'treeitem',
-            ],
-            table: ['grid'],
-            td: ['gridcell'],
-            fieldset: ['radiogroup', 'presentation'],
-          },
-        ],
-        'jsx-a11y/no-noninteractive-tabindex': [
-          'error',
-          {
-            tags: [],
-            roles: ['tabpanel'],
-            allowExpressionValues: true,
-          },
-        ],
-        'jsx-a11y/no-redundant-roles': 'error',
-        'jsx-a11y/no-static-element-interactions': [
-          'error',
-          {
-            allowExpressionValues: true,
-            handlers: ['onClick', 'onMouseDown', 'onMouseUp', 'onKeyPress', 'onKeyDown', 'onKeyUp'],
-          },
-        ],
-        'jsx-a11y/role-has-required-aria-props': 'error',
-        'jsx-a11y/role-supports-aria-props': 'error',
-        'jsx-a11y/scope': 'error',
-        'jsx-a11y/tabindex-no-positive': 'error',
       },
     },
     {

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2359,6 +2359,11 @@
       "count": 5
     }
   },
+  "web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx": {
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1
+    }
+  },
   "web/app/components/header/account-setting/model-provider-page/provider-added-card/cooldown-timer.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
@@ -2478,6 +2483,11 @@
   },
   "web/app/components/plugins/install-plugin/utils.ts": {
     "import/no-duplicates": {
+      "count": 1
+    }
+  },
+  "web/app/components/plugins/marketplace/home/home-trending.tsx": {
+    "jsx-a11y/no-static-element-interactions": {
       "count": 1
     }
   },
@@ -4428,6 +4438,11 @@
       "count": 4
     }
   },
+  "web/app/components/workflow/panel/version-history-panel/version-history-item.tsx": {
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1
+    }
+  },
   "web/app/components/workflow/panel/workflow-preview.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 4
@@ -4829,6 +4844,11 @@
   },
   "web/features/skills/detail/file-editor.tsx": {
     "@tanstack/query/prefer-query-options": {
+      "count": 2
+    }
+  },
+  "web/features/skills/detail/file-tree-items.tsx": {
+    "jsx-a11y/no-static-element-interactions": {
       "count": 2
     }
   },

--- a/packages/dify-ui/src/dropdown-menu/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/dropdown-menu/__tests__/index.spec.tsx
@@ -296,6 +296,7 @@ describe('dropdown-menu wrapper', () => {
         <DropdownMenu open>
           <DropdownMenuTrigger aria-label="menu trigger">Open</DropdownMenuTrigger>
           <DropdownMenuContent>
+            {/* oxlint-disable-next-line jsx-a11y/anchor-has-content -- Base UI merges this item's children and accessible name into the render element. */}
             <DropdownMenuLinkItem render={<a href="/account" />} aria-label="account link">
               Account settings
             </DropdownMenuLinkItem>

--- a/web/scripts/a11y/oxlint.config.ts
+++ b/web/scripts/a11y/oxlint.config.ts
@@ -1,10 +1,10 @@
 import type { OxlintConfig } from 'vite-plus/lint'
-import { webJsxA11yRules } from '../../../lint.config.ts'
+import { jsxA11yRules } from '../../../lint.config.ts'
 
 export default {
   categories: {
     correctness: 'off',
   },
   plugins: ['jsx-a11y'],
-  rules: webJsxA11yRules,
+  rules: jsxA11yRules,
 } satisfies OxlintConfig


### PR DESCRIPTION
## Summary

Fixes [SNP-780](https://linear.app/dify/issue/SNP-780)

Web and Dify UI currently duplicate JSX accessibility rules, with package-wide link-content and label-association exemptions in Dify UI. Share one rule set across both packages and the page-scoped a11y command, covering JSX and TSX.

- Expand interaction checks to pointer, touch, double-click, and context-menu events; enable language and hidden-focusable-element checks; remove the invalid `ul`/`ol` treegrid allowance.
- Restore Dify UI link and label checks, recognize Checkbox/Textarea label composition, and document one render-anchor test exception.
- Baseline five existing interaction diagnostics across four Web files in `oxlint-suppressions.json`. These remain unresolved; this PR changes lint policy without changing application behavior.

## Validation

- `vp run -w check`: passed, 0 errors and 1,952 existing warnings.
- Isolated a11y comparison: all 523 prior Web diagnostics retained; five additional diagnostics baselined.
- Dify UI dropdown-menu Browser Mode: 18 tests passed in Chromium.
- 27 valid and 36 invalid lint fixtures verified.

From Codex
