### PR TITLE
fix: parse WaterCrawl durations without fractional seconds or with days

### DIFF
--- a/api/core/rag/extractor/watercrawl/provider.py
+++ b/api/core/rag/extractor/watercrawl/provider.py
@@ -1,5 +1,5 @@
+import re
 from collections.abc import Generator
-from datetime import datetime
 from typing import Any, TypedDict
 
 from core.rag.extractor.watercrawl.client import PageOptions, SpiderOptions, WaterCrawlAPIClient
@@ -62,6 +62,33 @@ class WaterCrawlProvider:
 
         return {"status": "active", "job_id": result.get("uuid")}
 
+    @staticmethod
+    def _parse_duration_seconds(duration: str) -> float:
+        """Convert a WaterCrawl duration string to seconds.
+
+        WaterCrawl reports durations in Python ``str(timedelta)`` shape, which
+        omits the fractional part when it is zero and prefixes a day count for
+        durations of 24 hours or more, e.g. ``"0:00:05"``, ``"0:00:05.123456"``
+        or ``"1 day, 0:00:05"``.
+        """
+        match = re.fullmatch(
+            r"(?:(?P<days>\d+) days?, )?(?P<hours>\d+):(?P<minutes>\d{2}):(?P<seconds>\d{2})(?:\.(?P<fraction>\d+))?",
+            duration.strip(),
+        )
+        if not match:
+            raise ValueError(f"Unrecognized crawl duration format: {duration}")
+        parts = match.groupdict()
+        seconds = (
+            int(parts["days"] or 0) * 86400
+            + int(parts["hours"]) * 3600
+            + int(parts["minutes"]) * 60
+            + int(parts["seconds"])
+        )
+        fraction = parts["fraction"] or ""
+        if fraction:
+            seconds += int(fraction) / 10 ** len(fraction)
+        return seconds
+
     def get_crawl_status(self, crawl_request_id: str) -> WatercrawlCrawlStatusResponse:
         response = self.client.get_crawl_request(crawl_request_id)
         data: list[WatercrawlDocumentData] = []
@@ -74,10 +101,7 @@ class WaterCrawlProvider:
         time_str = response.get("duration")
         time_consuming: float = 0
         if time_str:
-            time_obj = datetime.strptime(time_str, "%H:%M:%S.%f")
-            time_consuming = (
-                time_obj.hour * 3600 + time_obj.minute * 60 + time_obj.second + time_obj.microsecond / 1_000_000
-            )
+            time_consuming = self._parse_duration_seconds(time_str)
 
         return {
             "status": status,

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -386,6 +386,32 @@ class TestWaterCrawlProvider:
         assert completed["status"] == "completed"
         assert completed["data"] == [{"url": "u"}]
 
+    def test_get_crawl_status_parses_duration_shapes(self, monkeypatch: pytest.MonkeyPatch):
+        """Durations without a fraction or with a day prefix must not crash status polling."""
+        provider = WaterCrawlProvider(api_key="k")
+
+        cases = [
+            ("0:00:05", 5.0),
+            ("00:00:05", 5.0),
+            ("0:00:05.123456", 5.123456),
+            ("1 day, 0:00:05", 86405.0),
+            ("2 days, 3:04:05.5", 2 * 86400 + 3 * 3600 + 4 * 60 + 5.5),
+        ]
+        for duration, expected_seconds in cases:
+            monkeypatch.setattr(
+                provider.client,
+                "get_crawl_request",
+                lambda job_id, duration=duration: {
+                    "status": "running",
+                    "uuid": job_id,
+                    "options": {"spider_options": {"page_limit": 1}},
+                    "number_of_documents": 0,
+                    "duration": duration,
+                },
+            )
+            status = provider.get_crawl_status("job")
+            assert status["time_consuming"] == pytest.approx(expected_seconds), duration
+
     def test_get_crawl_url_data_and_scrape(self, monkeypatch: pytest.MonkeyPatch):
         provider = WaterCrawlProvider(api_key="k")
 


### PR DESCRIPTION
## Summary

Fixes #42040

`WaterCrawlProvider.get_crawl_status` parsed the crawl `duration` with a strict `strptime(time_str, "%H:%M:%S.%f")`. WaterCrawl returns durations in `str(timedelta)` shape, which omits the fractional part when it is zero (`"0:00:05"`) and prefixes a day count past 24 hours (`"1 day, 0:00:05.000000"`). Both shapes raised `ValueError`, so status polling crashed and a finished crawl could never be reported as completed.

The duration is now parsed with a tolerant regex that accepts an optional day prefix and an optional fraction.

## Testing

- `pytest tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py` - 34 passed
- New test `test_get_crawl_status_parses_duration_shapes` covers `0:00:05`, `00:00:05`, `0:00:05.123456`, `1 day, 0:00:05`, `2 days, 3:04:05.5`; it fails on current `main` and passes with this fix.
- `ruff check` and `ruff format --check` clean on the changed files.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods