### PR TITLE
fix: raise when all detected encodings fail in CSV and Markdown extractors

### DIFF
--- a/api/core/rag/extractor/csv_extractor.py
+++ b/api/core/rag/extractor/csv_extractor.py
@@ -51,6 +51,10 @@ class CSVExtractor(BaseExtractor):
                         break
                     except UnicodeDecodeError:
                         continue
+                else:
+                    raise RuntimeError(
+                        f"Decode failed: {self._file_path}, all detected encodings failed. Original error: {e}"
+                    )
             else:
                 raise RuntimeError(f"Error loading {self._file_path}") from e
 

--- a/api/core/rag/extractor/markdown_extractor.py
+++ b/api/core/rag/extractor/markdown_extractor.py
@@ -109,6 +109,8 @@ class MarkdownExtractor(BaseExtractor):
                         break
                     except UnicodeDecodeError:
                         continue
+                else:
+                    raise RuntimeError(f"Decode failed: {filepath}, all detected encodings failed. Original error: {e}")
             else:
                 raise RuntimeError(f"Error loading {filepath}") from e
         except Exception as e:

--- a/api/tests/unit_tests/core/rag/extractor/test_csv_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_csv_extractor.py
@@ -99,7 +99,7 @@ class TestCSVExtractor:
         assert docs[0].page_content == "id: source-1;body: hello"
         assert attempted_encodings == [None, "bad", "utf-8"]
 
-    def test_extract_autodetect_encoding_all_attempts_fail_returns_empty(self, monkeypatch: pytest.MonkeyPatch):
+    def test_extract_autodetect_encoding_all_attempts_fail_raises(self, monkeypatch: pytest.MonkeyPatch):
         extractor = CSVExtractor("dummy.csv", autodetect_encoding=True)
 
         def always_raise(*args, **kwargs):
@@ -108,7 +108,8 @@ class TestCSVExtractor:
         monkeypatch.setattr("builtins.open", always_raise)
         monkeypatch.setattr(csv_module, "detect_file_encodings", lambda _: [SimpleNamespace(encoding="bad")])
 
-        assert extractor.extract() == []
+        with pytest.raises(RuntimeError, match="Decode failed: dummy.csv, all detected encodings failed"):
+            extractor.extract()
 
     def test_read_from_file_re_raises_csv_error(self, monkeypatch: pytest.MonkeyPatch):
         extractor = CSVExtractor("dummy.csv")

--- a/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_markdown_extractor.py
@@ -47,6 +47,18 @@ after
         assert tups[1][0] == "Header"
         assert "# this is not a heading" in tups[1][1]
 
+    def test_parse_tups_raises_when_all_detected_encodings_fail(self, monkeypatch: pytest.MonkeyPatch):
+        extractor = MarkdownExtractor(file_path="dummy.md", autodetect_encoding=True)
+
+        def always_raise(*args, **kwargs):
+            raise UnicodeDecodeError("utf-8", b"x", 0, 1, "decode error")
+
+        monkeypatch.setattr(Path, "read_text", always_raise)
+        monkeypatch.setattr(markdown_module, "detect_file_encodings", lambda _: [SimpleNamespace(encoding="bad")])
+
+        with pytest.raises(RuntimeError, match="Decode failed: dummy.md, all detected encodings failed"):
+            extractor.parse_tups("dummy.md")
+
     def test_remove_images_and_hyperlinks(self):
         extractor = MarkdownExtractor(file_path="dummy_path")
 


### PR DESCRIPTION
## Summary

Fixes #42041

When `autodetect_encoding=True` and the initial decode raises `UnicodeDecodeError`, `CSVExtractor` and `MarkdownExtractor` try each encoding from `detect_file_encodings` - but if every candidate also fails, neither raised. The CSV extractor returned `[]` and the Markdown extractor produced a `Document` with empty `page_content`, so corrupt or undecodable uploads were silently ingested as empty knowledge.

Both extractors now mirror `TextExtractor`'s `else: raise RuntimeError("Decode failed: ...")` on the fallback loop, chained from the original decode error.

## Testing

- `pytest tests/unit_tests/core/rag/extractor/test_csv_extractor.py tests/unit_tests/core/rag/extractor/test_markdown_extractor.py` - 24 passed
- The existing test that pinned the silent-empty behavior (`test_extract_autodetect_encoding_all_attempts_fail_returns_empty`) now asserts the raise; a matching Markdown test was added. Both fail on current `main` and pass with this fix.
- Successful fallback decoding (second candidate works) is still covered and passing.
- `ruff check` and `ruff format --check` clean on the changed files.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods