### PR TITLE
fix: escape double quotes in .xls cell values like the .xlsx path

### DIFF
--- a/api/core/rag/extractor/excel_extractor.py
+++ b/api/core/rag/extractor/excel_extractor.py
@@ -143,7 +143,10 @@ class ExcelExtractor(BaseExtractor):
                     page_content = []
                     for k, v in series_row.items():
                         if pd.notna(v):
-                            page_content.append(f'"{k}":"{v}"')
+                            # Escape embedded double quotes like the .xlsx branch
+                            # does, so quoted cell values do not corrupt the row.
+                            value = str(v).replace('"', '\\"')
+                            page_content.append(f'"{k}":"{value}"')
                     documents.append(
                         Document(page_content=";".join(page_content), metadata={"source": self._file_path})
                     )

--- a/api/tests/unit_tests/core/rag/extractor/test_excel_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_excel_extractor.py
@@ -260,6 +260,21 @@ class TestExcelExtractor:
         assert docs[0].page_content == '"A":"x";"B":"1.0"'
         assert docs[0].metadata == {"source": "/tmp/sample.xls"}
 
+    def test_extract_xls_escapes_double_quotes_like_xlsx(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeExcelFile:
+            sheet_names = ["Sheet1"]
+
+            def parse(self, sheet_name):
+                return pd.DataFrame([{"note": 'he said "hi"', "plain": "text"}])
+
+        monkeypatch.setattr(pd, "ExcelFile", lambda path, engine=None: FakeExcelFile())
+
+        extractor = ExcelExtractor("/tmp/sample.xls")
+        docs = extractor.extract()
+
+        assert len(docs) == 1
+        assert docs[0].page_content == '"note":"he said \\"hi\\"";"plain":"text"'
+
     def test_extract_unsupported_extension_raises(self):
         extractor = ExcelExtractor("/tmp/sample.txt")
 


### PR DESCRIPTION
## Summary

Fixes #42043

`ExcelExtractor` emits rows in a `"column":"value"` format. The `.xlsx` (openpyxl) branch escapes embedded double quotes before formatting; the legacy `.xls` (pandas/xlrd) branch interpolated raw values, so a cell containing `he said "hi"` was extracted as `"note":"he said "hi""`, corrupting the row structure and making the two engines inconsistent for the same content.

The `.xls` branch now applies the same `replace('"', '\\"')` escaping.

## Testing

- `pytest tests/unit_tests/core/rag/extractor/test_excel_extractor.py` - 9 passed
- New test `test_extract_xls_escapes_double_quotes_like_xlsx` covers quoted cell values; it fails on current `main` and passes with this fix. Existing `.xls` expectations (values without quotes) are unchanged.
- `ruff check` and `ruff format --check` clean on the changed files.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods