### PR TITLE
fix: join all rich_text/title segments in Notion database extraction

### DIFF
--- a/api/core/rag/extractor/notion_extractor.py
+++ b/api/core/rag/extractor/notion_extractor.py
@@ -135,10 +135,9 @@ class NotionExtractor(BaseExtractor):
                         for multi_select in multi_select_list:
                             value.append(multi_select["name"])
                     elif type in {"rich_text", "title"}:
-                        if len(property_value[type]) > 0:
-                            value = property_value[type][0]["plain_text"]
-                        else:
-                            value = ""
+                        # Notion splits formatted text into multiple segments;
+                        # join them all so no part of the value is dropped.
+                        value = "".join(segment.get("plain_text", "") for segment in property_value[type])
                     elif type in {"select", "status"}:
                         if property_value[type]:
                             value = property_value[type]["name"]

--- a/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
@@ -196,6 +196,49 @@ class TestNotionDatabase:
         assert "Row Page URL:https://notion.so/page-1" in content
         assert mock_post.call_count == 2
 
+    def test_get_notion_database_data_joins_all_rich_text_segments(self, mocker: MockerFixture):
+        """Formatted text arrives as multiple segments; all of them must be kept."""
+        extractor = notion_extractor.NotionExtractor(
+            notion_workspace_id="ws",
+            notion_obj_id="obj",
+            notion_page_type="database",
+            tenant_id="tenant",
+            notion_access_token="token",
+        )
+
+        page = {
+            "results": [
+                {
+                    "properties": {
+                        "title_prop": {
+                            "type": "title",
+                            "title": [{"plain_text": "Hello "}, {"plain_text": "world"}],
+                        },
+                        "rich": {
+                            "type": "rich_text",
+                            "rich_text": [
+                                {"plain_text": "first "},
+                                {"plain_text": "second"},
+                                {"plain_text": " third"},
+                            ],
+                        },
+                    },
+                    "url": "https://notion.so/page-1",
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        }
+
+        mocker.patch("httpx.post", return_value=_mock_response(page))
+
+        docs = extractor._get_notion_database_data("db-1")
+
+        assert len(docs) == 1
+        content = docs[0].page_content
+        assert "rich:first second third" in content
+        assert "title_prop:Hello world" in content
+
     def test_get_notion_database_data_handles_missing_results_and_empty_content(self, mocker: MockerFixture):
         extractor = notion_extractor.NotionExtractor(
             notion_workspace_id="ws",


### PR DESCRIPTION
## Summary

Fixes #42044

`NotionExtractor._get_notion_database_data` read `rich_text` and `title` database properties as only their first segment (`property_value[type][0]["plain_text"]`). Notion splits text into multiple segments whenever formatting changes (bold, links, mentions), so a title like `Hello world` with `world` in bold was indexed as just `Hello `.

All segments are now joined, matching what the table-cell path in the same file already does.

## Testing

- `pytest tests/unit_tests/core/rag/extractor/test_notion_extractor.py` - 23 passed
- New test `test_get_notion_database_data_joins_all_rich_text_segments` covers a two-segment title and a three-segment rich_text property; it fails on current `main` and passes with this fix.
- `ruff check` and `ruff format --check` clean on the changed files.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods