### PR TITLE
fix: escape double quotes in .xls extractor to match .xlsx behavior

### DIFF
--- a/api/core/rag/extractor/excel_extractor.py
+++ b/api/core/rag/extractor/excel_extractor.py
@@ -143,6 +143,7 @@ class ExcelExtractor(BaseExtractor):
                     page_content = []
                     for k, v in series_row.items():
                         if pd.notna(v):
+                            v = str(v).replace('"', '\\"')
                             page_content.append(f'"{k}":"{v}"')
                     documents.append(
                         Document(page_content=";".join(page_content), metadata={"source": self._file_path})


### PR DESCRIPTION
Fixes #42043

## Problem
The `ExcelExtractor`'s `.xlsx` branch escapes embedded double quotes in cell
values before formatting (`value.replace('"', '\"')`), but the legacy
`.xls` branch (pandas/xlrd) interpolates raw values without escaping.

This causes JSON corruption when a cell value contains double quotes:
`"note":"he said "hi""` becomes invalid.

## Fix
Apply the same `str(v).replace('"', '\"')` escaping in the `.xls` branch,
matching the `.xlsx` behavior.

## Testing
- Existing ExcelExtractor tests pass
- The `.xls` path now produces properly escaped JSON for values containing quotes