### PR TITLE
refactor(api): migrate installed app audio admission

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -227,6 +227,20 @@ forbidden_modules =
     sqlalchemy
     werkzeug
 
+[importlinter:contract:installed-app-audio-boundary]
+name = Installed app audio contract is framework and persistence neutral
+type = forbidden
+source_modules =
+    services.installed_app_audio_service
+forbidden_modules =
+    controllers
+    extensions
+    flask
+    models
+    repositories
+    sqlalchemy
+    werkzeug
+
 [importlinter:contract:installed-app-conversation-boundary]
 name = Installed app conversation service is framework and persistence neutral
 type = forbidden

--- a/api/.importlinter
+++ b/api/.importlinter
@@ -232,6 +232,7 @@ name = Installed app audio contract is framework and persistence neutral
 type = forbidden
 source_modules =
     services.installed_app_audio_service
+    services.audio_types
 forbidden_modules =
     controllers
     extensions

--- a/api/controllers/console/app/error.py
+++ b/api/controllers/console/app/error.py
@@ -89,6 +89,12 @@ class ProviderNotSupportSpeechToTextError(BaseHTTPException):
     code = 400
 
 
+class ProviderNotSupportTextToSpeechError(BaseHTTPException):
+    error_code = "provider_not_support_text_to_speech"
+    description = "Provider does not support text to speech."
+    code = 400
+
+
 class SpeechToTextDisabledError(BaseHTTPException):
     error_code = "speech_to_text_disabled"
     description = "Speech to text is disabled."

--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -1,12 +1,17 @@
+"""Installed-app audio admission, error translation, and response serialization."""
+
 import logging
+from collections.abc import Callable
+from functools import wraps
 
-from flask import request
-from werkzeug.exceptions import InternalServerError
+from flask import Response, request, stream_with_context
+from flask_restx import Resource
+from werkzeug.exceptions import HTTPException, InternalServerError
 
-import services
 from controllers.common.controller_schemas import TextToAudioPayload
 from controllers.common.fields import AudioBinaryResponse, AudioTranscriptResponse
 from controllers.common.schema import register_response_schema_models, register_schema_model
+from controllers.console import console_ns
 from controllers.console.app.error import (
     AppUnavailableError,
     AudioTooLargeError,
@@ -15,28 +20,32 @@ from controllers.console.app.error import (
     ProviderModelCurrentlyNotSupportError,
     ProviderNotInitializeError,
     ProviderNotSupportSpeechToTextError,
+    ProviderNotSupportTextToSpeechError,
     ProviderQuotaExceededError,
     SpeechToTextDisabledError,
     UnsupportedAudioTypeError,
 )
-from controllers.console.explore.wraps import InstalledAppResource
+from controllers.console.explore.error import InstalledAppNotFoundHTTPError
+from controllers.console.explore.installed_app_admission import get_installed_app
+from controllers.console.flask_admission import console_account_admission
 from controllers.console.wraps import model_validate
+from core.base.tts.audio_mime import inspect_audio_stream, resolve_audio_mime_type
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
-from extensions.ext_database import db
+from extensions.ext_application_services import application_services
 from graphon.model_runtime.errors.invoke import InvokeError
-from libs.login import current_account_with_tenant
-from models.model import InstalledApp
-from services.app_ref_service import AppRefService
-from services.audio_service import AudioService
+from libs.helper import dump_response
+from machinery.context import RequestContext
+from services.errors.app_model_config import AppModelConfigBrokenError
 from services.errors.audio import (
     AudioTooLargeServiceError,
     NoAudioUploadedServiceError,
     ProviderNotSupportSpeechToTextServiceError,
+    ProviderNotSupportTextToSpeechServiceError,
     SpeechToTextDisabledServiceError,
     UnsupportedAudioTypeServiceError,
 )
-
-from .. import console_ns
+from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
+from services.installed_app_audio_service import AudioUpload
 
 logger = logging.getLogger(__name__)
 
@@ -44,111 +53,92 @@ register_schema_model(console_ns, TextToAudioPayload)
 register_response_schema_models(console_ns, AudioBinaryResponse, AudioTranscriptResponse)
 
 
+def _audio_errors[**P, R](view: Callable[P, R]) -> Callable[P, R]:
+    @wraps(view)
+    def decorated(*args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return view(*args, **kwargs)
+        except InstalledAppNotFoundError as error:
+            raise InstalledAppNotFoundHTTPError() from error
+        except AppModelConfigBrokenError as error:
+            logger.exception("App model config broken")
+            raise AppUnavailableError() from error
+        except NoAudioUploadedServiceError as error:
+            raise NoAudioUploadedError() from error
+        except AudioTooLargeServiceError as error:
+            raise AudioTooLargeError(str(error)) from error
+        except UnsupportedAudioTypeServiceError as error:
+            raise UnsupportedAudioTypeError() from error
+        except ProviderNotSupportSpeechToTextServiceError as error:
+            raise ProviderNotSupportSpeechToTextError() from error
+        except ProviderNotSupportTextToSpeechServiceError as error:
+            raise ProviderNotSupportTextToSpeechError() from error
+        except SpeechToTextDisabledServiceError as error:
+            raise SpeechToTextDisabledError() from error
+        except ProviderTokenNotInitError as error:
+            raise ProviderNotInitializeError(error.description) from error
+        except QuotaExceededError as error:
+            raise ProviderQuotaExceededError() from error
+        except ModelCurrentlyNotSupportError as error:
+            raise ProviderModelCurrentlyNotSupportError() from error
+        except InvokeError as error:
+            raise CompletionRequestError(error.description) from error
+        except (HTTPException, ValueError):
+            raise
+        except Exception as error:
+            logger.exception("Installed-app audio operation failed")
+            raise InternalServerError() from error
+
+    return decorated
+
+
 @console_ns.route(
     "/installed-apps/<uuid:installed_app_id>/audio-to-text",
     endpoint="installed_app_audio",
 )
-class ChatAudioApi(InstalledAppResource):
+class ChatAudioApi(Resource):
     @console_ns.response(200, "Success", console_ns.models[AudioTranscriptResponse.__name__])
-    def post(self, installed_app: InstalledApp):
-        app_model = installed_app.app_with_session(session=db.session())
-        if app_model is None:
-            raise AppUnavailableError()
-
-        file = request.files["file"]
-
-        try:
-            response = AudioService.transcript_asr(
-                app_model=app_model,
-                file=file,
-                session=db.session(),
-                end_user=None,
-            )
-
-            return response
-        except services.errors.app_model_config.AppModelConfigBrokenError:
-            logger.exception("App model config broken.")
-            raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
-        except AudioTooLargeServiceError as e:
-            raise AudioTooLargeError(str(e))
-        except UnsupportedAudioTypeServiceError:
-            raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
-        except SpeechToTextDisabledServiceError:
-            raise SpeechToTextDisabledError()
-        except ProviderTokenNotInitError as ex:
-            raise ProviderNotInitializeError(ex.description)
-        except QuotaExceededError:
-            raise ProviderQuotaExceededError()
-        except ModelCurrentlyNotSupportError:
-            raise ProviderModelCurrentlyNotSupportError()
-        except InvokeError as e:
-            raise CompletionRequestError(e.description)
-        except ValueError as e:
-            raise e
-        except Exception as e:
-            logger.exception("internal server error.")
-            raise InternalServerError()
+    @console_account_admission()
+    @get_installed_app
+    @_audio_errors
+    def post(self, request_context: RequestContext, installed_app: InstalledAppRef) -> dict[str, object]:
+        file = request.files.get("file")
+        audio = AudioUpload(stream=file.stream, mime_type=file.mimetype) if file is not None else None
+        transcript = application_services().installed_app_audio.transcript_asr(installed_app=installed_app, audio=audio)
+        return dump_response(AudioTranscriptResponse, transcript)
 
 
 @console_ns.route(
     "/installed-apps/<uuid:installed_app_id>/text-to-audio",
     endpoint="installed_app_text",
 )
-class ChatTextApi(InstalledAppResource):
+class ChatTextApi(Resource):
     @console_ns.expect(console_ns.models[TextToAudioPayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[AudioBinaryResponse.__name__])
+    @console_account_admission()
+    @get_installed_app
     @model_validate(TextToAudioPayload)
-    def post(self, req_data: TextToAudioPayload, installed_app: InstalledApp):
-        app_model = installed_app.app_with_session(session=db.session())
-        if app_model is None:
-            raise AppUnavailableError()
-        try:
-            message_id = req_data.message_id
-            text = req_data.text
-            voice = req_data.voice
-            message_ref = None
-            if message_id:
-                current_user, _ = current_account_with_tenant()
-                app_ref = AppRefService.create_app_ref(app_model)
-                message_ref = AppRefService.create_message_ref(
-                    app_ref,
-                    message_id,
-                    account_id=current_user.id,
-                )
-
-            response = AudioService.transcript_tts(
-                app_model=app_model,
-                session=db.session(),
-                text=text,
-                voice=voice,
-                message_ref=message_ref,
-            )
-            return response
-        except services.errors.app_model_config.AppModelConfigBrokenError:
-            logger.exception("App model config broken.")
-            raise AppUnavailableError()
-        except NoAudioUploadedServiceError:
-            raise NoAudioUploadedError()
-        except AudioTooLargeServiceError as e:
-            raise AudioTooLargeError(str(e))
-        except UnsupportedAudioTypeServiceError:
-            raise UnsupportedAudioTypeError()
-        except ProviderNotSupportSpeechToTextServiceError:
-            raise ProviderNotSupportSpeechToTextError()
-        except ProviderTokenNotInitError as ex:
-            raise ProviderNotInitializeError(ex.description)
-        except QuotaExceededError:
-            raise ProviderQuotaExceededError()
-        except ModelCurrentlyNotSupportError:
-            raise ProviderModelCurrentlyNotSupportError()
-        except InvokeError as e:
-            raise CompletionRequestError(e.description)
-        except ValueError as e:
-            raise e
-        except Exception as e:
-            logger.exception("internal server error.")
-            raise InternalServerError()
+    @_audio_errors
+    def post(
+        self, payload: TextToAudioPayload, request_context: RequestContext, installed_app: InstalledAppRef
+    ) -> Response | None:
+        output = application_services().installed_app_audio.transcript_tts(
+            installed_app=installed_app,
+            account_id=request_context.account_id,
+            text=payload.text,
+            voice=payload.voice,
+            message_id=payload.message_id,
+        )
+        # response-contract:ignore audio_binary_response
+        if output is None:
+            return None
+        if isinstance(output.data, (bytes, bytearray, memoryview)):
+            data = bytes(output.data)
+            return Response(data, content_type=resolve_audio_mime_type(data, output.mime_type))
+        audio_stream, mime_type = inspect_audio_stream(output.data, output.mime_type)
+        # Preserve the shared MIME and request context behavior. TODO: Make the
+        # shared MIME iterator propagate close() to the provider stream.
+        return Response(
+            stream_with_context(audio_stream),  # pyrefly: ignore[no-matching-overload]
+            content_type=mime_type,
+        )

--- a/api/controllers/console/explore/wraps.py
+++ b/api/controllers/console/explore/wraps.py
@@ -4,10 +4,8 @@ from typing import Concatenate
 
 from flask_restx import Resource
 from sqlalchemy import select
-from werkzeug.exceptions import NotFound
 
 from controllers.console.explore.error import (
-    AppAccessDeniedError,
     TrialAppFeatureDisabledError,
     TrialAppLimitExceeded,
     TrialAppNotAllowed,
@@ -16,61 +14,7 @@ from controllers.console.wraps import account_initialization_required
 from extensions.ext_application_services import application_services
 from extensions.ext_database import db
 from libs.login import current_account_with_tenant, login_required
-from models import AccountTrialAppRecord, App, InstalledApp, TrialApp
-from services.enterprise.enterprise_service import EnterpriseService
-from services.system_feature_service import SystemFeatureService
-
-
-def installed_app_required[**P, R](view: Callable[Concatenate[InstalledApp, P], R] | None = None):
-    def decorator(view: Callable[Concatenate[InstalledApp, P], R]):
-        @wraps(view)
-        def decorated(installed_app_id: str, *args: P.args, **kwargs: P.kwargs):
-            _, current_tenant_id = current_account_with_tenant()
-            installed_app = db.session.scalar(
-                select(InstalledApp)
-                .where(InstalledApp.id == str(installed_app_id), InstalledApp.tenant_id == current_tenant_id)
-                .limit(1)
-            )
-
-            if installed_app is None:
-                raise NotFound("Installed app not found")
-
-            if not installed_app.app_with_session(session=db.session()):
-                db.session.delete(installed_app)
-                db.session.commit()
-
-                raise NotFound("Installed app not found")
-
-            return view(installed_app, *args, **kwargs)
-
-        return decorated
-
-    if view:
-        return decorator(view)
-    return decorator
-
-
-def user_allowed_to_access_app[**P, R](view: Callable[Concatenate[InstalledApp, P], R] | None = None):
-    def decorator(view: Callable[Concatenate[InstalledApp, P], R]):
-        @wraps(view)
-        def decorated(installed_app: InstalledApp, *args: P.args, **kwargs: P.kwargs):
-            current_user, _ = current_account_with_tenant()
-            if SystemFeatureService.is_webapp_auth_enabled():
-                app_id = installed_app.app_id
-                res = EnterpriseService.WebAppAuth.is_user_allowed_to_access_webapp(
-                    user_id=str(current_user.id),
-                    app_id=app_id,
-                )
-                if not res:
-                    raise AppAccessDeniedError()
-
-            return view(installed_app, *args, **kwargs)
-
-        return decorated
-
-    if view:
-        return decorator(view)
-    return decorator
+from models import AccountTrialAppRecord, App, TrialApp
 
 
 def trial_app_required[**P, R](view: Callable[Concatenate[App, P], R] | None = None):
@@ -115,17 +59,6 @@ def trial_feature_enable[**P, R](view: Callable[P, R]):
         return view(*args, **kwargs)
 
     return decorated
-
-
-class InstalledAppResource(Resource):
-    # must be reversed if there are multiple decorators
-
-    method_decorators = [
-        user_allowed_to_access_app,
-        installed_app_required,
-        account_initialization_required,
-        login_required,
-    ]
 
 
 class TrialAppResource(Resource):

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -162,6 +162,8 @@ from services.file_service import FileService
 from services.init_validation_service import InitValidationService
 from services.inner_mail_service import InnerMailService
 from services.installed_app_access_service import InstalledAppAccessService
+from services.installed_app_audio_adapters import InstalledAppAudioRuntime
+from services.installed_app_audio_service import InstalledAppAudio
 from services.installed_app_conversation_service import InstalledAppConversationService
 from services.installed_app_generation_adapters import AppGenerateServiceRuntime
 from services.installed_app_generation_service import InstalledAppGenerationService
@@ -321,6 +323,7 @@ class ApplicationServices:
     oauth_server: OAuthServerService
     init_validation: InitValidationService
     installed_app_access: InstalledAppAccessService
+    installed_app_audio: InstalledAppAudio
     installed_app_conversations: InstalledAppConversationService
     installed_app_generation: InstalledAppGenerationService
     installed_app_messages: InstalledAppMessageService
@@ -701,6 +704,7 @@ def build_application_services(
         data_source_oauth=_build_data_source_oauth_services(database_client=database_client),
         webapp_access=webapp_access,
         installed_app_access=installed_app_access,
+        installed_app_audio=InstalledAppAudioRuntime(session_factory=database_client),
         installed_app_conversations=InstalledAppConversationService(
             conversations=SQLAlchemyInstalledAppConversationRepository(session_factory=database_client),
             generate_name=_generate_installed_app_conversation_name,

--- a/api/services/audio_provider_gateway.py
+++ b/api/services/audio_provider_gateway.py
@@ -1,0 +1,68 @@
+"""Invoke the existing model runtime using plain audio values.
+
+Provider credential queries retain their existing scoped-session behavior.
+The InstalledApp runtime closes its configuration session before entering this
+module; legacy callers continue to own their request session.
+"""
+
+import io
+
+from core.app.entities.app_invoke_entities import get_credit_usage_app_type
+from core.base.tts.audio_mime import get_model_audio_mime_type
+from core.credit_usage import CreditUsageCreatedBy
+from core.model_manager import ModelManager
+from graphon.model_runtime.entities.model_entities import ModelType
+from graphon.model_runtime.protocols.tts_runtime import TTSModelVoice
+from services.audio_types import AudioAppRef, AudioOutput
+from services.errors.audio import (
+    ProviderNotSupportSpeechToTextServiceError,
+    ProviderNotSupportTextToSpeechServiceError,
+)
+
+
+def speech_to_text(*, app: AudioAppRef, content: bytes, end_user: str | None) -> str:
+    model_manager = ModelManager.for_tenant(
+        tenant_id=app.tenant_id,
+        user_id=end_user,
+        request_metadata={
+            "app_type": get_credit_usage_app_type(app.app_mode),
+            "created_by": CreditUsageCreatedBy.AUDIO,
+        },
+    )
+    model_instance = model_manager.get_default_model_instance(tenant_id=app.tenant_id, model_type=ModelType.SPEECH2TEXT)
+    if model_instance is None:
+        raise ProviderNotSupportSpeechToTextServiceError()
+    buffer = io.BytesIO(content)
+    buffer.name = "temp.mp3"
+    return model_instance.invoke_speech2text(file=buffer)
+
+
+def text_to_speech(*, app: AudioAppRef, text: str, voice: str | None, end_user: str | None) -> AudioOutput:
+    model_manager = ModelManager.for_tenant(
+        tenant_id=app.tenant_id,
+        user_id=end_user,
+        request_metadata={
+            "app_type": get_credit_usage_app_type(app.app_mode),
+            "created_by": CreditUsageCreatedBy.AUDIO,
+        },
+    )
+    model_instance = model_manager.get_default_model_instance(tenant_id=app.tenant_id, model_type=ModelType.TTS)
+    if not voice:
+        voices = model_instance.get_tts_voices()
+        if not voices or not (voice := voices[0].get("value")):
+            raise ValueError("Sorry, no voice available.")
+    return AudioOutput(
+        data=model_instance.invoke_tts(content_text=text, voice=voice),
+        mime_type=get_model_audio_mime_type(model_instance),
+    )
+
+
+def get_voices(*, tenant_id: str, language: str) -> list[TTSModelVoice]:
+    model_manager = ModelManager.for_tenant(
+        tenant_id=tenant_id,
+        request_metadata={"created_by": CreditUsageCreatedBy.AUDIO},
+    )
+    model_instance = model_manager.get_default_model_instance(tenant_id=tenant_id, model_type=ModelType.TTS)
+    if model_instance is None:
+        raise ProviderNotSupportTextToSpeechServiceError()
+    return model_instance.get_tts_voices(language)

--- a/api/services/audio_service.py
+++ b/api/services/audio_service.py
@@ -2,6 +2,7 @@ import io
 import logging
 import uuid
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import cast
 
 from flask import Response, stream_with_context
@@ -38,6 +39,14 @@ _ASR_MIME_TYPE_ALIASES = {
 }
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedTextToAudio:
+    """Message text and configured voice resolved before contacting a provider."""
+
+    text: str
+    voice: str | None
 
 
 def _create_tts_response(
@@ -85,19 +94,24 @@ class AudioService:
         Raises:
             SpeechToTextDisabledServiceError: If the effective feature configuration disables STT.
         """
+        cls.prepare_asr(app_model, session=session)
+        return cls.invoke_speech_to_text(app_model=app_model, file=file, end_user=end_user)
+
+    @classmethod
+    def prepare_asr(cls, app_model: App, *, session: Session) -> None:
+        """Validate the effective published ASR feature using the caller's session."""
         if app_model.mode == AppMode.AGENT:
             agent_soul = AgentRosterService(session).get_published_agent_soul_for_app(
                 tenant_id=app_model.tenant_id,
                 app_id=app_model.id,
             )
             if agent_soul is not None:
-                return cls.transcript_agent_asr(
+                cls._prepare_agent_asr(
                     app_model=app_model,
                     agent_soul=agent_soul,
-                    file=file,
                     session=session,
-                    end_user=end_user,
                 )
+                return
 
         if app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
             workflow = app_model.workflow_with_session(session=session)
@@ -115,8 +129,6 @@ class AudioService:
             if not app_model_config.speech_to_text_dict["enabled"]:
                 raise SpeechToTextDisabledServiceError()
 
-        return cls._invoke_speech_to_text(app_model=app_model, file=file, end_user=end_user)
-
     @classmethod
     def transcript_agent_asr(
         cls,
@@ -132,6 +144,11 @@ class AudioService:
         Raises:
             SpeechToTextDisabledServiceError: If the merged Agent feature configuration disables STT.
         """
+        cls._prepare_agent_asr(app_model=app_model, agent_soul=agent_soul, session=session)
+        return cls.invoke_speech_to_text(app_model=app_model, file=file, end_user=end_user)
+
+    @staticmethod
+    def _prepare_agent_asr(app_model: App, agent_soul: AgentSoulConfig, *, session: Session) -> None:
         app_model_config = app_model.app_model_config_with_session(session=session)
         annotation_reply = load_annotation_reply_config(session, app_model.id) if app_model_config else None
         features = merge_agent_app_features(
@@ -142,12 +159,11 @@ class AudioService:
         if not features.get("speech_to_text", {}).get("enabled"):
             raise SpeechToTextDisabledServiceError()
 
-        return cls._invoke_speech_to_text(app_model=app_model, file=file, end_user=end_user)
-
     @classmethod
-    def _invoke_speech_to_text(
-        cls, app_model: App, file: FileStorage | None, end_user: str | None = None
+    def invoke_speech_to_text(
+        cls, app_model: App, file: FileStorage | None, *, end_user: str | None = None
     ) -> dict[str, str]:
+        """Validate the upload and invoke ASR after application configuration is resolved."""
         if file is None:
             raise NoAudioUploadedServiceError()
 
@@ -192,62 +208,34 @@ class AudioService:
         end_user: str | None = None,
         message_ref: MessageRef | None = None,
         is_draft: bool = False,
-    ):
-        def invoke_tts(text_content: str, app_model: App, voice: str | None = None, is_draft: bool = False):
-            if voice is None:
-                if app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
-                    if is_draft:
-                        workflow = WorkflowService().get_draft_workflow(app_model=app_model, session=session)
-                    else:
-                        workflow = app_model.workflow_with_session(session=session)
-                    if (
-                        workflow is None
-                        or "text_to_speech" not in workflow.features_dict
-                        or not workflow.features_dict["text_to_speech"].get("enabled")
-                    ):
-                        raise ValueError("TTS is not enabled")
+    ) -> Response | None:
+        prepared = cls.prepare_tts(
+            app_model,
+            session=session,
+            text=text,
+            voice=voice,
+            message_ref=message_ref,
+            is_draft=is_draft,
+        )
+        if prepared is None:
+            return None
+        response, declared_mime_type = cls.invoke_tts(
+            app_model, text=prepared.text, voice=prepared.voice, end_user=end_user
+        )
+        return _create_tts_response(response, declared_mime_type)
 
-                    voice = workflow.features_dict["text_to_speech"].get("voice")
-                else:
-                    if not is_draft:
-                        app_model_config = app_model.app_model_config_with_session(session=session)
-                        if app_model_config is None:
-                            raise ValueError("AppModelConfig not found")
-                        text_to_speech_dict = app_model_config.text_to_speech_dict
-
-                        if not text_to_speech_dict.get("enabled"):
-                            raise ValueError("TTS is not enabled")
-
-                        voice = cast(str | None, text_to_speech_dict.get("voice"))
-
-            model_manager = ModelManager.for_tenant(
-                tenant_id=app_model.tenant_id,
-                user_id=end_user,
-                request_metadata={
-                    "app_type": get_credit_usage_app_type(app_model.mode),
-                    "created_by": CreditUsageCreatedBy.AUDIO,
-                },
-            )
-            model_instance = model_manager.get_default_model_instance(
-                tenant_id=app_model.tenant_id, model_type=ModelType.TTS
-            )
-            try:
-                if not voice:
-                    voices = model_instance.get_tts_voices()
-                    if voices:
-                        voice = voices[0].get("value")
-                        if not voice:
-                            raise ValueError("Sorry, no voice available.")
-                    else:
-                        raise ValueError("Sorry, no voice available.")
-
-                return (
-                    model_instance.invoke_tts(content_text=text_content.strip(), voice=voice),
-                    get_model_audio_mime_type(model_instance),
-                )
-            except Exception as e:
-                raise e
-
+    @classmethod
+    def prepare_tts(
+        cls,
+        app_model: App,
+        *,
+        session: Session,
+        text: str | None = None,
+        voice: str | None = None,
+        message_ref: MessageRef | None = None,
+        is_draft: bool = False,
+    ) -> PreparedTextToAudio | None:
+        """Resolve owned message text and configured voice without invoking TTS."""
         if message_ref:
             try:
                 uuid.UUID(message_ref.message_id)
@@ -258,19 +246,71 @@ class AudioService:
                 return None
             if message.answer == "" and message.status in {MessageStatus.NORMAL, MessageStatus.PAUSED}:
                 return None
+            text = message.answer
+        elif text is None:
+            raise ValueError("Text is required")
 
+        if voice is None:
+            if app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
+                if is_draft:
+                    workflow = WorkflowService().get_draft_workflow(app_model=app_model, session=session)
+                else:
+                    workflow = app_model.workflow_with_session(session=session)
+                if (
+                    workflow is None
+                    or "text_to_speech" not in workflow.features_dict
+                    or not workflow.features_dict["text_to_speech"].get("enabled")
+                ):
+                    raise ValueError("TTS is not enabled")
+
+                voice = workflow.features_dict["text_to_speech"].get("voice")
+            elif not is_draft:
+                app_model_config = app_model.app_model_config_with_session(session=session)
+                if app_model_config is None:
+                    raise ValueError("AppModelConfig not found")
+                text_to_speech_dict = app_model_config.text_to_speech_dict
+
+                if not text_to_speech_dict.get("enabled"):
+                    raise ValueError("TTS is not enabled")
+
+                voice = cast(str | None, text_to_speech_dict.get("voice"))
+
+        return PreparedTextToAudio(text=text, voice=voice)
+
+    @classmethod
+    def invoke_tts(
+        cls,
+        app_model: App,
+        *,
+        text: str,
+        voice: str | None,
+        end_user: str | None = None,
+    ) -> tuple[Iterable[bytes] | bytes | bytearray | memoryview, str | None]:
+        """Invoke the configured provider using text and voice resolved by preparation."""
+        model_manager = ModelManager.for_tenant(
+            tenant_id=app_model.tenant_id,
+            user_id=end_user,
+            request_metadata={
+                "app_type": get_credit_usage_app_type(app_model.mode),
+                "created_by": CreditUsageCreatedBy.AUDIO,
+            },
+        )
+        model_instance = model_manager.get_default_model_instance(
+            tenant_id=app_model.tenant_id, model_type=ModelType.TTS
+        )
+        if not voice:
+            voices = model_instance.get_tts_voices()
+            if voices:
+                voice = voices[0].get("value")
+                if not voice:
+                    raise ValueError("Sorry, no voice available.")
             else:
-                response, declared_mime_type = invoke_tts(
-                    text_content=message.answer, app_model=app_model, voice=voice, is_draft=is_draft
-                )
-                return _create_tts_response(response, declared_mime_type)
-        else:
-            if text is None:
-                raise ValueError("Text is required")
-            response, declared_mime_type = invoke_tts(
-                text_content=text, app_model=app_model, voice=voice, is_draft=is_draft
-            )
-            return _create_tts_response(response, declared_mime_type)
+                raise ValueError("Sorry, no voice available.")
+
+        return (
+            model_instance.invoke_tts(content_text=text.strip(), voice=voice),
+            get_model_audio_mime_type(model_instance),
+        )
 
     @classmethod
     def transcript_tts_voices(cls, tenant_id: str, language: str):

--- a/api/services/audio_service.py
+++ b/api/services/audio_service.py
@@ -1,4 +1,11 @@
-import io
+"""Shared audio policy and compatibility entry points for existing callers.
+
+TODO: Migrate configuration reads with the Agent/Workflow query owners before
+replacing these entry points. Keep feature precedence and message eligibility
+here so the InstalledApp runtime and legacy callers share one implementation.
+Provider SDK calls use the plain values in audio_types.
+"""
+
 import logging
 import uuid
 from collections.abc import Iterable
@@ -12,21 +19,18 @@ from werkzeug.datastructures import FileStorage
 
 from constants import AUDIO_EXTENSIONS
 from core.app.apps.agent_app.app_feature_projection import merge_agent_app_features
-from core.app.entities.app_invoke_entities import get_credit_usage_app_type
-from core.base.tts.audio_mime import get_model_audio_mime_type, inspect_audio_stream, resolve_audio_mime_type
-from core.credit_usage import CreditUsageCreatedBy
-from core.model_manager import ModelManager
-from graphon.model_runtime.entities.model_entities import ModelType
+from core.base.tts.audio_mime import inspect_audio_stream, resolve_audio_mime_type
+from graphon.model_runtime.protocols.tts_runtime import TTSModelVoice
 from models.agent_config_entities import AgentSoulConfig
 from models.enums import MessageStatus
 from models.model import App, AppMode, Message, load_annotation_reply_config
+from services import audio_provider_gateway
 from services.agent.roster_service import AgentRosterService
 from services.app_ref_service import MessageRef
+from services.audio_types import AudioAppRef, AudioOutput, AudioUpload
 from services.errors.audio import (
     AudioTooLargeServiceError,
     NoAudioUploadedServiceError,
-    ProviderNotSupportSpeechToTextServiceError,
-    ProviderNotSupportTextToSpeechServiceError,
     SpeechToTextDisabledServiceError,
     UnsupportedAudioTypeServiceError,
 )
@@ -95,7 +99,11 @@ class AudioService:
             SpeechToTextDisabledServiceError: If the effective feature configuration disables STT.
         """
         cls.prepare_asr(app_model, session=session)
-        return cls.invoke_speech_to_text(app_model=app_model, file=file, end_user=end_user)
+        return cls.invoke_speech_to_text(
+            app_model=app_model,
+            audio=AudioUpload(stream=file.stream, mime_type=file.mimetype) if file is not None else None,
+            end_user=end_user,
+        )
 
     @classmethod
     def prepare_asr(cls, app_model: App, *, session: Session) -> None:
@@ -145,7 +153,11 @@ class AudioService:
             SpeechToTextDisabledServiceError: If the merged Agent feature configuration disables STT.
         """
         cls._prepare_agent_asr(app_model=app_model, agent_soul=agent_soul, session=session)
-        return cls.invoke_speech_to_text(app_model=app_model, file=file, end_user=end_user)
+        return cls.invoke_speech_to_text(
+            app_model=app_model,
+            audio=AudioUpload(stream=file.stream, mime_type=file.mimetype) if file is not None else None,
+            end_user=end_user,
+        )
 
     @staticmethod
     def _prepare_agent_asr(app_model: App, agent_soul: AgentSoulConfig, *, session: Session) -> None:
@@ -161,41 +173,25 @@ class AudioService:
 
     @classmethod
     def invoke_speech_to_text(
-        cls, app_model: App, file: FileStorage | None, *, end_user: str | None = None
+        cls, app_model: App, audio: AudioUpload | None, *, end_user: str | None = None
     ) -> dict[str, str]:
         """Validate the upload and invoke ASR after application configuration is resolved."""
-        if file is None:
+        if audio is None:
             raise NoAudioUploadedServiceError()
 
-        mimetype = _ASR_MIME_TYPE_ALIASES.get(file.mimetype, file.mimetype)
+        mimetype = _ASR_MIME_TYPE_ALIASES.get(audio.mime_type, audio.mime_type)
         if mimetype not in [f"audio/{ext}" for ext in AUDIO_EXTENSIONS]:
             raise UnsupportedAudioTypeServiceError()
 
-        file_content = file.stream.read()
+        file_content = audio.stream.read()
         file_size = len(file_content)
 
         if file_size > FILE_SIZE_LIMIT:
             message = f"Audio size larger than {FILE_SIZE} mb"
             raise AudioTooLargeServiceError(message)
 
-        model_manager = ModelManager.for_tenant(
-            tenant_id=app_model.tenant_id,
-            user_id=end_user,
-            request_metadata={
-                "app_type": get_credit_usage_app_type(app_model.mode),
-                "created_by": CreditUsageCreatedBy.AUDIO,
-            },
-        )
-        model_instance = model_manager.get_default_model_instance(
-            tenant_id=app_model.tenant_id, model_type=ModelType.SPEECH2TEXT
-        )
-        if model_instance is None:
-            raise ProviderNotSupportSpeechToTextServiceError()
-
-        buffer = io.BytesIO(file_content)
-        buffer.name = "temp.mp3"
-
-        return {"text": model_instance.invoke_speech2text(file=buffer)}
+        app_ref = AudioAppRef(app_id=app_model.id, tenant_id=app_model.tenant_id, app_mode=app_model.mode.value)
+        return {"text": audio_provider_gateway.speech_to_text(app=app_ref, content=file_content, end_user=end_user)}
 
     @classmethod
     def transcript_tts(
@@ -219,10 +215,8 @@ class AudioService:
         )
         if prepared is None:
             return None
-        response, declared_mime_type = cls.invoke_tts(
-            app_model, text=prepared.text, voice=prepared.voice, end_user=end_user
-        )
-        return _create_tts_response(response, declared_mime_type)
+        output = cls.invoke_tts(app_model, text=prepared.text, voice=prepared.voice, end_user=end_user)
+        return _create_tts_response(output.data, output.mime_type)
 
     @classmethod
     def prepare_tts(
@@ -285,44 +279,11 @@ class AudioService:
         text: str,
         voice: str | None,
         end_user: str | None = None,
-    ) -> tuple[Iterable[bytes] | bytes | bytearray | memoryview, str | None]:
-        """Invoke the configured provider using text and voice resolved by preparation."""
-        model_manager = ModelManager.for_tenant(
-            tenant_id=app_model.tenant_id,
-            user_id=end_user,
-            request_metadata={
-                "app_type": get_credit_usage_app_type(app_model.mode),
-                "created_by": CreditUsageCreatedBy.AUDIO,
-            },
-        )
-        model_instance = model_manager.get_default_model_instance(
-            tenant_id=app_model.tenant_id, model_type=ModelType.TTS
-        )
-        if not voice:
-            voices = model_instance.get_tts_voices()
-            if voices:
-                voice = voices[0].get("value")
-                if not voice:
-                    raise ValueError("Sorry, no voice available.")
-            else:
-                raise ValueError("Sorry, no voice available.")
-
-        return (
-            model_instance.invoke_tts(content_text=text.strip(), voice=voice),
-            get_model_audio_mime_type(model_instance),
-        )
+    ) -> AudioOutput:
+        """Invoke the provider using text and voice resolved by preparation."""
+        app_ref = AudioAppRef(app_id=app_model.id, tenant_id=app_model.tenant_id, app_mode=app_model.mode.value)
+        return audio_provider_gateway.text_to_speech(app=app_ref, text=text.strip(), voice=voice, end_user=end_user)
 
     @classmethod
-    def transcript_tts_voices(cls, tenant_id: str, language: str):
-        model_manager = ModelManager.for_tenant(
-            tenant_id=tenant_id,
-            request_metadata={"created_by": CreditUsageCreatedBy.AUDIO},
-        )
-        model_instance = model_manager.get_default_model_instance(tenant_id=tenant_id, model_type=ModelType.TTS)
-        if model_instance is None:
-            raise ProviderNotSupportTextToSpeechServiceError()
-
-        try:
-            return model_instance.get_tts_voices(language)
-        except Exception as e:
-            raise e
+    def transcript_tts_voices(cls, tenant_id: str, language: str) -> list[TTSModelVoice]:
+        return audio_provider_gateway.get_voices(tenant_id=tenant_id, language=language)

--- a/api/services/audio_types.py
+++ b/api/services/audio_types.py
@@ -1,0 +1,26 @@
+"""Plain audio values shared by the application and provider boundary."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import IO
+
+
+@dataclass(frozen=True, slots=True)
+class AudioAppRef:
+    """App identity and mode snapshot; tenant_id identifies the app's owner."""
+
+    app_id: str
+    tenant_id: str
+    app_mode: str
+
+
+@dataclass(frozen=True, slots=True)
+class AudioUpload:
+    stream: IO[bytes]
+    mime_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class AudioOutput:
+    data: Iterable[bytes] | bytes | bytearray | memoryview
+    mime_type: str | None

--- a/api/services/installed_app_audio_adapters.py
+++ b/api/services/installed_app_audio_adapters.py
@@ -1,0 +1,68 @@
+"""Prepare installed-app audio in a session, then invoke the shared provider runtime."""
+
+from typing import override
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+from werkzeug.datastructures import FileStorage
+
+from models import App, InstalledApp
+from services.app_ref_service import AppRefService
+from services.audio_service import AudioService
+from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
+from services.installed_app_audio_service import AudioOutput, AudioUpload, InstalledAppAudio
+
+
+class InstalledAppAudioRuntime(InstalledAppAudio):
+    def __init__(self, *, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory: sessionmaker[Session] = session_factory
+
+    @override
+    def transcript_asr(self, *, installed_app: InstalledAppRef, audio: AudioUpload | None) -> dict[str, str]:
+        with self._session_factory(expire_on_commit=False) as session:
+            app = self._get_app(session=session, installed_app=installed_app)
+            AudioService.prepare_asr(app, session=session)
+
+        # Provider internals retain their existing scoped-session behavior.
+        # The app/configuration session above is released before those lookups
+        # and external calls; migrating provider persistence is a separate step.
+        file = FileStorage(stream=audio.stream, content_type=audio.mime_type) if audio is not None else None
+        return AudioService.invoke_speech_to_text(app, file, end_user=None)
+
+    @override
+    def transcript_tts(
+        self,
+        *,
+        installed_app: InstalledAppRef,
+        account_id: str,
+        text: str | None,
+        voice: str | None,
+        message_id: str | None,
+    ) -> AudioOutput | None:
+        with self._session_factory(expire_on_commit=False) as session:
+            app = self._get_app(session=session, installed_app=installed_app)
+            message_ref = (
+                AppRefService.create_message_ref(AppRefService.create_app_ref(app), message_id, account_id=account_id)
+                if message_id
+                else None
+            )
+            prepared = AudioService.prepare_tts(app, session=session, text=text, voice=voice, message_ref=message_ref)
+        if prepared is None:
+            return None
+        data, mime_type = AudioService.invoke_tts(app, text=prepared.text, voice=prepared.voice, end_user=None)
+        return AudioOutput(data=data, mime_type=mime_type)
+
+    @staticmethod
+    def _get_app(*, session: Session, installed_app: InstalledAppRef) -> App:
+        app = session.scalar(
+            select(App)
+            .join(InstalledApp, InstalledApp.app_id == App.id)
+            .where(
+                InstalledApp.id == installed_app.id,
+                InstalledApp.tenant_id == installed_app.tenant_id,
+                InstalledApp.app_id == installed_app.app_id,
+            )
+        )
+        if app is None:
+            raise InstalledAppNotFoundError(f"Installed app {installed_app.id} no longer exists")
+        return app

--- a/api/services/installed_app_audio_adapters.py
+++ b/api/services/installed_app_audio_adapters.py
@@ -1,10 +1,14 @@
-"""Prepare installed-app audio in a session, then invoke the shared provider runtime."""
+"""Prepare installed-app audio in a session, then invoke the shared provider runtime.
+
+TODO: Retire this bridge when audio configuration reads can use shared
+Agent/Workflow query boundaries. Until then, reuse AudioService's existing
+policy and release the configuration session before provider calls.
+"""
 
 from typing import override
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
-from werkzeug.datastructures import FileStorage
 
 from models import App, InstalledApp
 from services.app_ref_service import AppRefService
@@ -26,8 +30,7 @@ class InstalledAppAudioRuntime(InstalledAppAudio):
         # Provider internals retain their existing scoped-session behavior.
         # The app/configuration session above is released before those lookups
         # and external calls; migrating provider persistence is a separate step.
-        file = FileStorage(stream=audio.stream, content_type=audio.mime_type) if audio is not None else None
-        return AudioService.invoke_speech_to_text(app, file, end_user=None)
+        return AudioService.invoke_speech_to_text(app, audio, end_user=None)
 
     @override
     def transcript_tts(
@@ -49,8 +52,7 @@ class InstalledAppAudioRuntime(InstalledAppAudio):
             prepared = AudioService.prepare_tts(app, session=session, text=text, voice=voice, message_ref=message_ref)
         if prepared is None:
             return None
-        data, mime_type = AudioService.invoke_tts(app, text=prepared.text, voice=prepared.voice, end_user=None)
-        return AudioOutput(data=data, mime_type=mime_type)
+        return AudioService.invoke_tts(app, text=prepared.text, voice=prepared.voice, end_user=None)
 
     @staticmethod
     def _get_app(*, session: Session, installed_app: InstalledAppRef) -> App:

--- a/api/services/installed_app_audio_service.py
+++ b/api/services/installed_app_audio_service.py
@@ -1,22 +1,9 @@
 """Audio operations for an admitted installation, independent of HTTP and ORM."""
 
-from collections.abc import Iterable
-from dataclasses import dataclass
-from typing import IO, Protocol
+from typing import Protocol
 
+from services.audio_types import AudioOutput, AudioUpload
 from services.installed_app_access_service import InstalledAppRef
-
-
-@dataclass(frozen=True, slots=True)
-class AudioUpload:
-    stream: IO[bytes]
-    mime_type: str
-
-
-@dataclass(frozen=True, slots=True)
-class AudioOutput:
-    data: Iterable[bytes] | bytes | bytearray | memoryview
-    mime_type: str | None
 
 
 class InstalledAppAudio(Protocol):

--- a/api/services/installed_app_audio_service.py
+++ b/api/services/installed_app_audio_service.py
@@ -1,0 +1,33 @@
+"""Audio operations for an admitted installation, independent of HTTP and ORM."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import IO, Protocol
+
+from services.installed_app_access_service import InstalledAppRef
+
+
+@dataclass(frozen=True, slots=True)
+class AudioUpload:
+    stream: IO[bytes]
+    mime_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class AudioOutput:
+    data: Iterable[bytes] | bytes | bytearray | memoryview
+    mime_type: str | None
+
+
+class InstalledAppAudio(Protocol):
+    def transcript_asr(self, *, installed_app: InstalledAppRef, audio: AudioUpload | None) -> dict[str, str]: ...
+
+    def transcript_tts(
+        self,
+        *,
+        installed_app: InstalledAppRef,
+        account_id: str,
+        text: str | None,
+        voice: str | None,
+        message_id: str | None,
+    ) -> AudioOutput | None: ...

--- a/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
+++ b/api/tests/test_containers_integration_tests/services/test_audio_service_db.py
@@ -156,7 +156,7 @@ class TestAudioServiceTranscriptTTSMessageLookup:
         mock_model_manager = MagicMock()
         mock_model_manager.get_default_model_instance.return_value = mock_model_instance
 
-        with patch("services.audio_service.ModelManager.for_tenant", return_value=mock_model_manager):
+        with patch("services.audio_provider_gateway.ModelManager.for_tenant", return_value=mock_model_manager):
             result = AudioService.transcript_tts(
                 app_model=app,
                 session=db_session_with_containers,

--- a/api/tests/unit_tests/controllers/console/explore/test_audio.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_audio.py
@@ -1,461 +1,308 @@
+"""Explore audio HTTP contracts with real SQLite admission and an external runtime fake."""
+
+from collections.abc import Generator
+from dataclasses import dataclass, field
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from typing import Literal
+from uuid import uuid4
 
 import pytest
-from flask import Flask
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
-from werkzeug.exceptions import InternalServerError
+from flask import has_request_context, request
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session, sessionmaker
+from werkzeug.test import TestResponse
 
-import controllers.console.explore.audio as audio_module
-from controllers.console.app.error import (
-    AppUnavailableError,
-    AudioTooLargeError,
-    CompletionRequestError,
-    NoAudioUploadedError,
-    ProviderModelCurrentlyNotSupportError,
-    ProviderNotInitializeError,
-    ProviderQuotaExceededError,
-    SpeechToTextDisabledError,
-)
-from core.errors.error import (
-    ModelCurrentlyNotSupportError,
-    ProviderTokenNotInitError,
-    QuotaExceededError,
-)
+import controllers.console.explore.audio as module
+from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError
-from models import Account
-from models.model import App, AppMode, InstalledApp
-from services.app_ref_service import AppRef, MessageRef
+from models import App, AppMode, InstalledApp
+from services.errors.app_model_config import AppModelConfigBrokenError
 from services.errors.audio import (
     AudioTooLargeServiceError,
     NoAudioUploadedServiceError,
+    ProviderNotSupportSpeechToTextServiceError,
+    ProviderNotSupportTextToSpeechServiceError,
     SpeechToTextDisabledServiceError,
+    UnsupportedAudioTypeServiceError,
+)
+from services.installed_app_access_service import InstalledAppRef
+from services.installed_app_audio_service import AudioOutput, AudioUpload
+from tests.unit_tests.controllers.console.explore.test_installed_app_admission import (
+    _assert_json_response,
+    _Harness,
+    harness,
 )
 
+__all__ = ["harness"]
 
-def unwrap(func):
-    bound_self = getattr(func, "__self__", None)
-    while hasattr(func, "__wrapped__"):
-        func = func.__wrapped__
-    if bound_self is not None:
-        return func.__get__(bound_self, bound_self.__class__)
-    return func
+type _Operation = Literal["audio-to-text", "text-to-audio"]
+_OPERATIONS: tuple[_Operation, ...] = ("audio-to-text", "text-to-audio")
+_WAV = b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00audio-data"
 
 
-@pytest.fixture
-def installed_app(
-    sqlite_session: Session,
-    sqlite_session_factory: sessionmaker[Session],
-    monkeypatch: pytest.MonkeyPatch,
-):
-    app = App(
-        id="app-1",
-        tenant_id="tenant-1",
-        name="Explore App",
-        mode=AppMode.CHAT,
-        enable_site=True,
-        enable_api=False,
-    )
-    installed = InstalledApp(
-        tenant_id="viewer-tenant",
-        app_id=app.id,
-        app_owner_tenant_id=app.tenant_id,
-        position=0,
-        is_pinned=False,
-        last_used_at=None,
-    )
-    sqlite_session.add_all([app, installed])
-    sqlite_session.commit()
-    session_proxy = scoped_session(sqlite_session_factory)
-    monkeypatch.setattr(audio_module.db, "session", session_proxy)
-    yield installed
-    session_proxy.remove()
+@dataclass
+class _Runtime:
+    harness: _Harness
+    factory: sessionmaker[Session]
+    error: Exception | None = None
+    transcript: dict[str, str] = field(default_factory=lambda: {"text": "识别完成"})
+    output: AudioOutput | None = field(default_factory=lambda: AudioOutput(data=_WAV, mime_type=None))
+    asr_calls: list[tuple[InstalledAppRef, bytes | None, str | None]] = field(default_factory=list)
+    tts_calls: list[tuple[InstalledAppRef, str, str | None, str | None, str | None]] = field(default_factory=list)
 
-
-@pytest.fixture
-def audio_file():
-    return (BytesIO(b"audio"), "audio.wav")
-
-
-class TestChatAudioApi:
-    def setup_method(self):
-        self.api = audio_module.ChatAudioApi()
-        self.method = unwrap(self.api.post)
-
-    def test_post_success(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                return_value={"text": "ok"},
-            ),
-        ):
-            resp = self.method(installed_app)
-
-        assert resp == {"text": "ok"}
-
-    def test_app_unavailable(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=audio_module.services.errors.app_model_config.AppModelConfigBrokenError(),
-            ),
-        ):
-            with pytest.raises(AppUnavailableError):
-                self.method(installed_app)
-
-    def test_no_audio_uploaded(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=NoAudioUploadedServiceError(),
-            ),
-        ):
-            with pytest.raises(NoAudioUploadedError):
-                self.method(installed_app)
-
-    def test_audio_too_large(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=AudioTooLargeServiceError("too big"),
-            ),
-        ):
-            with pytest.raises(AudioTooLargeError):
-                self.method(installed_app)
-
-    def test_provider_quota_exceeded(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=QuotaExceededError(),
-            ),
-        ):
-            with pytest.raises(ProviderQuotaExceededError):
-                self.method(installed_app)
-
-    def test_unknown_exception(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=Exception("boom"),
-            ),
-        ):
-            with pytest.raises(InternalServerError):
-                self.method(installed_app)
-
-    def test_unsupported_audio_type(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=audio_module.UnsupportedAudioTypeServiceError(),
-            ),
-        ):
-            with pytest.raises(audio_module.UnsupportedAudioTypeError):
-                self.method(installed_app)
-
-    def test_provider_not_support_speech_to_text(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=audio_module.ProviderNotSupportSpeechToTextServiceError(),
-            ),
-        ):
-            with pytest.raises(audio_module.ProviderNotSupportSpeechToTextError):
-                self.method(installed_app)
-
-    def test_speech_to_text_disabled(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=SpeechToTextDisabledServiceError(),
-            ),
-        ):
-            with pytest.raises(SpeechToTextDisabledError):
-                self.method(installed_app)
-
-    def test_provider_not_initialized(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=ProviderTokenNotInitError("not init"),
-            ),
-        ):
-            with pytest.raises(ProviderNotInitializeError):
-                self.method(installed_app)
-
-    def test_model_currently_not_supported(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=ModelCurrentlyNotSupportError(),
-            ),
-        ):
-            with pytest.raises(ProviderModelCurrentlyNotSupportError):
-                self.method(installed_app)
-
-    def test_invoke_error_asr(self, app: Flask, installed_app, audio_file):
-        with (
-            app.test_request_context(
-                "/",
-                data={"file": audio_file},
-                content_type="multipart/form-data",
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_asr",
-                side_effect=InvokeError("invoke failed"),
-            ),
-        ):
-            with pytest.raises(CompletionRequestError):
-                self.method(installed_app)
-
-
-class TestChatTextApi:
-    def setup_method(self):
-        self.api = audio_module.ChatTextApi()
-        self.method = unwrap(self.api.post)
-
-    def test_post_success(self, app: Flask, installed_app):
-        account = Account(name="User", email="user@example.com")
-        account.id = "account-1"
-        transcript_tts = MagicMock(return_value={"audio": "ok"})
-
-        with (
-            app.test_request_context(
-                "/",
-                json={"message_id": "m1", "text": "hello", "voice": "v1"},
-            ),
-            patch.object(
-                audio_module,
-                "current_account_with_tenant",
-                return_value=(account, "tenant-1"),
-            ),
-            patch.object(audio_module.AudioService, "transcript_tts", transcript_tts),
-        ):
-            resp = self.method(
-                audio_module.TextToAudioPayload.model_validate({"message_id": "m1", "text": "hello", "voice": "v1"}),
-                installed_app,
-            )
-
-        assert resp == {"audio": "ok"}
-        assert transcript_tts.call_args.kwargs["message_ref"] == MessageRef(
-            app=AppRef(tenant_id="tenant-1", app_id="app-1"),
-            message_id="m1",
-            account_id="account-1",
+    def transcript_asr(self, *, installed_app: InstalledAppRef, audio: AudioUpload | None) -> dict[str, str]:
+        self._assert_reference(installed_app)
+        self.asr_calls.append(
+            (installed_app, audio.stream.read() if audio is not None else None, audio.mime_type if audio else None)
         )
+        if self.error is not None:
+            raise self.error
+        return self.transcript
 
-    def test_provider_not_initialized(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=ProviderTokenNotInitError("not init"),
-            ),
-        ):
-            with pytest.raises(ProviderNotInitializeError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
+    def transcript_tts(
+        self,
+        *,
+        installed_app: InstalledAppRef,
+        account_id: str,
+        text: str | None,
+        voice: str | None,
+        message_id: str | None,
+    ) -> AudioOutput | None:
+        self._assert_reference(installed_app)
+        self.tts_calls.append((installed_app, account_id, text, voice, message_id))
+        if self.error is not None:
+            raise self.error
+        return self.output
 
-    def test_model_not_supported(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=ModelCurrentlyNotSupportError(),
-            ),
-        ):
-            with pytest.raises(ProviderModelCurrentlyNotSupportError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
+    def _assert_reference(self, installed_app: InstalledAppRef) -> None:
+        assert inspect(installed_app, raiseerr=False) is None
+        assert installed_app.id == self.harness.installed_app.id
+        assert installed_app.tenant_id == self.harness.installed_app.tenant_id
+        assert installed_app.app_id == self.harness.target_app.id
+        assert installed_app.tenant_id != self.harness.target_app.tenant_id
+        with self.factory() as session:
+            installation = session.get(InstalledApp, installed_app.id)
+            assert installation is not None
+            assert installation.last_used_at is None
 
-    def test_invoke_error(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=InvokeError("invoke failed"),
-            ),
-        ):
-            with pytest.raises(CompletionRequestError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
+    def request(
+        self,
+        operation: _Operation,
+        *,
+        body: dict[str, object] | None = None,
+        installed_app_id: str | None = None,
+        upload: bool = True,
+    ) -> TestResponse:
+        url = f"/installed-apps/{installed_app_id or self.harness.installed_app.id}/{operation}"
+        if operation == "audio-to-text":
+            return self.harness.app.test_client().post(
+                url,
+                data={"file": (BytesIO(_WAV), "recording.wav", "audio/wav")} if upload else {},
+                content_type="multipart/form-data",
+            )
+        return self.harness.app.test_client().post(url, json=body if body is not None else {"text": "你好"})
 
-    def test_unknown_exception(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=Exception("boom"),
-            ),
-        ):
-            with pytest.raises(InternalServerError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
-    def test_app_unavailable_tts(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=audio_module.services.errors.app_model_config.AppModelConfigBrokenError(),
-            ),
-        ):
-            with pytest.raises(AppUnavailableError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
+@dataclass(frozen=True)
+class _Services:
+    installed_app_audio: _Runtime
 
-    def test_no_audio_uploaded_tts(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=NoAudioUploadedServiceError(),
-            ),
-        ):
-            with pytest.raises(NoAudioUploadedError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
-    def test_audio_too_large_tts(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=AudioTooLargeServiceError("too big"),
-            ),
-        ):
-            with pytest.raises(AudioTooLargeError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
+@pytest.fixture
+def runtime(
+    harness: _Harness, monkeypatch: pytest.MonkeyPatch, sqlite_session_factory: sessionmaker[Session]
+) -> _Runtime:
+    state = _Runtime(harness=harness, factory=sqlite_session_factory)
+    services = _Services(installed_app_audio=state)
+    monkeypatch.setattr(module, "application_services", lambda: services)
+    harness.api.add_resource(module.ChatAudioApi, "/installed-apps/<uuid:installed_app_id>/audio-to-text")
+    harness.api.add_resource(module.ChatTextApi, "/installed-apps/<uuid:installed_app_id>/text-to-audio")
+    return state
 
-    def test_unsupported_audio_type_tts(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=audio_module.UnsupportedAudioTypeServiceError(),
-            ),
-        ):
-            with pytest.raises(audio_module.UnsupportedAudioTypeError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
-    def test_provider_not_support_speech_to_text_tts(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=audio_module.ProviderNotSupportSpeechToTextServiceError(),
-            ),
-        ):
-            with pytest.raises(audio_module.ProviderNotSupportSpeechToTextError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
+def _error(response: TestResponse, *, status: int, code: str, message: str | None = None) -> None:
+    assert response.status_code == status
+    body = response.get_json()
+    assert body["code"] == code
+    assert body["status"] == status
+    assert isinstance(body["message"], str)
+    assert body["message"]
+    if message is not None:
+        assert body["message"] == message
+    assert response.headers["Content-Type"] == "application/json"
+    assert int(response.headers["Content-Length"]) == len(response.data)
 
-    def test_quota_exceeded_tts(self, app: Flask, installed_app):
-        with (
-            app.test_request_context(
-                "/",
-                json={"text": "hi"},
-            ),
-            patch.object(
-                audio_module.AudioService,
-                "transcript_tts",
-                side_effect=QuotaExceededError(),
-            ),
-        ):
-            with pytest.raises(ProviderQuotaExceededError):
-                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
+
+@pytest.mark.parametrize("text", ["识别完成", ""])
+def test_asr_preserves_transcript_and_upload_stream_and_mime(runtime: _Runtime, text: str) -> None:
+    runtime.transcript = {"text": text}
+    _assert_json_response(runtime.request("audio-to-text"), status=200, body={"text": text})
+    assert len(runtime.asr_calls) == 1
+    installed_app, data, mime_type = runtime.asr_calls[0]
+    assert installed_app.app_mode == "completion"
+    assert data == _WAV
+    assert mime_type == "audio/wav"
+    assert runtime.tts_calls == []
+
+
+def test_missing_upload_reaches_runtime_and_returns_specific_error(runtime: _Runtime) -> None:
+    runtime.error = NoAudioUploadedServiceError()
+    _error(runtime.request("audio-to-text", upload=False), status=400, code="no_audio_uploaded")
+    assert len(runtime.asr_calls) == 1
+    assert runtime.asr_calls[0][1:] == (None, None)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ({"text": "你好", "voice": "voice-1"}, ("你好", "voice-1", None)),
+        (
+            {"text": "ignored text", "voice": "", "message_id": "11111111-1111-4111-8111-111111111111"},
+            ("ignored text", "", "11111111-1111-4111-8111-111111111111"),
+        ),
+        ({}, (None, None, None)),
+        ({"text": "", "voice": None, "message_id": "malformed", "streaming": False}, ("", None, "malformed")),
+        ({"text": None, "streaming": True}, (None, None, None)),
+    ],
+)
+def test_tts_keeps_payload_values_and_authenticated_account(
+    runtime: _Runtime, body: dict[str, object], expected: tuple[str | None, str | None, str | None]
+) -> None:
+    response = runtime.request("text-to-audio", body=body)
+    assert response.status_code == 200
+    assert response.data == _WAV
+    assert response.headers["Content-Type"] == "audio/wav"
+    assert len(runtime.tts_calls) == 1
+    installed_app, account_id, text, voice, message_id = runtime.tts_calls[0]
+    assert installed_app.app_mode == "completion"
+    assert account_id == runtime.harness.account.id
+    assert (text, voice, message_id) == expected
+    assert runtime.asr_calls == []
+
+
+@pytest.mark.parametrize("data", [_WAV, bytearray(_WAV), memoryview(_WAV)])
+def test_tts_binary_carriers_preserve_bytes_and_audio_headers(
+    runtime: _Runtime, data: bytes | bytearray | memoryview
+) -> None:
+    runtime.output = AudioOutput(data=data, mime_type="audio/x-wav")
+    response = runtime.request("text-to-audio")
+    assert response.status_code == 200
+    assert response.data == _WAV
+    assert dict(response.headers) == {"Content-Type": "audio/wav", "Content-Length": str(len(_WAV))}
+
+
+def test_tts_stream_preserves_split_signature_and_all_chunks(runtime: _Runtime) -> None:
+    def chunks() -> Generator[bytes]:
+        yield _WAV[:2]
+        yield b""
+        yield _WAV[2:11]
+        yield _WAV[11:] + b"00"
+        # This tail is consumed after MIME probing and the controller return.
+        assert has_request_context()
+        assert request.path.endswith("/text-to-audio")
+        yield b"tail"
+
+    runtime.output = AudioOutput(data=chunks(), mime_type=None)
+    response = runtime.request("text-to-audio")
+    assert response.status_code == 200
+    assert response.data == _WAV + b"00tail"
+    assert dict(response.headers) == {"Content-Type": "audio/wav"}
+
+
+def test_tts_rejects_provider_mime_mismatch_with_specific_completion_error(runtime: _Runtime) -> None:
+    runtime.output = AudioOutput(data=_WAV, mime_type="audio/mpeg")
+    _error(
+        runtime.request("text-to-audio"),
+        status=400,
+        code="completion_request_error",
+        message="TTS provider output MIME does not match its audio bytes: declared audio/mpeg, detected audio/wav",
+    )
+
+
+def test_tts_no_result_remains_json_null(runtime: _Runtime) -> None:
+    runtime.output = None
+    response = runtime.request("text-to-audio", body={"message_id": "not-a-uuid"})
+    assert response.status_code == 200
+    assert response.get_json() is None
+    assert response.data == b"null\n"
+    assert response.headers["Content-Type"] == "application/json"
+    assert int(response.headers["Content-Length"]) == len(response.data)
+    assert runtime.tts_calls[0][-1] == "not-a-uuid"
+
+
+@pytest.mark.parametrize("body", [{"text": 123}, {"voice": []}, {"message_id": 123}, {"streaming": "invalid"}])
+def test_invalid_tts_body_uses_shared_422_before_runtime(runtime: _Runtime, body: dict[str, object]) -> None:
+    _error(runtime.request("text-to-audio", body=body), status=422, code="unprocessable_entity")
+    assert runtime.tts_calls == []
+
+
+@pytest.mark.parametrize("operation", _OPERATIONS)
+@pytest.mark.parametrize("mode", list(AppMode))
+def test_audio_endpoints_have_no_app_mode_gate(runtime: _Runtime, operation: _Operation, mode: AppMode) -> None:
+    with runtime.factory.begin() as session:
+        app = session.get(App, runtime.harness.target_app.id)
+        assert app is not None
+        app.mode = mode
+    assert runtime.request(operation).status_code == 200
+    calls = runtime.asr_calls if operation == "audio-to-text" else runtime.tts_calls
+    assert len(calls) == 1
+    assert calls[0][0].app_mode == mode.value
+
+
+@pytest.mark.parametrize("operation", _OPERATIONS)
+@pytest.mark.parametrize("admission", ["missing", "denied", "orphan"])
+def test_audio_endpoints_apply_admission_before_reading_or_generating_audio(
+    runtime: _Runtime, operation: _Operation, admission: str
+) -> None:
+    if admission == "denied":
+        runtime.harness.state.allowed = False
+    elif admission == "orphan":
+        with runtime.factory.begin() as session:
+            app = session.get(App, runtime.harness.target_app.id)
+            assert app is not None
+            session.delete(app)
+    _error(
+        runtime.request(operation, installed_app_id=str(uuid4()) if admission == "missing" else None),
+        status=403 if admission == "denied" else 404,
+        code="access_denied" if admission == "denied" else "installed_app_not_found",
+    )
+    assert runtime.asr_calls == runtime.tts_calls == []
+    if admission == "orphan":
+        assert runtime.harness.state.permission_calls == []
+        with runtime.factory() as session:
+            assert session.get(InstalledApp, runtime.harness.installed_app.id) is None
+
+
+@pytest.mark.parametrize("operation", _OPERATIONS)
+@pytest.mark.parametrize(
+    ("failure", "status", "code", "description"),
+    [
+        (AppModelConfigBrokenError(), 400, "app_unavailable", None),
+        (NoAudioUploadedServiceError(), 400, "no_audio_uploaded", None),
+        (AudioTooLargeServiceError("30 MB limit exceeded"), 413, "audio_too_large", "30 MB limit exceeded"),
+        (UnsupportedAudioTypeServiceError(), 415, "unsupported_audio_type", None),
+        (ProviderNotSupportSpeechToTextServiceError(), 400, "provider_not_support_speech_to_text", None),
+        (ProviderTokenNotInitError("Missing credentials"), 400, "provider_not_initialize", "Missing credentials"),
+        (QuotaExceededError(), 400, "provider_quota_exceeded", None),
+        (ModelCurrentlyNotSupportError(), 400, "model_currently_not_support", None),
+        (InvokeError("Provider rejected audio"), 400, "completion_request_error", "Provider rejected audio"),
+        (ValueError("Invalid audio arguments"), 400, "invalid_param", "Invalid audio arguments"),
+        (RuntimeError("Unexpected provider failure"), 500, "internal_server_error", None),
+    ],
+)
+def test_audio_and_provider_failures_keep_precise_http_contract(
+    runtime: _Runtime, operation: _Operation, failure: Exception, status: int, code: str, description: str | None
+) -> None:
+    runtime.error = failure
+    _error(runtime.request(operation), status=status, code=code, message=description)
+    assert len(runtime.asr_calls) + len(runtime.tts_calls) == 1
+
+
+def test_asr_disabled_feature_preserves_400(runtime: _Runtime) -> None:
+    runtime.error = SpeechToTextDisabledServiceError()
+    _error(runtime.request("audio-to-text"), status=400, code="speech_to_text_disabled")
+
+
+def test_unsupported_tts_provider_has_specific_error(runtime: _Runtime) -> None:
+    runtime.error = ProviderNotSupportTextToSpeechServiceError()
+    _error(runtime.request("text-to-audio"), status=400, code="provider_not_support_text_to_speech")

--- a/api/tests/unit_tests/controllers/console/explore/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_wraps.py
@@ -3,25 +3,20 @@ from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session, scoped_session
-from werkzeug.exceptions import NotFound
 
 import controllers.console.explore.wraps as wraps_module
 import models.model as model_module
 from controllers.console.explore.error import (
-    AppAccessDeniedError,
     TrialAppFeatureDisabledError,
     TrialAppLimitExceeded,
     TrialAppNotAllowed,
 )
 from controllers.console.explore.wraps import (
-    InstalledAppResource,
     TrialAppResource,
-    installed_app_required,
     trial_app_required,
     trial_feature_enable,
-    user_allowed_to_access_app,
 )
-from models import Account, AccountTrialAppRecord, App, AppMode, InstalledApp, TrialApp
+from models import Account, AccountTrialAppRecord, App, AppMode, TrialApp
 
 
 def _bind_database(monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
@@ -47,138 +42,6 @@ def _app() -> App:
     )
     app.id = str(uuid4())
     return app
-
-
-def _installed_app(*, app_id: str, tenant_id: str) -> InstalledApp:
-    return InstalledApp(
-        tenant_id=tenant_id,
-        app_id=app_id,
-        app_owner_tenant_id=str(uuid4()),
-        position=0,
-        is_pinned=False,
-        last_used_at=None,
-    )
-
-
-@pytest.mark.parametrize("sqlite_session", [(InstalledApp, App)], indirect=True)
-def test_installed_app_required_not_found(
-    monkeypatch: pytest.MonkeyPatch,
-    sqlite_session: Session,
-):
-    tenant_id = str(uuid4())
-    _bind_database(monkeypatch, sqlite_session)
-
-    @installed_app_required
-    def view(installed_app):
-        return "ok"
-
-    with patch(
-        "controllers.console.explore.wraps.current_account_with_tenant",
-        return_value=(_account(), tenant_id),
-    ):
-        with pytest.raises(NotFound):
-            view(str(uuid4()))
-
-
-@pytest.mark.parametrize("sqlite_session", [(InstalledApp, App)], indirect=True)
-def test_installed_app_required_app_deleted(
-    monkeypatch: pytest.MonkeyPatch,
-    sqlite_session: Session,
-):
-    tenant_id = str(uuid4())
-    installed_app = _installed_app(app_id=str(uuid4()), tenant_id=tenant_id)
-    sqlite_session.add(installed_app)
-    sqlite_session.commit()
-    installed_app_id = installed_app.id
-    _bind_database(monkeypatch, sqlite_session)
-
-    @installed_app_required
-    def view(installed_app):
-        return "ok"
-
-    with patch(
-        "controllers.console.explore.wraps.current_account_with_tenant",
-        return_value=(_account(), tenant_id),
-    ):
-        with pytest.raises(NotFound):
-            view(installed_app_id)
-
-    assert sqlite_session.get(InstalledApp, installed_app_id) is None
-
-
-@pytest.mark.parametrize("sqlite_session", [(InstalledApp, App)], indirect=True)
-def test_installed_app_required_success(
-    monkeypatch: pytest.MonkeyPatch,
-    sqlite_session: Session,
-):
-    app = _app()
-    installed_app = _installed_app(app_id=app.id, tenant_id=app.tenant_id)
-    sqlite_session.add_all([app, installed_app])
-    sqlite_session.commit()
-    _bind_database(monkeypatch, sqlite_session)
-
-    @installed_app_required
-    def view(installed_app):
-        return installed_app
-
-    with patch(
-        "controllers.console.explore.wraps.current_account_with_tenant",
-        return_value=(_account(), app.tenant_id),
-    ):
-        result = view(installed_app.id)
-
-    assert result.id == installed_app.id
-    assert result.app is not None
-    assert result.app.id == app.id
-
-
-def test_user_allowed_to_access_app_denied():
-    installed_app = _installed_app(app_id="app-1", tenant_id="tenant-1")
-
-    @user_allowed_to_access_app
-    def view(installed_app):
-        return "ok"
-
-    with (
-        patch(
-            "controllers.console.explore.wraps.current_account_with_tenant",
-            return_value=(_account(account_id="user-1"), None),
-        ),
-        patch(
-            "controllers.console.explore.wraps.SystemFeatureService.is_webapp_auth_enabled",
-            return_value=True,
-        ),
-        patch(
-            "controllers.console.explore.wraps.EnterpriseService.WebAppAuth.is_user_allowed_to_access_webapp",
-            return_value=False,
-        ),
-    ):
-        with pytest.raises(AppAccessDeniedError):
-            view(installed_app)
-
-
-def test_user_allowed_to_access_app_success():
-    installed_app = _installed_app(app_id="app-1", tenant_id="tenant-1")
-
-    @user_allowed_to_access_app
-    def view(installed_app):
-        return "ok"
-
-    with (
-        patch(
-            "controllers.console.explore.wraps.current_account_with_tenant",
-            return_value=(_account(account_id="user-1"), None),
-        ),
-        patch(
-            "controllers.console.explore.wraps.SystemFeatureService.is_webapp_auth_enabled",
-            return_value=True,
-        ),
-        patch(
-            "controllers.console.explore.wraps.EnterpriseService.WebAppAuth.is_user_allowed_to_access_webapp",
-            return_value=True,
-        ),
-    ):
-        assert view(installed_app) == "ok"
 
 
 @pytest.mark.parametrize("sqlite_session", [(TrialApp, App, AccountTrialAppRecord)], indirect=True)
@@ -278,11 +141,6 @@ def test_trial_feature_enable_enabled():
     services.recommended_app_queries.is_trial_enabled.return_value = True
     with patch("controllers.console.explore.wraps.application_services", return_value=services):
         assert view() == "ok"
-
-
-def test_installed_app_resource_decorators():
-    decorators = InstalledAppResource.method_decorators
-    assert len(decorators) == 4
 
 
 def test_trial_app_resource_decorators():

--- a/api/tests/unit_tests/services/test_audio_inputs.py
+++ b/api/tests/unit_tests/services/test_audio_inputs.py
@@ -1,0 +1,71 @@
+"""Validate plain audio uploads before calling the shared provider boundary."""
+
+from io import BytesIO
+
+import pytest
+
+from models import App, AppMode
+from services import audio_provider_gateway
+from services.audio_service import FILE_SIZE_LIMIT, AudioService
+from services.audio_types import AudioAppRef, AudioUpload
+from services.errors.audio import (
+    AudioTooLargeServiceError,
+    NoAudioUploadedServiceError,
+    UnsupportedAudioTypeServiceError,
+)
+
+
+@pytest.mark.parametrize("size", [0, FILE_SIZE_LIMIT, FILE_SIZE_LIMIT + 1])
+def test_asr_accepts_empty_and_exact_limit_but_rejects_oversized_upload(
+    monkeypatch: pytest.MonkeyPatch, size: int
+) -> None:
+    app = App(id="app", tenant_id="owner", mode=AppMode.CHAT)
+    contents: list[bytes] = []
+
+    def transcribe(*, app: AudioAppRef, content: bytes, end_user: str | None) -> str:
+        assert app == AudioAppRef(app_id="app", tenant_id="owner", app_mode="chat")
+        assert end_user == "provider-user"
+        contents.append(content)
+        return " transcript "
+
+    monkeypatch.setattr(audio_provider_gateway, "speech_to_text", transcribe)
+    content = b"a" * size
+    upload = AudioUpload(stream=BytesIO(content), mime_type="audio/x-m4a")
+    if size > FILE_SIZE_LIMIT:
+        with pytest.raises(AudioTooLargeServiceError, match="Audio size larger than 30 mb"):
+            AudioService.invoke_speech_to_text(app, upload, end_user="provider-user")
+        assert contents == []
+    else:
+        assert AudioService.invoke_speech_to_text(app, upload, end_user="provider-user") == {"text": " transcript "}
+        assert contents == [content]
+
+
+@pytest.mark.parametrize("missing", [False, True])
+def test_invalid_upload_does_not_read_stream_or_invoke_provider(monkeypatch: pytest.MonkeyPatch, missing: bool) -> None:
+    def unexpected_provider(*, app: AudioAppRef, content: bytes, end_user: str | None) -> str:
+        del app, content, end_user
+        pytest.fail("Invalid audio reached the provider")
+
+    monkeypatch.setattr(audio_provider_gateway, "speech_to_text", unexpected_provider)
+    app = App(id="app", tenant_id="owner", mode=AppMode.CHAT)
+    stream = BytesIO(b"unread")
+    audio = None if missing else AudioUpload(stream=stream, mime_type="application/octet-stream")
+    error = NoAudioUploadedServiceError if missing else UnsupportedAudioTypeServiceError
+    with pytest.raises(error):
+        AudioService.invoke_speech_to_text(app, audio)
+    assert stream.tell() == 0
+
+
+def test_provider_exception_propagates_without_losing_details(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = RuntimeError("provider transcription failed: timeout")
+
+    def transcribe(*, app: AudioAppRef, content: bytes, end_user: str | None) -> str:
+        del app, content, end_user
+        raise error
+
+    monkeypatch.setattr(audio_provider_gateway, "speech_to_text", transcribe)
+    app = App(id="app", tenant_id="owner", mode=AppMode.CHAT)
+    audio = AudioUpload(stream=BytesIO(b"input"), mime_type="audio/mp3")
+    with pytest.raises(RuntimeError) as caught:
+        AudioService.invoke_speech_to_text(app, audio)
+    assert caught.value is error

--- a/api/tests/unit_tests/services/test_audio_service.py
+++ b/api/tests/unit_tests/services/test_audio_service.py
@@ -55,7 +55,6 @@ Tests available voice retrieval:
 
 import json
 from decimal import Decimal
-from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
@@ -66,7 +65,9 @@ from werkzeug.datastructures import FileStorage
 
 from core.credit_usage import CreditUsageAppType, CreditUsageCreatedBy
 from core.plugin.entities.plugin_daemon import TTSAudioChunk
+from extensions.ext_database import db
 from graphon.model_runtime.errors.invoke import InvokeBadRequestError
+from models.agent import Agent, AgentConfigSnapshot, AgentScope, AgentSource
 from models.agent_config_entities import AgentSoulConfig
 from models.enums import ConversationFromSource, MessageStatus
 from models.model import App, AppMode, AppModelConfig, Message
@@ -163,7 +164,7 @@ class AudioServiceTestDataFactory:
         self.session.commit()
         return app
 
-    def create_workflow_mock(self, features_dict: dict[str, Any] | None = None, **kwargs) -> Workflow:
+    def create_workflow_mock(self, features_dict: dict[str, object] | None = None, **kwargs: object) -> Workflow:
         """
         Create and persist a Workflow model.
 
@@ -192,9 +193,9 @@ class AudioServiceTestDataFactory:
 
     def create_app_model_config_mock(
         self,
-        speech_to_text_dict: dict[str, Any] | None = None,
-        text_to_speech_dict: dict[str, Any] | None = None,
-        **kwargs,
+        speech_to_text_dict: dict[str, object] | None = None,
+        text_to_speech_dict: dict[str, object] | None = None,
+        **kwargs: object,
     ) -> AppModelConfig:
         """
         Create and persist an AppModelConfig model.
@@ -260,7 +261,7 @@ class TestAudioServiceASR:
     def _bind_sqlite_session(self, sqlite_session: Session) -> None:
         self.session = sqlite_session
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_asr_success_chat_mode(self, mock_model_manager_class, factory: AudioServiceTestDataFactory):
         """Test successful ASR transcription in CHAT mode."""
         # Arrange
@@ -292,10 +293,10 @@ class TestAudioServiceASR:
             },
         )
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_asr_accepts_x_m4a_mimetype(
-        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
-    ):
+        self, mock_model_manager_class: MagicMock, factory: AudioServiceTestDataFactory
+    ) -> None:
         """Test that the x-m4a MIME alias follows the normal m4a transcription flow."""
         # Arrange
         app_model_config = factory.create_app_model_config_mock(speech_to_text_dict={"enabled": True})
@@ -312,10 +313,10 @@ class TestAudioServiceASR:
         assert result == {"text": "M4A transcript"}
         mock_model_instance.invoke_speech2text.assert_called_once()
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_asr_success_advanced_chat_mode(
-        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
-    ):
+        self, mock_model_manager_class: MagicMock, factory: AudioServiceTestDataFactory
+    ) -> None:
         """Test successful ASR transcription in ADVANCED_CHAT mode."""
         # Arrange
         workflow = factory.create_workflow_mock(features_dict={"speech_to_text": {"enabled": True}})
@@ -337,18 +338,31 @@ class TestAudioServiceASR:
         # Assert
         assert result == {"text": "Workflow transcribed text"}
 
-    @patch("services.audio_service.AgentRosterService", autospec=True)
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_asr_success_published_agent_mode(
         self,
-        mock_model_manager_class,
-        mock_roster_service_class,
+        mock_model_manager_class: MagicMock,
         factory: AudioServiceTestDataFactory,
-    ):
+    ) -> None:
         app = factory.create_app_mock(mode=AppMode.AGENT)
         file = factory.create_file_storage_mock()
         agent_soul = AgentSoulConfig.model_validate({"app_features": {"speech_to_text": {"enabled": True}}})
-        mock_roster_service_class.return_value.get_published_agent_soul_for_app.return_value = agent_soul
+        agent = Agent(
+            tenant_id=app.tenant_id,
+            app_id=app.id,
+            name="Audio agent",
+            scope=AgentScope.ROSTER,
+            source=AgentSource.AGENT_APP,
+        )
+        self.session.add(agent)
+        self.session.flush()
+        snapshot = AgentConfigSnapshot(
+            tenant_id=app.tenant_id, agent_id=agent.id, version=1, config_snapshot=agent_soul
+        )
+        self.session.add(snapshot)
+        self.session.flush()
+        agent.active_config_snapshot_id = snapshot.id
+        self.session.commit()
         mock_model_instance = MagicMock()
         mock_model_instance.invoke_speech2text.return_value = "Published Agent transcript"
         mock_model_manager_class.return_value.get_default_model_instance.return_value = mock_model_instance
@@ -356,23 +370,24 @@ class TestAudioServiceASR:
         result = AudioService.transcript_asr(app_model=app, file=file, session=self.session, end_user="end-user-1")
 
         assert result == {"text": "Published Agent transcript"}
-        mock_roster_service_class.return_value.get_published_agent_soul_for_app.assert_called_once_with(
+        mock_model_manager_class.assert_called_once_with(
             tenant_id=app.tenant_id,
-            app_id=app.id,
+            user_id="end-user-1",
+            request_metadata={
+                "app_type": CreditUsageAppType.AGENT_V2,
+                "created_by": CreditUsageCreatedBy.AUDIO,
+            },
         )
 
-    @patch("services.audio_service.AgentRosterService", autospec=True)
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_asr_legacy_agent_falls_back_to_app_model_config(
         self,
-        mock_model_manager_class,
-        mock_roster_service_class,
+        mock_model_manager_class: MagicMock,
         factory: AudioServiceTestDataFactory,
-    ):
+    ) -> None:
         app_model_config = factory.create_app_model_config_mock(speech_to_text_dict={"enabled": True})
         app = factory.create_app_mock(mode=AppMode.AGENT, app_model_config=app_model_config)
         file = factory.create_file_storage_mock()
-        mock_roster_service_class.return_value.get_published_agent_soul_for_app.return_value = None
         mock_model_instance = MagicMock()
         mock_model_instance.invoke_speech2text.return_value = "Legacy Agent transcript"
         mock_model_manager_class.return_value.get_default_model_instance.return_value = mock_model_instance
@@ -381,10 +396,10 @@ class TestAudioServiceASR:
 
         assert result == {"text": "Legacy Agent transcript"}
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_agent_asr_uses_agent_soul_feature(
-        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
-    ):
+        self, mock_model_manager_class: MagicMock, factory: AudioServiceTestDataFactory
+    ) -> None:
         app = factory.create_app_mock(mode=AppMode.AGENT)
         file = factory.create_file_storage_mock()
         agent_soul = AgentSoulConfig.model_validate({"app_features": {"speech_to_text": {"enabled": True}}})
@@ -426,10 +441,10 @@ class TestAudioServiceASR:
         with pytest.raises(SpeechToTextDisabledServiceError):
             AudioService.transcript_agent_asr(app_model=app, agent_soul=agent_soul, file=file, session=self.session)
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_agent_asr_preserves_legacy_feature_fallback(
-        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
-    ):
+        self, mock_model_manager_class: MagicMock, factory: AudioServiceTestDataFactory
+    ) -> None:
         app_model_config = factory.create_app_model_config_mock(speech_to_text_dict={"enabled": True})
         app = factory.create_app_mock(mode=AppMode.AGENT, app_model_config=app_model_config)
         file = factory.create_file_storage_mock()
@@ -541,10 +556,10 @@ class TestAudioServiceASR:
         with pytest.raises(AudioTooLargeServiceError, match="Audio size larger than 30 mb"):
             AudioService.transcript_asr(app_model=app, file=file, session=self.session)
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_asr_raises_error_when_no_model_instance(
-        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
-    ):
+        self, mock_model_manager_class: MagicMock, factory: AudioServiceTestDataFactory
+    ) -> None:
         """Test that ASR raises error when no model instance is available."""
         # Arrange
         app_model_config = factory.create_app_model_config_mock(speech_to_text_dict={"enabled": True})
@@ -566,7 +581,36 @@ class TestAudioServiceASR:
 class TestAudioServiceTTS:
     """Test text-to-speech (TTS) operations."""
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
+    def test_legacy_tts_preserves_the_callers_uncommitted_transaction(
+        self,
+        mock_model_manager_class: MagicMock,
+        factory: AudioServiceTestDataFactory,
+        sqlite_session: Session,
+    ) -> None:
+        app = factory.create_app_mock()
+        sqlite_session.add(_message())
+        sqlite_session.flush()
+        mock_model_instance = mock_model_manager_class.return_value.get_default_model_instance.return_value
+        mock_model_instance.invoke_tts.return_value = b"pending message audio"
+
+        result = AudioService.transcript_tts(
+            app_model=app,
+            session=sqlite_session,
+            message_ref=MessageRef(
+                app=AppRef(tenant_id=TENANT_ID, app_id=APP_ID), message_id=MESSAGE_ID, account_id=ACCOUNT_ID
+            ),
+            voice="pending-voice",
+        )
+
+        assert result is not None
+        assert result.get_data() == b"pending message audio"
+        assert sqlite_session.in_transaction()
+        mock_model_instance.invoke_tts.assert_called_once_with(content_text="Message answer", voice="pending-voice")
+        sqlite_session.rollback()
+        assert sqlite_session.get(Message, MESSAGE_ID) is None
+
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_with_text_success(
         self,
         mock_model_manager_class: MagicMock,
@@ -615,7 +659,7 @@ class TestAudioServiceTTS:
             voice="en-US-Neural",
         )
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_with_default_voice(
         self,
         mock_model_manager_class: MagicMock,
@@ -653,7 +697,7 @@ class TestAudioServiceTTS:
         call_args = mock_model_instance.invoke_tts.call_args
         assert call_args.kwargs["voice"] == "default-voice"
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_gets_first_available_voice_when_none_configured(
         self,
         mock_model_manager_class: MagicMock,
@@ -691,48 +735,49 @@ class TestAudioServiceTTS:
         call_args = mock_model_instance.invoke_tts.call_args
         assert call_args.kwargs["voice"] == "auto-voice"
 
-    @patch("services.audio_service.WorkflowService", autospec=True)
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_workflow_mode_with_draft(
         self,
         mock_model_manager_class: MagicMock,
-        mock_workflow_service_class: MagicMock,
         factory: AudioServiceTestDataFactory,
         sqlite_session: Session,
     ) -> None:
         """Test TTS in WORKFLOW mode with draft workflow."""
         # Arrange
-        draft_workflow = factory.create_workflow_mock(
-            features_dict={"text_to_speech": {"enabled": True, "voice": "draft-voice"}}
-        )
+        factory.create_workflow_mock(features_dict={"text_to_speech": {"enabled": True, "voice": "draft-voice"}})
         app = factory.create_app_mock(
             mode=AppMode.WORKFLOW,
         )
-
-        # Mock WorkflowService
-        mock_workflow_service = mock_workflow_service_class.return_value
-        mock_workflow_service.get_draft_workflow.return_value = draft_workflow
 
         # Mock ModelManager
         mock_model_manager = mock_model_manager_class.return_value
         mock_model_instance = MagicMock()
         mock_model_instance.invoke_tts.return_value = b"draft audio"
         mock_model_manager.get_default_model_instance.return_value = mock_model_instance
-        # Act
-        result = AudioService.transcript_tts(
-            app_model=app,
-            session=sqlite_session,
-            text="Draft test",
-            is_draft=True,
-        )
+        # WorkflowService constructs its default repository from db.engine.
+        # Leave that database empty so the draft must come from sqlite_session.
+        flask_app = Flask(__name__)
+        flask_app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+        db.init_app(flask_app)
+        with flask_app.app_context():
+            try:
+                result = AudioService.transcript_tts(
+                    app_model=app,
+                    session=sqlite_session,
+                    text="Draft test",
+                    is_draft=True,
+                )
+            finally:
+                db.session.remove()
+                db.engine.dispose()
 
         # Assert
         assert result is not None
         assert result.content_type == "audio/mpeg"
         assert result.get_data() == b"draft audio"
-        mock_workflow_service.get_draft_workflow.assert_called_once_with(app_model=app, session=sqlite_session)
+        mock_model_instance.invoke_tts.assert_called_once_with(content_text="Draft test", voice="draft-voice")
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_message_id_uses_provided_session(
         self,
         mock_model_manager_class: MagicMock,
@@ -803,7 +848,7 @@ class TestAudioServiceTTS:
             voice="message-voice",
         )
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_uses_detected_wav_mime_type_for_streams(
         self,
         mock_model_manager_class: MagicMock,
@@ -833,7 +878,7 @@ class TestAudioServiceTTS:
         assert result.content_type == "audio/wav"
         assert result.get_data() == b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00audio-data"
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_returns_provider_output_error_for_mime_magic_mismatch(
         self,
         mock_model_manager_class,
@@ -873,7 +918,7 @@ class TestAudioServiceTTS:
         with pytest.raises(ValueError, match="Text is required"):
             AudioService.transcript_tts(app_model=app, session=sqlite_session, text=None)
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_raises_error_when_no_voices_available(
         self,
         mock_model_manager_class,
@@ -904,8 +949,8 @@ class TestAudioServiceTTS:
 class TestAudioServiceTTSVoices:
     """Test TTS voice listing operations."""
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
-    def test_transcript_tts_voices_success(self, mock_model_manager_class, factory: AudioServiceTestDataFactory):
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
+    def test_transcript_tts_voices_success(self, mock_model_manager_class: MagicMock) -> None:
         """Test successful retrieval of TTS voices."""
         # Arrange
         tenant_id = "tenant-123"
@@ -929,10 +974,10 @@ class TestAudioServiceTTSVoices:
         assert result == expected_voices
         mock_model_instance.get_tts_voices.assert_called_once_with(language)
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_voices_raises_error_when_no_model_instance(
-        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
-    ):
+        self, mock_model_manager_class: MagicMock
+    ) -> None:
         """Test that TTS voices raises error when no model instance is available."""
         # Arrange
         tenant_id = "tenant-123"
@@ -946,10 +991,8 @@ class TestAudioServiceTTSVoices:
         with pytest.raises(ProviderNotSupportTextToSpeechServiceError):
             AudioService.transcript_tts_voices(tenant_id=tenant_id, language=language)
 
-    @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
-    def test_transcript_tts_voices_propagates_exceptions(
-        self, mock_model_manager_class, factory: AudioServiceTestDataFactory
-    ):
+    @patch("services.audio_provider_gateway.ModelManager.for_tenant", autospec=True)
+    def test_transcript_tts_voices_propagates_exceptions(self, mock_model_manager_class: MagicMock) -> None:
         """Test that TTS voices propagates exceptions from model instance."""
         # Arrange
         tenant_id = "tenant-123"

--- a/api/tests/unit_tests/services/test_audio_service.py
+++ b/api/tests/unit_tests/services/test_audio_service.py
@@ -569,10 +569,10 @@ class TestAudioServiceTTS:
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_with_text_success(
         self,
-        mock_model_manager_class,
+        mock_model_manager_class: MagicMock,
         factory: AudioServiceTestDataFactory,
         sqlite_session: Session,
-    ):
+    ) -> None:
         """Test successful TTS with text input."""
         # Arrange
         app_model_config = factory.create_app_model_config_mock(
@@ -599,6 +599,7 @@ class TestAudioServiceTTS:
         )
 
         # Assert
+        assert result is not None
         assert result.content_type == "audio/mpeg"
         assert result.get_data() == b"audio data"
         mock_model_manager_class.assert_called_once_with(
@@ -617,10 +618,10 @@ class TestAudioServiceTTS:
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_with_default_voice(
         self,
-        mock_model_manager_class,
+        mock_model_manager_class: MagicMock,
         factory: AudioServiceTestDataFactory,
         sqlite_session: Session,
-    ):
+    ) -> None:
         """Test TTS uses default voice when none specified."""
         # Arrange
         app_model_config = factory.create_app_model_config_mock(
@@ -645,6 +646,7 @@ class TestAudioServiceTTS:
         )
 
         # Assert
+        assert result is not None
         assert result.content_type == "audio/mpeg"
         assert result.get_data() == b"audio data"
         # Verify default voice was used
@@ -654,10 +656,10 @@ class TestAudioServiceTTS:
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_gets_first_available_voice_when_none_configured(
         self,
-        mock_model_manager_class,
+        mock_model_manager_class: MagicMock,
         factory: AudioServiceTestDataFactory,
         sqlite_session: Session,
-    ):
+    ) -> None:
         """Test TTS gets first available voice when none is configured."""
         # Arrange
         app_model_config = factory.create_app_model_config_mock(
@@ -683,6 +685,7 @@ class TestAudioServiceTTS:
         )
 
         # Assert
+        assert result is not None
         assert result.content_type == "audio/mpeg"
         assert result.get_data() == b"audio data"
         call_args = mock_model_instance.invoke_tts.call_args
@@ -692,11 +695,11 @@ class TestAudioServiceTTS:
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_workflow_mode_with_draft(
         self,
-        mock_model_manager_class,
-        mock_workflow_service_class,
+        mock_model_manager_class: MagicMock,
+        mock_workflow_service_class: MagicMock,
         factory: AudioServiceTestDataFactory,
         sqlite_session: Session,
-    ):
+    ) -> None:
         """Test TTS in WORKFLOW mode with draft workflow."""
         # Arrange
         draft_workflow = factory.create_workflow_mock(
@@ -724,6 +727,7 @@ class TestAudioServiceTTS:
         )
 
         # Assert
+        assert result is not None
         assert result.content_type == "audio/mpeg"
         assert result.get_data() == b"draft audio"
         mock_workflow_service.get_draft_workflow.assert_called_once_with(app_model=app, session=sqlite_session)
@@ -731,10 +735,10 @@ class TestAudioServiceTTS:
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_message_id_uses_provided_session(
         self,
-        mock_model_manager_class,
+        mock_model_manager_class: MagicMock,
         factory: AudioServiceTestDataFactory,
         sqlite_session: Session,
-    ):
+    ) -> None:
         """Test TTS message lookup uses the injected session."""
         # Arrange
         app = factory.create_app_mock(app_id=APP_ID, tenant_id=TENANT_ID, mode=AppMode.CHAT)
@@ -791,6 +795,7 @@ class TestAudioServiceTTS:
         )
 
         # Assert
+        assert result is not None
         assert result.content_type == "audio/mpeg"
         assert result.get_data() == b"message audio"
         mock_model_instance.invoke_tts.assert_called_once_with(
@@ -801,11 +806,11 @@ class TestAudioServiceTTS:
     @patch("services.audio_service.ModelManager.for_tenant", autospec=True)
     def test_transcript_tts_uses_detected_wav_mime_type_for_streams(
         self,
-        mock_model_manager_class,
+        mock_model_manager_class: MagicMock,
         factory: AudioServiceTestDataFactory,
         sqlite_session: Session,
         app: Flask,
-    ):
+    ) -> None:
         app_model_config = factory.create_app_model_config_mock(
             text_to_speech_dict={"enabled": True, "voice": "en-US-Neural"}
         )
@@ -824,6 +829,7 @@ class TestAudioServiceTTS:
                 voice="en-US-Neural",
             )
 
+        assert result is not None
         assert result.content_type == "audio/wav"
         assert result.get_data() == b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00audio-data"
 

--- a/api/tests/unit_tests/services/test_installed_app_audio_adapters.py
+++ b/api/tests/unit_tests/services/test_installed_app_audio_adapters.py
@@ -1,0 +1,429 @@
+import io
+import json
+from collections.abc import Generator, Iterator, Mapping
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from typing import cast, override
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from flask import Flask
+from sqlalchemy import Connection, event, update
+from sqlalchemy.orm import Session, SessionTransaction, sessionmaker
+
+import services.audio_service as audio_module
+from core.credit_usage import CreditUsageAppType, CreditUsageCreatedBy
+from core.model_manager import ModelInstance, ModelManager
+from core.plugin.entities.plugin_daemon import TTSAudioChunk
+from extensions.ext_database import db
+from graphon.model_runtime.entities.model_entities import ModelPropertyKey, ModelType
+from models import App, AppMode, AppModelConfig, InstalledApp, Message
+from models.agent import Agent, AgentConfigSnapshot, AgentScope, AgentSource
+from models.agent_config_entities import AgentSoulConfig
+from models.enums import ConversationFromSource, MessageStatus
+from models.workflow import Workflow, WorkflowType
+from services.errors.audio import (
+    NoAudioUploadedServiceError,
+    SpeechToTextDisabledServiceError,
+    UnsupportedAudioTypeServiceError,
+)
+from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
+from services.installed_app_audio_adapters import InstalledAppAudioRuntime
+from services.installed_app_audio_service import AudioOutput, AudioUpload
+
+_ACCOUNT_ID = "11111111-1111-4111-8111-111111111111"
+
+
+@dataclass
+class _Harness:
+    runtime: InstalledAppAudioRuntime
+    installation: InstalledAppRef
+    owner_tenant_id: str
+    message_id: str
+    config_id: str
+    opened_sessions: list[Session]
+    closed_sessions: list[Session]
+    provider_calls: list[tuple[str, str | None, Mapping[str, object] | None]]
+    manager: MagicMock
+    model: MagicMock
+
+    def assert_database_closed(self) -> None:
+        assert self.opened_sessions
+        assert all(session in self.closed_sessions for session in self.opened_sessions)
+        assert all(not session.in_transaction() and not session.identity_map for session in self.opened_sessions)
+
+    def tts(
+        self, *, text: str | None = " Text input ", voice: str | None = None, message_id: str | None = None
+    ) -> AudioOutput | None:
+        return self.runtime.transcript_tts(
+            installed_app=self.installation, account_id=_ACCOUNT_ID, text=text, voice=voice, message_id=message_id
+        )
+
+
+@pytest.fixture
+def harness(sqlite_session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> Iterator[_Harness]:
+    with sqlite_session_factory.begin() as session:
+        app = App(tenant_id=str(uuid4()), name="Audio app", mode=AppMode.CHAT, enable_site=True, enable_api=True)
+        session.add(app)
+        session.flush()
+        config = AppModelConfig(
+            app_id=app.id,
+            speech_to_text='{"enabled":true}',
+            text_to_speech='{"enabled":true,"voice":"configured"}',
+        )
+        installed = InstalledApp(
+            tenant_id=str(uuid4()), app_id=app.id, app_owner_tenant_id=app.tenant_id, position=0, is_pinned=False
+        )
+        session.add_all([config, installed])
+        session.flush()
+        app.app_model_config_id = config.id
+        message = Message(
+            app_id=app.id,
+            conversation_id=str(uuid4()),
+            query="Question",
+            answer=" Message answer ",
+            inputs={},
+            message={},
+            message_unit_price=Decimal(0),
+            answer_unit_price=Decimal(0),
+            currency="USD",
+            from_source=ConversationFromSource.CONSOLE,
+            from_account_id=_ACCOUNT_ID,
+            from_end_user_id=None,
+            status=MessageStatus.NORMAL,
+        )
+        session.add(message)
+        session.flush()
+
+    opened_sessions: list[Session] = []
+    closed_sessions: list[Session] = []
+
+    class TrackedSession(Session):
+        @override
+        def close(self) -> None:
+            super().close()
+            closed_sessions.append(self)
+
+    factory = sessionmaker(bind=sqlite_session_factory.kw["bind"], class_=TrackedSession, expire_on_commit=True)
+
+    @event.listens_for(factory, "after_begin")
+    def capture_read_session(session: Session, _transaction: SessionTransaction, _connection: Connection) -> None:
+        opened_sessions.append(session)
+
+    manager = MagicMock(spec=ModelManager)
+    model = MagicMock(spec=ModelInstance)
+    manager.get_default_model_instance.return_value = model
+    model.get_model_schema.return_value.model_properties = {ModelPropertyKey.AUDIO_TYPE: "wav"}
+    model.get_tts_voices.return_value = [{"value": "provider-default"}]
+    model.invoke_tts.return_value = b"audio-bytes"
+    state = _Harness(
+        runtime=InstalledAppAudioRuntime(session_factory=cast(sessionmaker[Session], factory)),
+        installation=InstalledAppRef(id=installed.id, tenant_id=installed.tenant_id, app_id=app.id, app_mode="chat"),
+        owner_tenant_id=app.tenant_id,
+        message_id=message.id,
+        config_id=config.id,
+        opened_sessions=opened_sessions,
+        closed_sessions=closed_sessions,
+        provider_calls=[],
+        manager=manager,
+        model=model,
+    )
+
+    def provider(
+        *, tenant_id: str, user_id: str | None = None, request_metadata: Mapping[str, object] | None = None
+    ) -> ModelManager:
+        state.assert_database_closed()
+        assert tenant_id == state.owner_tenant_id
+        assert user_id is None
+        state.provider_calls.append((tenant_id, user_id, request_metadata))
+        return manager
+
+    monkeypatch.setattr(audio_module.ModelManager, "for_tenant", provider)
+    runtime_app = Flask(__name__)
+    runtime_app.config["SQLALCHEMY_DATABASE_URI"] = str(sqlite_session_factory.kw["bind"].url)
+    db.init_app(runtime_app)
+    with runtime_app.test_request_context():
+        try:
+            yield state
+        finally:
+            db.session.remove()
+            db.engine.dispose()
+
+
+@pytest.mark.parametrize("mime_type", ["audio/mp3", "audio/x-m4a"])
+def test_asr_preserves_upload_alias_owner_metadata_and_closes_preparation_before_provider(
+    harness: _Harness, mime_type: str
+) -> None:
+    def transcribe(*, file: io.BytesIO) -> str:
+        harness.assert_database_closed()
+        assert file.read() == b"uploaded-audio"
+        assert file.name == "temp.mp3"
+        return " transcript "
+
+    harness.model.invoke_speech2text.side_effect = transcribe
+    result = harness.runtime.transcript_asr(
+        installed_app=harness.installation, audio=AudioUpload(stream=io.BytesIO(b"uploaded-audio"), mime_type=mime_type)
+    )
+    assert result == {"text": " transcript "}
+    assert harness.provider_calls == [
+        (
+            harness.owner_tenant_id,
+            None,
+            {"app_type": CreditUsageAppType.CHATBOT, "created_by": CreditUsageCreatedBy.AUDIO},
+        )
+    ]
+    harness.manager.get_default_model_instance.assert_called_once_with(
+        tenant_id=harness.owner_tenant_id, model_type=ModelType.SPEECH2TEXT
+    )
+
+
+@pytest.mark.parametrize("missing", [False, True])
+def test_asr_upload_errors_preserve_precise_error_before_provider(harness: _Harness, missing: bool) -> None:
+    audio = None if missing else AudioUpload(stream=io.BytesIO(b"data"), mime_type="application/octet-stream")
+    error = NoAudioUploadedServiceError if missing else UnsupportedAudioTypeServiceError
+    with pytest.raises(error):
+        harness.runtime.transcript_asr(installed_app=harness.installation, audio=audio)
+    harness.assert_database_closed()
+    assert harness.provider_calls == []
+
+
+def test_asr_feature_error_still_precedes_missing_upload(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session]
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        session.execute(
+            update(AppModelConfig)
+            .where(AppModelConfig.id == harness.config_id)
+            .values(speech_to_text='{"enabled":false}')
+        )
+    with pytest.raises(SpeechToTextDisabledServiceError):
+        harness.runtime.transcript_asr(installed_app=harness.installation, audio=None)
+    harness.assert_database_closed()
+    assert harness.provider_calls == []
+
+
+@pytest.mark.parametrize("output", [b"audio-bytes", bytearray(b"audio-bytes"), memoryview(b"audio-bytes")])
+def test_tts_preserves_raw_output_type_mime_and_owner_metadata(
+    harness: _Harness, output: bytes | bytearray | memoryview
+) -> None:
+    def synthesize(*, content_text: str, voice: str) -> bytes | bytearray | memoryview:
+        harness.assert_database_closed()
+        assert (content_text, voice) == ("Text input", "configured")
+        return output
+
+    harness.model.invoke_tts.side_effect = synthesize
+    result = harness.tts()
+    assert result is not None
+    assert result.data is output
+    assert result.mime_type == "audio/wav"
+    assert harness.provider_calls == [
+        (
+            harness.owner_tenant_id,
+            None,
+            {"app_type": CreditUsageAppType.CHATBOT, "created_by": CreditUsageCreatedBy.AUDIO},
+        )
+    ]
+    harness.manager.get_default_model_instance.assert_called_once_with(
+        tenant_id=harness.owner_tenant_id, model_type=ModelType.TTS
+    )
+    harness.model.get_tts_voices.assert_not_called()
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_tts_stream_starts_after_preparation_session_closes_and_preserves_provider_chunks(
+    harness: _Harness, fail: bool
+) -> None:
+    first = TTSAudioChunk(b"RIFF\x24\x00\x00\x00WAVE", "audio/wav")
+    failure = RuntimeError("Provider stream interrupted")
+    events: list[str] = []
+
+    def chunks() -> Generator[bytes, None, None]:
+        harness.assert_database_closed()
+        events.append("first chunk")
+        yield first
+        if fail:
+            raise failure
+        yield b"remaining audio"
+
+    stream = chunks()
+    harness.model.invoke_tts.return_value = stream
+    result = harness.tts()
+    assert result is not None
+    assert result.mime_type == "audio/wav"
+    assert result.data is stream
+    assert events == []
+    assert next(stream) is first
+    if fail:
+        with pytest.raises(RuntimeError) as error:
+            next(stream)
+        assert error.value is failure
+    else:
+        assert list(stream) == [b"remaining audio"]
+    assert events == ["first chunk"]
+
+
+def test_tts_message_takes_priority_over_text_and_keeps_account_scope(harness: _Harness) -> None:
+    result = harness.tts(text="Ignored text", message_id=harness.message_id)
+    assert result is not None
+    harness.model.invoke_tts.assert_called_once_with(content_text="Message answer", voice="configured")
+
+
+@pytest.mark.parametrize("case", ["malformed", "missing", "other_app", "other_account", "empty_normal", "empty_paused"])
+def test_tts_unavailable_message_returns_none_without_falling_back_to_text(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session], case: str
+) -> None:
+    message_id = harness.message_id
+    if case == "malformed":
+        message_id = "invalid-uuid"
+    elif case == "missing":
+        message_id = str(uuid4())
+    else:
+        with sqlite_session_factory.begin() as session:
+            message = session.get(Message, message_id)
+            assert message is not None
+            if case == "other_app":
+                message.app_id = str(uuid4())
+            elif case == "other_account":
+                message.from_account_id = str(uuid4())
+            else:
+                message.answer = ""
+                message.status = MessageStatus.NORMAL if case == "empty_normal" else MessageStatus.PAUSED
+    assert harness.tts(text="Do not use as fallback", message_id=message_id) is None
+    harness.assert_database_closed()
+    assert harness.provider_calls == []
+
+
+@pytest.mark.parametrize("voice", ["explicit", "", None])
+def test_tts_explicit_voice_bypasses_config_and_empty_voice_uses_provider_default(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session], voice: str | None
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        config = session.get(AppModelConfig, harness.config_id)
+        assert config is not None
+        session.delete(config)
+    if voice is None:
+        with pytest.raises(ValueError, match="AppModelConfig not found"):
+            harness.tts(voice=voice)
+        assert harness.provider_calls == []
+    else:
+        assert harness.tts(voice=voice) is not None
+        harness.model.invoke_tts.assert_called_once_with(content_text="Text input", voice=voice or "provider-default")
+        assert harness.model.get_tts_voices.call_count == (0 if voice else 1)
+
+
+@pytest.mark.parametrize("mismatch", ["id", "tenant_id", "app_id", "deleted_app", "deleted_installation"])
+def test_both_audio_methods_revalidate_complete_installation_reference(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session], mismatch: str
+) -> None:
+    ref = harness.installation
+    if mismatch == "id":
+        ref = replace(ref, id=str(uuid4()))
+    elif mismatch == "tenant_id":
+        ref = replace(ref, tenant_id=str(uuid4()))
+    elif mismatch == "app_id":
+        ref = replace(ref, app_id=str(uuid4()))
+    else:
+        with sqlite_session_factory.begin() as session:
+            if mismatch == "deleted_app":
+                app = session.get(App, ref.app_id)
+                assert app is not None
+                session.delete(app)
+            else:
+                installed = session.get(InstalledApp, ref.id)
+                assert installed is not None
+                session.delete(installed)
+    with pytest.raises(InstalledAppNotFoundError):
+        harness.runtime.transcript_asr(
+            installed_app=ref, audio=AudioUpload(stream=io.BytesIO(b"audio"), mime_type="audio/mp3")
+        )
+    with pytest.raises(InstalledAppNotFoundError):
+        harness.runtime.transcript_tts(
+            installed_app=ref, account_id=_ACCOUNT_ID, text="Text", voice="explicit", message_id=None
+        )
+    assert harness.provider_calls == []
+    harness.assert_database_closed()
+
+
+@pytest.mark.parametrize("published", [False, True])
+def test_audio_uses_published_workflow_features_and_voice(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session], published: bool
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = session.get(App, harness.installation.app_id)
+        assert app is not None
+        app.mode = AppMode.ADVANCED_CHAT
+        workflow = Workflow(
+            tenant_id=app.tenant_id,
+            app_id=app.id,
+            type=WorkflowType.CHAT,
+            version="published" if published else Workflow.VERSION_DRAFT,
+            graph='{"nodes":[],"edges":[]}',
+            _features='{"speech_to_text":{"enabled":true},"text_to_speech":{"enabled":true,"voice":"workflow-voice"}}',
+            created_by=_ACCOUNT_ID,
+        )
+        session.add(workflow)
+        session.flush()
+        if published:
+            app.workflow_id = workflow.id
+    if published:
+        assert harness.tts() is not None
+        harness.model.invoke_tts.assert_called_once_with(content_text="Text input", voice="workflow-voice")
+        harness.model.invoke_speech2text.return_value = "Workflow transcription"
+        assert harness.runtime.transcript_asr(
+            installed_app=harness.installation, audio=AudioUpload(stream=io.BytesIO(b"audio"), mime_type="audio/mp3")
+        ) == {"text": "Workflow transcription"}
+    else:
+        with pytest.raises(ValueError, match="TTS is not enabled"):
+            harness.tts()
+        with pytest.raises(SpeechToTextDisabledServiceError):
+            harness.runtime.transcript_asr(
+                installed_app=harness.installation,
+                audio=AudioUpload(stream=io.BytesIO(b"audio"), mime_type="audio/mp3"),
+            )
+        assert harness.provider_calls == []
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_asr_uses_real_published_agent_soul_over_legacy_config(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session], enabled: bool
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = session.get(App, harness.installation.app_id)
+        assert app is not None
+        app.mode = AppMode.AGENT
+        config = session.get(AppModelConfig, harness.config_id)
+        assert config is not None
+        config.speech_to_text = json.dumps({"enabled": not enabled})
+        agent = Agent(
+            tenant_id=app.tenant_id,
+            name="Audio Agent",
+            app_id=app.id,
+            scope=AgentScope.ROSTER,
+            source=AgentSource.AGENT_APP,
+        )
+        session.add(agent)
+        session.flush()
+        snapshot = AgentConfigSnapshot(
+            tenant_id=app.tenant_id,
+            agent_id=agent.id,
+            version=1,
+            config_snapshot=AgentSoulConfig.model_validate({"app_features": {"speech_to_text": {"enabled": enabled}}}),
+        )
+        session.add(snapshot)
+        session.flush()
+        agent.active_config_snapshot_id = snapshot.id
+    audio = AudioUpload(stream=io.BytesIO(b"audio"), mime_type="audio/mp3")
+    if enabled:
+        harness.model.invoke_speech2text.return_value = "Agent transcription"
+        assert harness.runtime.transcript_asr(installed_app=harness.installation, audio=audio) == {
+            "text": "Agent transcription"
+        }
+        assert harness.provider_calls[0][2] == {
+            "app_type": CreditUsageAppType.AGENT_V2,
+            "created_by": CreditUsageCreatedBy.AUDIO,
+        }
+    else:
+        with pytest.raises(SpeechToTextDisabledServiceError):
+            harness.runtime.transcript_asr(installed_app=harness.installation, audio=audio)
+        assert harness.provider_calls == []

--- a/api/tests/unit_tests/services/test_installed_app_audio_adapters.py
+++ b/api/tests/unit_tests/services/test_installed_app_audio_adapters.py
@@ -12,17 +12,19 @@ from flask import Flask
 from sqlalchemy import Connection, event, update
 from sqlalchemy.orm import Session, SessionTransaction, sessionmaker
 
-import services.audio_service as audio_module
+import services.audio_provider_gateway as audio_module
 from core.credit_usage import CreditUsageAppType, CreditUsageCreatedBy
 from core.model_manager import ModelInstance, ModelManager
 from core.plugin.entities.plugin_daemon import TTSAudioChunk
 from extensions.ext_database import db
 from graphon.model_runtime.entities.model_entities import ModelPropertyKey, ModelType
 from models import App, AppMode, AppModelConfig, InstalledApp, Message
-from models.agent import Agent, AgentConfigSnapshot, AgentScope, AgentSource
+from models.agent import Agent, AgentConfigSnapshot, AgentScope, AgentSource, AgentStatus
 from models.agent_config_entities import AgentSoulConfig
 from models.enums import ConversationFromSource, MessageStatus
 from models.workflow import Workflow, WorkflowType
+from services.agent.errors import AgentVersionNotFoundError
+from services.audio_types import AudioOutput, AudioUpload
 from services.errors.audio import (
     NoAudioUploadedServiceError,
     SpeechToTextDisabledServiceError,
@@ -30,7 +32,6 @@ from services.errors.audio import (
 )
 from services.installed_app_access_service import InstalledAppNotFoundError, InstalledAppRef
 from services.installed_app_audio_adapters import InstalledAppAudioRuntime
-from services.installed_app_audio_service import AudioOutput, AudioUpload
 
 _ACCOUNT_ID = "11111111-1111-4111-8111-111111111111"
 
@@ -312,6 +313,37 @@ def test_tts_explicit_voice_bypasses_config_and_empty_voice_uses_provider_defaul
         assert harness.model.get_tts_voices.call_count == (0 if voice else 1)
 
 
+@pytest.mark.parametrize("mode", [AppMode.CHAT, AppMode.COMPLETION])
+@pytest.mark.parametrize("voice", [None, "explicit", ""])
+def test_tts_disabled_config_rejects_implicit_voice_and_preserves_explicit_bypass(
+    harness: _Harness,
+    sqlite_session_factory: sessionmaker[Session],
+    mode: AppMode,
+    voice: str | None,
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = session.get(App, harness.installation.app_id)
+        assert app is not None
+        app.mode = mode
+        config = session.get(AppModelConfig, harness.config_id)
+        assert config is not None
+        config.text_to_speech = '{"enabled":false,"voice":"disabled-config-voice"}'
+
+    if voice is None:
+        with pytest.raises(ValueError, match="^TTS is not enabled$"):
+            harness.tts(voice=voice)
+        assert harness.provider_calls == []
+        harness.model.invoke_tts.assert_not_called()
+        harness.model.get_tts_voices.assert_not_called()
+    else:
+        output = harness.tts(voice=voice)
+        assert output is not None
+        assert output.data == b"audio-bytes"
+        harness.model.invoke_tts.assert_called_once_with(content_text="Text input", voice=voice or "provider-default")
+        assert harness.model.get_tts_voices.call_count == (0 if voice else 1)
+    harness.assert_database_closed()
+
+
 @pytest.mark.parametrize("mismatch", ["id", "tenant_id", "app_id", "deleted_app", "deleted_installation"])
 def test_both_audio_methods_revalidate_complete_installation_reference(
     harness: _Harness, sqlite_session_factory: sessionmaker[Session], mismatch: str
@@ -427,3 +459,76 @@ def test_asr_uses_real_published_agent_soul_over_legacy_config(
         with pytest.raises(SpeechToTextDisabledServiceError):
             harness.runtime.transcript_asr(installed_app=harness.installation, audio=audio)
         assert harness.provider_calls == []
+
+
+@pytest.mark.parametrize("mismatch", ["tenant_id", "app_id", "scope", "source", "status"])
+def test_asr_agent_lookup_preserves_all_published_roster_predicates(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session], mismatch: str
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = session.get(App, harness.installation.app_id)
+        assert app is not None
+        app.mode = AppMode.AGENT
+        agent = Agent(
+            tenant_id=app.tenant_id,
+            name="Out-of-scope Agent",
+            app_id=app.id,
+            scope=AgentScope.ROSTER,
+            source=AgentSource.AGENT_APP,
+        )
+        if mismatch == "tenant_id":
+            agent.tenant_id = str(uuid4())
+        elif mismatch == "app_id":
+            agent.app_id = str(uuid4())
+        elif mismatch == "scope":
+            agent.scope = AgentScope.WORKFLOW_ONLY
+        elif mismatch == "source":
+            agent.source = AgentSource.ROSTER
+        else:
+            agent.status = AgentStatus.ARCHIVED
+        session.add(agent)
+    # An unowned Agent with no snapshot must not block the legacy config fallback.
+    harness.model.invoke_speech2text.return_value = "Fallback transcription"
+    assert harness.runtime.transcript_asr(
+        installed_app=harness.installation,
+        audio=AudioUpload(stream=io.BytesIO(b"audio"), mime_type="audio/mp3"),
+    ) == {"text": "Fallback transcription"}
+    harness.assert_database_closed()
+
+
+@pytest.mark.parametrize("mismatch", ["unset", "missing", "tenant_id", "agent_id"])
+def test_published_agent_snapshot_must_exist_and_match_its_owner(
+    harness: _Harness, sqlite_session_factory: sessionmaker[Session], mismatch: str
+) -> None:
+    with sqlite_session_factory.begin() as session:
+        app = session.get(App, harness.installation.app_id)
+        assert app is not None
+        app.mode = AppMode.AGENT
+        agent = Agent(
+            tenant_id=app.tenant_id,
+            name="Owned Agent",
+            app_id=app.id,
+            scope=AgentScope.ROSTER,
+            source=AgentSource.AGENT_APP,
+        )
+        session.add(agent)
+        session.flush()
+        if mismatch == "missing":
+            agent.active_config_snapshot_id = str(uuid4())
+        elif mismatch != "unset":
+            snapshot = AgentConfigSnapshot(
+                tenant_id=str(uuid4()) if mismatch == "tenant_id" else app.tenant_id,
+                agent_id=str(uuid4()) if mismatch == "agent_id" else agent.id,
+                version=1,
+                config_snapshot=AgentSoulConfig(),
+            )
+            session.add(snapshot)
+            session.flush()
+            agent.active_config_snapshot_id = snapshot.id
+    with pytest.raises(AgentVersionNotFoundError):
+        harness.runtime.transcript_asr(
+            installed_app=harness.installation,
+            audio=AudioUpload(stream=io.BytesIO(b"audio"), mime_type="audio/mp3"),
+        )
+    harness.assert_database_closed()
+    assert harness.provider_calls == []


### PR DESCRIPTION
Migrate the two InstalledApp audio endpoints to Console account admission and typed installation references. Resolve app configuration and account-owned message text in a bounded session, then release that session before invoking the existing audio provider runtime. Preserve transcript responses, binary audio/MIME handling, provider identity and voice selection. Missing multipart audio now returns the specific `no_audio_uploaded` error; unsupported TTS providers have a dedicated Console error code.

Remove the now-unused `InstalledAppResource` and its admission decorators. Share plain audio input/output values and extract existing provider SDK calls, so the InstalledApp runtime no longer wraps uploads back into Flask file objects. Configuration precedence, Agent/Workflow policy and message eligibility remain in the existing `AudioService`; Web, Service API, Console app/debug and Trial retain their current entry points and dependency wiring.

HTTP and SQLite tests cover admission, tenant/account ownership, upload limits, MIME handling, disabled CHAT/COMPLETION TTS configuration, explicit/empty voice behavior, Agent configuration and session release. Validation: 307 focused audio/controller/application-services tests passed, along with Ruff and the staged no-new-getattr guard. Earlier validation also passed mypy and 34 import-linter contracts. Full Pyrefly remains blocked by two existing Tencent tracing imports; container integration tests were not run locally.

Stacked on #42016. Shared configuration-query migration, provider-internal scoped sessions and stream close propagation remain follow-up work.
