### PR TITLE
chore(lint): tighten inline disable enforcement

### DIFF
--- a/cli/src/version/render.test.ts
+++ b/cli/src/version/render.test.ts
@@ -24,7 +24,6 @@ function compatible(): VersionReport['compat'] {
 }
 
 // Regex matching the ANSI CSI introducer (ESC `[`).
-// eslint-disable-next-line no-control-regex
 const ANSI_RE = /\[/
 
 describe('renderVersionText', () => {

--- a/cli/test/e2e/helpers/assert.ts
+++ b/cli/test/e2e/helpers/assert.ts
@@ -10,7 +10,6 @@ import { expect } from 'vite-plus/test'
 import './vitest-context.js'
 
 // ── ANSI ──────────────────────────────────────────────────────────────────
-// eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1B\[[0-9;]*[mGKHFA-DJsuhl]/g
 
 function redact(text: string): string {

--- a/cli/test/e2e/suites/output/table-output.e2e.ts
+++ b/cli/test/e2e/suites/output/table-output.e2e.ts
@@ -146,7 +146,6 @@ describe('E2E / table output — header and column format (spec 5.1–5.19)', ()
     const result = await fx.r(['get', 'app'])
     assertExitCode(result, 0)
     // No NUL, BEL, BS, VT, FF, SO–US, DEL bytes that would corrupt a pipe
-    // eslint-disable-next-line no-control-regex
     expect(result.stdout).not.toMatch(/[\x00-\x08\v\f\x0E-\x1F\x7F]/)
   })
 
@@ -155,7 +154,6 @@ describe('E2E / table output — header and column format (spec 5.1–5.19)', ()
     const result = await fx.r(['get', 'app'])
     assertExitCode(result, 0)
     assertNoAnsi(result.stdout, 'stdout')
-    // eslint-disable-next-line no-control-regex
     expect(result.stdout).not.toMatch(/[\x00-\x08\v\f\x0E-\x1F\x7F]/)
   })
 

--- a/lint.config.ts
+++ b/lint.config.ts
@@ -205,7 +205,7 @@ export const lintConfig = {
     'eslint-plugin-storybook',
   ],
   options: {
-    reportUnusedDisableDirectives: 'warn',
+    reportUnusedDisableDirectives: 'error',
     respectEslintDisableDirectives: false,
     typeAware: true,
     typeCheck: true,
@@ -458,6 +458,9 @@ export const lintConfig = {
     ],
     'vars-on-top': 'error',
     yoda: ['error', 'never'],
+    'unicorn/no-abusive-eslint-disable': 'error',
+    'dify/no-file-wide-disable': 'error',
+    'dify/require-disable-directive-description': 'warn',
     'eslint-comments/no-aggregating-enable': 'error',
     'eslint-comments/no-duplicate-disable': 'error',
     'eslint-comments/no-unlimited-disable': 'error',

--- a/lint.config.ts
+++ b/lint.config.ts
@@ -460,7 +460,7 @@ export const lintConfig = {
     yoda: ['error', 'never'],
     'unicorn/no-abusive-eslint-disable': 'error',
     'dify/no-file-wide-disable': 'error',
-    'dify/require-disable-directive-description': 'warn',
+    'dify/require-disable-directive-description': 'error',
     'eslint-comments/no-aggregating-enable': 'error',
     'eslint-comments/no-duplicate-disable': 'error',
     'eslint-comments/no-unlimited-disable': 'error',

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1,4 +1,9 @@
 {
+  "cli/src/framework/run.test.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "cli/test/e2e/suites/output/json-yaml-output.e2e.ts": {
     "prefer-const": {
       "count": 1
@@ -40,6 +45,9 @@
     }
   },
   "web/__mocks__/zustand.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "no-barrel-files/no-barrel-files": {
       "count": 1
     }
@@ -323,6 +331,11 @@
       "count": 1
     }
   },
+  "web/app/components/app/configuration/config-var/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/app/configuration/config-var/select-var-type.tsx": {
     "typescript/no-explicit-any": {
       "count": 1
@@ -377,6 +390,9 @@
     }
   },
   "web/app/components/app/configuration/config/agent/agent-tools/setting-built-in-tool.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "eslint-react/set-state-in-effect": {
       "count": 1
     },
@@ -530,6 +546,11 @@
       "count": 2
     }
   },
+  "web/app/components/app/create-app-dialog/app-card/__tests__/index.spec.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/app/create-app-dialog/app-list/sidebar.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1
@@ -633,6 +654,9 @@
     }
   },
   "web/app/components/app/text-generate/item/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 4
+    },
     "typescript/no-explicit-any": {
       "count": 3
     }
@@ -714,12 +738,30 @@
       "count": 1
     }
   },
+  "web/app/components/base/audio-btn/audio.player.manager.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
+  "web/app/components/base/audio-btn/audio.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/base/audio-gallery/AudioPlayer.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "jsx-a11y/media-has-caption": {
       "count": 1
     },
     "typescript/no-explicit-any": {
       "count": 2
+    }
+  },
+  "web/app/components/base/audio-gallery/__tests__/AudioPlayer.spec.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/app/components/base/auto-height-textarea/index.stories.tsx": {
@@ -731,6 +773,9 @@
     }
   },
   "web/app/components/base/auto-height-textarea/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "jsx-a11y/no-autofocus": {
       "count": 1
     }
@@ -815,12 +860,20 @@
       "count": 1
     }
   },
+  "web/app/components/base/chat/chat/chat-input-area/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/base/chat/chat/check-input-forms-hooks.ts": {
     "typescript/no-explicit-any": {
       "count": 1
     }
   },
   "web/app/components/base/chat/chat/citation/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "eslint-react/set-state-in-effect": {
       "count": 1
     }
@@ -870,6 +923,9 @@
     }
   },
   "web/app/components/base/chat/embedded-chatbot/hooks.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 3
+    },
     "eslint-react/set-state-in-effect": {
       "count": 3
     },
@@ -977,6 +1033,9 @@
     }
   },
   "web/app/components/base/features/new-feature-panel/conversation-opener/modal.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "jsx-a11y/click-events-have-key-events": {
       "count": 2
     },
@@ -1515,6 +1574,9 @@
     }
   },
   "web/app/components/base/markdown/error-boundary.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 2
+    },
     "typescript/no-explicit-any": {
       "count": 3
     }
@@ -1550,6 +1612,11 @@
     },
     "typescript/no-explicit-any": {
       "count": 4
+    }
+  },
+  "web/app/components/base/message-log-modal/__tests__/index.spec.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/app/components/base/message-log-modal/index.stories.tsx": {
@@ -1780,12 +1847,22 @@
       "count": 1
     }
   },
+  "web/app/components/base/search-input/__tests__/index.spec.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/base/search-input/index.stories.tsx": {
     "jsx-a11y/label-has-associated-control": {
       "count": 3
     },
     "no-console": {
       "count": 3
+    }
+  },
+  "web/app/components/base/search-input/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/app/components/base/svg-gallery/index.tsx": {
@@ -1847,6 +1924,11 @@
       "count": 2
     },
     "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/base/zendesk/runtime.ts": {
+    "dify/require-disable-directive-description": {
       "count": 1
     }
   },
@@ -1982,6 +2064,11 @@
       "count": 1
     }
   },
+  "web/app/components/datasets/create/step-two/__tests__/index.spec.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 3
+    }
+  },
   "web/app/components/datasets/create/step-two/components/index.ts": {
     "no-barrel-files/no-barrel-files": {
       "count": 5
@@ -2011,6 +2098,11 @@
     },
     "eslint-react/set-state-in-effect": {
       "count": 3
+    }
+  },
+  "web/app/components/datasets/create/step-two/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 2
     }
   },
   "web/app/components/datasets/create/website/base/crawled-result-item.tsx": {
@@ -2440,6 +2532,9 @@
     }
   },
   "web/app/components/explore/try-app/app/text-generation.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "jsx-a11y/click-events-have-key-events": {
       "count": 1
     },
@@ -2688,6 +2783,11 @@
       "count": 3
     }
   },
+  "web/app/components/plugins/install-plugin/install-bundle/steps/hooks/use-install-multi-state.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/plugins/install-plugin/install-from-github/index.tsx": {
     "typescript/no-explicit-any": {
       "count": 2
@@ -2723,6 +2823,11 @@
   },
   "web/app/components/plugins/marketplace/query.ts": {
     "@tanstack/query/prefer-query-options": {
+      "count": 1
+    }
+  },
+  "web/app/components/plugins/marketplace/search-box/index.tsx": {
+    "dify/require-disable-directive-description": {
       "count": 1
     }
   },
@@ -3141,6 +3246,9 @@
     }
   },
   "web/app/components/share/text-generation/run-once/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "eslint-react/set-state-in-effect": {
       "count": 1
     },
@@ -3175,6 +3283,11 @@
     },
     "jsx-a11y/no-static-element-interactions": {
       "count": 5
+    }
+  },
+  "web/app/components/snippets/hooks/use-nodes-sync-draft.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/app/components/snippets/hooks/use-snippet-run.ts": {
@@ -3282,6 +3395,11 @@
       "count": 3
     }
   },
+  "web/app/components/workflow/block-selector/tool-picker.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/workflow/block-selector/use-sticky-scroll.ts": {
     "erasable-syntax-only/enums": {
       "count": 1
@@ -3327,11 +3445,17 @@
     }
   },
   "web/app/components/workflow/header/test-run-menu-helpers.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "react/only-export-components": {
       "count": 2
     }
   },
   "web/app/components/workflow/header/test-run-menu.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "erasable-syntax-only/enums": {
       "count": 1
     },
@@ -3727,6 +3851,9 @@
     }
   },
   "web/app/components/workflow/nodes/_base/hooks/use-one-step-run.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "eslint-react/set-state-in-effect": {
       "count": 2
     },
@@ -4029,6 +4156,9 @@
     }
   },
   "web/app/components/workflow/nodes/if-else/use-single-run-form-params.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 3
+    },
     "typescript/no-explicit-any": {
       "count": 5
     }
@@ -4459,11 +4589,19 @@
     }
   },
   "web/app/components/workflow/nodes/trigger-schedule/default.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "regexp/no-unused-capturing-group": {
       "count": 2
     },
     "typescript/no-explicit-any": {
       "count": 4
+    }
+  },
+  "web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/app/components/workflow/nodes/trigger-webhook/components/parameter-table.tsx": {
@@ -4711,6 +4849,11 @@
       "count": 2
     }
   },
+  "web/app/components/workflow/panel/env-panel/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/workflow/panel/env-panel/variable-modal.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 4
@@ -4797,6 +4940,9 @@
     }
   },
   "web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 2
+    },
     "unicorn/prefer-number-properties": {
       "count": 1
     }
@@ -5046,9 +5192,22 @@
       "count": 5
     }
   },
+  "web/app/components/workflow/workflow-generator/__tests__/example-prompts.spec.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/app/components/workflow/workflow-generator/example-prompts.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    },
     "no-useless-return": {
       "count": 1
+    }
+  },
+  "web/app/components/workflow/workflow-generator/index.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 2
     }
   },
   "web/app/components/workflow/workflow-preview/components/nodes/constants.ts": {
@@ -5062,6 +5221,9 @@
     }
   },
   "web/app/device/page.tsx": {
+    "dify/require-disable-directive-description": {
+      "count": 5
+    },
     "jsx-a11y/no-autofocus": {
       "count": 1
     }
@@ -5114,8 +5276,18 @@
       "count": 1
     }
   },
+  "web/features/account-profile/client.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/features/agent-v2/agent-detail/configure/components/orchestrate/files/__tests__/index.spec.tsx": {
     "@tanstack/query/prefer-query-options": {
+      "count": 1
+    }
+  },
+  "web/features/agent-v2/agent-detail/configure/components/preview/chat-session.tsx": {
+    "dify/require-disable-directive-description": {
       "count": 1
     }
   },
@@ -5137,6 +5309,11 @@
   "web/features/new-rag/__tests__/use-query-data-update-count.spec.tsx": {
     "@tanstack/query/prefer-query-options": {
       "count": 1
+    }
+  },
+  "web/features/skills/client.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 2
     }
   },
   "web/features/skills/detail/builder-panel.tsx": {
@@ -5247,8 +5424,28 @@
       "count": 1
     }
   },
+  "web/proxy.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 2
+    }
+  },
+  "web/scripts/analyze-i18n-diff.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
+  "web/scripts/gen-doc-paths.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 3
+    }
+  },
   "web/service/__tests__/base.spec.ts": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "web/service/__tests__/sse-generator-post.spec.ts": {
+    "dify/require-disable-directive-description": {
       "count": 1
     }
   },
@@ -5315,6 +5512,11 @@
       "count": 3
     }
   },
+  "web/service/base.spec.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/service/base.ts": {
     "no-restricted-imports": {
       "count": 2
@@ -5350,6 +5552,11 @@
     },
     "typescript/no-explicit-any": {
       "count": 6
+    }
+  },
+  "web/service/fetch.spec.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/service/fetch.ts": {
@@ -5459,6 +5666,9 @@
   "web/service/use-common.ts": {
     "@tanstack/query/prefer-query-options": {
       "count": 10
+    },
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/service/use-datasource.ts": {
@@ -5528,6 +5738,9 @@
   "web/service/use-plugins.ts": {
     "@tanstack/query/prefer-query-options": {
       "count": 13
+    },
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/service/use-share.ts": {
@@ -5595,6 +5808,11 @@
       "count": 1
     }
   },
+  "web/service/workflow-generator.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
+    }
+  },
   "web/service/workflow.ts": {
     "no-restricted-imports": {
       "count": 1
@@ -5641,6 +5859,11 @@
   "web/utils/gtag.ts": {
     "typescript/no-explicit-any": {
       "count": 2
+    }
+  },
+  "web/utils/index.spec.ts": {
+    "dify/require-disable-directive-description": {
+      "count": 1
     }
   },
   "web/utils/index.ts": {

--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -102,6 +102,11 @@
       "count": 2
     }
   },
+  "web/app/components/app/annotation/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 7
+    }
+  },
   "web/app/components/app/annotation/add-annotation-modal/edit-item/index.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1
@@ -117,6 +122,11 @@
     },
     "react/only-export-components": {
       "count": 1
+    }
+  },
+  "web/app/components/app/annotation/batch-add-annotation-modal/__tests__/csv-downloader.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
     }
   },
   "web/app/components/app/annotation/batch-add-annotation-modal/csv-downloader.tsx": {
@@ -166,6 +176,11 @@
       "count": 1
     }
   },
+  "web/app/components/app/annotation/header-opts/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
   "web/app/components/app/annotation/header-opts/index.tsx": {
     "typescript/no-explicit-any": {
       "count": 1
@@ -195,11 +210,44 @@
       "count": 1
     }
   },
+  "web/app/components/app/app-publisher/__tests__/features-wrapper.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 6
+    }
+  },
+  "web/app/components/app/app-publisher/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 9
+    }
+  },
+  "web/app/components/app/app-publisher/__tests__/sections.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
+  "web/app/components/app/app-publisher/__tests__/version-info-modal.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 3
+    }
+  },
+  "web/app/components/app/configuration/config-prompt/__tests__/advanced-prompt-input.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
   "web/app/components/app/configuration/config-prompt/__tests__/index.spec.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1
     },
     "jsx-a11y/no-static-element-interactions": {
+      "count": 1
+    },
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/app/configuration/config-prompt/__tests__/simple-prompt-input.spec.tsx": {
+    "typescript/no-explicit-any": {
       "count": 1
     }
   },
@@ -234,6 +282,19 @@
   "web/app/components/app/configuration/config-var/config-modal/__tests__/form-fields.spec.tsx": {
     "no-unused-vars": {
       "count": 1
+    },
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/app/configuration/config-var/config-modal/__tests__/index-logic.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 3
+    }
+  },
+  "web/app/components/app/configuration/config-var/config-modal/__tests__/type-select.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
     }
   },
   "web/app/components/app/configuration/config-var/config-modal/form-fields.tsx": {
@@ -270,6 +331,41 @@
   "web/app/components/app/configuration/config-var/var-item.tsx": {
     "jsx-a11y/mouse-events-have-key-events": {
       "count": 1
+    }
+  },
+  "web/app/components/app/configuration/config-vision/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/app/configuration/config/__tests__/agent-setting-button.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
+  "web/app/components/app/configuration/config/__tests__/config-audio.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/app/configuration/config/__tests__/config-document.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/app/configuration/config/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 6
+    }
+  },
+  "web/app/components/app/configuration/config/agent/agent-tools/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 3
+    }
+  },
+  "web/app/components/app/configuration/config/agent/agent-tools/__tests__/setting-built-in-tool.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 5
     }
   },
   "web/app/components/app/configuration/config/agent/agent-tools/index.tsx": {
@@ -316,6 +412,11 @@
       "count": 1
     }
   },
+  "web/app/components/app/configuration/dataset-config/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 36
+    }
+  },
   "web/app/components/app/configuration/dataset-config/context-var/var-picker.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1
@@ -337,6 +438,11 @@
       "count": 1
     }
   },
+  "web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
   "web/app/components/app/configuration/dataset-config/settings-modal/index.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 2
@@ -349,6 +455,16 @@
     },
     "typescript/no-explicit-any": {
       "count": 1
+    }
+  },
+  "web/app/components/app/configuration/debug/__tests__/hooks.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/app/configuration/debug/debug-with-multiple-model/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 5
     }
   },
   "web/app/components/app/configuration/debug/debug-with-multiple-model/chat-item.tsx": {
@@ -364,6 +480,11 @@
   "web/app/components/app/configuration/debug/debug-with-multiple-model/text-generation-item.tsx": {
     "typescript/no-explicit-any": {
       "count": 8
+    }
+  },
+  "web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 3
     }
   },
   "web/app/components/app/configuration/debug/debug-with-single-model/index.tsx": {
@@ -389,12 +510,37 @@
       "count": 1
     }
   },
+  "web/app/components/app/configuration/hooks/__tests__/use-advanced-prompt-config.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 4
+    }
+  },
+  "web/app/components/app/configuration/hooks/__tests__/use-configuration-utils.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 52
+    }
+  },
+  "web/app/components/app/configuration/hooks/__tests__/use-configuration.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 3
+    }
+  },
+  "web/app/components/app/configuration/prompt-value-panel/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
   "web/app/components/app/create-app-dialog/app-list/sidebar.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1
     },
     "react/only-export-components": {
       "count": 1
+    }
+  },
+  "web/app/components/app/create-from-dsl-modal/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
     }
   },
   "web/app/components/app/deploy/shared/deployment-configuration/use-deployment-configuration-queries.ts": {
@@ -405,6 +551,21 @@
   "web/app/components/app/in-site-message/__tests__/notification.spec.tsx": {
     "@tanstack/query/prefer-query-options": {
       "count": 1
+    }
+  },
+  "web/app/components/app/log/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 5
+    }
+  },
+  "web/app/components/app/log/__tests__/list-utils.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
+  "web/app/components/app/log/__tests__/list.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 11
     }
   },
   "web/app/components/app/log/filter.tsx": {
@@ -433,12 +594,42 @@
       "count": 2
     }
   },
+  "web/app/components/app/overview/__tests__/app-chart-utils.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
   "web/app/components/app/overview/apikey-info-panel/index.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1
     },
     "jsx-a11y/no-static-element-interactions": {
       "count": 1
+    }
+  },
+  "web/app/components/app/overview/app-chart.tsx": {
+    "react/only-export-components": {
+      "count": 12
+    }
+  },
+  "web/app/components/app/text-generate/item/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
+  "web/app/components/app/text-generate/item/__tests__/result-tab.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "web/app/components/app/text-generate/item/__tests__/utils.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 4
+    }
+  },
+  "web/app/components/app/text-generate/item/__tests__/workflow-body.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 3
     }
   },
   "web/app/components/app/text-generate/item/index.tsx": {
@@ -462,6 +653,11 @@
   "web/app/components/app/type-selector/index.tsx": {
     "unicorn/prefer-includes": {
       "count": 2
+    }
+  },
+  "web/app/components/app/workflow-log/__tests__/list.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 1
     }
   },
   "web/app/components/app/workflow-log/filter.tsx": {
@@ -545,6 +741,9 @@
     }
   },
   "web/app/components/base/carousel/index.tsx": {
+    "eslint-react/set-state-in-effect": {
+      "count": 3
+    },
     "react/only-export-components": {
       "count": 1
     }
@@ -673,6 +872,19 @@
   "web/app/components/base/chat/embedded-chatbot/hooks.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 3
+    },
+    "typescript/no-explicit-any": {
+      "count": 14
+    }
+  },
+  "web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/content.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 5
+    }
+  },
+  "web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/index.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 6
     }
   },
   "web/app/components/base/chat/embedded-chatbot/inputs-form/content.tsx": {
@@ -2235,6 +2447,11 @@
       "count": 1
     }
   },
+  "web/app/components/explore/try-app/preview/basic-app-preview.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
+    }
+  },
   "web/app/components/goto-anything/actions/commands/command-bus.ts": {
     "typescript/no-explicit-any": {
       "count": 2
@@ -2497,6 +2714,11 @@
     },
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "web/app/components/plugins/marketplace/list/carousel.tsx": {
+    "eslint-react/set-state-in-effect": {
+      "count": 4
     }
   },
   "web/app/components/plugins/marketplace/query.ts": {
@@ -3104,6 +3326,11 @@
       "count": 1
     }
   },
+  "web/app/components/workflow/header/test-run-menu-helpers.tsx": {
+    "react/only-export-components": {
+      "count": 2
+    }
+  },
   "web/app/components/workflow/header/test-run-menu.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1
@@ -3189,6 +3416,11 @@
   "web/app/components/workflow/hooks/use-workflow-variables.ts": {
     "typescript/no-explicit-any": {
       "count": 1
+    }
+  },
+  "web/app/components/workflow/node-actions-menu/__tests__/details.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 8
     }
   },
   "web/app/components/workflow/nodes/_base/components/add-variable-popup-with-position.tsx": {
@@ -3533,6 +3765,11 @@
       "count": 6
     }
   },
+  "web/app/components/workflow/nodes/agent/__tests__/integration.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 20
+    }
+  },
   "web/app/components/workflow/nodes/agent/default.ts": {
     "typescript/no-explicit-any": {
       "count": 3
@@ -3562,6 +3799,11 @@
   "web/app/components/workflow/nodes/agent/use-config.ts": {
     "typescript/no-explicit-any": {
       "count": 7
+    }
+  },
+  "web/app/components/workflow/nodes/assigner/__tests__/integration.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 15
     }
   },
   "web/app/components/workflow/nodes/assigner/components/var-list/index.tsx": {
@@ -3750,6 +3992,11 @@
       "count": 1
     }
   },
+  "web/app/components/workflow/nodes/human-input/components/variable-in-markdown.tsx": {
+    "react/only-export-components": {
+      "count": 2
+    }
+  },
   "web/app/components/workflow/nodes/human-input/types.ts": {
     "erasable-syntax-only/enums": {
       "count": 2
@@ -3921,6 +4168,11 @@
       "count": 5
     }
   },
+  "web/app/components/workflow/nodes/list-operator/__tests__/integration.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 16
+    }
+  },
   "web/app/components/workflow/nodes/list-operator/components/filter-condition.tsx": {
     "typescript/no-explicit-any": {
       "count": 1
@@ -4072,6 +4324,11 @@
       "count": 9
     }
   },
+  "web/app/components/workflow/nodes/question-classifier/__tests__/integration.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 15
+    }
+  },
   "web/app/components/workflow/nodes/question-classifier/components/class-item.tsx": {
     "jsx-a11y/no-autofocus": {
       "count": 1
@@ -4189,6 +4446,16 @@
   "web/app/components/workflow/nodes/trigger-plugin/use-config.ts": {
     "typescript/no-explicit-any": {
       "count": 1
+    }
+  },
+  "web/app/components/workflow/nodes/trigger-schedule/__tests__/panel.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 15
+    }
+  },
+  "web/app/components/workflow/nodes/trigger-schedule/components/__tests__/integration.spec.tsx": {
+    "typescript/no-explicit-any": {
+      "count": 2
     }
   },
   "web/app/components/workflow/nodes/trigger-schedule/default.ts": {
@@ -4384,6 +4651,36 @@
   "web/app/components/workflow/panel/debug-and-preview/__tests__/hooks.spec.ts": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-resume.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 69
+    }
+  },
+  "web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-send.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 16
+    }
+  },
+  "web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-stop-restart.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 15
+    }
+  },
+  "web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/misc.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 17
+    }
+  },
+  "web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/opening-statement.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 5
+    }
+  },
+  "web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/sse-callbacks.spec.ts": {
+    "typescript/no-explicit-any": {
+      "count": 34
     }
   },
   "web/app/components/workflow/panel/debug-and-preview/chat-wrapper.tsx": {
@@ -4842,14 +5139,27 @@
       "count": 1
     }
   },
+  "web/features/skills/detail/builder-panel.tsx": {
+    "eslint-react/set-state-in-effect": {
+      "count": 1
+    }
+  },
   "web/features/skills/detail/file-editor.tsx": {
     "@tanstack/query/prefer-query-options": {
       "count": 2
+    },
+    "eslint-react/set-state-in-effect": {
+      "count": 24
     }
   },
   "web/features/skills/detail/file-tree-items.tsx": {
     "jsx-a11y/no-static-element-interactions": {
       "count": 2
+    }
+  },
+  "web/features/skills/detail/page.tsx": {
+    "eslint-react/set-state-in-effect": {
+      "count": 4
     }
   },
   "web/features/tag-management/components/tag-item-editor.tsx": {

--- a/web/app/components/app/annotation/__tests__/index.spec.tsx
+++ b/web/app/components/app/annotation/__tests__/index.spec.tsx
@@ -22,7 +22,6 @@ import Annotation from '../index'
 import { AnnotationEnableStatus, JobStatus } from '../type'
 
 let annotationQuota = { size: 0, limit: 10 }
-/* oxlint-disable typescript/no-explicit-any */
 
 vi.mock('@/context/i18n', () => ({
   useDocLink: () => (path: string) => `https://docs.example.com${path}`,

--- a/web/app/components/app/annotation/batch-add-annotation-modal/__tests__/csv-downloader.spec.tsx
+++ b/web/app/components/app/annotation/batch-add-annotation-modal/__tests__/csv-downloader.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { Mock } from 'vite-plus/test'
 import type { Locale } from '@/i18n-config'
 import { render, screen } from '@testing-library/react'

--- a/web/app/components/app/annotation/header-opts/__tests__/index.spec.tsx
+++ b/web/app/components/app/annotation/header-opts/__tests__/index.spec.tsx
@@ -10,8 +10,6 @@ import { clearAllAnnotations, fetchExportAnnotationList } from '@/service/annota
 import { renderWithConsoleQuery as render } from '@/test/console/query-data'
 import HeaderOptions from '../index'
 
-/* oxlint-disable typescript/no-explicit-any */
-
 const mockJsonToCSV = vi.fn((_: unknown) => 'csv-content')
 const mockCSVDownloader = vi.fn(({ children }) => <>{children}</>)
 

--- a/web/app/components/app/app-publisher/__tests__/features-wrapper.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/features-wrapper.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import FeaturesWrappedAppPublisher from '../features-wrapper'
 

--- a/web/app/components/app/app-publisher/__tests__/index.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { EnvironmentStatus, RuntimeState } from '@dify/contracts/enterprise-app-deploy/types.gen'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/app-publisher/__tests__/sections.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/sections.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { VersionHistory } from '@/types/workflow'
 import { fireEvent, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/app-publisher/__tests__/version-info-modal.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/version-info-modal.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { toast } from '@langgenius/dify-ui/toast'
 import { fireEvent, render, screen } from '@testing-library/react'
 import VersionInfoModal from '../version-info-modal'

--- a/web/app/components/app/configuration/config-prompt/__tests__/advanced-prompt-input.spec.tsx
+++ b/web/app/components/app/configuration/config-prompt/__tests__/advanced-prompt-input.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ReactNode } from 'react'
 import type { PromptRole } from '@/models/debug'
 import { fireEvent, render, screen } from '@testing-library/react'

--- a/web/app/components/app/configuration/config-prompt/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config-prompt/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { IPromptProps } from '../index'
 import type { PromptItem, PromptVariable } from '@/models/debug'
 import { fireEvent, render, screen } from '@testing-library/react'

--- a/web/app/components/app/configuration/config-prompt/__tests__/simple-prompt-input.spec.tsx
+++ b/web/app/components/app/configuration/config-prompt/__tests__/simple-prompt-input.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ReactNode } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { INSERT_VARIABLE_VALUE_BLOCK_COMMAND } from '@/app/components/base/prompt-editor/plugins/variable-block'

--- a/web/app/components/app/configuration/config-var/config-modal/__tests__/form-fields.spec.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/__tests__/form-fields.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ReactNode } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/configuration/config-var/config-modal/__tests__/index-logic.spec.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/__tests__/index-logic.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { InputVar } from '@/app/components/workflow/types'
 import type { App, AppSSO } from '@/types/app'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'

--- a/web/app/components/app/configuration/config-var/config-modal/__tests__/type-select.spec.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/__tests__/type-select.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TypeSelector from '../type-select'

--- a/web/app/components/app/configuration/config-vision/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config-vision/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { Mock } from 'vite-plus/test'
 import type { FeatureStoreState } from '@/app/components/base/features/store'
 import type { FileUpload } from '@/app/components/base/features/types'

--- a/web/app/components/app/configuration/config/__tests__/agent-setting-button.spec.tsx
+++ b/web/app/components/app/configuration/config/__tests__/agent-setting-button.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { AgentConfig } from '@/models/debug'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/configuration/config/__tests__/config-audio.spec.tsx
+++ b/web/app/components/app/configuration/config/__tests__/config-audio.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { FeatureStoreState } from '@/app/components/base/features/store'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/configuration/config/__tests__/config-document.spec.tsx
+++ b/web/app/components/app/configuration/config/__tests__/config-document.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { FeatureStoreState } from '@/app/components/base/features/store'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/configuration/config/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ModelConfig, PromptVariable } from '@/models/debug'
 import type { ToolItem } from '@/types/app'
 import { render, screen } from '@testing-library/react'

--- a/web/app/components/app/configuration/config/agent/agent-tools/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { PropsWithChildren } from 'react'
 import type { Mock } from 'vite-plus/test'
 import type SettingBuiltInToolType from '../setting-built-in-tool'

--- a/web/app/components/app/configuration/config/agent/agent-tools/__tests__/setting-built-in-tool.spec.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/__tests__/setting-built-in-tool.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { Tool, ToolParameter } from '@/app/components/tools/types'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/configuration/dataset-config/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { DataSet } from '@/models/datasets'
 import type { DatasetConfigs } from '@/models/debug'
 import { fireEvent, screen, within } from '@testing-library/react'

--- a/web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { DataSet } from '@/models/datasets'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import * as React from 'react'

--- a/web/app/components/app/configuration/debug/__tests__/hooks.spec.tsx
+++ b/web/app/components/app/configuration/debug/__tests__/hooks.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { act, renderHook } from '@testing-library/react'
 import { AgentStrategy } from '@/types/app'
 import {

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { CSSProperties } from 'react'
 import type { ModelAndParameter } from '../../types'
 import type { DebugWithMultipleModelContextType } from '../context'

--- a/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ReactNode, RefObject } from 'react'
 import type { DebugWithSingleModelRefType } from '../index'
 import type { ChatItem } from '@/app/components/base/chat/types'

--- a/web/app/components/app/configuration/hooks/__tests__/use-advanced-prompt-config.spec.tsx
+++ b/web/app/components/app/configuration/hooks/__tests__/use-advanced-prompt-config.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { act, renderHook, waitFor } from '@testing-library/react'
 import {
   CONTEXT_PLACEHOLDER_TEXT,

--- a/web/app/components/app/configuration/hooks/__tests__/use-configuration-utils.spec.ts
+++ b/web/app/components/app/configuration/hooks/__tests__/use-configuration-utils.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { VisionSettings } from '@/types/app'
 import { DEFAULT_CHAT_PROMPT_CONFIG, DEFAULT_COMPLETION_PROMPT_CONFIG } from '@/config'
 import { withSelectorKey } from '@/test/i18n-mock'

--- a/web/app/components/app/configuration/hooks/__tests__/use-configuration.spec.tsx
+++ b/web/app/components/app/configuration/hooks/__tests__/use-configuration.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { act, waitFor } from '@testing-library/react'
 import { updateAppModelConfig } from '@/service/apps'
 import { consoleQuery } from '@/service/console'

--- a/web/app/components/app/configuration/prompt-value-panel/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/prompt-value-panel/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { IPromptValuePanelProps } from '../index'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/create-from-dsl-modal/__tests__/index.spec.tsx
+++ b/web/app/components/app/create-from-dsl-modal/__tests__/index.spec.tsx
@@ -7,8 +7,6 @@ import { AppModeEnum } from '@/types/app'
 import CreateFromDSLModal from '../index'
 import { CreateFromDSLModalTab } from '../types'
 
-/* oxlint-disable typescript/no-explicit-any */
-
 const mockPush = vi.fn()
 const mockImportDSL = vi.fn()
 const mockImportDSLConfirm = vi.fn()

--- a/web/app/components/app/log/__tests__/index.spec.tsx
+++ b/web/app/components/app/log/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { CloudSandboxPlanState } from '../cloud-sandbox-retention'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/app/log/__tests__/list-utils.spec.ts
+++ b/web/app/components/app/log/__tests__/list-utils.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { IChatItem } from '@/app/components/base/chat/chat/type'
 import {
   applyAnnotationAdded,

--- a/web/app/components/app/log/__tests__/list.spec.tsx
+++ b/web/app/components/app/log/__tests__/list.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ReactNode } from 'react'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { createAccountProfileQueryClient } from '@/test/console/account-profile'

--- a/web/app/components/app/overview/__tests__/app-chart-utils.spec.ts
+++ b/web/app/components/app/overview/__tests__/app-chart-utils.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import {
   buildChartOptions,
   getChartValueField,

--- a/web/app/components/app/overview/app-chart.tsx
+++ b/web/app/components/app/overview/app-chart.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable react/only-export-components */
 'use client'
 import type { QueryKey, UseQueryOptions } from '@tanstack/react-query'
 import type { Dayjs } from 'dayjs'

--- a/web/app/components/app/text-generate/item/__tests__/index.spec.tsx
+++ b/web/app/components/app/text-generate/item/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { AppSourceType } from '@/service/share'
 import GenerationItem from '../index'

--- a/web/app/components/app/text-generate/item/__tests__/result-tab.spec.tsx
+++ b/web/app/components/app/text-generate/item/__tests__/result-tab.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 import ResultTab from '../result-tab'
 

--- a/web/app/components/app/text-generate/item/__tests__/utils.spec.ts
+++ b/web/app/components/app/text-generate/item/__tests__/utils.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import {
   buildPromptLogItem,
   getCopyContent,

--- a/web/app/components/app/text-generate/item/__tests__/workflow-body.spec.tsx
+++ b/web/app/components/app/text-generate/item/__tests__/workflow-body.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { fireEvent, render, screen } from '@testing-library/react'
 import WorkflowBody from '../workflow-body'
 

--- a/web/app/components/app/workflow-log/__tests__/list.spec.tsx
+++ b/web/app/components/app/workflow-log/__tests__/list.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 /**
  * WorkflowAppLogList Component Tests
  *

--- a/web/app/components/base/carousel/index.tsx
+++ b/web/app/components/base/carousel/index.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable eslint-react/set-state-in-effect */
 import type { UseEmblaCarouselType } from 'embla-carousel-react'
 import { cn } from '@langgenius/dify-ui/cn'
 import Autoplay from 'embla-carousel-autoplay'

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -1,5 +1,4 @@
 import type { ChatConfig, ChatItem, OnFeedback } from '../types'
-/* oxlint-disable typescript/no-explicit-any */
 import type { InputValueTypes } from '@/app/components/share/text-generation/types'
 import type { Locale } from '@/i18n-config'
 import type { AppData, ConversationItem } from '@/models/share'

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/content.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/content.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { InputVarType } from '@/app/components/workflow/types'

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AppSourceType } from '@/service/share'

--- a/web/app/components/explore/try-app/index.tsx
+++ b/web/app/components/explore/try-app/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable style/multiline-ternary */
 'use client'
 import type { RecommendedAppResponse } from '@dify/contracts/api/console/explore/types.gen'
 import { Button } from '@langgenius/dify-ui/button'

--- a/web/app/components/explore/try-app/preview/basic-app-preview.tsx
+++ b/web/app/components/explore/try-app/preview/basic-app-preview.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 'use client'
 import type { FC } from 'react'
 import type { Features as FeaturesData, FileUpload } from '@/app/components/base/features/types'

--- a/web/app/components/plugins/marketplace/list/carousel.tsx
+++ b/web/app/components/plugins/marketplace/list/carousel.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-/* oxlint-disable eslint-react/set-state-in-effect */
 import type { ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import Autoplay from 'embla-carousel-autoplay'

--- a/web/app/components/step-by-step-tour/coachmark.tsx
+++ b/web/app/components/step-by-step-tour/coachmark.tsx
@@ -278,7 +278,7 @@ export function StepByStepTourCoachmark({
       {stableOverlay?.interactionPolicy === 'target-only' ? (
         targetBlockerStyles.map((style, index) => (
           <div
-            // eslint-disable-next-line react/no-array-index-key -- The four blocker slices are static and positional.
+            // oxlint-disable-next-line react/no-array-index-key -- The four blocker slices are static and positional.
             key={index}
             aria-hidden="true"
             data-step-by-step-tour-backdrop=""

--- a/web/app/components/workflow/header/test-run-menu-helpers.tsx
+++ b/web/app/components/workflow/header/test-run-menu-helpers.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable react/only-export-components */
 import type { MouseEvent, MouseEventHandler, ReactElement } from 'react'
 import type { TriggerOption } from './test-run-menu'
 import { DropdownMenuItem } from '@langgenius/dify-ui/dropdown-menu'

--- a/web/app/components/workflow/node-actions-menu/__tests__/details.spec.tsx
+++ b/web/app/components/workflow/node-actions-menu/__tests__/details.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/web/app/components/workflow/nodes/agent/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/agent/__tests__/integration.spec.tsx
@@ -1,6 +1,5 @@
 import type { GetWorkspacesCurrentModelsModelTypesByModelTypeData } from '@dify/contracts/api/console/workspaces/types.gen'
 import type { OperationKey } from '@orpc/tanstack-query'
-/* oxlint-disable typescript/no-explicit-any */
 import type { AgentNodeType } from '../types'
 import type { StrategyParamItem } from '@/app/components/plugins/types'
 import type { PanelProps } from '@/types/workflow'

--- a/web/app/components/workflow/nodes/assigner/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/assigner/__tests__/integration.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { AssignerNodeOperation, AssignerNodeType } from '../types'
 import type { PanelProps } from '@/types/workflow'
 import { fireEvent, render, screen } from '@testing-library/react'

--- a/web/app/components/workflow/nodes/human-input/components/variable-in-markdown.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/variable-in-markdown.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable react/only-export-components */
 import type { TFunction } from 'i18next'
 import type { FormInputItem } from '../types'
 import { cn } from '@langgenius/dify-ui/cn'

--- a/web/app/components/workflow/nodes/list-operator/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/list-operator/__tests__/integration.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ListFilterNodeType } from '../types'
 import type { PanelProps } from '@/types/workflow'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'

--- a/web/app/components/workflow/nodes/question-classifier/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/__tests__/integration.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { QuestionClassifierNodeType, Topic } from '../types'
 import type { PanelProps } from '@/types/workflow'
 import { fireEvent, render, screen } from '@testing-library/react'

--- a/web/app/components/workflow/nodes/trigger-schedule/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/__tests__/panel.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ScheduleTriggerNodeType } from '../types'
 import type { PanelProps } from '@/types/workflow'
 import { fireEvent, render, screen } from '@testing-library/react'

--- a/web/app/components/workflow/nodes/trigger-schedule/components/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-schedule/components/__tests__/integration.spec.tsx
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ScheduleTriggerNodeType } from '../../types'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-resume.spec.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-resume.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ChatItemInTree } from '@/app/components/base/chat/types'
 import { act, renderHook } from '@testing-library/react'
 import { useChat } from '../../hooks'

--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-send.spec.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-send.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { act, renderHook } from '@testing-library/react'
 import { useChat } from '../../hooks'
 

--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-stop-restart.spec.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-stop-restart.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { act, renderHook } from '@testing-library/react'
 import { useChat } from '../../hooks'
 

--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/misc.spec.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/misc.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ChatItemInTree } from '@/app/components/base/chat/types'
 import { act, renderHook } from '@testing-library/react'
 import { useChat } from '../../hooks'

--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/opening-statement.spec.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/opening-statement.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import type { ChatItemInTree } from '@/app/components/base/chat/types'
 import { renderHook } from '@testing-library/react'
 import { useChat } from '../../hooks'

--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/sse-callbacks.spec.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/sse-callbacks.spec.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-explicit-any */
 import { act, renderHook } from '@testing-library/react'
 import { useChat } from '../../hooks'
 

--- a/web/docs/lint.md
+++ b/web/docs/lint.md
@@ -94,9 +94,28 @@ ESLint is intentionally limited to non-code files. The remaining limitations and
 | Non-JavaScript formats   | Oxlint plugins cannot provide custom parsers or file languages. ESLint covers JSON, JSONC, YAML, TOML, and Markdown semantic rules, while Oxfmt remains responsible for their formatting.                        |
 | Markdown code blocks     | ESLint validates the Markdown document, but fenced JavaScript and TypeScript blocks are not passed through the former overlapping preset. This remains deferred rather than duplicating the Oxlint rule set.     |
 | Override-scoped settings | The three Dify UI Tailwind rules are disabled with the rest of ESLint's code path. Oxlint still applies the web `react-x.additionalStateHooks` setting globally because it cannot scope settings to an override. |
-| Oxlint disable severity  | Oxlint only accepts `reportUnusedDisableDirectives` at the root, where it remains `warn`; the former Dify UI-specific ESLint `error` severity is no longer applied to code files.                                |
 
 Suppression comments belong to exactly one linter. Use `oxlint-disable` for code rules from `lint.config.ts`, and use `eslint-disable` only for non-code rules from `eslint.config.mjs`. Oxlint deliberately sets `respectEslintDisableDirectives` to `false`, so an ESLint comment cannot hide an Oxlint finding.
+
+### Inline Disable Comments
+
+Prefer fixing the finding. When an exception is necessary, name the specific rule and use `oxlint-disable-next-line` at the affected statement. For a shared exception spanning several statements, use a bounded disable/enable pair. File-wide disable comments are forbidden, including in tests. `dify/no-file-wide-disable` reports an error when a block disable has any rules left disabled at the end of the file; a matching enable must restore every disabled rule. The native `unicorn/no-abusive-eslint-disable` rule also rejects disables without rule names, which would otherwise suppress the custom check itself.
+
+For existing violations that cannot be fixed in the current change, remove the file-wide comment and record a scoped bulk-suppression baseline instead of turning the rule off for the file:
+
+```sh
+vp run -w lint:oxlint path/to/file.spec.tsx --suppress-all
+```
+
+Review the `oxlint-suppressions.json` diff and retain only the intended file/rule counts. The rule remains active and findings beyond the recorded count are reported; this is a count baseline, not a list of specific suppressed lines. Avoid repository-wide `--suppress-all` for a scoped cleanup. After fixing violations, use `--prune-suppressions` as described above.
+
+Use `lint.config.ts` overrides only when a rule is intentionally inapplicable to a file, and `ignorePatterns` only when the entire file must be excluded, such as generated output. Explain the reason next to the configuration. Do not migrate existing violations to a blanket rule-off override or broaden exceptions to future files with a directory glob.
+
+Explain the concrete reason after `--`: which external contract, lifecycle, or rule limitation makes the exception necessary. A description that merely repeats the rule or says "fix lint" is insufficient. New or modified disables must include this explanation; existing test typing exceptions can be addressed incrementally.
+
+`dify/require-disable-directive-description` uses Oxlint's parsed directives to report missing explanations, including JSX comments. It runs at `warn` while existing undescribed exceptions are reviewed; enable comments do not need a repeated explanation. This rule does not assess whether a reason is valid and does not replace review. Do not add generic descriptions just to silence it.
+
+`reportUnusedDisableDirectives` runs at `error` repository-wide. Remove an exception when the finding no longer exists. Keep both checks active: a described disable may still be unused, and a used disable may still lack a reason.
 
 ### Introducing New Plugins or Rules
 

--- a/web/docs/lint.md
+++ b/web/docs/lint.md
@@ -113,7 +113,7 @@ Use `lint.config.ts` overrides only when a rule is intentionally inapplicable to
 
 Explain the concrete reason after `--`: which external contract, lifecycle, or rule limitation makes the exception necessary. A description that merely repeats the rule or says "fix lint" is insufficient. New or modified disables must include this explanation; existing test typing exceptions can be addressed incrementally.
 
-`dify/require-disable-directive-description` uses Oxlint's parsed directives to report missing explanations, including JSX comments. It runs at `warn` while existing undescribed exceptions are reviewed; enable comments do not need a repeated explanation. This rule does not assess whether a reason is valid and does not replace review. Do not add generic descriptions just to silence it.
+`dify/require-disable-directive-description` uses Oxlint's parsed directives to report missing explanations, including JSX comments. It runs at `error`; existing undescribed exceptions are tracked in the bulk-suppression baseline for incremental cleanup. Enable comments do not need a repeated explanation. This rule does not assess whether a reason is valid and does not replace review. Do not add generic descriptions just to silence it.
 
 `reportUnusedDisableDirectives` runs at `error` repository-wide. Remove an exception when the finding no longer exists. Keep both checks active: a described disable may still be unused, and a used disable may still lack a reason.
 

--- a/web/features/skills/detail/builder-panel.tsx
+++ b/web/features/skills/detail/builder-panel.tsx
@@ -4,7 +4,6 @@ import type {
   SkillDetailResponse,
   SkillFileResponse,
 } from '@dify/contracts/api/console/workspaces/types.gen'
-/* oxlint-disable eslint-react/set-state-in-effect -- The builder resets its local transcript when the authoritative detail snapshot changes. */
 import type { BuilderChatMessage, SkillBuilderAttachment, SkillBuilderModel } from './shared'
 import type { FormValue } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { Button } from '@langgenius/dify-ui/button'

--- a/web/features/skills/detail/file-editor.tsx
+++ b/web/features/skills/detail/file-editor.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-/* oxlint-disable eslint-react/set-state-in-effect -- Extracted editor owners intentionally mirror authoritative snapshots into local draft state. */
-
 import type {
   SkillDetailResponse,
   SkillFileResponse,

--- a/web/features/skills/detail/page.tsx
+++ b/web/features/skills/detail/page.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-/* oxlint-disable eslint-react/set-state-in-effect -- The detail route resets local draft overrides when the selected skill or authoritative query snapshot changes. */
-
 import type { SkillDetailResponse } from '@dify/contracts/api/console/workspaces/types.gen'
 import type { SkillFileMutationCoordinator } from './shared'
 import {

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -15,7 +15,6 @@ declare global {
     (command: 'set', config: GtagEventParams): void
   }
 
-  // eslint-disable-next-line ts/consistent-type-definitions -- interface required for declaration merging
   interface Window {
     gtag?: Gtag
     dataLayer?: unknown[]

--- a/web/plugins/eslint/index.js
+++ b/web/plugins/eslint/index.js
@@ -1,7 +1,9 @@
 import consistentPlaceholders from './rules/consistent-placeholders.js'
 import i18nFlatKey from './rules/i18n-flat-key.js'
 import noExtraKeys from './rules/no-extra-keys.js'
+import noFileWideDisable from './rules/no-file-wide-disable.js'
 import preferTailwindIcons from './rules/prefer-tailwind-icons.js'
+import requireDisableDirectiveDescription from './rules/require-disable-directive-description.js'
 import requireTitleForTruncatedText from './rules/require-title-for-truncated-text.js'
 
 /** @type {import('eslint').ESLint.Plugin} */
@@ -14,7 +16,9 @@ const plugin = {
     'consistent-placeholders': consistentPlaceholders,
     'i18n-flat-key': i18nFlatKey,
     'no-extra-keys': noExtraKeys,
+    'no-file-wide-disable': noFileWideDisable,
     'prefer-tailwind-icons': preferTailwindIcons,
+    'require-disable-directive-description': requireDisableDirectiveDescription,
     'require-title-for-truncated-text': requireTitleForTruncatedText,
   },
 }

--- a/web/plugins/eslint/rules/no-file-wide-disable.js
+++ b/web/plugins/eslint/rules/no-file-wide-disable.js
@@ -1,0 +1,45 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Require block disables to end with a matching enable.' },
+    schema: [],
+    messages: {
+      fileWideDisable:
+        'File-wide disables are forbidden. Use a matching enable, or baseline existing errors with `vp run -w lint:oxlint <path> --suppress-all`. For intentional file exclusions, configure lint.config.ts with a reason.',
+    },
+  },
+  create(context) {
+    return {
+      Program() {
+        const pending = new Map()
+        for (const directive of context.sourceCode.getDisableDirectives().directives) {
+          const rules = directive.value
+            .split(',')
+            .map((rule) => rule.trim())
+            .filter(Boolean)
+          if (directive.type === 'disable') {
+            // null represents disabling all rules, which only a bare enable can close.
+            pending.set(directive, rules.length ? new Set(rules) : null)
+          } else if (directive.type === 'enable') {
+            for (const [disable, remaining] of pending) {
+              if (
+                disable.node.value.trimStart().startsWith('oxlint-') !==
+                directive.node.value.trimStart().startsWith('oxlint-')
+              )
+                continue
+              if (!rules.length) {
+                pending.delete(disable)
+              } else if (remaining) {
+                for (const rule of rules) remaining.delete(rule)
+                if (!remaining.size) pending.delete(disable)
+              }
+            }
+          }
+        }
+        for (const directive of pending.keys()) {
+          context.report({ node: directive.node, messageId: 'fileWideDisable' })
+        }
+      },
+    }
+  },
+}

--- a/web/plugins/eslint/rules/require-disable-directive-description.js
+++ b/web/plugins/eslint/rules/require-disable-directive-description.js
@@ -1,0 +1,26 @@
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Require a reason for disabling a lint rule.',
+    },
+    schema: [],
+    messages: {
+      missingDescription: 'Explain why this disable is necessary after `--`.',
+    },
+  },
+  create(context) {
+    return {
+      Program() {
+        for (const directive of context.sourceCode.getDisableDirectives().directives) {
+          if (directive.type !== 'enable' && !directive.justification.trim()) {
+            context.report({
+              node: directive.node,
+              messageId: 'missingDescription',
+            })
+          }
+        }
+      },
+    }
+  },
+}

--- a/web/plugins/eslint/rules/require-disable-directive-description.test.js
+++ b/web/plugins/eslint/rules/require-disable-directive-description.test.js
@@ -1,0 +1,119 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { expect, it } from 'vite-plus/test'
+
+function lintFixture(source, rules) {
+  const require = createRequire(import.meta.url)
+  const viteRequire = createRequire(require.resolve('vite-plus/package.json'))
+  const oxlintBin = join(dirname(dirname(viteRequire.resolve('oxlint'))), 'bin', 'oxlint')
+  const directory = mkdtempSync(join(tmpdir(), 'dify-disable-description-'))
+  try {
+    writeFileSync(
+      join(directory, 'plugin.mjs'),
+      `export { default } from ${JSON.stringify(require.resolve('../index.js'))};`,
+    )
+    writeFileSync(
+      join(directory, '.oxlintrc.json'),
+      JSON.stringify({
+        categories: { correctness: 'off' },
+        jsPlugins: ['./plugin.mjs'],
+        options: { respectEslintDisableDirectives: false },
+        rules,
+      }),
+    )
+    writeFileSync(join(directory, 'fixture.jsx'), source)
+    const result = spawnSync(
+      process.execPath,
+      [oxlintBin, '--config', join(directory, '.oxlintrc.json'), '--format', 'json', 'fixture.jsx'],
+      {
+        cwd: directory,
+        encoding: 'utf8',
+      },
+    )
+    expect(result.error).toBeUndefined()
+    expect([0, 1], result.stderr + result.stdout).toContain(result.status)
+    return JSON.parse(result.stdout).diagnostics
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+it('checks actual Oxlint directives, including JSX and both prefixes, without requiring enable reasons', () => {
+  const diagnostics = lintFixture(
+    [
+      '// oxlint-disable-next-line no-console',
+      'console.log(1);',
+      'console.log(2); // oxlint-disable-line no-console --   ',
+      '/* oxlint-disable no-console */',
+      'console.log(3);',
+      '/* oxlint-enable no-console */',
+      '// oxlint-disable-next-line no-console -- CLI output is intentional.',
+      'console.log(4);',
+      'const content = <div>',
+      '  {/* oxlint-disable-next-line jsx-a11y/anchor-has-content */}',
+      '  <a />',
+      '  {/* oxlint-disable-next-line jsx-a11y/anchor-has-content -- The renderer supplies the accessible name. */}',
+      '  <a />',
+      '</div>;',
+      '// An ordinary comment mentioning oxlint-disable is not a directive.',
+      '// eslint-disable-next-line no-console',
+      'console.log(5);',
+    ].join('\n'),
+    { 'dify/require-disable-directive-description': 'error' },
+  )
+  expect(diagnostics.map(({ code, labels }) => ({ code, line: labels[0].span.line }))).toEqual([
+    { code: 'dify(require-disable-directive-description)', line: 1 },
+    { code: 'dify(require-disable-directive-description)', line: 3 },
+    { code: 'dify(require-disable-directive-description)', line: 4 },
+    { code: 'dify(require-disable-directive-description)', line: 10 },
+    { code: 'dify(require-disable-directive-description)', line: 16 },
+  ])
+})
+
+it.each([
+  ['different linter enable', '/* oxlint-disable no-console */\n/* eslint-enable no-console */', 1],
+  ['unclosed rule', '/* oxlint-disable no-console -- Legacy output. */\nconsole.log(1)', 1],
+  ['blanket disable', '/* oxlint-disable -- Legacy file. */\nconsole.log(1)', 1],
+  ['ESLint prefix', '/* eslint-disable no-console -- Legacy output. */\nconsole.log(1)', 1],
+  ['wrong enable', '/* oxlint-disable no-console */\n/* oxlint-enable no-debugger */', 1],
+  [
+    'partial enable',
+    '/* oxlint-disable no-console, no-debugger */\n/* oxlint-enable no-console */',
+    1,
+  ],
+  ['enable before disable', '/* oxlint-enable no-console */\n/* oxlint-disable no-console */', 1],
+  [
+    'paired interval',
+    '/* oxlint-disable no-console */\nconsole.log(1)\n/* oxlint-enable no-console */',
+    0,
+  ],
+  [
+    'separate enables',
+    '/* oxlint-disable no-console, no-debugger */\n/* oxlint-enable no-console */\n/* oxlint-enable no-debugger */',
+    0,
+  ],
+  ['enable all', '/* oxlint-disable no-console */\n/* oxlint-enable */', 0],
+  ['blanket interval', '/* oxlint-disable */\nconsole.log(1)\n/* oxlint-enable */', 1],
+  [
+    'line disables',
+    '// oxlint-disable-next-line no-console\nconsole.log(1)\nconsole.log(2) // oxlint-disable-line no-console',
+    0,
+  ],
+])('enforces bounded disables: %s', (_name, source, count) => {
+  const diagnostics = lintFixture(source, {
+    'dify/no-file-wide-disable': 'error',
+    'unicorn/no-abusive-eslint-disable': 'error',
+  })
+  expect(diagnostics).toHaveLength(count)
+  for (const diagnostic of diagnostics) {
+    expect(diagnostic.code).toBe(
+      _name.startsWith('blanket')
+        ? 'unicorn(no-abusive-eslint-disable)'
+        : 'dify(no-file-wide-disable)',
+    )
+    expect(diagnostic.severity).toBe('error')
+  }
+})

--- a/web/types/i18n.d.ts
+++ b/web/types/i18n.d.ts
@@ -2,7 +2,6 @@ import type { defaultNS, Namespace, Resources } from '../i18n-config/resources'
 import 'i18next'
 
 declare module 'i18next' {
-  // eslint-disable-next-line ts/consistent-type-definitions
   interface CustomTypeOptions {
     defaultNS: typeof defaultNS
     enableSelector: 'optimize'

--- a/web/types/jsx.d.ts
+++ b/web/types/jsx.d.ts
@@ -5,7 +5,6 @@ import 'react'
 
 declare module 'react' {
   namespace JSX {
-    // eslint-disable-next-line ts/consistent-type-definitions
     interface IntrinsicElements {
       'em-emoji': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
     }


### PR DESCRIPTION
## Summary

Fixes #42057

Reject file-wide lint disable comments that lack matching enables, reject disables without rule names, require explanations, and make unused disables errors. Remove stale ESLint directives from code files and migrate the necessary coachmark exception to Oxlint.

Replace 64 existing file-wide exceptions with 525 scoped error counts in `oxlint-suppressions.json`. The affected rules remain enabled and errors beyond each file/rule count are reported. Document bounded inline exceptions and scoped `--suppress-all` usage. The 74 existing missing explanations are also recorded in the baseline; the description rule is enforced at error severity. Application behavior is unchanged.

## Validation

- 13 real Oxlint integration tests passed, covering both prefixes, JSX, descriptions, paired intervals, partial enables, and blanket disables.
- Full `vp check` passed with existing warnings.
- `vp staged` passed, including ESLint on changed non-code files.
- Full repository ESLint could not complete locally due to heap exhaustion, including a serial retry with an 8 GB heap.

## Screenshots

Not applicable; lint infrastructure and comments only.

## Checklist

- [ ] This change requires an external Dify documentation update (not needed; repository lint guide updated).
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added focused tests for the introduced rule behavior and kept the change atomic.
- [x] I've updated the documentation accordingly.
- [x] I ran `vp staged` (frontend); backend checks are not applicable.

From Codex

