### PR TITLE
fix(web): hide decorative content and redundant list semantics

### DIFF
--- a/web/app/components/base/checkbox-list/index.tsx
+++ b/web/app/components/base/checkbox-list/index.tsx
@@ -148,7 +148,7 @@ export const CheckboxList = ({
               <div className="px-3 py-6 text-center text-sm text-text-tertiary">
                 {searchQuery ? (
                   <div className="flex flex-col items-center justify-center gap-2">
-                    <img alt="search menu" src={SearchMenu.src} width={32} />
+                    <img alt="" src={SearchMenu.src} width={32} />
                     <span className="system-sm-regular text-text-secondary">
                       {t(($) => $['operation.noSearchResults'], { ns: 'common', content: title })}
                     </span>

--- a/web/app/components/base/notion-icon/index.tsx
+++ b/web/app/components/base/notion-icon/index.tsx
@@ -7,24 +7,39 @@ type NotionIconProps = {
   type?: IconTypes
   name?: string | null
   className?: string
+  decorative?: boolean
   src?: string | null | DataSourceNotionPage['page_icon']
 }
-const NotionIcon = ({ type = 'workspace', src, name, className }: NotionIconProps) => {
+const NotionIcon = ({
+  type = 'workspace',
+  src,
+  name,
+  className,
+  decorative = false,
+}: NotionIconProps) => {
   if (type === 'workspace') {
     if (typeof src === 'string') {
       if (src.startsWith('https://') || src.startsWith('http://')) {
         return (
           <img
-            alt="workspace icon"
+            alt={decorative ? '' : 'workspace icon'}
             src={src}
             className={cn('block size-5 object-cover', className)}
           />
         )
       }
-      return <div className={cn('flex size-5 items-center justify-center', className)}>{src}</div>
+      return (
+        <div
+          aria-hidden={decorative || undefined}
+          className={cn('flex size-5 items-center justify-center', className)}
+        >
+          {src}
+        </div>
+      )
     }
     return (
       <div
+        aria-hidden={decorative || undefined}
         className={cn(
           'flex size-5 items-center justify-center rounded-sm bg-gray-200 text-xs font-medium text-gray-500',
           className,
@@ -39,18 +54,28 @@ const NotionIcon = ({ type = 'workspace', src, name, className }: NotionIconProp
     if (src?.type === 'url') {
       return (
         <img
-          alt="page icon"
+          alt={decorative ? '' : 'page icon'}
           src={src.url || ''}
           className={cn('block size-5 object-cover', className)}
         />
       )
     }
     return (
-      <div className={cn('flex size-5 items-center justify-center', className)}>{src?.emoji}</div>
+      <div
+        aria-hidden={decorative || undefined}
+        className={cn('flex size-5 items-center justify-center', className)}
+      >
+        {src?.emoji}
+      </div>
     )
   }
 
-  return <RiFileTextLine className={cn('size-5 text-text-tertiary', className)} />
+  return (
+    <RiFileTextLine
+      aria-hidden={decorative || undefined}
+      className={cn('size-5 text-text-tertiary', className)}
+    />
+  )
 }
 
 export default NotionIcon

--- a/web/app/components/base/notion-page-selector/page-selector/page-row.tsx
+++ b/web/app/components/base/notion-page-selector/page-selector/page-row.tsx
@@ -83,7 +83,7 @@ const NotionPageRow = ({
       {!searchValue && !row.hasChild && row.parentExists && (
         <div className="mr-1 size-5 shrink-0" style={{ marginLeft: row.depth * 8 }} />
       )}
-      <NotionIcon className="mr-1 shrink-0" type="page" src={row.page.page_icon} />
+      <NotionIcon decorative className="mr-1 shrink-0" type="page" src={row.page.page_icon} />
       <div
         className="grow truncate text-[13px] leading-4 font-medium text-text-secondary"
         title={row.page.page_name}

--- a/web/app/components/datasets/create/notion-page-preview/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/create/notion-page-preview/__tests__/index.spec.tsx
@@ -170,10 +170,11 @@ describe('NotionPagePreview', () => {
     it('should render image icon when page_icon has url type', async () => {
       const page = createMockNotionPageWithUrlIcon('https://example.com/icon.png')
 
-      const { container } = await renderNotionPagePreview({ currentPage: page })
+      await renderNotionPagePreview({ currentPage: page })
 
-      const img = container.querySelector('img[alt="page icon"]')
-      expect(img).toBeInTheDocument()
+      const img = screen.getByRole('presentation')
+      expect(img).toBeVisible()
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
       expect(img).toHaveAttribute('src', 'https://example.com/icon.png')
     })
   })
@@ -861,10 +862,11 @@ describe('NotionPagePreview', () => {
     it('should handle page with url icon object', async () => {
       const page = createMockNotionPageWithUrlIcon('https://example.com/custom-icon.png')
 
-      const { container } = await renderNotionPagePreview({ currentPage: page })
+      await renderNotionPagePreview({ currentPage: page })
 
-      const img = container.querySelector('img[alt="page icon"]')
-      expect(img).toBeInTheDocument()
+      const img = screen.getByRole('presentation')
+      expect(img).toBeVisible()
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
       expect(img).toHaveAttribute('src', 'https://example.com/custom-icon.png')
     })
   })

--- a/web/app/components/datasets/create/notion-page-preview/index.tsx
+++ b/web/app/components/datasets/create/notion-page-preview/index.tsx
@@ -56,7 +56,12 @@ const NotionPagePreview = ({ currentPage, notionCredentialId, hidePreview }: IPr
           </button>
         </div>
         <div className={cn(s.fileName, 'system-xs-medium')}>
-          <NotionIcon className="mr-1 shrink-0" type="page" src={currentPage?.page_icon} />
+          <NotionIcon
+            decorative
+            className="mr-1 shrink-0"
+            type="page"
+            src={currentPage?.page_icon}
+          />
           {currentPage?.page_name}
         </div>
       </div>

--- a/web/app/components/explore/learn-dify/item.tsx
+++ b/web/app/components/explore/learn-dify/item.tsx
@@ -65,6 +65,7 @@ const LearnDifyItem = ({ canCreate, item, onCreate, onTry }: LearnDifyItemProps)
       )}
       <div className="flex flex-col items-start gap-2 pb-1">
         <AppIcon
+          decorative
           size="large"
           iconType={appBasicInfo.icon_type}
           icon={appBasicInfo.icon}

--- a/web/app/components/explore/try-app/app/chat.tsx
+++ b/web/app/components/explore/try-app/app/chat.tsx
@@ -61,6 +61,7 @@ const TryApp: FC<Props> = ({ appId, appDetail, className }) => {
         <div className="flex shrink-0 justify-between p-3">
           <div className="flex grow items-center space-x-2">
             <AppIcon
+              decorative
               size="large"
               iconType={appDetail.site.icon_type}
               icon={appDetail.site.icon ?? undefined}

--- a/web/app/components/header/account-setting/workspace-role-checkbox-list.tsx
+++ b/web/app/components/header/account-setting/workspace-role-checkbox-list.tsx
@@ -271,7 +271,7 @@ const WorkspaceRoleCheckboxList = ({
                       const disabled = disabledRoleIdSet.has(role.id)
 
                       return (
-                        <li key={role.id}>
+                        <li key={role.id} role="presentation">
                           <RadioItem
                             value={role.id}
                             disabled={disabled}

--- a/web/app/components/plugins/plugin-item/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-item/__tests__/index.spec.tsx
@@ -195,7 +195,7 @@ describe('PluginItem', () => {
       expect(screen.getByTestId('version-badge')).toBeInTheDocument()
     })
 
-    it('should render plugin icon', () => {
+    it('should keep the plugin name visible without exposing a decorative image', () => {
       // Arrange
       const plugin = createPluginDetail()
 
@@ -203,12 +203,8 @@ describe('PluginItem', () => {
       render(<PluginItem plugin={plugin} />)
 
       // Assert
-      const img = screen.getByRole('img')
-      expect(img).toHaveAttribute('alt', `plugin-${plugin.plugin_unique_identifier}-logo`)
-      expect(img).toHaveAttribute('loading', 'lazy')
-      expect(img).toHaveAttribute('decoding', 'async')
-      expect(img).toHaveAttribute('width', '40')
-      expect(img).toHaveAttribute('height', '40')
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+      expect(screen.getByText('Test Plugin')).toBeVisible()
     })
 
     it('should not render category label in corner mark', () => {
@@ -719,7 +715,7 @@ describe('PluginItem', () => {
       render(<PluginItem plugin={plugin} />)
 
       // Assert
-      const img = screen.getByRole('img')
+      const img = screen.getByRole('presentation')
       expect(img.getAttribute('src')).toContain('dark-icon.png')
     })
 
@@ -737,7 +733,7 @@ describe('PluginItem', () => {
       render(<PluginItem plugin={plugin} />)
 
       // Assert
-      const img = screen.getByRole('img')
+      const img = screen.getByRole('presentation')
       expect(img.getAttribute('src')).toContain('light-icon.png')
     })
 
@@ -755,7 +751,7 @@ describe('PluginItem', () => {
       render(<PluginItem plugin={plugin} />)
 
       // Assert
-      const img = screen.getByRole('img')
+      const img = screen.getByRole('presentation')
       expect(img.getAttribute('src')).toContain('light-icon.png')
     })
 
@@ -771,7 +767,7 @@ describe('PluginItem', () => {
       render(<PluginItem plugin={plugin} />)
 
       // Assert
-      const img = screen.getByRole('img')
+      const img = screen.getByRole('presentation')
       expect(img).toHaveAttribute('src', 'https://example.com/icon.png')
     })
   })
@@ -851,7 +847,7 @@ describe('PluginItem', () => {
       expect(() => render(<PluginItem plugin={plugin} />)).not.toThrow()
 
       // The img element should still be rendered
-      const img = screen.getByRole('img')
+      const img = screen.getByRole('presentation')
       expect(img).toBeInTheDocument()
     })
 

--- a/web/app/components/plugins/plugin-item/index.tsx
+++ b/web/app/components/plugins/plugin-item/index.tsx
@@ -146,7 +146,7 @@ const PluginItem: FC<Props> = ({
               height={40}
               loading="lazy"
               src={iconSrc}
-              alt={`plugin-${plugin_unique_identifier}-logo`}
+              alt=""
               width={40}
             />
           </div>

--- a/web/app/components/workflow/nodes/_base/components/agent-strategy-selector.tsx
+++ b/web/app/components/workflow/nodes/_base/components/agent-strategy-selector.tsx
@@ -174,7 +174,7 @@ export const AgentStrategySelector = memo((props: AgentStrategySelectorProps) =>
                   width={20}
                   height={20}
                   className="rounded-md border-[0.5px] border-components-panel-border-subtle bg-background-default-dodge"
-                  alt="icon"
+                  alt=""
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary

Decorative icons currently expose generic labels such as `page icon`, `icon`, or a plugin identifier even when adjacent text already identifies the content. Hide these images from assistive technology, use the existing AppIcon decorative mode, and add an opt-in decorative mode to NotionIcon for page selection and preview. Preserve the visible labels and interactive controls.

Remove the intermediate list-item semantics in the workspace-role radio group with `role="presentation"`. Update plugin and Notion preview tests to match decorative image semantics while retaining image-source checks.

Fixed: SNP-778
Reference: [WAI-ARIA APG: Hiding Semantics](https://www.w3.org/WAI/ARIA/apg/practices/hiding-semantics/)

## Validation

- Related unit suites: 17 files, 255 tests passed.
- Staged formatting, lint, and type checks passed.
- Repository lint/type checks (`vp check --no-fmt`) passed with existing warnings; non-code ESLint passed.
- Full `vp run -w check` is blocked by a pre-existing formatting issue in unchanged `web/app/device/page.tsx`.
- E2E locator review found no dependencies on the removed icon labels or list-item semantics. E2E and screen-reader flows were not run.

## Screenshots

No visual changes.

From Codex
