### PR TITLE
fix(web): restore focus after closing overlays

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4629,14 +4629,8 @@
     "eslint-react/set-state-in-effect": {
       "count": 1
     },
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 2
-    },
     "jsx-a11y/no-autofocus": {
       "count": 1
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 2
     },
     "no-restricted-imports": {
       "count": 1

--- a/web/app/components/app/log/__tests__/list.spec.tsx
+++ b/web/app/components/app/log/__tests__/list.spec.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createAccountProfileQueryClient } from '@/test/console/account-profile'
 import { QueryClientTestProvider } from '@/test/console/query-provider'
 import { renderWithNuqs } from '@/test/nuqs-testing'
@@ -305,6 +306,34 @@ describe('ConversationList', () => {
     expect(update.searchParams.get('conversation_id')).toBe('conversation-1')
     expect(update.options.history).toBe('push')
   })
+
+  it.each(['keyboard', 'row'])(
+    'restores focus to the conversation entry after %s opening',
+    async (opening) => {
+      const user = userEvent.setup()
+      const { onUrlUpdate } = renderConversationList()
+      const trigger = screen.getByRole('button', { name: 'formatted-1710000000' })
+      if (opening === 'keyboard') {
+        trigger.focus()
+        await user.keyboard('{Enter}')
+      } else {
+        await user.click(screen.getByText('hello world'))
+      }
+      await screen.findByRole('dialog')
+      await waitFor(() => {
+        expect(onUrlUpdate.mock.calls.at(-1)![0].searchParams.get('conversation_id')).toBe(
+          'conversation-1',
+        )
+      })
+      await user.keyboard('{Escape}')
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        expect(trigger).toHaveFocus()
+      })
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1)
+      expect(onUrlUpdate.mock.calls.at(-1)![0].searchParams.has('conversation_id')).toBe(false)
+    },
+  )
 
   it('should close the drawer, refresh, and clear modal flags', async () => {
     mockChatConversationDetail = {

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -19,7 +19,6 @@ import type { App } from '@/types/app'
 import { HandThumbDownIcon, HandThumbUpIcon } from '@heroicons/react/24/outline'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
-  createDrawerHandle,
   Drawer,
   DrawerBackdrop,
   DrawerContent,
@@ -778,7 +777,6 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
   const media = useBreakpoints()
   const isMobile = media === MediaType.mobile
 
-  const [drawerHandle] = useState(() => createDrawerHandle())
   const [showDrawer, setShowDrawer] = useState<boolean>(false) // Whether to display the chat details drawer
   const [currentConversation, setCurrentConversation] = useState<
     ConversationSelection | undefined
@@ -915,158 +913,7 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
 
   return (
     <div className="relative mt-2 grow overflow-x-auto">
-      <table className={cn('w-full min-w-110 border-collapse border-0')}>
-        <thead className="system-xs-medium-uppercase text-text-tertiary">
-          <tr>
-            <td className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 whitespace-nowrap"></td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {isChatMode
-                ? t(($) => $['table.header.summary'], { ns: 'appLog' })
-                : t(($) => $['table.header.input'], { ns: 'appLog' })}
-            </td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.endUser'], { ns: 'appLog' })}
-            </td>
-            {isChatflow && (
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-                {t(($) => $['table.header.status'], { ns: 'appLog' })}
-              </td>
-            )}
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {isChatMode
-                ? t(($) => $['table.header.messageCount'], { ns: 'appLog' })
-                : t(($) => $['table.header.output'], { ns: 'appLog' })}
-            </td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.userRate'], { ns: 'appLog' })}
-            </td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.adminRate'], { ns: 'appLog' })}
-            </td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.updatedTime'], { ns: 'appLog' })}
-            </td>
-            <td className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.time'], { ns: 'appLog' })}
-            </td>
-          </tr>
-        </thead>
-        <tbody className="system-sm-regular text-text-secondary">
-          {logs.data.map((log: any) => {
-            const { endUser, isLeftEmpty, isRightEmpty, leftValue, rightValue } =
-              getConversationRowValues({
-                isChatMode,
-                log,
-                noChatLabel: t(($) => $['table.empty.noChat'], { ns: 'appLog' }),
-                noOutputLabel: t(($) => $['table.empty.noOutput'], { ns: 'appLog' }),
-              })
-            return (
-              <tr
-                key={log.id}
-                className={cn(
-                  'cursor-pointer border-b border-divider-subtle hover:bg-background-default-hover',
-                  activeConversationId !== log.id ? '' : 'bg-background-default-hover',
-                )}
-                onClick={(event) => {
-                  if ((event.target as HTMLElement).closest('button, a')) return
-                  event.currentTarget
-                    .querySelector<HTMLButtonElement>('button[data-log-detail-trigger]')
-                    ?.click()
-                }}
-              >
-                <td className="h-4">
-                  {!log.read_at && (
-                    <div className="flex items-center p-3 pr-0.5">
-                      <span className="inline-block size-1.5 rounded-sm bg-util-colors-blue-blue-500"></span>
-                    </div>
-                  )}
-                </td>
-                <td className="w-40 p-3 pr-2" style={{ maxWidth: isChatMode ? 300 : 200 }}>
-                  {renderTdValue(leftValue, isLeftEmpty, isChatMode && log.annotated)}
-                </td>
-                <td className="p-3 pr-2">{renderTdValue(endUser || defaultValue, !endUser)}</td>
-                {isChatflow && (
-                  <td className="w-40 p-3 pr-2" style={{ maxWidth: isChatMode ? 300 : 200 }}>
-                    {statusTdRender(log.status_count)}
-                  </td>
-                )}
-                <td className="p-3 pr-2" style={{ maxWidth: isChatMode ? 100 : 200 }}>
-                  {renderTdValue(
-                    rightValue,
-                    isRightEmpty,
-                    !isChatMode && !!log.annotation?.content,
-                    log.annotation,
-                  )}
-                </td>
-                <td className="p-3 pr-2">
-                  {!log.user_feedback_stats.like && !log.user_feedback_stats.dislike ? (
-                    renderTdValue(defaultValue, true)
-                  ) : (
-                    <>
-                      {!!log.user_feedback_stats.like && (
-                        <HandThumbIconWithCount
-                          iconType="up"
-                          count={log.user_feedback_stats.like}
-                        />
-                      )}
-                      {!!log.user_feedback_stats.dislike && (
-                        <HandThumbIconWithCount
-                          iconType="down"
-                          count={log.user_feedback_stats.dislike}
-                        />
-                      )}
-                    </>
-                  )}
-                </td>
-                <td className="p-3 pr-2">
-                  {!log.admin_feedback_stats.like && !log.admin_feedback_stats.dislike ? (
-                    renderTdValue(defaultValue, true)
-                  ) : (
-                    <>
-                      {!!log.admin_feedback_stats.like && (
-                        <HandThumbIconWithCount
-                          iconType="up"
-                          count={log.admin_feedback_stats.like}
-                        />
-                      )}
-                      {!!log.admin_feedback_stats.dislike && (
-                        <HandThumbIconWithCount
-                          iconType="down"
-                          count={log.admin_feedback_stats.dislike}
-                        />
-                      )}
-                    </>
-                  )}
-                </td>
-                <td className="w-40 p-3 pr-2">
-                  {formatTime(
-                    log.updated_at,
-                    t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
-                  )}
-                </td>
-                <td className="w-40 p-3 pr-2">
-                  <DrawerTrigger
-                    data-log-detail-trigger
-                    handle={drawerHandle}
-                    className="w-full cursor-pointer rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      handleRowClick(log)
-                    }}
-                  >
-                    {formatTime(
-                      log.created_at,
-                      t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
-                    )}
-                  </DrawerTrigger>
-                </td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
       <Drawer
-        handle={drawerHandle}
         open={showDrawer}
         modal
         swipeDirection="right"
@@ -1074,6 +921,155 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
           if (!open) onCloseDrawer()
         }}
       >
+        <table className={cn('w-full min-w-110 border-collapse border-0')}>
+          <thead className="system-xs-medium-uppercase text-text-tertiary">
+            <tr>
+              <td className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 whitespace-nowrap"></td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {isChatMode
+                  ? t(($) => $['table.header.summary'], { ns: 'appLog' })
+                  : t(($) => $['table.header.input'], { ns: 'appLog' })}
+              </td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.endUser'], { ns: 'appLog' })}
+              </td>
+              {isChatflow && (
+                <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                  {t(($) => $['table.header.status'], { ns: 'appLog' })}
+                </td>
+              )}
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {isChatMode
+                  ? t(($) => $['table.header.messageCount'], { ns: 'appLog' })
+                  : t(($) => $['table.header.output'], { ns: 'appLog' })}
+              </td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.userRate'], { ns: 'appLog' })}
+              </td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.adminRate'], { ns: 'appLog' })}
+              </td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.updatedTime'], { ns: 'appLog' })}
+              </td>
+              <td className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.time'], { ns: 'appLog' })}
+              </td>
+            </tr>
+          </thead>
+          <tbody className="system-sm-regular text-text-secondary">
+            {logs.data.map((log: any) => {
+              const { endUser, isLeftEmpty, isRightEmpty, leftValue, rightValue } =
+                getConversationRowValues({
+                  isChatMode,
+                  log,
+                  noChatLabel: t(($) => $['table.empty.noChat'], { ns: 'appLog' }),
+                  noOutputLabel: t(($) => $['table.empty.noOutput'], { ns: 'appLog' }),
+                })
+              return (
+                <tr
+                  key={log.id}
+                  className={cn(
+                    'cursor-pointer border-b border-divider-subtle hover:bg-background-default-hover',
+                    activeConversationId !== log.id ? '' : 'bg-background-default-hover',
+                  )}
+                  onClick={(event) => {
+                    if ((event.target as HTMLElement).closest('button, a')) return
+                    event.currentTarget
+                      .querySelector<HTMLButtonElement>('button[data-log-detail-trigger]')
+                      ?.click()
+                  }}
+                >
+                  <td className="h-4">
+                    {!log.read_at && (
+                      <div className="flex items-center p-3 pr-0.5">
+                        <span className="inline-block size-1.5 rounded-sm bg-util-colors-blue-blue-500"></span>
+                      </div>
+                    )}
+                  </td>
+                  <td className="w-40 p-3 pr-2" style={{ maxWidth: isChatMode ? 300 : 200 }}>
+                    {renderTdValue(leftValue, isLeftEmpty, isChatMode && log.annotated)}
+                  </td>
+                  <td className="p-3 pr-2">{renderTdValue(endUser || defaultValue, !endUser)}</td>
+                  {isChatflow && (
+                    <td className="w-40 p-3 pr-2" style={{ maxWidth: isChatMode ? 300 : 200 }}>
+                      {statusTdRender(log.status_count)}
+                    </td>
+                  )}
+                  <td className="p-3 pr-2" style={{ maxWidth: isChatMode ? 100 : 200 }}>
+                    {renderTdValue(
+                      rightValue,
+                      isRightEmpty,
+                      !isChatMode && !!log.annotation?.content,
+                      log.annotation,
+                    )}
+                  </td>
+                  <td className="p-3 pr-2">
+                    {!log.user_feedback_stats.like && !log.user_feedback_stats.dislike ? (
+                      renderTdValue(defaultValue, true)
+                    ) : (
+                      <>
+                        {!!log.user_feedback_stats.like && (
+                          <HandThumbIconWithCount
+                            iconType="up"
+                            count={log.user_feedback_stats.like}
+                          />
+                        )}
+                        {!!log.user_feedback_stats.dislike && (
+                          <HandThumbIconWithCount
+                            iconType="down"
+                            count={log.user_feedback_stats.dislike}
+                          />
+                        )}
+                      </>
+                    )}
+                  </td>
+                  <td className="p-3 pr-2">
+                    {!log.admin_feedback_stats.like && !log.admin_feedback_stats.dislike ? (
+                      renderTdValue(defaultValue, true)
+                    ) : (
+                      <>
+                        {!!log.admin_feedback_stats.like && (
+                          <HandThumbIconWithCount
+                            iconType="up"
+                            count={log.admin_feedback_stats.like}
+                          />
+                        )}
+                        {!!log.admin_feedback_stats.dislike && (
+                          <HandThumbIconWithCount
+                            iconType="down"
+                            count={log.admin_feedback_stats.dislike}
+                          />
+                        )}
+                      </>
+                    )}
+                  </td>
+                  <td className="w-40 p-3 pr-2">
+                    {formatTime(
+                      log.updated_at,
+                      t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
+                    )}
+                  </td>
+                  <td className="w-40 p-3 pr-2">
+                    <DrawerTrigger
+                      data-log-detail-trigger
+                      className="w-full cursor-pointer rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        handleRowClick(log)
+                      }}
+                    >
+                      {formatTime(
+                        log.created_at,
+                        t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
+                      )}
+                    </DrawerTrigger>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
         <DrawerPortal>
           <DrawerBackdrop className={cn(!isMobile && 'bg-transparent')} />
           <DrawerViewport>

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -19,11 +19,13 @@ import type { App } from '@/types/app'
 import { HandThumbDownIcon, HandThumbUpIcon } from '@heroicons/react/24/outline'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
+  createDrawerHandle,
   Drawer,
   DrawerBackdrop,
   DrawerContent,
   DrawerPopup,
   DrawerPortal,
+  DrawerTrigger,
   DrawerViewport,
 } from '@langgenius/dify-ui/drawer'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
@@ -776,6 +778,7 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
   const media = useBreakpoints()
   const isMobile = media === MediaType.mobile
 
+  const [drawerHandle] = useState(() => createDrawerHandle())
   const [showDrawer, setShowDrawer] = useState<boolean>(false) // Whether to display the chat details drawer
   const [currentConversation, setCurrentConversation] = useState<
     ConversationSelection | undefined
@@ -964,7 +967,12 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
                   'cursor-pointer border-b border-divider-subtle hover:bg-background-default-hover',
                   activeConversationId !== log.id ? '' : 'bg-background-default-hover',
                 )}
-                onClick={() => handleRowClick(log)}
+                onClick={(event) => {
+                  if ((event.target as HTMLElement).closest('button, a')) return
+                  event.currentTarget
+                    .querySelector<HTMLButtonElement>('button[data-log-detail-trigger]')
+                    ?.click()
+                }}
               >
                 <td className="h-4">
                   {!log.read_at && (
@@ -1037,10 +1045,20 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
                   )}
                 </td>
                 <td className="w-40 p-3 pr-2">
-                  {formatTime(
-                    log.created_at,
-                    t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
-                  )}
+                  <DrawerTrigger
+                    data-log-detail-trigger
+                    handle={drawerHandle}
+                    className="w-full cursor-pointer rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      handleRowClick(log)
+                    }}
+                  >
+                    {formatTime(
+                      log.created_at,
+                      t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
+                    )}
+                  </DrawerTrigger>
                 </td>
               </tr>
             )
@@ -1048,6 +1066,7 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
         </tbody>
       </table>
       <Drawer
+        handle={drawerHandle}
         open={showDrawer}
         modal
         swipeDirection="right"

--- a/web/app/components/app/workflow-log/__tests__/list.spec.tsx
+++ b/web/app/components/app/workflow-log/__tests__/list.spec.tsx
@@ -457,6 +457,44 @@ describe('WorkflowAppLogList', () => {
       expect(screen.getByText('appLog.runDetail.workflowTitle'))!.toBeInTheDocument()
     })
 
+    it.each(['keyboard', 'row'])(
+      'restores focus to the selected log after %s opening and refresh',
+      async (opening) => {
+        const user = userEvent.setup()
+        const appDetail = createMockApp()
+        const onRefresh = vi.fn()
+        useAppStore.setState({ appDetail })
+        const logs = createMockLogsResponse([
+          createMockWorkflowLog({ id: 'log-1', created_at: 100 }),
+          createMockWorkflowLog({ id: 'log-2', created_at: 200 }),
+        ])
+        const { rerender } = render(
+          <WorkflowAppLogList logs={logs} appDetail={appDetail} onRefresh={onRefresh} />,
+        )
+        const trigger = screen.getByRole('button', { name: 'formatted-100' })
+        if (opening === 'keyboard') {
+          trigger.focus()
+          await user.keyboard('{Enter}')
+        } else {
+          await user.click(screen.getAllByRole('row')[2]!)
+        }
+        await screen.findByRole('dialog')
+        rerender(
+          <WorkflowAppLogList
+            logs={createMockLogsResponse(logs.data.map((log) => ({ ...log, read_at: 300 })))}
+            appDetail={appDetail}
+            onRefresh={onRefresh}
+          />,
+        )
+        await user.keyboard('{Escape}')
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+          expect(trigger).toHaveFocus()
+        })
+        expect(onRefresh).toHaveBeenCalledTimes(1)
+      },
+    )
+
     it('should close drawer and call onRefresh when closing', async () => {
       const user = userEvent.setup()
       const onRefresh = vi.fn()

--- a/web/app/components/app/workflow-log/list.tsx
+++ b/web/app/components/app/workflow-log/list.tsx
@@ -9,7 +9,6 @@ import type { App } from '@/types/app'
 import { ArrowDownIcon } from '@heroicons/react/24/outline'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
-  createDrawerHandle,
   Drawer,
   DrawerBackdrop,
   DrawerContent,
@@ -44,7 +43,6 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
   const media = useBreakpoints()
   const isMobile = media === MediaType.mobile
 
-  const [drawerHandle] = useState(() => createDrawerHandle())
   const [showDrawer, setShowDrawer] = useState<boolean>(false)
   const [currentLog, setCurrentLog] = useState<WorkflowAppLogDetail | undefined>()
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
@@ -131,130 +129,7 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
 
   return (
     <div className="overflow-x-auto">
-      <table className={cn('mt-2 w-full min-w-110 border-collapse border-0')}>
-        <thead className="system-xs-medium-uppercase text-text-tertiary">
-          <tr>
-            <td className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 whitespace-nowrap"></td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              <button
-                type="button"
-                className="flex cursor-pointer items-center border-none bg-transparent p-0 text-left hover:text-text-secondary focus-visible:ring-1 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
-                onClick={handleSort}
-              >
-                {t(($) => $['table.header.startTime'], { ns: 'appLog' })}
-                <ArrowDownIcon
-                  className={cn(
-                    'ml-0.5 size-3 stroke-current stroke-2 transition-all',
-                    'text-text-tertiary',
-                    sortOrder === 'asc' ? 'rotate-180' : '',
-                  )}
-                  aria-hidden="true"
-                />
-              </button>
-            </td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.status'], { ns: 'appLog' })}
-            </td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.runtime'], { ns: 'appLog' })}
-            </td>
-            <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-              {t(($) => $['table.header.tokens'], { ns: 'appLog' })}
-            </td>
-            <td
-              className={cn(
-                'bg-background-section-burn py-1.5 pl-3 whitespace-nowrap',
-                !isWorkflow ? 'rounded-r-lg' : '',
-              )}
-            >
-              {t(($) => $['table.header.user'], { ns: 'appLog' })}
-            </td>
-            {isWorkflow && (
-              <td className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
-                {t(($) => $['table.header.triggered_from'], { ns: 'appLog' })}
-              </td>
-            )}
-          </tr>
-        </thead>
-        <tbody className="system-sm-regular text-text-secondary">
-          {localLogs.map((log: WorkflowAppLogDetail) => {
-            const endUser = log.created_by_end_user
-              ? log.created_by_end_user.session_id
-              : log.created_by_account
-                ? log.created_by_account.name
-                : defaultValue
-            return (
-              <tr
-                key={log.id}
-                className={cn(
-                  'cursor-pointer border-b border-divider-subtle hover:bg-background-default-hover',
-                  currentLog?.id !== log.id ? '' : 'bg-background-default-hover',
-                )}
-                onClick={(event) => {
-                  if ((event.target as HTMLElement).closest('button, a')) return
-                  event.currentTarget
-                    .querySelector<HTMLButtonElement>('button[data-log-detail-trigger]')
-                    ?.click()
-                }}
-              >
-                <td className="h-4">
-                  {!log.read_at && (
-                    <div className="flex items-center p-3 pr-0.5">
-                      <span className="inline-block size-1.5 rounded-sm bg-util-colors-blue-blue-500"></span>
-                    </div>
-                  )}
-                </td>
-                <td className="w-45 p-3 pr-2">
-                  <DrawerTrigger
-                    data-log-detail-trigger
-                    handle={drawerHandle}
-                    className="w-full cursor-pointer rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      setCurrentLog(log)
-                      setShowDrawer(true)
-                    }}
-                  >
-                    {formatTime(
-                      log.created_at,
-                      t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
-                    )}
-                  </DrawerTrigger>
-                </td>
-                <td className="p-3 pr-2">{statusTdRender(log.workflow_run.status)}</td>
-                <td className="p-3 pr-2">
-                  <div
-                    className={cn(log.workflow_run.elapsed_time === 0 && 'text-text-quaternary')}
-                  >
-                    {`${log.workflow_run.elapsed_time.toFixed(3)}s`}
-                  </div>
-                </td>
-                <td className="p-3 pr-2">{log.workflow_run.total_tokens}</td>
-                <td className="p-3 pr-2">
-                  <div
-                    className={cn(
-                      endUser === defaultValue ? 'text-text-quaternary' : 'text-text-secondary',
-                      'truncate',
-                    )}
-                  >
-                    {endUser}
-                  </div>
-                </td>
-                {isWorkflow && (
-                  <td className="p-3 pr-2">
-                    <TriggerByDisplay
-                      triggeredFrom={log.workflow_run.triggered_from as WorkflowRunTriggeredFrom}
-                      triggerMetadata={log.details?.trigger_metadata}
-                    />
-                  </td>
-                )}
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
       <Drawer
-        handle={drawerHandle}
         open={showDrawer}
         modal
         swipeDirection="right"
@@ -262,6 +137,127 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
           if (!open) onCloseDrawer()
         }}
       >
+        <table className={cn('mt-2 w-full min-w-110 border-collapse border-0')}>
+          <thead className="system-xs-medium-uppercase text-text-tertiary">
+            <tr>
+              <td className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 whitespace-nowrap"></td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                <button
+                  type="button"
+                  className="flex cursor-pointer items-center border-none bg-transparent p-0 text-left hover:text-text-secondary focus-visible:ring-1 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
+                  onClick={handleSort}
+                >
+                  {t(($) => $['table.header.startTime'], { ns: 'appLog' })}
+                  <ArrowDownIcon
+                    className={cn(
+                      'ml-0.5 size-3 stroke-current stroke-2 transition-all',
+                      'text-text-tertiary',
+                      sortOrder === 'asc' ? 'rotate-180' : '',
+                    )}
+                    aria-hidden="true"
+                  />
+                </button>
+              </td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.status'], { ns: 'appLog' })}
+              </td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.runtime'], { ns: 'appLog' })}
+              </td>
+              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                {t(($) => $['table.header.tokens'], { ns: 'appLog' })}
+              </td>
+              <td
+                className={cn(
+                  'bg-background-section-burn py-1.5 pl-3 whitespace-nowrap',
+                  !isWorkflow ? 'rounded-r-lg' : '',
+                )}
+              >
+                {t(($) => $['table.header.user'], { ns: 'appLog' })}
+              </td>
+              {isWorkflow && (
+                <td className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                  {t(($) => $['table.header.triggered_from'], { ns: 'appLog' })}
+                </td>
+              )}
+            </tr>
+          </thead>
+          <tbody className="system-sm-regular text-text-secondary">
+            {localLogs.map((log: WorkflowAppLogDetail) => {
+              const endUser = log.created_by_end_user
+                ? log.created_by_end_user.session_id
+                : log.created_by_account
+                  ? log.created_by_account.name
+                  : defaultValue
+              return (
+                <tr
+                  key={log.id}
+                  className={cn(
+                    'cursor-pointer border-b border-divider-subtle hover:bg-background-default-hover',
+                    currentLog?.id !== log.id ? '' : 'bg-background-default-hover',
+                  )}
+                  onClick={(event) => {
+                    if ((event.target as HTMLElement).closest('button, a')) return
+                    event.currentTarget
+                      .querySelector<HTMLButtonElement>('button[data-log-detail-trigger]')
+                      ?.click()
+                  }}
+                >
+                  <td className="h-4">
+                    {!log.read_at && (
+                      <div className="flex items-center p-3 pr-0.5">
+                        <span className="inline-block size-1.5 rounded-sm bg-util-colors-blue-blue-500"></span>
+                      </div>
+                    )}
+                  </td>
+                  <td className="w-45 p-3 pr-2">
+                    <DrawerTrigger
+                      data-log-detail-trigger
+                      className="w-full cursor-pointer rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        setCurrentLog(log)
+                        setShowDrawer(true)
+                      }}
+                    >
+                      {formatTime(
+                        log.created_at,
+                        t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
+                      )}
+                    </DrawerTrigger>
+                  </td>
+                  <td className="p-3 pr-2">{statusTdRender(log.workflow_run.status)}</td>
+                  <td className="p-3 pr-2">
+                    <div
+                      className={cn(log.workflow_run.elapsed_time === 0 && 'text-text-quaternary')}
+                    >
+                      {`${log.workflow_run.elapsed_time.toFixed(3)}s`}
+                    </div>
+                  </td>
+                  <td className="p-3 pr-2">{log.workflow_run.total_tokens}</td>
+                  <td className="p-3 pr-2">
+                    <div
+                      className={cn(
+                        endUser === defaultValue ? 'text-text-quaternary' : 'text-text-secondary',
+                        'truncate',
+                      )}
+                    >
+                      {endUser}
+                    </div>
+                  </td>
+                  {isWorkflow && (
+                    <td className="p-3 pr-2">
+                      <TriggerByDisplay
+                        triggeredFrom={log.workflow_run.triggered_from as WorkflowRunTriggeredFrom}
+                        triggerMetadata={log.details?.trigger_metadata}
+                      />
+                    </td>
+                  )}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
         <DrawerPortal>
           <DrawerBackdrop className={cn(!isMobile && 'bg-transparent')} />
           <DrawerViewport>

--- a/web/app/components/app/workflow-log/list.tsx
+++ b/web/app/components/app/workflow-log/list.tsx
@@ -9,11 +9,13 @@ import type { App } from '@/types/app'
 import { ArrowDownIcon } from '@heroicons/react/24/outline'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
+  createDrawerHandle,
   Drawer,
   DrawerBackdrop,
   DrawerContent,
   DrawerPopup,
   DrawerPortal,
+  DrawerTrigger,
   DrawerViewport,
 } from '@langgenius/dify-ui/drawer'
 import { StatusDot } from '@langgenius/dify-ui/status-dot'
@@ -42,6 +44,7 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
   const media = useBreakpoints()
   const isMobile = media === MediaType.mobile
 
+  const [drawerHandle] = useState(() => createDrawerHandle())
   const [showDrawer, setShowDrawer] = useState<boolean>(false)
   const [currentLog, setCurrentLog] = useState<WorkflowAppLogDetail | undefined>()
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
@@ -187,9 +190,11 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
                   'cursor-pointer border-b border-divider-subtle hover:bg-background-default-hover',
                   currentLog?.id !== log.id ? '' : 'bg-background-default-hover',
                 )}
-                onClick={() => {
-                  setCurrentLog(log)
-                  setShowDrawer(true)
+                onClick={(event) => {
+                  if ((event.target as HTMLElement).closest('button, a')) return
+                  event.currentTarget
+                    .querySelector<HTMLButtonElement>('button[data-log-detail-trigger]')
+                    ?.click()
                 }}
               >
                 <td className="h-4">
@@ -200,10 +205,21 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
                   )}
                 </td>
                 <td className="w-45 p-3 pr-2">
-                  {formatTime(
-                    log.created_at,
-                    t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
-                  )}
+                  <DrawerTrigger
+                    data-log-detail-trigger
+                    handle={drawerHandle}
+                    className="w-full cursor-pointer rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      setCurrentLog(log)
+                      setShowDrawer(true)
+                    }}
+                  >
+                    {formatTime(
+                      log.created_at,
+                      t(($) => $.dateTimeFormat, { ns: 'appLog' }) as string,
+                    )}
+                  </DrawerTrigger>
                 </td>
                 <td className="p-3 pr-2">{statusTdRender(log.workflow_run.status)}</td>
                 <td className="p-3 pr-2">
@@ -238,6 +254,7 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
         </tbody>
       </table>
       <Drawer
+        handle={drawerHandle}
         open={showDrawer}
         modal
         swipeDirection="right"

--- a/web/app/components/base/chat/chat/answer/__tests__/feedback-focus.browser.spec.tsx
+++ b/web/app/components/base/chat/chat/answer/__tests__/feedback-focus.browser.spec.tsx
@@ -23,6 +23,69 @@ vi.mock('@/app/components/base/chat/chat/log', () => ({ default: () => null }))
 
 const item: ChatItem = { id: 'answer', content: 'An answer', isAnswer: true }
 
+// The exit transition is rendered by Chromium; the default test setup disables it.
+it.each(['cancel', 'submit'])(
+  'preserves the feedback draft during the %s exit animation',
+  async (close) => {
+    const settings = globalThis as typeof globalThis & { BASE_UI_ANIMATIONS_DISABLED: boolean }
+    const animationsDisabled = settings.BASE_UI_ANIMATIONS_DISABLED
+    settings.BASE_UI_ANIMATIONS_DISABLED = false
+    feedback.admin = false
+    feedback.onFeedback.mockReset().mockResolvedValue(undefined)
+    try {
+      const screen = await render(
+        <article aria-label="Answer" className="group relative m-10 h-32 w-96">
+          <p>{item.content}</p>
+          <Operation
+            item={item}
+            question="Question"
+            index={0}
+            maxSize={500}
+            contentWidth={100}
+            hasWorkflowProcess={false}
+          />
+        </article>,
+      )
+      await screen.getByRole('article', { name: 'Answer' }).hover()
+      const trigger = screen.getByRole('button', {
+        name: 'appLog.table.header.userRate: appLog.detail.operation.dislike',
+      })
+      await trigger.click()
+      const dialog = screen.getByRole('dialog')
+      const popup = dialog.element()
+      const textbox = dialog.getByRole('textbox')
+      await textbox.fill('Please explain the answer')
+      await expect.poll(() => getComputedStyle(popup).opacity).toBe('1')
+      const input = textbox.element() as HTMLTextAreaElement
+      const exitFrame = new Promise<{ draft: string; opacity: number }>((resolve) => {
+        const onTransition = (event: Event) => {
+          if (event.target !== popup || (event as TransitionEvent).propertyName !== 'opacity')
+            return
+          popup.removeEventListener('transitionrun', onTransition)
+          resolve({ draft: input.value, opacity: Number(getComputedStyle(popup).opacity) })
+        }
+        popup.addEventListener('transitionrun', onTransition)
+      })
+
+      await dialog.getByRole('button', { name: `common.operation.${close}` }).click()
+
+      const closing = await exitFrame
+      expect(closing.opacity).toBeGreaterThan(0)
+      expect(closing.draft).toBe('Please explain the answer')
+      await expect.element(dialog).not.toBeInTheDocument()
+      await expect.element(trigger).toHaveFocus()
+      if (close === 'cancel') {
+        await trigger.click()
+        await expect.element(screen.getByRole('dialog').getByRole('textbox')).toHaveValue('')
+        await userEvent.keyboard('{Escape}')
+        await expect.element(dialog).not.toBeInTheDocument()
+      }
+    } finally {
+      settings.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled
+    }
+  },
+)
+
 describe('Feedback dialog focus', () => {
   beforeEach(() => {
     feedback.onFeedback.mockReset().mockResolvedValue(undefined)

--- a/web/app/components/base/chat/chat/answer/__tests__/feedback-focus.browser.spec.tsx
+++ b/web/app/components/base/chat/chat/answer/__tests__/feedback-focus.browser.spec.tsx
@@ -1,0 +1,90 @@
+import type { ChatItem } from '../../../types'
+import { userEvent } from 'vite-plus/test/browser'
+import { render } from 'vitest-browser-react'
+import Operation from '../operation'
+
+const feedback = vi.hoisted(() => ({ admin: false, onFeedback: vi.fn() }))
+
+vi.mock('../../context', () => ({
+  useChatContext: () => ({
+    config: { supportFeedback: true, supportAnnotation: feedback.admin },
+    onFeedback: feedback.onFeedback,
+  }),
+}))
+
+// These independently owned features do not participate in feedback focus restoration.
+vi.mock('@/app/components/app/annotation/edit-annotation-modal', () => ({ default: () => null }))
+vi.mock(
+  '@/app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button',
+  () => ({ default: () => null }),
+)
+vi.mock('@/app/components/base/new-audio-button', () => ({ default: () => null }))
+vi.mock('@/app/components/base/chat/chat/log', () => ({ default: () => null }))
+
+const item: ChatItem = { id: 'answer', content: 'An answer', isAnswer: true }
+
+describe('Feedback dialog focus', () => {
+  beforeEach(() => {
+    feedback.onFeedback.mockReset().mockResolvedValue(undefined)
+  })
+
+  // Browser-owned contract: CSS hover visibility must not make the return target unfocusable.
+  it.each([
+    { admin: false, close: 'Escape' },
+    { admin: true, close: 'cancel' },
+    { admin: false, close: 'submit' },
+    { admin: true, close: 'submit' },
+  ])(
+    'returns to the visible feedback button after $close (admin: $admin)',
+    async ({ admin, close }) => {
+      feedback.admin = admin
+      const screen = await render(
+        <>
+          <button type="button">Before answer</button>
+          <article aria-label="Answer" className="group relative m-10 h-32 w-96">
+            <p>{item.content}</p>
+            <Operation
+              item={item}
+              question="Question"
+              index={0}
+              maxSize={500}
+              contentWidth={100}
+              hasWorkflowProcess={false}
+            />
+          </article>
+        </>,
+      )
+      const trigger = screen.getByRole('button', {
+        name: `${admin ? 'appLog.table.header.adminRate' : 'appLog.table.header.userRate'}: appLog.detail.operation.dislike`,
+      })
+      if (close === 'Escape') {
+        await screen.getByRole('button', { name: 'Before answer' }).click()
+        await userEvent.keyboard('{Tab}{Tab}')
+        await expect.element(trigger).toHaveFocus()
+        await userEvent.keyboard('{Enter}')
+      } else {
+        await screen.getByRole('article', { name: 'Answer' }).hover()
+        await trigger.click()
+      }
+      const dialog = screen.getByRole('dialog')
+      await expect.element(dialog).toBeVisible()
+      await dialog.getByRole('textbox').hover()
+      if (close === 'Escape') await userEvent.keyboard('{Escape}')
+      else if (close === 'submit')
+        await dialog.getByRole('button', { name: 'common.operation.submit' }).click()
+      else await dialog.getByRole('button', { name: 'common.operation.cancel' }).click()
+
+      await expect.element(dialog).not.toBeInTheDocument()
+      await expect.element(trigger).toBeVisible()
+      await expect.element(trigger).toHaveFocus()
+      expect(trigger.element().checkVisibility({ checkOpacity: true })).toBe(true)
+      if (close === 'submit') {
+        await expect.element(trigger).toHaveAttribute('aria-pressed', 'true')
+        expect(feedback.onFeedback).toHaveBeenCalledWith('answer', {
+          rating: 'dislike',
+          content: '',
+        })
+      }
+    },
+  )
+})

--- a/web/app/components/base/chat/chat/answer/operation.tsx
+++ b/web/app/components/base/chat/chat/answer/operation.tsx
@@ -3,7 +3,6 @@ import type { ChatItem, Feedback } from '../../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
-  createDialogHandle,
   Dialog,
   DialogClose,
   DialogContent,
@@ -103,7 +102,6 @@ function Operation({
     readonly,
   } = useChatContext()
   const [isShowReplyModal, setIsShowReplyModal] = useState(false)
-  const [feedbackDialogHandle] = useState(() => createDialogHandle())
   // Submitting replaces the dialog trigger with the current rating button.
   const userFeedbackRef = useRef<HTMLButtonElement>(null)
   const adminFeedbackRef = useRef<HTMLButtonElement>(null)
@@ -189,12 +187,10 @@ function Operation({
     const succeeded = await handleFeedback('dislike', feedbackContent, feedbackTarget)
     if (!succeeded) return
 
-    setFeedbackContent('')
     setIsShowFeedbackModal(false)
   }
 
   const handleFeedbackCancel = () => {
-    setFeedbackContent('')
     setIsShowFeedbackModal(false)
   }
 
@@ -238,166 +234,228 @@ function Operation({
         style={!hasWorkflowProcess && positionRight ? { left: contentWidth + 8 } : {}}
         data-testid="operation-bar"
       >
-        {shouldShowUserFeedbackBar && !humanInputFormDataList?.length && (
-          <div
-            className={cn(
-              'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
-              hasUserFeedback ? 'flex' : feedbackActionsClassName,
-            )}
-          >
-            {hasUserFeedback ? (
-              <FeedbackTooltip
-                content={buildFeedbackTooltip(displayUserFeedback, userFeedbackLabel)}
-              >
-                <Toggle
-                  ref={userFeedbackRef}
-                  className={
-                    displayUserFeedback?.rating === 'like'
-                      ? accentPressedClassName
-                      : destructivePressedClassName
-                  }
-                  pressed
-                  onPressedChange={(pressed) =>
-                    !pressed && void handleFeedback(null, undefined, 'user')
-                  }
-                  render={
-                    <IconButton
-                      aria-label={`${userFeedbackLabel}: ${displayUserFeedback?.rating === 'like' ? likeLabel : dislikeLabel}`}
-                    >
-                      {displayUserFeedback?.rating === 'like' ? (
+        <Dialog
+          open={isShowFeedbackModal}
+          onOpenChange={setIsShowFeedbackModal}
+          onOpenChangeComplete={(open) => {
+            if (!open) setFeedbackContent('')
+          }}
+        >
+          {shouldShowUserFeedbackBar && !humanInputFormDataList?.length && (
+            <div
+              className={cn(
+                'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
+                hasUserFeedback ? 'flex' : feedbackActionsClassName,
+              )}
+            >
+              {hasUserFeedback ? (
+                <FeedbackTooltip
+                  content={buildFeedbackTooltip(displayUserFeedback, userFeedbackLabel)}
+                >
+                  <Toggle
+                    ref={userFeedbackRef}
+                    className={
+                      displayUserFeedback?.rating === 'like'
+                        ? accentPressedClassName
+                        : destructivePressedClassName
+                    }
+                    pressed
+                    onPressedChange={(pressed) =>
+                      !pressed && void handleFeedback(null, undefined, 'user')
+                    }
+                    render={
+                      <IconButton
+                        aria-label={`${userFeedbackLabel}: ${displayUserFeedback?.rating === 'like' ? likeLabel : dislikeLabel}`}
+                      >
+                        {displayUserFeedback?.rating === 'like' ? (
+                          <span aria-hidden="true" className="i-ri-thumb-up-line size-4" />
+                        ) : (
+                          <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
+                        )}
+                      </IconButton>
+                    }
+                  />
+                </FeedbackTooltip>
+              ) : (
+                <>
+                  <Toggle
+                    className={accentPressedClassName}
+                    pressed={false}
+                    onPressedChange={(pressed) => pressed && handleLikeClick('user')}
+                    render={
+                      <IconButton aria-label={`${userFeedbackLabel}: ${likeLabel}`}>
                         <span aria-hidden="true" className="i-ri-thumb-up-line size-4" />
-                      ) : (
+                      </IconButton>
+                    }
+                  />
+                  <DialogTrigger
+                    ref={userFeedbackRef}
+                    onClick={() => setFeedbackTarget('user')}
+                    render={
+                      <IconButton aria-label={`${userFeedbackLabel}: ${dislikeLabel}`}>
                         <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
-                      )}
-                    </IconButton>
-                  }
-                />
-              </FeedbackTooltip>
-            ) : (
-              <>
-                <Toggle
-                  className={accentPressedClassName}
-                  pressed={false}
-                  onPressedChange={(pressed) => pressed && handleLikeClick('user')}
-                  render={
-                    <IconButton aria-label={`${userFeedbackLabel}: ${likeLabel}`}>
-                      <span aria-hidden="true" className="i-ri-thumb-up-line size-4" />
-                    </IconButton>
-                  }
-                />
-                <DialogTrigger
-                  handle={feedbackDialogHandle}
-                  ref={userFeedbackRef}
-                  onClick={() => setFeedbackTarget('user')}
-                  render={
-                    <IconButton aria-label={`${userFeedbackLabel}: ${dislikeLabel}`}>
-                      <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
-                    </IconButton>
-                  }
-                />
-              </>
-            )}
-          </div>
-        )}
-        {shouldShowAdminFeedbackBar && !humanInputFormDataList?.length && (
-          <div
-            className={cn(
-              'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
-              hasAdminFeedback || hasUserFeedback ? 'flex' : feedbackActionsClassName,
-            )}
-          >
-            {displayUserFeedback?.rating && (
-              <FeedbackTooltip
-                content={buildFeedbackTooltip(displayUserFeedback, userFeedbackLabel)}
-              >
-                <span
-                  role="img"
-                  aria-label={buildFeedbackTooltip(displayUserFeedback, userFeedbackLabel)}
-                  className={cn(
-                    'inline-flex size-6 items-center justify-center rounded-lg p-0.5',
-                    displayUserFeedback.rating === 'like'
-                      ? 'bg-state-accent-active text-text-accent'
-                      : 'bg-state-destructive-hover text-text-destructive',
-                  )}
+                      </IconButton>
+                    }
+                  />
+                </>
+              )}
+            </div>
+          )}
+          {shouldShowAdminFeedbackBar && !humanInputFormDataList?.length && (
+            <div
+              className={cn(
+                'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
+                hasAdminFeedback || hasUserFeedback ? 'flex' : feedbackActionsClassName,
+              )}
+            >
+              {displayUserFeedback?.rating && (
+                <FeedbackTooltip
+                  content={buildFeedbackTooltip(displayUserFeedback, userFeedbackLabel)}
                 >
                   <span
-                    aria-hidden="true"
+                    role="img"
+                    aria-label={buildFeedbackTooltip(displayUserFeedback, userFeedbackLabel)}
                     className={cn(
-                      'size-4',
+                      'inline-flex size-6 items-center justify-center rounded-lg p-0.5',
                       displayUserFeedback.rating === 'like'
-                        ? 'i-ri-thumb-up-line'
-                        : 'i-ri-thumb-down-line',
+                        ? 'bg-state-accent-active text-text-accent'
+                        : 'bg-state-destructive-hover text-text-destructive',
                     )}
-                  />
-                </span>
-              </FeedbackTooltip>
-            )}
-
-            {displayUserFeedback?.rating && (
-              <div className="mx-1 h-3 w-[0.5px] bg-components-actionbar-border" />
-            )}
-            {hasAdminFeedback ? (
-              <FeedbackTooltip
-                content={buildFeedbackTooltip(displayAdminFeedback, adminFeedbackLabel)}
-              >
-                <Toggle
-                  ref={adminFeedbackRef}
-                  className={
-                    displayAdminFeedback?.rating === 'like'
-                      ? accentPressedClassName
-                      : destructivePressedClassName
-                  }
-                  pressed
-                  onPressedChange={(pressed) =>
-                    !pressed && void handleFeedback(null, undefined, 'admin')
-                  }
-                  render={
-                    <IconButton
-                      aria-label={`${adminFeedbackLabel}: ${displayAdminFeedback?.rating === 'like' ? likeLabel : dislikeLabel}`}
-                    >
-                      {displayAdminFeedback?.rating === 'like' ? (
-                        <span aria-hidden="true" className="i-ri-thumb-up-line size-4" />
-                      ) : (
-                        <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        'size-4',
+                        displayUserFeedback.rating === 'like'
+                          ? 'i-ri-thumb-up-line'
+                          : 'i-ri-thumb-down-line',
                       )}
-                    </IconButton>
-                  }
-                />
-              </FeedbackTooltip>
-            ) : (
-              <>
+                    />
+                  </span>
+                </FeedbackTooltip>
+              )}
+
+              {displayUserFeedback?.rating && (
+                <div className="mx-1 h-3 w-[0.5px] bg-components-actionbar-border" />
+              )}
+              {hasAdminFeedback ? (
                 <FeedbackTooltip
                   content={buildFeedbackTooltip(displayAdminFeedback, adminFeedbackLabel)}
                 >
                   <Toggle
-                    className={accentPressedClassName}
-                    pressed={false}
-                    onPressedChange={(pressed) => pressed && handleLikeClick('admin')}
-                    render={
-                      <IconButton aria-label={`${adminFeedbackLabel}: ${likeLabel}`}>
-                        <span aria-hidden="true" className="i-ri-thumb-up-line size-4" />
-                      </IconButton>
-                    }
-                  />
-                </FeedbackTooltip>
-                <FeedbackTooltip
-                  content={buildFeedbackTooltip(displayAdminFeedback, adminFeedbackLabel)}
-                >
-                  <DialogTrigger
-                    handle={feedbackDialogHandle}
                     ref={adminFeedbackRef}
-                    onClick={() => setFeedbackTarget('admin')}
+                    className={
+                      displayAdminFeedback?.rating === 'like'
+                        ? accentPressedClassName
+                        : destructivePressedClassName
+                    }
+                    pressed
+                    onPressedChange={(pressed) =>
+                      !pressed && void handleFeedback(null, undefined, 'admin')
+                    }
                     render={
-                      <IconButton aria-label={`${adminFeedbackLabel}: ${dislikeLabel}`}>
-                        <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
+                      <IconButton
+                        aria-label={`${adminFeedbackLabel}: ${displayAdminFeedback?.rating === 'like' ? likeLabel : dislikeLabel}`}
+                      >
+                        {displayAdminFeedback?.rating === 'like' ? (
+                          <span aria-hidden="true" className="i-ri-thumb-up-line size-4" />
+                        ) : (
+                          <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
+                        )}
                       </IconButton>
                     }
                   />
                 </FeedbackTooltip>
-              </>
-            )}
-          </div>
-        )}
+              ) : (
+                <>
+                  <FeedbackTooltip
+                    content={buildFeedbackTooltip(displayAdminFeedback, adminFeedbackLabel)}
+                  >
+                    <Toggle
+                      className={accentPressedClassName}
+                      pressed={false}
+                      onPressedChange={(pressed) => pressed && handleLikeClick('admin')}
+                      render={
+                        <IconButton aria-label={`${adminFeedbackLabel}: ${likeLabel}`}>
+                          <span aria-hidden="true" className="i-ri-thumb-up-line size-4" />
+                        </IconButton>
+                      }
+                    />
+                  </FeedbackTooltip>
+                  <FeedbackTooltip
+                    content={buildFeedbackTooltip(displayAdminFeedback, adminFeedbackLabel)}
+                  >
+                    <DialogTrigger
+                      ref={adminFeedbackRef}
+                      onClick={() => setFeedbackTarget('admin')}
+                      render={
+                        <IconButton aria-label={`${adminFeedbackLabel}: ${dislikeLabel}`}>
+                          <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
+                        </IconButton>
+                      }
+                    />
+                  </FeedbackTooltip>
+                </>
+              )}
+            </div>
+          )}
+          <DialogContent
+            finalFocus={feedbackTarget === 'user' ? userFeedbackRef : adminFeedbackRef}
+            backdropProps={{ forceRender: true }}
+            className="p-0"
+          >
+            <div className="flex max-h-[80dvh] flex-col">
+              <div className="relative shrink-0 p-6 pr-14 pb-3">
+                <DialogTitle className="title-2xl-semi-bold text-text-primary">
+                  {t(($) => $['feedback.title'], { ns: 'common' }) || 'Provide Feedback'}
+                </DialogTitle>
+                <DialogDescription className="mt-1 system-xs-regular text-text-tertiary">
+                  {t(($) => $['feedback.subtitle'], { ns: 'common' }) ||
+                    'Please tell us what went wrong with this response'}
+                </DialogDescription>
+                <DialogClose
+                  render={
+                    <IconButton
+                      aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                      size="lg"
+                      className="absolute top-5 right-5"
+                    >
+                      <span aria-hidden className="i-ri-close-line size-4" />
+                    </IconButton>
+                  }
+                />
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
+                <label
+                  htmlFor={feedbackTextareaId}
+                  className="mb-2 block system-sm-semibold text-text-secondary"
+                >
+                  {t(($) => $['feedback.content'], { ns: 'common' }) || 'Feedback Content'}
+                </label>
+                <Textarea
+                  id={feedbackTextareaId}
+                  name="feedback-content"
+                  value={feedbackContent}
+                  onValueChange={(value) => setFeedbackContent(value)}
+                  placeholder={
+                    t(($) => $['feedback.placeholder'], { ns: 'common' }) ||
+                    'Please describe what went wrong or how we can improve…'
+                  }
+                  rows={4}
+                  className="w-full"
+                />
+              </div>
+              <div className="flex shrink-0 justify-end p-6 pt-5">
+                <Button onClick={handleFeedbackCancel}>
+                  {t(($) => $['operation.cancel'], { ns: 'common' }) || 'Cancel'}
+                </Button>
+                <Button className="ml-2" variant="primary" onClick={handleFeedbackSubmit}>
+                  {t(($) => $['operation.submit'], { ns: 'common' }) || 'Submit'}
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
         {showPromptLog && !isOpeningStatement && (
           <div className={cn('hidden', answerActiveBlockClassName)}>
             <Log logItem={item} />
@@ -464,71 +522,6 @@ function Operation({
           onRemove={() => onAnnotationRemoved?.(index)}
         />
       )}
-      <Dialog
-        handle={feedbackDialogHandle}
-        open={isShowFeedbackModal}
-        onOpenChange={(open) => {
-          if (open) setIsShowFeedbackModal(true)
-          else handleFeedbackCancel()
-        }}
-      >
-        <DialogContent
-          finalFocus={feedbackTarget === 'user' ? userFeedbackRef : adminFeedbackRef}
-          backdropProps={{ forceRender: true }}
-          className="p-0"
-        >
-          <div className="flex max-h-[80dvh] flex-col">
-            <div className="relative shrink-0 p-6 pr-14 pb-3">
-              <DialogTitle className="title-2xl-semi-bold text-text-primary">
-                {t(($) => $['feedback.title'], { ns: 'common' }) || 'Provide Feedback'}
-              </DialogTitle>
-              <DialogDescription className="mt-1 system-xs-regular text-text-tertiary">
-                {t(($) => $['feedback.subtitle'], { ns: 'common' }) ||
-                  'Please tell us what went wrong with this response'}
-              </DialogDescription>
-              <DialogClose
-                render={
-                  <IconButton
-                    aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-                    size="lg"
-                    className="absolute top-5 right-5"
-                  >
-                    <span aria-hidden className="i-ri-close-line size-4" />
-                  </IconButton>
-                }
-              />
-            </div>
-            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
-              <label
-                htmlFor={feedbackTextareaId}
-                className="mb-2 block system-sm-semibold text-text-secondary"
-              >
-                {t(($) => $['feedback.content'], { ns: 'common' }) || 'Feedback Content'}
-              </label>
-              <Textarea
-                id={feedbackTextareaId}
-                name="feedback-content"
-                value={feedbackContent}
-                onValueChange={(value) => setFeedbackContent(value)}
-                placeholder={
-                  t(($) => $['feedback.placeholder'], { ns: 'common' }) ||
-                  'Please describe what went wrong or how we can improve…'
-                }
-                rows={4}
-                className="w-full"
-              />
-            </div>
-            <div className="flex shrink-0 justify-end p-6 pt-5">
-              <Button onClick={handleFeedbackCancel}>
-                {t(($) => $['operation.cancel'], { ns: 'common' }) || 'Cancel'}
-              </Button>
-              <Button className="ml-2" variant="primary" onClick={handleFeedbackSubmit}>
-                {t(($) => $['operation.submit'], { ns: 'common' }) || 'Submit'}
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
     </>
   )
 }

--- a/web/app/components/base/chat/chat/answer/operation.tsx
+++ b/web/app/components/base/chat/chat/answer/operation.tsx
@@ -3,11 +3,13 @@ import type { ChatItem, Feedback } from '../../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
+  createDialogHandle,
   Dialog,
   DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
+  DialogTrigger,
 } from '@langgenius/dify-ui/dialog'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Textarea } from '@langgenius/dify-ui/textarea'
@@ -15,7 +17,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { Toggle } from '@langgenius/dify-ui/toggle'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import copy from 'copy-to-clipboard'
-import { memo, useId, useMemo, useState } from 'react'
+import { memo, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import EditReplyModal from '@/app/components/app/annotation/edit-annotation-modal'
 import Log from '@/app/components/base/chat/chat/log'
@@ -45,6 +47,8 @@ type FeedbackTooltipProps = {
 const feedbackTooltipClassName = 'max-w-[260px]'
 const answerActiveFlexClassName = 'group-hover:flex group-has-[[data-popup-open]]:flex'
 const answerActiveBlockClassName = 'group-hover:block group-has-[[data-popup-open]]:block'
+const feedbackActionsClassName =
+  'flex pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 has-[[data-popup-open]]:pointer-events-auto has-[[data-popup-open]]:opacity-100'
 const accentPressedClassName =
   'data-pressed:bg-state-accent-active data-pressed:text-text-accent data-pressed:hover:bg-state-accent-active-alt'
 const destructivePressedClassName =
@@ -99,6 +103,10 @@ function Operation({
     readonly,
   } = useChatContext()
   const [isShowReplyModal, setIsShowReplyModal] = useState(false)
+  const [feedbackDialogHandle] = useState(() => createDialogHandle())
+  // Submitting replaces the dialog trigger with the current rating button.
+  const userFeedbackRef = useRef<HTMLButtonElement>(null)
+  const adminFeedbackRef = useRef<HTMLButtonElement>(null)
   const [isShowFeedbackModal, setIsShowFeedbackModal] = useState(false)
   const [feedbackContent, setFeedbackContent] = useState('')
   const { id, isOpeningStatement, annotation, feedback, adminFeedback, humanInputFormDataList } =
@@ -177,11 +185,6 @@ function Operation({
     void handleFeedback('like', undefined, target)
   }
 
-  const handleDislikeClick = (target: 'user' | 'admin') => {
-    setFeedbackTarget(target)
-    setIsShowFeedbackModal(true)
-  }
-
   const handleFeedbackSubmit = async () => {
     const succeeded = await handleFeedback('dislike', feedbackContent, feedbackTarget)
     if (!succeeded) return
@@ -239,7 +242,7 @@ function Operation({
           <div
             className={cn(
               'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
-              hasUserFeedback ? 'flex' : `hidden ${answerActiveFlexClassName}`,
+              hasUserFeedback ? 'flex' : feedbackActionsClassName,
             )}
           >
             {hasUserFeedback ? (
@@ -247,6 +250,7 @@ function Operation({
                 content={buildFeedbackTooltip(displayUserFeedback, userFeedbackLabel)}
               >
                 <Toggle
+                  ref={userFeedbackRef}
                   className={
                     displayUserFeedback?.rating === 'like'
                       ? accentPressedClassName
@@ -281,10 +285,10 @@ function Operation({
                     </IconButton>
                   }
                 />
-                <Toggle
-                  className={destructivePressedClassName}
-                  pressed={false}
-                  onPressedChange={(pressed) => pressed && handleDislikeClick('user')}
+                <DialogTrigger
+                  handle={feedbackDialogHandle}
+                  ref={userFeedbackRef}
+                  onClick={() => setFeedbackTarget('user')}
                   render={
                     <IconButton aria-label={`${userFeedbackLabel}: ${dislikeLabel}`}>
                       <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
@@ -299,7 +303,7 @@ function Operation({
           <div
             className={cn(
               'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
-              hasAdminFeedback || hasUserFeedback ? 'flex' : `hidden ${answerActiveFlexClassName}`,
+              hasAdminFeedback || hasUserFeedback ? 'flex' : feedbackActionsClassName,
             )}
           >
             {displayUserFeedback?.rating && (
@@ -337,6 +341,7 @@ function Operation({
                 content={buildFeedbackTooltip(displayAdminFeedback, adminFeedbackLabel)}
               >
                 <Toggle
+                  ref={adminFeedbackRef}
                   className={
                     displayAdminFeedback?.rating === 'like'
                       ? accentPressedClassName
@@ -378,10 +383,10 @@ function Operation({
                 <FeedbackTooltip
                   content={buildFeedbackTooltip(displayAdminFeedback, adminFeedbackLabel)}
                 >
-                  <Toggle
-                    className={destructivePressedClassName}
-                    pressed={false}
-                    onPressedChange={(pressed) => pressed && handleDislikeClick('admin')}
+                  <DialogTrigger
+                    handle={feedbackDialogHandle}
+                    ref={adminFeedbackRef}
+                    onClick={() => setFeedbackTarget('admin')}
                     render={
                       <IconButton aria-label={`${adminFeedbackLabel}: ${dislikeLabel}`}>
                         <span aria-hidden="true" className="i-ri-thumb-down-line size-4" />
@@ -459,67 +464,71 @@ function Operation({
           onRemove={() => onAnnotationRemoved?.(index)}
         />
       )}
-      {isShowFeedbackModal && (
-        <Dialog
-          open
-          onOpenChange={(open) => {
-            if (!open) handleFeedbackCancel()
-          }}
+      <Dialog
+        handle={feedbackDialogHandle}
+        open={isShowFeedbackModal}
+        onOpenChange={(open) => {
+          if (open) setIsShowFeedbackModal(true)
+          else handleFeedbackCancel()
+        }}
+      >
+        <DialogContent
+          finalFocus={feedbackTarget === 'user' ? userFeedbackRef : adminFeedbackRef}
+          backdropProps={{ forceRender: true }}
+          className="p-0"
         >
-          <DialogContent backdropProps={{ forceRender: true }} className="p-0">
-            <div className="flex max-h-[80dvh] flex-col">
-              <div className="relative shrink-0 p-6 pr-14 pb-3">
-                <DialogTitle className="title-2xl-semi-bold text-text-primary">
-                  {t(($) => $['feedback.title'], { ns: 'common' }) || 'Provide Feedback'}
-                </DialogTitle>
-                <DialogDescription className="mt-1 system-xs-regular text-text-tertiary">
-                  {t(($) => $['feedback.subtitle'], { ns: 'common' }) ||
-                    'Please tell us what went wrong with this response'}
-                </DialogDescription>
-                <DialogClose
-                  render={
-                    <IconButton
-                      aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-                      size="lg"
-                      className="absolute top-5 right-5"
-                    >
-                      <span aria-hidden className="i-ri-close-line size-4" />
-                    </IconButton>
-                  }
-                />
-              </div>
-              <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
-                <label
-                  htmlFor={feedbackTextareaId}
-                  className="mb-2 block system-sm-semibold text-text-secondary"
-                >
-                  {t(($) => $['feedback.content'], { ns: 'common' }) || 'Feedback Content'}
-                </label>
-                <Textarea
-                  id={feedbackTextareaId}
-                  name="feedback-content"
-                  value={feedbackContent}
-                  onValueChange={(value) => setFeedbackContent(value)}
-                  placeholder={
-                    t(($) => $['feedback.placeholder'], { ns: 'common' }) ||
-                    'Please describe what went wrong or how we can improve…'
-                  }
-                  rows={4}
-                  className="w-full"
-                />
-              </div>
-              <div className="flex shrink-0 justify-end p-6 pt-5">
-                <Button onClick={handleFeedbackCancel}>
-                  {t(($) => $['operation.cancel'], { ns: 'common' }) || 'Cancel'}
-                </Button>
-                <Button className="ml-2" variant="primary" onClick={handleFeedbackSubmit}>
-                  {t(($) => $['operation.submit'], { ns: 'common' }) || 'Submit'}
-                </Button>
-              </div>
+          <div className="flex max-h-[80dvh] flex-col">
+            <div className="relative shrink-0 p-6 pr-14 pb-3">
+              <DialogTitle className="title-2xl-semi-bold text-text-primary">
+                {t(($) => $['feedback.title'], { ns: 'common' }) || 'Provide Feedback'}
+              </DialogTitle>
+              <DialogDescription className="mt-1 system-xs-regular text-text-tertiary">
+                {t(($) => $['feedback.subtitle'], { ns: 'common' }) ||
+                  'Please tell us what went wrong with this response'}
+              </DialogDescription>
+              <DialogClose
+                render={
+                  <IconButton
+                    aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                    size="lg"
+                    className="absolute top-5 right-5"
+                  >
+                    <span aria-hidden className="i-ri-close-line size-4" />
+                  </IconButton>
+                }
+              />
             </div>
-          </DialogContent>
-        </Dialog>
-      )}
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
+              <label
+                htmlFor={feedbackTextareaId}
+                className="mb-2 block system-sm-semibold text-text-secondary"
+              >
+                {t(($) => $['feedback.content'], { ns: 'common' }) || 'Feedback Content'}
+              </label>
+              <Textarea
+                id={feedbackTextareaId}
+                name="feedback-content"
+                value={feedbackContent}
+                onValueChange={(value) => setFeedbackContent(value)}
+                placeholder={
+                  t(($) => $['feedback.placeholder'], { ns: 'common' }) ||
+                  'Please describe what went wrong or how we can improve…'
+                }
+                rows={4}
+                className="w-full"
+              />
+            </div>
+            <div className="flex shrink-0 justify-end p-6 pt-5">
+              <Button onClick={handleFeedbackCancel}>
+                {t(($) => $['operation.cancel'], { ns: 'common' }) || 'Cancel'}
+              </Button>
+              <Button className="ml-2" variant="primary" onClick={handleFeedbackSubmit}>
+                {t(($) => $['operation.submit'], { ns: 'common' }) || 'Submit'}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/focus.browser.spec.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/focus.browser.spec.tsx
@@ -1,0 +1,79 @@
+import type { PipelineTemplate } from '@/models/pipeline'
+import { Button } from '@langgenius/dify-ui/button'
+import { DialogTitle } from '@langgenius/dify-ui/dialog'
+import { userEvent } from 'vite-plus/test/browser'
+import { render } from 'vitest-browser-react'
+import { ChunkingMode } from '@/models/datasets'
+import TemplateCard from '../index'
+
+vi.mock('@/next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/app/components/base/amplitude', () => ({ trackEvent: vi.fn() }))
+vi.mock('@/app/components/workflow/plugin-dependency/hooks', () => ({
+  usePluginDependencies: () => ({ handleCheckPluginDependencies: vi.fn() }),
+}))
+vi.mock('@/service/knowledge/use-create-dataset', () => ({
+  useCreatePipelineDatasetFromCustomized: () => ({ mutateAsync: vi.fn() }),
+}))
+vi.mock('@/service/knowledge/use-dataset', () => ({ useInvalidDatasetList: () => vi.fn() }))
+vi.mock('@/service/use-pipeline', () => ({
+  usePipelineTemplateById: () => ({ refetch: vi.fn() }),
+  useDeleteTemplate: () => ({ mutateAsync: vi.fn() }),
+  useExportTemplateDSL: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useInvalidCustomizedTemplateList: () => vi.fn(),
+}))
+
+// The workflow preview and edit form do not own the card's dialog or trigger.
+vi.mock('../details', () => ({
+  default: ({ onClose }: { onClose: () => void }) => (
+    <div className="flex h-full flex-col items-end justify-end">
+      <DialogTitle>Template details</DialogTitle>
+      <Button onClick={onClose}>Close details</Button>
+    </div>
+  ),
+}))
+vi.mock('../edit-pipeline-info', () => ({ default: () => null }))
+
+const pipeline: PipelineTemplate = {
+  id: 'template-1',
+  name: 'Document pipeline',
+  description: 'Process documents',
+  icon: { icon_type: 'emoji', icon: '📊', icon_background: '#FFF4ED', icon_url: '' },
+  chunk_structure: ChunkingMode.text,
+  position: 1,
+}
+
+describe('Template card focus', () => {
+  it('reveals keyboard actions and restores visible focus after details closes away from the card', async () => {
+    // Browser mode is required: display:none prevents native focus restoration,
+    // and CSS hover/focus-within decides whether the returned button is visible.
+    const screen = await render(
+      <>
+        <Button>Before template</Button>
+        <div className="w-80">
+          <TemplateCard pipeline={pipeline} type="built-in" showMoreOperations={false} />
+        </div>
+      </>,
+    )
+    await screen.getByRole('button', { name: 'Before template' }).click()
+    await userEvent.tab()
+    const choose = screen.getByRole('button', { name: 'datasetPipeline.operations.choose' })
+    await expect.element(choose).toHaveFocus()
+    expect(choose.element().checkVisibility({ checkOpacity: true })).toBe(true)
+    await userEvent.tab()
+    const details = screen.getByRole('button', { name: 'datasetPipeline.operations.details' })
+    await expect.element(details).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+    const dialog = screen.getByRole('dialog', { name: 'Template details' })
+    await expect.element(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Close details' }).click()
+    await expect.element(dialog).not.toBeInTheDocument()
+    await expect.element(details).toHaveFocus()
+    expect(details.element().checkVisibility({ checkOpacity: true })).toBe(true)
+    await userEvent.keyboard('{Enter}')
+    await expect.element(dialog).toBeVisible()
+    await userEvent.keyboard('{Escape}')
+    await expect.element(dialog).not.toBeInTheDocument()
+    await expect.element(details).toHaveFocus()
+    expect(details.element().checkVisibility({ checkOpacity: true })).toBe(true)
+  })
+})

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-import type { DialogHandle } from '@langgenius/dify-ui/dialog'
 import type { PipelineTemplate } from '@/models/pipeline'
 import { DialogTrigger } from '@langgenius/dify-ui/dialog'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -47,14 +46,12 @@ let _capturedOpenEditModal: (() => void) | undefined
 vi.mock('../actions', () => ({
   default: ({
     onApplyTemplate,
-    detailsDialogHandle,
     showMoreOperations,
     openEditModal,
     handleExportDSL,
     handleDelete,
   }: {
     onApplyTemplate: () => void
-    detailsDialogHandle: DialogHandle
     showMoreOperations: boolean
     openEditModal: () => void
     handleExportDSL: () => void
@@ -68,9 +65,7 @@ vi.mock('../actions', () => ({
         <button data-testid="action-choose" onClick={onApplyTemplate}>
           operations.choose
         </button>
-        <DialogTrigger handle={detailsDialogHandle} data-testid="action-details">
-          operations.details
-        </DialogTrigger>
+        <DialogTrigger data-testid="action-details">operations.details</DialogTrigger>
         {showMoreOperations && (
           <>
             <button data-testid="action-edit" onClick={openEditModal}>

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/__tests__/index.spec.tsx
@@ -1,4 +1,6 @@
+import type { DialogHandle } from '@langgenius/dify-ui/dialog'
 import type { PipelineTemplate } from '@/models/pipeline'
+import { DialogTrigger } from '@langgenius/dify-ui/dialog'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { ChunkingMode } from '@/models/datasets'
@@ -45,14 +47,14 @@ let _capturedOpenEditModal: (() => void) | undefined
 vi.mock('../actions', () => ({
   default: ({
     onApplyTemplate,
-    handleShowTemplateDetails,
+    detailsDialogHandle,
     showMoreOperations,
     openEditModal,
     handleExportDSL,
     handleDelete,
   }: {
     onApplyTemplate: () => void
-    handleShowTemplateDetails: () => void
+    detailsDialogHandle: DialogHandle
     showMoreOperations: boolean
     openEditModal: () => void
     handleExportDSL: () => void
@@ -66,9 +68,9 @@ vi.mock('../actions', () => ({
         <button data-testid="action-choose" onClick={onApplyTemplate}>
           operations.choose
         </button>
-        <button data-testid="action-details" onClick={handleShowTemplateDetails}>
+        <DialogTrigger handle={detailsDialogHandle} data-testid="action-details">
           operations.details
-        </button>
+        </DialogTrigger>
         {showMoreOperations && (
           <>
             <button data-testid="action-edit" onClick={openEditModal}>

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
@@ -1,4 +1,3 @@
-import type { DialogHandle } from '@langgenius/dify-ui/dialog'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { DialogTrigger } from '@langgenius/dify-ui/dialog'
@@ -15,7 +14,6 @@ import Operations from './operations'
 
 type ActionsProps = {
   onApplyTemplate: () => void
-  detailsDialogHandle: DialogHandle
   showMoreOperations: boolean
   openEditModal: () => void
   handleExportDSL: (includeSecret?: boolean) => void
@@ -24,7 +22,6 @@ type ActionsProps = {
 
 const Actions = ({
   onApplyTemplate,
-  detailsDialogHandle,
   showMoreOperations,
   openEditModal,
   handleExportDSL,
@@ -46,7 +43,6 @@ const Actions = ({
         <span>{t(($) => $['operations.choose'], { ns: 'datasetPipeline' })}</span>
       </Button>
       <DialogTrigger
-        handle={detailsDialogHandle}
         render={
           <Button variant="secondary" className="grow">
             <span aria-hidden className="i-ri-arrow-right-up-line size-4" />

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
@@ -1,5 +1,7 @@
+import type { DialogHandle } from '@langgenius/dify-ui/dialog'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
+import { DialogTrigger } from '@langgenius/dify-ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuPopup,
@@ -13,7 +15,7 @@ import Operations from './operations'
 
 type ActionsProps = {
   onApplyTemplate: () => void
-  handleShowTemplateDetails: () => void
+  detailsDialogHandle: DialogHandle
   showMoreOperations: boolean
   openEditModal: () => void
   handleExportDSL: (includeSecret?: boolean) => void
@@ -22,7 +24,7 @@ type ActionsProps = {
 
 const Actions = ({
   onApplyTemplate,
-  handleShowTemplateDetails,
+  detailsDialogHandle,
   showMoreOperations,
   openEditModal,
   handleExportDSL,
@@ -34,18 +36,24 @@ const Actions = ({
   return (
     <div
       className={cn(
-        'absolute bottom-0 left-0 z-10 w-full items-center gap-x-1 bg-pipeline-template-card-hover-bg p-4 pt-8',
-        isMoreOperationsOpen ? 'flex' : 'hidden group-hover:flex',
+        'absolute bottom-0 left-0 z-10 flex w-full items-center gap-x-1 bg-pipeline-template-card-hover-bg p-4 pt-8',
+        !isMoreOperationsOpen &&
+          'pointer-events-none opacity-0 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 has-[[data-popup-open]]:pointer-events-auto has-[[data-popup-open]]:opacity-100',
       )}
     >
       <Button variant="primary" onClick={onApplyTemplate} className="grow">
         <span aria-hidden className="i-ri-add-line size-4" />
         <span>{t(($) => $['operations.choose'], { ns: 'datasetPipeline' })}</span>
       </Button>
-      <Button variant="secondary" onClick={handleShowTemplateDetails} className="grow">
-        <span aria-hidden className="i-ri-arrow-right-up-line size-4" />
-        <span>{t(($) => $['operations.details'], { ns: 'datasetPipeline' })}</span>
-      </Button>
+      <DialogTrigger
+        handle={detailsDialogHandle}
+        render={
+          <Button variant="secondary" className="grow">
+            <span aria-hidden className="i-ri-arrow-right-up-line size-4" />
+            <span>{t(($) => $['operations.details'], { ns: 'datasetPipeline' })}</span>
+          </Button>
+        }
+      />
       {showMoreOperations && (
         <DropdownMenu open={isMoreOperationsOpen} onOpenChange={setIsMoreOperationsOpen}>
           <DropdownMenuTrigger

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/index.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/index.tsx
@@ -8,7 +8,7 @@ import {
   AlertDialogDescription,
   AlertDialogTitle,
 } from '@langgenius/dify-ui/alert-dialog'
-import { createDialogHandle, Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
 import { toast } from '@langgenius/dify-ui/toast'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
@@ -42,7 +42,6 @@ const TemplateCard = ({ pipeline, showMoreOperations = true, type }: TemplateCar
   const [showEditModal, setShowEditModal] = useState(false)
   const [showDeleteConfirm, setShowConfirmDelete] = useState(false)
   const [showDetailModal, setShowDetailModal] = useState(false)
-  const [detailsDialogHandle] = useState(createDialogHandle)
 
   const { refetch: getPipelineTemplateInfo } = usePipelineTemplateById(
     {
@@ -149,14 +148,23 @@ const TemplateCard = ({ pipeline, showMoreOperations = true, type }: TemplateCar
         iconInfo={pipeline.icon}
         chunkStructure={pipeline.chunk_structure}
       />
-      <Actions
-        onApplyTemplate={handleUseTemplate}
-        detailsDialogHandle={detailsDialogHandle}
-        showMoreOperations={showMoreOperations}
-        openEditModal={openEditModal}
-        handleExportDSL={handleExportDSL}
-        handleDelete={handleDelete}
-      />
+      <Dialog open={showDetailModal} onOpenChange={setShowDetailModal}>
+        <Actions
+          onApplyTemplate={handleUseTemplate}
+          showMoreOperations={showMoreOperations}
+          openEditModal={openEditModal}
+          handleExportDSL={handleExportDSL}
+          handleDelete={handleDelete}
+        />
+        <DialogContent className="h-[calc(100dvh-64px)] max-h-[calc(100dvh-64px)] w-[calc(100vw-2rem)] max-w-[1680px]! overflow-hidden! rounded-3xl border-none p-0 text-left align-middle">
+          <Details
+            id={pipeline.id}
+            type={type}
+            onClose={closeDetailsModal}
+            onApplyTemplate={handleUseTemplate}
+          />
+        </DialogContent>
+      </Dialog>
       {showEditModal && (
         <Dialog
           open={showEditModal}
@@ -189,16 +197,6 @@ const TemplateCard = ({ pipeline, showMoreOperations = true, type }: TemplateCar
           </AlertDialogActions>
         </AlertDialogContent>
       </AlertDialog>
-      <Dialog handle={detailsDialogHandle} open={showDetailModal} onOpenChange={setShowDetailModal}>
-        <DialogContent className="h-[calc(100dvh-64px)] max-h-[calc(100dvh-64px)] w-[calc(100vw-2rem)] max-w-[1680px]! overflow-hidden! rounded-3xl border-none p-0 text-left align-middle">
-          <Details
-            id={pipeline.id}
-            type={type}
-            onClose={closeDetailsModal}
-            onApplyTemplate={handleUseTemplate}
-          />
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/index.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/index.tsx
@@ -8,7 +8,7 @@ import {
   AlertDialogDescription,
   AlertDialogTitle,
 } from '@langgenius/dify-ui/alert-dialog'
-import { Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
+import { createDialogHandle, Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
 import { toast } from '@langgenius/dify-ui/toast'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
@@ -42,6 +42,7 @@ const TemplateCard = ({ pipeline, showMoreOperations = true, type }: TemplateCar
   const [showEditModal, setShowEditModal] = useState(false)
   const [showDeleteConfirm, setShowConfirmDelete] = useState(false)
   const [showDetailModal, setShowDetailModal] = useState(false)
+  const [detailsDialogHandle] = useState(createDialogHandle)
 
   const { refetch: getPipelineTemplateInfo } = usePipelineTemplateById(
     {
@@ -91,10 +92,6 @@ const TemplateCard = ({ pipeline, showMoreOperations = true, type }: TemplateCar
     pipeline.id,
     type,
   ])
-
-  const handleShowTemplateDetails = useCallback(() => {
-    setShowDetailModal(true)
-  }, [])
 
   const openEditModal = useCallback(() => {
     setShowEditModal(true)
@@ -154,7 +151,7 @@ const TemplateCard = ({ pipeline, showMoreOperations = true, type }: TemplateCar
       />
       <Actions
         onApplyTemplate={handleUseTemplate}
-        handleShowTemplateDetails={handleShowTemplateDetails}
+        detailsDialogHandle={detailsDialogHandle}
         showMoreOperations={showMoreOperations}
         openEditModal={openEditModal}
         handleExportDSL={handleExportDSL}
@@ -192,23 +189,16 @@ const TemplateCard = ({ pipeline, showMoreOperations = true, type }: TemplateCar
           </AlertDialogActions>
         </AlertDialogContent>
       </AlertDialog>
-      {showDetailModal && (
-        <Dialog
-          open={showDetailModal}
-          onOpenChange={(open) => {
-            if (!open) closeDetailsModal()
-          }}
-        >
-          <DialogContent className="h-[calc(100dvh-64px)] max-h-[calc(100dvh-64px)] w-[calc(100vw-2rem)] max-w-[1680px]! overflow-hidden! rounded-3xl border-none p-0 text-left align-middle">
-            <Details
-              id={pipeline.id}
-              type={type}
-              onClose={closeDetailsModal}
-              onApplyTemplate={handleUseTemplate}
-            />
-          </DialogContent>
-        </Dialog>
-      )}
+      <Dialog handle={detailsDialogHandle} open={showDetailModal} onOpenChange={setShowDetailModal}>
+        <DialogContent className="h-[calc(100dvh-64px)] max-h-[calc(100dvh-64px)] w-[calc(100vw-2rem)] max-w-[1680px]! overflow-hidden! rounded-3xl border-none p-0 text-left align-middle">
+          <Details
+            id={pipeline.id}
+            type={type}
+            onClose={closeDetailsModal}
+            onApplyTemplate={handleUseTemplate}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/web/app/components/workflow/note-node/note-editor/__tests__/store.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/__tests__/store.spec.tsx
@@ -87,7 +87,7 @@ describe('note editor store', () => {
 
       store.getState().setLinkAnchorElement(link)
       expect(store.getState().linkAnchorElement).toBe(link)
-      expect(store.getState().linkEditorDismissed).toBe(false)
+      expect(store.getState().dismissedLinkKey).toBeNull()
     } finally {
       vi.useRealTimers()
     }

--- a/web/app/components/workflow/note-node/note-editor/__tests__/store.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/__tests__/store.spec.tsx
@@ -69,6 +69,30 @@ describe('note editor store', () => {
     expect(storeResult.current).toBe(store)
   })
 
+  it('keeps a dismissed link closed when an earlier anchor request finishes', () => {
+    vi.useFakeTimers()
+    try {
+      const store = createNoteEditorStore()
+      const link = document.createElement('a')
+      const text = document.createTextNode('Link')
+      link.appendChild(text)
+      vi.spyOn(window, 'getSelection').mockReturnValue({ focusNode: text } as unknown as Selection)
+
+      store.getState().setLinkAnchorElement(true)
+      store.getState().dismissLinkEditor()
+      vi.runAllTimers()
+
+      expect(store.getState().linkAnchorElement).toBeNull()
+      expect(store.getState().linkOperatorShow).toBe(false)
+
+      store.getState().setLinkAnchorElement(link)
+      expect(store.getState().linkAnchorElement).toBe(link)
+      expect(store.getState().linkEditorDismissed).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('throws when the note editor store provider is missing', () => {
     expect(() => renderHook(() => useStore((state) => state.selectedIsBold))).toThrow(
       'Missing NoteEditorContext.Provider in the tree',

--- a/web/app/components/workflow/note-node/note-editor/plugins/format-detector-plugin/__tests__/hooks.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/format-detector-plugin/__tests__/hooks.spec.tsx
@@ -4,6 +4,7 @@ import { useFormatDetector } from '../hooks'
 type MockParent = {
   isLink?: boolean
   getURL?: () => string
+  getKey?: () => string
   isListItem?: boolean
 } | null
 
@@ -16,6 +17,7 @@ const {
   mockSetSelectedIsItalic,
   mockSetSelectedIsStrikeThrough,
   mockSetSelectedLinkUrl,
+  mockSetSelectedLinkKey,
   mockSetSelectedIsLink,
   mockSetSelectedIsBullet,
   mockEditorIsComposing,
@@ -30,12 +32,14 @@ const {
     isLink: false,
     isListItem: false,
     getURL: vi.fn(() => ''),
+    getKey: vi.fn(() => 'link-node'),
     getParent: vi.fn<() => MockParent>(() => null),
   },
   mockSetSelectedIsBold: vi.fn(),
   mockSetSelectedIsItalic: vi.fn(),
   mockSetSelectedIsStrikeThrough: vi.fn(),
   mockSetSelectedLinkUrl: vi.fn(),
+  mockSetSelectedLinkKey: vi.fn(),
   mockSetSelectedIsLink: vi.fn(),
   mockSetSelectedIsBullet: vi.fn(),
   mockEditorIsComposing: vi.fn(() => false),
@@ -93,6 +97,7 @@ vi.mock('../../../store', () => ({
       setSelectedIsItalic: mockSetSelectedIsItalic,
       setSelectedIsStrikeThrough: mockSetSelectedIsStrikeThrough,
       setSelectedLinkUrl: mockSetSelectedLinkUrl,
+      setSelectedLinkKey: mockSetSelectedLinkKey,
       setSelectedIsLink: mockSetSelectedIsLink,
       setSelectedIsBullet: mockSetSelectedIsBullet,
     }),

--- a/web/app/components/workflow/note-node/note-editor/plugins/format-detector-plugin/hooks.ts
+++ b/web/app/components/workflow/note-node/note-editor/plugins/format-detector-plugin/hooks.ts
@@ -25,6 +25,7 @@ export const useFormatDetector = () => {
           setSelectedIsItalic,
           setSelectedIsStrikeThrough,
           setSelectedLinkUrl,
+          setSelectedLinkKey,
           setSelectedIsLink,
           setSelectedIsBullet,
         } = noteEditorStore.getState()
@@ -33,11 +34,13 @@ export const useFormatDetector = () => {
         setSelectedIsStrikeThrough(selection.hasFormat('strikethrough'))
         const parent = node.getParent()
         if ($isLinkNode(parent) || $isLinkNode(node)) {
-          const linkUrl = ($isLinkNode(parent) ? parent : (node as LinkNode)).getURL()
-          setSelectedLinkUrl(linkUrl)
+          const linkNode = $isLinkNode(parent) ? parent : (node as LinkNode)
+          setSelectedLinkUrl(linkNode.getURL())
+          setSelectedLinkKey(linkNode.getKey())
           setSelectedIsLink(true)
         } else {
           setSelectedLinkUrl('')
+          setSelectedLinkKey(null)
           setSelectedIsLink(false)
         }
 

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/component.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/component.spec.tsx
@@ -10,6 +10,7 @@ vi.mock('../hooks', () => ({
   useLink: () => ({
     handleSaveLink: mockHandleSaveLink,
     handleUnlink: mockHandleUnlink,
+    restoreEditorFocus: vi.fn(),
   }),
 }))
 

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
@@ -10,7 +10,7 @@ import Editor from '../../../editor'
 import { createNoteEditorStore } from '../../../store'
 import theme from '../../../theme'
 
-function Harness() {
+function Harness({ secondLinkUrl }: { secondLinkUrl?: string }) {
   const [store] = useState(createNoteEditorStore)
   const [container, setContainer] = useState<HTMLDivElement | null>(null)
 
@@ -24,11 +24,16 @@ function Harness() {
           throw error
         },
         editorState: () => {
-          $getRoot().append(
-            $createParagraphNode().append(
-              $createLinkNode('https://example.com').append($createTextNode('hello')),
-            ),
+          const paragraph = $createParagraphNode().append(
+            $createLinkNode('https://example.com').append($createTextNode('hello')),
           )
+          if (secondLinkUrl) {
+            paragraph.append(
+              $createTextNode(' '),
+              $createLinkNode(secondLinkUrl).append($createTextNode('world')),
+            )
+          }
+          $getRoot().append(paragraph)
         },
       }}
     >
@@ -154,5 +159,27 @@ it.each(['{Enter}', '{Space}'])(
     await expect.element(note).toHaveFocus()
     await userEvent.keyboard('X')
     await expect.element(note).toHaveTextContent('heXllo')
+  },
+)
+
+it.each(['https://second.example.com', 'https://example.com'])(
+  'opens a different link after dismissing the first when its URL is %s',
+  async (secondLinkUrl) => {
+    await render(<Harness secondLinkUrl={secondLinkUrl} />)
+    const note = page.getByRole('region', { name: 'Note editor' }).getByRole('textbox')
+    const openLink = page.getByRole('link', { name: /workflow.nodes.note.editor.openLink/ })
+    await expect.element(page.getByRole('link', { name: 'hello', exact: true })).toBeVisible()
+    await expect.element(page.getByRole('link', { name: 'world', exact: true })).toBeVisible()
+    await note.click()
+    await userEvent.keyboard('{Home}{ArrowRight}')
+    await page.getByRole('button', { name: 'common.operation.edit', exact: true }).click()
+    await userEvent.keyboard('{Escape}')
+    await expect.element(note).toHaveFocus()
+    await expect.element(openLink).not.toBeInTheDocument()
+
+    await userEvent.keyboard('{End}{ArrowLeft}')
+
+    await expect.element(openLink).toBeVisible()
+    await expect.element(openLink).toHaveAttribute('href', secondLinkUrl)
   },
 )

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
@@ -34,7 +34,9 @@ function Harness() {
     >
       <NoteEditorContext value={store}>
         <div ref={setContainer} style={{ padding: 100 }}>
-          <Editor containerElement={container} />
+          <section aria-label="Note editor">
+            <Editor containerElement={container} />
+          </section>
           <button type="button" style={{ display: 'block', marginTop: 100 }}>
             Outside action
           </button>
@@ -45,20 +47,51 @@ function Harness() {
 }
 
 // Chromium owns contenteditable selection and the native input that follows focus restoration.
-it('resumes typing at the saved note selection after cancelling link editing', async () => {
-  await render(<Harness />)
-  const note = page.getByRole('textbox', { name: '' })
-  await note.click()
-  await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
-  await page.getByRole('button', { name: 'common.operation.edit', exact: true }).click()
-  await expect.element(page.getByPlaceholder('workflow.nodes.note.editor.enterUrl')).toHaveFocus()
+it.each(['URL input', 'confirm button', 'toolbar edit button'])(
+  'dismisses the entire link popup with Escape from the %s until explicitly reopened',
+  async (target) => {
+    await render(<Harness />)
+    const note = page.getByRole('region', { name: 'Note editor' }).getByRole('textbox')
+    const edit = page.getByRole('button', { name: 'common.operation.edit', exact: true })
+    const openLink = page.getByRole('link', { name: /workflow.nodes.note.editor.openLink/ })
+    const urlInput = page.getByPlaceholder('workflow.nodes.note.editor.enterUrl')
+    await note.click()
+    await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
 
-  await userEvent.keyboard('{Escape}')
+    if (target === 'toolbar edit button') {
+      await expect.element(openLink).toBeVisible()
+      ;(openLink.element() as HTMLAnchorElement).focus()
+      await userEvent.keyboard('{Tab}')
+      await expect.element(edit).toHaveFocus()
+    } else {
+      await edit.click()
+      await expect.element(urlInput).toHaveFocus()
+      if (target === 'confirm button') {
+        await userEvent.keyboard('{Tab}')
+        await expect
+          .element(page.getByRole('button', { name: 'common.operation.ok' }))
+          .toHaveFocus()
+      }
+    }
 
-  await expect.element(note).toHaveFocus()
-  await userEvent.keyboard('X')
-  await expect.element(note).toHaveTextContent('heXllo')
-})
+    await userEvent.keyboard('{Escape}')
+
+    await expect.element(note).toHaveFocus()
+    await expect.element(urlInput).not.toBeInTheDocument()
+    await expect.element(openLink).not.toBeInTheDocument()
+    await expect.element(edit).not.toBeInTheDocument()
+    await userEvent.keyboard('X')
+    await expect.element(note).toHaveTextContent('heXllo')
+    await expect.element(urlInput).not.toBeInTheDocument()
+    await expect.element(openLink).not.toBeInTheDocument()
+    await expect.element(edit).not.toBeInTheDocument()
+
+    await page.getByRole('link', { name: 'heXllo' }).click()
+
+    await expect.element(openLink).toBeVisible()
+    await expect.element(edit).toBeVisible()
+  },
+)
 
 it('keeps focus on the outside action when it dismisses link editing', async () => {
   await render(<Harness />)
@@ -77,7 +110,7 @@ it('keeps focus on the outside action when it dismisses link editing', async () 
 // Native button activation and sequential focus navigation must preserve the Lexical selection.
 it.each(['{Enter}', '{Space}'])('opens link editing with %s from the keyboard', async (key) => {
   await render(<Harness />)
-  const note = page.getByRole('textbox', { name: '' })
+  const note = page.getByRole('region', { name: 'Note editor' }).getByRole('textbox')
   await note.click()
   await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
   const openLink = page.getByRole('link', { name: /workflow.nodes.note.editor.openLink/ })
@@ -104,7 +137,7 @@ it.each(['{Enter}', '{Space}'])(
   'removes the selected link with %s from the keyboard',
   async (key) => {
     await render(<Harness />)
-    const note = page.getByRole('textbox', { name: '' })
+    const note = page.getByRole('region', { name: 'Note editor' }).getByRole('textbox')
     await note.click()
     await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
     const openLink = page.getByRole('link', { name: /workflow.nodes.note.editor.openLink/ })

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
@@ -1,0 +1,75 @@
+import { $createLinkNode, LinkNode } from '@lexical/link'
+import { ListItemNode, ListNode } from '@lexical/list'
+import { LexicalComposer } from '@lexical/react/LexicalComposer'
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical'
+import { useState } from 'react'
+import { page, userEvent } from 'vite-plus/test/browser'
+import { render } from 'vitest-browser-react'
+import NoteEditorContext from '../../../context'
+import Editor from '../../../editor'
+import { createNoteEditorStore } from '../../../store'
+import theme from '../../../theme'
+
+function Harness() {
+  const [store] = useState(createNoteEditorStore)
+  const [container, setContainer] = useState<HTMLDivElement | null>(null)
+
+  return (
+    <LexicalComposer
+      initialConfig={{
+        namespace: 'link-focus-test',
+        nodes: [LinkNode, ListNode, ListItemNode],
+        theme,
+        onError: (error) => {
+          throw error
+        },
+        editorState: () => {
+          $getRoot().append(
+            $createParagraphNode().append(
+              $createLinkNode('https://example.com').append($createTextNode('hello')),
+            ),
+          )
+        },
+      }}
+    >
+      <NoteEditorContext value={store}>
+        <div ref={setContainer} style={{ padding: 100 }}>
+          <Editor containerElement={container} />
+          <button type="button" style={{ display: 'block', marginTop: 100 }}>
+            Outside action
+          </button>
+        </div>
+      </NoteEditorContext>
+    </LexicalComposer>
+  )
+}
+
+// Chromium owns contenteditable selection and the native input that follows focus restoration.
+it('resumes typing at the saved note selection after cancelling link editing', async () => {
+  await render(<Harness />)
+  const note = page.getByRole('textbox', { name: '' })
+  await note.click()
+  await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
+  await page.getByText('common.operation.edit', { exact: true }).click()
+  await expect.element(page.getByPlaceholder('workflow.nodes.note.editor.enterUrl')).toHaveFocus()
+
+  await userEvent.keyboard('{Escape}')
+
+  await expect.element(note).toHaveFocus()
+  await userEvent.keyboard('X')
+  await expect.element(note).toHaveTextContent('heXllo')
+})
+
+it('keeps focus on the outside action when it dismisses link editing', async () => {
+  await render(<Harness />)
+  await page.getByRole('link', { name: 'hello' }).click()
+  await page.getByText('common.operation.edit', { exact: true }).click()
+  const outside = page.getByRole('button', { name: 'Outside action' })
+
+  await outside.click()
+
+  await expect
+    .element(page.getByPlaceholder('workflow.nodes.note.editor.enterUrl'))
+    .not.toBeInTheDocument()
+  await expect.element(outside).toHaveFocus()
+})

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/__tests__/focus.browser.spec.tsx
@@ -50,7 +50,7 @@ it('resumes typing at the saved note selection after cancelling link editing', a
   const note = page.getByRole('textbox', { name: '' })
   await note.click()
   await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
-  await page.getByText('common.operation.edit', { exact: true }).click()
+  await page.getByRole('button', { name: 'common.operation.edit', exact: true }).click()
   await expect.element(page.getByPlaceholder('workflow.nodes.note.editor.enterUrl')).toHaveFocus()
 
   await userEvent.keyboard('{Escape}')
@@ -63,7 +63,7 @@ it('resumes typing at the saved note selection after cancelling link editing', a
 it('keeps focus on the outside action when it dismisses link editing', async () => {
   await render(<Harness />)
   await page.getByRole('link', { name: 'hello' }).click()
-  await page.getByText('common.operation.edit', { exact: true }).click()
+  await page.getByRole('button', { name: 'common.operation.edit', exact: true }).click()
   const outside = page.getByRole('button', { name: 'Outside action' })
 
   await outside.click()
@@ -73,3 +73,53 @@ it('keeps focus on the outside action when it dismisses link editing', async () 
     .not.toBeInTheDocument()
   await expect.element(outside).toHaveFocus()
 })
+
+// Native button activation and sequential focus navigation must preserve the Lexical selection.
+it.each(['{Enter}', '{Space}'])('opens link editing with %s from the keyboard', async (key) => {
+  await render(<Harness />)
+  const note = page.getByRole('textbox', { name: '' })
+  await note.click()
+  await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
+  const openLink = page.getByRole('link', { name: /workflow.nodes.note.editor.openLink/ })
+  await expect.element(openLink).toBeVisible()
+  ;(openLink.element() as HTMLAnchorElement).focus()
+  await userEvent.keyboard('{Tab}')
+  const edit = page.getByRole('button', { name: 'common.operation.edit', exact: true })
+  await expect.element(edit).toHaveFocus()
+  await userEvent.keyboard('{Tab}')
+  await expect
+    .element(page.getByRole('button', { name: 'workflow.nodes.note.editor.unlink' }))
+    .toHaveFocus()
+  await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+  await expect.element(edit).toHaveFocus()
+
+  await userEvent.keyboard(key)
+
+  await expect.element(page.getByPlaceholder('workflow.nodes.note.editor.enterUrl')).toHaveFocus()
+  await userEvent.keyboard('{Escape}X')
+  await expect.element(note).toHaveTextContent('heXllo')
+})
+
+it.each(['{Enter}', '{Space}'])(
+  'removes the selected link with %s from the keyboard',
+  async (key) => {
+    await render(<Harness />)
+    const note = page.getByRole('textbox', { name: '' })
+    await note.click()
+    await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}')
+    const openLink = page.getByRole('link', { name: /workflow.nodes.note.editor.openLink/ })
+    await expect.element(openLink).toBeVisible()
+    ;(openLink.element() as HTMLAnchorElement).focus()
+    await userEvent.keyboard('{Tab}{Tab}')
+    await expect
+      .element(page.getByRole('button', { name: 'workflow.nodes.note.editor.unlink' }))
+      .toHaveFocus()
+
+    await userEvent.keyboard(key)
+
+    await expect.element(page.getByRole('link', { name: 'hello' })).not.toBeInTheDocument()
+    await expect.element(note).toHaveFocus()
+    await userEvent.keyboard('X')
+    await expect.element(note).toHaveTextContent('heXllo')
+  },
+)

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
@@ -1,4 +1,12 @@
-import { flip, FloatingPortal, offset, shift, useFloating } from '@floating-ui/react'
+import {
+  flip,
+  FloatingPortal,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useInteractions,
+} from '@floating-ui/react'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { RiExternalLinkLine } from '@remixicon/react'
@@ -18,24 +26,31 @@ const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => 
   const selectedLinkUrl = useStore((s) => s.selectedLinkUrl)
   const linkAnchorElement = useStore((s) => s.linkAnchorElement)
   const linkOperatorShow = useStore((s) => s.linkOperatorShow)
-  const setLinkAnchorElement = useStore((s) => s.setLinkAnchorElement)
+  const dismissLinkEditor = useStore((s) => s.dismissLinkEditor)
   const setLinkOperatorShow = useStore((s) => s.setLinkOperatorShow)
   const [url, setUrl] = useState(selectedLinkUrl)
   const floatingRef = useRef<HTMLDivElement | null>(null)
-  const { refs, floatingStyles, elements } = useFloating({
-    placement: 'top',
-    middleware: [offset(4), shift(), flip()],
-  })
-
   const handleCancelLinkEdit = useCallback(() => {
     if (!linkOperatorShow && !selectedLinkUrl) {
       handleUnlink()
       return
     }
 
-    setLinkAnchorElement()
-    setLinkOperatorShow(false)
-  }, [handleUnlink, linkOperatorShow, selectedLinkUrl, setLinkAnchorElement, setLinkOperatorShow])
+    dismissLinkEditor()
+  }, [handleUnlink, linkOperatorShow, selectedLinkUrl, dismissLinkEditor])
+
+  const { refs, floatingStyles, elements, context } = useFloating({
+    open: !!linkAnchorElement,
+    onOpenChange: (open, _event, reason) => {
+      if (open) return
+      handleCancelLinkEdit()
+      if (reason === 'escape-key') restoreEditorFocus()
+    },
+    placement: 'top',
+    middleware: [offset(4), shift(), flip()],
+  })
+  const dismiss = useDismiss(context, { outsidePress: false })
+  const { getFloatingProps } = useInteractions([dismiss])
 
   useClickAway(() => {
     handleCancelLinkEdit()
@@ -54,6 +69,7 @@ const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => 
       {elements.reference && (
         <FloatingPortal root={containerElement}>
           <div
+            {...getFloatingProps()}
             className={cn(
               'nodrag nopan z-10 inline-flex w-max items-center rounded-md border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg',
               !linkOperatorShow && 'p-1 shadow-md',
@@ -76,14 +92,6 @@ const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => 
                       e.preventDefault()
                       e.stopPropagation()
                       if (url) handleSaveLink(url)
-                      return
-                    }
-
-                    if (e.key === 'Escape') {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      handleCancelLinkEdit()
-                      restoreEditorFocus()
                     }
                   }}
                   placeholder={t(($) => $['nodes.note.editor.enterUrl'], { ns: 'workflow' }) || ''}

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
@@ -14,7 +14,7 @@ type LinkEditorComponentProps = {
 }
 const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => {
   const { t } = useTranslation()
-  const { handleSaveLink, handleUnlink } = useLink()
+  const { handleSaveLink, handleUnlink, restoreEditorFocus } = useLink()
   const selectedLinkUrl = useStore((s) => s.selectedLinkUrl)
   const linkAnchorElement = useStore((s) => s.linkAnchorElement)
   const linkOperatorShow = useStore((s) => s.linkOperatorShow)
@@ -83,6 +83,7 @@ const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => 
                       e.preventDefault()
                       e.stopPropagation()
                       handleCancelLinkEdit()
+                      restoreEditorFocus()
                     }
                   }}
                   placeholder={t(($) => $['nodes.note.editor.enterUrl'], { ns: 'workflow' }) || ''}

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/component.tsx
@@ -1,7 +1,7 @@
 import { flip, FloatingPortal, offset, shift, useFloating } from '@floating-ui/react'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { RiEditLine, RiExternalLinkLine, RiLinkUnlinkM } from '@remixicon/react'
+import { RiExternalLinkLine } from '@remixicon/react'
 import { useClickAway } from 'ahooks'
 import { escape } from 'es-toolkit/string'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
@@ -116,23 +116,27 @@ const LinkEditorComponent = ({ containerElement }: LinkEditorComponentProps) => 
                   </div>
                 </a>
                 <div className="mx-1 h-3.5 w-px bg-divider-regular"></div>
-                <div
-                  className="mr-0.5 flex h-6 cursor-pointer items-center rounded-md px-2 hover:bg-state-base-hover"
+                <Button
+                  variant="ghost"
+                  size="small"
+                  className="mr-0.5 px-2 text-text-tertiary"
                   onClick={(e) => {
                     e.stopPropagation()
                     setLinkOperatorShow(false)
                   }}
                 >
-                  <RiEditLine className="mr-1 size-3" />
+                  <span aria-hidden className="i-ri-edit-line size-3" />
                   {t(($) => $['operation.edit'], { ns: 'common' })}
-                </div>
-                <div
-                  className="flex h-6 cursor-pointer items-center rounded-md px-2 hover:bg-state-base-hover"
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="small"
+                  className="px-2 text-text-tertiary"
                   onClick={handleUnlink}
                 >
-                  <RiLinkUnlinkM className="mr-1 size-3" />
+                  <span aria-hidden className="i-ri-link-unlink-m size-3" />
                   {t(($) => $['nodes.note.editor.unlink'], { ns: 'workflow' })}
-                </div>
+                </Button>
               </>
             )}
           </div>

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/hooks.ts
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/hooks.ts
@@ -22,9 +22,16 @@ export const useOpenLink = () => {
     return mergeRegister(
       editor.registerUpdateListener(() => {
         setTimeout(() => {
-          const { selectedLinkUrl, selectedIsLink, setLinkAnchorElement, setLinkOperatorShow } =
-            noteEditorStore.getState()
+          const {
+            selectedLinkUrl,
+            selectedIsLink,
+            linkEditorDismissed,
+            setLinkAnchorElement,
+            setLinkOperatorShow,
+          } = noteEditorStore.getState()
           if (selectedIsLink) {
+            // Restoring the editor selection must not reopen a dismissed surface.
+            if (linkEditorDismissed) return
             setLinkAnchorElement(true)
             if (selectedLinkUrl) setLinkOperatorShow(true)
             else setLinkOperatorShow(false)

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/hooks.ts
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/hooks.ts
@@ -103,8 +103,12 @@ export const useLink = () => {
     const { setLinkAnchorElement } = noteEditorStore.getState()
     setLinkAnchorElement()
   }, [editor, noteEditorStore])
+  const restoreEditorFocus = useCallback(() => {
+    editor.focus()
+  }, [editor])
   return {
     handleSaveLink,
     handleUnlink,
+    restoreEditorFocus,
   }
 }

--- a/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/hooks.ts
+++ b/web/app/components/workflow/note-node/note-editor/plugins/link-editor-plugin/hooks.ts
@@ -25,13 +25,14 @@ export const useOpenLink = () => {
           const {
             selectedLinkUrl,
             selectedIsLink,
-            linkEditorDismissed,
+            selectedLinkKey,
+            dismissedLinkKey,
             setLinkAnchorElement,
             setLinkOperatorShow,
           } = noteEditorStore.getState()
           if (selectedIsLink) {
             // Restoring the editor selection must not reopen a dismissed surface.
-            if (linkEditorDismissed) return
+            if (dismissedLinkKey && dismissedLinkKey === selectedLinkKey) return
             setLinkAnchorElement(true)
             if (selectedLinkUrl) setLinkOperatorShow(true)
             else setLinkOperatorShow(false)

--- a/web/app/components/workflow/note-node/note-editor/store.ts
+++ b/web/app/components/workflow/note-node/note-editor/store.ts
@@ -5,6 +5,8 @@ import NoteEditorContext from './context'
 
 type Shape = {
   linkAnchorElement: HTMLElement | null
+  linkEditorDismissed: boolean
+  dismissLinkEditor: () => void
   setLinkAnchorElement: (open?: boolean | HTMLElement | null) => void
   linkOperatorShow: boolean
   setLinkOperatorShow: (linkOperatorShow: boolean) => void
@@ -23,16 +25,24 @@ type Shape = {
 }
 
 export const createNoteEditorStore = () => {
+  let pendingAnchor: ReturnType<typeof setTimeout> | undefined
   return createStore<Shape>((set) => ({
     linkAnchorElement: null,
+    linkEditorDismissed: false,
+    dismissLinkEditor: () => {
+      clearTimeout(pendingAnchor)
+      set({ linkAnchorElement: null, linkOperatorShow: false, linkEditorDismissed: true })
+    },
     setLinkAnchorElement: (open) => {
+      clearTimeout(pendingAnchor)
       if (open instanceof HTMLElement) {
-        set(() => ({ linkAnchorElement: open }))
+        set({ linkAnchorElement: open, linkEditorDismissed: false })
         return
       }
 
       if (open) {
-        setTimeout(() => {
+        set({ linkEditorDismissed: false })
+        pendingAnchor = setTimeout(() => {
           const nativeSelection = window.getSelection()
 
           if (nativeSelection?.focusNode) {
@@ -41,7 +51,7 @@ export const createNoteEditorStore = () => {
           }
         })
       } else {
-        set(() => ({ linkAnchorElement: null }))
+        set({ linkAnchorElement: null, linkEditorDismissed: false })
       }
     },
     linkOperatorShow: false,

--- a/web/app/components/workflow/note-node/note-editor/store.ts
+++ b/web/app/components/workflow/note-node/note-editor/store.ts
@@ -1,3 +1,4 @@
+import type { NodeKey } from 'lexical'
 import { use } from 'react'
 import { useStore as useZustandStore } from 'zustand'
 import { createStore } from 'zustand/vanilla'
@@ -5,7 +6,7 @@ import NoteEditorContext from './context'
 
 type Shape = {
   linkAnchorElement: HTMLElement | null
-  linkEditorDismissed: boolean
+  dismissedLinkKey: NodeKey | null
   dismissLinkEditor: () => void
   setLinkAnchorElement: (open?: boolean | HTMLElement | null) => void
   linkOperatorShow: boolean
@@ -17,6 +18,8 @@ type Shape = {
   selectedIsStrikeThrough: boolean
   setSelectedIsStrikeThrough: (selectedIsStrikeThrough: boolean) => void
   selectedLinkUrl: string
+  selectedLinkKey: NodeKey | null
+  setSelectedLinkKey: (selectedLinkKey: NodeKey | null) => void
   setSelectedLinkUrl: (selectedLinkUrl: string) => void
   selectedIsLink: boolean
   setSelectedIsLink: (selectedIsLink: boolean) => void
@@ -26,22 +29,26 @@ type Shape = {
 
 export const createNoteEditorStore = () => {
   let pendingAnchor: ReturnType<typeof setTimeout> | undefined
-  return createStore<Shape>((set) => ({
+  return createStore<Shape>((set, get) => ({
     linkAnchorElement: null,
-    linkEditorDismissed: false,
+    dismissedLinkKey: null,
     dismissLinkEditor: () => {
       clearTimeout(pendingAnchor)
-      set({ linkAnchorElement: null, linkOperatorShow: false, linkEditorDismissed: true })
+      set({
+        linkAnchorElement: null,
+        linkOperatorShow: false,
+        dismissedLinkKey: get().selectedLinkKey,
+      })
     },
     setLinkAnchorElement: (open) => {
       clearTimeout(pendingAnchor)
       if (open instanceof HTMLElement) {
-        set({ linkAnchorElement: open, linkEditorDismissed: false })
+        set({ linkAnchorElement: open, dismissedLinkKey: null })
         return
       }
 
       if (open) {
-        set({ linkEditorDismissed: false })
+        set({ dismissedLinkKey: null })
         pendingAnchor = setTimeout(() => {
           const nativeSelection = window.getSelection()
 
@@ -51,7 +58,7 @@ export const createNoteEditorStore = () => {
           }
         })
       } else {
-        set({ linkAnchorElement: null, linkEditorDismissed: false })
+        set({ linkAnchorElement: null, dismissedLinkKey: null })
       }
     },
     linkOperatorShow: false,
@@ -64,6 +71,13 @@ export const createNoteEditorStore = () => {
     setSelectedIsStrikeThrough: (selectedIsStrikeThrough) =>
       set(() => ({ selectedIsStrikeThrough })),
     selectedLinkUrl: '',
+    selectedLinkKey: null,
+    setSelectedLinkKey: (selectedLinkKey) =>
+      set((state) => ({
+        selectedLinkKey,
+        dismissedLinkKey:
+          selectedLinkKey === state.dismissedLinkKey ? state.dismissedLinkKey : null,
+      })),
     setSelectedLinkUrl: (selectedLinkUrl) => set(() => ({ selectedLinkUrl })),
     selectedIsLink: false,
     setSelectedIsLink: (selectedIsLink) => set(() => ({ selectedIsLink })),


### PR DESCRIPTION
## Summary

Fixes [SNP-776](https://linear.app/dify/issue/SNP-776/修复关闭弹窗后焦点没有恢复).

Closing several overlays could leave focus on the page body or an unrelated control. For example, opening feedback or template details and moving the pointer away hid the button that should receive focus on close.

- Connect template details and chat feedback to the existing Dialog through DialogTrigger. Keep their actions keyboard-accessible and visible when focused, and restore feedback focus to the replacement rating button after submission.
- Connect both workflow and conversation log details to DrawerTrigger buttons while preserving whole-row clicks, URL state, and refresh behavior.
- Restore the Lexical editor's focus and saved selection after Escape cancels note-link editing, while preserving focus on outside controls when they dismiss the editor.

## Validation

- 165 focused unit tests passed.
- 7 Chromium tests passed, covering rendered visibility, keyboard access, cancellation, feedback submission, and typing at the restored note selection.
- Changed-file formatting, lint, and type checks passed.
- Repository-wide `vp check --no-fmt` and `vp run lint:eslint` passed with existing warnings.
- Full `vp run -w check` stops on an existing formatting issue in the unchanged `web/app/device/page.tsx`.

## Checklist

- [x] Linked the issue describing the change.
- [x] Added regression coverage for the changed behavior.
- [x] Frontend staged checks passed.
- [ ] Documentation update required (not applicable: no API or setup changes).

From Codex