### PR TITLE
refactor(web): migrate conversation variable inputs

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4708,14 +4708,6 @@
       "count": 2
     }
   },
-  "web/app/components/workflow/panel/chat-variable-panel/components/array-value-list.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "typescript/no-explicit-any": {
-      "count": 4
-    }
-  },
   "web/app/components/workflow/panel/chat-variable-panel/components/object-value-item.tsx": {
     "react/only-export-components": {
       "count": 1
@@ -4732,11 +4724,6 @@
   "web/app/components/workflow/panel/chat-variable-panel/components/variable-item.tsx": {
     "jsx-a11y/mouse-events-have-key-events": {
       "count": 2
-    }
-  },
-  "web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.sections.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.tsx": {

--- a/web/app/components/workflow/panel/chat-variable-panel/components/__tests__/array-value-list.spec.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/__tests__/array-value-list.spec.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import ArrayValueList from '../array-value-list'
 
 describe('ArrayValueList', () => {
@@ -10,24 +11,48 @@ describe('ArrayValueList', () => {
       <ArrayValueList isString list={['alpha', 'beta']} onChange={onChange} />,
     )
 
-    fireEvent.change(screen.getByDisplayValue('alpha'), { target: { value: 'updated' } })
+    await user.type(
+      screen.getByRole('textbox', { name: 'workflow.chatVariable.modal.arrayValue 1' }),
+      'x',
+    )
     await user.click(screen.getByText('workflow.chatVariable.modal.addArrayValue'))
     await user.click(container.querySelector('button') as HTMLButtonElement)
 
-    expect(onChange).toHaveBeenNthCalledWith(1, ['updated', 'beta'])
+    expect(onChange).toHaveBeenNthCalledWith(1, ['alphax', 'beta'])
     expect(onChange).toHaveBeenNthCalledWith(2, ['alpha', 'beta', undefined])
     expect(onChange).toHaveBeenNthCalledWith(3, ['beta'])
   })
 
-  it('coerces number inputs and appends an undefined slot', async () => {
+  it('edits decimal numbers and keeps cleared rows empty instead of converting them to zero', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<ArrayValueList isString={false} list={[1]} onChange={onChange} />)
+    function NumericArray() {
+      const [list, setList] = useState<Array<string | number | undefined>>([1])
+      return (
+        <ArrayValueList
+          isString={false}
+          list={list}
+          onChange={(value) => {
+            setList(value)
+            onChange(value)
+          }}
+        />
+      )
+    }
+    render(<NumericArray />)
 
-    fireEvent.change(screen.getByDisplayValue('1'), { target: { value: '7' } })
+    const input = screen.getByRole('textbox', { name: 'workflow.chatVariable.modal.arrayValue 1' })
+    await user.clear(input)
+    await user.type(input, '-7.123456')
+    await user.tab()
+    expect(onChange).toHaveBeenLastCalledWith([-7.123456])
+    expect(input).toHaveValue('-7.123456')
+    await user.clear(input)
+    await user.tab()
+    expect(input).toHaveValue('')
+    expect(onChange).toHaveBeenLastCalledWith([undefined])
     await user.click(screen.getByText('workflow.chatVariable.modal.addArrayValue'))
 
-    expect(onChange).toHaveBeenNthCalledWith(1, [7])
-    expect(onChange).toHaveBeenNthCalledWith(2, [1, undefined])
+    expect(onChange).toHaveBeenLastCalledWith([undefined, undefined])
   })
 })

--- a/web/app/components/workflow/panel/chat-variable-panel/components/__tests__/variable-modal.spec.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/__tests__/variable-modal.spec.tsx
@@ -193,7 +193,7 @@ describe('variable-modal', () => {
     fireEvent.change(input, { target: { value: '1bad' } })
     await userEvent.click(screen.getByText('common.operation.save'))
 
-    expect(input.value).toBe('')
+    expect(input).toHaveValue('')
     expect(mockToastError).toHaveBeenCalled()
     expect(onSave).not.toHaveBeenCalled()
   })
@@ -235,9 +235,9 @@ describe('variable-modal', () => {
       },
     })
 
-    const input = screen.getByDisplayValue('3') as HTMLInputElement
+    const input = screen.getByRole('textbox', { name: 'workflow.chatVariable.modal.value' })
     await user.clear(input)
 
-    expect(input.value).toBe('')
+    expect(input).toHaveValue('')
   })
 })

--- a/web/app/components/workflow/panel/chat-variable-panel/components/array-value-list.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/array-value-list.tsx
@@ -1,33 +1,34 @@
 'use client'
 import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
+import { Input } from '@langgenius/dify-ui/input'
+import { NumberField, NumberFieldGroup, NumberFieldInput } from '@langgenius/dify-ui/number-field'
 import { RiAddLine } from '@remixicon/react'
 import { produce } from 'immer'
 import * as React from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import RemoveButton from '@/app/components/workflow/nodes/_base/components/remove-button'
 
 type Props = Readonly<{
   isString: boolean
-  list: any[]
-  onChange: (list: any[]) => void
+  list: Array<string | number | undefined>
+  onChange: (list: Array<string | number | undefined>) => void
 }>
 
 const ArrayValueList: FC<Props> = ({ isString = true, list, onChange }) => {
   const { t } = useTranslation()
 
-  const handleNameChange = useCallback(
+  const handleValueChange = useCallback(
     (index: number) => {
-      return (e: React.ChangeEvent<HTMLInputElement>) => {
-        const newList = produce(list, (draft: any[]) => {
-          draft[index] = isString ? e.target.value : Number(e.target.value)
+      return (value: string | number | undefined) => {
+        const newList = produce(list, (draft) => {
+          draft[index] = value
         })
         onChange(newList)
       }
     },
-    [isString, list, onChange],
+    [list, onChange],
   )
 
   const handleItemRemove = useCallback(
@@ -43,7 +44,7 @@ const ArrayValueList: FC<Props> = ({ isString = true, list, onChange }) => {
   )
 
   const handleItemAdd = useCallback(() => {
-    const newList = produce(list, (draft: any[]) => {
+    const newList = produce(list, (draft) => {
       draft.push(undefined)
     })
     onChange(newList)
@@ -52,13 +53,31 @@ const ArrayValueList: FC<Props> = ({ isString = true, list, onChange }) => {
   return (
     <div className="w-full space-y-2">
       {list.map((item, index) => (
-        <div className="flex items-center space-x-1" key={index}>
-          <Input
-            placeholder={t(($) => $['chatVariable.modal.arrayValue'], { ns: 'workflow' }) || ''}
-            value={list[index]}
-            onChange={handleNameChange(index)}
-            type={isString ? 'text' : 'number'}
-          />
+        <div className="flex items-center gap-1" key={index}>
+          {isString ? (
+            <Input
+              className="min-w-0 flex-1"
+              aria-label={`${t(($) => $['chatVariable.modal.arrayValue'], { ns: 'workflow' })} ${index + 1}`}
+              placeholder={t(($) => $['chatVariable.modal.arrayValue'], { ns: 'workflow' })}
+              value={typeof item === 'string' ? item : ''}
+              onValueChange={handleValueChange(index)}
+            />
+          ) : (
+            <NumberField
+              format={{ maximumSignificantDigits: 21, useGrouping: false }}
+              className="min-w-0 flex-1"
+              value={typeof item === 'number' ? item : null}
+              onValueChange={(value) => handleValueChange(index)(value ?? undefined)}
+            >
+              <NumberFieldGroup>
+                <NumberFieldInput
+                  inputMode="decimal"
+                  aria-label={`${t(($) => $['chatVariable.modal.arrayValue'], { ns: 'workflow' })} ${index + 1}`}
+                  placeholder={t(($) => $['chatVariable.modal.arrayValue'], { ns: 'workflow' })}
+                />
+              </NumberFieldGroup>
+            </NumberField>
+          )}
           <RemoveButton
             className="bg-gray-100! p-2! hover:bg-gray-200!"
             onClick={handleItemRemove(index)}
@@ -66,7 +85,7 @@ const ArrayValueList: FC<Props> = ({ isString = true, list, onChange }) => {
         </div>
       ))}
       <Button variant="tertiary" className="w-full" onClick={handleItemAdd}>
-        <RiAddLine className="size-4" />
+        <RiAddLine className="size-4" aria-hidden />
         <span>{t(($) => $['chatVariable.modal.addArrayValue'], { ns: 'workflow' })}</span>
       </Button>
     </div>

--- a/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.sections.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.sections.tsx
@@ -7,8 +7,11 @@ import type {
 } from './variable-modal.helpers'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Field, FieldLabel } from '@langgenius/dify-ui/field'
+import { Input } from '@langgenius/dify-ui/input'
+import { NumberField, NumberFieldGroup, NumberFieldInput } from '@langgenius/dify-ui/number-field'
 import { RiDraftLine, RiInputField } from '@remixicon/react'
-import Input from '@/app/components/base/input'
+import { useId } from 'react'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import { ChatVarType } from '../type'
@@ -43,18 +46,16 @@ type NameSectionProps = {
 }
 
 export const NameSection = ({ name, onBlur, onChange, placeholder, title }: NameSectionProps) => (
-  <div className="mb-4">
-    <SectionTitle>{title}</SectionTitle>
-    <div className="flex">
-      <Input
-        placeholder={placeholder}
-        value={name}
-        onChange={onChange}
-        onBlur={(e) => onBlur(e.target.value)}
-        type="text"
-      />
-    </div>
-  </div>
+  <Field className="mb-4">
+    <FieldLabel className="system-sm-semibold">{title}</FieldLabel>
+    <Input
+      placeholder={placeholder}
+      value={name}
+      onChange={onChange}
+      onBlur={(e) => onBlur(e.target.value)}
+      type="text"
+    />
+  </Field>
 )
 
 type TypeSectionProps = {
@@ -112,87 +113,103 @@ export const ValueSection = ({
   toggleLabelKey,
   type,
   value,
-}: ValueSectionProps) => (
-  <div className="mb-4">
-    <div className="mb-1 flex h-6 items-center justify-between system-sm-semibold text-text-secondary">
-      <div>{t(($) => $['chatVariable.modal.value'], { ns: 'workflow' })}</div>
-      {toggleLabelKey && (
-        <Button
-          variant="ghost"
-          size="small"
-          className="text-text-tertiary"
-          onClick={() => onEditorChange(!editInJSON)}
-        >
-          {editInJSON ? (
-            <RiInputField className="size-3.5" />
-          ) : (
-            <RiDraftLine className="size-3.5" />
-          )}
-          {t(editorToggleLabelSelectors[toggleLabelKey], { ns: 'workflow' })}
-        </Button>
-      )}
-    </div>
-    <div className="flex">
-      {type === ChatVarType.String && (
-        <textarea
-          className="block h-20 w-full resize-none appearance-none rounded-lg border border-transparent bg-components-input-bg-normal p-2 system-sm-regular text-components-input-text-filled caret-primary-600 outline-hidden placeholder:system-sm-regular placeholder:text-components-input-text-placeholder hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs"
-          value={(value as string) || ''}
-          placeholder={t(($) => $['chatVariable.modal.valuePlaceholder'], { ns: 'workflow' }) || ''}
-          onChange={(e) => onArrayChange([e.target.value])}
-        />
-      )}
-      {type === ChatVarType.Number && (
-        <Input
-          placeholder={t(($) => $['chatVariable.modal.valuePlaceholder'], { ns: 'workflow' }) || ''}
-          value={value as number | undefined}
-          onChange={(e) => {
-            const rawValue = e.target.value
-            onArrayChange([rawValue === '' ? undefined : Number(rawValue)])
-          }}
-          type="number"
-        />
-      )}
-      {type === ChatVarType.Boolean && (
-        <BoolValue value={value as boolean} onChange={onValueChange} />
-      )}
-      {type === ChatVarType.Object && !editInJSON && (
-        <ObjectValueList list={objectValue} onChange={onObjectChange} />
-      )}
-      {type === ChatVarType.ArrayString && !editInJSON && (
-        <ArrayValueList
-          isString
-          list={(value as Array<string | undefined>) || [undefined]}
-          onChange={onArrayChange}
-        />
-      )}
-      {type === ChatVarType.ArrayNumber && !editInJSON && (
-        <ArrayValueList
-          isString={false}
-          list={(value as Array<number | undefined>) || [undefined]}
-          onChange={onArrayChange}
-        />
-      )}
-      {type === ChatVarType.ArrayBoolean && !editInJSON && (
-        <ArrayBoolList list={(value as boolean[]) || [true]} onChange={onArrayBoolChange} />
-      )}
-      {editInJSON && (
-        <div
-          className="w-full rounded-[10px] bg-components-input-bg-normal py-2 pr-1 pl-3"
-          style={{ height: editorMinHeight }}
-        >
-          <CodeEditor
-            isExpand
-            noWrapper
-            language={CodeLanguage.json}
-            value={editorContent}
-            placeholder={<div className="whitespace-pre">{placeholder}</div>}
-            onChange={onEditorValueChange}
+}: ValueSectionProps) => {
+  const numberInputId = useId()
+  return (
+    <div className="mb-4">
+      <div className="mb-1 flex h-6 items-center justify-between system-sm-semibold text-text-secondary">
+        {type === ChatVarType.Number ? (
+          <label htmlFor={numberInputId}>
+            {t(($) => $['chatVariable.modal.value'], { ns: 'workflow' })}
+          </label>
+        ) : (
+          <div>{t(($) => $['chatVariable.modal.value'], { ns: 'workflow' })}</div>
+        )}
+        {toggleLabelKey && (
+          <Button
+            variant="ghost"
+            size="small"
+            className="text-text-tertiary"
+            onClick={() => onEditorChange(!editInJSON)}
+          >
+            {editInJSON ? (
+              <RiInputField className="size-3.5" />
+            ) : (
+              <RiDraftLine className="size-3.5" />
+            )}
+            {t(editorToggleLabelSelectors[toggleLabelKey], { ns: 'workflow' })}
+          </Button>
+        )}
+      </div>
+      <div className="flex">
+        {type === ChatVarType.String && (
+          <textarea
+            className="block h-20 w-full resize-none appearance-none rounded-lg border border-transparent bg-components-input-bg-normal p-2 system-sm-regular text-components-input-text-filled caret-primary-600 outline-hidden placeholder:system-sm-regular placeholder:text-components-input-text-placeholder hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs"
+            value={(value as string) || ''}
+            placeholder={
+              t(($) => $['chatVariable.modal.valuePlaceholder'], { ns: 'workflow' }) || ''
+            }
+            onChange={(e) => onArrayChange([e.target.value])}
           />
-        </div>
-      )}
+        )}
+        {type === ChatVarType.Number && (
+          <NumberField
+            format={{ maximumSignificantDigits: 21, useGrouping: false }}
+            id={numberInputId}
+            className="w-full"
+            value={typeof value === 'number' ? value : null}
+            onValueChange={(value) => onArrayChange([value ?? undefined])}
+          >
+            <NumberFieldGroup>
+              <NumberFieldInput
+                inputMode="decimal"
+                placeholder={t(($) => $['chatVariable.modal.valuePlaceholder'], { ns: 'workflow' })}
+              />
+            </NumberFieldGroup>
+          </NumberField>
+        )}
+        {type === ChatVarType.Boolean && (
+          <BoolValue value={value as boolean} onChange={onValueChange} />
+        )}
+        {type === ChatVarType.Object && !editInJSON && (
+          <ObjectValueList list={objectValue} onChange={onObjectChange} />
+        )}
+        {type === ChatVarType.ArrayString && !editInJSON && (
+          <ArrayValueList
+            isString
+            list={(value as Array<string | undefined>) || [undefined]}
+            onChange={onArrayChange}
+          />
+        )}
+        {type === ChatVarType.ArrayNumber && !editInJSON && (
+          <ArrayValueList
+            isString={false}
+            list={(value as Array<number | undefined>) || [undefined]}
+            onChange={onArrayChange}
+          />
+        )}
+        {type === ChatVarType.ArrayBoolean && !editInJSON && (
+          <ArrayBoolList list={(value as boolean[]) || [true]} onChange={onArrayBoolChange} />
+        )}
+        {editInJSON && (
+          <div
+            className="w-full rounded-[10px] bg-components-input-bg-normal py-2 pr-1 pl-3"
+            style={{ height: editorMinHeight }}
+          >
+            <CodeEditor
+              isExpand
+              noWrapper
+              language={CodeLanguage.json}
+              value={editorContent}
+              placeholder={<div className="whitespace-pre">{placeholder}</div>}
+              onChange={onEditorValueChange}
+            />
+          </div>
+        )}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 type DescriptionSectionProps = {
   description: string


### PR DESCRIPTION
## Summary
- Migrate variable names and string/number array inputs to Dify UI Input and NumberField.
- Associate visible labels with their controls and name repeated array inputs.
- Preserve numeric precision and empty values without event parsing or compatibility wrappers.

## Verification
- Conversation variable tests: 13 suites, 45 tests passed.
- Workspace check passed (existing warnings only); commit hooks passed.
- Chrome at localhost:3000: compared main and branch dimensions, checked label activation, keyboard focus, long text, decimal values, and array add/clear behavior. No test variable was saved.