### PR TITLE
fix(web): keep recommend banner logos intact and open templates in the detail dialog

### DIFF
--- a/web/app/components/plugins/marketplace/__tests__/hydration-server.spec.tsx
+++ b/web/app/components/plugins/marketplace/__tests__/hydration-server.spec.tsx
@@ -112,7 +112,7 @@ describe('HydrateQueryClient', () => {
     expect(state.queries[0]?.queryKey).toEqual([
       'marketplace',
       'collections',
-      { input: { query: { limit: 20 } } },
+      { input: { query: {} } },
     ])
   })
 

--- a/web/app/components/plugins/marketplace/__tests__/utils.spec.ts
+++ b/web/app/components/plugins/marketplace/__tests__/utils.spec.ts
@@ -267,13 +267,12 @@ describe('getMarketplacePluginsByCollectionId', () => {
     )
   })
 
-  it('should send the warmed preview limit when query is omitted', async () => {
+  it('should omit a preview limit when query is omitted', async () => {
     mockCollectionPlugins.mockResolvedValueOnce({
       data: { plugins: [] },
     })
 
-    const { COLLECTION_PREVIEW_PLUGIN_LIMIT, getMarketplacePluginsByCollectionId } =
-      await import('../utils')
+    const { getMarketplacePluginsByCollectionId } = await import('../utils')
     await getMarketplacePluginsByCollectionId('test-collection')
 
     expect(mockCollectionPlugins).toHaveBeenCalledWith(
@@ -281,7 +280,7 @@ describe('getMarketplacePluginsByCollectionId', () => {
         params: {
           collectionId: 'test-collection',
         },
-        body: { limit: COLLECTION_PREVIEW_PLUGIN_LIMIT },
+        body: {},
       },
       expect.objectContaining({
         signal: undefined,
@@ -319,8 +318,7 @@ describe('getMarketplaceCollectionsAndPlugins', () => {
     mockCollections.mockResolvedValueOnce({ data: { collections: mockCollectionData } })
     mockCollectionPlugins.mockResolvedValue({ data: { plugins: mockPluginData } })
 
-    const { COLLECTION_PREVIEW_PLUGIN_LIMIT, getMarketplaceCollectionsAndPlugins } =
-      await import('../utils')
+    const { getMarketplaceCollectionsAndPlugins } = await import('../utils')
     const result = await getMarketplaceCollectionsAndPlugins({
       condition: 'category=tool',
       type: 'plugin',
@@ -334,14 +332,13 @@ describe('getMarketplaceCollectionsAndPlugins', () => {
         body: {
           condition: 'category=tool',
           type: 'plugin',
-          limit: COLLECTION_PREVIEW_PLUGIN_LIMIT,
         },
       }),
       expect.any(Object),
     )
   })
 
-  it('posts the warmed preview limit when the catalog has no extra filters', async () => {
+  it('posts without a preview limit when the catalog has no extra filters', async () => {
     mockCollections.mockResolvedValueOnce({
       data: {
         collections: [
@@ -358,14 +355,13 @@ describe('getMarketplaceCollectionsAndPlugins', () => {
     })
     mockCollectionPlugins.mockResolvedValue({ data: { plugins: [] } })
 
-    const { COLLECTION_PREVIEW_PLUGIN_LIMIT, getMarketplaceCollectionsAndPlugins } =
-      await import('../utils')
+    const { getMarketplaceCollectionsAndPlugins } = await import('../utils')
     await getMarketplaceCollectionsAndPlugins()
 
     expect(mockCollectionPlugins).toHaveBeenCalledWith(
       expect.objectContaining({
         params: { collectionId: 'featured' },
-        body: { limit: COLLECTION_PREVIEW_PLUGIN_LIMIT },
+        body: {},
       }),
       expect.any(Object),
     )
@@ -446,22 +442,18 @@ describe('getMarketplaceCollectionsAndPlugins', () => {
 })
 
 describe('getCollectionsParams', () => {
-  it('should return the warmed preview limit for all category', async () => {
-    const { COLLECTION_PREVIEW_PLUGIN_LIMIT, getCollectionsParams } = await import('../utils')
-    expect(getCollectionsParams(PLUGIN_TYPE_SEARCH_MAP.all)).toEqual({
-      limit: COLLECTION_PREVIEW_PLUGIN_LIMIT,
-    })
-    expect(COLLECTION_PREVIEW_PLUGIN_LIMIT).toBe(20)
+  it('should return an empty query for all category', async () => {
+    const { getCollectionsParams } = await import('../utils')
+    expect(getCollectionsParams(PLUGIN_TYPE_SEARCH_MAP.all)).toEqual({})
   })
 
-  it('should return category, condition, type, and preview limit for tool category', async () => {
-    const { COLLECTION_PREVIEW_PLUGIN_LIMIT, getCollectionsParams } = await import('../utils')
+  it('should return category, condition, and type for tool category', async () => {
+    const { getCollectionsParams } = await import('../utils')
     const result = getCollectionsParams(PLUGIN_TYPE_SEARCH_MAP.tool)
     expect(result).toEqual({
       category: PluginCategoryEnum.tool,
       condition: 'category=tool',
       type: 'plugin',
-      limit: COLLECTION_PREVIEW_PLUGIN_LIMIT,
     })
   })
 })

--- a/web/app/components/plugins/marketplace/home/__tests__/home-trending.spec.tsx
+++ b/web/app/components/plugins/marketplace/home/__tests__/home-trending.spec.tsx
@@ -189,6 +189,18 @@ describe('HomeTrending', () => {
     )
   })
 
+  it('fits recommend card icons inside the frame instead of cover-cropping them', () => {
+    render(<HomeTrending banners={banners} isMarketplacePlatform page="plugins" />)
+
+    const icon = within(screen.getByRole('group', { name: 'Trending' }))
+      .getByRole('link', { name: 'Dropbox' })
+      .querySelector('img')
+
+    expect(icon?.getAttribute('src')).toContain('/plugins/langgenius/dropbox/icon')
+    expect(icon).toHaveClass('object-contain')
+    expect(icon).not.toHaveClass('object-cover')
+  })
+
   it('marks inactive standalone slides so mobile CSS can collapse mixed banner heights', () => {
     render(<HomeTrending banners={banners} isMarketplacePlatform page="plugins" />)
 
@@ -766,6 +778,48 @@ describe('HomeTrending', () => {
         item_name: 'Dropbox',
       }),
     )
+  })
+
+  it('shows the served author on recommend template cards the same way as plugins', () => {
+    const banner: PluginBanner = {
+      id: 'recommend-templates',
+      style_type: 'recommend',
+      title: 'Trending',
+      sort: 0,
+      language: 'en',
+      content: {
+        theme_type: 'newest',
+        cards: [
+          {
+            item_type: 'template',
+            item_id: 'tpl-authored',
+            display_name: 'Go-to-Market',
+            creator: 'aisa-team',
+            link: '/templates/tpl-authored',
+            card_position: 0,
+          },
+          {
+            item_type: 'template',
+            item_id: 'tpl-anonymous',
+            display_name: 'Untitled Flow',
+            link: '/templates/tpl-anonymous',
+            card_position: 1,
+          },
+        ],
+      },
+    }
+
+    render(<HomeTrending banners={[banner]} isMarketplacePlatform page="templates" />)
+
+    const authored = screen.getByRole('link', { name: 'Go-to-Market' })
+    const anonymous = screen.getByRole('link', { name: 'Untitled Flow' })
+
+    expect(
+      within(authored).getByText('plugin.marketplace.home.trendingByCreator'),
+    ).toBeInTheDocument()
+    expect(
+      within(anonymous).queryByText('plugin.marketplace.home.trendingByCreator'),
+    ).not.toBeInTheDocument()
   })
 
   it('keeps standalone recommend plugin cards on local detail routes', () => {

--- a/web/app/components/plugins/marketplace/home/__tests__/home-trending.spec.tsx
+++ b/web/app/components/plugins/marketplace/home/__tests__/home-trending.spec.tsx
@@ -37,6 +37,10 @@ vi.mock('@/config', async (importOriginal) => ({
   MARKETPLACE_URL_PREFIX: 'https://marketplace.example.com',
 }))
 
+vi.mock('@/next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 vi.mock('@/app/components/plugins/install-plugin/hooks/use-check-installed', () => ({
   default: () => ({ installedInfo: {} }),
 }))
@@ -58,6 +62,21 @@ vi.mock('../../detail-dialog', () => ({
     open ? (
       <div role="dialog" aria-label="plugin-detail">
         {plugin.name}
+      </div>
+    ) : null,
+}))
+
+vi.mock('../../templates/template-detail-dialog', () => ({
+  default: ({
+    open,
+    template,
+  }: {
+    open: boolean
+    template: { id: string; template_name: string }
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="template-detail">
+        {template.template_name}
       </div>
     ) : null,
 }))
@@ -761,10 +780,7 @@ describe('HomeTrending', () => {
 
     expect(screen.queryByRole('link', { name: 'Dropbox' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Notion' })).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Support Bot' })).toHaveAttribute(
-      'href',
-      '/templates?tid=tpl-1',
-    )
+    expect(screen.queryByRole('link', { name: 'Support Bot' })).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Dropbox' }))
 
@@ -778,6 +794,82 @@ describe('HomeTrending', () => {
         item_name: 'Dropbox',
       }),
     )
+  })
+
+  it('opens embedded recommend template cards in the template dialog', async () => {
+    const user = userEvent.setup()
+    const bannerWithTemplates: PluginBanner = {
+      id: 'recommend-templates-embedded',
+      style_type: 'recommend',
+      title: 'Trending',
+      sort: 0,
+      language: 'en',
+      content: {
+        theme_type: 'newest',
+        cards: [
+          {
+            item_type: 'template',
+            item_id: 'tpl-1',
+            display_name: 'Support Bot',
+            creator: 'aisa-team',
+            link: 'https://external.example.com/support-bot',
+            card_position: 0,
+          },
+        ],
+      },
+    }
+
+    render(
+      <HomeTrending
+        banners={[bannerWithTemplates]}
+        isMarketplacePlatform={false}
+        page="templates"
+      />,
+    )
+
+    expect(screen.queryByRole('link', { name: 'Support Bot' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Support Bot' }))
+
+    expect(screen.getByRole('dialog', { name: 'template-detail' })).toHaveTextContent('Support Bot')
+    expect(mockTrackMarketplaceSiteEvent).toHaveBeenCalledWith(
+      'marketplace_banner_click',
+      expect.objectContaining({
+        click_target: 'recommendation',
+        item_id: 'tpl-1',
+        item_type: 'template',
+        item_name: 'Support Bot',
+      }),
+    )
+  })
+
+  it('opens embedded recommend plugin cards from /plugins links when item_id is not org/name', async () => {
+    const user = userEvent.setup()
+    const banner: PluginBanner = {
+      id: 'recommend-plugin-href',
+      style_type: 'recommend',
+      title: 'Trending',
+      sort: 0,
+      language: 'en',
+      content: {
+        theme_type: 'hottest',
+        cards: [
+          {
+            item_type: 'plugin',
+            item_id: 'baserow',
+            display_name: 'Baserow',
+            link: '/plugins/langgenius/baserow',
+            card_position: 0,
+          },
+        ],
+      },
+    }
+
+    render(<HomeTrending banners={[banner]} isMarketplacePlatform={false} page="plugins" />)
+
+    expect(screen.queryByRole('link', { name: 'Baserow' })).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Baserow' }))
+    expect(screen.getByRole('dialog', { name: 'plugin-detail' })).toHaveTextContent('baserow')
   })
 
   it('shows the served author on recommend template cards the same way as plugins', () => {

--- a/web/app/components/plugins/marketplace/home/home-trending-slides.tsx
+++ b/web/app/components/plugins/marketplace/home/home-trending-slides.tsx
@@ -117,6 +117,7 @@ const recommendCardClassName = cn(
 
 const getCardCreator = (card: BannerRecommendCard) => {
   if (card.creator) return card.creator
+  // Template item_id is a UUID, not org/name, so author has to come from the payload.
   if (card.item_type !== 'plugin') return ''
 
   return card.item_id.split('/')[0] || ''
@@ -230,7 +231,7 @@ function RecommendCardFace({ card }: { card: BannerRecommendCard }) {
             height={40}
             alt=""
             aria-hidden
-            className="size-full object-cover"
+            className="size-full object-contain object-center"
           />
         ) : card.icon ? (
           <span className="text-xl leading-none">{card.icon}</span>

--- a/web/app/components/plugins/marketplace/home/home-trending-slides.tsx
+++ b/web/app/components/plugins/marketplace/home/home-trending-slides.tsx
@@ -6,6 +6,7 @@ import type {
   BannerEvent,
   BannerRecommend,
   BannerRecommendCard,
+  MarketplaceTemplate,
   PluginBanner,
 } from '@dify/contracts/marketplace'
 import type { MarketplaceBannerPage } from './banners'
@@ -20,13 +21,15 @@ import useCheckInstalled from '@/app/components/plugins/install-plugin/hooks/use
 import { PluginCategoryEnum } from '@/app/components/plugins/types'
 import { MARKETPLACE_API_PREFIX } from '@/config'
 import Link from '@/next/link'
+import { useRouter } from '@/next/navigation'
 import { fetchPluginInfoFromMarketPlace } from '@/service/plugins'
 import {
   rememberMarketplaceSiteReferrer,
   trackMarketplaceSiteEvent,
 } from '@/utils/marketplace-site-track'
 import MarketplaceDetailDialog from '../detail-dialog'
-import { getPluginLinkInMarketplace } from '../utils'
+import TemplateDetailDialog from '../templates/template-detail-dialog'
+import { getPluginLinkInMarketplace, getTemplateLinkInMarketplace } from '../utils'
 import background from './assets/background.webp'
 import difyUpdatesArt from './assets/dify-updates-art.png'
 import {
@@ -53,21 +56,49 @@ const getMarketplaceAssetURL = (path?: string) => {
 }
 
 const getPluginIdentity = (itemId: string) => {
-  const [org, name] = itemId.split('/')
+  const [org, name, ...rest] = itemId.split('/')
+  if (!org || !name || rest.length > 0) return null
+  return { org, name }
+}
+
+const pathFromHref = (href: string) => {
+  if (href.startsWith('/') && !href.startsWith('//')) return href
+  try {
+    return new URL(href).pathname
+  } catch {
+    return href
+  }
+}
+
+const pluginIdentityFromHref = (href: string) => {
+  const parts = pathFromHref(href).split('/').filter(Boolean)
+  const index = parts.findIndex((part) => part === 'plugin' || part === 'plugins')
+  if (index < 0 || index + 2 >= parts.length) return null
+  const org = decodeURIComponent(parts[index + 1] ?? '')
+  const name = decodeURIComponent(parts[index + 2] ?? '')
   if (!org || !name) return null
   return { org, name }
 }
 
+const templateIdFromHref = (href: string) => {
+  const path = pathFromHref(href)
+  const tid = new URL(path, 'https://marketplace.local').searchParams.get('tid')
+  if (tid) return tid
+  const parts = path.split('/').filter(Boolean)
+  if (parts[0] === 'templates' && parts[1]) return decodeURIComponent(parts[1])
+  return null
+}
+
 const pluginFromRecommendCard = (card: BannerRecommendCard): Plugin | null => {
   if (card.item_type !== 'plugin') return null
-  const identity = getPluginIdentity(card.item_id)
+  const identity = getPluginIdentity(card.item_id) ?? pluginIdentityFromHref(card.link)
   if (!identity) return null
 
   return {
     type: 'plugin',
     org: identity.org,
     name: identity.name,
-    plugin_id: card.item_id,
+    plugin_id: `${identity.org}/${identity.name}`,
     version: '',
     latest_version: '',
     latest_package_identifier: '',
@@ -87,6 +118,25 @@ const pluginFromRecommendCard = (card: BannerRecommendCard): Plugin | null => {
       authorized_category: card.badges?.includes('partner') ? 'partner' : 'community',
     },
     from: 'marketplace',
+  }
+}
+
+const templateFromRecommendCard = (card: BannerRecommendCard): MarketplaceTemplate | null => {
+  if (card.item_type !== 'template') return null
+  const id = card.item_id || templateIdFromHref(card.link)
+  if (!id) return null
+
+  return {
+    id,
+    template_name: card.display_name,
+    overview: '',
+    icon: card.icon ?? '',
+    icon_background: card.icon_background ?? '',
+    icon_file_key: '',
+    publisher_unique_handle: card.creator,
+    usage_count: 0,
+    categories: [],
+    badges: card.badges,
   }
 }
 
@@ -332,6 +382,47 @@ function EmbeddedRecommendPluginCard({
   )
 }
 
+function EmbeddedRecommendTemplateCard({
+  banner,
+  card,
+  template,
+  page,
+}: {
+  banner: BannerRecommend
+  card: BannerRecommendCard
+  template: MarketplaceTemplate
+  page: MarketplaceBannerPage
+}) {
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+  const href = getTemplateLinkInMarketplace(template)
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={card.display_name}
+        className={cn(recommendCardClassName, 'cursor-pointer border-0 text-left')}
+        onClick={() => {
+          trackRecommendCardClick(banner, card, page, href)
+          setOpen(true)
+        }}
+      >
+        <RecommendCardFace card={card} />
+      </button>
+      <TemplateDetailDialog
+        open={open}
+        template={template}
+        onInstall={() => {
+          setOpen(false)
+          router.push(`/apps?template-id=${encodeURIComponent(template.id)}`)
+        }}
+        onOpenChange={setOpen}
+      />
+    </>
+  )
+}
+
 function TrendingCard({
   banner,
   card,
@@ -343,16 +434,34 @@ function TrendingCard({
   isMarketplacePlatform: boolean
   page: MarketplaceBannerPage
 }) {
-  const embeddedPlugin = isMarketplacePlatform ? null : pluginFromRecommendCard(card)
-  if (embeddedPlugin) {
-    return (
-      <EmbeddedRecommendPluginCard
-        banner={banner}
-        card={card}
-        initialPlugin={embeddedPlugin}
-        page={page}
-      />
-    )
+  if (!isMarketplacePlatform) {
+    if (card.item_type === 'plugin') {
+      const embeddedPlugin = pluginFromRecommendCard(card)
+      if (embeddedPlugin) {
+        return (
+          <EmbeddedRecommendPluginCard
+            banner={banner}
+            card={card}
+            initialPlugin={embeddedPlugin}
+            page={page}
+          />
+        )
+      }
+    }
+
+    if (card.item_type === 'template') {
+      const embeddedTemplate = templateFromRecommendCard(card)
+      if (embeddedTemplate) {
+        return (
+          <EmbeddedRecommendTemplateCard
+            banner={banner}
+            card={card}
+            template={embeddedTemplate}
+            page={page}
+          />
+        )
+      }
+    }
   }
 
   const href = getCardHref(card, isMarketplacePlatform)

--- a/web/app/components/plugins/marketplace/utils.ts
+++ b/web/app/components/plugins/marketplace/utils.ts
@@ -16,10 +16,6 @@ type MarketplaceFetchOptions = {
   signal?: AbortSignal
 }
 
-// Matches backend warmup homepageCollectionPluginsRequests Limit: 20 so the
-// public POST hits the Redis bucket the scheduler already writes.
-export const COLLECTION_PREVIEW_PLUGIN_LIMIT = 20
-
 type MarketplacePluginListExtras = {
   agent_strategy?: unknown
   data_sources?: unknown
@@ -160,7 +156,7 @@ export const getMarketplacePluginsByCollectionId = async (
       params: {
         collectionId,
       },
-      body: { limit: COLLECTION_PREVIEW_PLUGIN_LIMIT, ...query },
+      body: query ?? {},
     },
     {
       signal: options?.signal,
@@ -301,12 +297,11 @@ export function getCollectionsParams(
   category: ActivePluginType,
 ): CollectionsAndPluginsSearchParams {
   if (category === PLUGIN_TYPE_SEARCH_MAP.all) {
-    return { limit: COLLECTION_PREVIEW_PLUGIN_LIMIT }
+    return {}
   }
   return {
     category,
     condition: getMarketplaceListCondition(category),
     type: getMarketplaceListFilterType(category),
-    limit: COLLECTION_PREVIEW_PLUGIN_LIMIT,
   }
 }

--- a/web/service/marketplace-template-discovery.spec.ts
+++ b/web/service/marketplace-template-discovery.spec.ts
@@ -52,7 +52,7 @@ describe('marketplace template discovery', () => {
       1,
       {
         params: { collectionName: 'featured' },
-        body: { limit: 20 },
+        body: {},
       },
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )

--- a/web/service/marketplace-template-discovery.ts
+++ b/web/service/marketplace-template-discovery.ts
@@ -32,8 +32,6 @@ const FAILED_COLLECTIONS_RESULT: MarketplaceTemplateCollectionsResult = {
   ok: false,
 }
 
-const COLLECTION_PREVIEW_TEMPLATE_LIMIT = 20
-
 type MarketplaceTemplateListExtras = {
   asset_files?: unknown
   asset_tree_nodes?: unknown
@@ -102,7 +100,7 @@ async function fetchCollectionsAndTemplates(): Promise<MarketplaceTemplateCollec
               const collectionResponse = await marketplaceClient.templateCollectionTemplates(
                 {
                   params: { collectionName: collection.name },
-                  body: { limit: COLLECTION_PREVIEW_TEMPLATE_LIMIT },
+                  body: {},
                 },
                 { signal: budget },
               )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Cherry-pick of #41980 and #42063 onto `hotfix/1.17.0-fix.15`.

- Recommend banner cards fit non-square plugin logos with `object-contain`, and template cards show `by {author}` from the served `creator`.
- In-app recommend template cards open `TemplateDetailDialog` instead of navigating to `/templates/{id}`. The standalone marketplace still navigates to the template page.

Marketplace companions: langgenius/dify-marketplace#168, langgenius/dify-marketplace#172.

## Screenshots

N/A — covered by unit tests (`home-trending.spec.tsx`).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Grok