### PR TITLE
fix: prevent note bold shortcut from toggling the sidebar

### DIFF
--- a/web/app/components/detail-sidebar/__tests__/index.spec.tsx
+++ b/web/app/components/detail-sidebar/__tests__/index.spec.tsx
@@ -1,30 +1,8 @@
-import { act, fireEvent, screen } from '@testing-library/react'
+import { HotkeysProvider } from '@tanstack/react-hotkeys'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithConsoleQuery } from '@/test/console/query-data'
 import { DetailSidebarFrame } from '..'
 import { DETAIL_SIDEBAR_STORAGE_KEY } from '../storage'
-
-const { hotkeyRegistrations } = vi.hoisted(() => ({
-  hotkeyRegistrations: new Map<
-    string,
-    {
-      handler: () => void
-      options?: { ignoreInputs?: boolean; preventDefault?: boolean }
-    }
-  >(),
-}))
-vi.mock('@tanstack/react-hotkeys', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@tanstack/react-hotkeys')>()
-  return {
-    ...actual,
-    useHotkey: (
-      hotkey: string,
-      handler: () => void,
-      options?: { ignoreInputs?: boolean; preventDefault?: boolean },
-    ) => {
-      hotkeyRegistrations.set(hotkey, { handler, options })
-    },
-  }
-})
 
 vi.mock('@/app/components/main-nav/components/account-section', () => ({
   default: ({ compact }: { compact?: boolean }) => (
@@ -46,22 +24,32 @@ vi.mock('@/app/components/header/env-nav', () => ({
   default: () => <div>Environment tag</div>,
 }))
 
-function renderDetailSidebarFrame(currentEnv: string | null = null) {
+function renderDetailSidebarFrame(
+  currentEnv: string | null = null,
+  platform: 'mac' | 'windows' = 'mac',
+) {
   return renderWithConsoleQuery(
-    <DetailSidebarFrame
-      renderTop={({ expand, onToggle }) => (
-        <div data-testid="detail-top" data-expand={expand}>
-          <button type="button" data-testid="detail-toggle" onClick={onToggle}>
-            Toggle
-          </button>
-        </div>
-      )}
-      renderSection={({ expand }) => (
-        <div data-testid="detail-section" data-expand={expand}>
-          Section
-        </div>
-      )}
-    />,
+    <HotkeysProvider defaultOptions={{ hotkey: { platform } }}>
+      <DetailSidebarFrame
+        renderTop={({ expand, onToggle }) => (
+          <div data-testid="detail-top" data-expand={expand}>
+            <button type="button" data-testid="detail-toggle" onClick={onToggle}>
+              Toggle
+            </button>
+          </div>
+        )}
+        renderSection={({ expand }) => (
+          <div data-testid="detail-section" data-expand={expand}>
+            Section
+          </div>
+        )}
+      />
+      <div contentEditable suppressContentEditableWarning role="textbox" aria-label="Note">
+        <span>Note text</span>
+      </div>
+      <input aria-label="Name" />
+      <textarea aria-label="Description" />
+    </HotkeysProvider>,
     { accountProfileMeta: { currentEnv } },
   )
 }
@@ -69,26 +57,53 @@ function renderDetailSidebarFrame(currentEnv: string | null = null) {
 describe('DetailSidebarFrame', () => {
   beforeEach(() => {
     localStorage.clear()
-    hotkeyRegistrations.clear()
   })
 
-  it('renders expanded detail content by default and registers the shortcut for focused inputs', () => {
+  it('renders expanded detail content by default', () => {
     renderDetailSidebarFrame()
 
     expect(screen.getByTestId('detail-top')).toHaveAttribute('data-expand', 'true')
     expect(screen.getByTestId('detail-section')).toHaveAttribute('data-expand', 'true')
-    expect(hotkeyRegistrations.get('Mod+B')?.options).toEqual(
-      expect.objectContaining({ ignoreInputs: false, preventDefault: true }),
-    )
   })
 
-  it('toggles detail content from the registered shortcut', () => {
-    renderDetailSidebarFrame()
+  describe.each(['mac', 'windows'] as const)('%s shortcut', (platform) => {
+    const modifiers = platform === 'mac' ? { metaKey: true } : { ctrlKey: true }
 
-    act(() => hotkeyRegistrations.get('Mod+B')?.handler())
+    it('toggles detail content outside editing fields', () => {
+      renderDetailSidebarFrame(null, platform)
 
-    expect(screen.getByTestId('detail-top')).toHaveAttribute('data-expand', 'false')
-    expect(localStorage.getItem(DETAIL_SIDEBAR_STORAGE_KEY)).toBe('collapse')
+      fireEvent.keyDown(document.body, { key: 'b', ...modifiers })
+
+      expect(screen.getByTestId('detail-top')).toHaveAttribute('data-expand', 'false')
+      expect(localStorage.getItem(DETAIL_SIDEBAR_STORAGE_KEY)).toBe('collapse')
+
+      fireEvent.keyDown(document.body, { key: 'b', ...modifiers })
+
+      expect(screen.getByTestId('detail-top')).toHaveAttribute('data-expand', 'true')
+      expect(localStorage.getItem(DETAIL_SIDEBAR_STORAGE_KEY)).toBe('expand')
+    })
+
+    it.each(['Note', 'Note text', 'Name', 'Description'])(
+      'leaves the shortcut to the %s editor',
+      (name) => {
+        renderDetailSidebarFrame(null, platform)
+        const editor =
+          name === 'Note text' ? screen.getByText(name) : screen.getByRole('textbox', { name })
+        editor.focus()
+        const event = new KeyboardEvent('keydown', {
+          key: 'b',
+          ...modifiers,
+          bubbles: true,
+          cancelable: true,
+        })
+
+        fireEvent(editor, event)
+
+        expect(event.defaultPrevented).toBe(false)
+        expect(screen.getByTestId('detail-top')).toHaveAttribute('data-expand', 'true')
+        expect(localStorage.getItem(DETAIL_SIDEBAR_STORAGE_KEY)).toBe('expand')
+      },
+    )
   })
 
   it('collapses detail content from the top toggle and hides environment metadata', () => {

--- a/web/app/components/detail-sidebar/index.tsx
+++ b/web/app/components/detail-sidebar/index.tsx
@@ -110,7 +110,7 @@ export function DetailSidebarFrame({
   }, [])
 
   useHotkey(DETAIL_SIDEBAR_TOGGLE_HOTKEY, handleToggleDetailNavigation, {
-    ignoreInputs: false,
+    ignoreInputs: true,
     preventDefault: true,
   })
 


### PR DESCRIPTION
## Summary

Fixes [SNP-786](https://linear.app/dify/issue/SNP-786).

Pressing Command+B to bold text in a workflow note also toggled the app detail sidebar. Make the sidebar's Mod+B command ignore editing fields so it leaves rich-text shortcuts to the editor.

This applies to all inputs, textareas, and contenteditable regions wherever the shared detail sidebar is used. The sidebar shortcut still toggles outside editing fields, and its toggle button remains available.

Replace the mocked hotkey registration tests with real keyboard-event coverage for macOS and Windows, including nested rich-text content and toggling in both directions.

## Validation

- Passed: detail-sidebar suite, 18 tests.
- Passed: scoped `vp check` for both changed files and staged commit checks.
- Full `vp run -w check` is blocked by a pre-existing formatting issue in `web/app/device/page.tsx`; that file is unchanged by this PR.
- Actual selected-text formatting was not browser-tested; regression tests verify sidebar shortcut isolation.

From Codex