### PR TITLE
perf(web): cache server system features for ten minutes

### DIFF
--- a/web/features/system-features/README.md
+++ b/web/features/system-features/README.md
@@ -1,9 +1,10 @@
 # System Features
 
-This feature owns the deployment-wide capability query contract and application bootstrap boundary. It is neither a
-cross-request server cache nor a general configuration registry.
+This feature owns the deployment-wide capability query contract, server cache policy, and application bootstrap boundary.
 
 - The generated System Features operation owns the shared query identity and response contract.
+- `server.ts` uses oRPC context to request an anonymous snapshot with 600-second server revalidation,
+  allowing separate RSC requests to reuse the cached response.
 - `server.ts` owns request-scoped imperative resolution and dehydration. Under the [TanStack Query prefetching] semantics,
   `'static'` accepts any successful request-local snapshot, even after invalidation. Optional access maps an initial
   no-data failure to `undefined` without another optional attempt; required access reuses a successful snapshot, starts

--- a/web/features/system-features/server.ts
+++ b/web/features/system-features/server.ts
@@ -8,7 +8,15 @@ import 'server-only'
 const getRequestQueryClient = cache(getQueryClient)
 
 const systemFeaturesServerQueryOptions = () =>
-  consoleQuery.systemFeatures.get.queryOptions({ staleTime: 'static' })
+  consoleQuery.systemFeatures.get.queryOptions({
+    staleTime: 'static',
+    context: {
+      server: {
+        forwardIdentity: false,
+        revalidate: 600,
+      },
+    },
+  })
 
 export const getOptionalSystemFeatures = async () => {
   await connection()

--- a/web/service/console/README.md
+++ b/web/service/console/README.md
@@ -11,6 +11,9 @@ transport for the Python Console API.
   [Instrumentation] and the [root layout]
   register this transport. Only the transport is shared globally;
   request identity is resolved per request.
+- Server queries forward identity and use `no-store` by default. Feature-owned `context.server` options can disable
+  identity forwarding with `forwardIdentity: false` and enable fetch caching with `revalidate > 0` (seconds).
+  The browser transport ignores these options.
 - Shared query/mutation defaults live in
   [query-policies.ts].
   In oRPC v1, caller options override defaults, including callbacks.

--- a/web/service/console/index.ts
+++ b/web/service/console/index.ts
@@ -10,6 +10,10 @@ import { createConsoleQuery } from './query-policies'
 export type ConsoleClientContext = TanstackQueryOperationContext & {
   keepalive?: boolean
   silent?: boolean
+  server?: {
+    forwardIdentity?: boolean
+    revalidate?: number
+  }
 }
 
 export type ConsoleClient = JsonifiedClient<

--- a/web/service/console/server.spec.ts
+++ b/web/service/console/server.spec.ts
@@ -28,6 +28,10 @@ vi.mock('@/next/headers', () => ({
   cookies: () => mocks.cookies(),
 }))
 
+vi.mock('@/next/server', () => ({
+  connection: vi.fn(async () => undefined),
+}))
+
 beforeEach(() => {
   vi.clearAllMocks()
   vi.unstubAllGlobals()
@@ -41,6 +45,34 @@ beforeEach(() => {
 })
 
 describe('server console oRPC client', () => {
+  it.each(['getOptionalSystemFeatures', 'getSystemFeatures'] as const)(
+    '%s requests an anonymous snapshot with 600-second revalidation',
+    async (accessor) => {
+      const { createSystemFeaturesFixture } = await import('@/test/console/system-features')
+      const snapshot = createSystemFeaturesFixture()
+      const fetch = vi.fn(async (_request: Request) => Response.json(snapshot))
+      vi.stubGlobal('fetch', fetch)
+      await import('./server')
+      const systemFeatures = await import('@/features/system-features/server')
+
+      await expect(systemFeatures[accessor]()).resolves.toEqual(snapshot)
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          cache: 'force-cache',
+          next: { revalidate: 600 },
+        }),
+      )
+      const request = fetch.mock.calls[0]![0]
+      expect(request.url).toBe('http://localhost:5001/console/api/system-features')
+      expect(request.headers.has('cookie')).toBe(false)
+      expect(request.headers.has('X-CSRF-Token')).toBe(false)
+      expect(mocks.headers).not.toHaveBeenCalled()
+      expect(mocks.cookies).not.toHaveBeenCalled()
+    },
+  )
+
   it('should resolve server console API URLs only from configured or absolute prefixes', async () => {
     const { resolveServerConsoleApiPrefix, resolveServerConsoleApiUrl } = await import('./server')
 

--- a/web/service/console/server.ts
+++ b/web/service/console/server.ts
@@ -64,17 +64,22 @@ function createServerConsoleOpenAPILink(
 ): ClientLink<ConsoleClientContext> {
   return new OpenAPILink<ConsoleClientContext>(contract, {
     url: getServerConsoleApiPrefix,
-    headers: getServerConsoleRequestHeaders,
-    fetch: (request, init) => {
+    headers: ({ context }) =>
+      context.server?.forwardIdentity === false
+        ? new Headers({ Accept: 'application/json' })
+        : getServerConsoleRequestHeaders(),
+    fetch: (request, init, { context }) => {
       if (request.body && !request.headers.has('content-type'))
         request.headers.set('Content-Type', 'application/json')
 
       const normalizedURL = normalizeConsoleOpenAPIURL(request.url)
       const normalizedRequest =
         normalizedURL === request.url ? request : new Request(normalizedURL, request)
+      const revalidate = context.server?.revalidate
       return globalThis.fetch(normalizedRequest, {
         ...init,
-        cache: 'no-store',
+        cache: revalidate !== undefined && revalidate > 0 ? 'force-cache' : 'no-store',
+        ...(revalidate === undefined ? {} : { next: { revalidate } }),
       })
     },
     interceptors: [


### PR DESCRIPTION
## Summary

New RSC requests currently refetch `/console/api/system-features` because the server transport uses `no-store`; request-scoped QueryClient reuse does not prevent cross-request backend calls.

Declare anonymous reads and 600-second revalidation in the System Features server query context. The generic Console transport applies the policy without recognizing individual business endpoints. Existing contract validation, request-local query reuse, hydration, and default authenticated `no-store` requests are preserved.

Enterprise configuration changes may remain stale until revalidation succeeds. This does not schedule browser refreshes or guarantee that changes appear within ten minutes.

Fixes [SNP-787](https://linear.app/dify/issue/SNP-787).

## Validation

- 68 tests passed across Console service, System Features, and Root Layout suites.
- `vp run -w check` passed.
- A Next 16.3.4 runtime probe using the real patched fetch and IncrementalCache with an in-memory storage handler confirmed reuse across separate request stores, stale-while-revalidate after expiry, and uncached default requests. A deployed RSC end-to-end test was not run.

From Codex
