### PR TITLE
docs(api): fix working directory instructions for running tests

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -89,8 +89,9 @@ The scripts resolve paths relative to their location, so you can run them from a
 
 1. Run the tests locally with mocked system environment variables in `tool.pytest_env` section in `pyproject.toml`, more can check [Claude.md](../CLAUDE.md)
 
+   Continue in the `api` directory from the previous step.
+
    ```bash
-   cd api
    uv run pytest                           # Run all tests
    uv run pytest tests/unit_tests/         # Unit tests only
    uv run pytest tests/integration_tests/  # Integration tests


### PR DESCRIPTION
## Summary

Fixes #42084.

Following the Testing instructions in `api/README.md` sequentially in the same terminal enters `api` twice. The second `cd api` fails because `api/api` does not exist.

Remove the redundant directory change and clarify that step 2 continues in the `api` directory established by step 1.

## Validation

- Extracted and executed only the directory-change commands from the Testing section, starting at the repository root: the original sequence exits with a missing-directory error; the updated sequence succeeds and remains in `api`.
- `git diff --check` passed.
- Confirmed the upstream comparison contains one commit changing only `api/README.md` (+2/-1 lines).
- Backend tests and code linters were not run because this change only updates Markdown instructions.

## Screenshots

Not applicable; documentation only.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Codex