### PR TITLE
fix(web): restore content-sized search shortcut keycap

### DIFF
--- a/web/app/components/main-nav/components/search-button.tsx
+++ b/web/app/components/main-nav/components/search-button.tsx
@@ -49,7 +49,7 @@ export function MainNavSearchButton({
       <Kbd
         aria-hidden="true"
         data-pending={displayPlatform === null ? '' : undefined}
-        className="h-4.5 w-9 min-w-0 shrink-0 rounded-[5px] border border-divider-deep bg-components-badge-bg-dimm px-1 py-0.5 system-2xs-medium-uppercase text-text-tertiary data-pending:invisible"
+        className="h-4.5 min-w-0 shrink-0 rounded-[5px] border border-divider-deep bg-components-badge-bg-dimm px-1 py-0.5 system-2xs-medium-uppercase text-text-tertiary data-pending:invisible"
       >
         {displayPlatform !== null &&
           GOTO_ANYTHING_HOTKEY.split('+').map((key) => (


### PR DESCRIPTION
Fixes a visual regression introduced by commit 5f02726207a274621cef46e97fb92e350b11a867 (#42088): the main navigation shortcut keycap gained a fixed 36px width, leaving extra space around shorter shortcut labels such as `⌘K`.

Remove `w-9` so the keycap sizes to its content again, including `CtrlK`, while retaining the existing padding and platform detection logic.

Validation: targeted formatting, lint, and type checks passed. The full repository check (`vp run -w check`) also passed with 0 errors and 1,939 warnings. Browser visual verification was not performed.
