### PR TITLE
fix(api): propagate audio stream closure to providers

### DIFF
--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -136,9 +136,9 @@ class ChatTextApi(Resource):
             data = bytes(output.data)
             return Response(data, content_type=resolve_audio_mime_type(data, output.mime_type))
         audio_stream, mime_type = inspect_audio_stream(output.data, output.mime_type)
-        # Preserve the shared MIME and request context behavior. TODO: Make the
-        # shared MIME iterator propagate close() to the provider stream.
-        return Response(
+        response = Response(
             stream_with_context(audio_stream),  # pyrefly: ignore[no-matching-overload]
             content_type=mime_type,
         )
+        response.call_on_close(audio_stream.close)
+        return response

--- a/api/core/base/tts/app_generator_tts_publisher.py
+++ b/api/core/base/tts/app_generator_tts_publisher.py
@@ -3,6 +3,7 @@ import logging
 import queue
 import re
 import threading
+from contextlib import closing
 
 from core.app.entities.queue_entities import (
     MessageQueueMessage,
@@ -75,7 +76,7 @@ class AppGeneratorTTSPublisher:
         self._cancelled.set()
         self._msg_queue.put(None)
 
-    def _runtime(self):
+    def _runtime(self) -> None:
         audio_type = self._declared_audio_mime_type or DEFAULT_TTS_AUDIO_MIME_TYPE
         resolved_audio_type: str | None = None
         try:
@@ -121,29 +122,30 @@ class AppGeneratorTTSPublisher:
                 if text_content and not text_content.isspace():
                     invoke_result = self.model_instance.invoke_tts(content_text=text_content.strip(), voice=self.voice)
                     audio_stream, next_audio_type = inspect_audio_stream(invoke_result, self._declared_audio_mime_type)
-                    if self._cancelled.is_set():
-                        return
-                    if incremental_request and next_audio_type != DEFAULT_TTS_AUDIO_MIME_TYPE:
-                        raise InvokeBadRequestError(
-                            "The TTS model declared MP3 but returned a format that cannot be played incrementally"
-                        )
-                    if resolved_audio_type and resolved_audio_type != next_audio_type:
-                        raise InvokeBadRequestError(
-                            "TTS provider changed MIME type between audio responses: "
-                            f"{resolved_audio_type} then {next_audio_type}"
-                        )
-                    resolved_audio_type = audio_type = next_audio_type
-                    for audio in audio_stream:
-                        # ponytail: reads stop at the next chunk; add transport cancellation when Graphon exposes it.
+                    with closing(audio_stream):
                         if self._cancelled.is_set():
                             return
-                        self._audio_queue.put(
-                            AudioTrunk(
-                                "responding",
-                                audio=base64.b64encode(audio),
-                                audio_type=audio_type,
+                        if incremental_request and next_audio_type != DEFAULT_TTS_AUDIO_MIME_TYPE:
+                            raise InvokeBadRequestError(
+                                "The TTS model declared MP3 but returned a format that cannot be played incrementally"
                             )
-                        )
+                        if resolved_audio_type and resolved_audio_type != next_audio_type:
+                            raise InvokeBadRequestError(
+                                "TTS provider changed MIME type between audio responses: "
+                                f"{resolved_audio_type} then {next_audio_type}"
+                            )
+                        resolved_audio_type = audio_type = next_audio_type
+                        for audio in audio_stream:
+                            # ponytail: stop at the next chunk; add transport cancellation when Graphon exposes it.
+                            if self._cancelled.is_set():
+                                return
+                            self._audio_queue.put(
+                                AudioTrunk(
+                                    "responding",
+                                    audio=base64.b64encode(audio),
+                                    audio_type=audio_type,
+                                )
+                            )
 
                 if message is None:
                     break

--- a/api/core/base/tts/audio_mime.py
+++ b/api/core/base/tts/audio_mime.py
@@ -1,11 +1,12 @@
 import logging
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Iterator
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from core.plugin.entities.plugin_daemon import TTSAudioChunk
 from graphon.model_runtime.entities.model_entities import ModelPropertyKey
 from graphon.model_runtime.errors.invoke import InvokeBadRequestError
+from libs.stream import close_stream
 
 if TYPE_CHECKING:
     from core.model_manager import ModelInstance
@@ -140,32 +141,73 @@ def resolve_audio_mime_type(
     return normalized_declared_mime_type or DEFAULT_TTS_AUDIO_MIME_TYPE
 
 
+type _AudioChunk = bytes | bytearray | memoryview | TTSAudioChunk
+
+
+class AudioStream(Iterator[bytes]):
+    """Own a MIME-checked stream, including resources opened while peeking."""
+
+    def __init__(
+        self, chunks: Generator[bytes, None, None], *, source: Iterable[_AudioChunk], iterator: Iterator[_AudioChunk]
+    ) -> None:
+        self._chunks: Generator[bytes, None, None] = chunks
+        self._source: Iterable[_AudioChunk] = source
+        self._iterator: Iterator[_AudioChunk] = iterator
+        self._closed: bool = False
+
+    @override
+    def __next__(self) -> bytes:
+        try:
+            return next(self._chunks)
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        # The validation generator may never have started, but peeking has
+        # already opened the provider. Close its source explicitly as well.
+        close_stream(self._chunks)
+        close_stream(self._iterator)
+        if self._source is not self._iterator:
+            close_stream(self._source)
+
+
 def inspect_audio_stream(
-    audio_stream: Iterable[bytes | bytearray | memoryview | TTSAudioChunk], declared_mime_type: str | None = None
-) -> tuple[Generator[bytes, None, None], str]:
-    """Peek at and validate a TTS stream without dropping its leading bytes."""
-    iterator = iter(audio_stream)
+    audio_stream: Iterable[_AudioChunk], declared_mime_type: str | None = None
+) -> tuple[AudioStream, str]:
+    """Peek and validate without dropping bytes; the returned stream owns cleanup."""
+    iterator: Iterator[_AudioChunk] | None = None
     leading_chunks: list[bytes] = []
     signature = bytearray()
     reported_mime_type: str | None = None
 
-    while len(signature) < _SIGNATURE_SIZE:
-        try:
-            chunk, chunk_mime_type = _extract_audio_chunk(next(iterator))
-        except StopIteration:
-            break
-        normalized_chunk_mime_type = _normalize_reported_mime_type(chunk_mime_type, "chunk")
-        if normalized_chunk_mime_type:
-            if reported_mime_type and reported_mime_type != normalized_chunk_mime_type:
-                raise InvokeBadRequestError(
-                    "TTS provider changed MIME type within one audio response: "
-                    f"{reported_mime_type} then {normalized_chunk_mime_type}"
-                )
-            reported_mime_type = normalized_chunk_mime_type
-        leading_chunks.append(chunk)
-        signature.extend(chunk[: _SIGNATURE_SIZE - len(signature)])
+    try:
+        iterator = iter(audio_stream)
+        while len(signature) < _SIGNATURE_SIZE:
+            try:
+                chunk, chunk_mime_type = _extract_audio_chunk(next(iterator))
+            except StopIteration:
+                break
+            normalized_chunk_mime_type = _normalize_reported_mime_type(chunk_mime_type, "chunk")
+            if normalized_chunk_mime_type:
+                if reported_mime_type and reported_mime_type != normalized_chunk_mime_type:
+                    raise InvokeBadRequestError(
+                        "TTS provider changed MIME type within one audio response: "
+                        f"{reported_mime_type} then {normalized_chunk_mime_type}"
+                    )
+                reported_mime_type = normalized_chunk_mime_type
+            leading_chunks.append(chunk)
+            signature.extend(chunk[: _SIGNATURE_SIZE - len(signature)])
 
-    mime_type = resolve_audio_mime_type(signature, declared_mime_type, reported_mime_type)
+        mime_type = resolve_audio_mime_type(signature, declared_mime_type, reported_mime_type)
+    except BaseException:
+        close_stream(iterator)
+        if audio_stream is not iterator:
+            close_stream(audio_stream)
+        raise
 
     def validated_stream() -> Generator[bytes, None, None]:
         for chunk in chain(leading_chunks, iterator):
@@ -178,4 +220,4 @@ def inspect_audio_stream(
                 )
             yield audio
 
-    return validated_stream(), mime_type
+    return AudioStream(validated_stream(), source=audio_stream, iterator=iterator), mime_type

--- a/api/core/model_manager.py
+++ b/api/core/model_manager.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
+from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from copy import deepcopy
 from typing import IO, Any, Literal, Optional, ParamSpec, TypeVar, Union, cast, overload, override
 from uuid import UUID
@@ -35,6 +35,7 @@ from graphon.model_runtime.model_providers.base.rerank_model import RerankModel
 from graphon.model_runtime.model_providers.base.speech2text_model import Speech2TextModel
 from graphon.model_runtime.model_providers.base.text_embedding_model import TextEmbeddingModel
 from graphon.model_runtime.model_providers.base.tts_model import TTSModel
+from libs.stream import close_stream
 from models.provider import ProviderType
 
 logger = logging.getLogger(__name__)
@@ -806,17 +807,25 @@ class QuotaManagedModelInstance(ModelInstance):
     ) -> Generator[bytes, None, None]:
         effective_request_metadata = self._resolve_request_metadata(request_metadata)
         reservation = self._reserve_quota_for_request(effective_request_metadata)
+        response: Iterable[bytes] | None = None
+        iterator: Iterator[bytes] | None = None
         try:
             response = super().invoke_tts(
                 content_text=content_text,
                 voice=voice,
                 request_metadata=effective_request_metadata,
             )
-            for chunk in response:
+            iterator = iter(response)
+            for chunk in iterator:
                 reservation.commit()
                 yield chunk
         finally:
-            self.release_quota_safely(reservation)
+            try:
+                close_stream(iterator)
+                if response is not iterator:
+                    close_stream(response)
+            finally:
+                self.release_quota_safely(reservation)
 
 
 class ModelManager:

--- a/api/core/plugin/backwards_invocation/base.py
+++ b/api/core/plugin/backwards_invocation/base.py
@@ -2,10 +2,15 @@ from collections.abc import Generator, Mapping
 
 from pydantic import BaseModel
 
+from libs.stream import close_stream
+
 
 class BaseBackwardsInvocation:
     @classmethod
-    def convert_to_event_stream(cls, response: Generator[BaseModel | Mapping | str, None, None] | BaseModel | Mapping):
+    def convert_to_event_stream(
+        cls,
+        response: Generator[BaseModel | Mapping[str, object] | str, None, None] | BaseModel | Mapping[str, object],
+    ) -> Generator[bytes, None, None]:
         if isinstance(response, Generator):
             try:
                 for chunk in response:
@@ -14,6 +19,8 @@ class BaseBackwardsInvocation:
             except Exception as e:
                 error_message = BaseBackwardsInvocationResponse(error=str(e)).model_dump_json()
                 yield error_message.encode()
+            finally:
+                close_stream(response)
         else:
             yield BaseBackwardsInvocationResponse(data=response).model_dump_json().encode()
 

--- a/api/core/plugin/backwards_invocation/model.py
+++ b/api/core/plugin/backwards_invocation/model.py
@@ -1,7 +1,6 @@
 import tempfile
 from binascii import hexlify, unhexlify
 from collections.abc import Generator
-from typing import Any
 
 from core.base.tts.audio_mime import get_model_audio_mime_type, inspect_audio_stream
 from core.credit_usage import CreditUsageCreatedBy
@@ -34,6 +33,7 @@ from graphon.model_runtime.entities.message_entities import (
     UserPromptMessage,
 )
 from graphon.model_runtime.entities.model_entities import ModelType
+from libs.stream import close_stream
 from models.account import Tenant
 
 
@@ -206,7 +206,9 @@ class PluginModelBackwardsInvocation(BaseBackwardsInvocation):
         return response
 
     @classmethod
-    def invoke_tts(cls, user_id: str, tenant: Tenant, payload: RequestInvokeTTS):
+    def invoke_tts(
+        cls, user_id: str, tenant: Tenant, payload: RequestInvokeTTS
+    ) -> Generator[dict[str, str], None, None]:
         """
         invoke tts
         """
@@ -218,11 +220,14 @@ class PluginModelBackwardsInvocation(BaseBackwardsInvocation):
             model=payload.model,
         )
 
-        def handle() -> Generator[dict[str, Any], None, None]:
+        def handle() -> Generator[dict[str, str], None, None]:
             response = model_instance.invoke_tts(content_text=payload.content_text, voice=payload.voice)
             audio_stream, mime_type = inspect_audio_stream(response, get_model_audio_mime_type(model_instance))
-            for chunk in audio_stream:
-                yield {"result": hexlify(chunk).decode("utf-8"), "mime_type": mime_type}
+            try:
+                for chunk in audio_stream:
+                    yield {"result": hexlify(chunk).decode("utf-8"), "mime_type": mime_type}
+            finally:
+                close_stream(audio_stream)
 
         return handle()
 

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -47,6 +47,7 @@ from graphon.model_runtime.errors.invoke import (
     InvokeServerUnavailableError,
 )
 from graphon.model_runtime.errors.validate import CredentialsValidateFailedError
+from libs.stream import close_stream
 
 plugin_daemon_inner_api_baseurl = URL(str(dify_config.PLUGIN_DAEMON_URL))
 _plugin_daemon_timeout_config = cast(
@@ -362,34 +363,38 @@ class BasePluginClient:
         """
         Make a stream request to the plugin daemon inner API and yield the response as a model.
         """
-        for line in self._stream_request(method, path, params, headers, data, files):
-            try:
-                rep = PluginDaemonBasicResponse[type_].model_validate_json(line)  # type: ignore
-            except (ValueError, TypeError):
-                # TODO modify this when line_data has code and message
+        response = self._stream_request(method, path, params, headers, data, files)
+        try:
+            for line in response:
                 try:
-                    line_data = json.loads(line)
+                    rep = PluginDaemonBasicResponse[type_].model_validate_json(line)  # type: ignore
                 except (ValueError, TypeError):
-                    raise ValueError(line)
-                # If the dictionary contains the `error` key, use its value as the argument
-                # for `ValueError`.
-                # Otherwise, use the `line` to provide better contextual information about the error.
-                raise ValueError(line_data.get("error", line))
-
-            if rep.code != 0:
-                if rep.code == -500:
+                    # TODO modify this when line_data has code and message
                     try:
-                        error = PluginDaemonError.model_validate(json.loads(rep.message))
-                    except Exception:
-                        raise PluginDaemonInnerError(code=rep.code, message=rep.message)
+                        line_data = json.loads(line)
+                    except (ValueError, TypeError):
+                        raise ValueError(line)
+                    # If the dictionary contains the `error` key, use its value as the argument
+                    # for `ValueError`.
+                    # Otherwise, use the `line` to provide better contextual information about the error.
+                    raise ValueError(line_data.get("error", line))
 
-                    logger.error("Error in stream response for plugin %s", rep.__dict__)
-                    self._handle_plugin_daemon_error(error.error_type, error.message)
-                raise ValueError(f"plugin daemon: {rep.message}, code: {rep.code}")
-            if rep.data is None:
-                frame = inspect.currentframe()
-                raise ValueError(f"got empty data from plugin daemon: {frame.f_lineno if frame else 'unknown'}")
-            yield rep.data
+                if rep.code != 0:
+                    if rep.code == -500:
+                        try:
+                            error = PluginDaemonError.model_validate(json.loads(rep.message))
+                        except Exception:
+                            raise PluginDaemonInnerError(code=rep.code, message=rep.message)
+
+                        logger.error("Error in stream response for plugin %s", rep.__dict__)
+                        self._handle_plugin_daemon_error(error.error_type, error.message)
+                    raise ValueError(f"plugin daemon: {rep.message}, code: {rep.code}")
+                if rep.data is None:
+                    frame = inspect.currentframe()
+                    raise ValueError(f"got empty data from plugin daemon: {frame.f_lineno if frame else 'unknown'}")
+                yield rep.data
+        finally:
+            close_stream(response)
 
     def _handle_plugin_daemon_error(self, error_type: str, message: str):
         """

--- a/api/core/plugin/impl/model.py
+++ b/api/core/plugin/impl/model.py
@@ -24,6 +24,7 @@ from graphon.model_runtime.entities.rerank_entities import MultimodalRerankInput
 from graphon.model_runtime.entities.text_embedding_entities import EmbeddingResult
 from graphon.model_runtime.protocols.tts_runtime import TTSModelVoice
 from graphon.model_runtime.utils.encoders import jsonable_encoder
+from libs.stream import close_stream
 
 _POLLING_UNSUPPORTED_INVOKE_ERROR_TYPES = frozenset((NotImplementedError.__name__,))
 _POLLING_UNSUPPORTED_ERROR_MESSAGE = "does not support polling"
@@ -616,6 +617,8 @@ class PluginModelClient(BasePluginClient):
                 yield TTSAudioChunk(binascii.unhexlify(hex_str), mime_type=result.mime_type)
         except PluginDaemonInnerError as e:
             raise ValueError(e.message + str(e.code))
+        finally:
+            close_stream(response)
 
     def get_tts_model_voices(
         self,

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -25,6 +25,7 @@ from core.app.features.rate_limiting.rate_limit import RateLimitGenerator
 from extensions.ext_redis import redis_client
 from graphon.file import helpers as file_helpers
 from graphon.model_runtime.utils.encoders import jsonable_encoder
+from libs.stream import close_stream
 
 if TYPE_CHECKING:
     from models import Account
@@ -484,19 +485,32 @@ def length_prefixed_response(
             )
 
     stream_response = response
+    closed = False
+
+    def close_response() -> None:
+        nonlocal closed
+        if not closed:
+            closed = True
+            close_stream(stream_response)
 
     def generate() -> Generator[bytes, None, None]:
-        for chunk in stream_response:
-            if isinstance(chunk, str):
-                yield pack_response_with_length_prefix(chunk.encode("utf-8"))
-            else:
-                yield pack_response_with_length_prefix(chunk)
+        try:
+            for chunk in stream_response:
+                if isinstance(chunk, str):
+                    yield pack_response_with_length_prefix(chunk.encode("utf-8"))
+                else:
+                    yield pack_response_with_length_prefix(chunk)
+        finally:
+            close_response()
 
-    return Response(
+    http_response = Response(
         _stream_with_request_context(generate()),
         status=200,
         mimetype="text/event-stream",
     )
+    # Flask's wrapper may be closed before generate() enters its finally block.
+    http_response.call_on_close(close_response)
+    return http_response
 
 
 class TokenManager:

--- a/api/libs/stream.py
+++ b/api/libs/stream.py
@@ -1,0 +1,20 @@
+"""Release optional stream resources without replacing an invocation error."""
+
+import logging
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class _Closable(Protocol):
+    def close(self) -> None: ...
+
+
+def close_stream(stream: object) -> None:
+    """Close resource-owning streams; plain iterables need no cleanup."""
+    if isinstance(stream, _Closable):
+        try:
+            stream.close()
+        except Exception:
+            logger.warning("Failed to close stream", exc_info=True)

--- a/api/services/audio_service.py
+++ b/api/services/audio_service.py
@@ -62,10 +62,12 @@ def _create_tts_response(
         return Response(audio_bytes, content_type=resolve_audio_mime_type(audio_bytes, declared_mime_type))
 
     audio_stream, mime_type = inspect_audio_stream(audio, declared_mime_type)
-    return Response(
+    response = Response(
         stream_with_context(audio_stream),  # pyrefly: ignore[no-matching-overload]
         content_type=mime_type,
     )
+    response.call_on_close(audio_stream.close)
+    return response
 
 
 class AudioService:

--- a/api/tests/unit_tests/controllers/console/explore/test_audio.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_audio.py
@@ -209,6 +209,49 @@ def test_tts_stream_preserves_split_signature_and_all_chunks(runtime: _Runtime) 
     assert dict(response.headers) == {"Content-Type": "audio/wav"}
 
 
+@pytest.mark.parametrize("consumed_chunks", [0, 1, 2, None])
+def test_tts_http_response_closes_retained_provider_stream(runtime: _Runtime, consumed_chunks: int | None) -> None:
+    closed: list[bool] = []
+    audio_chunks = [_WAV + b"\x00" * 32, b"first-tail", b"second-tail"]
+    path = f"/installed-apps/{runtime.harness.installed_app.id}/text-to-audio"
+
+    def chunks() -> Generator[bytes]:
+        try:
+            for chunk in audio_chunks:
+                assert has_request_context()
+                assert request.path == path
+                yield chunk
+        finally:
+            closed.append(True)
+
+    source = chunks()
+    runtime.output = AudioOutput(data=source, mime_type="audio/x-wav")
+    # Dispatch without the test client's initial WSGI read, including the case
+    # where the HTTP response is closed before any audio bytes are consumed.
+    with runtime.harness.app.test_request_context(path, method="POST", json={"text": "你好"}):
+        response = runtime.harness.app.full_dispatch_request()
+
+    assert response.status_code == 200
+    assert dict(response.headers) == {"Content-Type": "audio/wav"}
+    assert response.is_streamed
+    assert closed == []
+    try:
+        iterator = iter(response.response)
+        if consumed_chunks is None:
+            assert list(iterator) == audio_chunks
+            assert closed == [True]
+        else:
+            assert [next(iterator) for _ in range(consumed_chunks)] == audio_chunks[:consumed_chunks]
+            assert closed == []
+    finally:
+        response.close()
+        response.close()
+
+    assert closed == [True]
+    with pytest.raises(StopIteration):
+        next(source)
+
+
 def test_tts_rejects_provider_mime_mismatch_with_specific_completion_error(runtime: _Runtime) -> None:
     runtime.output = AudioOutput(data=_WAV, mime_type="audio/mpeg")
     _error(

--- a/api/tests/unit_tests/controllers/inner_api/plugin/test_plugin_tts_stream.py
+++ b/api/tests/unit_tests/controllers/inner_api/plugin/test_plugin_tts_stream.py
@@ -1,0 +1,205 @@
+"""Exercise TTS cleanup through the real inner-API handler and HTTP encoders."""
+
+import struct
+from collections.abc import Callable, Iterator
+from types import SimpleNamespace
+from typing import override
+
+import pytest
+from flask import Flask
+from flask_login import LoginManager
+from flask_restx import Api
+
+from controllers.inner_api.plugin.plugin import PluginInvokeTTSApi
+from core.plugin.backwards_invocation.base import BaseBackwardsInvocationResponse
+from core.plugin.backwards_invocation.model import PluginModelBackwardsInvocation
+from core.plugin.entities.plugin_daemon import TTSAudioChunk
+from extensions.ext_database import db
+from graphon.model_runtime.entities.model_entities import ModelPropertyKey, ModelType
+from models.account import Tenant
+from models.enums import EndUserType
+from models.model import EndUser
+
+_PATH = "/inner/api/invoke/tts"
+_TENANT_ID = "11111111-1111-4111-8111-111111111111"
+_USER_ID = "22222222-2222-4222-8222-222222222222"
+_WAV = b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00" + b"a" * 32
+_PAYLOAD = {
+    "tenant_id": _TENANT_ID,
+    "user_id": _USER_ID,
+    "provider": "provider-a",
+    "model": "tts-model",
+    "content_text": "hello",
+    "voice": "voice-a",
+}
+_HEADERS = {"X-Inner-Api-Key": "test-inner-key"}
+
+
+class _ProviderStream(Iterator[bytes]):
+    def __init__(self, chunks: list[bytes | Exception], *, close_error: bool = False) -> None:
+        self._chunks = iter(chunks)
+        self.close_error = close_error
+        self.close_calls = 0
+        self.read_calls = 0
+
+    @override
+    def __next__(self) -> bytes:
+        self.read_calls += 1
+        chunk = next(self._chunks)
+        if isinstance(chunk, Exception):
+            raise chunk
+        return chunk
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error:
+            raise RuntimeError("provider cleanup failed")
+
+
+class _ProviderModel:
+    def __init__(self) -> None:
+        self.stream = _ProviderStream([_WAV, b"second", b"third"])
+        self.invoke_calls = 0
+
+    def invoke_tts(self, *, content_text: str, voice: str) -> _ProviderStream:
+        assert content_text == "hello"
+        assert voice == "voice-a"
+        self.invoke_calls += 1
+        return self.stream
+
+    def get_model_schema(self) -> SimpleNamespace:
+        return SimpleNamespace(model_properties={ModelPropertyKey.AUDIO_TYPE: "wav"})
+
+
+@pytest.fixture
+def app(config_overrides: Callable[..., None]) -> Iterator[Flask]:
+    config_overrides(
+        DEPLOYMENT_EDITION="CLOUD",
+        PLUGIN_DAEMON_KEY="test-daemon-key",
+        INNER_API_KEY_FOR_PLUGIN="test-inner-key",
+    )
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SQLALCHEMY_DATABASE_URI="sqlite://")
+    db.init_app(app)
+    LoginManager(app)
+    Api(app).add_resource(PluginInvokeTTSApi, _PATH)
+    with app.app_context():
+        Tenant.metadata.create_all(
+            db.engine, tables=[Tenant.metadata.tables["tenants"], EndUser.metadata.tables["end_users"]]
+        )
+        tenant = Tenant(name="TTS workspace")
+        tenant.id = _TENANT_ID
+        db.session.add_all(
+            [
+                tenant,
+                EndUser(
+                    id=_USER_ID,
+                    tenant_id=_TENANT_ID,
+                    type=EndUserType.SERVICE_API,
+                    session_id=_USER_ID,
+                    is_anonymous=False,
+                ),
+            ]
+        )
+        db.session.commit()
+        yield app
+        db.session.remove()
+        db.engine.dispose()
+
+
+@pytest.fixture
+def provider(monkeypatch: pytest.MonkeyPatch) -> _ProviderModel:
+    model_instance = _ProviderModel()
+
+    def bind_model(
+        *, tenant_id: str, user_id: str | None, provider: str, model_type: ModelType, model: str
+    ) -> _ProviderModel:
+        assert (tenant_id, user_id) == (_TENANT_ID, _USER_ID)
+        assert (provider, model_type, model) == ("provider-a", ModelType.TTS, "tts-model")
+        return model_instance
+
+    monkeypatch.setattr(PluginModelBackwardsInvocation, "_get_bound_model_instance", staticmethod(bind_model))
+    return model_instance
+
+
+def _decode_frame(frame: bytes | str) -> BaseBackwardsInvocationResponse[dict[str, str]]:
+    assert isinstance(frame, bytes)
+    magic, reserved, header_length, data_length = struct.unpack("<BBHI", frame[:8])
+    assert (magic, reserved, header_length) == (0xF, 0, 0xA)
+    assert frame[8:14] == b"\x00" * 6
+    assert len(frame[14:]) == data_length
+    return BaseBackwardsInvocationResponse[dict[str, str]].model_validate_json(frame[14:])
+
+
+def test_unconsumed_tts_http_response_does_not_invoke_provider(app: Flask, provider: _ProviderModel) -> None:
+    # Dispatch without the test client's eager first WSGI iteration.
+    with app.test_request_context(_PATH, method="POST", json=_PAYLOAD, headers=_HEADERS):
+        response = app.full_dispatch_request()
+        assert response.status_code == 200
+        response.close()
+    assert provider.invoke_calls == 0
+    assert provider.stream.read_calls == 0
+    assert provider.stream.close_calls == 0
+
+
+def test_partial_tts_http_response_closes_provider_without_reading_remaining_chunks(
+    app: Flask, provider: _ProviderModel
+) -> None:
+    response = app.test_client().post(_PATH, json=_PAYLOAD, headers=_HEADERS, buffered=False)
+    assert response.status_code == 200
+    assert response.mimetype == "text/event-stream"
+    first = _decode_frame(next(iter(response.response)))
+    assert first.data == {"result": _WAV.hex(), "mime_type": "audio/wav"}
+    assert first.error == ""
+    assert provider.stream.read_calls == 1
+    response.close()
+    response.close()
+    # The fixture retains the provider stream, so garbage collection cannot
+    # conceal a missing close() anywhere in the HTTP wrapping chain.
+    assert provider.stream.close_calls == 1
+    assert provider.stream.read_calls == 1
+
+
+def test_fully_consumed_tts_http_response_closes_provider_and_preserves_frames(
+    app: Flask, provider: _ProviderModel
+) -> None:
+    response = app.test_client().post(_PATH, json=_PAYLOAD, headers=_HEADERS, buffered=False)
+    frames = [_decode_frame(frame) for frame in response.response]
+    assert [frame.data for frame in frames] == [
+        {"result": chunk.hex(), "mime_type": "audio/wav"} for chunk in [_WAV, b"second", b"third"]
+    ]
+    assert all(frame.error == "" for frame in frames)
+    assert provider.stream.close_calls == 1
+    response.close()
+    assert provider.stream.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("chunks", "error_prefix", "successful_frames"),
+    [
+        ([RuntimeError("provider first chunk failed")], "provider first chunk failed", 0),
+        ([TTSAudioChunk(_WAV, "audio/mpeg")], "TTS provider output MIME does not match", 0),
+        ([_WAV, RuntimeError("provider next chunk failed")], "provider next chunk failed", 1),
+    ],
+    ids=["first-chunk", "mime", "later-chunk"],
+)
+@pytest.mark.parametrize("close_error", [False, True], ids=["clean-close", "failed-close"])
+def test_tts_http_error_frame_preserves_invocation_error_and_closes_provider(
+    app: Flask,
+    provider: _ProviderModel,
+    chunks: list[bytes | Exception],
+    error_prefix: str,
+    successful_frames: int,
+    close_error: bool,
+) -> None:
+    provider.stream = _ProviderStream(chunks, close_error=close_error)
+    response = app.test_client().post(_PATH, json=_PAYLOAD, headers=_HEADERS, buffered=False)
+    assert response.status_code == 200
+    frames = [_decode_frame(frame) for frame in response.response]
+    assert len(frames) == successful_frames + 1
+    assert all(frame.error == "" for frame in frames[:successful_frames])
+    assert frames[-1].data is None
+    assert frames[-1].error.startswith(error_prefix)
+    assert provider.stream.close_calls == 1
+    response.close()
+    assert provider.stream.close_calls == 1

--- a/api/tests/unit_tests/core/base/test_app_generator_tts_publisher.py
+++ b/api/tests/unit_tests/core/base/test_app_generator_tts_publisher.py
@@ -1,5 +1,7 @@
 import base64
+from collections.abc import Generator, Iterator
 from types import SimpleNamespace
+from typing import override
 from unittest.mock import MagicMock
 
 import pytest
@@ -47,6 +49,19 @@ def _run(publisher: AppGeneratorTTSPublisher, *messages: MagicMock) -> None:
         publisher._msg_queue.put(message)
     publisher._msg_queue.put(None)
     publisher._runtime()
+
+
+class _CloseRecordingStream(Iterator[bytes]):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks: Iterator[bytes] = iter(chunks)
+        self.close_calls: int = 0
+
+    @override
+    def __next__(self) -> bytes:
+        return next(self._chunks)
+
+    def close(self) -> None:
+        self.close_calls += 1
 
 
 class TestAudioTrunk:
@@ -141,6 +156,80 @@ class TestAppGeneratorTTSPublisher:
         assert publisher._audio_queue.get().audio == base64.b64encode(b"audio1")
         assert publisher._audio_queue.get().audio == base64.b64encode(b"audio2")
         assert publisher._audio_queue.get().status == "finish"
+
+    def test_runtime_closes_the_provider_stream_after_normal_completion(
+        self, mock_model_manager: MagicMock, mock_model_instance: MagicMock
+    ) -> None:
+        stream = _CloseRecordingStream([b"\xff\xfb" + b"\x00" * 30, b"audio-tail"])
+        mock_model_instance.invoke_tts.return_value = stream
+        publisher = AppGeneratorTTSPublisher("tenant", "voice1")
+        publisher.msg_text = "Hello"
+
+        _run(publisher)
+
+        assert stream.close_calls == 1
+        assert publisher._audio_queue.get().status == "responding"
+        assert publisher._audio_queue.get().status == "responding"
+        assert publisher._audio_queue.get().status == "finish"
+
+    @pytest.mark.parametrize("cancel_during_inspection", [True, False])
+    def test_runtime_closes_the_provider_stream_when_cancelled(
+        self,
+        mock_model_manager: MagicMock,
+        mock_model_instance: MagicMock,
+        cancel_during_inspection: bool,
+    ) -> None:
+        publisher = AppGeneratorTTSPublisher("tenant", "voice1")
+        publisher.msg_text = "Hello"
+        closed = False
+
+        def audio_chunks() -> Generator[bytes, None, None]:
+            nonlocal closed
+            try:
+                if cancel_during_inspection:
+                    publisher.cancel()
+                yield b"\xff\xfb" + b"\x00" * 30
+                publisher.cancel()
+                yield b"audio-tail"
+            finally:
+                closed = True
+
+        # Keep the generator alive so garbage collection cannot stand in for explicit close.
+        stream = audio_chunks()
+        mock_model_instance.invoke_tts.return_value = stream
+
+        _run(publisher)
+
+        assert closed
+        if not cancel_during_inspection:
+            assert publisher._audio_queue.get().status == "responding"
+        assert publisher._audio_queue.empty()
+
+    def test_runtime_closes_the_provider_stream_when_incremental_format_validation_fails(
+        self, mock_model_manager: MagicMock, mock_model_instance: MagicMock
+    ) -> None:
+        publisher = AppGeneratorTTSPublisher("tenant", "voice1")
+        closed = False
+
+        def audio_chunks() -> Generator[TTSAudioChunk, None, None]:
+            nonlocal closed
+            try:
+                yield TTSAudioChunk(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 20, "audio/wav")
+                pytest.fail("The rejected provider stream must not be consumed further")
+            finally:
+                closed = True
+
+        stream = audio_chunks()
+        mock_model_instance.invoke_tts.return_value = stream
+
+        _run(publisher, _text_event("First. Second. tail"))
+
+        assert closed
+        terminal = publisher._audio_queue.get()
+        assert terminal.status == "error"
+        assert isinstance(terminal.error, InvokeBadRequestError)
+        assert "cannot be played incrementally" in str(terminal.error)
+        assert publisher._audio_queue.empty()
 
     def test_runtime_skips_an_empty_final_buffer(self, mock_model_manager, mock_model_instance: MagicMock):
         publisher = AppGeneratorTTSPublisher("tenant", "voice1")

--- a/api/tests/unit_tests/core/base/tts/test_audio_mime.py
+++ b/api/tests/unit_tests/core/base/tts/test_audio_mime.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator, Iterator
 from types import SimpleNamespace
-from typing import cast
+from typing import cast, override
 
 import pytest
 
@@ -64,3 +65,148 @@ def test_id3_metadata_is_not_treated_as_proof_of_an_mp3_codec() -> None:
 
     assert sniff_audio_mime_type(signature) is None
     assert resolve_audio_mime_type(signature, reported_mime_type="audio/aac") == "audio/aac"
+
+
+class _TrackedStream(Iterator[bytes]):
+    def __init__(self, chunks: Iterator[bytes], *, close_error: Exception | None = None) -> None:
+        self._chunks: Iterator[bytes] = chunks
+        self._close_error: Exception | None = close_error
+        self.close_calls: int = 0
+
+    @override
+    def __next__(self) -> bytes:
+        return next(self._chunks)
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self._close_error is not None:
+            raise self._close_error
+
+
+@pytest.mark.parametrize("consumed_chunks", [0, 1, 2, 3])
+def test_inspected_stream_closes_source_once_even_before_consumption(consumed_chunks: int) -> None:
+    chunks = [b"x" * 32, b"middle", b"last"]
+    source = _TrackedStream(iter(chunks))
+    stream, mime_type = inspect_audio_stream(source)
+
+    assert mime_type == "audio/mpeg"
+    assert [next(stream) for _ in range(consumed_chunks)] == chunks[:consumed_chunks]
+    assert source.close_calls == 0
+    stream.close()
+    stream.close()
+
+    assert source.close_calls == 1
+    assert list(stream) == []
+
+
+@pytest.mark.parametrize("chunks", [[], [b"short"], [b"x" * 32, b"last"]])
+def test_exhausting_inspected_stream_closes_source(chunks: list[bytes]) -> None:
+    source = _TrackedStream(iter(chunks))
+    stream, _ = inspect_audio_stream(source)
+
+    assert list(stream) == chunks
+    assert source.close_calls == 1
+    stream.close()
+    assert source.close_calls == 1
+
+
+def test_closing_inspected_stream_runs_provider_finally_without_gc() -> None:
+    released: list[bool] = []
+
+    def provider() -> Generator[bytes, None, None]:
+        try:
+            yield b"x" * 32
+            yield b"unread"
+        finally:
+            released.append(True)
+
+    source = provider()
+    stream, _ = inspect_audio_stream(source)
+    assert released == []
+
+    stream.close()
+
+    assert released == [True]
+    assert list(source) == []
+
+
+@pytest.mark.parametrize("after_prefix", [False, True])
+def test_provider_error_closes_source_without_being_replaced_by_cleanup_error(
+    after_prefix: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    provider_error = RuntimeError("provider interrupted")
+
+    def provider() -> Generator[bytes, None, None]:
+        if after_prefix:
+            yield b"x" * 32
+        raise provider_error
+
+    source = _TrackedStream(provider(), close_error=RuntimeError("cleanup failed"))
+    with pytest.raises(RuntimeError) as raised:
+        list(inspect_audio_stream(source)[0])
+
+    assert raised.value is provider_error
+    assert source.close_calls == 1
+    assert "cleanup failed" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        [TTSAudioChunk(b"x", "application/octet-stream")],
+        [TTSAudioChunk(b"RIFF\x24\x00\x00\x00WAVEfmt ", "audio/mpeg")],
+        [TTSAudioChunk(b"x", "audio/mpeg"), TTSAudioChunk(b"y", "audio/ogg")],
+        [b"x" * 32, TTSAudioChunk(b"later", "audio/ogg")],
+    ],
+)
+def test_mime_rejection_closes_provider_during_peek_or_later(chunks: list[bytes]) -> None:
+    source = _TrackedStream(iter(chunks))
+
+    with pytest.raises(InvokeBadRequestError):
+        list(inspect_audio_stream(source)[0])
+
+    assert source.close_calls == 1
+
+
+def test_closing_inspected_stream_closes_distinct_iterable_owner_and_iterator() -> None:
+    iterator = _TrackedStream(iter([b"x" * 32, b"remaining"]))
+
+    class ProviderResponse:
+        def __init__(self) -> None:
+            self.close_calls: int = 0
+
+        def __iter__(self) -> Iterator[bytes]:
+            return iterator
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    source = ProviderResponse()
+    stream, _ = inspect_audio_stream(source)
+
+    stream.close()
+    stream.close()
+
+    assert iterator.close_calls == 1
+    assert source.close_calls == 1
+
+
+def test_iterator_creation_failure_closes_provider_response() -> None:
+    error = RuntimeError("cannot start reading")
+
+    class ProviderResponse:
+        def __init__(self) -> None:
+            self.closed: bool = False
+
+        def __iter__(self) -> Iterator[bytes]:
+            raise error
+
+        def close(self) -> None:
+            self.closed = True
+
+    source = ProviderResponse()
+    with pytest.raises(RuntimeError) as raised:
+        inspect_audio_stream(source)
+
+    assert raised.value is error
+    assert source.closed

--- a/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
@@ -1,7 +1,9 @@
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from typing import override
 from urllib.parse import quote
 
+import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -40,6 +42,23 @@ class _StreamContext:
 
     def iter_lines(self):
         return self._lines
+
+
+class _TrackedHTTPStream(httpx.SyncByteStream):
+    def __init__(self, chunks: list[bytes], *, fail_close: bool = False) -> None:
+        self._chunks: list[bytes] = chunks
+        self._fail_close: bool = fail_close
+        self.close_calls: int = 0
+
+    @override
+    def __iter__(self) -> Iterator[bytes]:
+        yield from self._chunks
+
+    @override
+    def close(self) -> None:
+        self.close_calls += 1
+        if self._fail_close:
+            raise RuntimeError("HTTP close failed")
 
 
 class TestBasePluginClientImpl:
@@ -172,6 +191,48 @@ class TestBasePluginClientImpl:
 
         with pytest.raises(ValueError, match="got empty data"):
             list(client._request_with_plugin_daemon_response_stream("GET", "p", bool))
+
+    @pytest.mark.parametrize("consume_all", [False, True])
+    def test_response_decoder_closes_retained_http_stream(self, mocker: MockerFixture, consume_all: bool) -> None:
+        client = BasePluginClient()
+        transport_stream = _TrackedHTTPStream(
+            [b'{"code":0,"message":"","data":true}\n', b'{"code":0,"message":"","data":false}\n']
+        )
+        transport = httpx.MockTransport(lambda _: httpx.Response(200, stream=transport_stream))
+
+        with httpx.Client(transport=transport) as http_client:
+            mocker.patch("core.plugin.impl.base._httpx_client", http_client)
+            # Keep the live transport generator referenced so GC cannot hide a missing close.
+            request_stream = client._stream_request("GET", "plugin/tenant/stream")
+            mocker.patch.object(client, "_stream_request", return_value=request_stream)
+            response = client._request_with_plugin_daemon_response_stream("GET", "plugin/tenant/stream", bool)
+            assert next(response) is True
+            assert transport_stream.close_calls == 0
+            if consume_all:
+                assert list(response) == [False]
+            response.close()
+            response.close()
+
+            assert transport_stream.close_calls == 1
+
+    @pytest.mark.parametrize("valid_first_chunk", [False, True])
+    @pytest.mark.parametrize("fail_close", [False, True])
+    def test_response_decoder_preserves_invalid_frame_error_when_http_cleanup_fails(
+        self, mocker: MockerFixture, valid_first_chunk: bool, fail_close: bool
+    ) -> None:
+        client = BasePluginClient()
+        chunks = [b'{"code":0,"message":"","data":true}\n'] if valid_first_chunk else []
+        transport_stream = _TrackedHTTPStream([*chunks, b"broken-json\n"], fail_close=fail_close)
+        transport = httpx.MockTransport(lambda _: httpx.Response(200, stream=transport_stream))
+
+        with httpx.Client(transport=transport) as http_client:
+            mocker.patch("core.plugin.impl.base._httpx_client", http_client)
+            request_stream = client._stream_request("GET", "plugin/tenant/stream")
+            mocker.patch.object(client, "_stream_request", return_value=request_stream)
+            with pytest.raises(ValueError, match="^broken-json$"):
+                list(client._request_with_plugin_daemon_response_stream("GET", "plugin/tenant/stream", bool))
+
+            assert transport_stream.close_calls == 1
 
     @pytest.mark.parametrize(
         ("error_type", "expected"),

--- a/api/tests/unit_tests/core/plugin/impl/test_model_client.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_model_client.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import io
 import json
+from collections.abc import Generator, Iterator
 from types import SimpleNamespace
+from typing import override
 
 import pytest
 from pytest_mock import MockerFixture
 
-from core.plugin.entities.plugin_daemon import PluginDaemonInnerError
+from core.plugin.entities.plugin_daemon import PluginDaemonInnerError, PluginTTSResultResponse
 from core.plugin.impl.exc import PluginInvokeError, PluginLLMPollingUnsupportedError
 from core.plugin.impl.model import PluginModelClient
 from graphon.model_runtime.entities.llm_entities import LLMPollingResult, LLMPollingStatus, LLMResult, LLMUsage
@@ -546,6 +548,85 @@ class TestPluginModelClient:
 
         with pytest.raises(ValueError, match="tts error-400"):
             list(client.invoke_tts("tenant-1", "user-1", "org/plugin:1", "provider-a", "tts-a", {}, "hello", "alloy"))
+
+    @pytest.mark.parametrize("consume_all", [False, True])
+    def test_invoke_tts_closes_retained_daemon_stream(self, mocker: MockerFixture, consume_all: bool) -> None:
+        client = PluginModelClient()
+        closed: list[bool] = []
+
+        def daemon_stream() -> Generator[PluginTTSResultResponse, None, None]:
+            try:
+                yield PluginTTSResultResponse(result="6869", mime_type="audio/wav")
+                yield PluginTTSResultResponse(result="21", mime_type="audio/wav")
+            finally:
+                closed.append(True)
+
+        daemon = daemon_stream()
+        mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=daemon)
+        response = client.invoke_tts("tenant-1", "user-1", "org/plugin:1", "provider-a", "tts-a", {}, "hi", "alloy")
+        assert next(response) == b"hi"
+        if consume_all:
+            assert list(response) == [b"!"]
+        response.close()
+        response.close()
+
+        assert closed == [True]
+
+    @pytest.mark.parametrize("valid_first_chunk", [False, True])
+    def test_invoke_tts_closes_daemon_on_hex_decode_failure(
+        self, mocker: MockerFixture, valid_first_chunk: bool
+    ) -> None:
+        client = PluginModelClient()
+        closed: list[bool] = []
+
+        def daemon_stream() -> Generator[PluginTTSResultResponse, None, None]:
+            try:
+                if valid_first_chunk:
+                    yield PluginTTSResultResponse(result="6869")
+                yield PluginTTSResultResponse(result="not-hex")
+            finally:
+                closed.append(True)
+
+        daemon = daemon_stream()
+        mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=daemon)
+        response = client.invoke_tts("tenant-1", "user-1", "org/plugin:1", "provider-a", "tts-a", {}, "hi", "alloy")
+        with pytest.raises(ValueError):
+            list(response)
+
+        assert closed == [True]
+
+    @pytest.mark.parametrize("valid_first_chunk", [False, True])
+    def test_invoke_tts_preserves_daemon_error_when_cleanup_fails(
+        self, mocker: MockerFixture, valid_first_chunk: bool
+    ) -> None:
+        error = RuntimeError("daemon failed")
+
+        class DaemonStream(Iterator[PluginTTSResultResponse]):
+            def __init__(self) -> None:
+                self._chunks: Iterator[PluginTTSResultResponse] = iter(
+                    [PluginTTSResultResponse(result="6869")] if valid_first_chunk else []
+                )
+                self.close_calls: int = 0
+
+            @override
+            def __next__(self) -> PluginTTSResultResponse:
+                try:
+                    return next(self._chunks)
+                except StopIteration:
+                    raise error
+
+            def close(self) -> None:
+                self.close_calls += 1
+                raise RuntimeError("close failed")
+
+        client = PluginModelClient()
+        daemon = DaemonStream()
+        mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=daemon)
+        with pytest.raises(RuntimeError) as exc_info:
+            list(client.invoke_tts("tenant-1", "user-1", "org/plugin:1", "provider-a", "tts-a", {}, "hi", "alloy"))
+
+        assert exc_info.value is error
+        assert daemon.close_calls == 1
 
     def test_get_tts_model_voices(self, mocker: MockerFixture):
         client = PluginModelClient()

--- a/api/tests/unit_tests/core/test_model_manager.py
+++ b/api/tests/unit_tests/core/test_model_manager.py
@@ -1,5 +1,6 @@
-from collections.abc import Callable
+from collections.abc import Callable, Generator, Iterator
 from io import BytesIO
+from typing import override
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -456,6 +457,184 @@ def test_quota_managed_tts_releases_when_provider_fails_before_first_chunk() -> 
         list(model_instance.invoke_tts(content_text="hello"))
 
     reservation.commit.assert_not_called()
+    reservation.release.assert_called_once_with()
+
+
+class _TrackedTTSStream(Iterator[bytes]):
+    def __init__(self, chunks: list[bytes], *, error: Exception | None = None, fail_close: bool = False) -> None:
+        self._chunks: Iterator[bytes] = iter(chunks)
+        self._error: Exception | None = error
+        self._fail_close: bool = fail_close
+        self.close_calls: int = 0
+
+    @override
+    def __next__(self) -> bytes:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            if self._error is not None:
+                raise self._error
+            raise
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self._fail_close:
+            raise RuntimeError("provider close failed")
+
+
+@pytest.mark.parametrize("consume_all", [False, True])
+def test_quota_managed_tts_closes_retained_provider_generator(consume_all: bool) -> None:
+    manager, _ = _build_model_manager_bundle(
+        provider_type=ProviderType.SYSTEM,
+        restrict_models=[RestrictModel(model="tts-model", model_type=ModelType.TTS)],
+        model_type=ModelType.TTS,
+    )
+    model_instance = manager.get_model_instance("tenant-1", "openai", ModelType.TTS, "tts-model")
+    reservation = MagicMock()
+    events: list[str] = []
+    reservation.release.side_effect = lambda: events.append("release")
+
+    def provider_stream() -> Generator[bytes, None, None]:
+        try:
+            yield b"first"
+            yield b"second"
+        finally:
+            events.append("close")
+
+    provider = provider_stream()
+    with (
+        patch.object(model_instance, "reserve_quota", return_value=reservation),
+        patch.object(ModelInstance, "invoke_tts", return_value=provider),
+    ):
+        response = model_instance.invoke_tts(content_text="hello")
+        assert isinstance(response, Generator)
+        assert next(response) == b"first"
+        if consume_all:
+            assert list(response) == [b"second"]
+        response.close()
+        response.close()
+
+    assert events == ["close", "release"]
+
+
+def test_quota_managed_tts_close_before_iteration_does_not_reserve_or_invoke() -> None:
+    manager, _ = _build_model_manager_bundle(
+        provider_type=ProviderType.SYSTEM,
+        restrict_models=[RestrictModel(model="tts-model", model_type=ModelType.TTS)],
+        model_type=ModelType.TTS,
+    )
+    model_instance = manager.get_model_instance("tenant-1", "openai", ModelType.TTS, "tts-model")
+    with (
+        patch.object(model_instance, "reserve_quota") as reserve,
+        patch.object(ModelInstance, "invoke_tts") as invoke,
+    ):
+        response = model_instance.invoke_tts(content_text="hello")
+        assert isinstance(response, Generator)
+        response.close()
+
+    reserve.assert_not_called()
+    invoke.assert_not_called()
+
+
+@pytest.mark.parametrize("chunks", [[], [b"first"]])
+@pytest.mark.parametrize("fail_close", [False, True])
+def test_quota_managed_tts_preserves_provider_error_and_releases_after_close_failure(
+    chunks: list[bytes], fail_close: bool
+) -> None:
+    manager, _ = _build_model_manager_bundle(
+        provider_type=ProviderType.SYSTEM,
+        restrict_models=[RestrictModel(model="tts-model", model_type=ModelType.TTS)],
+        model_type=ModelType.TTS,
+    )
+    model_instance = manager.get_model_instance("tenant-1", "openai", ModelType.TTS, "tts-model")
+    reservation = MagicMock()
+    error = RuntimeError("provider failed")
+    provider = _TrackedTTSStream(chunks, error=error, fail_close=fail_close)
+
+    with (
+        patch.object(model_instance, "reserve_quota", return_value=reservation),
+        patch.object(ModelInstance, "invoke_tts", return_value=provider),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        list(model_instance.invoke_tts(content_text="hello"))
+
+    assert exc_info.value is error
+    assert provider.close_calls == 1
+    assert reservation.commit.call_count == len(chunks)
+    reservation.release.assert_called_once_with()
+
+
+def test_quota_managed_tts_closes_separate_iterator_and_iterable() -> None:
+    manager, _ = _build_model_manager_bundle(
+        provider_type=ProviderType.SYSTEM,
+        restrict_models=[RestrictModel(model="tts-model", model_type=ModelType.TTS)],
+        model_type=ModelType.TTS,
+    )
+    model_instance = manager.get_model_instance("tenant-1", "openai", ModelType.TTS, "tts-model")
+    iterator = _TrackedTTSStream([b"first", b"second"])
+
+    class ProviderResponse:
+        def __init__(self) -> None:
+            self.close_calls: int = 0
+
+        def __iter__(self) -> Iterator[bytes]:
+            return iterator
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    provider = ProviderResponse()
+    with (
+        patch.object(model_instance, "reserve_quota"),
+        patch.object(ModelInstance, "invoke_tts", return_value=provider),
+    ):
+        response = model_instance.invoke_tts(content_text="hello")
+        assert isinstance(response, Generator)
+        assert next(response) == b"first"
+        response.close()
+
+    assert iterator.close_calls == 1
+    assert provider.close_calls == 1
+
+
+def test_quota_managed_tts_closes_provider_when_first_chunk_commit_fails() -> None:
+    manager, _ = _build_model_manager_bundle(
+        provider_type=ProviderType.SYSTEM,
+        restrict_models=[RestrictModel(model="tts-model", model_type=ModelType.TTS)],
+        model_type=ModelType.TTS,
+    )
+    model_instance = manager.get_model_instance("tenant-1", "openai", ModelType.TTS, "tts-model")
+    reservation = MagicMock()
+    error = RuntimeError("quota commit failed")
+    reservation.commit.side_effect = error
+    provider = _TrackedTTSStream([b"first"], fail_close=True)
+    with (
+        patch.object(model_instance, "reserve_quota", return_value=reservation),
+        patch.object(ModelInstance, "invoke_tts", return_value=provider),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        list(model_instance.invoke_tts(content_text="hello"))
+
+    assert exc_info.value is error
+    assert provider.close_calls == 1
+    reservation.release.assert_called_once_with()
+
+
+def test_quota_managed_tts_accepts_plain_iterable_without_close() -> None:
+    manager, _ = _build_model_manager_bundle(
+        provider_type=ProviderType.SYSTEM,
+        restrict_models=[RestrictModel(model="tts-model", model_type=ModelType.TTS)],
+        model_type=ModelType.TTS,
+    )
+    model_instance = manager.get_model_instance("tenant-1", "openai", ModelType.TTS, "tts-model")
+    reservation = MagicMock()
+    with (
+        patch.object(model_instance, "reserve_quota", return_value=reservation),
+        patch.object(ModelInstance, "invoke_tts", return_value=[b"first", b"second"]),
+    ):
+        assert list(model_instance.invoke_tts(content_text="hello")) == [b"first", b"second"]
+
+    assert reservation.commit.call_count == 2
     reservation.release.assert_called_once_with()
 
 

--- a/api/tests/unit_tests/libs/test_helper.py
+++ b/api/tests/unit_tests/libs/test_helper.py
@@ -1,8 +1,17 @@
+from collections.abc import Generator
 from datetime import datetime
 
 import pytest
+from flask import Flask
 
-from libs.helper import OptionalTimestampField, alphanumeric, email, escape_like_pattern, extract_tenant_id
+from libs.helper import (
+    OptionalTimestampField,
+    alphanumeric,
+    email,
+    escape_like_pattern,
+    extract_tenant_id,
+    length_prefixed_response,
+)
 from models.account import Account
 from models.model import EndUser
 
@@ -197,3 +206,51 @@ class TestAlphanumericValidator:
             alphanumeric("tool.name")
         with pytest.raises(ValueError, match="not a valid alphanumeric value"):
             alphanumeric("tool/name")
+
+
+@pytest.mark.parametrize("consume_frame", [False, True])
+def test_length_prefixed_response_closes_prestarted_source(consume_frame: bool) -> None:
+    released: list[bool] = []
+
+    def generate() -> Generator[bytes, None, None]:
+        try:
+            yield b"prefetched"
+            yield b"next"
+            yield b"remaining"
+        finally:
+            released.append(True)
+
+    source = generate()
+    assert next(source) == b"prefetched"
+    with Flask(__name__).test_request_context():
+        response = length_prefixed_response(0xF, source)
+        if consume_frame:
+            assert next(iter(response.response))[14:] == b"next"
+        assert released == []
+        response.close()
+        response.close()
+
+        assert released == [True]
+        with pytest.raises(StopIteration):
+            next(source)
+
+
+def test_length_prefix_encoding_error_closes_source_immediately() -> None:
+    released: list[bool] = []
+
+    def generate() -> Generator[str, None, None]:
+        try:
+            yield "\ud800"
+            yield "remaining"
+        finally:
+            released.append(True)
+
+    source = generate()
+    with Flask(__name__).test_request_context():
+        response = length_prefixed_response(0xF, source)
+        try:
+            with pytest.raises(UnicodeEncodeError):
+                next(iter(response.response))
+            assert released == [True]
+        finally:
+            response.close()

--- a/api/tests/unit_tests/services/test_audio_service.py
+++ b/api/tests/unit_tests/services/test_audio_service.py
@@ -54,12 +54,13 @@ Tests available voice retrieval:
 """
 
 import json
+from collections.abc import Generator
 from decimal import Decimal
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
 import pytest
-from flask import Flask
+from flask import Flask, has_request_context, request
 from sqlalchemy.orm import Session
 from werkzeug.datastructures import FileStorage
 
@@ -73,7 +74,7 @@ from models.enums import ConversationFromSource, MessageStatus
 from models.model import App, AppMode, AppModelConfig, Message
 from models.workflow import Workflow, WorkflowType
 from services.app_ref_service import AppRef, MessageRef
-from services.audio_service import AudioService
+from services.audio_service import AudioService, _create_tts_response
 from services.errors.audio import (
     AudioTooLargeServiceError,
     NoAudioUploadedServiceError,
@@ -252,6 +253,46 @@ class AudioServiceTestDataFactory:
 def factory(sqlite_session: Session) -> AudioServiceTestDataFactory:
     """Provide the test data factory to all tests."""
     return AudioServiceTestDataFactory(sqlite_session)
+
+
+@pytest.mark.parametrize("consumed_chunks", [0, 1, 2, None])
+def test_tts_response_closes_retained_provider_stream(consumed_chunks: int | None) -> None:
+    closed: list[bool] = []
+    audio_chunks = [b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 32, b"first-tail", b"second-tail"]
+
+    def chunks() -> Generator[bytes]:
+        try:
+            for chunk in audio_chunks:
+                assert has_request_context()
+                assert request.path == "/text-to-audio"
+                yield chunk
+        finally:
+            closed.append(True)
+
+    source = chunks()
+    app = Flask(__name__)
+    with app.test_request_context("/text-to-audio", method="POST"):
+        response = _create_tts_response(source, "audio/x-wav")
+
+    assert response.status_code == 200
+    assert dict(response.headers) == {"Content-Type": "audio/wav"}
+    assert response.is_streamed
+    assert closed == []
+    try:
+        iterator = iter(response.response)
+        if consumed_chunks is None:
+            assert list(iterator) == audio_chunks
+            assert closed == [True]
+        else:
+            assert [next(iterator) for _ in range(consumed_chunks)] == audio_chunks[:consumed_chunks]
+            assert closed == []
+    finally:
+        response.close()
+        response.close()
+
+    assert closed == [True]
+    with pytest.raises(StopIteration):
+        next(source)
 
 
 class TestAudioServiceASR:


### PR DESCRIPTION
## Summary

Closing a TTS HTTP response after consuming one frame could leave its provider stream open because intermediate MIME, plugin, and response iterators did not propagate `close()`. MIME inspection also opens the source before the response iterator starts, so a generator `finally` alone cannot release every source.

Propagate cleanup through shared audio responses, the background TTS publisher, quota-managed model streams, plugin-daemon decoding, and plugin backwards invocation. The MIME stream explicitly owns resources opened during inspection; Flask close callbacks cover responses closed before iteration. Cleanup is idempotent at the owning wrappers, and cleanup failures are logged without replacing invocation failures. Audio bytes, MIME selection, length-prefixed frames, and quota accounting retain their existing behavior.

Stacked on #42056. This PR contains only stream lifecycle fixes and their regression tests.

