### PR TITLE
fix: log bodies for structured JSON media types

### DIFF
--- a/api/extensions/ext_request_logging.py
+++ b/api/extensions/ext_request_logging.py
@@ -17,7 +17,8 @@ def _is_content_type_json(content_type: str) -> bool:
     if not content_type:
         return False
     content_type_no_option, _ = werkzeug.http.parse_options_header(content_type)
-    return content_type_no_option.lower() == "application/json"
+    media_type = content_type_no_option.lower()
+    return media_type == "application/json" or (media_type.startswith("application/") and media_type.endswith("+json"))
 
 
 def _log_request_started(_sender, **_extra):

--- a/api/tests/unit_tests/extensions/test_ext_request_logging.py
+++ b/api/tests/unit_tests/extensions/test_ext_request_logging.py
@@ -21,6 +21,8 @@ def test_is_content_type_json():
     assert _is_content_type_json("application/json; charset=utf-8") is True
     # content type header with charset option, in uppercase.
     assert _is_content_type_json("APPLICATION/JSON; CHARSET=UTF-8") is True
+    assert _is_content_type_json("application/problem+json") is True
+    assert _is_content_type_json("application/vnd.api+json; charset=utf-8") is True
     assert _is_content_type_json("text/html") is False
     assert _is_content_type_json("") is False
 


### PR DESCRIPTION
## Summary

- recognize `application/*+json` as JSON in request logging
- keep parameter and case normalization intact
- cover problem-details and vendor JSON media types

Fixes #42100

## Screenshots

Not applicable.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

## Testing

- `pytest -o addopts='' tests/unit_tests/extensions/test_ext_request_logging.py -q` (15 passed)
- `ruff check extensions/ext_request_logging.py tests/unit_tests/extensions/test_ext_request_logging.py`
- `ruff format --check extensions/ext_request_logging.py tests/unit_tests/extensions/test_ext_request_logging.py`

Broader test suites were not run.