### PR TITLE
fix(web): remove local search delay and clean up component lifecycles

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -1860,11 +1860,6 @@
       "count": 1
     }
   },
-  "web/app/components/base/svg-gallery/index.tsx": {
-    "node-js/prefer-global/buffer": {
-      "count": 1
-    }
-  },
   "web/app/components/base/tag-input/index.stories.tsx": {
     "jsx-a11y/label-has-associated-control": {
       "count": 12
@@ -2668,11 +2663,6 @@
   },
   "web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx": {
     "jsx-a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
-  "web/app/components/header/account-setting/model-provider-page/provider-added-card/cooldown-timer.tsx": {
-    "eslint-react/set-state-in-effect": {
       "count": 1
     }
   },

--- a/web/app/components/base/carousel/__tests__/index.spec.tsx
+++ b/web/app/components/base/carousel/__tests__/index.spec.tsx
@@ -193,7 +193,7 @@ describe('Carousel', () => {
       expect(dots[2])!.toHaveAttribute('data-state', 'active')
     })
 
-    it('should subscribe to embla events and unsubscribe from select on unmount', () => {
+    it('should release embla subscriptions on unmount', () => {
       const { unmount } = renderCarouselWithControls()
 
       const selectCallback = mockApi.on.mock.calls.find(
@@ -205,6 +205,7 @@ describe('Carousel', () => {
 
       unmount()
 
+      expect(mockApi.off).toHaveBeenCalledWith('reInit', selectCallback)
       expect(mockApi.off).toHaveBeenCalledWith('select', selectCallback)
     })
   })

--- a/web/app/components/base/carousel/index.tsx
+++ b/web/app/components/base/carousel/index.tsx
@@ -36,180 +36,162 @@ function useCarousel() {
   return context
 }
 
-type TCarousel = {
-  Content: typeof CarouselContent
-  Item: typeof CarouselItem
-  Previous: typeof CarouselPrevious
-  Next: typeof CarouselNext
-  Dot: typeof CarouselDot
-  Plugin: typeof CarouselPlugins
-} & React.ForwardRefExoticComponent<
-  React.HTMLAttributes<HTMLDivElement> & CarouselProps & React.RefAttributes<CarouselContextValue>
->
+function Carousel({
+  ref,
+  orientation = 'horizontal',
+  opts,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> &
+  CarouselProps & { ref?: React.Ref<CarouselContextValue> }) {
+  const [carouselRef, api] = useEmblaCarousel(
+    { ...opts, axis: orientation === 'horizontal' ? 'x' : 'y' },
+    plugins,
+  )
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+  const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const [selectedIndex, setSelectedIndex] = React.useState(0)
 
-const Carousel: TCarousel = React.forwardRef(
-  ({ orientation = 'horizontal', opts, plugins, className, children, ...props }, ref) => {
-    const [carouselRef, api] = useEmblaCarousel(
-      { ...opts, axis: orientation === 'horizontal' ? 'x' : 'y' },
-      plugins,
-    )
-    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-    const [canScrollNext, setCanScrollNext] = React.useState(false)
-    const [selectedIndex, setSelectedIndex] = React.useState(0)
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
 
-    const scrollPrev = React.useCallback(() => {
-      api?.scrollPrev()
-    }, [api])
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext()
+  }, [api])
 
-    const scrollNext = React.useCallback(() => {
-      api?.scrollNext()
-    }, [api])
+  React.useEffect(() => {
+    if (!api) return
 
-    React.useEffect(() => {
+    const onSelect = (api: CarouselApi) => {
       if (!api) return
 
-      const onSelect = (api: CarouselApi) => {
-        if (!api) return
+      setSelectedIndex(api.selectedScrollSnap())
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }
 
-        setSelectedIndex(api.selectedScrollSnap())
-        setCanScrollPrev(api.canScrollPrev())
-        setCanScrollNext(api.canScrollNext())
-      }
+    onSelect(api)
+    api.on('reInit', onSelect)
+    api.on('select', onSelect)
 
-      onSelect(api)
-      api.on('reInit', onSelect)
-      api.on('select', onSelect)
+    return () => {
+      api.off('reInit', onSelect)
+      api.off('select', onSelect)
+    }
+  }, [api])
 
-      return () => {
-        api?.off('select', onSelect)
-      }
-    }, [api])
+  React.useImperativeHandle(ref, () => ({
+    carouselRef,
+    api,
+    opts,
+    orientation,
+    scrollPrev,
+    scrollNext,
+    selectedIndex,
+    canScrollPrev,
+    canScrollNext,
+  }))
 
-    React.useImperativeHandle(ref, () => ({
-      carouselRef,
-      api,
-      opts,
-      orientation,
-      scrollPrev,
-      scrollNext,
-      selectedIndex,
-      canScrollPrev,
-      canScrollNext,
-    }))
-
-    return (
-      <CarouselContext.Provider
-        value={{
-          carouselRef,
-          api,
-          opts,
-          orientation,
-          scrollPrev,
-          scrollNext,
-          selectedIndex,
-          canScrollPrev,
-          canScrollNext,
-        }}
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api,
+        opts,
+        orientation,
+        scrollPrev,
+        scrollNext,
+        selectedIndex,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        ref={carouselRef}
+        // onKeyDownCapture={handleKeyDown}
+        className={cn('relative overflow-hidden', className)}
+        role="region"
+        aria-roledescription="carousel"
+        {...props}
       >
-        <div
-          ref={carouselRef}
-          // onKeyDownCapture={handleKeyDown}
-          className={cn('relative overflow-hidden', className)}
-          role="region"
-          aria-roledescription="carousel"
-          {...props}
-        >
-          {children}
-        </div>
-      </CarouselContext.Provider>
-    )
-  },
-) as TCarousel
-Carousel.displayName = 'Carousel'
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  )
+}
 
-const CarouselContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    const { orientation } = useCarousel()
+function CarouselContent({ ref, className, ...props }: React.ComponentPropsWithRef<'div'>) {
+  const { orientation } = useCarousel()
 
-    return (
-      <div
-        ref={ref}
-        className={cn('flex', orientation === 'vertical' && 'flex-col', className)}
-        {...props}
-      />
-    )
-  },
-)
-CarouselContent.displayName = 'CarouselContent'
+  return (
+    <div
+      ref={ref}
+      className={cn('flex', orientation === 'vertical' && 'flex-col', className)}
+      {...props}
+    />
+  )
+}
 
-const CarouselItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        role="group"
-        aria-roledescription="slide"
-        className={cn('min-w-0 shrink-0 grow-0 basis-full', className)}
-        {...props}
-      />
-    )
-  },
-)
-CarouselItem.displayName = 'CarouselItem'
+function CarouselItem({ ref, className, ...props }: React.ComponentPropsWithRef<'div'>) {
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn('min-w-0 shrink-0 grow-0 basis-full', className)}
+      {...props}
+    />
+  )
+}
 
 type CarouselActionProps = Readonly<{
+  ref?: React.Ref<HTMLButtonElement>
   children?: React.ReactNode
 }> &
   Omit<React.HTMLAttributes<HTMLButtonElement>, 'disabled' | 'onClick'>
 
-const CarouselPrevious = React.forwardRef<HTMLButtonElement, CarouselActionProps>(
-  ({ children, ...props }, ref) => {
-    const { scrollPrev, canScrollPrev } = useCarousel()
+function CarouselPrevious({ ref, children, ...props }: CarouselActionProps) {
+  const { scrollPrev, canScrollPrev } = useCarousel()
 
+  return (
+    <button ref={ref} {...props} disabled={!canScrollPrev} onClick={scrollPrev}>
+      {children}
+    </button>
+  )
+}
+
+function CarouselNext({ ref, children, ...props }: CarouselActionProps) {
+  const { scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <button ref={ref} {...props} disabled={!canScrollNext} onClick={scrollNext}>
+      {children}
+    </button>
+  )
+}
+
+function CarouselDot({ ref, children, ...props }: CarouselActionProps) {
+  const { api, selectedIndex } = useCarousel()
+
+  return api?.slideNodes().map((_, index) => {
     return (
-      <button ref={ref} {...props} disabled={!canScrollPrev} onClick={scrollPrev}>
+      <button
+        key={index}
+        ref={ref}
+        {...props}
+        data-state={index === selectedIndex ? 'active' : 'inactive'}
+        onClick={() => {
+          api.scrollTo(index)
+        }}
+      >
         {children}
       </button>
     )
-  },
-)
-CarouselPrevious.displayName = 'CarouselPrevious'
-
-const CarouselNext = React.forwardRef<HTMLButtonElement, CarouselActionProps>(
-  ({ children, ...props }, ref) => {
-    const { scrollNext, canScrollNext } = useCarousel()
-
-    return (
-      <button ref={ref} {...props} disabled={!canScrollNext} onClick={scrollNext}>
-        {children}
-      </button>
-    )
-  },
-)
-CarouselNext.displayName = 'CarouselNext'
-
-const CarouselDot = React.forwardRef<HTMLButtonElement, CarouselActionProps>(
-  ({ children, ...props }, ref) => {
-    const { api, selectedIndex } = useCarousel()
-
-    return api?.slideNodes().map((_, index) => {
-      return (
-        <button
-          key={index}
-          ref={ref}
-          {...props}
-          data-state={index === selectedIndex ? 'active' : 'inactive'}
-          onClick={() => {
-            api.scrollTo(index)
-          }}
-        >
-          {children}
-        </button>
-      )
-    })
-  },
-)
-CarouselDot.displayName = 'CarouselDot'
+  })
+}
 
 const CarouselPlugins = {
   Autoplay,

--- a/web/app/components/base/svg-gallery/__tests__/index.spec.tsx
+++ b/web/app/components/base/svg-gallery/__tests__/index.spec.tsx
@@ -68,21 +68,6 @@ describe('SVGRenderer', () => {
       })
     })
 
-    it('re-renders on window resize', async () => {
-      render(<SVGRenderer content={validSvg} />)
-      await waitFor(() => {
-        expect(mockAddTo).toHaveBeenCalledTimes(1)
-      })
-
-      await act(async () => {
-        window.dispatchEvent(new Event('resize'))
-      })
-
-      await waitFor(() => {
-        expect(mockAddTo).toHaveBeenCalledTimes(2)
-      })
-    })
-
     it('uses default values for width/height if not present', async () => {
       const mockSvgElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
       parseFromStringSpy.mockReturnValue({

--- a/web/app/components/base/svg-gallery/index.tsx
+++ b/web/app/components/base/svg-gallery/index.tsx
@@ -8,27 +8,13 @@ const SVGRenderer = ({ content }: { content: string }) => {
   const { t } = useTranslation('common')
   const svgRef = useRef<HTMLDivElement>(null)
   const [imagePreview, setImagePreview] = useState('')
-  const [windowSize, setWindowSize] = useState({
-    /* v8 ignore start -- this client component can still be evaluated in non-browser contexts (SSR/type tooling); window fallback prevents reference errors. @preserve */
-    width: typeof window !== 'undefined' ? window.innerWidth : 0,
-    height: typeof window !== 'undefined' ? window.innerHeight : 0,
-    /* v8 ignore stop */
-  })
 
   const svgToDataURL = (svgElement: Element): string => {
     const svgString = new XMLSerializer().serializeToString(svgElement)
-    const base64String = Buffer.from(svgString).toString('base64')
+    const bytes = new TextEncoder().encode(svgString)
+    const base64String = btoa(Array.from(bytes, (byte) => String.fromCodePoint(byte)).join(''))
     return `data:image/svg+xml;base64,${base64String}`
   }
-
-  useEffect(() => {
-    const handleResize = () => {
-      setWindowSize({ width: window.innerWidth, height: window.innerHeight })
-    }
-
-    window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
-  }, [])
 
   useEffect(() => {
     /* v8 ignore next 2 -- ref is expected after mount, but null can occur during rapid mount/unmount timing in React lifecycle edges. @preserve */
@@ -63,7 +49,7 @@ const SVGRenderer = ({ content }: { content: string }) => {
       generatingMessage.textContent = t(($) => $['svgRenderer.generatingImage'])
       svgRef.current.replaceChildren(generatingMessage)
     }
-  }, [content, t, windowSize])
+  }, [content, t])
 
   return (
     <>

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/cooldown-timer.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/cooldown-timer.spec.tsx
@@ -1,28 +1,76 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
+import { StrictMode } from 'react'
 import CooldownTimer from '../cooldown-timer'
 
 describe('CooldownTimer', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
   })
 
-  it('should not render when secondsRemaining is zero', () => {
-    const { container } = render(<CooldownTimer secondsRemaining={0} />)
-    expect(container.firstChild).toBeNull()
-  })
-
-  it('should not render when secondsRemaining is undefined', () => {
-    const { container } = render(<CooldownTimer />)
-    expect(container.firstChild).toBeNull()
-  })
-
-  it('should call onFinish after countdown completes', () => {
-    vi.useFakeTimers()
-    const onFinish = vi.fn()
-    render(<CooldownTimer secondsRemaining={1} onFinish={onFinish} />)
-
-    vi.advanceTimersByTime(2000)
-    expect(onFinish).toHaveBeenCalled()
+  afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it.each([0, undefined])('does not show an inactive cooldown (%s)', (secondsRemaining) => {
+    const { container } = render(<CooldownTimer secondsRemaining={secondsRemaining} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('clears the cooldown indicator and finishes once when the deadline is reached', () => {
+    const onFinish = vi.fn()
+    const { container } = render(
+      <StrictMode>
+        <CooldownTimer secondsRemaining={2} onFinish={onFinish} />
+      </StrictMode>,
+    )
+
+    expect(container.firstChild).not.toBeNull()
+    act(() => vi.advanceTimersByTime(1000))
+    expect(onFinish).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(1000))
+    expect(container.firstChild).toBeNull()
+    expect(onFinish).toHaveBeenCalledTimes(1)
+
+    act(() => vi.advanceTimersByTime(5000))
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the latest completion callback without restarting the cooldown', () => {
+    const onFinish = vi.fn()
+    const onUpdatedFinish = vi.fn()
+    const { rerender } = render(<CooldownTimer secondsRemaining={3} onFinish={onFinish} />)
+
+    act(() => vi.advanceTimersByTime(1000))
+    rerender(<CooldownTimer secondsRemaining={3} onFinish={onUpdatedFinish} />)
+    act(() => vi.advanceTimersByTime(2000))
+
+    expect(onFinish).not.toHaveBeenCalled()
+    expect(onUpdatedFinish).toHaveBeenCalledTimes(1)
+  })
+
+  it('restarts from an updated cooldown duration', () => {
+    const onFinish = vi.fn()
+    const { rerender } = render(<CooldownTimer secondsRemaining={2} onFinish={onFinish} />)
+
+    act(() => vi.advanceTimersByTime(1000))
+    rerender(<CooldownTimer secondsRemaining={4} onFinish={onFinish} />)
+    act(() => vi.advanceTimersByTime(3000))
+    expect(onFinish).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(1000))
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not finish a cooldown after its row is removed', () => {
+    const onFinish = vi.fn()
+    const { unmount } = render(<CooldownTimer secondsRemaining={2} onFinish={onFinish} />)
+
+    act(() => vi.advanceTimersByTime(1000))
+    unmount()
+    act(() => vi.advanceTimersByTime(5000))
+
+    expect(onFinish).not.toHaveBeenCalled()
   })
 })

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/cooldown-timer.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/cooldown-timer.tsx
@@ -1,6 +1,5 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
-import { useLatest } from 'ahooks'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useEffectEvent, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SimplePieChart from '@/app/components/base/simple-pie-chart'
 
@@ -9,47 +8,35 @@ type CooldownTimerProps = {
   onFinish?: () => void
 }
 
-const CooldownTimer = ({ secondsRemaining, onFinish }: CooldownTimerProps) => {
+const CooldownTimer = ({ secondsRemaining = 0, onFinish }: CooldownTimerProps) => {
   const { t } = useTranslation()
 
-  const targetTime = useRef<number>(Date.now())
-  const [currentTime, setCurrentTime] = useState(targetTime.current)
-  const displayTime = useMemo(
-    () => Math.ceil((targetTime.current - currentTime) / 1000),
-    [currentTime],
-  )
+  const [countdown, setCountdown] = useState({ secondsRemaining, displayTime: secondsRemaining })
+  if (countdown.secondsRemaining !== secondsRemaining) {
+    setCountdown({ secondsRemaining, displayTime: secondsRemaining })
+  }
 
-  const countdownTimeout = useRef<number>(undefined)
-  const clearCountdown = useCallback(() => {
-    if (countdownTimeout.current) {
-      window.clearTimeout(countdownTimeout.current)
-      countdownTimeout.current = undefined
-    }
-  }, [])
-
-  const onFinishRef = useLatest(onFinish)
-
-  const countdown = useCallback(() => {
-    clearCountdown()
-    countdownTimeout.current = window.setTimeout(() => {
-      const now = Date.now()
-      if (now <= targetTime.current) {
-        setCurrentTime(Date.now())
-        countdown()
-      } else {
-        onFinishRef.current?.()
-        clearCountdown()
-      }
-    }, 1000)
-  }, [clearCountdown, onFinishRef])
+  const onCountdownFinish = useEffectEvent(() => {
+    onFinish?.()
+  })
 
   useEffect(() => {
-    const now = Date.now()
-    targetTime.current = now + (secondsRemaining ?? 0) * 1000
-    setCurrentTime(now)
-    countdown()
-    return clearCountdown
-  }, [clearCountdown, countdown, secondsRemaining])
+    if (secondsRemaining <= 0) return
+
+    const targetTime = Date.now() + secondsRemaining * 1000
+    const interval = window.setInterval(() => {
+      const displayTime = Math.max(0, Math.ceil((targetTime - Date.now()) / 1000))
+      setCountdown({ secondsRemaining, displayTime })
+      if (displayTime === 0) {
+        window.clearInterval(interval)
+        onCountdownFinish()
+      }
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [secondsRemaining])
+
+  const { displayTime } = countdown
 
   return displayTime ? (
     <Tooltip>
@@ -65,4 +52,4 @@ const CooldownTimer = ({ secondsRemaining, onFinish }: CooldownTimerProps) => {
   ) : null
 }
 
-export default memo(CooldownTimer)
+export default CooldownTimer

--- a/web/features/home/home-content/__tests__/home-content.spec.tsx
+++ b/web/features/home/home-content/__tests__/home-content.spec.tsx
@@ -921,6 +921,8 @@ describe('HomeContent', () => {
     })
 
     it('should keep selected category when clearing search text', async () => {
+      vi.useRealTimers()
+      const user = userEvent.setup()
       mockExploreData = {
         categories: ['Writing', 'Translate'],
         allList: [
@@ -935,15 +937,9 @@ describe('HomeContent', () => {
 
       renderHomeContent({ searchParams: { category: 'Writing' } })
 
-      const input = screen.getByPlaceholderText('common.operation.search')
-      fireEvent.change(input, { target: { value: 'alp' } })
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500)
-      })
-      fireEvent.click(screen.getByRole('button', { name: 'common.operation.clear' }))
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500)
-      })
+      const input = screen.getByRole('searchbox', { name: 'common.operation.search' })
+      await user.type(input, 'alp')
+      await user.click(screen.getByRole('button', { name: 'common.operation.clear' }))
 
       expect(screen.getByText('Alpha')).toBeInTheDocument()
       expect(screen.queryByText('Beta')).not.toBeInTheDocument()
@@ -951,7 +947,9 @@ describe('HomeContent', () => {
   })
 
   describe('User Interactions', () => {
-    it('should filter apps by search keywords', async () => {
+    it('should filter local templates immediately as the user types', async () => {
+      vi.useRealTimers()
+      const user = userEvent.setup()
       mockExploreData = {
         categories: ['Writing'],
         allList: [
@@ -961,12 +959,8 @@ describe('HomeContent', () => {
       }
       renderHomeContent()
 
-      const input = screen.getByPlaceholderText('common.operation.search')
-      fireEvent.change(input, { target: { value: 'gam' } })
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500)
-      })
+      const input = screen.getByRole('searchbox', { name: 'common.operation.search' })
+      await user.type(input, 'gam')
 
       expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
       expect(screen.getByText('Gamma')).toBeInTheDocument()
@@ -1379,6 +1373,8 @@ describe('HomeContent', () => {
 
   describe('Edge Cases', () => {
     it('should reset search results when clear icon is clicked', async () => {
+      vi.useRealTimers()
+      const user = userEvent.setup()
       mockExploreData = {
         categories: ['Writing'],
         allList: [
@@ -1388,17 +1384,11 @@ describe('HomeContent', () => {
       }
       renderHomeContent()
 
-      const input = screen.getByPlaceholderText('common.operation.search')
-      fireEvent.change(input, { target: { value: 'gam' } })
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500)
-      })
+      const input = screen.getByRole('searchbox', { name: 'common.operation.search' })
+      await user.type(input, 'gam')
       expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
 
-      fireEvent.click(screen.getByRole('button', { name: 'common.operation.clear' }))
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500)
-      })
+      await user.click(screen.getByRole('button', { name: 'common.operation.clear' }))
 
       expect(screen.getByText('Alpha')).toBeInTheDocument()
       expect(screen.getByText('Gamma')).toBeInTheDocument()

--- a/web/features/home/home-content/home-content.tsx
+++ b/web/features/home/home-content/home-content.tsx
@@ -6,7 +6,6 @@ import type { StepByStepTourTaskId } from '@/app/components/step-by-step-tour/ty
 import type { TrackCreateAppParams } from '@/utils/create-app-tracking'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQueryClient, useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query'
-import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -110,8 +109,6 @@ export function HomeContent() {
   )
 
   const [keywords, setKeywords] = useState('')
-  const debouncedKeywords = useDebouncedValue(keywords, 500)
-  const searchKeywords = keywords ? debouncedKeywords : ''
 
   const [currCategory, setCurrCategory] = useQueryState('category', {
     defaultValue: allCategoriesEn,
@@ -137,15 +134,15 @@ export function HomeContent() {
   }, [templatesData, activeCategory, allCategoriesEn])
 
   const searchFilteredList = useMemo(() => {
-    if (!searchKeywords || !filteredList || filteredList.length === 0) return filteredList
+    if (!keywords || !filteredList || filteredList.length === 0) return filteredList
 
-    const lowerCaseSearchKeywords = searchKeywords.toLowerCase()
+    const lowerCaseSearchKeywords = keywords.toLowerCase()
 
     return filteredList.filter(
       (item) =>
         item.app && item.app.name && item.app.name.toLowerCase().includes(lowerCaseSearchKeywords),
     )
-  }, [searchKeywords, filteredList])
+  }, [keywords, filteredList])
 
   const [currApp, setCurrApp] = useState<RecommendedAppResponse | null>(null)
   const [isShowCreateModal, setIsShowCreateModal] = useState(false)


### PR DESCRIPTION
## Summary

Home filters templates that are already loaded locally, but previously delayed results by 500 ms. Filter on the current search value while preserving the shared SearchInput composition and clear behavior and the selected category.

This PR also cleans up existing component lifecycles:

- Keep SVG rendering tied to content and locale, removing an unused window-size subscription that rebuilt the SVG on every resize. Encode preview data with browser APIs instead of relying on a global Node Buffer, preserving UTF-8 content.
- Give CooldownTimer an effect-owned clock and cleanup, with an Effect Event for the latest completion callback. Show the initial duration immediately, finish when the deadline is reached, and restart only when the duration changes. Remove render-time clock/ref reads and the obsolete lint suppression.
- Accept ref as a prop in Carousel and its compound components, preserving the imperative handle and compound API. Release both Embla select and reInit subscriptions on cleanup.

These are focused engineering fixes following #42093; they do not require React 19.3-specific features.

## Validation

- 315 focused unit tests passed across 26 files, including Home, SearchInput, SVG, Carousel, marketplace carousel, and model-provider configuration.
- Updated existing Home tests to type and clear through user-event without debounce waits. Added cooldown checks for deadline completion, callback replacement, duration changes, Strict Mode, and row removal. Removed the SVG test that required rebuilding on resize.
- Repository static checks and Web TSSLint passed.
- Next production build passed.
- One-off Chromium verification passed for SVG resizing, updated Unicode content, and opening/closing the preview. No browser test file is included.

From Codex
