### PR TITLE
fix(agent): pin chatflow participant versions across config updates

### DIFF
--- a/api/core/workflow/nodes/agent_v2/agent_node.py
+++ b/api/core/workflow/nodes/agent_v2/agent_node.py
@@ -187,6 +187,7 @@ class DifyAgentNode(Node[DifyAgentNodeData]):
                 node_id=self._node_id,
                 binding_id=existing_scope.workflow_agent_binding_id if existing_scope is not None else None,
                 snapshot_id=existing_scope.agent_config_snapshot_id if existing_scope is not None else None,
+                conversation_id=conversation_id,
             )
         except WorkflowAgentBindingError as error:
             yield self._failure_event(

--- a/api/core/workflow/nodes/agent_v2/binding_resolver.py
+++ b/api/core/workflow/nodes/agent_v2/binding_resolver.py
@@ -6,14 +6,17 @@ from sqlalchemy import select
 
 from core.agent.publish_visibility import workflow_callable_active_snapshot_filter
 from core.db.session_factory import session_factory
+from core.workflow.nodes.agent_v2.session_store import resolve_workflow_agent_workspace_owner_scope
 from models.agent import (
     Agent,
     AgentConfigSnapshot,
+    AgentConfigVersionKind,
     AgentScope,
     AgentStatus,
     WorkflowAgentBindingType,
     WorkflowAgentNodeBinding,
 )
+from services.agent.workspace_service import AgentWorkspaceService
 
 
 class WorkflowAgentBindingError(Exception):
@@ -43,8 +46,9 @@ class WorkflowAgentBindingResolver:
         node_id: str,
         binding_id: str | None = None,
         snapshot_id: str | None = None,
+        conversation_id: str | None = None,
     ) -> WorkflowAgentBindingBundle:
-        """Resolve the current binding, optionally at a generation pinned by an existing execution."""
+        """Resolve the generation pinned by an execution or a Chatflow conversation participant."""
 
         if (binding_id is None) != (snapshot_id is None):
             raise WorkflowAgentBindingError(
@@ -85,6 +89,29 @@ class WorkflowAgentBindingResolver:
                     "agent_not_available",
                     f"Agent {binding.agent_id} is not available or has not been published.",
                 )
+
+            # A new node execution in the same conversation must keep its participant's
+            # config/Home generation even after the roster Agent publishes a new version.
+            if snapshot_id is None and conversation_id:
+                participant = AgentWorkspaceService.resolve_active_binding_for_scope(
+                    session=session,
+                    scope=resolve_workflow_agent_workspace_owner_scope(
+                        tenant_id=tenant_id,
+                        app_id=app_id,
+                        conversation_id=conversation_id,
+                        workflow_run_id=None,
+                        node_id=node_id,
+                        workflow_agent_binding_id=binding.id,
+                    ),
+                    agent_id=agent.id,
+                )
+                if participant is not None:
+                    if participant.agent_config_version_kind != AgentConfigVersionKind.SNAPSHOT:
+                        raise WorkflowAgentBindingError(
+                            "agent_binding_generation_invalid",
+                            "Chatflow Agent participant must reference a config snapshot.",
+                        )
+                    snapshot_id = participant.agent_config_version_id
 
             effective_snapshot_id = (
                 (

--- a/api/core/workflow/nodes/agent_v2/binding_resolver.py
+++ b/api/core/workflow/nodes/agent_v2/binding_resolver.py
@@ -6,7 +6,10 @@ from sqlalchemy import select
 
 from core.agent.publish_visibility import workflow_callable_active_snapshot_filter
 from core.db.session_factory import session_factory
-from core.workflow.nodes.agent_v2.session_store import resolve_workflow_agent_workspace_owner_scope
+from core.workflow.nodes.agent_v2.session_store import (
+    WorkflowAgentWorkspaceStore,
+    resolve_workflow_agent_workspace_owner_scope,
+)
 from models.agent import (
     Agent,
     AgentConfigSnapshot,
@@ -16,7 +19,6 @@ from models.agent import (
     WorkflowAgentBindingType,
     WorkflowAgentNodeBinding,
 )
-from services.agent.workspace_service import AgentWorkspaceService
 
 
 class WorkflowAgentBindingError(Exception):
@@ -93,7 +95,7 @@ class WorkflowAgentBindingResolver:
             # A new node execution in the same conversation must keep its participant's
             # config/Home generation even after the roster Agent publishes a new version.
             if snapshot_id is None and conversation_id:
-                participant = AgentWorkspaceService.resolve_active_binding_for_scope(
+                participant = WorkflowAgentWorkspaceStore.load_active_participant(
                     session=session,
                     scope=resolve_workflow_agent_workspace_owner_scope(
                         tenant_id=tenant_id,

--- a/api/core/workflow/nodes/agent_v2/session_store.py
+++ b/api/core/workflow/nodes/agent_v2/session_store.py
@@ -104,6 +104,21 @@ class StoredWorkflowAgentSession:
 class WorkflowAgentWorkspaceStore:
     """Load or create the participant named by a node execution caller row."""
 
+    @staticmethod
+    def load_active_participant(
+        *,
+        session: Session,
+        scope: WorkspaceOwnerScope,
+        agent_id: str,
+    ) -> AgentWorkspaceBinding | None:
+        """Look up the participant that pins a Chatflow node's generation."""
+
+        return AgentWorkspaceService.resolve_active_binding_for_scope(
+            session=session,
+            scope=scope,
+            agent_id=agent_id,
+        )
+
     def load_existing_node_execution_scope(
         self,
         *,
@@ -315,7 +330,7 @@ class WorkflowAgentWorkspaceStore:
         """Reuse a conversation-scoped participant or allocate a new one."""
 
         if scope.conversation_id is not None:
-            existing_binding = AgentWorkspaceService.resolve_active_binding_for_scope(
+            existing_binding = WorkflowAgentWorkspaceStore.load_active_participant(
                 session=session,
                 scope=scope.workspace_owner,
                 agent_id=scope.agent_id,

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_agent_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_agent_node.py
@@ -581,6 +581,7 @@ def test_agent_node_resume_resolves_the_generation_from_the_persisted_execution(
     assert store.existing_scope_lookups[0]["node_execution_id"] == node.execution_id
     assert binding_resolver.calls[0]["binding_id"] == "binding-1"
     assert binding_resolver.calls[0]["snapshot_id"] == "snapshot-pinned"
+    assert binding_resolver.calls[0]["conversation_id"] == "conversation-1"
 
 
 def test_agent_node_maps_persisted_participant_lookup_error_to_node_failure() -> None:

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_binding_resolver.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_binding_resolver.py
@@ -80,12 +80,19 @@ def _conversation_participant(
 
 
 @pytest.mark.parametrize("sqlite_session", [CHATFLOW_MODELS], indirect=True)
-def test_chatflow_keeps_participant_config_and_home_after_roster_publish(
+@pytest.mark.parametrize("binding_type", [WorkflowAgentBindingType.ROSTER_AGENT, WorkflowAgentBindingType.INLINE_AGENT])
+def test_chatflow_keeps_participant_config_and_home_after_agent_update(
     sqlite_session: Session,
     monkeypatch: pytest.MonkeyPatch,
+    binding_type: WorkflowAgentBindingType,
 ) -> None:
     ids = {**_resolve_ids(), "conversation_id": str(uuid4())}
-    agent = _agent(tenant_id=ids["tenant_id"], scope=AgentScope.ROSTER, source=AgentSource.ROSTER)
+    is_roster = binding_type == WorkflowAgentBindingType.ROSTER_AGENT
+    agent = _agent(
+        tenant_id=ids["tenant_id"],
+        scope=AgentScope.ROSTER if is_roster else AgentScope.WORKFLOW_ONLY,
+        source=AgentSource.ROSTER if is_roster else AgentSource.WORKFLOW,
+    )
     sqlite_session.add(agent)
     sqlite_session.flush()
     original = _snapshot(tenant_id=ids["tenant_id"], agent_id=agent.id)
@@ -93,9 +100,7 @@ def test_chatflow_keeps_participant_config_and_home_after_roster_publish(
     sqlite_session.add(original)
     sqlite_session.flush()
     agent.active_config_snapshot_id = original.id
-    binding = _binding(
-        ids=ids, agent_id=agent.id, snapshot_id=original.id, binding_type=WorkflowAgentBindingType.ROSTER_AGENT
-    )
+    binding = _binding(ids=ids, agent_id=agent.id, snapshot_id=original.id, binding_type=binding_type)
     sqlite_session.add(binding)
     sqlite_session.flush()
     participant = _conversation_participant(sqlite_session, ids=ids, binding=binding, snapshot=original)
@@ -109,13 +114,23 @@ def test_chatflow_keeps_participant_config_and_home_after_roster_publish(
     sqlite_session.add(published)
     sqlite_session.flush()
     agent.active_config_snapshot_id = published.id
+    if not is_roster:
+        binding.current_snapshot_id = published.id
     sqlite_session.commit()
 
     continuing = resolver.resolve(**ids)
     assert continuing.snapshot.id == original.id
     assert continuing.snapshot.home_snapshot_id == original.home_snapshot_id
     assert resolver.resolve(**{**ids, "conversation_id": str(uuid4())}).snapshot.id == published.id
-    assert resolver.resolve(**{**ids, "conversation_id": None}).snapshot.id == published.id
+    assert (
+        resolver.resolve(
+            tenant_id=ids["tenant_id"],
+            app_id=ids["app_id"],
+            workflow_id=ids["workflow_id"],
+            node_id=ids["node_id"],
+        ).snapshot.id
+        == published.id
+    )
 
     execution = WorkflowNodeExecutionModel(
         tenant_id=ids["tenant_id"],

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_binding_resolver.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_binding_resolver.py
@@ -1,26 +1,237 @@
 from collections.abc import Iterator
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
+from agenton.compositor import CompositorSessionSnapshot
 from sqlalchemy import event, inspect
 from sqlalchemy.orm import ORMExecuteState, Session, sessionmaker
 from sqlalchemy.sql import Executable
 
 from core.workflow.nodes.agent_v2.binding_resolver import WorkflowAgentBindingError, WorkflowAgentBindingResolver
+from core.workflow.nodes.agent_v2.session_store import WorkflowAgentSessionScope, WorkflowAgentWorkspaceStore
+from graphon.enums import WorkflowNodeExecutionStatus
 from models.agent import (
     Agent,
     AgentConfigRevision,
     AgentConfigRevisionOperation,
     AgentConfigSnapshot,
+    AgentConfigVersionKind,
+    AgentHomeSnapshot,
     AgentScope,
     AgentSource,
     AgentStatus,
+    AgentWorkingResourceStatus,
+    AgentWorkspace,
+    AgentWorkspaceBinding,
+    AgentWorkspaceOwnerType,
     WorkflowAgentBindingType,
     WorkflowAgentNodeBinding,
 )
 from models.agent_config_entities import AgentSoulConfig, AgentSoulModelConfig, WorkflowNodeJobConfig
+from models.enums import CreatorUserRole
+from models.workflow import WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom
+from services.agent.workspace_service import AgentWorkspaceService
 
 RESOLVER_MODELS = (WorkflowAgentNodeBinding, Agent, AgentConfigSnapshot, AgentConfigRevision)
+CHATFLOW_MODELS = (
+    *RESOLVER_MODELS,
+    AgentWorkspace,
+    AgentWorkspaceBinding,
+    AgentHomeSnapshot,
+    WorkflowNodeExecutionModel,
+)
+
+
+def _conversation_participant(
+    session: Session,
+    *,
+    ids: dict[str, str],
+    binding: WorkflowAgentNodeBinding,
+    snapshot: AgentConfigSnapshot,
+) -> AgentWorkspaceBinding:
+    workspace = AgentWorkspace(
+        tenant_id=ids["tenant_id"],
+        app_id=ids["app_id"],
+        owner_type=AgentWorkspaceOwnerType.CONVERSATION,
+        owner_id=ids["conversation_id"],
+        owner_scope_key=f"{ids['node_id']}:{binding.id}",
+        backend_workspace_ref="workspace-ref",
+        status=AgentWorkingResourceStatus.ACTIVE,
+        active_guard=1,
+    )
+    session.add(workspace)
+    session.flush()
+    participant = AgentWorkspaceBinding(
+        tenant_id=ids["tenant_id"],
+        app_id=ids["app_id"],
+        workspace_id=workspace.id,
+        agent_id=snapshot.agent_id,
+        agent_config_version_id=snapshot.id,
+        agent_config_version_kind=AgentConfigVersionKind.SNAPSHOT,
+        base_home_snapshot_id=snapshot.home_snapshot_id,
+        backend_binding_ref="participant-ref",
+        status=AgentWorkingResourceStatus.ACTIVE,
+        session_snapshot=CompositorSessionSnapshot(layers=[]).model_dump_json(),
+    )
+    session.add(participant)
+    session.flush()
+    return participant
+
+
+@pytest.mark.parametrize("sqlite_session", [CHATFLOW_MODELS], indirect=True)
+def test_chatflow_keeps_participant_config_and_home_after_roster_publish(
+    sqlite_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ids = {**_resolve_ids(), "conversation_id": str(uuid4())}
+    agent = _agent(tenant_id=ids["tenant_id"], scope=AgentScope.ROSTER, source=AgentSource.ROSTER)
+    sqlite_session.add(agent)
+    sqlite_session.flush()
+    original = _snapshot(tenant_id=ids["tenant_id"], agent_id=agent.id)
+    original.home_snapshot_id = str(uuid4())
+    sqlite_session.add(original)
+    sqlite_session.flush()
+    agent.active_config_snapshot_id = original.id
+    binding = _binding(
+        ids=ids, agent_id=agent.id, snapshot_id=original.id, binding_type=WorkflowAgentBindingType.ROSTER_AGENT
+    )
+    sqlite_session.add(binding)
+    sqlite_session.flush()
+    participant = _conversation_participant(sqlite_session, ids=ids, binding=binding, snapshot=original)
+    sqlite_session.commit()
+    resolver = WorkflowAgentBindingResolver()
+    assert resolver.resolve(**ids).snapshot.id == original.id
+
+    published = _snapshot(tenant_id=ids["tenant_id"], agent_id=agent.id)
+    published.version = 2
+    published.home_snapshot_id = str(uuid4())
+    sqlite_session.add(published)
+    sqlite_session.flush()
+    agent.active_config_snapshot_id = published.id
+    sqlite_session.commit()
+
+    continuing = resolver.resolve(**ids)
+    assert continuing.snapshot.id == original.id
+    assert continuing.snapshot.home_snapshot_id == original.home_snapshot_id
+    assert resolver.resolve(**{**ids, "conversation_id": str(uuid4())}).snapshot.id == published.id
+    assert resolver.resolve(**{**ids, "conversation_id": None}).snapshot.id == published.id
+
+    execution = WorkflowNodeExecutionModel(
+        tenant_id=ids["tenant_id"],
+        app_id=ids["app_id"],
+        workflow_id=ids["workflow_id"],
+        triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+        workflow_run_id=str(uuid4()),
+        index=1,
+        node_execution_id=str(uuid4()),
+        node_id=ids["node_id"],
+        node_type="agent",
+        title="Agent",
+        status=WorkflowNodeExecutionStatus.RUNNING,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by=str(uuid4()),
+    )
+    sqlite_session.add(execution)
+    sqlite_session.commit()
+    create_binding = MagicMock(side_effect=AssertionError("must reuse the existing participant"))
+    monkeypatch.setattr(AgentWorkspaceService, "create_binding", create_binding)
+    scope = WorkflowAgentSessionScope(
+        **ids,
+        workflow_run_id=execution.workflow_run_id,
+        node_execution_id=execution.id,
+        workflow_agent_binding_id=binding.id,
+        agent_id=agent.id,
+        agent_config_snapshot_id=continuing.snapshot.id,
+    )
+    stored = WorkflowAgentWorkspaceStore().load_or_create_node_execution_session(
+        scope,
+        home_snapshot_id=continuing.snapshot.home_snapshot_id,
+    )
+    assert stored.binding_id == participant.id
+    assert stored.backend_binding_ref == participant.backend_binding_ref
+    assert stored.session_snapshot == CompositorSessionSnapshot(layers=[])
+    create_binding.assert_not_called()
+
+    agent.status = AgentStatus.ARCHIVED
+    sqlite_session.commit()
+    with pytest.raises(WorkflowAgentBindingError, match="not available"):
+        resolver.resolve(**ids)
+
+
+@pytest.mark.parametrize("mismatch", ["tenant", "app", "conversation", "node", "agent", "retired"])
+@pytest.mark.parametrize("sqlite_session", [CHATFLOW_MODELS], indirect=True)
+def test_chatflow_pin_is_scoped_to_active_conversation_node_participant(
+    sqlite_session: Session,
+    mismatch: str,
+) -> None:
+    ids = {**_resolve_ids(), "conversation_id": str(uuid4())}
+    agent = _agent(tenant_id=ids["tenant_id"], scope=AgentScope.ROSTER, source=AgentSource.ROSTER)
+    sqlite_session.add(agent)
+    sqlite_session.flush()
+    current = _snapshot(tenant_id=ids["tenant_id"], agent_id=agent.id)
+    sqlite_session.add(current)
+    sqlite_session.flush()
+    agent.active_config_snapshot_id = current.id
+    binding = _binding(
+        ids=ids, agent_id=agent.id, snapshot_id=current.id, binding_type=WorkflowAgentBindingType.ROSTER_AGENT
+    )
+    sqlite_session.add(binding)
+    sqlite_session.flush()
+    participant = _conversation_participant(sqlite_session, ids=ids, binding=binding, snapshot=current)
+    participant.agent_config_version_id = str(uuid4())
+    workspace = sqlite_session.get(AgentWorkspace, participant.workspace_id)
+    assert workspace is not None
+    match mismatch:
+        case "tenant":
+            workspace.tenant_id = str(uuid4())
+        case "app":
+            workspace.app_id = str(uuid4())
+        case "conversation":
+            workspace.owner_id = str(uuid4())
+        case "node":
+            workspace.owner_scope_key = "another-node:another-binding"
+        case "agent":
+            participant.agent_id = str(uuid4())
+        case "retired":
+            participant.status = AgentWorkingResourceStatus.RETIRED
+    sqlite_session.commit()
+
+    assert WorkflowAgentBindingResolver().resolve(**ids).snapshot.id == current.id
+
+
+@pytest.mark.parametrize("version_kind", [AgentConfigVersionKind.DRAFT, AgentConfigVersionKind.SNAPSHOT])
+@pytest.mark.parametrize("sqlite_session", [CHATFLOW_MODELS], indirect=True)
+def test_chatflow_never_falls_back_from_invalid_pinned_generation(
+    sqlite_session: Session,
+    version_kind: AgentConfigVersionKind,
+) -> None:
+    ids = {**_resolve_ids(), "conversation_id": str(uuid4())}
+    agent = _agent(tenant_id=ids["tenant_id"], scope=AgentScope.ROSTER, source=AgentSource.ROSTER)
+    sqlite_session.add(agent)
+    sqlite_session.flush()
+    current = _snapshot(tenant_id=ids["tenant_id"], agent_id=agent.id)
+    sqlite_session.add(current)
+    sqlite_session.flush()
+    agent.active_config_snapshot_id = current.id
+    binding = _binding(
+        ids=ids, agent_id=agent.id, snapshot_id=current.id, binding_type=WorkflowAgentBindingType.ROSTER_AGENT
+    )
+    sqlite_session.add(binding)
+    sqlite_session.flush()
+    participant = _conversation_participant(sqlite_session, ids=ids, binding=binding, snapshot=current)
+    participant.agent_config_version_kind = version_kind
+    participant.agent_config_version_id = str(uuid4())
+    sqlite_session.commit()
+
+    with pytest.raises(WorkflowAgentBindingError) as exc_info:
+        WorkflowAgentBindingResolver().resolve(**ids)
+    expected = (
+        "agent_binding_generation_invalid"
+        if version_kind == AgentConfigVersionKind.DRAFT
+        else "agent_config_snapshot_not_found"
+    )
+    assert exc_info.value.error_code == expected
 
 
 def _resolve_ids() -> dict[str, str]:


### PR DESCRIPTION
## Summary

Follow-up to #41871 for #41734.

After #41871, Chatflow Agent nodes reuse a conversation-scoped participant across turns. The binding resolver still selected the latest roster snapshot for every new node execution. Publishing a new roster version between turns therefore paired a new config/Home generation with the previous participant and failed generation validation.

Resolve the snapshot from an existing active conversation participant before selecting the latest Agent version. The lookup uses the existing tenant, app, conversation, node, workflow binding, and Agent scope. Existing execution-level pins still take precedence, and Agent availability/publish checks still apply. Missing or invalid pinned snapshots fail explicitly instead of silently switching versions.

- Existing Chatflow conversations keep their config, Home generation, and session state after roster publication or an inline config update.
- New conversations select the current version. Pure Workflow runs keep their existing per-run behavior.
- Reuses the existing workspace/binding records; no new table, migration, environment variable, or frontend change.
- Explicitly upgrading existing conversations to a newer Agent version is not included.

## Verification

Deployed to dev through `deploy/agent` at `ac7cd31248`; [deployment succeeded](https://github.com/langgenius/dify/actions/runs/34433822932). #41871 was applied as a prerequisite on dev because it was not there yet; it is already on main and is not included again in this PR.

Real HTTP/API regression on dev with GPT-5.5 and isolated test resources:

- Draft Chatflow: first turn, dirty unpublished roster draft, roster V2 publication, existing and new conversations. Old conversations retained the original version and remembered a prior code; new conversations used V2 without the old memory.
- Configuration-file references remained tied to the selected snapshot; workflow Agent sandbox file inspection remained available.
- Published Chatflow through `/v1/chat-messages`: existing conversation retained V2 after publishing V3; a new conversation used V3.
- Inline Chatflow: an inline composer update did not switch an existing conversation; a new conversation used the updated snapshot.
- Ordinary Workflow: latest snapshot selected, run-scoped workspace retired on completion.
- Console and Service API conversation deletion retired participant resources. Test apps and temporary API credentials were cleaned up.

Local verification on the main-based branch:

- 342 tests passed across Agent V2 nodes, workspace/retirement services, and conversation cleanup.
- SQLite regression tests cover different config and Home snapshots, roster and inline bindings, scope isolation, archived Agents, invalid pins, and reusing the persisted session without creating a new binding.
- Ruff checks and formatting passed for all changed files. Full `make type-check-core` passed (1,795 source files), as did all 31 import-layer contracts. Participant queries stay behind the existing session-store persistence boundary; no type-check or import-linter exclusions were added.

## Checklist

- [x] Added regression tests for the changed behavior.
- [x] Verified configuration and runtime paths on dev before opening this PR.
- [x] Kept the main PR limited to the verified backend fix and tests.
- [x] Full API unit tests, all four API integration shards, Python Style, autofix, and all browser E2E shards passed on `79e0dc4f79`.

From Codex
