### PR TITLE
feat(api): add service API document indexing retry

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -203,6 +203,18 @@ class WorkflowUpdatePayload(BaseModel):
 
 
 DOCUMENT_BATCH_DOWNLOAD_ZIP_MAX_DOCS = 100
+DOCUMENT_BATCH_RETRY_MAX_DOCS = 100
+
+
+class DocumentBatchRetryPayload(BaseModel):
+    """Request payload for retrying document indexing."""
+
+    document_ids: list[UUID] = Field(
+        ...,
+        min_length=1,
+        max_length=DOCUMENT_BATCH_RETRY_MAX_DOCS,
+        description="List of document IDs to retry.",
+    )
 
 
 class ChildChunkCreatePayload(BaseModel):

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -28,7 +28,7 @@ from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services
-from controllers.common.controller_schemas import DocumentBatchDownloadZipPayload
+from controllers.common.controller_schemas import DocumentBatchDownloadZipPayload, DocumentBatchRetryPayload
 from controllers.common.errors import (
     FilenameNotExistsError,
     FileTooLargeError,
@@ -50,6 +50,7 @@ from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import ProviderNotInitializeError
 from controllers.service_api.dataset.error import (
     ArchivedDocumentImmutableError,
+    DocumentAlreadyFinishedError,
     DocumentIndexingError,
     InvalidMetadataError,
 )
@@ -77,7 +78,8 @@ from libs.helper import dump_response
 from libs.login import current_user
 from libs.pagination import paginate_query
 from models.dataset import Dataset, Document, DocumentSegment
-from models.enums import SegmentStatus
+from models.enums import IndexingStatus, SegmentStatus
+from services.dataset_ref_service import DatasetRefService
 from services.dataset_service import DatasetService, DocumentService
 from services.entities.knowledge_entities.knowledge_entities import (
     DocForm,
@@ -374,6 +376,7 @@ register_schema_models(
     DocumentListQuery,
     DocumentGetQuery,
     DocumentBatchDownloadZipPayload,
+    DocumentBatchRetryPayload,
     Rule,
     PreProcessingRule,
     Segmentation,
@@ -1055,6 +1058,71 @@ class DocumentListApi(DatasetApiResource):
         }
 
         return dump_response(DocumentListResponse, response)
+
+
+@service_api_ns.route("/datasets/<uuid:dataset_id>/documents/retry")
+class DocumentBatchRetryApi(DatasetApiResource):
+    """Retry indexing for existing documents without re-uploading their source."""
+
+    @service_api_ns.doc(
+        summary="Retry Document Indexing",
+        description=(
+            "Retry indexing for up to `100` existing documents in a knowledge base. Documents are "
+            "processed asynchronously; poll their indexing status until they reach `completed` or `error`. "
+            "Completed and archived documents are rejected."
+        ),
+        tags=["Documents"],
+        responses={
+            204: "Document retry started successfully.",
+            400: "`document_indexing` : A document is already being retried.",
+            404: "`not_found` : Knowledge base or document not found.",
+        },
+    )
+    @service_api_ns.expect(service_api_ns.models[DocumentBatchRetryPayload.__name__])
+    @service_api_ns.doc("retry_documents")
+    @service_api_ns.doc(description="Retry indexing for existing documents")
+    @service_api_ns.doc(params={"dataset_id": "Knowledge base ID."})
+    @service_api_ns.doc(
+        responses={
+            204: "Document retry started successfully",
+            401: "Unauthorized - invalid API token",
+            404: "Dataset or document not found",
+        }
+    )
+    @service_api_ns.response(204, "Document retry started successfully")
+    @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
+    @with_session
+    @model_validate(DocumentBatchRetryPayload)
+    def post(self, payload: DocumentBatchRetryPayload, session: Session, tenant_id, dataset_id: UUID):
+        dataset = DatasetService.get_dataset_for_tenant(str(dataset_id), str(tenant_id), session=session)
+        if not dataset:
+            raise NotFound("Dataset not found.")
+
+        document_ids = [str(document_id) for document_id in payload.document_ids]
+        documents = DocumentService.get_documents_by_ids(
+            DatasetRefService.create_dataset_ref(dataset), document_ids, session
+        )
+        documents_by_id = {str(document.id): document for document in documents}
+
+        missing_document_ids = set(document_ids) - set(documents_by_id)
+        if missing_document_ids:
+            raise NotFound("Document not found.")
+
+        retry_documents = []
+        for document_id in document_ids:
+            document = documents_by_id[document_id]
+            if DocumentService.check_archived(document):
+                raise ArchivedDocumentImmutableError()
+            if document.indexing_status == IndexingStatus.COMPLETED:
+                raise DocumentAlreadyFinishedError()
+            retry_documents.append(document)
+
+        try:
+            DocumentService.retry_document(str(dataset_id), retry_documents, session)
+        except ValueError as exc:
+            raise DocumentIndexingError(str(exc)) from exc
+
+        return "", 204
 
 
 @service_api_ns.route("/datasets/<uuid:dataset_id>/documents/download-zip")

--- a/api/tests/unit_tests/commands/test_generate_swagger_specs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_specs.py
@@ -337,6 +337,11 @@ def test_generate_specs_writes_service_api_reference_descriptions(tmp_path: Path
     pipeline_operation = payload["paths"]["/datasets/{dataset_id}/pipeline/run"]["post"]
     assert pipeline_operation["operationId"] == "run_pipeline"
 
+    retry_operation = payload["paths"]["/datasets/{dataset_id}/documents/retry"]["post"]
+    assert retry_operation["operationId"] == "retry_documents"
+    assert _request_schema(retry_operation)["$ref"] == "#/components/schemas/DocumentBatchRetryPayload"
+    assert retry_operation["responses"]["204"]["description"] == "Document retry started successfully."
+
     chat_error_content = chat_operation["responses"]["401"]["content"]
     assert chat_error_content == {"application/json": {}}
     chat_success_content = chat_operation["responses"]["200"]["content"]

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
@@ -29,6 +29,7 @@ from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden, NotFound
 
+from controllers.common.controller_schemas import DocumentBatchRetryPayload
 from controllers.common.errors import FileTooLargeError as FileTooLargeHTTPError
 from controllers.service_api.dataset import document as document_module
 from controllers.service_api.dataset.document import (
@@ -38,6 +39,7 @@ from controllers.service_api.dataset.document import (
     DocumentAddByFileApi,
     DocumentAddByTextApi,
     DocumentApi,
+    DocumentBatchRetryApi,
     DocumentIndexingStatusApi,
     DocumentListApi,
     DocumentListQuery,
@@ -46,7 +48,11 @@ from controllers.service_api.dataset.document import (
     DocumentUpdateByTextApi,
     InvalidMetadataError,
 )
-from controllers.service_api.dataset.error import ArchivedDocumentImmutableError
+from controllers.service_api.dataset.error import (
+    ArchivedDocumentImmutableError,
+    DocumentAlreadyFinishedError,
+    DocumentIndexingError,
+)
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from enums import DeploymentEdition
 from extensions.storage.storage_type import StorageType
@@ -1685,6 +1691,165 @@ class TestDocumentUpdateByTextApiPost(SQLiteControllerTest):
                     tenant_id=mock_tenant,
                     dataset_id=mock_dataset.id,
                     document_id=doc_id,
+                )
+
+
+class TestDocumentBatchRetryApi(SQLiteControllerTest):
+    """Test suite for the batch document retry endpoint."""
+
+    @patch("controllers.service_api.dataset.document.DocumentService")
+    def test_retry_documents_success(self, mock_doc_svc, app: Flask, mock_tenant, mock_dataset):
+        """Retry documents in request order after validating dataset scope."""
+        self._persist_dataset(mock_dataset)
+        first_id = uuid.uuid4()
+        second_id = uuid.uuid4()
+        first_document = make_serializable_document(
+            id=str(first_id),
+            tenant_id=mock_tenant,
+            dataset_id=mock_dataset.id,
+            indexing_status=IndexingStatus.ERROR,
+        )
+        second_document = make_serializable_document(
+            id=str(second_id),
+            tenant_id=mock_tenant,
+            dataset_id=mock_dataset.id,
+            indexing_status=IndexingStatus.PAUSED,
+        )
+        mock_doc_svc.get_documents_by_ids.return_value = [second_document, first_document]
+        mock_doc_svc.check_archived.return_value = False
+        payload = DocumentBatchRetryPayload(document_ids=[first_id, second_id])
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/retry",
+            method="POST",
+        ):
+            api = DocumentBatchRetryApi()
+            response, status = _unwrap_non_wrapped_controller(type(api).post)(
+                api,
+                payload,
+                self.session,
+                tenant_id=mock_tenant,
+                dataset_id=mock_dataset.id,
+            )
+
+        assert (response, status) == ("", 204)
+        dataset_ref = mock_doc_svc.get_documents_by_ids.call_args.args[0]
+        assert dataset_ref.tenant_id == mock_tenant
+        assert dataset_ref.dataset_id == mock_dataset.id
+        mock_doc_svc.retry_document.assert_called_once_with(
+            mock_dataset.id, [first_document, second_document], self.session
+        )
+
+    @patch("controllers.service_api.dataset.document.DocumentService")
+    def test_retry_documents_rejects_missing_document(self, mock_doc_svc, app: Flask, mock_tenant, mock_dataset):
+        self._persist_dataset(mock_dataset)
+        missing_id = uuid.uuid4()
+        mock_doc_svc.get_documents_by_ids.return_value = []
+        payload = DocumentBatchRetryPayload(document_ids=[missing_id])
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/retry",
+            method="POST",
+        ):
+            api = DocumentBatchRetryApi()
+            with pytest.raises(NotFound, match="Document not found"):
+                _unwrap_non_wrapped_controller(type(api).post)(
+                    api,
+                    payload,
+                    self.session,
+                    tenant_id=mock_tenant,
+                    dataset_id=mock_dataset.id,
+                )
+
+        mock_doc_svc.retry_document.assert_not_called()
+
+    @patch("controllers.service_api.dataset.document.DocumentService")
+    def test_retry_documents_rejects_completed_document(self, mock_doc_svc, app: Flask, mock_tenant, mock_dataset):
+        self._persist_dataset(mock_dataset)
+        document_id = uuid.uuid4()
+        document = make_serializable_document(
+            id=str(document_id),
+            tenant_id=mock_tenant,
+            dataset_id=mock_dataset.id,
+            indexing_status=IndexingStatus.COMPLETED,
+        )
+        mock_doc_svc.get_documents_by_ids.return_value = [document]
+        mock_doc_svc.check_archived.return_value = False
+        payload = DocumentBatchRetryPayload(document_ids=[document_id])
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/retry",
+            method="POST",
+        ):
+            api = DocumentBatchRetryApi()
+            with pytest.raises(DocumentAlreadyFinishedError):
+                _unwrap_non_wrapped_controller(type(api).post)(
+                    api,
+                    payload,
+                    self.session,
+                    tenant_id=mock_tenant,
+                    dataset_id=mock_dataset.id,
+                )
+
+        mock_doc_svc.retry_document.assert_not_called()
+
+    @patch("controllers.service_api.dataset.document.DocumentService")
+    def test_retry_documents_rejects_archived_document(self, mock_doc_svc, app: Flask, mock_tenant, mock_dataset):
+        self._persist_dataset(mock_dataset)
+        document_id = uuid.uuid4()
+        document = make_serializable_document(
+            id=str(document_id),
+            tenant_id=mock_tenant,
+            dataset_id=mock_dataset.id,
+            indexing_status=IndexingStatus.ERROR,
+        )
+        mock_doc_svc.get_documents_by_ids.return_value = [document]
+        mock_doc_svc.check_archived.return_value = True
+        payload = DocumentBatchRetryPayload(document_ids=[document_id])
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/retry",
+            method="POST",
+        ):
+            api = DocumentBatchRetryApi()
+            with pytest.raises(ArchivedDocumentImmutableError):
+                _unwrap_non_wrapped_controller(type(api).post)(
+                    api,
+                    payload,
+                    self.session,
+                    tenant_id=mock_tenant,
+                    dataset_id=mock_dataset.id,
+                )
+
+        mock_doc_svc.retry_document.assert_not_called()
+
+    @patch("controllers.service_api.dataset.document.DocumentService")
+    def test_retry_documents_maps_concurrent_retry_error(self, mock_doc_svc, app: Flask, mock_tenant, mock_dataset):
+        self._persist_dataset(mock_dataset)
+        document_id = uuid.uuid4()
+        document = make_serializable_document(
+            id=str(document_id),
+            tenant_id=mock_tenant,
+            dataset_id=mock_dataset.id,
+            indexing_status=IndexingStatus.ERROR,
+        )
+        mock_doc_svc.get_documents_by_ids.return_value = [document]
+        mock_doc_svc.check_archived.return_value = False
+        mock_doc_svc.retry_document.side_effect = ValueError("Document is being retried")
+        payload = DocumentBatchRetryPayload(document_ids=[document_id])
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/documents/retry",
+            method="POST",
+        ):
+            api = DocumentBatchRetryApi()
+            with pytest.raises(DocumentIndexingError, match="Document is being retried"):
+                _unwrap_non_wrapped_controller(type(api).post)(
+                    api,
+                    payload,
+                    self.session,
+                    tenant_id=mock_tenant,
+                    dataset_id=mock_dataset.id,
                 )
 
 


### PR DESCRIPTION
## Summary

Add a Service API endpoint to retry indexing for existing documents in a knowledge base without re-uploading their source content.

## Problem

The console already supports retrying documents, but Service API clients have no way to recover a document after upload/indexing fails. That makes API-driven synchronization jobs unable to retry failed documents.

## Solution

Add `POST /v1/datasets/{dataset_id}/documents/retry`.

Request body, up to 100 UUIDs:

```json
{
  "document_ids": ["..."]
}
```

Returns `204 No Content` and retries indexing asynchronously. The endpoint uses the existing Dataset API key authentication and tenant/dataset scoping, then delegates to `DocumentService.retry_document(...)`.

## Validation

- New document retry tests: `5 passed`
- `test_document.py`: `101 passed`
- `test_generate_swagger_specs.py`: `17 passed`
- `ruff check` and `ruff format --check`: passed

Closes #42104