### PR TITLE
fix(api): recover parallel HITL resume when overlapping submissions race

### DIFF
--- a/api/core/app/layers/pause_state_persist_layer.py
+++ b/api/core/app/layers/pause_state_persist_layer.py
@@ -15,6 +15,7 @@ from graphon.graph_events import GraphEngineEvent, GraphRunPausedEvent
 from models.model import AppMode
 from repositories.api_workflow_run_repository import APIWorkflowRunRepository
 from repositories.factory import DifyAPIRepositoryFactory
+from services.human_input_resume_coordinator import maybe_enqueue_resume_for_submitted_hitl_pause
 
 
 # Wrapper types for `WorkflowAppGenerateEntity` and
@@ -161,6 +162,11 @@ class PauseStatePersistenceLayer(GraphEngineLayer):
             state_owner_user_id=self._state_owner_user_id,
             state=state.dumps(),
             pause_reasons=pause_reasons,
+        )
+        maybe_enqueue_resume_for_submitted_hitl_pause(
+            workflow_run_id=workflow_run_id,
+            pause_reasons=pause_reasons,
+            session_factory=self._session_maker,
         )
 
     @override

--- a/api/services/human_input_resume_coordinator.py
+++ b/api/services/human_input_resume_coordinator.py
@@ -1,0 +1,63 @@
+"""Coordinate workflow resumes when parallel HITL form submissions race."""
+
+import logging
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from core.workflow.nodes.human_input.enums import HumanInputFormStatus
+from core.workflow.nodes.human_input.pause_reason import HumanInputRequired, PauseReason
+from models.human_input import HumanInputForm
+
+logger = logging.getLogger(__name__)
+
+
+def _hitl_form_ids_from_pause_reasons(pause_reasons: Sequence[PauseReason]) -> list[str]:
+    return [reason.form_id for reason in pause_reasons if isinstance(reason, HumanInputRequired)]
+
+
+def all_hitl_forms_submitted(session: Session, form_ids: Sequence[str]) -> bool:
+    if not form_ids:
+        return False
+
+    unique_form_ids = list(dict.fromkeys(form_ids))
+    forms = session.scalars(select(HumanInputForm).where(HumanInputForm.id.in_(unique_form_ids))).all()
+    if len(forms) != len(unique_form_ids):
+        return False
+
+    return all(
+        form.status == HumanInputFormStatus.SUBMITTED or form.submitted_at is not None for form in forms
+    )
+
+
+def maybe_enqueue_resume_for_submitted_hitl_pause(
+    *,
+    workflow_run_id: str,
+    pause_reasons: Sequence[PauseReason],
+    session_factory: sessionmaker[Session],
+) -> None:
+    """Enqueue a follow-up resume when a pause still references already-submitted HITL forms.
+
+    Parallel form submissions can enqueue overlapping resume tasks. The first task
+    may pause again before the second submission is observed, leaving the workflow
+    stuck even though every form is already submitted in the database.
+    """
+    form_ids = _hitl_form_ids_from_pause_reasons(pause_reasons)
+    if not form_ids:
+        return
+
+    with session_factory() as session:
+        if not all_hitl_forms_submitted(session, form_ids):
+            return
+
+    logger.info(
+        "All HITL forms already submitted for paused workflow run %s; enqueueing follow-up resume",
+        workflow_run_id,
+    )
+    try:
+        from tasks.app_generate.workflow_execute_task import resume_app_execution
+
+        resume_app_execution.apply_async(kwargs={"payload": {"workflow_run_id": workflow_run_id}})
+    except Exception:  # pragma: no cover
+        logger.exception("Failed to enqueue follow-up resume for workflow run %s", workflow_run_id)

--- a/api/services/human_input_resume_coordinator.py
+++ b/api/services/human_input_resume_coordinator.py
@@ -26,9 +26,7 @@ def all_hitl_forms_submitted(session: Session, form_ids: Sequence[str]) -> bool:
     if len(forms) != len(unique_form_ids):
         return False
 
-    return all(
-        form.status == HumanInputFormStatus.SUBMITTED or form.submitted_at is not None for form in forms
-    )
+    return all(form.status == HumanInputFormStatus.SUBMITTED or form.submitted_at is not None for form in forms)
 
 
 def maybe_enqueue_resume_for_submitted_hitl_pause(

--- a/api/tasks/app_generate/workflow_execute_task.py
+++ b/api/tasks/app_generate/workflow_execute_task.py
@@ -565,6 +565,15 @@ def _resume_app_execution(payload: dict[str, Any]) -> None:
     # deliberately, so drop them before any engine can observe them.
     clear_app_task_cancellation_signals(generate_entity.task_id)
 
+    with session_factory() as status_session:
+        current_status = status_session.scalar(select(WorkflowRun.status).where(WorkflowRun.id == workflow_run_id))
+    if current_status == WorkflowExecutionStatus.RUNNING:
+        logger.info(
+            "Skipping overlapping resume attempt for workflow run %s because execution is already running",
+            workflow_run_id,
+        )
+        return
+
     workflow_run_repo.resume_workflow_pause(workflow_run_id, pause_entity)
 
     pause_config = PauseStateLayerConfig(

--- a/api/tests/unit_tests/core/app/layers/test_pause_state_persist_layer.py
+++ b/api/tests/unit_tests/core/app/layers/test_pause_state_persist_layer.py
@@ -352,6 +352,54 @@ class TestPauseStatePersistenceLayer:
         )
         assert mock_repo.create_workflow_pause.call_args.kwargs["pause_reasons"] == [enriched_reason]
 
+    def test_on_event_enqueues_follow_up_resume_when_hitl_forms_already_submitted(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session_factory: sessionmaker[Session]
+    ):
+        generate_entity = self._create_generate_entity(workflow_execution_id="run-123")
+        layer = PauseStatePersistenceLayer(
+            session_factory=sqlite_session_factory,
+            state_owner_user_id="owner-123",
+            generate_entity=generate_entity,
+            response_stream_filter=_create_initialized_response_stream_filter(),
+        )
+
+        mock_repo = Mock()
+        mock_factory = Mock(return_value=mock_repo)
+        enriched_reason = HumanInputRequired(
+            form_id="form-123",
+            form_content="Rendered content",
+            inputs=[],
+            actions=[],
+            node_id="node-123",
+            node_title="Ask for approval",
+        )
+        enqueue_mock = Mock()
+        monkeypatch.setattr(DifyAPIRepositoryFactory, "create_api_workflow_run_repository", mock_factory)
+        monkeypatch.setattr(
+            pause_layer_module,
+            "enrich_graph_pause_reasons",
+            Mock(return_value=[enriched_reason]),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            pause_layer_module,
+            "maybe_enqueue_resume_for_submitted_hitl_pause",
+            enqueue_mock,
+            raising=False,
+        )
+
+        graph_runtime_state = MockReadOnlyGraphRuntimeState(workflow_execution_id="run-123")
+        command_channel = MockCommandChannel()
+        layer.initialize(graph_runtime_state, command_channel)
+
+        layer.on_event(GraphRunPausedEvent(reasons=[], outputs={}))
+
+        enqueue_mock.assert_called_once_with(
+            workflow_run_id="run-123",
+            pause_reasons=[enriched_reason],
+            session_factory=sqlite_session_factory,
+        )
+
     def test_on_event_ignores_non_paused_events(
         self, monkeypatch: pytest.MonkeyPatch, sqlite_session_factory: sessionmaker[Session]
     ):

--- a/api/tests/unit_tests/services/test_human_input_resume_coordinator.py
+++ b/api/tests/unit_tests/services/test_human_input_resume_coordinator.py
@@ -1,0 +1,106 @@
+from datetime import timedelta
+import pytest
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from core.workflow.nodes.human_input.entities import HumanInputNodeData, UserActionConfig
+from core.workflow.nodes.human_input.enums import HumanInputFormStatus
+from core.workflow.nodes.human_input.pause_reason import HumanInputRequired
+from libs.datetime_utils import naive_utc_now
+from models.human_input import HumanInputForm
+from services.human_input_resume_coordinator import (
+    all_hitl_forms_submitted,
+    maybe_enqueue_resume_for_submitted_hitl_pause,
+)
+
+
+@pytest.fixture
+def sqlite_session_factory(sqlite_engine: Engine) -> sessionmaker[Session]:
+    return sessionmaker(sqlite_engine, expire_on_commit=False)
+
+
+def _pause_reason(form_id: str) -> HumanInputRequired:
+    return HumanInputRequired(
+        form_id=form_id,
+        form_content="Approve?",
+        inputs=[],
+        actions=[UserActionConfig(id="approve", title="Approve")],
+        node_id="human-node",
+        node_title="Human Input",
+    )
+
+
+def _persist_form(
+    session_factory: sessionmaker[Session],
+    *,
+    form_id: str,
+    submitted: bool,
+) -> None:
+    expiration_time = naive_utc_now() + timedelta(days=1)
+    definition = HumanInputNodeData(
+        title="Human Input",
+        form_content="Approve?",
+        user_actions=[UserActionConfig(id="approve", title="Approve")],
+    )
+    form = HumanInputForm(
+        tenant_id="tenant-id",
+        app_id="app-id",
+        workflow_run_id="workflow-run-id",
+        node_id="human-node",
+        form_definition=definition.model_dump_json(),
+        rendered_content="Approve?",
+        expiration_time=expiration_time,
+        status=HumanInputFormStatus.SUBMITTED if submitted else HumanInputFormStatus.WAITING,
+        submitted_at=naive_utc_now() if submitted else None,
+        selected_action_id="approve" if submitted else None,
+    )
+    form.id = form_id
+    with session_factory.begin() as session:
+        session.add(form)
+
+
+def test_all_hitl_forms_submitted_requires_every_form(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _persist_form(sqlite_session_factory, form_id="form-1", submitted=True)
+    _persist_form(sqlite_session_factory, form_id="form-2", submitted=False)
+
+    with sqlite_session_factory() as session:
+        assert all_hitl_forms_submitted(session, ["form-1", "form-2"]) is False
+        assert all_hitl_forms_submitted(session, ["form-1"]) is True
+
+
+def test_maybe_enqueue_resume_for_submitted_hitl_pause_skips_waiting_form(
+    mocker: pytest.MonkeyPatch,
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _persist_form(sqlite_session_factory, form_id="form-1", submitted=True)
+    _persist_form(sqlite_session_factory, form_id="form-2", submitted=False)
+    resume_task = mocker.patch("tasks.app_generate.workflow_execute_task.resume_app_execution")
+
+    maybe_enqueue_resume_for_submitted_hitl_pause(
+        workflow_run_id="workflow-run-id",
+        pause_reasons=[_pause_reason("form-1"), _pause_reason("form-2")],
+        session_factory=sqlite_session_factory,
+    )
+
+    resume_task.apply_async.assert_not_called()
+
+
+def test_maybe_enqueue_resume_for_submitted_hitl_pause_enqueues_when_all_submitted(
+    mocker: pytest.MonkeyPatch,
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    _persist_form(sqlite_session_factory, form_id="form-1", submitted=True)
+    _persist_form(sqlite_session_factory, form_id="form-2", submitted=True)
+    resume_task = mocker.patch("tasks.app_generate.workflow_execute_task.resume_app_execution")
+
+    maybe_enqueue_resume_for_submitted_hitl_pause(
+        workflow_run_id="workflow-run-id",
+        pause_reasons=[_pause_reason("form-1"), _pause_reason("form-2")],
+        session_factory=sqlite_session_factory,
+    )
+
+    resume_task.apply_async.assert_called_once_with(
+        kwargs={"payload": {"workflow_run_id": "workflow-run-id"}},
+    )

--- a/api/tests/unit_tests/services/test_human_input_resume_coordinator.py
+++ b/api/tests/unit_tests/services/test_human_input_resume_coordinator.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+
 import pytest
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker

--- a/api/tests/unit_tests/services/test_human_input_resume_coordinator.py
+++ b/api/tests/unit_tests/services/test_human_input_resume_coordinator.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -72,7 +73,7 @@ def test_all_hitl_forms_submitted_requires_every_form(
 
 
 def test_maybe_enqueue_resume_for_submitted_hitl_pause_skips_waiting_form(
-    mocker: pytest.MonkeyPatch,
+    mocker: MockerFixture,
     sqlite_session_factory: sessionmaker[Session],
 ) -> None:
     _persist_form(sqlite_session_factory, form_id="form-1", submitted=True)
@@ -89,7 +90,7 @@ def test_maybe_enqueue_resume_for_submitted_hitl_pause_skips_waiting_form(
 
 
 def test_maybe_enqueue_resume_for_submitted_hitl_pause_enqueues_when_all_submitted(
-    mocker: pytest.MonkeyPatch,
+    mocker: MockerFixture,
     sqlite_session_factory: sessionmaker[Session],
 ) -> None:
     _persist_form(sqlite_session_factory, form_id="form-1", submitted=True)

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -224,7 +224,7 @@ def _persist_resumption_models(
         version=workflow.version,
         graph="{}",
         inputs="{}",
-        status=WorkflowExecutionStatus.RUNNING,
+        status=WorkflowExecutionStatus.PAUSED,
         created_by_role=CreatorUserRole.ACCOUNT,
         created_by="account-id",
     )
@@ -975,6 +975,59 @@ def test_resume_app_execution_clears_stale_cancellation_signals_before_resuming(
     clear_signals.assert_called_once_with(generate_entity.task_id)
     # Clearing after the engine started would let it observe the stale abort first.
     assert calls == [f"clear:{generate_entity.task_id}", "resume"]
+
+
+def test_resume_app_execution_skips_overlapping_resume_when_workflow_already_running(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_engine: Engine,
+    sqlite_session_factory: sessionmaker[Session],
+):
+    workflow_run_id = "run-id"
+    _persist_resumption_models(sqlite_session_factory, workflow_run_id=workflow_run_id)
+
+    with sqlite_session_factory.begin() as session:
+        workflow_run = session.get(WorkflowRun, workflow_run_id)
+        assert workflow_run is not None
+        workflow_run.status = WorkflowExecutionStatus.RUNNING
+
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task.db", SimpleNamespace(engine=sqlite_engine))
+
+    pause_entity = MagicMock()
+    pause_entity.get_state.return_value = b"state"
+
+    workflow_run_repo = MagicMock()
+    workflow_run_repo.get_workflow_pause.return_value = pause_entity
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.DifyAPIRepositoryFactory.create_api_workflow_run_repository",
+        lambda *_args, **_kwargs: workflow_run_repo,
+    )
+
+    generate_entity = _build_workflow_generate_entity(stream=False)
+    resumption_context = MagicMock()
+    resumption_context.serialized_graph_runtime_state = "{}"
+    resumption_context.get_generate_entity.return_value = generate_entity
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.WorkflowResumptionContext.loads",
+        lambda *_args, **_kwargs: resumption_context,
+    )
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task.GraphRuntimeState.from_snapshot",
+        lambda *_args, **_kwargs: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "tasks.app_generate.workflow_execute_task._resolve_user_for_run", lambda *_args, **_kwargs: MagicMock()
+    )
+
+    clear_signals = MagicMock()
+    resume_workflow = MagicMock()
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task.clear_app_task_cancellation_signals", clear_signals)
+    monkeypatch.setattr("tasks.app_generate.workflow_execute_task._resume_workflow", resume_workflow)
+
+    _resume_app_execution({"workflow_run_id": workflow_run_id})
+
+    clear_signals.assert_called_once_with(generate_entity.task_id)
+    workflow_run_repo.resume_workflow_pause.assert_not_called()
+    resume_workflow.assert_not_called()
 
 
 def test_resume_app_execution_keeps_cancellation_signals_when_resume_is_abandoned(


### PR DESCRIPTION
## Summary

Fixes #42103

When two Human Input forms are submitted in quick succession, each submission enqueues a `resume_app_execution` task. The first task moves the workflow from `PAUSED` to `RUNNING`; the second fails with `WorkflowRun is not in PAUSED status`. If the first resume pauses again before it observes the second submission, there is no effective follow-up resume and the workflow can remain `paused` even though every form is already submitted.

This change:

- Skips overlapping resume attempts when the workflow is already `RUNNING`, instead of failing the Celery task.
- After persisting a new pause, checks whether all HITL forms referenced by the pause reasons are already submitted in the database and, if so, enqueues a follow-up resume automatically.

## Test plan

- [x] `uv run --project api --dev pytest tests/unit_tests/services/test_human_input_resume_coordinator.py`
- [x] `uv run --project api --dev pytest tests/unit_tests/core/app/layers/test_pause_state_persist_layer.py`
- [x] `uv run --project api --dev pytest tests/unit_tests/tasks/test_workflow_execute_task.py`
- [x] `uv run --project api --dev pytest tests/unit_tests/core/workflow/graph_engine/test_parallel_human_input_join_resume.py`