### PR TITLE
fix(dify-ui): preserve invalid focus colors and remove shadow transitions

### DIFF
--- a/packages/dify-ui/src/autocomplete/index.tsx
+++ b/packages/dify-ui/src/autocomplete/index.tsx
@@ -81,7 +81,7 @@ const autocompleteItemClassName = [
 
 const autocompleteInputGroupVariants = cva(
   [
-    'group/autocomplete flex w-full min-w-0 items-center border border-transparent bg-components-input-bg-normal text-components-input-text-filled shadow-none outline-hidden transition-[background-color,border-color,box-shadow]',
+    'group/autocomplete flex w-full min-w-0 items-center border border-transparent bg-components-input-bg-normal text-components-input-text-filled shadow-none outline-hidden transition-[background-color,border-color]',
     'hover:border-components-input-border-hover hover:bg-components-input-bg-hover',
     textControlCompoundInputFocusClassName,
     'data-focused:border-components-input-border-active data-focused:bg-components-input-bg-active data-focused:shadow-xs',

--- a/packages/dify-ui/src/combobox/index.tsx
+++ b/packages/dify-ui/src/combobox/index.tsx
@@ -145,7 +145,7 @@ function ComboboxTrigger({
 
 const comboboxInputGroupVariants = cva(
   [
-    'group/combobox flex w-full min-w-0 items-center border border-transparent bg-components-input-bg-normal text-components-input-text-filled shadow-none outline-hidden transition-[background-color,border-color,box-shadow]',
+    'group/combobox flex w-full min-w-0 items-center border border-transparent bg-components-input-bg-normal text-components-input-text-filled shadow-none outline-hidden transition-[background-color,border-color]',
     'hover:border-components-input-border-hover hover:bg-components-input-bg-hover',
     textControlCompoundInputFocusClassName,
     'data-focused:border-components-input-border-active data-focused:bg-components-input-bg-active data-focused:shadow-xs',

--- a/packages/dify-ui/src/input-group/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/input-group/__tests__/index.spec.tsx
@@ -148,3 +148,45 @@ describe('InputGroup', () => {
     await expect.element(addonButton).toHaveFocus()
   })
 })
+
+describe('Invalid focus colors', () => {
+  it.each(['light', 'dark'])(
+    'preserves error colors through keyboard and pointer focus in %s',
+    async (theme) => {
+      const previousTheme = document.documentElement.dataset.theme
+      document.documentElement.dataset.theme = theme
+      try {
+        const screen = await render(
+          <>
+            <Button>Before</Button>
+            <Field invalid>
+              <FieldLabel>Invalid value</FieldLabel>
+              <InputGroup data-testid="invalid-surface">
+                <InputGroupInput defaultValue="Invalid value" />
+                <InputGroupAddon>suffix</InputGroupAddon>
+              </InputGroup>
+            </Field>
+          </>,
+        )
+        const input = screen.getByRole('textbox', { name: 'Invalid value' })
+        const surface = screen.getByTestId('invalid-surface').element()
+        const colors = () => {
+          const style = getComputedStyle(surface)
+          return [style.borderTopColor, style.backgroundColor]
+        }
+        const restingColors = colors()
+        const restingShadow = getComputedStyle(surface).boxShadow
+        await screen.getByRole('button', { name: 'Before' }).click()
+        await userEvent.keyboard('{Tab}')
+        await expect.element(input).toHaveFocus()
+        await expect.element(input).toHaveAttribute('aria-invalid', 'true')
+        await expect.poll(colors).toEqual(restingColors)
+        await expect.poll(() => getComputedStyle(surface).boxShadow).not.toBe(restingShadow)
+        await input.click()
+        await expect.poll(colors).toEqual(restingColors)
+      } finally {
+        document.documentElement.dataset.theme = previousTheme
+      }
+    },
+  )
+})

--- a/packages/dify-ui/src/input-group/index.stories.tsx
+++ b/packages/dify-ui/src/input-group/index.stories.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '../dropdown-menu'
-import { Field, FieldDescription, FieldLabel } from '../field'
+import { Field, FieldDescription, FieldError, FieldLabel } from '../field'
 import { IconButton } from '../icon-button'
 import { InputGroup, InputGroupAddon, InputGroupInput } from './index'
 
@@ -214,5 +214,25 @@ export const WithDropdownAction: Story = {
     await waitFor(async () => {
       await expect(trigger).toHaveFocus()
     })
+  },
+}
+
+export const Invalid: Story = {
+  render: () => (
+    <Field invalid className="w-80">
+      <FieldLabel>Repository URL</FieldLabel>
+      <InputGroup>
+        <InputGroupInput defaultValue="invalid repository" />
+        <InputGroupAddon className="pe-0">https://</InputGroupAddon>
+      </InputGroup>
+      <FieldError match>Please enter a valid repository URL.</FieldError>
+    </Field>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole('textbox', { name: 'Repository URL' })
+    await userEvent.click(input)
+    await expect(input).toHaveFocus()
+    await expect(input).toHaveAttribute('aria-invalid', 'true')
+    await expect(input).toHaveAccessibleDescription('Please enter a valid repository URL.')
   },
 }

--- a/packages/dify-ui/src/input-group/index.tsx
+++ b/packages/dify-ui/src/input-group/index.tsx
@@ -19,9 +19,9 @@ function InputGroup({ className, onMouseDown, ...props }: InputGroupProps) {
       {...props}
       className={cn(
         [
-          'flex min-h-8 w-full min-w-0 items-center rounded-lg border border-transparent bg-components-input-bg-normal transition-[background-color,border-color,box-shadow]',
-          'has-[>input:enabled]:not-has-[>input[readonly]]:hover:border-components-input-border-hover has-[>input:enabled]:not-has-[>input[readonly]]:hover:bg-components-input-bg-hover',
-          'has-[>input:focus]:not-has-[>input[readonly]]:border-components-input-border-active has-[>input:focus]:not-has-[>input[readonly]]:bg-components-input-bg-active has-[>input:focus]:not-has-[>input[readonly]]:shadow-xs',
+          'flex min-h-8 w-full min-w-0 items-center rounded-lg border border-transparent bg-components-input-bg-normal transition-[background-color,border-color]',
+          'has-[>input:enabled]:not-has-[>input:is([readonly],[data-invalid])]:hover:border-components-input-border-hover has-[>input:enabled]:not-has-[>input:is([readonly],[data-invalid])]:hover:bg-components-input-bg-hover',
+          'has-[>input:focus]:not-has-[>input:is([readonly],[data-invalid])]:border-components-input-border-active has-[>input:focus]:not-has-[>input:is([readonly],[data-invalid])]:bg-components-input-bg-active has-[>input:focus]:not-has-[>input[readonly]]:shadow-xs',
           'has-[>input[data-invalid]]:border-components-input-border-destructive has-[>input[data-invalid]]:bg-components-input-bg-destructive',
           'has-[>input[data-disabled]]:cursor-not-allowed has-[>input[data-disabled]]:border-transparent has-[>input[data-disabled]]:bg-components-input-bg-disabled has-[>input[data-disabled]]:text-components-input-text-filled-disabled',
           'has-[>input[data-disabled]]:*:data-align:cursor-not-allowed has-[>input[data-disabled]]:*:data-align:text-components-input-text-filled-disabled',

--- a/packages/dify-ui/src/input/index.tsx
+++ b/packages/dify-ui/src/input/index.tsx
@@ -14,7 +14,7 @@ function Input({ className, ...props }: InputProps) {
     <BaseInput
       className={cn(
         [
-          'w-full appearance-none rounded-lg border border-transparent bg-components-input-bg-normal px-3 py-1.75 system-sm-regular text-components-input-text-filled caret-primary-600 outline-hidden transition-[background-color,border-color,box-shadow]',
+          'w-full appearance-none rounded-lg border border-transparent bg-components-input-bg-normal px-3 py-1.75 system-sm-regular text-components-input-text-filled caret-primary-600 outline-hidden transition-[background-color,border-color]',
           'placeholder:text-components-input-text-placeholder',
           'hover:border-components-input-border-hover hover:bg-components-input-bg-hover',
           textControlFocusClassName,

--- a/packages/dify-ui/src/number-field/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/number-field/__tests__/index.spec.tsx
@@ -9,6 +9,7 @@ import type {
 import * as React from 'react'
 import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
+import { Button } from '../../button'
 import { Field, FieldLabel } from '../../field'
 import {
   NumberField,
@@ -257,4 +258,47 @@ describe('NumberField wrapper', () => {
         .toHaveAttribute('title', 'decrement-title')
     })
   })
+})
+
+describe('Invalid focus colors', () => {
+  it.each(['light', 'dark'])(
+    'preserves error colors through keyboard and pointer focus in %s',
+    async (theme) => {
+      const previousTheme = document.documentElement.dataset.theme
+      document.documentElement.dataset.theme = theme
+      try {
+        const screen = await render(
+          <>
+            <Button>Before</Button>
+            <Field invalid>
+              <FieldLabel>Invalid value</FieldLabel>
+              <NumberField defaultValue={120}>
+                <NumberFieldGroup data-testid="invalid-surface">
+                  <NumberFieldInput />
+                </NumberFieldGroup>
+              </NumberField>
+            </Field>
+          </>,
+        )
+        const input = screen.getByRole('textbox', { name: 'Invalid value' })
+        const surface = screen.getByTestId('invalid-surface').element()
+        const colors = () => {
+          const style = getComputedStyle(surface)
+          return [style.borderTopColor, style.backgroundColor]
+        }
+        const restingColors = colors()
+        const restingShadow = getComputedStyle(surface).boxShadow
+        await screen.getByRole('button', { name: 'Before' }).click()
+        await userEvent.keyboard('{Tab}')
+        await expect.element(input).toHaveFocus()
+        await expect.element(input).toHaveAttribute('aria-invalid', 'true')
+        await expect.poll(colors).toEqual(restingColors)
+        await expect.poll(() => getComputedStyle(surface).boxShadow).not.toBe(restingShadow)
+        await input.click()
+        await expect.poll(colors).toEqual(restingColors)
+      } finally {
+        document.documentElement.dataset.theme = previousTheme
+      }
+    },
+  )
 })

--- a/packages/dify-ui/src/number-field/index.tsx
+++ b/packages/dify-ui/src/number-field/index.tsx
@@ -12,11 +12,12 @@ type NumberFieldProps = BaseNumberField.Root.Props
 
 const numberFieldGroupVariants = cva(
   [
-    'group/number-field flex w-full min-w-0 items-stretch overflow-hidden border border-transparent bg-components-input-bg-normal text-components-input-text-filled shadow-none outline-hidden transition-[background-color,border-color,box-shadow]',
+    'group/number-field flex w-full min-w-0 items-stretch overflow-hidden border border-transparent bg-components-input-bg-normal text-components-input-text-filled shadow-none outline-hidden transition-[background-color,border-color]',
     'hover:border-components-input-border-hover hover:bg-components-input-bg-hover',
     textControlCompoundInputFocusClassName,
     'data-focused:border-components-input-border-active data-focused:bg-components-input-bg-active data-focused:shadow-xs',
     'data-invalid:border-components-input-border-destructive data-invalid:bg-components-input-bg-destructive',
+    'data-invalid:has-[input:focus]:border-components-input-border-destructive data-invalid:has-[input:focus]:bg-components-input-bg-destructive',
     'data-disabled:cursor-not-allowed data-disabled:border-transparent data-disabled:bg-components-input-bg-disabled data-disabled:text-components-input-text-filled-disabled',
     'data-disabled:hover:border-transparent data-disabled:hover:bg-components-input-bg-disabled',
     'data-readonly:shadow-none data-readonly:hover:border-transparent data-readonly:hover:bg-components-input-bg-normal motion-reduce:transition-none',

--- a/packages/dify-ui/src/textarea/index.tsx
+++ b/packages/dify-ui/src/textarea/index.tsx
@@ -10,7 +10,7 @@ import { textControlFocusClassName } from '../form-control-shared'
 
 const textareaVariants = cva(
   [
-    'min-h-20 w-full appearance-none overflow-auto border border-transparent bg-components-input-bg-normal text-components-input-text-filled caret-primary-600 outline-hidden transition-[background-color,border-color,box-shadow]',
+    'min-h-20 w-full appearance-none overflow-auto border border-transparent bg-components-input-bg-normal text-components-input-text-filled caret-primary-600 outline-hidden transition-[background-color,border-color]',
     'placeholder:text-components-input-text-placeholder',
     'hover:border-components-input-border-hover hover:bg-components-input-bg-hover',
     textControlFocusClassName,


### PR DESCRIPTION
## Summary

Invalid NumberField and InputGroup surfaces could lose their error border and background when focused or hovered, even while the input still reported `aria-invalid="true"`. For example, a focused invalid NumberField changed from the existing light-theme error border (`#fda29b`) to the normal active border (`#d0d5dc`).

- Give NumberField's existing invalid border and background precedence while its input is focused.
- Exclude invalid inputs from InputGroup's normal hover/focus color rules, while retaining its existing focus shadow.
- Remove only `box-shadow` from the transition list on Input, Textarea, InputGroup, NumberField, Autocomplete, and the Combobox input surface. Shadows and rings now switch immediately; background and border colors retain their existing 150ms transitions.
- Add browser regression tests for both invalid surfaces in light and dark themes, checking keyboard focus, pointer interaction, `aria-invalid`, retained error colors, and the existing focus shadow.
- Add an InputGroup Invalid story with a linked error message and interaction assertions for focus, invalid semantics, and the accessible description.

Existing color tokens, border widths, shadow definitions, and readonly focus rings remain unchanged. This change does not introduce a new focus design or change component APIs.

## Validation

- `vp check --fix packages/dify-ui` — formatting, lint, and type checks passed.
- `vp staged` — passed; commit hooks also passed.
- From `packages/dify-ui`: `vp test run --project unit src/number-field/ src/input-group/` — 22 tests passed. The four new theme-specific regression cases reproduced the original failures before the fix.
- From `packages/dify-ui`: `vp test run --project storybook src/input-group/index.stories.tsx src/number-field/index.stories.tsx` — 11 tests passed.
- Manually inspected all six changed input surfaces in Storybook at port 6006. Verified the invalid NumberField and InputGroup appearance in both themes and confirmed computed transitions retain only background and border colors at 150ms.

## Checklist

- [x] Added regression coverage and a Storybook example for the invalid-state behavior.
- [x] Ran frontend staged checks and focused browser tests.
- [x] Visually verified every changed form component.
- [x] No external documentation update is required; the component API is unchanged.

From Codex
