### PR TITLE
fix: parse Redis Sentinel and Cluster nodes safely

### DIFF
--- a/api/extensions/ext_redis.py
+++ b/api/extensions/ext_redis.py
@@ -371,6 +371,18 @@ def _get_base_redis_params() -> RedisBaseParamsDict:
     )
 
 
+def _parse_redis_nodes(value: str) -> list[tuple[str, int]]:
+    nodes = []
+    for raw_node in value.split(","):
+        host, separator, port = raw_node.strip().rpartition(":")
+        if not separator or not host or not port:
+            raise ValueError(f"Invalid Redis node: {raw_node}")
+        if host.startswith("[") and host.endswith("]"):
+            host = host[1:-1]
+        nodes.append((host, int(port)))
+    return nodes
+
+
 def _create_sentinel_client(redis_params: RedisBaseParamsDict) -> Union[redis.Redis, RedisCluster]:
     """Create Redis client using Sentinel configuration."""
     if not dify_config.REDIS_SENTINELS:
@@ -379,7 +391,7 @@ def _create_sentinel_client(redis_params: RedisBaseParamsDict) -> Union[redis.Re
     if not dify_config.REDIS_SENTINEL_SERVICE_NAME:
         raise ValueError("REDIS_SENTINEL_SERVICE_NAME must be set when REDIS_USE_SENTINEL is True")
 
-    sentinel_hosts = [(node.split(":")[0], int(node.split(":")[1])) for node in dify_config.REDIS_SENTINELS.split(",")]
+    sentinel_hosts = _parse_redis_nodes(dify_config.REDIS_SENTINELS)
 
     health_params = _get_connection_health_params()
 
@@ -409,10 +421,7 @@ def _create_cluster_client() -> Union[redis.Redis, RedisCluster]:
     if not dify_config.REDIS_CLUSTERS:
         raise ValueError("REDIS_CLUSTERS must be set when REDIS_USE_CLUSTERS is True")
 
-    nodes = [
-        ClusterNode(host=node.split(":")[0], port=int(node.split(":")[1]))
-        for node in dify_config.REDIS_CLUSTERS.split(",")
-    ]
+    nodes = [ClusterNode(host=host, port=port) for host, port in _parse_redis_nodes(dify_config.REDIS_CLUSTERS)]
 
     cluster_kwargs: dict[str, Any] = {
         "startup_nodes": nodes,

--- a/api/tests/unit_tests/extensions/test_redis.py
+++ b/api/tests/unit_tests/extensions/test_redis.py
@@ -10,6 +10,7 @@ from extensions.ext_redis import (
     _get_cluster_connection_health_params,
     _get_connection_health_params,
     _normalize_redis_key_prefix,
+    _parse_redis_nodes,
     _serialize_redis_name,
     redis_fallback,
 )
@@ -76,6 +77,14 @@ class TestGetBaseRedisParams:
         # Existing params still present
         assert params["db"] == 0
         assert params["encoding"] == "utf-8"
+
+
+class TestParseRedisNodes:
+    def test_trims_nodes(self):
+        assert _parse_redis_nodes("redis-a:6379, redis-b:6380") == [("redis-a", 6379), ("redis-b", 6380)]
+
+    def test_supports_bracketed_ipv6(self):
+        assert _parse_redis_nodes("[2001:db8::10]:6379") == [("2001:db8::10", 6379)]
 
 
 class TestRedisFallback:


### PR DESCRIPTION
## Summary

- share parsing for Sentinel and Cluster node lists
- support bracketed IPv6 endpoints
- trim whitespace around comma-separated nodes
- add regression tests for both cases

Fixes #42110

## Screenshots

Not applicable.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

## Testing

- `pytest -o addopts='' tests/unit_tests/extensions/test_redis.py -q` (21 passed)
- `ruff check extensions/ext_redis.py tests/unit_tests/extensions/test_redis.py`
- `ruff format --check extensions/ext_redis.py tests/unit_tests/extensions/test_redis.py`

Broader test suites were not run.