### PR TITLE
fix(ui): let collapsible consumers own trigger styling

### DIFF
--- a/packages/dify-ui/src/collapsible/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/collapsible/__tests__/index.spec.tsx
@@ -1,34 +1,56 @@
+import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
+import { IconButton } from '../../icon-button'
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from '../index'
 
-describe('Collapsible wrappers', () => {
-  it('forwards className to every compound part', async () => {
-    const screen = await render(
-      <Collapsible defaultOpen className="custom-root">
-        <CollapsibleTrigger className="custom-trigger">Custom</CollapsibleTrigger>
-        <CollapsiblePanel className="custom-panel">Custom panel</CollapsiblePanel>
-      </Collapsible>,
-    )
-
-    await expect
-      .element(screen.getByRole('button', { name: 'Custom' }))
-      .toHaveClass('custom-trigger')
-    expect(screen.getByText('Custom panel').element()).toHaveClass('custom-panel')
-    expect(screen.container.querySelector('.custom-root')).toBeInTheDocument()
-  })
-
-  it('keeps closed panel content mounted when requested', async () => {
-    const screen = await render(
+it('preserves IconButton appearance and keyboard focus when used as a disclosure trigger', async () => {
+  const screen = await render(
+    <div className="flex items-start gap-4">
+      <IconButton aria-label="Reference">
+        <span aria-hidden className="i-ri-information-2-line size-4" />
+      </IconButton>
       <Collapsible>
-        <CollapsibleTrigger>Recovery options</CollapsibleTrigger>
-        <CollapsiblePanel keepMounted>Recovery codes</CollapsiblePanel>
-      </Collapsible>,
-    )
+        <CollapsibleTrigger
+          render={
+            <IconButton aria-label="Details">
+              <span aria-hidden className="i-ri-information-2-line size-4" />
+            </IconButton>
+          }
+        />
+        <CollapsiblePanel>Build details</CollapsiblePanel>
+      </Collapsible>
+    </div>,
+  )
+  const reference = screen.getByRole('button', { name: 'Reference' })
+  const trigger = screen.getByRole('button', { name: 'Details', exact: true })
+  const appearance = (element: Element) => {
+    const style = getComputedStyle(element)
+    return {
+      width: style.width,
+      height: style.height,
+      padding: style.padding,
+      borderRadius: style.borderRadius,
+      color: style.color,
+      backgroundColor: style.backgroundColor,
+      boxShadow: style.boxShadow,
+    }
+  }
 
-    await expect
-      .element(screen.getByRole('button', { name: 'Recovery options' }))
-      .toHaveAttribute('aria-expanded', 'false')
-    await expect.element(screen.getByText('Recovery codes')).toBeInTheDocument()
-    await expect.element(screen.getByText('Recovery codes')).not.toBeVisible()
-  })
+  expect(appearance(trigger.element())).toEqual(appearance(reference.element()))
+  await reference.hover()
+  const hovered = appearance(reference.element())
+  await trigger.hover()
+  expect(appearance(trigger.element())).toEqual(hovered)
+
+  await reference.hover()
+  await userEvent.tab()
+  await expect.element(reference).toHaveFocus()
+  const focused = appearance(reference.element())
+  await trigger.hover()
+  await userEvent.tab()
+  await expect.element(trigger).toHaveFocus()
+  expect(getComputedStyle(trigger.element()).boxShadow).not.toBe('none')
+  expect(appearance(trigger.element())).toEqual(focused)
+  await userEvent.keyboard('{Enter}')
+  await expect.element(screen.getByText('Build details')).toBeVisible()
 })

--- a/packages/dify-ui/src/collapsible/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/collapsible/__tests__/index.spec.tsx
@@ -36,10 +36,11 @@ it('preserves IconButton appearance and keyboard focus when used as a disclosure
     }
   }
 
-  expect(appearance(trigger.element())).toEqual(appearance(reference.element()))
   await reference.hover()
+  const idle = appearance(trigger.element())
   const hovered = appearance(reference.element())
   await trigger.hover()
+  expect(appearance(reference.element())).toEqual(idle)
   expect(appearance(trigger.element())).toEqual(hovered)
 
   await reference.hover()

--- a/packages/dify-ui/src/collapsible/index.stories.tsx
+++ b/packages/dify-ui/src/collapsible/index.stories.tsx
@@ -1,18 +1,29 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import * as React from 'react'
+import type { CollapsiblePanelProps } from '.'
+import { useState } from 'react'
 import { expect, waitFor } from 'storybook/test'
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from '.'
+import { Button } from '../button'
 import { cn } from '../cn'
+import { IconButton } from '../icon-button'
 
 const meta = {
   title: 'Base/UI/Collapsible',
   component: Collapsible,
+  decorators: [
+    (Story, { parameters }) => (
+      <div className="p-4" style={{ height: parameters.docs.story.height }}>
+        <Story />
+      </div>
+    ),
+  ],
   parameters: {
     layout: 'centered',
     docs: {
+      story: { height: '240px' },
       description: {
         component:
-          'Styled Dify disclosure wrapper over Base UI Collapsible. It preserves the official Root, Trigger, and Panel anatomy while providing Dify layout, focus, disabled, and motion styles.',
+          'Trigger exposes Base UI disclosure behavior without styles. Compose Button or IconButton with render, or style the native button and its focus indicator. Root and Panel provide Dify layout and motion defaults.',
       },
     },
   },
@@ -23,47 +34,40 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 const rootClassName =
-  'w-72 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-1 shadow-lg shadow-shadow-shadow-5'
-const triggerClassName = 'h-8'
+  'w-72 rounded-lg border border-components-panel-border bg-components-panel-bg p-1'
+const triggerClassName =
+  'group/collapsible flex min-h-8 w-full items-center rounded-lg px-2.5 text-start system-sm-medium text-text-secondary outline-hidden hover:not-data-disabled:bg-components-panel-on-panel-item-bg-hover hover:not-data-disabled:text-text-primary focus-visible:ring-2 focus-visible:ring-state-accent-solid data-panel-open:text-text-primary data-disabled:cursor-not-allowed data-disabled:text-text-disabled'
 const panelClassName = 'system-sm-regular text-text-secondary'
-const contentClassName = 'flex flex-col gap-2 px-2.5 pb-2 pt-1'
-const iconClassName =
-  'i-ri-arrow-right-s-line size-4 shrink-0 text-text-tertiary transition-transform duration-100 ease-out group-data-panel-open:rotate-90 motion-reduce:transition-none'
-const sectionRootClassName =
-  'w-90 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-1 shadow-lg shadow-shadow-shadow-5'
-const sectionTriggerClassName = cn(triggerClassName, 'h-auto min-h-12 px-3 py-2')
-const sectionPanelClassName = panelClassName
 
 function TriggerIcon() {
-  return <span aria-hidden="true" className={iconClassName} />
+  return (
+    <span
+      aria-hidden
+      className="i-ri-arrow-right-s-line size-4 shrink-0 text-text-tertiary transition-transform duration-100 ease-out group-data-panel-open/collapsible:rotate-90 motion-reduce:transition-none"
+    />
+  )
 }
 
-function RecoveryKeys({
-  panelProps,
-}: {
-  panelProps?: React.ComponentProps<typeof CollapsiblePanel>
-}) {
+function RecoveryKeys(props: Pick<CollapsiblePanelProps, 'keepMounted' | 'hiddenUntilFound'>) {
   return (
-    <React.Fragment>
-      <CollapsibleTrigger className={triggerClassName}>
+    <>
+      <CollapsibleTrigger className={cn(triggerClassName, 'justify-between gap-2')}>
         Recovery keys
         <TriggerIcon />
       </CollapsibleTrigger>
-      <CollapsiblePanel className={panelClassName} {...panelProps}>
-        <div className={contentClassName}>
+      <CollapsiblePanel className={panelClassName} {...props}>
+        <div className="flex flex-col gap-2 px-2.5 pt-1 pb-2">
           <div>alien-bean-pasta</div>
           <div>wild-irish-burrito</div>
           <div>horse-battery-staple</div>
         </div>
       </CollapsiblePanel>
-    </React.Fragment>
+    </>
   )
 }
 
 export const Anatomy: Story = {
-  args: {
-    defaultOpen: true,
-  },
+  args: { defaultOpen: true },
   render: (args) => (
     <Collapsible {...args} className={rootClassName}>
       <RecoveryKeys />
@@ -77,44 +81,87 @@ export const DefaultClosed: Story = {
       <RecoveryKeys />
     </Collapsible>
   ),
-  play: async ({ canvas, userEvent }) => {
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const canvasHeight = canvasElement.getBoundingClientRect().height
     const trigger = canvas.getByRole('button', { name: 'Recovery keys' })
-
-    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
-    await expect(canvas.queryByText('alien-bean-pasta')).not.toBeInTheDocument()
-
-    await userEvent.click(trigger)
-
+    await userEvent.tab()
+    await expect(trigger).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
     await expect(trigger).toHaveAttribute('aria-expanded', 'true')
     await expect(canvas.getByText('alien-bean-pasta')).toBeVisible()
-
-    await userEvent.click(trigger)
-    await waitFor(async () => {
-      await expect(canvas.queryByText('alien-bean-pasta')).not.toBeInTheDocument()
-    })
+    await expect(canvasElement.getBoundingClientRect().height).toBe(canvasHeight)
+    await userEvent.keyboard(' ')
+    await waitFor(() => expect(canvas.queryByText('alien-bean-pasta')).not.toBeInTheDocument())
+    await expect(trigger).toHaveFocus()
+    await expect(canvasElement.getBoundingClientRect().height).toBe(canvasHeight)
   },
 }
 
-export const DefaultOpen: Story = {
+export const ButtonTrigger: Story = {
   render: () => (
-    <Collapsible defaultOpen className={rootClassName}>
-      <RecoveryKeys />
+    <Collapsible className="w-72 items-start gap-2">
+      <CollapsibleTrigger render={<Button variant="secondary" />}>
+        Advanced options
+      </CollapsibleTrigger>
+      <CollapsiblePanel className={panelClassName}>
+        <p>Configure retry limits and response timeouts.</p>
+      </CollapsiblePanel>
     </Collapsible>
   ),
+  play: async ({ canvas, userEvent }) => {
+    const trigger = canvas.getByRole('button', { name: 'Advanced options' })
+    await userEvent.click(trigger)
+    await expect(canvas.getByText('Configure retry limits and response timeouts.')).toBeVisible()
+    await userEvent.click(trigger)
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('Configure retry limits and response timeouts.'),
+      ).not.toBeInTheDocument(),
+    )
+  },
+}
+
+export const IconButtonTrigger: Story = {
+  render: () => (
+    <Collapsible className="w-72 gap-2">
+      <div className="flex items-center justify-between">
+        <span className="system-sm-medium text-text-secondary">Build details</span>
+        <CollapsibleTrigger
+          render={
+            <IconButton aria-label="Build details">
+              <span aria-hidden className="i-ri-information-2-line size-4" />
+            </IconButton>
+          }
+        />
+      </div>
+      <CollapsiblePanel className={panelClassName}>
+        <p>The draft contains two changes ready to review.</p>
+      </CollapsiblePanel>
+    </Collapsible>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const trigger = canvas.getByRole('button', { name: 'Build details' })
+    await userEvent.tab()
+    await expect(trigger).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+    await expect(canvas.getByText('The draft contains two changes ready to review.')).toBeVisible()
+    await userEvent.keyboard(' ')
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('The draft contains two changes ready to review.'),
+      ).not.toBeInTheDocument(),
+    )
+    await expect(trigger).toHaveFocus()
+  },
 }
 
 function ControlledDemo() {
-  const [open, setOpen] = React.useState(true)
-
+  const [open, setOpen] = useState(true)
   return (
     <div className="flex flex-col items-start gap-3">
-      <button
-        type="button"
-        className="rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 system-sm-medium text-components-button-secondary-text shadow-xs shadow-shadow-shadow-3 outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
-        onClick={() => setOpen((value) => !value)}
-      >
-        {open ? 'Close panel' : 'Open panel'}
-      </button>
+      <Button variant="secondary" onClick={() => setOpen(true)}>
+        Reset disclosure
+      </Button>
       <Collapsible open={open} onOpenChange={setOpen} className={rootClassName}>
         <RecoveryKeys />
       </Collapsible>
@@ -124,28 +171,51 @@ function ControlledDemo() {
 
 export const Controlled: Story = {
   render: () => <ControlledDemo />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Recovery keys' }))
+    await waitFor(() => expect(canvas.queryByText('alien-bean-pasta')).not.toBeInTheDocument())
+    await userEvent.click(canvas.getByRole('button', { name: 'Reset disclosure' }))
+    await expect(canvas.getByText('alien-bean-pasta')).toBeVisible()
+  },
 }
 
 export const Disabled: Story = {
   render: () => (
-    <Collapsible disabled className={rootClassName}>
-      <RecoveryKeys />
+    <Collapsible disabled className="w-72 items-start">
+      <CollapsibleTrigger render={<Button variant="secondary" />}>
+        Unavailable options
+      </CollapsibleTrigger>
+      <CollapsiblePanel>These options are not available.</CollapsiblePanel>
     </Collapsible>
   ),
+  play: async ({ canvas, userEvent }) => {
+    const trigger = canvas.getByRole('button', { name: 'Unavailable options' })
+    await expect(trigger).toHaveAttribute('aria-disabled', 'true')
+    await userEvent.click(trigger)
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(canvas.queryByText('These options are not available.')).not.toBeInTheDocument()
+  },
 }
 
 export const KeepMounted: Story = {
   render: () => (
     <Collapsible className={rootClassName}>
-      <RecoveryKeys panelProps={{ keepMounted: true }} />
+      <RecoveryKeys keepMounted />
     </Collapsible>
   ),
+  play: async ({ canvas, userEvent }) => {
+    await expect(canvas.getByText('alien-bean-pasta')).not.toBeVisible()
+    await userEvent.click(canvas.getByRole('button', { name: 'Recovery keys' }))
+    await expect(canvas.getByText('alien-bean-pasta')).toBeVisible()
+    await userEvent.click(canvas.getByRole('button', { name: 'Recovery keys' }))
+    await waitFor(() => expect(canvas.getByText('alien-bean-pasta')).not.toBeVisible())
+  },
 }
 
 export const HiddenUntilFound: Story = {
   render: () => (
     <Collapsible className={rootClassName}>
-      <RecoveryKeys panelProps={{ hiddenUntilFound: true }} />
+      <RecoveryKeys hiddenUntilFound />
     </Collapsible>
   ),
 }
@@ -154,48 +224,44 @@ const settingSections = [
   {
     title: 'Model routing',
     description: 'Fallback model enabled, retry budget set to 2 attempts.',
-    defaultOpen: true,
   },
   {
     title: 'Knowledge access',
     description: 'Retrieval is limited to approved workspace datasets.',
-    defaultOpen: false,
   },
   {
     title: 'Observability',
     description: 'Request logs and workflow traces stay available for debugging.',
-    defaultOpen: false,
   },
-] as const
+]
 
-export const SettingsSections: Story = {
+export const IndependentSections: Story = {
   parameters: {
-    layout: 'padded',
+    docs: { story: { height: '400px' } },
   },
   render: () => (
-    <div className={sectionRootClassName}>
-      {settingSections.map((section, index) => (
-        <Collapsible
-          key={section.title}
-          defaultOpen={section.defaultOpen}
-          className={cn(index > 0 && 'mt-px')}
-        >
-          <CollapsibleTrigger className={sectionTriggerClassName}>
-            <span className="flex min-w-0 flex-col gap-1">
-              <span className="truncate system-sm-medium text-text-primary">{section.title}</span>
-              <span className="line-clamp-2 system-xs-regular text-text-tertiary">
-                {section.description}
-              </span>
-            </span>
-            <TriggerIcon />
-          </CollapsibleTrigger>
-          <CollapsiblePanel className={sectionPanelClassName}>
-            <div className="px-3 pt-1 pb-3 system-sm-regular text-text-secondary">
-              {section.description}
-            </div>
+    <div className="w-90 space-y-2">
+      {settingSections.map((section) => (
+        <Collapsible key={section.title} className="rounded-lg border border-divider-subtle p-2">
+          <h3>
+            <CollapsibleTrigger className={cn(triggerClassName, 'justify-start gap-1')}>
+              <TriggerIcon />
+              {section.title}
+            </CollapsibleTrigger>
+          </h3>
+          <CollapsiblePanel className={panelClassName}>
+            <p className="px-2.5 py-2">{section.description}</p>
           </CollapsiblePanel>
         </Collapsible>
       ))}
     </div>
   ),
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const canvasHeight = canvasElement.getBoundingClientRect().height
+    for (const { title } of settingSections)
+      await userEvent.click(canvas.getByRole('button', { name: title }))
+    for (const { description } of settingSections)
+      await expect(canvas.getByText(description)).toBeVisible()
+    await expect(canvasElement.getBoundingClientRect().height).toBe(canvasHeight)
+  },
 }

--- a/packages/dify-ui/src/collapsible/index.tsx
+++ b/packages/dify-ui/src/collapsible/index.tsx
@@ -11,24 +11,8 @@ function Collapsible({ className, ...props }: CollapsibleProps) {
   return <BaseCollapsible.Root className={cn('flex min-w-0 flex-col', className)} {...props} />
 }
 
-type CollapsibleTriggerProps = Omit<BaseCollapsibleNS.Trigger.Props, 'className'> & {
-  className?: string
-}
-function CollapsibleTrigger({ className, ...props }: CollapsibleTriggerProps) {
-  return (
-    <BaseCollapsible.Trigger
-      className={cn(
-        'group flex min-h-8 w-full touch-manipulation items-center justify-between gap-2 rounded-lg px-2.5 text-start system-sm-medium text-text-secondary outline-hidden select-none',
-        'hover:not-data-disabled:bg-components-panel-on-panel-item-bg-hover hover:not-data-disabled:text-text-primary',
-        'focus-visible:ring-2 focus-visible:ring-state-accent-solid',
-        'data-panel-open:text-text-primary',
-        'data-disabled:cursor-not-allowed data-disabled:text-text-disabled data-disabled:hover:bg-transparent',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
+const CollapsibleTrigger = BaseCollapsible.Trigger
+type CollapsibleTriggerProps = BaseCollapsibleNS.Trigger.Props
 
 type CollapsiblePanelProps = Omit<BaseCollapsibleNS.Panel.Props, 'className'> & {
   className?: string

--- a/web/app/components/app/configuration/debug/index.tsx
+++ b/web/app/components/app/configuration/debug/index.tsx
@@ -475,7 +475,7 @@ const Debug: FC<IDebug> = ({
                       <TooltipTrigger
                         render={
                           <CollapsibleTrigger
-                            className="size-6 min-h-0 justify-center gap-0 p-0.5 hover:not-data-disabled:text-text-secondary data-panel-open:bg-state-accent-active data-panel-open:text-text-accent data-panel-open:hover:bg-state-accent-active-alt"
+                            className="rounded-lg text-text-secondary data-panel-open:bg-state-accent-active data-panel-open:text-text-accent data-panel-open:hover:bg-state-accent-active-alt"
                             render={
                               <IconButton
                                 aria-label={t(($) => $['panel.userInputField'], { ns: 'workflow' })}

--- a/web/app/components/base/chat/chat/answer/agent-roster-response-content.tsx
+++ b/web/app/components/base/chat/chat/answer/agent-roster-response-content.tsx
@@ -217,7 +217,7 @@ function ToolActivityItem({ tool }: { tool: ToolActivity }) {
     <div className="flex w-full max-w-full min-w-0 flex-col items-start">
       {hasDetails ? (
         <Collapsible className="w-full max-w-full items-start">
-          <CollapsibleTrigger className="group/tool h-6 min-h-0 w-auto max-w-full justify-start gap-0 rounded-md p-1 text-left system-xs-medium text-text-tertiary hover:not-data-disabled:bg-state-base-hover focus-visible:bg-state-base-hover">
+          <CollapsibleTrigger className="group/tool flex h-6 min-h-0 max-w-full touch-manipulation items-center justify-start gap-0 rounded-md p-1 text-left system-xs-medium text-text-tertiary outline-hidden select-none hover:bg-state-base-hover hover:text-text-primary focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid data-panel-open:text-text-primary">
             {content}
           </CollapsibleTrigger>
           <CollapsiblePanel className="w-full max-w-full">
@@ -308,7 +308,7 @@ function AgentActivityDisclosure({
     <Collapsible className="w-full max-w-full items-start gap-1" defaultOpen={defaultOpen}>
       <CollapsibleTrigger
         aria-label={title}
-        className="group/thinking h-6 min-h-0 w-auto max-w-full justify-start gap-1 rounded-md p-1 text-left system-xs-medium text-text-tertiary hover:not-data-disabled:bg-state-base-hover focus-visible:bg-state-base-hover"
+        className="group/thinking flex h-6 min-h-0 max-w-full touch-manipulation items-center justify-start gap-1 rounded-md p-1 text-left system-xs-medium text-text-tertiary outline-hidden select-none hover:bg-state-base-hover hover:text-text-primary focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid data-panel-open:text-text-primary"
       >
         <span>{thinking}</span>
         {duration && (

--- a/web/app/components/header/account-setting/access-rules-page/access-rule-section.tsx
+++ b/web/app/components/header/account-setting/access-rules-page/access-rule-section.tsx
@@ -100,10 +100,7 @@ const AccessRuleSection = ({
       }
     >
       <div className="flex items-center gap-4 p-4">
-        <CollapsibleTrigger
-          className="min-h-0 w-auto min-w-0 flex-1 justify-start gap-0 rounded-none px-0 hover:not-data-disabled:bg-transparent"
-          render={<button type="button" className="min-w-0 flex-1 text-left" />}
-        >
+        <CollapsibleTrigger className="flex min-h-0 min-w-0 flex-1 touch-manipulation items-center justify-start gap-0 text-start system-sm-medium text-text-secondary outline-hidden select-none hover:text-text-primary focus-visible:ring-2 focus-visible:ring-state-accent-solid data-panel-open:text-text-primary">
           <div className="flex min-w-0 items-center gap-4">
             <span className="truncate system-sm-semibold text-text-primary">{title}</span>
             <span className="shrink-0 system-xs-regular text-text-tertiary">
@@ -119,7 +116,7 @@ const AccessRuleSection = ({
             </Button>
           )}
           <CollapsibleTrigger
-            className="size-8 min-h-0 justify-center gap-0 p-1.5 hover:not-data-disabled:text-text-secondary data-panel-open:bg-state-accent-active data-panel-open:text-text-accent data-panel-open:hover:bg-state-accent-active-alt"
+            className="group/collapsible text-text-secondary data-panel-open:bg-state-accent-active data-panel-open:text-text-accent data-panel-open:hover:bg-state-accent-active-alt"
             render={
               <IconButton
                 size="lg"
@@ -131,7 +128,7 @@ const AccessRuleSection = ({
               >
                 <span
                   aria-hidden="true"
-                  className="i-ri-arrow-right-s-line size-4 text-text-tertiary transition-transform group-data-panel-open:rotate-90"
+                  className="i-ri-arrow-right-s-line size-4 text-text-tertiary transition-transform group-data-panel-open/collapsible:rotate-90"
                 />
               </IconButton>
             }

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/marketplace-section.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/marketplace-section.tsx
@@ -47,7 +47,7 @@ function MarketplaceSection({
         <div className="flex h-5.5 items-center pr-2 pl-4">
           <CollapsibleTrigger
             id={headingId}
-            className="group/marketplace min-h-0 flex-1 justify-start gap-0 rounded-none p-0 system-sm-medium text-text-primary hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-primary data-panel-open:text-text-primary"
+            className="group/marketplace flex min-h-0 w-full flex-1 touch-manipulation items-center justify-start gap-0 text-start system-sm-medium text-text-primary outline-hidden select-none focus-visible:ring-2 focus-visible:ring-state-accent-solid"
           >
             {t(($) => $['modelProvider.selector.fromMarketplace'], { ns: 'common' })}
             <span

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup-item.tsx
@@ -131,7 +131,7 @@ function PopupItem({
       <div className="sticky top-0 z-1 flex min-h-5.5 min-w-0 items-center justify-between gap-2 bg-components-panel-bg px-3 text-xs font-medium text-text-tertiary">
         <CollapsibleTrigger
           id={providerHeadingId}
-          className="group/provider min-h-0 w-auto min-w-0 justify-start gap-0 rounded-none p-0 text-xs font-medium text-text-tertiary hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-tertiary data-panel-open:text-text-tertiary"
+          className="group/provider flex min-h-0 min-w-0 touch-manipulation items-center justify-start gap-0 text-xs font-medium text-text-tertiary outline-hidden select-none focus-visible:ring-2 focus-visible:ring-state-accent-solid"
         >
           <span className="truncate">{providerLabel}</span>
           <span

--- a/web/app/components/integrations/index.tsx
+++ b/web/app/components/integrations/index.tsx
@@ -232,13 +232,13 @@ export default function IntegrationsPage({
   const toolsNavItemClassName = cn(
     integrationSidebarNavItemClassName,
     integrationSidebarInactiveNavItemClassName,
-    'group',
+    'group/collapsible',
   )
   const toolsNavItemContent = (
     <>
       <span aria-hidden className="flex size-5 shrink-0 items-center justify-center">
-        <ToolsDisclosureIcon className="h-3.5 w-3 group-hover:hidden group-focus-visible:hidden" />
-        <span className="i-ri-arrow-down-s-line hidden size-4 transition-transform duration-100 ease-out group-hover:inline-block group-focus-visible:inline-block group-data-panel-open:rotate-180 motion-reduce:transition-none" />
+        <ToolsDisclosureIcon className="h-3.5 w-3 group-hover/collapsible:hidden group-focus-visible/collapsible:hidden" />
+        <span className="i-ri-arrow-down-s-line hidden size-4 transition-transform duration-100 ease-out group-hover/collapsible:inline-block group-focus-visible/collapsible:inline-block group-data-panel-open/collapsible:rotate-180 motion-reduce:transition-none" />
       </span>
       <span className="min-w-0 flex-1 truncate">
         {t(($) => $['menus.tools'], { ns: 'common' })}
@@ -300,7 +300,7 @@ export default function IntegrationsPage({
               <CollapsibleTrigger
                 className={cn(
                   toolsNavItemClassName,
-                  'border-none bg-transparent data-panel-open:text-components-menu-item-text',
+                  'min-h-8 touch-manipulation justify-between border-none bg-transparent select-none data-panel-open:text-components-menu-item-text',
                 )}
               >
                 {toolsNavItemContent}

--- a/web/app/components/main-nav/components/web-apps-section.tsx
+++ b/web/app/components/main-nav/components/web-apps-section.tsx
@@ -225,14 +225,14 @@ const WebAppsSectionContent = () => {
     >
       <CollapsibleTrigger
         ref={sectionToggleRef}
-        className="col-start-1 row-start-1 my-1 ml-2 min-h-6 w-fit min-w-0 justify-start gap-0 rounded-md px-2 py-1 text-left text-text-tertiary hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-secondary data-panel-open:text-text-tertiary"
+        className="group/collapsible col-start-1 row-start-1 my-1 ml-2 flex min-h-6 w-fit min-w-0 touch-manipulation items-center justify-start gap-0 rounded-md px-2 py-1 text-left system-sm-medium text-text-tertiary outline-hidden select-none hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid"
       >
         <span id={sectionLabelId} className="system-xs-medium-uppercase">
           {t(($) => $['sidebar.webApps'], { ns: 'explore' })}
         </span>
         <span
           aria-hidden
-          className="i-ri-arrow-down-s-fill h-4 w-4 shrink-0 -rotate-90 transition-transform group-data-panel-open:rotate-0 motion-reduce:transition-none"
+          className="i-ri-arrow-down-s-fill h-4 w-4 shrink-0 -rotate-90 transition-transform group-data-panel-open/collapsible:rotate-0 motion-reduce:transition-none"
         />
       </CollapsibleTrigger>
       <Collapsible
@@ -241,7 +241,7 @@ const WebAppsSectionContent = () => {
         className="contents"
       >
         <CollapsibleTrigger
-          className="col-start-2 row-start-1 my-1 mr-2 size-6 min-h-0 w-6 justify-center gap-0 self-center rounded-md p-0.5 hover:not-data-disabled:bg-state-base-hover hover:not-data-disabled:text-text-secondary data-panel-open:bg-state-base-hover data-panel-open:text-text-secondary"
+          className="col-start-2 row-start-1 my-1 mr-2 self-center text-text-secondary data-panel-open:bg-state-base-hover"
           render={
             <IconButton aria-label={t(($) => $['operation.search'], { ns: 'common' })}>
               <span aria-hidden className="i-ri-search-line size-3.5" />

--- a/web/app/components/main-nav/components/workspace-switcher.tsx
+++ b/web/app/components/main-nav/components/workspace-switcher.tsx
@@ -118,7 +118,7 @@ function WorkspaceSwitchControls({
         </DropdownMenu>
         <CollapsibleTrigger
           disabled={disabled}
-          className="size-6 min-h-0 w-6 justify-center gap-0 rounded-md p-0.5 data-panel-open:bg-state-base-hover data-panel-open:text-text-secondary"
+          className="text-text-secondary data-panel-open:bg-state-base-hover"
           render={
             <IconButton aria-label={t(($) => $['operation.search'], { ns: 'common' })}>
               <span aria-hidden className={workspaceSwitchActionIconWrapClassName}>

--- a/web/app/components/plugins/plugin-detail-panel/multiple-tool-selector/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/multiple-tool-selector/index.tsx
@@ -129,7 +129,7 @@ const MultipleToolSelector = ({
           {supportCollapse ? (
             <CollapsibleTrigger
               aria-label={label}
-              className="group/collapse h-6 min-h-0 w-auto min-w-0 justify-start gap-0.5 bg-transparent p-0 hover:not-data-disabled:bg-transparent"
+              className="group/collapse flex h-6 min-h-0 min-w-0 touch-manipulation items-center justify-start gap-0.5 rounded-lg bg-transparent system-sm-medium text-text-secondary outline-hidden select-none hover:text-text-primary focus-visible:ring-2 focus-visible:ring-state-accent-solid data-panel-open:text-text-primary"
             >
               <span className="truncate system-sm-semibold-uppercase text-text-secondary">
                 {label}

--- a/web/app/components/workflow/block-selector/featured-tools.tsx
+++ b/web/app/components/workflow/block-selector/featured-tools.tsx
@@ -125,13 +125,13 @@ const FeaturedTools = ({
       open={!isCollapsed}
       onOpenChange={(open) => setIsCollapsed(!open)}
     >
-      <CollapsibleTrigger className="-ml-2 min-h-0 w-fit justify-start gap-0 rounded-md px-2 py-1 hover:not-data-disabled:bg-transparent focus-visible:ring-inset">
+      <CollapsibleTrigger className="group/collapsible -ml-2 flex min-h-0 w-fit touch-manipulation items-center justify-start gap-0 rounded-md px-2 py-1 text-start system-sm-medium text-text-secondary outline-hidden select-none hover:text-text-primary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:ring-inset data-panel-open:text-text-primary">
         <span className="system-xs-medium text-text-primary">
           {t(($) => $['tabs.featuredTools'], { ns: 'workflow' })}
         </span>
         <span
           aria-hidden
-          className="ml-0.5 i-custom-vender-solid-arrows-arrow-down-round-fill size-4 -rotate-90 text-text-tertiary transition-transform group-data-panel-open:rotate-0 motion-reduce:transition-none"
+          className="ml-0.5 i-custom-vender-solid-arrows-arrow-down-round-fill size-4 -rotate-90 text-text-tertiary transition-transform group-data-panel-open/collapsible:rotate-0 motion-reduce:transition-none"
         />
       </CollapsibleTrigger>
 

--- a/web/app/components/workflow/block-selector/featured-triggers.tsx
+++ b/web/app/components/workflow/block-selector/featured-triggers.tsx
@@ -129,13 +129,13 @@ const FeaturedTriggers = ({
       open={!isCollapsed}
       onOpenChange={(open) => setIsCollapsed(!open)}
     >
-      <CollapsibleTrigger className="ml-2 min-h-0 w-fit justify-start gap-0 rounded-md px-2 py-1 hover:not-data-disabled:bg-transparent focus-visible:ring-inset">
+      <CollapsibleTrigger className="group/collapsible ml-2 flex min-h-0 w-fit touch-manipulation items-center justify-start gap-0 rounded-md px-2 py-1 text-start system-sm-medium text-text-secondary outline-hidden select-none hover:text-text-primary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:ring-inset data-panel-open:text-text-primary">
         <span className="system-xs-medium text-text-primary">
           {t(($) => $['tabs.featuredTools'], { ns: 'workflow' })}
         </span>
         <span
           aria-hidden
-          className="ml-0.5 i-custom-vender-solid-arrows-arrow-down-round-fill size-4 -rotate-90 text-text-tertiary transition-transform group-data-panel-open:rotate-0 motion-reduce:transition-none"
+          className="ml-0.5 i-custom-vender-solid-arrows-arrow-down-round-fill size-4 -rotate-90 text-text-tertiary transition-transform group-data-panel-open/collapsible:rotate-0 motion-reduce:transition-none"
         />
       </CollapsibleTrigger>
 

--- a/web/app/components/workflow/block-selector/tool/tool.tsx
+++ b/web/app/components/workflow/block-selector/tool/tool.tsx
@@ -226,7 +226,7 @@ function Tool({
       <div className="group/item relative flex w-full items-center rounded-lg">
         <CollapsibleTrigger
           aria-controls={panelId}
-          className="h-8 min-h-8 w-full min-w-0 justify-start gap-0 rounded-lg bg-transparent py-0 pr-2 pl-3 group-hover/item:bg-state-base-hover hover:not-data-disabled:bg-state-base-hover focus-visible:ring-inset"
+          className="group/collapsible flex h-8 min-h-8 w-full min-w-0 touch-manipulation items-center justify-start gap-0 rounded-lg bg-transparent pr-2 pl-3 text-start system-sm-medium text-text-secondary outline-hidden select-none group-hover/item:bg-state-base-hover hover:bg-state-base-hover hover:text-text-primary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:ring-inset data-panel-open:text-text-primary"
         >
           {providerDetails}
           {!isShowCanNotChooseMCPTip && !canNotSelectMultiple && selectedStatus && (
@@ -243,7 +243,7 @@ function Tool({
           <span
             aria-hidden
             className={cn(
-              'ml-2 i-ri-arrow-right-s-line size-4 shrink-0 text-text-quaternary transition-transform group-data-panel-open:rotate-90 motion-reduce:transition-none',
+              'ml-2 i-ri-arrow-right-s-line size-4 shrink-0 text-text-quaternary transition-transform group-data-panel-open/collapsible:rotate-90 motion-reduce:transition-none',
               !isShowCanNotChooseMCPTip &&
                 !canNotSelectMultiple &&
                 !isAllSelected &&

--- a/web/app/components/workflow/nodes/_base/components/collapse/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/collapse/index.tsx
@@ -38,11 +38,15 @@ export function CollapseActions({ children }: CollapseActionsProps) {
   return <div className="ml-auto shrink-0">{children}</div>
 }
 
-export function CollapseTrigger({ className, ...props }: CollapsibleTriggerProps) {
+type CollapseTriggerProps = Omit<CollapsibleTriggerProps, 'className'> & {
+  className?: string
+}
+
+export function CollapseTrigger({ className, ...props }: CollapseTriggerProps) {
   return (
     <CollapsibleTrigger
       className={cn(
-        'group/collapse ml-4 flex h-6 min-h-0 w-auto min-w-0 shrink-0 items-center justify-start gap-0 rounded-md px-0 py-0 text-text-secondary hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-secondary data-panel-open:text-text-secondary',
+        'group/collapse ml-4 flex h-6 min-h-0 min-w-0 shrink-0 touch-manipulation items-center justify-start gap-0 rounded-md text-start system-sm-medium text-text-secondary outline-hidden select-none hover:not-data-disabled:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid data-disabled:cursor-not-allowed data-disabled:text-text-disabled data-panel-open:text-text-secondary',
         className,
       )}
       {...props}

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/edit-card.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/edit-card.tsx
@@ -156,10 +156,10 @@ export function OutputEditCard({
         </div>
         {allowDefaultValue && (
           <Collapsible>
-            <CollapsibleTrigger className="h-8 min-h-8 justify-start gap-x-0.5 rounded-none border-y border-divider-subtle pr-2 pl-2.5 system-xs-regular text-text-tertiary hover:not-data-disabled:bg-state-base-hover hover:not-data-disabled:text-text-tertiary focus-visible:bg-state-base-hover focus-visible:ring-inset data-panel-open:text-text-tertiary">
+            <CollapsibleTrigger className="group/collapsible flex h-8 min-h-8 w-full touch-manipulation items-center justify-start gap-2 gap-x-0.5 border-y border-divider-subtle pr-2 pl-2.5 text-start system-xs-regular text-text-tertiary outline-hidden select-none hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:ring-inset">
               <span
                 aria-hidden="true"
-                className="i-ri-arrow-down-double-line size-3 transition-transform duration-100 ease-out group-data-panel-open:rotate-180 motion-reduce:transition-none"
+                className="i-ri-arrow-down-double-line size-3 transition-transform duration-100 ease-out group-data-panel-open/collapsible:rotate-180 motion-reduce:transition-none"
               />
               {t(($) => $['nodes.agent.outputVars.showAdvancedOptions'], { ns: 'workflow' })}
             </CollapsibleTrigger>

--- a/web/app/components/workflow/panel/chat-variable-panel/index.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/index.tsx
@@ -213,7 +213,7 @@ const ChatVariablePanel = () => {
         {t(($) => $['chatVariable.panelTitle'], { ns: 'workflow' })}
         <div className="flex items-center gap-1">
           <CollapsibleTrigger
-            className="size-6 min-h-0 justify-center gap-0 p-0.5 hover:not-data-disabled:text-text-secondary data-panel-open:bg-state-accent-active data-panel-open:text-text-accent data-panel-open:hover:bg-state-accent-active-alt"
+            className="rounded-lg text-text-secondary data-panel-open:bg-state-accent-active data-panel-open:text-text-accent data-panel-open:hover:bg-state-accent-active-alt"
             render={
               <IconButton aria-label={t(($) => $['chatVariable.tips'], { ns: 'workflow' })}>
                 <span aria-hidden="true" className="i-ri-book-open-line size-4" />

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/section.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/section.tsx
@@ -70,7 +70,7 @@ export function ConfigureSection({
           <div className={cn('group/collapse-title flex min-w-0 items-center', titleRowClassName)}>
             <Heading id={labelId} className="relative min-w-0 shrink-0">
               {isBuildDraftChanged && <AgentBuildDraftChangeDot />}
-              <CollapsibleTrigger className="h-6 min-h-0 w-auto max-w-full justify-start gap-0 rounded-sm px-0 text-text-secondary hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-secondary data-panel-open:text-text-secondary">
+              <CollapsibleTrigger className="flex h-6 min-h-0 max-w-full touch-manipulation items-center justify-start gap-0 rounded-sm system-sm-medium text-text-secondary outline-hidden select-none focus-visible:ring-2 focus-visible:ring-state-accent-solid">
                 <span className="min-w-0 truncate system-sm-semibold-uppercase">{label}</span>
               </CollapsibleTrigger>
             </Heading>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
@@ -312,7 +312,7 @@ export const AgentProviderToolItem = memo(
         className="overflow-hidden rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-1 shadow-xs shadow-shadow-shadow-3"
       >
         <div className="flex min-h-7 items-center gap-1 rounded-lg py-0.5 pr-0.5 pl-1">
-          <CollapsibleTrigger className="group min-h-0 min-w-0 flex-1 justify-start gap-2 rounded-md px-0 pr-1 text-left hover:not-data-disabled:bg-transparent hover:not-data-disabled:text-text-secondary data-panel-open:text-text-secondary">
+          <CollapsibleTrigger className="group/collapsible flex min-h-0 w-full min-w-0 flex-1 touch-manipulation items-center justify-start gap-2 rounded-md pr-1 text-left system-sm-medium text-text-secondary outline-hidden select-none focus-visible:ring-2 focus-visible:ring-state-accent-solid">
             <ProviderIcon icon={icon} iconClassName={tool.iconClassName} />
             <span className="flex min-w-0 items-center">
               <span className="min-w-0 truncate system-sm-medium text-text-primary">
@@ -321,7 +321,7 @@ export const AgentProviderToolItem = memo(
               <span
                 aria-hidden
                 className={cn(
-                  'i-custom-vender-solid-arrows-arrow-down-round-fill size-4 shrink-0 -rotate-90 text-text-quaternary transition-transform group-data-panel-open:rotate-0 motion-reduce:transition-none',
+                  'i-custom-vender-solid-arrows-arrow-down-round-fill size-4 shrink-0 -rotate-90 text-text-quaternary transition-transform group-data-panel-open/collapsible:rotate-0 motion-reduce:transition-none',
                 )}
               />
             </span>


### PR DESCRIPTION
## Summary

CollapsibleTrigger imposed row layout, typography, and high-specificity hover rules on every consumer, including composed IconButtons and navigation controls. Export the Base UI Trigger directly so each consumer owns its appearance while Base UI continues to own disclosure semantics and interaction.

- Migrate every Web trigger consumer, preserving layout, spacing, typography, radii, expanded states, and visible keyboard focus. Restore the intended IconButton and navigation hover styles previously masked by the wrapper.
- Use named groups only where descendants consume trigger state. Keep Root, Panel, animation defaults, and application state logic unchanged.
- Document native button, Button, IconButton, controlled, disabled, mounting, and independent disclosure examples. Reserve stable story canvas heights and padding so expansion does not resize Docs sections or clip focus rings; remove decorative example shadows.

Related: #42113.

## Validation

- Audited all 19 direct Web consumer files and the workflow CollapseTrigger consumers.
- Relevant Web unit suites: 19 files, 314 tests passed.
- Collapsible primitive and Storybook: 10 tests passed, including enabled accessibility checks and IconButton appearance/focus composition.
- Web Apps Chromium tests: 3 passed, covering virtualized keyboard navigation, focused-item retention, and rapid toggling without scrollbar flashes.
- Chrome on localhost:3000: checked tool-provider and Featured disclosure interaction, focus rings, and layout.
- Chrome Storybook Docs: all examples fit after expansion; canvas heights remain 240px/400px, and the IconButton focus ring is fully visible.
- `vp run -w check`, `vp staged`, and `git diff --check` passed. The repository-wide check reports 0 errors and 1930 existing warnings.

Browser verification covers Chromium and representative application surfaces; it is not an exhaustive cross-browser or screen-reader audit. Storybook's existing global color-contrast exclusion remains unchanged.

## Checklist

- [x] Added focused regression coverage for trigger composition and documented interactive examples.
- [x] Updated component documentation through Storybook.
- [x] Ran frontend staged checks and the repository-wide check.
- [x] Reviewed the final diff and removed temporary diagnostic test files.

From Codex
