### PR TITLE
fix(api): require exact match for CSRF whitelist paths

### DIFF
--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -204,7 +204,7 @@ def check_csrf_token(request: Request, user_id: str):
         raise Unauthorized("CSRF token is missing or invalid.")
 
     for pattern in CSRF_WHITE_LIST:
-        if pattern.match(request.path):
+        if pattern.fullmatch(request.path):
             return
 
     csrf_token = extract_csrf_token(request)

--- a/api/tests/unit_tests/libs/test_token.py
+++ b/api/tests/unit_tests/libs/test_token.py
@@ -100,6 +100,38 @@ def test_non_whitelisted_path_requires_csrf():
         token.check_csrf_token(request, "account-1")
 
 
+def test_exact_workflow_draft_path_bypasses_csrf():
+    request = cast(
+        Request,
+        MockRequest(
+            headers={},
+            cookies={},
+            args={},
+            path="/console/api/apps/5923ce20-2914-44af-45f0-580fb49f1cc9/workflows/draft",
+        ),
+    )
+
+    token.check_csrf_token(request, "account-1")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/console/api/apps/5923ce20-2914-44af-45f0-580fb49f1cc9/workflows/draft/variables",
+        "/console/api/apps/5923ce20-2914-44af-45f0-580fb49f1cc9/workflows/draft/nodes/node-1/variables",
+        "/console/api/apps/5923ce20-2914-44af-45f0-580fb49f1cc9/workflows/draft/conversation-variables",
+        "/console/api/apps/5923ce20-2914-44af-45f0-580fb49f1cc9/workflows/draft/iteration/nodes/node-1/run",
+        "/console/api/apps/5923ce20-2914-44af-45f0-580fb49f1cc9/workflows/draft/loop/nodes/node-1/run",
+        "/console/api/workflow-run-archives/downloads/5923ce20291444af45f0580fb49f1cc9/file/extra",
+    ],
+)
+def test_whitelist_prefix_paths_still_require_csrf(path: str):
+    request = cast(Request, MockRequest(headers={}, cookies={}, args={}, path=path))
+
+    with pytest.raises(Unauthorized):
+        token.check_csrf_token(request, "account-1")
+
+
 def test_admin_api_key_header_bypasses_csrf_when_console_cookie_is_present(config_overrides):
     config_overrides(
         ADMIN_API_KEY_ENABLE=True,


### PR DESCRIPTION
## Summary

Fixes #42117.

`check_csrf_token()` matched `CSRF_WHITE_LIST` with `pattern.match()`, which anchors only at the start of the path. That silently exempted every route starting with a whitelisted prefix — e.g. all `workflows/draft/*` variable CRUD and iteration/loop node-run endpoints — from CSRF validation. Only the two intended endpoints (keepalive draft autosave, archive file download) should be exempt.

One-line change: `match()` -> `fullmatch()` in `api/libs/token.py`, plus regression tests locking the exact-path exemptions in and the prefix paths out.

## Screenshots

| Before | After |
| ------ | ----- |
| `.../workflows/draft/variables` with no tokens passes the CSRF check | same request raises `Unauthorized` |

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran the backend unit tests for the touched area (`tests/unit_tests/libs/`, plus neighboring controller suites) — all green.
- [ ] This change requires a documentation update

From Hermes Agent