### PR TITLE
fix(web): center settings dialog across viewport sizes

### DIFF
--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -178,7 +178,7 @@ export default function AccountSetting({
 
   return (
     <MenuDialog title={t(($) => $['settings.settings'], { ns: 'common' })} onClose={onCancelAction}>
-      <div className="flex h-screen w-full max-w-full pl-0 sm:pl-58">
+      <div className="mx-auto flex h-screen w-full max-w-270 px-4">
         <div className="flex w-11 shrink-0 flex-col pr-6 pl-4 sm:w-56">
           <div className="mt-6 mb-8 flex h-9.5 items-center px-3 title-2xl-semi-bold whitespace-nowrap text-text-primary">
             {t(($) => $['settings.settings'], { ns: 'common' })}
@@ -224,7 +224,7 @@ export default function AccountSetting({
             ))}
           </div>
         </div>
-        <div className="relative flex min-h-0 w-206 min-w-0">
+        <div className="relative flex min-h-0 min-w-0 flex-1">
           <ScrollArea className="h-full min-h-0 min-w-0 flex-1 bg-components-panel-bg">
             <ScrollAreaViewport
               ref={scrollContainerRef}

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -225,6 +225,10 @@ export default function AccountSetting({
           </div>
         </div>
         <div className="relative flex min-h-0 min-w-0 flex-1">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 left-full w-screen bg-components-panel-bg"
+          />
           <ScrollArea className="h-full min-h-0 min-w-0 flex-1 bg-components-panel-bg">
             <ScrollAreaViewport
               ref={scrollContainerRef}


### PR DESCRIPTION
## Summary

At 1024px and 1159px laptop widths, workspace Settings reserves a fixed 232px left gutter, shifting the dialog content to the right and reducing the available form width. Center the navigation and content within a 1080px container (1048px of content plus 16px padding on each side), and let the content column shrink with the viewport. This also removes breakpoint-dependent horizontal jumps. Extend the panel background from the content column to the right viewport edge, matching the Figma design, using a non-interactive decorative layer clipped by the existing dialog wrapper.

Fixes #42119

## Screenshots

Original layout compared with the final PR implementation, including the background extension. All viewports are 863px tall.

| Viewport width | Before | After |
| --- | --- | --- |
| 1024px | ![Before at 1024px](https://raw.githubusercontent.com/hyoban/dify/d2930f1728da8c0932ae13af7a264672a715fb1b/before-1024.png) | ![After at 1024px](https://raw.githubusercontent.com/hyoban/dify/d2930f1728da8c0932ae13af7a264672a715fb1b/after-1024.png) |
| 1159px | ![Before at 1159px](https://raw.githubusercontent.com/hyoban/dify/d2930f1728da8c0932ae13af7a264672a715fb1b/before-1159.png) | ![After at 1159px](https://raw.githubusercontent.com/hyoban/dify/d2930f1728da8c0932ae13af7a264672a715fb1b/after-1159.png) |
| 1440px | ![Before at 1440px](https://raw.githubusercontent.com/hyoban/dify/d2930f1728da8c0932ae13af7a264672a715fb1b/before-1440.png) | ![After at 1440px](https://raw.githubusercontent.com/hyoban/dify/d2930f1728da8c0932ae13af7a264672a715fb1b/after-1440.png) |

## Validation

- Compared before/after browser screenshots at 1024 × 863, 1159 × 863, and 1440 × 863.
- Verified the extended panel background in the browser at 1440px.
- `vp run -w check` passed with warnings and no errors.
- `vp staged` passed.
- Checks and browser validation ran in the development checkout; the same layout changes were then cherry-picked onto latest `main` and the PR diff checked for whitespace errors.
- No automated tests added for this CSS-only adjustment; responsive layout was verified in the browser.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — not required.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. — browser verification described above.
- [ ] I've updated the documentation accordingly. — not required.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods — frontend only.

From Codex

