### PR TITLE
fix(web): align home skeleton with template layout

### DIFF
--- a/web/features/home/__tests__/page.spec.tsx
+++ b/web/features/home/__tests__/page.spec.tsx
@@ -1,0 +1,73 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { HomePage } from '../page'
+
+const mocks = vi.hoisted(() => ({
+  getQueryClient: vi.fn(),
+  recentApps: vi.fn(),
+}))
+
+vi.mock('@/app/get-query-client', () => ({ getQueryClient: mocks.getQueryClient }))
+vi.mock('@/i18n-config/server', () => ({ getLocaleOnServer: async () => 'en-US' }))
+vi.mock('@/features/system-features/server', () => ({
+  getOptionalSystemFeatures: async () => ({ enable_explore_banner: false }),
+}))
+vi.mock('@/service/console', () => ({
+  consoleQuery: {
+    apps: {
+      recent: {
+        get: {
+          queryOptions: () => ({
+            queryKey: ['recent-apps'],
+            queryFn: mocks.recentApps,
+          }),
+        },
+      },
+    },
+    explore: {
+      apps: {
+        get: {
+          queryOptions: () => ({
+            queryKey: ['templates'],
+            queryFn: async () => ({ recommended_apps: [], categories: [] }),
+          }),
+        },
+      },
+    },
+  },
+}))
+vi.mock('../home-content/home-content', () => ({
+  HomeContent: () => {
+    throw new Promise(() => {})
+  },
+}))
+vi.mock('../home-skeleton', () => ({
+  HomeSkeleton: () => <div role="status">Loading home</div>,
+}))
+
+describe('HomePage initial layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getQueryClient.mockReturnValue(
+      new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      }),
+    )
+  })
+
+  it('returns the loading shell without waiting for recent apps', async () => {
+    let resolveRecentApps!: (value: { data: [] }) => void
+    mocks.recentApps.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRecentApps = resolve
+      }),
+    )
+
+    const page = await HomePage()
+    expect(mocks.recentApps).toHaveBeenCalledOnce()
+    render(<QueryClientProvider client={new QueryClient()}>{page}</QueryClientProvider>)
+    expect(screen.getByRole('status')).toHaveTextContent('Loading home')
+
+    resolveRecentApps({ data: [] })
+  })
+})

--- a/web/features/home/home-content/__tests__/home-content.spec.tsx
+++ b/web/features/home/home-content/__tests__/home-content.spec.tsx
@@ -17,6 +17,7 @@ import userEvent from '@testing-library/user-event'
 import { createStore, Provider as JotaiProvider, useSetAtom } from 'jotai'
 import { queryClientAtom } from 'jotai-tanstack-query'
 import { useHydrateAtoms } from 'jotai/utils'
+import { Suspense } from 'react'
 import { LEARN_DIFY_HIDDEN_STORAGE_KEY } from '@/app/components/explore/learn-dify/storage'
 import {
   resetStepByStepTourSessionAtom,
@@ -595,7 +596,9 @@ const renderHomeContent = ({
   )
   const rendered = renderWithNuqs(
     <Wrapped>
-      <HomeContent />
+      <Suspense fallback={<div role="status">Loading home</div>}>
+        <HomeContent />
+      </Suspense>
     </Wrapped>,
     { searchParams },
   )
@@ -811,7 +814,7 @@ describe('HomeContent', () => {
     })
 
     it.each([false, true])(
-      'should keep templates visible while recent apps load (has apps: %s)',
+      'should wait for recent apps before revealing templates (has apps: %s)',
       async (hasApps) => {
         vi.useRealTimers()
         let resolveRecentApps!: (response: { data: RecentAppResponse[] }) => void
@@ -822,7 +825,8 @@ describe('HomeContent', () => {
 
         renderHomeContent({ hasEditPermission: true, enableLearnApp: false })
 
-        expect(screen.getByRole('button', { name: 'Alpha' })).toBeVisible()
+        expect(screen.queryByRole('button', { name: 'Alpha' })).not.toBeInTheDocument()
+        expect(screen.getByRole('status')).toHaveTextContent('Loading home')
         expect(
           screen.queryByRole('heading', { name: 'explore.continueWork.title' }),
         ).not.toBeInTheDocument()
@@ -843,7 +847,8 @@ describe('HomeContent', () => {
             ).not.toBeInTheDocument()
           })
         }
-        expect(screen.getByRole('button', { name: 'Alpha' })).toBeVisible()
+        expect(await screen.findByRole('button', { name: 'Alpha' })).toBeVisible()
+        expect(screen.queryByRole('status')).not.toBeInTheDocument()
       },
     )
 

--- a/web/features/home/home-content/__tests__/home-content.spec.tsx
+++ b/web/features/home/home-content/__tests__/home-content.spec.tsx
@@ -59,6 +59,7 @@ let mockExploreData: { categories: string[]; allList: RecommendedAppResponse[] }
 let mockLearnDifyApps: RecommendedAppResponse[] = []
 let mockLearnDifyLoading = false
 let mockWorkspaceApps: RecentAppResponse[] = []
+let mockRecentAppsRequest: Promise<{ data: RecentAppResponse[] }> | undefined
 let mockBanners: BannerResponse[] = []
 const mockHandleImportDSL = vi.fn()
 const mockHandleImportDSLConfirm = vi.fn()
@@ -282,8 +283,8 @@ vi.mock('@/service/console', () => ({
             }
             return {
               queryKey: ['console', 'apps', 'recent', 'get', options],
-              queryFn: () => Promise.resolve(response),
-              initialData: response,
+              queryFn: () => mockRecentAppsRequest ?? Promise.resolve(response),
+              initialData: mockRecentAppsRequest ? undefined : response,
               select: options.select,
             }
           },
@@ -633,6 +634,7 @@ describe('HomeContent', () => {
     ]
     mockLearnDifyLoading = false
     mockWorkspaceApps = []
+    mockRecentAppsRequest = undefined
     mockBanners = []
     mockStepByStepTour.reset()
   })
@@ -807,6 +809,43 @@ describe('HomeContent', () => {
         message: 'app.noAccessResourcePermission',
       })
     })
+
+    it.each([false, true])(
+      'should keep templates visible while recent apps load (has apps: %s)',
+      async (hasApps) => {
+        vi.useRealTimers()
+        let resolveRecentApps!: (response: { data: RecentAppResponse[] }) => void
+        mockRecentAppsRequest = new Promise((resolve) => {
+          resolveRecentApps = resolve
+        })
+        mockExploreData = { categories: ['Writing'], allList: [createApp()] }
+
+        renderHomeContent({ hasEditPermission: true, enableLearnApp: false })
+
+        expect(screen.getByRole('button', { name: 'Alpha' })).toBeVisible()
+        expect(
+          screen.queryByRole('heading', { name: 'explore.continueWork.title' }),
+        ).not.toBeInTheDocument()
+
+        await act(async () => {
+          resolveRecentApps({ data: hasApps ? [createWorkspaceApp()] : [] })
+          await mockRecentAppsRequest
+        })
+
+        if (hasApps) {
+          expect(
+            await screen.findByRole('heading', { name: 'explore.continueWork.title' }),
+          ).toBeVisible()
+        } else {
+          await waitFor(() => {
+            expect(
+              screen.queryByRole('heading', { name: 'explore.continueWork.title' }),
+            ).not.toBeInTheDocument()
+          })
+        }
+        expect(screen.getByRole('button', { name: 'Alpha' })).toBeVisible()
+      },
+    )
 
     it('should hide continue work when there are no workspace apps', () => {
       mockExploreData = {

--- a/web/features/home/home-content/home-content.tsx
+++ b/web/features/home/home-content/home-content.tsx
@@ -5,7 +5,7 @@ import type { CreateAppModalProps } from '@/app/components/explore/create-app-mo
 import type { StepByStepTourTaskId } from '@/app/components/step-by-step-tour/types'
 import type { TrackCreateAppParams } from '@/utils/create-app-tracking'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useQueryClient, useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query'
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -58,18 +58,11 @@ export function HomeContent() {
   const queryClient = useQueryClient()
   const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
-  const [templatesQuery, recentAppsQuery] = useSuspenseQueries({
-    queries: [
-      consoleQuery.explore.apps.get.queryOptions({
-        input: { query: { language: locale } },
-      }),
-      consoleQuery.apps.recent.get.queryOptions({
-        input: { query: { limit: 8 } },
-      }),
-    ],
-  })
-  const templatesData = templatesQuery.data
-  const continueWorkApps = recentAppsQuery.data.data
+  const { data: templatesData } = useSuspenseQuery(
+    consoleQuery.explore.apps.get.queryOptions({
+      input: { query: { language: locale } },
+    }),
+  )
   const allCategoriesEn = t(($) => $['apps.allCategories'], { ns: 'explore', lng: 'en' })
   const canCreateApp = hasPermission(workspacePermissionKeys, 'app.create_and_management')
   const activeStepByStepTourTaskId = useAtomValue(activeStepByStepTourTaskIdAtom)
@@ -406,12 +399,11 @@ export function HomeContent() {
 
   return (
     <HomeShell>
-      <div className="flex flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-1 [scrollbar-gutter:stable] flex-col overflow-y-auto">
         <HomeIntro />
         {systemFeatures.enable_explore_banner && <HomeBanner />}
         <HomeRecommendations
           canCreate={canCreateApp}
-          continueWorkApps={continueWorkApps}
           forceShowLearnDify={shouldForceShowLearnDifyForTour}
           onCreate={handleCreateFromLearnDify}
           onTry={handleTryAppFromLearnDify}

--- a/web/features/home/home-content/recommendations.tsx
+++ b/web/features/home/home-content/recommendations.tsx
@@ -1,29 +1,35 @@
 'use client'
 
-import type { RecentAppResponse } from '@dify/contracts/api/console/apps/types.gen'
 import type { RecommendedAppResponse } from '@dify/contracts/api/console/explore/types.gen'
+import { useQuery } from '@tanstack/react-query'
 import { STEP_BY_STEP_TOUR_TARGETS } from '@/app/components/step-by-step-tour/target-registry'
 import dynamic from '@/next/dynamic'
+import { consoleQuery } from '@/service/console'
 import { ContinueWork } from '../continue-work/continue-work'
 
 const LearnDify = dynamic(() => import('@/app/components/explore/learn-dify'), { ssr: false })
 
 export function HomeRecommendations({
   canCreate,
-  continueWorkApps,
   forceShowLearnDify,
   onCreate,
   onTry,
 }: {
   canCreate: boolean
-  continueWorkApps: RecentAppResponse[]
   forceShowLearnDify?: boolean
   onCreate: (app: RecommendedAppResponse) => void
   onTry: (app: RecommendedAppResponse) => void
 }) {
+  const { data: recentApps } = useQuery({
+    ...consoleQuery.apps.recent.get.queryOptions({
+      input: { query: { limit: 8 } },
+    }),
+    throwOnError: (_error, query) => query.state.data === undefined,
+  })
+
   return (
     <>
-      <ContinueWork apps={continueWorkApps} />
+      {recentApps && <ContinueWork apps={recentApps.data} />}
       <LearnDify
         canCreate={canCreate}
         className="pb-0"

--- a/web/features/home/home-content/recommendations.tsx
+++ b/web/features/home/home-content/recommendations.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { RecommendedAppResponse } from '@dify/contracts/api/console/explore/types.gen'
-import { useQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { STEP_BY_STEP_TOUR_TARGETS } from '@/app/components/step-by-step-tour/target-registry'
 import dynamic from '@/next/dynamic'
 import { consoleQuery } from '@/service/console'
@@ -20,16 +20,15 @@ export function HomeRecommendations({
   onCreate: (app: RecommendedAppResponse) => void
   onTry: (app: RecommendedAppResponse) => void
 }) {
-  const { data: recentApps } = useQuery({
+  const { data: recentApps } = useSuspenseQuery({
     ...consoleQuery.apps.recent.get.queryOptions({
       input: { query: { limit: 8 } },
     }),
-    throwOnError: (_error, query) => query.state.data === undefined,
   })
 
   return (
     <>
-      {recentApps && <ContinueWork apps={recentApps.data} />}
+      <ContinueWork apps={recentApps.data} />
       <LearnDify
         canCreate={canCreate}
         className="pb-0"

--- a/web/features/home/home-skeleton.tsx
+++ b/web/features/home/home-skeleton.tsx
@@ -28,6 +28,31 @@ function HomeTemplateCardSkeleton() {
   )
 }
 
+function HomeRecommendationsSkeleton() {
+  return (
+    <div className="px-8 pb-5" aria-hidden="true">
+      <div className="flex items-center justify-between pt-2">
+        <SkeletonRectangle className="my-0 h-6 w-48 animate-pulse" />
+        <SkeletonRectangle className="my-0 h-4 w-20 animate-pulse" />
+      </div>
+      <div className={cn('gap-2.5 pt-2', MAIN_NAV_APP_CARD_GRID_CLASS_NAME)}>
+        {Array.from({ length: 4 }, (_, index) => (
+          <div
+            key={index}
+            className="flex min-w-0 items-center gap-3 overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg px-4 py-4 shadow-xs shadow-shadow-shadow-3"
+          >
+            <SkeletonRectangle className="my-0 size-10 shrink-0 animate-pulse rounded-lg" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <SkeletonRectangle className="my-0 h-4 w-2/3 animate-pulse" />
+              <SkeletonRectangle className="my-0 h-3 w-1/2 animate-pulse" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function HomeTemplatesHeaderSkeletonBody() {
   return (
     <div className="sticky top-0 z-10 bg-background-body">
@@ -82,6 +107,7 @@ export function HomeSkeleton({ showBanner }: { showBanner: boolean }) {
     <div role="status" aria-label={t(($) => $.loading, { ns: 'common' })} className="contents">
       <HomeIntroSkeleton />
       {showBanner && <HomeBannerSkeleton />}
+      <HomeRecommendationsSkeleton />
       <HomeTemplatesHeaderSkeletonBody />
       <div className="relative flex flex-1 shrink-0 grow flex-col pb-6">
         <HomeTemplatesSkeletonBody />

--- a/web/features/home/home-skeleton.tsx
+++ b/web/features/home/home-skeleton.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@langgenius/dify-ui/cn'
 import { useTranslation } from 'react-i18next'
-import { SkeletonContainer, SkeletonRectangle, SkeletonRow } from '@/app/components/base/skeleton'
+import { SkeletonRectangle } from '@/app/components/base/skeleton'
 import { MAIN_NAV_APP_CARD_GRID_CLASS_NAME } from '@/app/components/main-nav/app-card-grid'
 import { HomeIntroSkeleton } from './home-intro'
 
@@ -24,40 +24,7 @@ function HomeTemplateCardSkeleton() {
           <SkeletonRectangle className="my-0 h-3 w-4/5 animate-pulse" />
         </div>
       </div>
-      <div className="relative flex h-6.5 w-full shrink-0 flex-col gap-2 overflow-hidden px-3">
-        <div className="flex w-full shrink-0 items-center gap-1 rounded-lg p-1">
-          <SkeletonRectangle className="my-0 h-5 w-20 animate-pulse rounded-[5px]" />
-        </div>
-      </div>
     </div>
-  )
-}
-
-function HomeRecommendationsSkeleton() {
-  return (
-    <SkeletonContainer className="gap-0">
-      <div className="flex items-center justify-between pt-2">
-        <div className="min-w-0 flex-1">
-          <SkeletonRectangle className="my-0 h-6 w-48 animate-pulse" />
-        </div>
-      </div>
-      <div className={cn('gap-2.5 pt-2', MAIN_NAV_APP_CARD_GRID_CLASS_NAME)}>
-        {Array.from({ length: 4 }, (_, index) => (
-          <div
-            key={index}
-            className="rounded-xl border-[0.5px] border-components-panel-border-subtle bg-components-panel-on-panel-item-bg px-4 py-4 shadow-md"
-          >
-            <SkeletonRow className="gap-3">
-              <SkeletonRectangle className="my-0 size-10 shrink-0 animate-pulse rounded-lg" />
-              <div className="flex min-w-0 flex-1 flex-col gap-1">
-                <SkeletonRectangle className="my-0 h-4 w-2/3 animate-pulse" />
-                <SkeletonRectangle className="my-0 h-3 w-1/2 animate-pulse" />
-              </div>
-            </SkeletonRow>
-          </div>
-        ))}
-      </div>
-    </SkeletonContainer>
   )
 }
 
@@ -71,9 +38,15 @@ function HomeTemplatesHeaderSkeletonBody() {
         <SkeletonRectangle className="my-0 h-4 w-20 shrink-0 animate-pulse" />
       </div>
       <div className="flex items-start justify-between gap-2 px-8 pt-3 pb-3">
-        <div className="flex min-w-0 flex-1 gap-1">
-          {Array.from({ length: 4 }, (_, index) => (
-            <SkeletonRectangle key={index} className="my-0 h-8 w-24 animate-pulse rounded-lg" />
+        <div className="flex min-w-0 flex-1 flex-wrap gap-1">
+          {Array.from({ length: 8 }, (_, index) => (
+            <SkeletonRectangle
+              key={index}
+              className={cn(
+                'my-0 h-8 shrink-0 animate-pulse rounded-lg',
+                ['w-12', 'w-18', 'w-32', 'w-32', 'w-32', 'w-36', 'w-28', 'w-28'][index],
+              )}
+            />
           ))}
         </div>
         <SkeletonRectangle className="my-0 h-8 w-40 shrink-0 animate-pulse rounded-lg" />
@@ -109,9 +82,6 @@ export function HomeSkeleton({ showBanner }: { showBanner: boolean }) {
     <div role="status" aria-label={t(($) => $.loading, { ns: 'common' })} className="contents">
       <HomeIntroSkeleton />
       {showBanner && <HomeBannerSkeleton />}
-      <section className="px-8 pb-5">
-        <HomeRecommendationsSkeleton />
-      </section>
       <HomeTemplatesHeaderSkeletonBody />
       <div className="relative flex flex-1 shrink-0 grow flex-col pb-6">
         <HomeTemplatesSkeletonBody />

--- a/web/features/home/page.tsx
+++ b/web/features/home/page.tsx
@@ -45,7 +45,7 @@ export async function HomePage() {
       <Suspense
         fallback={
           <HomeShell>
-            <div className="flex flex-1 flex-col overflow-y-auto">
+            <div className="flex flex-1 [scrollbar-gutter:stable] flex-col overflow-y-auto">
               <HomeSkeleton showBanner={enableExploreBanner} />
             </div>
           </HomeShell>


### PR DESCRIPTION
## Summary

Fixes #42122.

The Home Skeleton category and card placeholders differed from the loaded Templates section. Allow category placeholders to wrap, remove the obsolete template-card footer placeholder, and align the recent-app placeholders with the current card styling.

Keep four fixed recent-app placeholders and a shared Suspense boundary: recent apps and templates reveal together, so a slow recent-app request does not insert the section above already-visible templates. Server prefetch remains non-blocking; the loading shell does not wait for the actual recent-app count.

Reserve scrollbar space in both loading and loaded layouts to prevent the card grid from narrowing when a longer template list introduces a scrollbar.

The placeholders intentionally approximate the final layout. Empty or differently sized recent-app lists can still change the section height after loading, category widths remain estimates, and independently loaded Learn Dify content can still shift the page.

## Screenshots

Visual comparison performed in the local browser at 1159 × 863 before moving the patch onto main. Verified category wrapping and template-card geometry, including stable scrollbar space. The fixed recommendation placeholders may occupy a different number of rows from the final list. No screenshot files are attached.

## Validation

- HomeContent and HomePage unit suites: 36 tests passed, including shared loading for empty/populated recent-app responses and non-blocking server prefetch.
- Full repository check (`vp run -w check`): passed with existing repository warnings and no errors.
- Frontend staged checks (`vp staged`): passed.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — not required.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. Behavioral coverage is automated; layout changes were verified visually.
- [ ] I've updated the documentation accordingly. — not required.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods.

From Codex
