### PR TITLE
chore: restore grid and table accessibility

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2416,14 +2416,6 @@
       "count": 1
     }
   },
-  "web/app/components/datasets/hit-testing/components/records.tsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/hit-testing/components/result-item-external.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1

--- a/web/app/components/app/annotation/batch-add-annotation-modal/csv-downloader.tsx
+++ b/web/app/components/app/annotation/batch-add-annotation-modal/csv-downloader.tsx
@@ -37,12 +37,12 @@ const CSVDownload: FC = () => {
         <table className="w-full table-fixed border-separate border-spacing-0 rounded-lg border border-divider-regular text-xs">
           <thead className="text-text-tertiary">
             <tr>
-              <td className="h-9 border-b border-divider-regular pr-2 pl-3">
+              <th className="h-9 border-b border-divider-regular pr-2 pl-3 text-left font-[weight:inherit]">
                 {t(($) => $['batchModal.question'], { ns: 'appAnnotation' })}
-              </td>
-              <td className="h-9 border-b border-divider-regular pr-2 pl-3">
+              </th>
+              <th className="h-9 border-b border-divider-regular pr-2 pl-3 text-left font-[weight:inherit]">
                 {t(($) => $['batchModal.answer'], { ns: 'appAnnotation' })}
-              </td>
+              </th>
             </tr>
           </thead>
           <tbody className="text-text-secondary">

--- a/web/app/components/app/annotation/list.tsx
+++ b/web/app/components/app/annotation/list.tsx
@@ -97,7 +97,7 @@ export function List({
           <table className="w-full min-w-110 border-collapse border-0">
             <thead className="system-xs-medium-uppercase text-text-tertiary">
               <tr>
-                <td className="w-12 rounded-l-lg bg-background-section-burn px-2 align-middle whitespace-nowrap">
+                <th className="w-12 rounded-l-lg bg-background-section-burn px-2 text-left align-middle font-[weight:inherit] whitespace-nowrap">
                   <div className="flex items-center">
                     <Checkbox
                       className="shrink-0"
@@ -105,22 +105,22 @@ export function List({
                       aria-label={t(($) => $['operation.selectAll'], { ns: 'common' })}
                     />
                   </div>
-                </td>
-                <td className="w-5 bg-background-section-burn pr-1 pl-2 whitespace-nowrap">
+                </th>
+                <th className="w-5 bg-background-section-burn pr-1 pl-2 text-left font-[weight:inherit] whitespace-nowrap">
                   {t(($) => $['table.header.question'], { ns: 'appAnnotation' })}
-                </td>
-                <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                </th>
+                <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                   {t(($) => $['table.header.answer'], { ns: 'appAnnotation' })}
-                </td>
-                <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                </th>
+                <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                   {t(($) => $['table.header.createdAt'], { ns: 'appAnnotation' })}
-                </td>
-                <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                </th>
+                <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                   {t(($) => $['table.header.hits'], { ns: 'appAnnotation' })}
-                </td>
-                <td className="w-24 rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                </th>
+                <th className="w-24 rounded-r-lg bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                   {t(($) => $['table.header.actions'], { ns: 'appAnnotation' })}
-                </td>
+                </th>
               </tr>
             </thead>
             <tbody className="system-sm-regular text-text-secondary">

--- a/web/app/components/app/annotation/view-annotation-modal/index.tsx
+++ b/web/app/components/app/annotation/view-annotation-modal/index.tsx
@@ -147,24 +147,24 @@ const ViewAnnotationModal: FC<Props> = ({ appId, isShow, onHide, item, onSave, o
         <table className={cn('w-full min-w-110 border-collapse border-0')}>
           <thead className="system-xs-medium-uppercase text-text-tertiary">
             <tr>
-              <td className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 whitespace-nowrap">
+              <th className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['hitHistoryTable.query'], { ns: 'appAnnotation' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['hitHistoryTable.match'], { ns: 'appAnnotation' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['hitHistoryTable.response'], { ns: 'appAnnotation' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['hitHistoryTable.source'], { ns: 'appAnnotation' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['hitHistoryTable.score'], { ns: 'appAnnotation' })}
-              </td>
-              <td className="w-40 rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="w-40 rounded-r-lg bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['hitHistoryTable.time'], { ns: 'appAnnotation' })}
-              </td>
+              </th>
             </tr>
           </thead>
           <tbody className="system-sm-regular text-text-secondary">

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -925,36 +925,36 @@ const ConversationList: FC<IConversationList> = ({ logs, appDetail, onRefresh })
           <thead className="system-xs-medium-uppercase text-text-tertiary">
             <tr>
               <td className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 whitespace-nowrap"></td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {isChatMode
                   ? t(($) => $['table.header.summary'], { ns: 'appLog' })
                   : t(($) => $['table.header.input'], { ns: 'appLog' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.endUser'], { ns: 'appLog' })}
-              </td>
+              </th>
               {isChatflow && (
-                <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                   {t(($) => $['table.header.status'], { ns: 'appLog' })}
-                </td>
+                </th>
               )}
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {isChatMode
                   ? t(($) => $['table.header.messageCount'], { ns: 'appLog' })
                   : t(($) => $['table.header.output'], { ns: 'appLog' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.userRate'], { ns: 'appLog' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.adminRate'], { ns: 'appLog' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.updatedTime'], { ns: 'appLog' })}
-              </td>
-              <td className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.time'], { ns: 'appLog' })}
-              </td>
+              </th>
             </tr>
           </thead>
           <tbody className="system-sm-regular text-text-secondary">

--- a/web/app/components/app/workflow-log/__tests__/list.spec.tsx
+++ b/web/app/components/app/workflow-log/__tests__/list.spec.tsx
@@ -408,14 +408,16 @@ describe('WorkflowAppLogList', () => {
         <WorkflowAppLogList logs={logs} appDetail={createMockApp()} onRefresh={defaultOnRefresh} />,
       )
 
-      // Click on the start time header to toggle sort
-      const startTimeHeader = screen.getByText('appLog.table.header.startTime')
-      await user.click(startTimeHeader)
-
-      // Arrow should rotate (indicated by class change)
-      // The sort icon should have rotate-180 class for ascending
-      const sortIcon = startTimeHeader.closest('div')?.querySelector('svg')
-      expect(sortIcon)!.toBeInTheDocument()
+      const startTimeHeader = screen.getByRole('columnheader', {
+        name: 'appLog.table.header.startTime',
+      })
+      const sortButton = screen.getByRole('button', { name: 'appLog.table.header.startTime' })
+      expect(startTimeHeader).toHaveAttribute('aria-sort', 'descending')
+      sortButton.focus()
+      await user.keyboard('{Enter}')
+      expect(startTimeHeader).toHaveAttribute('aria-sort', 'ascending')
+      await user.keyboard(' ')
+      expect(startTimeHeader).toHaveAttribute('aria-sort', 'descending')
     })
 
     it('should render sort arrow icon', () => {

--- a/web/app/components/app/workflow-log/list.tsx
+++ b/web/app/components/app/workflow-log/list.tsx
@@ -141,7 +141,10 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
           <thead className="system-xs-medium-uppercase text-text-tertiary">
             <tr>
               <td className="w-5 rounded-l-lg bg-background-section-burn pr-1 pl-2 whitespace-nowrap"></td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              <th
+                aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}
+                className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap"
+              >
                 <button
                   type="button"
                   className="flex cursor-pointer items-center border-none bg-transparent p-0 text-left hover:text-text-secondary focus-visible:ring-1 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
@@ -157,28 +160,28 @@ const WorkflowAppLogList: FC<ILogs> = ({ logs, appDetail, onRefresh }) => {
                     aria-hidden="true"
                   />
                 </button>
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.status'], { ns: 'appLog' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.runtime'], { ns: 'appLog' })}
-              </td>
-              <td className="bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+              </th>
+              <th className="bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                 {t(($) => $['table.header.tokens'], { ns: 'appLog' })}
-              </td>
-              <td
+              </th>
+              <th
                 className={cn(
-                  'bg-background-section-burn py-1.5 pl-3 whitespace-nowrap',
+                  'bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap',
                   !isWorkflow ? 'rounded-r-lg' : '',
                 )}
               >
                 {t(($) => $['table.header.user'], { ns: 'appLog' })}
-              </td>
+              </th>
               {isWorkflow && (
-                <td className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 whitespace-nowrap">
+                <th className="rounded-r-lg bg-background-section-burn py-1.5 pl-3 text-left font-[weight:inherit] whitespace-nowrap">
                   {t(($) => $['table.header.triggered_from'], { ns: 'appLog' })}
-                </td>
+                </th>
               )}
             </tr>
           </thead>

--- a/web/app/components/base/date-and-time-picker/calendar/__tests__/item.spec.tsx
+++ b/web/app/components/base/date-and-time-picker/calendar/__tests__/item.spec.tsx
@@ -4,7 +4,15 @@ import userEvent from '@testing-library/user-event'
 import dayjs from '../../utils/dayjs'
 import Item from '../item'
 
-const locale = vi.hoisted(() => ({ value: 'en-US' }))
+const { locale, translations } = vi.hoisted(() => ({
+  locale: { value: 'en-US' },
+  translations: { 'common.calendar.selectedDate': 'Selected' },
+}))
+
+vi.mock('react-i18next', async () => {
+  const { createReactI18nextMock } = await import('@/test/i18n-mock')
+  return createReactI18nextMock(translations)
+})
 
 vi.mock('@/context/i18n', () => ({
   useLocale: () => locale.value,
@@ -28,6 +36,7 @@ describe('CalendarItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     locale.value = 'en-US'
+    translations['common.calendar.selectedDate'] = 'Selected'
   })
 
   describe('Rendering', () => {
@@ -43,13 +52,18 @@ describe('CalendarItem', () => {
 
     it('should localize the full date without changing the calendar date across time zones', () => {
       locale.value = 'zh-Hans'
+      translations['common.calendar.selectedDate'] = '已选中'
       const props = createItemProps({
         day: createMockDay({ date: dayjs.tz('2024-06-15 00:00', 'Pacific/Kiritimati') }),
+        selectedDate: dayjs.tz('2024-06-15 00:00', 'Pacific/Kiritimati'),
       })
 
       render(<Item {...props} />)
 
       expect(screen.getByRole('button', { name: '2024年6月15日星期六' })).toHaveTextContent('15')
+      expect(
+        screen.getByRole('button', { name: '2024年6月15日星期六' }),
+      ).toHaveAccessibleDescription('已选中')
     })
 
     it.each([
@@ -62,19 +76,19 @@ describe('CalendarItem', () => {
       expect(screen.getByRole('button', { name })).toHaveTextContent('15')
     })
 
-    it('should expose selection and update it when another date is selected', () => {
+    it('should describe selection without toggle semantics and clear it when another date is selected', () => {
       const props = createItemProps({ selectedDate: dayjs('2024-06-15') })
       const { rerender } = render(<Item {...props} />)
 
-      expect(screen.getByRole('button', { pressed: true })).toHaveAccessibleName(
-        'Saturday, June 15, 2024',
-      )
+      const button = screen.getByRole('button', { name: 'Saturday, June 15, 2024' })
+      expect(button).toHaveAccessibleDescription('Selected')
+      expect(button).not.toHaveAttribute('aria-pressed')
 
       rerender(<Item {...props} selectedDate={dayjs('2024-06-16')} />)
 
-      expect(screen.getByRole('button', { pressed: false })).toHaveAccessibleName(
-        'Saturday, June 15, 2024',
-      )
+      expect(button).toHaveAccessibleName('Saturday, June 15, 2024')
+      expect(button).not.toHaveAccessibleDescription()
+      expect(button).not.toHaveAttribute('aria-pressed')
     })
   })
 
@@ -132,12 +146,13 @@ describe('CalendarItem', () => {
   })
 
   describe('Edge Cases', () => {
-    it('should handle undefined selectedDate', () => {
+    it('should leave an unselected date without a selection description or toggle state', () => {
       const props = createItemProps({ selectedDate: undefined })
 
       render(<Item {...props} />)
 
-      expect(screen.getByRole('button')).toBeInTheDocument()
+      expect(screen.getByRole('button')).not.toHaveAccessibleDescription()
+      expect(screen.getByRole('button')).not.toHaveAttribute('aria-pressed')
     })
   })
 })

--- a/web/app/components/base/date-and-time-picker/calendar/__tests__/item.spec.tsx
+++ b/web/app/components/base/date-and-time-picker/calendar/__tests__/item.spec.tsx
@@ -1,7 +1,14 @@
 import type { CalendarItemProps, Day } from '../../types'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import dayjs from '../../utils/dayjs'
 import Item from '../item'
+
+const locale = vi.hoisted(() => ({ value: 'en-US' }))
+
+vi.mock('@/context/i18n', () => ({
+  useLocale: () => locale.value,
+}))
 
 const createMockDay = (overrides: Partial<Day> = {}): Day => ({
   date: dayjs('2024-06-15'),
@@ -20,6 +27,7 @@ const createItemProps = (overrides: Partial<CalendarItemProps> = {}): CalendarIt
 describe('CalendarItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    locale.value = 'en-US'
   })
 
   describe('Rendering', () => {
@@ -28,29 +36,70 @@ describe('CalendarItem', () => {
 
       render(<Item {...props} />)
 
-      expect(screen.getByRole('button', { name: '15' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Saturday, June 15, 2024' })).toHaveTextContent(
+        '15',
+      )
+    })
+
+    it('should localize the full date without changing the calendar date across time zones', () => {
+      locale.value = 'zh-Hans'
+      const props = createItemProps({
+        day: createMockDay({ date: dayjs.tz('2024-06-15 00:00', 'Pacific/Kiritimati') }),
+      })
+
+      render(<Item {...props} />)
+
+      expect(screen.getByRole('button', { name: '2024年6月15日星期六' })).toHaveTextContent('15')
+    })
+
+    it.each([
+      ['fa-IR', 'شنبه ۱۵ ژوئن ۲۰۲۴'],
+      ['th-TH', 'วันเสาร์ที่ 15 มิถุนายน ค.ศ. 2024'],
+    ])('should keep the displayed Gregorian date in %s', (language, name) => {
+      locale.value = language
+      render(<Item {...createItemProps()} />)
+
+      expect(screen.getByRole('button', { name })).toHaveTextContent('15')
+    })
+
+    it('should expose selection and update it when another date is selected', () => {
+      const props = createItemProps({ selectedDate: dayjs('2024-06-15') })
+      const { rerender } = render(<Item {...props} />)
+
+      expect(screen.getByRole('button', { pressed: true })).toHaveAccessibleName(
+        'Saturday, June 15, 2024',
+      )
+
+      rerender(<Item {...props} selectedDate={dayjs('2024-06-16')} />)
+
+      expect(screen.getByRole('button', { pressed: false })).toHaveAccessibleName(
+        'Saturday, June 15, 2024',
+      )
     })
   })
 
   describe('Click Behavior', () => {
-    it('should call onClick with the date when clicked', () => {
+    it('should call onClick with the date when clicked', async () => {
+      const user = userEvent.setup()
       const onClick = vi.fn()
       const day = createMockDay()
       const props = createItemProps({ day, onClick })
 
       render(<Item {...props} />)
-      fireEvent.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button'))
 
       expect(onClick).toHaveBeenCalledTimes(1)
       expect(onClick).toHaveBeenCalledWith(day.date)
     })
 
-    it('should not call onClick when isDisabled is true', () => {
+    it('should expose disabled dates and prevent activation', async () => {
+      const user = userEvent.setup()
       const onClick = vi.fn()
       const props = createItemProps({ onClick, isDisabled: true })
 
       render(<Item {...props} />)
-      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByRole('button')).toBeDisabled()
+      await user.click(screen.getByRole('button'))
 
       expect(onClick).not.toHaveBeenCalled()
     })
@@ -66,9 +115,7 @@ describe('CalendarItem', () => {
       render(<Item {...props} />)
 
       const button = screen.getByRole('button')
-      expect(button).toBeInTheDocument()
-      // Today's button should contain a child indicator element
-      expect(button.children.length).toBeGreaterThan(0)
+      expect(button).toHaveAttribute('aria-current', 'date')
     })
 
     it('should not render today indicator when date is not today', () => {
@@ -80,8 +127,7 @@ describe('CalendarItem', () => {
       render(<Item {...props} />)
 
       const button = screen.getByRole('button')
-      // Non-today button should only contain the day number text, no extra children
-      expect(button.children.length).toBe(0)
+      expect(button).not.toHaveAttribute('aria-current')
     })
   })
 

--- a/web/app/components/base/date-and-time-picker/calendar/item.tsx
+++ b/web/app/components/base/date-and-time-picker/calendar/item.tsx
@@ -2,11 +2,14 @@ import type { FC } from 'react'
 import type { CalendarItemProps } from '../types'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { useLocale } from '@/context/i18n'
 import dayjs from '../utils/dayjs'
 
 const Item: FC<CalendarItemProps> = ({ day, selectedDate, onClick, isDisabled }) => {
   const locale = useLocale()
+  const { t } = useTranslation('common')
+  const selectedDescriptionId = React.useId()
   const { date, isCurrentMonth } = day
   const isSelected = selectedDate?.isSame(date, 'date')
   const isToday = date.isSame(dayjs(), 'date')
@@ -20,7 +23,7 @@ const Item: FC<CalendarItemProps> = ({ day, selectedDate, onClick, isDisabled })
     <button
       type="button"
       aria-label={dateLabel}
-      aria-pressed={!!isSelected}
+      aria-describedby={isSelected ? selectedDescriptionId : undefined}
       aria-current={isToday ? 'date' : undefined}
       disabled={isDisabled}
       onClick={() => !isDisabled && onClick(date)}
@@ -34,6 +37,11 @@ const Item: FC<CalendarItemProps> = ({ day, selectedDate, onClick, isDisabled })
       )}
     >
       {date.date()}
+      {isSelected && (
+        <span id={selectedDescriptionId} className="sr-only">
+          {t(($) => $['calendar.selectedDate'])}
+        </span>
+      )}
       {isToday && (
         <div
           aria-hidden

--- a/web/app/components/base/date-and-time-picker/calendar/item.tsx
+++ b/web/app/components/base/date-and-time-picker/calendar/item.tsx
@@ -2,19 +2,30 @@ import type { FC } from 'react'
 import type { CalendarItemProps } from '../types'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
+import { useLocale } from '@/context/i18n'
 import dayjs from '../utils/dayjs'
 
 const Item: FC<CalendarItemProps> = ({ day, selectedDate, onClick, isDisabled }) => {
+  const locale = useLocale()
   const { date, isCurrentMonth } = day
   const isSelected = selectedDate?.isSame(date, 'date')
   const isToday = date.isSame(dayjs(), 'date')
+  const dateLabel = new Intl.DateTimeFormat(locale.replace('_', '-'), {
+    dateStyle: 'full',
+    calendar: 'gregory',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(date.year(), date.month(), date.date())))
 
   return (
     <button
       type="button"
+      aria-label={dateLabel}
+      aria-pressed={!!isSelected}
+      aria-current={isToday ? 'date' : undefined}
+      disabled={isDisabled}
       onClick={() => !isDisabled && onClick(date)}
       className={cn(
-        'relative flex items-center justify-center rounded-lg px-1 py-2 system-sm-medium',
+        'relative flex items-center justify-center rounded-lg px-1 py-2 system-sm-medium focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden',
         isCurrentMonth ? 'text-text-secondary' : 'text-text-quaternary hover:text-text-secondary',
         isSelected
           ? 'bg-components-button-primary-bg system-sm-medium text-components-button-primary-text'
@@ -24,7 +35,10 @@ const Item: FC<CalendarItemProps> = ({ day, selectedDate, onClick, isDisabled })
     >
       {date.date()}
       {isToday && (
-        <div className="absolute bottom-1 mx-auto size-1 rounded-full bg-components-button-primary-bg" />
+        <div
+          aria-hidden
+          className="absolute bottom-1 mx-auto size-1 rounded-full bg-components-button-primary-bg"
+        />
       )}
     </button>
   )

--- a/web/app/components/base/date-and-time-picker/date-picker/__tests__/index.spec.tsx
+++ b/web/app/components/base/date-and-time-picker/date-picker/__tests__/index.spec.tsx
@@ -68,7 +68,7 @@ describe('DatePicker', () => {
       const initialText = trigger.textContent
 
       await user.click(trigger)
-      await user.click(screen.getByRole('button', { name: '20' }))
+      await user.click(screen.getByRole('button', { name: / 20, \d{4}$/ }))
 
       expect(trigger.textContent).not.toBe(initialText)
       expect(trigger).toHaveAccessibleName(`Select date: ${trigger.textContent}`)
@@ -349,7 +349,7 @@ describe('DatePicker', () => {
       openPicker()
 
       // Click on a day in the calendar - day "20"
-      const dayButton = screen.getByRole('button', { name: '20' })
+      const dayButton = screen.getByRole('button', { name: / 20, \d{4}$/ })
       fireEvent.click(dayButton)
 
       // The date should now appear in the header/display
@@ -365,7 +365,7 @@ describe('DatePicker', () => {
       openPicker()
 
       // Click on a day
-      const dayButton = screen.getByRole('button', { name: '20' })
+      const dayButton = screen.getByRole('button', { name: / 20, \d{4}$/ })
       fireEvent.click(dayButton)
 
       expect(onChange).toHaveBeenCalledTimes(1)
@@ -377,7 +377,7 @@ describe('DatePicker', () => {
       render(<DatePicker {...props} />)
 
       openPicker()
-      fireEvent.click(screen.getByRole('button', { name: '20' }))
+      fireEvent.click(screen.getByRole('button', { name: / 20, \d{4}$/ }))
 
       expect(onChange).toHaveBeenCalledTimes(1)
     })

--- a/web/app/components/datasets/documents/components/__tests__/list.spec.tsx
+++ b/web/app/components/datasets/documents/components/__tests__/list.spec.tsx
@@ -1,5 +1,6 @@
 import type { SimpleDocumentDetail } from '@/models/datasets'
 import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { renderWithAccountProfile as render } from '@/test/console/account-profile'
 import { useDocumentSort } from '../document-list/hooks'
@@ -57,26 +58,13 @@ vi.mock('@/context/dataset-detail', () => ({
 }))
 
 // Mock child components that are complex
-vi.mock('../document-list/components', () => ({
+vi.mock('../document-list/components', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../document-list/components')>()),
   DocumentTableRow: ({ doc, index }: { doc: SimpleDocumentDetail; index: number }) => (
     <tr data-testid={`doc-row-${doc.id}`}>
       <td>{index + 1}</td>
       <td>{doc.name}</td>
     </tr>
-  ),
-  renderTdValue: (val: string) => val || '-',
-  SortHeader: ({
-    field,
-    label,
-    onSort,
-  }: {
-    field: string
-    label: string
-    onSort: (f: string) => void
-  }) => (
-    <button data-testid={`sort-${field}`} onClick={() => onSort(field)}>
-      {label}
-    </button>
   ),
 }))
 
@@ -159,9 +147,16 @@ describe('DocumentList', () => {
     it('should render the document table with headers', () => {
       render(<DocumentList {...defaultProps} />)
 
-      expect(screen.getByText('#')).toBeInTheDocument()
-      expect(screen.getByTestId('sort-hit_count')).toBeInTheDocument()
-      expect(screen.getByTestId('sort-created_at')).toBeInTheDocument()
+      expect(screen.getAllByRole('columnheader')).toHaveLength(8)
+      expect(
+        screen.getByRole('columnheader', { name: 'datasetDocuments.list.table.header.fileName' }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'datasetDocuments.list.table.header.hitCount' }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'datasetDocuments.list.table.header.uploadTime' }),
+      ).toBeInTheDocument()
     })
 
     it('should render select-all area when embeddingAvailable is true', () => {
@@ -173,10 +168,9 @@ describe('DocumentList', () => {
     })
 
     it('should still render # column when embeddingAvailable is false', () => {
-      const { container } = render(<DocumentList {...defaultProps} embeddingAvailable={false} />)
+      render(<DocumentList {...defaultProps} embeddingAvailable={false} />)
 
-      const firstTd = container.querySelector('thead td')
-      expect(firstTd?.textContent).toContain('#')
+      expect(screen.getByRole('columnheader', { name: '#' })).toBeInTheDocument()
     })
 
     it('should render document rows from sortedDocuments', () => {
@@ -207,12 +201,48 @@ describe('DocumentList', () => {
     })
   })
 
+  it('exposes sorting only on the current column and supports keyboard activation', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useDocumentSort).mockReturnValue({
+      sortField: 'created_at',
+      sortOrder: 'desc',
+      handleSort: mockHandleSort,
+    })
+    const { rerender } = render(<DocumentList {...defaultProps} embeddingAvailable={false} />)
+    const uploadedHeader = screen.getByRole('columnheader', {
+      name: 'datasetDocuments.list.table.header.uploadTime',
+    })
+    const hitsHeader = screen.getByRole('columnheader', {
+      name: 'datasetDocuments.list.table.header.hitCount',
+    })
+    expect(uploadedHeader).toHaveAttribute('aria-sort', 'descending')
+    expect(hitsHeader).not.toHaveAttribute('aria-sort')
+
+    await user.tab()
+    expect(
+      screen.getByRole('button', { name: 'datasetDocuments.list.table.header.hitCount' }),
+    ).toHaveFocus()
+    await user.keyboard('{Enter}')
+    expect(mockHandleSort).toHaveBeenCalledWith('hit_count')
+
+    vi.mocked(useDocumentSort).mockReturnValue({
+      sortField: 'hit_count',
+      sortOrder: 'asc',
+      handleSort: mockHandleSort,
+    })
+    rerender(<DocumentList {...defaultProps} embeddingAvailable={false} />)
+    expect(hitsHeader).toHaveAttribute('aria-sort', 'ascending')
+    expect(uploadedHeader).not.toHaveAttribute('aria-sort')
+  })
+
   // Verify sort headers trigger sort handler
   describe('Sorting', () => {
     it('should call handleSort when sort header is clicked', () => {
       render(<DocumentList {...defaultProps} />)
 
-      fireEvent.click(screen.getByTestId('sort-created_at'))
+      fireEvent.click(
+        screen.getByRole('button', { name: 'datasetDocuments.list.table.header.uploadTime' }),
+      )
 
       expect(mockHandleSort).toHaveBeenCalledWith('created_at')
     })

--- a/web/app/components/datasets/documents/components/__tests__/list.spec.tsx
+++ b/web/app/components/datasets/documents/components/__tests__/list.spec.tsx
@@ -3,11 +3,9 @@ import { fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { renderWithAccountProfile as render } from '@/test/console/account-profile'
-import { useDocumentSort } from '../document-list/hooks'
 import DocumentList from '../list'
 
 // Mock hooks used by DocumentList
-const mockHandleSort = vi.fn()
 const mockClearSelection = vi.fn()
 const mockHandleAction = vi.fn(() => vi.fn())
 const mockHandleBatchReIndex = vi.fn()
@@ -23,12 +21,8 @@ vi.mock('@/context/workspace-state', async () => {
   }))
 })
 
-vi.mock('../document-list/hooks', () => ({
-  useDocumentSort: vi.fn(() => ({
-    sortField: null,
-    sortOrder: 'desc',
-    handleSort: mockHandleSort,
-  })),
+vi.mock('../document-list/hooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../document-list/hooks')>()),
   useDocumentSelection: vi.fn(() => ({
     hasErrorDocumentsSelected: false,
     downloadableSelectedIds: [],
@@ -175,12 +169,6 @@ describe('DocumentList', () => {
 
     it('should render document rows from sortedDocuments', () => {
       const docs = [createDoc({ id: 'a', name: 'Doc A' }), createDoc({ id: 'b', name: 'Doc B' })]
-      vi.mocked(useDocumentSort).mockReturnValue({
-        sortField: 'created_at',
-        sortOrder: 'desc',
-        handleSort: mockHandleSort,
-      } as unknown as ReturnType<typeof useDocumentSort>)
-
       render(<DocumentList {...defaultProps} documents={docs} />)
 
       expect(screen.getByTestId('doc-row-a')).toBeInTheDocument()
@@ -203,11 +191,6 @@ describe('DocumentList', () => {
 
   it('exposes sorting only on the current column and supports keyboard activation', async () => {
     const user = userEvent.setup()
-    vi.mocked(useDocumentSort).mockReturnValue({
-      sortField: 'created_at',
-      sortOrder: 'desc',
-      handleSort: mockHandleSort,
-    })
     const { rerender } = render(<DocumentList {...defaultProps} embeddingAvailable={false} />)
     const uploadedHeader = screen.getByRole('columnheader', {
       name: 'datasetDocuments.list.table.header.uploadTime',
@@ -223,29 +206,42 @@ describe('DocumentList', () => {
       screen.getByRole('button', { name: 'datasetDocuments.list.table.header.hitCount' }),
     ).toHaveFocus()
     await user.keyboard('{Enter}')
-    expect(mockHandleSort).toHaveBeenCalledWith('hit_count')
+    expect(defaultProps.onSortChange).toHaveBeenLastCalledWith('-hit_count')
 
-    vi.mocked(useDocumentSort).mockReturnValue({
-      sortField: 'hit_count',
-      sortOrder: 'asc',
-      handleSort: mockHandleSort,
-    })
-    rerender(<DocumentList {...defaultProps} embeddingAvailable={false} />)
+    rerender(
+      <DocumentList {...defaultProps} embeddingAvailable={false} remoteSortValue="-hit_count" />,
+    )
+    expect(hitsHeader).toHaveAttribute('aria-sort', 'descending')
+    expect(uploadedHeader).not.toHaveAttribute('aria-sort')
+
+    await user.keyboard(' ')
+    expect(defaultProps.onSortChange).toHaveBeenLastCalledWith('hit_count')
+
+    rerender(
+      <DocumentList {...defaultProps} embeddingAvailable={false} remoteSortValue="hit_count" />,
+    )
     expect(hitsHeader).toHaveAttribute('aria-sort', 'ascending')
     expect(uploadedHeader).not.toHaveAttribute('aria-sort')
-  })
 
-  // Verify sort headers trigger sort handler
-  describe('Sorting', () => {
-    it('should call handleSort when sort header is clicked', () => {
-      render(<DocumentList {...defaultProps} />)
+    await user.click(
+      screen.getByRole('button', { name: 'datasetDocuments.list.table.header.uploadTime' }),
+    )
+    expect(defaultProps.onSortChange).toHaveBeenLastCalledWith('-created_at')
 
-      fireEvent.click(
-        screen.getByRole('button', { name: 'datasetDocuments.list.table.header.uploadTime' }),
-      )
+    rerender(
+      <DocumentList {...defaultProps} embeddingAvailable={false} remoteSortValue="-created_at" />,
+    )
+    expect(uploadedHeader).toHaveAttribute('aria-sort', 'descending')
+    expect(hitsHeader).not.toHaveAttribute('aria-sort')
 
-      expect(mockHandleSort).toHaveBeenCalledWith('created_at')
-    })
+    await user.keyboard('{Enter}')
+    expect(defaultProps.onSortChange).toHaveBeenLastCalledWith('created_at')
+
+    rerender(
+      <DocumentList {...defaultProps} embeddingAvailable={false} remoteSortValue="created_at" />,
+    )
+    expect(uploadedHeader).toHaveAttribute('aria-sort', 'ascending')
+    expect(hitsHeader).not.toHaveAttribute('aria-sort')
   })
 
   // Verify batch action bar appears when items selected
@@ -284,13 +280,6 @@ describe('DocumentList', () => {
   // Verify empty state
   describe('Edge Cases', () => {
     it('should render table with no document rows when sortedDocuments is empty', () => {
-      // Reset sort mock to return empty sorted list
-      vi.mocked(useDocumentSort).mockReturnValue({
-        sortField: null,
-        sortOrder: 'desc',
-        handleSort: mockHandleSort,
-      } as unknown as ReturnType<typeof useDocumentSort>)
-
       render(<DocumentList {...defaultProps} documents={[]} />)
 
       expect(screen.queryByTestId(/^doc-row-/)).not.toBeInTheDocument()

--- a/web/app/components/datasets/documents/components/__tests__/operations.spec.tsx
+++ b/web/app/components/datasets/documents/components/__tests__/operations.spec.tsx
@@ -177,6 +177,31 @@ describe('Operations', () => {
   })
 
   describe('switch toggle', () => {
+    it.each([
+      { enabled: true, archived: false, embeddingAvailable: true, canEdit: true },
+      { enabled: false, archived: false, embeddingAvailable: true, canEdit: true },
+      { enabled: false, archived: true, embeddingAvailable: true, canEdit: true },
+      { enabled: false, archived: false, embeddingAvailable: false, canEdit: true },
+      { enabled: true, archived: false, embeddingAvailable: true, canEdit: false },
+    ])(
+      'names the document enable switch across supported states: %j',
+      ({ enabled, archived, embeddingAvailable, canEdit }) => {
+        render(
+          <Operations
+            {...defaultProps}
+            detail={{ ...defaultDetail, enabled, archived }}
+            embeddingAvailable={embeddingAvailable}
+            canEdit={canEdit}
+          />,
+        )
+        expect(
+          screen.getByRole('switch', {
+            name: 'datasetDocuments.list.status.enabled: Test Document',
+          }),
+        ).toBeInTheDocument()
+      },
+    )
+
     it('should render switch in list scene', () => {
       render(<Operations {...defaultProps} scene="list" />)
       const switches = document.querySelectorAll('[role="switch"], [class*="switch"]')

--- a/web/app/components/datasets/documents/components/document-list/components/__tests__/document-table-row.spec.tsx
+++ b/web/app/components/datasets/documents/components/document-list/components/__tests__/document-table-row.spec.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import type { SimpleDocumentDetail } from '@/models/datasets'
 import { CheckboxGroup } from '@langgenius/dify-ui/checkbox-group'
 import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { DataSourceType } from '@/models/datasets'
 import { createConsoleQueryWrapper } from '@/test/console/query-data'
@@ -160,6 +161,26 @@ describe('DocumentTableRow', () => {
   })
 
   describe('Row Navigation', () => {
+    it('provides a keyboard-accessible detail link preserving search parameters', async () => {
+      const user = userEvent.setup()
+      mockSearchParams = 'page=2&status=error'
+      render(<DocumentTableRow {...defaultProps} />, { wrapper: createWrapper() })
+
+      const link = screen.getByRole('link', { name: 'test-document.txt' })
+      expect(link).toHaveAttribute(
+        'href',
+        '/datasets/dataset-1/documents/doc-1?page=2&status=error',
+      )
+      await user.tab()
+      expect(getRowCheckbox()).toHaveFocus()
+      await user.tab()
+      expect(link).toHaveFocus()
+      await user.keyboard('{Control>}')
+      await user.click(link)
+      await user.keyboard('{/Control}')
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
     it('should navigate to document detail on row click', () => {
       render(<DocumentTableRow {...defaultProps} />, { wrapper: createWrapper() })
 

--- a/web/app/components/datasets/documents/components/document-list/components/document-table-row.tsx
+++ b/web/app/components/datasets/documents/components/document-list/components/document-table-row.tsx
@@ -16,6 +16,7 @@ import { workspacePermissionKeysAtom } from '@/context/permission-state'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import useTimestamp from '@/hooks/use-timestamp'
 import { DataSourceType } from '@/models/datasets'
+import Link from '@/next/link'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { formatNumber } from '@/utils/format'
 import { getDatasetACLCapabilities } from '@/utils/permission'
@@ -83,11 +84,14 @@ const DocumentTableRow = React.memo(
     const fileType = isFile ? doc.data_source_detail_dict?.upload_file?.extension : ''
     const queryString = searchParams.toString()
 
-    const handleRowClick = useCallback(() => {
-      router.push(
-        `/datasets/${datasetId}/documents/${doc.id}${queryString ? `?${queryString}` : ''}`,
-      )
-    }, [router, datasetId, doc.id, queryString])
+    const documentHref = `/datasets/${datasetId}/documents/${doc.id}${queryString ? `?${queryString}` : ''}`
+    const handleRowClick = useCallback(
+      (event: React.MouseEvent<HTMLTableRowElement>) => {
+        if ((event.target as HTMLElement).closest('a, button, input')) return
+        router.push(documentHref)
+      },
+      [router, documentHref],
+    )
 
     const stopPropagation = useCallback((e: React.SyntheticEvent) => {
       e.stopPropagation()
@@ -121,9 +125,13 @@ const DocumentTableRow = React.memo(
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <span id={documentNameId} className="grow truncate text-sm">
+                  <Link
+                    id={documentNameId}
+                    href={documentHref}
+                    className="grow truncate rounded-sm text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
+                  >
                     {doc.name}
-                  </span>
+                  </Link>
                 }
               />
               <TooltipContent>{doc.name}</TooltipContent>

--- a/web/app/components/datasets/documents/components/document-list/components/sort-header.tsx
+++ b/web/app/components/datasets/documents/components/document-list/components/sort-header.tsx
@@ -19,11 +19,12 @@ const SortHeader: FC<SortHeaderProps> = React.memo(
     return (
       <button
         type="button"
-        className="flex items-center bg-transparent p-0 text-left hover:text-text-secondary"
+        className="flex items-center bg-transparent p-0 text-left hover:text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
         onClick={() => onSort(field)}
       >
         {label}
         <span
+          aria-hidden="true"
           className={cn(
             'ml-0.5 i-ri-arrow-down-line size-3 transition-all',
             isActive ? 'text-text-tertiary' : 'text-text-disabled',

--- a/web/app/components/datasets/documents/components/list.tsx
+++ b/web/app/components/datasets/documents/components/list.tsx
@@ -152,8 +152,8 @@ const DocumentList = ({
           className={`w-full max-w-full min-w-175 border-collapse border-0 text-sm ${s.documentTable}`}
         >
           <thead className="h-8 border-b border-divider-subtle text-xs/8 font-medium text-text-tertiary uppercase">
-            <tr>
-              <td className="w-12">
+            <tr className="[&>th]:text-left [&>th]:font-[weight:inherit]">
+              <th className="w-12">
                 <div className="flex items-center" onClick={(e) => e.stopPropagation()}>
                   {embeddingAvailable && (
                     <Checkbox
@@ -164,15 +164,24 @@ const DocumentList = ({
                   )}
                   #
                 </div>
-              </td>
-              <td>{t(($) => $['list.table.header.fileName'], { ns: 'datasetDocuments' })}</td>
-              <td className="w-32.5">
+              </th>
+              <th>{t(($) => $['list.table.header.fileName'], { ns: 'datasetDocuments' })}</th>
+              <th className="w-32.5">
                 {t(($) => $['list.table.header.chunkingMode'], { ns: 'datasetDocuments' })}
-              </td>
-              <td className="w-24">
+              </th>
+              <th className="w-24">
                 {t(($) => $['list.table.header.words'], { ns: 'datasetDocuments' })}
-              </td>
-              <td className="w-44">
+              </th>
+              <th
+                className="w-44"
+                aria-sort={
+                  sortField === 'hit_count'
+                    ? sortOrder === 'asc'
+                      ? 'ascending'
+                      : 'descending'
+                    : undefined
+                }
+              >
                 <SortHeader
                   field="hit_count"
                   label={t(($) => $['list.table.header.hitCount'], { ns: 'datasetDocuments' })}
@@ -180,8 +189,17 @@ const DocumentList = ({
                   sortOrder={sortOrder}
                   onSort={handleSort}
                 />
-              </td>
-              <td className="w-44">
+              </th>
+              <th
+                className="w-44"
+                aria-sort={
+                  sortField === 'created_at'
+                    ? sortOrder === 'asc'
+                      ? 'ascending'
+                      : 'descending'
+                    : undefined
+                }
+              >
                 <SortHeader
                   field="created_at"
                   label={t(($) => $['list.table.header.uploadTime'], { ns: 'datasetDocuments' })}
@@ -189,13 +207,13 @@ const DocumentList = ({
                   sortOrder={sortOrder}
                   onSort={handleSort}
                 />
-              </td>
-              <td className="w-40">
+              </th>
+              <th className="w-40">
                 {t(($) => $['list.table.header.status'], { ns: 'datasetDocuments' })}
-              </td>
-              <td className="w-20">
+              </th>
+              <th className="w-20">
                 {t(($) => $['list.table.header.action'], { ns: 'datasetDocuments' })}
-              </td>
+              </th>
             </tr>
           </thead>
           <tbody className="text-text-secondary">

--- a/web/app/components/datasets/documents/components/operations.tsx
+++ b/web/app/components/datasets/documents/components/operations.tsx
@@ -321,10 +321,12 @@ const Operations = ({
       </span>
     </button>
   )
+  const enabledLabel = `${t(($) => $['list.status.enabled'], { ns: 'datasetDocuments' })}: ${name}`
   const renderListSwitch = () => {
     if (!canEdit)
       return (
         <Switch
+          aria-label={enabledLabel}
           checked={archived ? false : enabled}
           onCheckedChange={noop}
           disabled={true}
@@ -340,7 +342,13 @@ const Operations = ({
             openOnHover
             render={
               <div>
-                <Switch checked={false} onCheckedChange={noop} disabled={true} size="md" />
+                <Switch
+                  aria-label={enabledLabel}
+                  checked={false}
+                  onCheckedChange={noop}
+                  disabled={true}
+                  size="md"
+                />
               </div>
             }
           />
@@ -353,6 +361,7 @@ const Operations = ({
 
     return (
       <Switch
+        aria-label={enabledLabel}
         checked={enabled}
         onCheckedChange={(v) => handleSwitch(v ? 'enable' : 'disable')}
         size="md"
@@ -364,7 +373,13 @@ const Operations = ({
     // oxlint-disable-next-line jsx-a11y/no-static-element-interactions -- Only stops child control events from reaching row navigation.
     <div className="flex items-center" onClick={stopPropagation} onKeyDown={stopPropagation}>
       {isListScene && !embeddingAvailable && (
-        <Switch checked={false} onCheckedChange={noop} disabled={true} size="md" />
+        <Switch
+          aria-label={enabledLabel}
+          checked={false}
+          onCheckedChange={noop}
+          disabled={true}
+          size="md"
+        />
       )}
       {isListScene && embeddingAvailable && (
         <>

--- a/web/app/components/datasets/documents/detail/batch-modal/csv-downloader.tsx
+++ b/web/app/components/datasets/documents/detail/batch-modal/csv-downloader.tsx
@@ -45,12 +45,12 @@ const CSVDownload: FC<{ docForm: ChunkingMode }> = ({ docForm }) => {
           <table className="w-full table-fixed border-separate border-spacing-0 rounded-lg border border-divider-subtle text-xs">
             <thead className="text-text-secondary">
               <tr>
-                <td className="h-9 border-b border-divider-subtle pr-2 pl-3">
+                <th className="h-9 border-b border-divider-subtle pr-2 pl-3 text-left font-[weight:inherit]">
                   {t(($) => $['list.batchModal.question'], { ns: 'datasetDocuments' })}
-                </td>
-                <td className="h-9 border-b border-divider-subtle pr-2 pl-3">
+                </th>
+                <th className="h-9 border-b border-divider-subtle pr-2 pl-3 text-left font-[weight:inherit]">
                   {t(($) => $['list.batchModal.answer'], { ns: 'datasetDocuments' })}
-                </td>
+                </th>
               </tr>
             </thead>
             <tbody className="text-text-tertiary">
@@ -77,9 +77,9 @@ const CSVDownload: FC<{ docForm: ChunkingMode }> = ({ docForm }) => {
           <table className="w-full table-fixed border-separate border-spacing-0 rounded-lg border border-divider-subtle text-xs">
             <thead className="text-text-secondary">
               <tr>
-                <td className="h-9 border-b border-divider-subtle pr-2 pl-3">
+                <th className="h-9 border-b border-divider-subtle pr-2 pl-3 text-left font-[weight:inherit]">
                   {t(($) => $['list.batchModal.contentTitle'], { ns: 'datasetDocuments' })}
-                </td>
+                </th>
               </tr>
             </thead>
             <tbody className="text-text-tertiary">

--- a/web/app/components/datasets/documents/style.module.css
+++ b/web/app/components/datasets/documents/style.module.css
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   max-width: 200px;
 }
-.documentTable thead td {
+.documentTable thead th {
   padding: 0px 10px 0px 12px;
   box-sizing: border-box;
   max-width: 200px;

--- a/web/app/components/datasets/hit-testing/components/__tests__/records.spec.tsx
+++ b/web/app/components/datasets/hit-testing/components/__tests__/records.spec.tsx
@@ -1,5 +1,6 @@
 import type { HitTestingRecord } from '@/models/datasets'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import Records from '../records'
 
@@ -30,9 +31,15 @@ describe('Records', () => {
 
   it('should render table headers', () => {
     render(<Records records={[]} onClickRecord={mockOnClick} />)
-    expect(screen.getByText('datasetHitTesting.table.header.queryContent')).toBeInTheDocument()
-    expect(screen.getByText('datasetHitTesting.table.header.source')).toBeInTheDocument()
-    expect(screen.getByText('datasetHitTesting.table.header.time')).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: 'datasetHitTesting.table.header.queryContent' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: 'datasetHitTesting.table.header.source' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: 'datasetHitTesting.table.header.time' }),
+    ).toBeInTheDocument()
   })
 
   it('should render records', () => {
@@ -41,10 +48,11 @@ describe('Records', () => {
     expect(screen.getAllByText('query text')).toHaveLength(2)
   })
 
-  it('should call onClickRecord when row clicked', () => {
+  it('should call onClickRecord when row clicked', async () => {
+    const user = userEvent.setup()
     const records = [makeRecord('1', 'app', 1000)]
     render(<Records records={records} onClickRecord={mockOnClick} />)
-    fireEvent.click(screen.getByText('query text'))
+    await user.click(screen.getByText('query text'))
     expect(mockOnClick).toHaveBeenCalledWith(records[0])
   })
 
@@ -61,20 +69,40 @@ describe('Records', () => {
     expect(rows[2]).toHaveTextContent('early')
   })
 
-  it('should toggle sort order on time header click', () => {
+  it('exposes the current sort order and toggles it from the keyboard', async () => {
+    const user = userEvent.setup()
     const records = [makeRecord('1', 'app', 1000, 'early'), makeRecord('2', 'app', 3000, 'late')]
     render(<Records records={records} onClickRecord={mockOnClick} />)
 
-    // Default: desc, so late first
-    let rows = screen.getAllByRole('row').slice(1)
-    expect(rows[0]).toHaveTextContent('late')
+    const header = screen.getByRole('columnheader', { name: 'datasetHitTesting.table.header.time' })
+    expect(header).toHaveAttribute('aria-sort', 'descending')
+    await user.tab()
+    expect(
+      screen.getByRole('button', { name: 'datasetHitTesting.table.header.time' }),
+    ).toHaveFocus()
+    await user.keyboard('{Enter}')
 
-    fireEvent.click(screen.getByText('datasetHitTesting.table.header.time'))
-    rows = screen.getAllByRole('row').slice(1)
-    expect(rows[0]).toHaveTextContent('early')
+    expect(header).toHaveAttribute('aria-sort', 'ascending')
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('early')
+    await user.keyboard(' ')
+    expect(header).toHaveAttribute('aria-sort', 'descending')
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('late')
   })
 
-  it('should render image list for image queries', () => {
+  it('reuses a record once through its keyboard-accessible time button', async () => {
+    const user = userEvent.setup()
+    const record = makeRecord('1', 'app', 1000)
+    render(<Records records={[record]} onClickRecord={mockOnClick} />)
+
+    await user.tab()
+    await user.tab()
+    expect(screen.getByRole('button', { name: 'time-1000' })).toHaveFocus()
+    await user.keyboard('{Enter}')
+    expect(mockOnClick).toHaveBeenCalledExactlyOnceWith(record)
+  })
+
+  it('provides a reuse button for image-only queries', async () => {
+    const user = userEvent.setup()
     const records = [
       {
         id: '1',
@@ -98,5 +126,7 @@ describe('Records', () => {
     ] as unknown as HitTestingRecord[]
     render(<Records records={records} onClickRecord={mockOnClick} />)
     expect(screen.getByTestId('image-list')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'time-1000' }))
+    expect(mockOnClick).toHaveBeenCalledExactlyOnceWith(records[0])
   })
 })

--- a/web/app/components/datasets/hit-testing/components/records.tsx
+++ b/web/app/components/datasets/hit-testing/components/records.tsx
@@ -46,21 +46,29 @@ const Records = ({ records, onClickRecord }: RecordsProps) => {
     <div className="grow overflow-y-auto">
       <table className="w-full border-collapse border-0 text-[13px] leading-4 text-text-secondary">
         <thead className="sticky top-0 h-7 text-xs leading-7 font-medium text-text-tertiary uppercase backdrop-blur-[5px]">
-          <tr>
-            <td className="rounded-l-lg bg-background-section-burn pl-3">
+          <tr className="[&>th]:text-left [&>th]:font-[weight:inherit]">
+            <th className="rounded-l-lg bg-background-section-burn pl-3">
               {t(($) => $['table.header.queryContent'], { ns: 'datasetHitTesting' })}
-            </td>
-            <td className="w-32 bg-background-section-burn pl-3">
+            </th>
+            <th className="w-32 bg-background-section-burn pl-3">
               {t(($) => $['table.header.source'], { ns: 'datasetHitTesting' })}
-            </td>
-            <td className="w-48 rounded-r-lg bg-background-section-burn pl-3">
-              <div className="flex cursor-pointer items-center" onClick={handleSortTime}>
+            </th>
+            <th
+              className="w-48 rounded-r-lg bg-background-section-burn pl-3"
+              aria-sort={sortTimeOrder === 'asc' ? 'ascending' : 'descending'}
+            >
+              <button
+                type="button"
+                className="flex cursor-pointer items-center focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
+                onClick={handleSortTime}
+              >
                 {t(($) => $['table.header.time'], { ns: 'datasetHitTesting' })}
                 <RiArrowDownLine
+                  aria-hidden="true"
                   className={cn('ml-0.5 size-3.5', sortTimeOrder === 'asc' ? 'rotate-180' : '')}
                 />
-              </div>
-            </td>
+              </button>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -74,7 +82,10 @@ const Records = ({ records, onClickRecord }: RecordsProps) => {
               <tr
                 key={id}
                 className="group cursor-pointer border-b border-divider-subtle hover:bg-background-default-hover"
-                onClick={() => onClickRecord(record)}
+                onClick={(event) => {
+                  if ((event.target as HTMLElement).closest('button, a')) return
+                  onClickRecord(record)
+                }}
               >
                 <td className="max-w-xs p-3 pr-2">
                   <div className="flex flex-col gap-y-1">
@@ -86,17 +97,23 @@ const Records = ({ records, onClickRecord }: RecordsProps) => {
                 </td>
                 <td className="w-32 p-3 pr-2">
                   <div className="flex items-center">
-                    <SourceIcon className="mr-1 size-4 text-text-tertiary" />
+                    <SourceIcon aria-hidden="true" className="mr-1 size-4 text-text-tertiary" />
                     <span className="capitalize">
                       {source.replace('_', ' ').replace('hit testing', 'retrieval test')}
                     </span>
                   </div>
                 </td>
                 <td className="w-48 p-3 pr-2">
-                  {formatTime(
-                    created_at,
-                    t(($) => $.dateTimeFormat, { ns: 'datasetHitTesting' }) as string,
-                  )}
+                  <button
+                    type="button"
+                    className="w-full cursor-pointer rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-accent-solid"
+                    onClick={() => onClickRecord(record)}
+                  >
+                    {formatTime(
+                      created_at,
+                      t(($) => $.dateTimeFormat, { ns: 'datasetHitTesting' }) as string,
+                    )}
+                  </button>
                 </td>
               </tr>
             )

--- a/web/app/components/header/account-setting/members-page/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/__tests__/index.spec.tsx
@@ -42,7 +42,7 @@ const renderMembersPage = () =>
 
 const getMemberDetailsButton = (memberId: string) =>
   within(screen.getByTestId(`member-row-${memberId}`)).getByRole('button', {
-    name: /members\.memberDetails\.openAria/i,
+    name: memberId === '1' ? 'Owner User' : 'Admin User',
   })
 
 const createRole = (overrides: Partial<Role>): Role => ({
@@ -259,17 +259,25 @@ describe('MembersPage', () => {
     expect(screen.getByText('Admin User'))!.toBeInTheDocument()
   })
 
-  it('should render fixed name column and flexible role column layout', () => {
+  it('should expose member columns and keep row data separate from the details button', () => {
     renderMembersPage()
 
+    const table = screen.getByRole('table')
     expect(
-      screen.getByText('common.members.name', { selector: '.system-xs-medium-uppercase' }),
-    )!.toHaveClass('w-65', 'shrink-0')
+      within(table).getByRole('columnheader', { name: 'common.members.name' }),
+    ).toBeInTheDocument()
     expect(
-      screen.getByText('common.members.role', { selector: '.system-xs-medium-uppercase' }),
-    )!.toHaveClass('min-w-0', 'grow')
-    expect(getMemberDetailsButton('1').children[0])!.toHaveClass('w-65', 'shrink-0')
-    expect(getMemberDetailsButton('1').children[2])!.toHaveClass('min-w-0', 'grow')
+      within(table).getByRole('columnheader', { name: 'common.members.lastActive' }),
+    ).toBeInTheDocument()
+    expect(
+      within(table).getByRole('columnheader', { name: 'common.members.role' }),
+    ).toBeInTheDocument()
+    const row = within(table).getByRole('row', { name: /owner@example.com/ })
+    expect(within(row).getByRole('cell', { name: 'just now' })).toBeInTheDocument()
+    expect(within(row).getByRole('cell', { name: 'Owner' })).toBeInTheDocument()
+    expect(within(row).getByRole('button', { name: 'Owner User' })).not.toHaveTextContent(
+      'owner@example.com',
+    )
   })
 
   it('should render plural roles column header when RBAC is enabled', () => {
@@ -282,9 +290,7 @@ describe('MembersPage', () => {
       },
     })
 
-    expect(
-      screen.getByText('common.members.roles', { selector: '.system-xs-medium-uppercase' }),
-    )!.toHaveClass('min-w-0', 'grow')
+    expect(screen.getByRole('columnheader', { name: 'common.members.roles' })).toBeInTheDocument()
     expect(
       screen.queryByText('common.members.role', { selector: '.system-xs-medium-uppercase' }),
     ).not.toBeInTheDocument()
@@ -562,7 +568,7 @@ describe('MembersPage', () => {
     expect(screen.getByText('Admin'))!.toBeInTheDocument()
   })
 
-  it('should expose member details as a native row button without nesting member actions', () => {
+  it('should expose a member details button without nesting member actions', () => {
     renderMembersPage()
 
     const row = screen.getByTestId('member-row-2')
@@ -570,16 +576,11 @@ describe('MembersPage', () => {
     const memberMenu = within(row).getByTestId('member-menu')
 
     expect(row).not.toHaveAttribute('role', 'button')
-    expect(row).not.toHaveClass('hover:bg-state-base-hover')
     expect(detailsButton).toHaveAttribute('type', 'button')
-    expect(detailsButton).toHaveClass(
-      'hover:bg-state-base-hover',
-      'focus-visible:bg-state-base-hover',
-    )
     expect(detailsButton).not.toContainElement(memberMenu)
   })
 
-  it('should open member details modal when a member row is clicked', async () => {
+  it('should open member details modal when a member name is clicked', async () => {
     const user = userEvent.setup()
 
     renderMembersPage()

--- a/web/app/components/header/account-setting/members-page/__tests__/member-row.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/__tests__/member-row.spec.tsx
@@ -1,0 +1,108 @@
+import type { Member } from '@/models/common'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useFormatTimeFromNow } from '@/hooks/use-format-time-from-now'
+import { useUpdateRolesOfMember } from '@/service/access-control/use-member-roles'
+import { renderWithConsoleQuery } from '@/test/console/query-data'
+import MemberRow from '../member-row'
+
+vi.mock('@/hooks/use-format-time-from-now')
+vi.mock('@/service/access-control/use-member-roles')
+
+const member: Member = {
+  id: 'member-1',
+  name: 'Member User',
+  email: 'member@example.com',
+  avatar: '',
+  avatar_url: '',
+  role: 'normal',
+  roles: [],
+  last_active_at: '1731000000',
+  last_login_at: '1731000000',
+  created_at: '1731000000',
+  status: 'active',
+}
+
+const renderMemberRow = (onOpenDetails = vi.fn()) => {
+  renderWithConsoleQuery(
+    <table>
+      <tbody>
+        <MemberRow
+          member={member}
+          roles={[{ id: 'role-1', name: 'Editor' }]}
+          isCurrentUser={false}
+          canManage
+          canTransferOwnership={false}
+          allowMultipleRoles={false}
+          onOpenDetails={onOpenDetails}
+          onTransferOwnership={vi.fn()}
+        />
+      </tbody>
+    </table>,
+  )
+  return onOpenDetails
+}
+
+describe('MemberRow details entry points', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useFormatTimeFromNow).mockReturnValue({
+      formatTimeFromNow: () => 'just now',
+    })
+    vi.mocked(useUpdateRolesOfMember).mockReturnValue({
+      mutateAsync: vi.fn(),
+    } as unknown as ReturnType<typeof useUpdateRolesOfMember>)
+  })
+
+  it.each([
+    ['email', 'member@example.com'],
+    ['last activity', 'just now'],
+    ['role', 'Editor'],
+    ['avatar', 'M'],
+  ])('should open details once when clicking the %s', async (_region, text) => {
+    const user = userEvent.setup()
+    const onOpenDetails = renderMemberRow()
+
+    await user.click(within(screen.getByRole('row')).getByText(text))
+
+    expect(onOpenDetails).toHaveBeenCalledExactlyOnceWith(member)
+  })
+
+  it.each(['pointer', 'Enter', 'Space'])(
+    'should open details once from the name button with %s',
+    async (interaction) => {
+      const user = userEvent.setup()
+      const onOpenDetails = renderMemberRow()
+      const nameButton = screen.getByRole('button', { name: 'Member User' })
+
+      if (interaction === 'pointer') {
+        await user.click(nameButton)
+      } else {
+        nameButton.focus()
+        await user.keyboard(interaction === 'Enter' ? '{Enter}' : ' ')
+      }
+
+      expect(onOpenDetails).toHaveBeenCalledExactlyOnceWith(member)
+    },
+  )
+
+  it('should keep member menu and its portaled confirmation separate from details', async () => {
+    const user = userEvent.setup()
+    const onOpenDetails = renderMemberRow()
+
+    await user.click(screen.getByRole('button', { name: /common\.members\.memberActions/ }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(onOpenDetails).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('menuitem', { name: 'common.members.removeFromTeam' }))
+    const confirmation = screen.getByRole('alertdialog')
+    expect(onOpenDetails).not.toHaveBeenCalled()
+
+    await user.click(
+      within(confirmation).getByText('common.members.removeFromTeamConfirmDescription'),
+    )
+    await user.click(within(confirmation).getByRole('button', { name: 'common.operation.cancel' }))
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(onOpenDetails).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/components/header/account-setting/members-page/index.tsx
+++ b/web/app/components/header/account-setting/members-page/index.tsx
@@ -181,35 +181,46 @@ const MembersPage = () => {
             )}
           </div>
         </div>
-        <div className="overflow-visible lg:overflow-visible">
-          <div className="flex min-w-120 items-center border-b border-divider-regular py-1.75">
-            <div className="w-65 shrink-0 px-3 system-xs-medium-uppercase text-text-tertiary">
-              {t(($) => $['members.name'], { ns: 'common' })}
-            </div>
-            <div className="w-30 shrink-0 system-xs-medium-uppercase text-text-tertiary">
-              {t(($) => $['members.lastActive'], { ns: 'common' })}
-            </div>
-            <div className="min-w-0 grow px-3 system-xs-medium-uppercase text-text-tertiary">
-              {roleColumnLabel}
-            </div>
-          </div>
-          <div className="relative min-w-120">
-            {accounts.map((account) => (
-              <MemberRow
-                key={account.id}
-                member={account}
-                roles={account.roles}
-                isCurrentUser={userProfileEmail === account.email}
-                canManage={canManageMembers}
-                canTransferOwnership={
-                  isCurrentWorkspaceOwner && features?.is_allow_transfer_workspace === true
-                }
-                allowMultipleRoles={systemFeatures.rbac_enabled}
-                onOpenDetails={handleOpenDetails}
-                onTransferOwnership={handleTransferOwnership}
-              />
-            ))}
-          </div>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-150 table-fixed text-left">
+            <colgroup>
+              <col className="w-65" />
+              <col className="w-30" />
+              <col />
+              {canManageMembers && <col className="w-12" />}
+            </colgroup>
+            <thead>
+              <tr className="border-b border-divider-regular">
+                <th className="px-3 py-1.75 text-left system-xs-medium-uppercase text-text-tertiary">
+                  {t(($) => $['members.name'], { ns: 'common' })}
+                </th>
+                <th className="py-1.75 text-left system-xs-medium-uppercase text-text-tertiary">
+                  {t(($) => $['members.lastActive'], { ns: 'common' })}
+                </th>
+                <th className="px-3 py-1.75 text-left system-xs-medium-uppercase text-text-tertiary">
+                  {roleColumnLabel}
+                </th>
+                {canManageMembers && <td />}
+              </tr>
+            </thead>
+            <tbody>
+              {accounts.map((account) => (
+                <MemberRow
+                  key={account.id}
+                  member={account}
+                  roles={account.roles}
+                  isCurrentUser={userProfileEmail === account.email}
+                  canManage={canManageMembers}
+                  canTransferOwnership={
+                    isCurrentWorkspaceOwner && features?.is_allow_transfer_workspace === true
+                  }
+                  allowMultipleRoles={systemFeatures.rbac_enabled}
+                  onOpenDetails={handleOpenDetails}
+                  onTransferOwnership={handleTransferOwnership}
+                />
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
       {invitationResults && (

--- a/web/app/components/header/account-setting/members-page/member-row.tsx
+++ b/web/app/components/header/account-setting/members-page/member-row.tsx
@@ -1,4 +1,5 @@
 'use client'
+import type { MouseEvent } from 'react'
 import type { Member } from '@/models/common'
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { memo, useCallback } from 'react'
@@ -40,8 +41,26 @@ const MemberRow = ({
     onOpenDetails(member)
   }, [member, onOpenDetails])
 
+  const handleRowClick = useCallback(
+    (event: MouseEvent<HTMLTableRowElement>) => {
+      const target = event.target
+      if (
+        !(target instanceof Element) ||
+        !event.currentTarget.contains(target) ||
+        target.closest('button, a')
+      )
+        return
+      openDetails()
+    },
+    [openDetails],
+  )
+
   return (
-    <tr data-testid={`member-row-${member.id}`} className="border-b border-divider-subtle">
+    <tr
+      data-testid={`member-row-${member.id}`}
+      className="cursor-pointer border-b border-divider-subtle hover:bg-state-base-hover"
+      onClick={handleRowClick}
+    >
       <td className="px-3 py-2">
         <div className="flex min-w-0 items-center">
           <Avatar avatar={member.avatar_url} size="sm" className="mr-2" name={member.name} />

--- a/web/app/components/header/account-setting/members-page/member-row.tsx
+++ b/web/app/components/header/account-setting/members-page/member-row.tsx
@@ -1,7 +1,6 @@
 'use client'
 import type { Member } from '@/models/common'
 import { Avatar } from '@langgenius/dify-ui/avatar'
-import { cn } from '@langgenius/dify-ui/cn'
 import { memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useFormatTimeFromNow } from '@/hooks/use-format-time-from-now'
@@ -42,28 +41,19 @@ const MemberRow = ({
   }, [member, onOpenDetails])
 
   return (
-    <div
-      data-testid={`member-row-${member.id}`}
-      className="relative border-b border-divider-subtle"
-    >
-      <button
-        type="button"
-        aria-label={t(($) => $['members.memberDetails.openAria'], {
-          ns: 'common',
-          name: member.name,
-          defaultValue: 'Open member details for {{name}}',
-        })}
-        className={cn(
-          'flex w-full min-w-0 cursor-pointer bg-transparent text-left hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:outline-hidden',
-          canManage && 'pr-12',
-        )}
-        onClick={openDetails}
-      >
-        <span className="flex w-65 shrink-0 items-center px-3 py-2">
+    <tr data-testid={`member-row-${member.id}`} className="border-b border-divider-subtle">
+      <td className="px-3 py-2">
+        <div className="flex min-w-0 items-center">
           <Avatar avatar={member.avatar_url} size="sm" className="mr-2" name={member.name} />
-          <span className="min-w-0">
-            <span className="block system-sm-medium text-text-secondary">
-              {member.name}
+          <div className="min-w-0">
+            <div className="system-sm-medium text-text-secondary">
+              <button
+                type="button"
+                className="max-w-full cursor-pointer rounded-sm text-left wrap-break-word hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
+                onClick={openDetails}
+              >
+                {member.name}
+              </button>
               {member.status === 'pending' && (
                 <span className="ml-1 system-xs-medium text-text-warning">
                   {t(($) => $['members.pending'], { ns: 'common' })}
@@ -74,19 +64,21 @@ const MemberRow = ({
                   {t(($) => $['members.you'], { ns: 'common' })}
                 </span>
               )}
-            </span>
-            <span className="block system-xs-regular text-text-tertiary">{member.email}</span>
-          </span>
-        </span>
-        <span className="flex w-30 shrink-0 items-center py-2 system-sm-regular text-text-secondary">
-          {formatTimeFromNow(Number(member.last_active_at || member.created_at) * 1000)}
-        </span>
-        <span className="flex min-w-0 grow items-center gap-2 px-3">
-          <RoleBadges className="grow" roleNames={roleNames} />
-        </span>
-      </button>
-      <div className="absolute inset-y-0 right-0 flex items-center px-3">
-        {canManage && (
+            </div>
+            <div className="system-xs-regular wrap-break-word text-text-tertiary">
+              {member.email}
+            </div>
+          </div>
+        </div>
+      </td>
+      <td className="py-2 system-sm-regular text-text-secondary">
+        {formatTimeFromNow(Number(member.last_active_at || member.created_at) * 1000)}
+      </td>
+      <td className="px-3 py-2">
+        <RoleBadges roleNames={roleNames} />
+      </td>
+      {canManage && (
+        <td className="px-3 py-2">
           <MemberMenu
             member={member}
             isCurrentUser={isCurrentUser}
@@ -94,9 +86,9 @@ const MemberRow = ({
             allowMultipleRoles={allowMultipleRoles}
             onTransferOwnership={onTransferOwnership}
           />
-        )}
-      </div>
-    </div>
+        </td>
+      )}
+    </tr>
   )
 }
 

--- a/web/app/components/header/account-setting/workflow-log-archives-page/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/workflow-log-archives-page/__tests__/index.spec.tsx
@@ -1,8 +1,8 @@
 import type { CloudPlan } from '@dify/contracts/api/console/features/types.gen'
 import type { GetWorkflowRunArchivesResponse } from '@dify/contracts/api/console/workflow-run-archives/types.gen'
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { consoleQuery } from '@/service/console'
 import {
   createConsoleQueryClient,
@@ -27,6 +27,17 @@ vi.mock('@/context/modal-context', async (importOriginal) => {
   }
 })
 
+const archiveMonth: GetWorkflowRunArchivesResponse['months'][number] = {
+  year: 2025,
+  month: 3,
+  workflow_run_count: 125,
+  row_count: 1125,
+  archive_bytes: 1048576,
+  bundle_count: 2,
+  latest_archived_at: '2025-03-03T00:00:00Z',
+  download_task: null,
+}
+
 const archiveData: GetWorkflowRunArchivesResponse = {
   summary: {
     archived_month_count: 1,
@@ -34,25 +45,16 @@ const archiveData: GetWorkflowRunArchivesResponse = {
     archive_bytes: 1048576,
     latest_archived_at: '2025-03-03T00:00:00Z',
   },
-  months: [
-    {
-      year: 2025,
-      month: 3,
-      workflow_run_count: 125,
-      row_count: 1125,
-      archive_bytes: 1048576,
-      bundle_count: 2,
-      latest_archived_at: '2025-03-03T00:00:00Z',
-      download_task: null,
-    },
-  ],
+  months: [archiveMonth],
 }
 
 let plan: CloudPlan = 'professional'
 
-function renderPage() {
-  const queryClient = createConsoleQueryClient()
-  queryClient.setQueryData(consoleQuery.workflowRunArchives.get.queryKey(), archiveData)
+function renderPage(
+  data: GetWorkflowRunArchivesResponse | null = archiveData,
+  queryClient = createConsoleQueryClient(),
+) {
+  if (data) queryClient.setQueryData(consoleQuery.workflowRunArchives.get.queryKey(), data)
 
   return render(<WorkflowLogArchivesPage />, {
     queryClient,
@@ -70,6 +72,124 @@ describe('WorkflowLogArchivesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     plan = 'professional'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('Archive table states', () => {
+    it('should hide loading rows from assistive technology until archives arrive', async () => {
+      const queryClient = createConsoleQueryClient()
+      let resolveArchives!: (data: GetWorkflowRunArchivesResponse) => void
+      const response = new Promise<GetWorkflowRunArchivesResponse>((resolve) => {
+        resolveArchives = resolve
+      })
+      const request = queryClient.query({
+        queryKey: consoleQuery.workflowRunArchives.get.queryKey(),
+        queryFn: () => response,
+      })
+
+      renderPage(null, queryClient)
+
+      const table = screen.getByRole('table')
+      expect(within(table).getAllByRole('row')).toHaveLength(1)
+      expect(within(table).getAllByRole('row', { hidden: true }).length).toBeGreaterThan(1)
+      expect(within(table).queryByText('appLog.archives.empty.title')).not.toBeInTheDocument()
+
+      await act(async () => {
+        resolveArchives(archiveData)
+        await request
+      })
+
+      expect(await within(table).findByRole('row', { name: /2025-03/ })).toBeInTheDocument()
+      expect(within(table).getAllByRole('row', { hidden: true })).toHaveLength(2)
+    })
+
+    it('should present an archive request error in a cell spanning the table columns', async () => {
+      const queryClient = createConsoleQueryClient()
+      const queryKey = consoleQuery.workflowRunArchives.get.queryKey()
+      queryClient.setQueryDefaults(queryKey, { retryOnMount: false })
+      await queryClient
+        .query({
+          queryKey,
+          queryFn: () => Promise.reject(new Error('Archives unavailable')),
+        })
+        .catch(() => undefined)
+
+      renderPage(null, queryClient)
+
+      const table = screen.getByRole('table')
+      const errorCell = within(table).getByRole('cell', { name: /appLog\.archives\.error\.title/ })
+      expect(errorCell).toHaveAttribute('colspan', '4')
+      expect(within(errorCell).getByText('appLog.archives.error.description')).toBeInTheDocument()
+      expect(within(table).queryByText('appLog.archives.empty.title')).not.toBeInTheDocument()
+      expect(within(table).queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('should present an empty archive message in a cell spanning the table columns', () => {
+      renderPage({
+        months: [],
+        summary: {
+          archived_month_count: 0,
+          workflow_run_count: 0,
+          archive_bytes: 0,
+          latest_archived_at: null,
+        },
+      })
+
+      const table = screen.getByRole('table')
+      const emptyCell = within(table).getByRole('cell', { name: /appLog\.archives\.empty\.title/ })
+      expect(emptyCell).toHaveAttribute('colspan', '4')
+      expect(within(emptyCell).getByText('appLog.archives.empty.description')).toBeInTheDocument()
+      expect(within(table).queryByText('appLog.archives.error.title')).not.toBeInTheDocument()
+      expect(within(table).queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('should reveal remaining archive months when the load-more region enters view', () => {
+      let intersect: (isIntersecting: boolean) => void = () => {}
+      vi.stubGlobal(
+        'IntersectionObserver',
+        class {
+          constructor(callback: IntersectionObserverCallback) {
+            intersect = (isIntersecting) =>
+              callback(
+                [{ isIntersecting } as IntersectionObserverEntry],
+                this as unknown as IntersectionObserver,
+              )
+          }
+
+          observe() {}
+          disconnect() {}
+        },
+      )
+      const months = Array.from({ length: 21 }, (_, index) => ({
+        ...archiveMonth,
+        year: 2025 + Math.floor(index / 12),
+        month: (index % 12) + 1,
+      }))
+      renderPage({
+        months,
+        summary: {
+          ...archiveData.summary,
+          archived_month_count: months.length,
+          workflow_run_count: months.length * 125,
+          archive_bytes: months.length * 1048576,
+        },
+      })
+
+      const table = screen.getByRole('table')
+      expect(within(table).getAllByRole('row')).toHaveLength(21)
+      expect(within(table).queryByRole('row', { name: /2026-09/ })).not.toBeInTheDocument()
+
+      act(() => intersect(false))
+      expect(within(table).queryByRole('row', { name: /2026-09/ })).not.toBeInTheDocument()
+
+      act(() => intersect(true))
+      expect(within(table).getByRole('row', { name: /2026-09/ })).toBeInTheDocument()
+      expect(within(table).getAllByRole('row')).toHaveLength(22)
+      expect(within(table).getAllByRole('row', { hidden: true })).toHaveLength(22)
+    })
   })
 
   describe('Plan access', () => {

--- a/web/app/components/header/account-setting/workflow-log-archives-page/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/workflow-log-archives-page/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import type { CloudPlan } from '@dify/contracts/api/console/features/types.gen'
 import type { GetWorkflowRunArchivesResponse } from '@dify/contracts/api/console/workflow-run-archives/types.gen'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { consoleQuery } from '@/service/console'
@@ -109,7 +109,19 @@ describe('WorkflowLogArchivesPage', () => {
       // Assert
       expect(screen.queryByText('appLog.archives.upgradeTip.title')).not.toBeInTheDocument()
       expect(screen.getByText('2025-03')).toBeInTheDocument()
-      expect(screen.getAllByText('125').length).toBeGreaterThan(0)
+      const table = screen.getByRole('table')
+      expect(
+        within(table)
+          .getAllByRole('columnheader')
+          .map((header) => header.textContent),
+      ).toEqual([
+        'appLog.archives.table.month',
+        'appLog.archives.table.runs',
+        'appLog.archives.table.size',
+        'appLog.archives.table.action',
+      ])
+      const row = within(table).getByRole('row', { name: /2025-03/ })
+      expect(within(row).getByRole('cell', { name: '125' })).toBeInTheDocument()
       expect(
         screen.getByRole('button', {
           name: 'appLog.archives.action.prepareDownload 2025-03',

--- a/web/app/components/header/account-setting/workflow-log-archives-page/index.tsx
+++ b/web/app/components/header/account-setting/workflow-log-archives-page/index.tsx
@@ -63,8 +63,6 @@ function buildArchiveDownloadFileUrl(downloadId: string) {
   return `${API_PREFIX}/workflow-run-archives/downloads/${downloadId}/file`
 }
 
-const tableGridClassName = 'grid-cols-[0.66fr_0.78fr_0.78fr_1fr]'
-
 export default function WorkflowLogArchivesPage() {
   const { t } = useTranslation()
   const { data: deploymentEdition } = useSuspenseQuery({
@@ -171,94 +169,111 @@ export default function WorkflowLogArchivesPage() {
 
       <div className="overflow-hidden rounded-xl border-[0.5px] border-components-card-border bg-components-card-bg shadow-xs">
         <div className="overflow-x-auto">
-          <div className="min-w-115">
-            <div
-              className={cn(
-                'grid h-8 items-center gap-3 border-b border-divider-subtle bg-background-section-burn px-4 system-xs-medium-uppercase text-text-tertiary',
-                tableGridClassName,
+          <table className="w-full min-w-115 table-fixed">
+            <colgroup>
+              <col className="w-[20.5%]" />
+              <col className="w-[24.2%]" />
+              <col className="w-[24.2%]" />
+              <col />
+            </colgroup>
+            <thead>
+              <tr className="h-8 border-b border-divider-subtle bg-background-section-burn">
+                <th className="px-2 text-center system-xs-medium-uppercase text-text-tertiary">
+                  {t(($) => $['archives.table.month'], { ns: 'appLog' })}
+                </th>
+                <th className="px-2 text-center system-xs-medium-uppercase text-text-tertiary">
+                  {t(($) => $['archives.table.runs'], { ns: 'appLog' })}
+                </th>
+                <th className="px-2 text-center system-xs-medium-uppercase text-text-tertiary">
+                  {t(($) => $['archives.table.size'], { ns: 'appLog' })}
+                </th>
+                <th className="px-2 text-center system-xs-medium-uppercase text-text-tertiary">
+                  {t(($) => $['archives.table.action'], { ns: 'appLog' })}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && (
+                <>
+                  {['first', 'second', 'third'].map((key) => (
+                    <tr
+                      key={key}
+                      className="h-15 border-b border-divider-subtle last:border-b-0"
+                      aria-hidden="true"
+                    >
+                      <td className="px-2 py-3">
+                        <SkeletonRectangle className="mx-auto h-4 w-16 animate-pulse" />
+                      </td>
+                      <td className="px-2 py-3">
+                        <SkeletonRectangle className="mx-auto h-4 w-16 animate-pulse" />
+                      </td>
+                      <td className="px-2 py-3">
+                        <SkeletonRectangle className="mx-auto h-4 w-14 animate-pulse" />
+                      </td>
+                      <td className="px-2 py-3">
+                        <SkeletonRectangle className="mx-auto h-8 w-24 animate-pulse rounded-lg" />
+                      </td>
+                    </tr>
+                  ))}
+                </>
               )}
-            >
-              <div className="text-center">
-                {t(($) => $['archives.table.month'], { ns: 'appLog' })}
-              </div>
-              <div className="text-center">
-                {t(($) => $['archives.table.runs'], { ns: 'appLog' })}
-              </div>
-              <div className="text-center">
-                {t(($) => $['archives.table.size'], { ns: 'appLog' })}
-              </div>
-              <div className="text-center">
-                {t(($) => $['archives.table.action'], { ns: 'appLog' })}
-              </div>
-            </div>
-            {isLoading && (
-              <>
-                {['first', 'second', 'third'].map((key) => (
-                  <div
-                    key={key}
-                    className={cn(
-                      'grid min-h-15 items-center gap-3 border-b border-divider-subtle px-4 py-3 last:border-b-0',
-                      tableGridClassName,
-                    )}
-                  >
-                    <div className="flex justify-center">
-                      <SkeletonRectangle className="h-4 w-16 animate-pulse" />
+              {!isLoading && archiveListQuery.isError && (
+                <tr>
+                  <td colSpan={4}>
+                    <div className="flex min-h-36 flex-col items-center justify-center gap-2 px-4 text-center">
+                      <span
+                        className="i-ri-error-warning-line size-6 text-text-tertiary"
+                        aria-hidden="true"
+                      />
+                      <div className="system-sm-semibold text-text-secondary">
+                        {t(($) => $['archives.error.title'], { ns: 'appLog' })}
+                      </div>
+                      <div className="system-xs-regular text-text-tertiary">
+                        {t(($) => $['archives.error.description'], { ns: 'appLog' })}
+                      </div>
                     </div>
-                    <div className="flex justify-center">
-                      <SkeletonRectangle className="h-4 w-16 animate-pulse" />
+                  </td>
+                </tr>
+              )}
+              {!isLoading && !archiveListQuery.isError && archiveMonths.length === 0 && (
+                <tr>
+                  <td colSpan={4}>
+                    <div className="flex min-h-36 flex-col items-center justify-center gap-2 px-4 text-center">
+                      <span
+                        className="i-ri-archive-line size-6 text-text-tertiary"
+                        aria-hidden="true"
+                      />
+                      <div className="system-sm-semibold text-text-secondary">
+                        {t(($) => $['archives.empty.title'], { ns: 'appLog' })}
+                      </div>
+                      <div className="system-xs-regular text-text-tertiary">
+                        {t(($) => $['archives.empty.description'], { ns: 'appLog' })}
+                      </div>
                     </div>
-                    <div className="flex justify-center">
-                      <SkeletonRectangle className="h-4 w-14 animate-pulse" />
-                    </div>
-                    <div className="flex justify-center">
-                      <SkeletonRectangle className="h-8 w-24 animate-pulse rounded-lg" />
-                    </div>
-                  </div>
-                ))}
-              </>
-            )}
-            {!isLoading && archiveListQuery.isError && (
-              <div className="flex min-h-36 flex-col items-center justify-center gap-2 px-4 text-center">
-                <span
-                  className="i-ri-error-warning-line size-6 text-text-tertiary"
-                  aria-hidden="true"
-                />
-                <div className="system-sm-semibold text-text-secondary">
-                  {t(($) => $['archives.error.title'], { ns: 'appLog' })}
-                </div>
-                <div className="system-xs-regular text-text-tertiary">
-                  {t(($) => $['archives.error.description'], { ns: 'appLog' })}
-                </div>
-              </div>
-            )}
-            {!isLoading && !archiveListQuery.isError && archiveMonths.length === 0 && (
-              <div className="flex min-h-36 flex-col items-center justify-center gap-2 px-4 text-center">
-                <span className="i-ri-archive-line size-6 text-text-tertiary" aria-hidden="true" />
-                <div className="system-sm-semibold text-text-secondary">
-                  {t(($) => $['archives.empty.title'], { ns: 'appLog' })}
-                </div>
-                <div className="system-xs-regular text-text-tertiary">
-                  {t(($) => $['archives.empty.description'], { ns: 'appLog' })}
-                </div>
-              </div>
-            )}
-            {!isLoading &&
-              !archiveListQuery.isError &&
-              visibleArchiveMonths.map((archive) => {
-                const archiveMonth = formatMonth(archive.year, archive.month)
+                  </td>
+                </tr>
+              )}
+              {!isLoading &&
+                !archiveListQuery.isError &&
+                visibleArchiveMonths.map((archive) => {
+                  const archiveMonth = formatMonth(archive.year, archive.month)
 
-                return <WorkflowArchiveMonthRow key={archiveMonth} archive={archive} />
-              })}
-            {!isLoading && !archiveListQuery.isError && hasMoreArchives && (
-              <div
-                ref={loadMoreRef}
-                className="flex h-10 items-center justify-center border-t border-divider-subtle bg-components-card-bg"
-                aria-hidden="true"
-              >
-                <SkeletonRectangle className="h-4 w-20 animate-pulse rounded-md" />
-              </div>
-            )}
-          </div>
+                  return <WorkflowArchiveMonthRow key={archiveMonth} archive={archive} />
+                })}
+              {!isLoading && !archiveListQuery.isError && hasMoreArchives && (
+                <tr aria-hidden="true">
+                  <td colSpan={4}>
+                    <div
+                      ref={loadMoreRef}
+                      className="flex h-10 items-center justify-center border-t border-divider-subtle bg-components-card-bg"
+                    >
+                      <SkeletonRectangle className="h-4 w-20 animate-pulse rounded-md" />
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -380,24 +395,19 @@ function WorkflowArchiveMonthRow({ archive }: { archive: WorkflowRunArchiveMonth
   const onAction = isReady ? downloadArchive : prepareDownload
 
   return (
-    <div
-      className={cn(
-        'grid min-h-15 items-center gap-3 border-b border-divider-subtle px-4 py-3 last:border-b-0',
-        tableGridClassName,
-      )}
-    >
-      <div className="min-w-0 text-center">
+    <tr className="h-15 border-b border-divider-subtle last:border-b-0">
+      <td className="px-2 py-3 text-center">
         <span id={archiveMonthLabelId} className="truncate system-sm-semibold text-text-primary">
           {archiveMonth}
         </span>
-      </div>
-      <div className="text-center system-sm-medium text-text-secondary tabular-nums">
+      </td>
+      <td className="px-2 py-3 text-center system-sm-medium text-text-secondary tabular-nums">
         {formatNumber(archive.workflow_run_count)}
-      </div>
-      <div className="text-center system-sm-medium text-text-secondary tabular-nums">
+      </td>
+      <td className="px-2 py-3 text-center system-sm-medium text-text-secondary tabular-nums">
         {formatBytes(archive.archive_bytes)}
-      </div>
-      <div className="flex min-w-0 justify-center">
+      </td>
+      <td className="px-2 py-3 text-center">
         <Tooltip>
           <TooltipTrigger
             render={
@@ -426,7 +436,7 @@ function WorkflowArchiveMonthRow({ archive }: { archive: WorkflowRunArchiveMonth
             {downloadHint}
           </TooltipContent>
         </Tooltip>
-      </div>
-    </div>
+      </td>
+    </tr>
   )
 }

--- a/web/app/components/share/text-generation/run-batch/csv-download/index.tsx
+++ b/web/app/components/share/text-generation/run-batch/csv-download/index.tsx
@@ -31,9 +31,12 @@ const CSVDownload: FC<ICSVDownloadProps> = ({ vars }) => {
           <thead className="text-text-tertiary">
             <tr>
               {addQueryContentVars.map((item, i) => (
-                <td key={i} className="h-9 border-b border-divider-regular pr-2 pl-3">
+                <th
+                  key={i}
+                  className="h-9 border-b border-divider-regular pr-2 pl-3 text-left font-[weight:inherit]"
+                >
                   {item.name}
-                </td>
+                </th>
               ))}
             </tr>
           </thead>

--- a/web/app/components/workflow/dsl-export-confirm-modal.tsx
+++ b/web/app/components/workflow/dsl-export-confirm-modal.tsx
@@ -59,12 +59,12 @@ export const DSLExportConfirmContent = ({
           <table className="w-full border-separate border-spacing-0 rounded-lg border border-divider-regular shadow-xs">
             <thead className="system-xs-medium-uppercase text-text-tertiary">
               <tr>
-                <td width={220} className="h-7 border-r border-b border-divider-regular pl-3">
+                <th className="h-7 w-55 border-r border-b border-divider-regular pl-3 text-left font-[weight:inherit]">
                   {t(($) => $['env.export.name'], { ns: 'workflow' })}
-                </td>
-                <td className="h-7 border-b border-divider-regular pl-3">
+                </th>
+                <th className="h-7 border-b border-divider-regular pl-3 text-left font-[weight:inherit]">
                   {t(($) => $['env.export.value'], { ns: 'workflow' })}
-                </td>
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/web/app/components/workflow/nodes/trigger-webhook/components/__tests__/generic-table.browser.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/__tests__/generic-table.browser.spec.tsx
@@ -1,0 +1,38 @@
+import { userEvent } from 'vite-plus/test/browser'
+import { render } from 'vitest-browser-react'
+import GenericTable from '../generic-table'
+
+describe('Webhook parameter table keyboard visibility', () => {
+  it('reveals the delete action when keyboard focus reaches its row', async () => {
+    // Chromium computes ancestor opacity and focus-within styling; DOM-only tests cannot verify visibility.
+    const screen = await render(
+      <>
+        <button type="button">Before parameters</button>
+        <GenericTable
+          title="Headers"
+          columns={[{ key: 'name', title: 'Name', type: 'input', width: 'flex-1' }]}
+          data={[{ name: 'Authorization' }]}
+          emptyRowData={{ name: '' }}
+          onChange={() => {}}
+        />
+      </>,
+    )
+
+    const before = screen.getByRole('button', { name: 'Before parameters' })
+    await before.click()
+    await userEvent.tab()
+    await userEvent.tab()
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete row' })
+    expect(deleteButton.element()).toHaveFocus()
+    let effectiveOpacity = 1
+    for (
+      let element: Element | null = deleteButton.element();
+      element;
+      element = element.parentElement
+    )
+      effectiveOpacity *= Number(getComputedStyle(element).opacity)
+    expect(effectiveOpacity).toBe(1)
+    expect(getComputedStyle(deleteButton.element()).boxShadow).not.toBe('none')
+  })
+})

--- a/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/components/generic-table.tsx
@@ -327,11 +327,11 @@ const GenericTable: FC<GenericTableProps> = ({
                   </div>
                 ))}
                 {!readonly && dataIndex !== null && hasContent && (
-                  <div className="absolute top-1/2 right-2 -translate-y-1/2 opacity-0 group-hover:opacity-100">
+                  <div className="absolute top-1/2 right-2 -translate-y-1/2 opacity-0 group-focus-within:opacity-100 group-hover:opacity-100">
                     <button
                       type="button"
                       onClick={() => removeRow(dataIndex)}
-                      className="p-1"
+                      className="rounded-sm p-1 focus-visible:ring-2 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
                       aria-label="Delete row"
                     >
                       {/* oxlint-disable-next-line dify/prefer-tailwind-icons */}

--- a/web/features/agent-v2/agent-detail/logs/__tests__/page.spec.tsx
+++ b/web/features/agent-v2/agent-detail/logs/__tests__/page.spec.tsx
@@ -4,7 +4,7 @@ import type {
   AgentLogSourceListResponse,
 } from '@dify/contracts/api/console/agent/types.gen'
 import { QueryClient } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClientTestProvider } from '@/test/console/query-provider'
 import { createSystemFeaturesFixture } from '@/test/console/system-features'
@@ -329,6 +329,15 @@ describe('AgentLogsPage', () => {
 
       renderPage()
 
+      const createdHeader = screen.getByRole('columnheader', {
+        name: 'agentV2.agentDetail.logs.table.createdTime',
+      })
+      const updatedHeader = screen.getByRole('columnheader', {
+        name: 'agentV2.agentDetail.logs.table.updatedTime',
+      })
+      expect(createdHeader).toHaveAttribute('aria-sort', 'descending')
+      expect(updatedHeader).not.toHaveAttribute('aria-sort')
+
       await user.click(screen.getByRole('button', { name: /appLog\.filter\.sortBy/ }))
       await user.click(
         await screen.findByRole('menuitemradio', {
@@ -345,6 +354,9 @@ describe('AgentLogsPage', () => {
         )
       })
 
+      expect(createdHeader).not.toHaveAttribute('aria-sort')
+      expect(updatedHeader).toHaveAttribute('aria-sort', 'descending')
+
       await user.click(screen.getByRole('button', { name: 'appLog.filter.ascending' }))
 
       await waitFor(() => {
@@ -355,6 +367,33 @@ describe('AgentLogsPage', () => {
           }),
         )
       })
+      expect(createdHeader).not.toHaveAttribute('aria-sort')
+      expect(updatedHeader).toHaveAttribute('aria-sort', 'ascending')
+    })
+
+    it('should expose unread status in the matching log row', async () => {
+      const readLog = populatedLogsResponse.data[0]!
+      mocks.logsQueryFn.mockResolvedValue({
+        ...populatedLogsResponse,
+        data: [
+          readLog,
+          { ...readLog, id: 'unread-log', title: 'Unread conversation', unread: true },
+        ],
+        total: 2,
+      })
+
+      renderPage()
+
+      const unreadRow = await screen.findByRole('row', { name: /Unread conversation/ })
+      const readRow = screen.getByRole('row', { name: /Previous conversation/ })
+      expect(
+        within(unreadRow).getByRole('cell', {
+          name: 'agentV2.agentDetail.logs.table.unread',
+        }),
+      ).toBeInTheDocument()
+      expect(
+        within(readRow).queryByText('agentV2.agentDetail.logs.table.unread'),
+      ).not.toBeInTheDocument()
     })
 
     it('should keep existing log rows visible while filter changes refetch', async () => {

--- a/web/features/agent-v2/agent-detail/logs/components/logs-table.tsx
+++ b/web/features/agent-v2/agent-detail/logs/components/logs-table.tsx
@@ -13,12 +13,18 @@ import { useTranslation } from 'react-i18next'
 import useTimestamp from '@/hooks/use-timestamp'
 import { LogSourceCell } from './source-cell'
 
+export type AgentLogsSort = {
+  field: 'created_at' | 'updated_at'
+  order: 'asc' | 'desc'
+}
+
 export function AgentLogsTable({
   logs,
   isPending,
   isError,
   isSuccess,
   selectedLogId,
+  sort,
   onOpenLog,
   onRetry,
 }: {
@@ -27,6 +33,7 @@ export function AgentLogsTable({
   isError: boolean
   isSuccess: boolean
   selectedLogId?: string
+  sort: AgentLogsSort
   onOpenLog: (log: AgentLogConversationItemResponse) => void
   onRetry: () => void
 }) {
@@ -48,7 +55,7 @@ export function AgentLogsTable({
       <div className="shrink-0 pr-3">
         <table aria-hidden="true" className="w-full table-fixed border-collapse">
           <LogsTableColGroup />
-          <LogsTableHeader labels={tableHeaderLabels} />
+          <LogsTableHeader labels={tableHeaderLabels} sort={sort} />
         </table>
       </div>
 
@@ -62,7 +69,7 @@ export function AgentLogsTable({
           <ScrollAreaContent className="pr-3">
             <table className="w-full table-fixed border-collapse">
               <LogsTableColGroup />
-              <LogsTableHeader labels={tableHeaderLabels} rowClassName="sr-only" />
+              <LogsTableHeader labels={tableHeaderLabels} sort={sort} rowClassName="sr-only" />
               <AgentLogsTableBody
                 logs={logs}
                 isPending={isPending}
@@ -144,11 +151,15 @@ function AgentLogsTableBody({
             >
               <td className="px-0">
                 <span
+                  aria-hidden
                   className={cn(
                     'mx-auto block size-1.5 rounded-full',
                     log.unread ? 'bg-util-colors-blue-blue-500' : 'bg-transparent',
                   )}
                 />
+                {log.unread && (
+                  <span className="sr-only">{t(($) => $['agentDetail.logs.table.unread'])}</span>
+                )}
               </td>
               <TableCell>
                 <button
@@ -202,10 +213,13 @@ type LogsTableHeaderLabels = {
 function LogsTableHeader({
   labels,
   rowClassName,
+  sort,
 }: {
   labels: LogsTableHeaderLabels
   rowClassName?: string
+  sort: AgentLogsSort
 }) {
+  const sortDirection = sort.order === 'asc' ? 'ascending' : 'descending'
   return (
     <thead>
       <tr
@@ -223,8 +237,15 @@ function LogsTableHeader({
         <TableHead>{labels.messageCount}</TableHead>
         <TableHead>{labels.userRate}</TableHead>
         <TableHead>{labels.operationRate}</TableHead>
-        <TableHead>{labels.updatedTime}</TableHead>
-        <TableHead className="rounded-r-lg">{labels.createdTime}</TableHead>
+        <TableHead aria-sort={sort.field === 'updated_at' ? sortDirection : undefined}>
+          {labels.updatedTime}
+        </TableHead>
+        <TableHead
+          aria-sort={sort.field === 'created_at' ? sortDirection : undefined}
+          className="rounded-r-lg"
+        >
+          {labels.createdTime}
+        </TableHead>
       </tr>
     </thead>
   )

--- a/web/features/agent-v2/agent-detail/logs/page.tsx
+++ b/web/features/agent-v2/agent-detail/logs/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { AgentLogConversationItemResponse } from '@dify/contracts/api/console/agent/types.gen'
+import type { AgentLogsSort } from './components/logs-table'
 import type { SourceFilterValue } from './components/source-picker'
 import {
   Drawer,
@@ -27,8 +28,6 @@ import { AgentLogsTable } from './components/logs-table'
 import { AgentLogSourcePicker } from './components/source-picker'
 
 type PeriodKey = 'last7days' | 'last30days' | 'allTime'
-type LogsSortField = 'created_at' | 'updated_at'
-type LogsSortOrder = 'asc' | 'desc'
 
 type AgentLogsPageProps = {
   agentId: string
@@ -58,12 +57,7 @@ const getPeriodQuery = (period: PeriodKey) => {
   }
 }
 
-const parseSortValue = (
-  value: string,
-): {
-  field: LogsSortField
-  order: LogsSortOrder
-} => {
+const parseSortValue = (value: string): AgentLogsSort => {
   const isDescending = value.startsWith('-')
   const field = isDescending ? value.slice(1) : value
 
@@ -82,7 +76,7 @@ export function AgentLogsPage({ agentId }: AgentLogsPageProps) {
   const [period, setPeriod] = useState<PeriodKey>('last7days')
   const [source, setSource] = useState<SourceFilterValue>([])
   const [keyword, setKeyword] = useState('')
-  const [sort, setSort] = useState<{ field: LogsSortField; order: LogsSortOrder }>({
+  const [sort, setSort] = useState<AgentLogsSort>({
     field: 'created_at',
     order: 'desc',
   })
@@ -223,6 +217,7 @@ export function AgentLogsPage({ agentId }: AgentLogsPageProps) {
           isError={logsQuery.isError}
           isSuccess={logsQuery.isSuccess}
           selectedLogId={selectedLog?.id}
+          sort={sort}
           onOpenLog={setSelectedLog}
           onRetry={() => {
             void logsQuery.refetch()

--- a/web/i18n/ar-TN/common.json
+++ b/web/i18n/ar-TN/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "هل أنت متأكد أنك تريد إزالة صورة ملفك الشخصي؟ سيستخدم حسابك الصورة الرمزية الأولية الافتراضية.",
   "avatar.deleteTitle": "إزالة الصورة الرمزية",
   "avatar.editAction": "تعديل الصورة الرمزية",
+  "calendar.selectedDate": "تم التحديد",
   "chat.citation.characters": "الشخصيات:",
   "chat.citation.hitCount": "عدد الاسترجاع:",
   "chat.citation.hitScore": "درجة الاسترجاع:",

--- a/web/i18n/de-DE/common.json
+++ b/web/i18n/de-DE/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Bist du sicher, dass du dein Profilbild entfernen möchtest? Dein Konto wird das standardmäßige Anfangs-Avatar verwenden.",
   "avatar.deleteTitle": "Avatar entfernen",
   "avatar.editAction": "Avatar bearbeiten",
+  "calendar.selectedDate": "Ausgewählt",
   "chat.citation.characters": "Zeichen:",
   "chat.citation.hitCount": "Abrufanzahl:",
   "chat.citation.hitScore": "Abrufwertung:",

--- a/web/i18n/en-US/common.json
+++ b/web/i18n/en-US/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Are you sure you want to remove your profile picture? Your account will use the default initial avatar.",
   "avatar.deleteTitle": "Remove Avatar",
   "avatar.editAction": "Edit Avatar",
+  "calendar.selectedDate": "Selected",
   "chat.citation.characters": "Characters:",
   "chat.citation.hitCount": "Retrieval count:",
   "chat.citation.hitScore": "Retrieval Score:",

--- a/web/i18n/es-ES/common.json
+++ b/web/i18n/es-ES/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "¿Estás seguro de que deseas eliminar tu foto de perfil? Tu cuenta usará el avatar inicial predeterminado.",
   "avatar.deleteTitle": "Eliminar Avatar",
   "avatar.editAction": "Editar Avatar",
+  "calendar.selectedDate": "Seleccionada",
   "chat.citation.characters": "Caracteres:",
   "chat.citation.hitCount": "Conteo de recuperaciones:",
   "chat.citation.hitScore": "Puntuación de recuperación:",

--- a/web/i18n/fa-IR/common.json
+++ b/web/i18n/fa-IR/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "آیا مطمئن هستید که می‌خواهید تصویر پروفایل خود را حذف کنید؟ حساب شما از آواتار اولیه پیش‌فرض استفاده خواهد کرد.",
   "avatar.deleteTitle": "حذف آواتار",
   "avatar.editAction": "ویرایش آواتار",
+  "calendar.selectedDate": "انتخاب‌شده",
   "chat.citation.characters": "کاراکترها:",
   "chat.citation.hitCount": "تعداد بازیابی:",
   "chat.citation.hitScore": "امتیاز بازیابی:",

--- a/web/i18n/fr-FR/common.json
+++ b/web/i18n/fr-FR/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Êtes-vous sûr de vouloir supprimer votre photo de profil ? Votre compte utilisera l'avatar par défaut.",
   "avatar.deleteTitle": "Supprimer l'avatar",
   "avatar.editAction": "Modifier l'avatar",
+  "calendar.selectedDate": "Sélectionnée",
   "chat.citation.characters": "Personnages :",
   "chat.citation.hitCount": "Nombre de récupérations :",
   "chat.citation.hitScore": "Score de Récupération:",

--- a/web/i18n/hi-IN/common.json
+++ b/web/i18n/hi-IN/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "क्या आप सुनिश्चित हैं कि आप अपनी प्रोफ़ाइल तस्वीर को हटाना चाहते हैं? आपका खाता डिफ़ॉल्ट प्रारंभिक अवतार का उपयोग करेगा।",
   "avatar.deleteTitle": "अवतार हटाएँ",
   "avatar.editAction": "अवतार संपादित करें",
+  "calendar.selectedDate": "चयनित",
   "chat.citation.characters": "वर्ण:",
   "chat.citation.hitCount": "पुनः प्राप्ति गिनती:",
   "chat.citation.hitScore": "पुनः प्राप्ति स्कोर:",

--- a/web/i18n/id-ID/common.json
+++ b/web/i18n/id-ID/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Apakah Anda yakin ingin menghapus gambar profil Anda? Akun Anda akan menggunakan avatar awal default.",
   "avatar.deleteTitle": "Hapus Avatar",
   "avatar.editAction": "Edit Avatar",
+  "calendar.selectedDate": "Dipilih",
   "chat.citation.characters": "Karakter:",
   "chat.citation.hitCount": "Jumlah pengambilan:",
   "chat.citation.hitScore": "Skor Pengambilan:",

--- a/web/i18n/it-IT/common.json
+++ b/web/i18n/it-IT/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Sei sicuro di voler rimuovere la tua immagine del profilo? Il tuo account utilizzerà l'avatar iniziale predefinito.",
   "avatar.deleteTitle": "Rimuovi avatar",
   "avatar.editAction": "Modifica avatar",
+  "calendar.selectedDate": "Selezionata",
   "chat.citation.characters": "Caratteri:",
   "chat.citation.hitCount": "Conteggio dei recuperi:",
   "chat.citation.hitScore": "Punteggio di recupero:",

--- a/web/i18n/ja-JP/common.json
+++ b/web/i18n/ja-JP/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "本当にプロフィール写真を削除してもよろしいですか？あなたのアカウントはデフォルトの初期アバターを使用します。",
   "avatar.deleteTitle": "アバターを削除する",
   "avatar.editAction": "アバターを編集する",
+  "calendar.selectedDate": "選択済み",
   "chat.citation.characters": "文字数：",
   "chat.citation.hitCount": "検索回数：",
   "chat.citation.hitScore": "検索スコア：",

--- a/web/i18n/ko-KR/common.json
+++ b/web/i18n/ko-KR/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "프로필 사진을 제거하시겠습니까? 귀하의 계정은 기본 초기 아바타를 사용하게 됩니다.",
   "avatar.deleteTitle": "아바타 제거하기",
   "avatar.editAction": "아바타 편집하기",
+  "calendar.selectedDate": "선택됨",
   "chat.citation.characters": "문자수:",
   "chat.citation.hitCount": "검색 횟수:",
   "chat.citation.hitScore": "검색 점수:",

--- a/web/i18n/lo-LA/common.json
+++ b/web/i18n/lo-LA/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "ທ່ານແນ່ໃຈບໍວ່າຕ້ອງການລຶບຮູບໂປຣໄຟລ໌ຂອງທ່ານ? ບັນຊີຂອງທ່ານຈະກັບໄປໃຊ້ຮູບເລີ່ມຕົ້ນ.",
   "avatar.deleteTitle": "ລຶບຮູບໂປຣໄຟລ໌",
   "avatar.editAction": "ແກ້ໄຂຮູບໂປຣໄຟລ໌",
+  "calendar.selectedDate": "ເລືອກແລ້ວ",
   "chat.citation.characters": "ຕົວອັກສອນ:",
   "chat.citation.hitCount": "ຈຳນວນການດຶງຂໍ້ມູນ:",
   "chat.citation.hitScore": "ຄະແນນການດຶງຂໍ້ມູນ:",

--- a/web/i18n/nl-NL/common.json
+++ b/web/i18n/nl-NL/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Are you sure you want to remove your profile picture? Your account will use the default initial avatar.",
   "avatar.deleteTitle": "Remove Avatar",
   "avatar.editAction": "Avatar bewerken",
+  "calendar.selectedDate": "Geselecteerd",
   "chat.citation.characters": "Characters:",
   "chat.citation.hitCount": "Retrieval count:",
   "chat.citation.hitScore": "Retrieval Score:",

--- a/web/i18n/pl-PL/common.json
+++ b/web/i18n/pl-PL/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Czy na pewno chcesz usunąć swoje zdjęcie profilowe? Twoje konto będzie używać domyślnego, początkowego awatara.",
   "avatar.deleteTitle": "Usuń awatar",
   "avatar.editAction": "Edytuj awatar",
+  "calendar.selectedDate": "Wybrana",
   "chat.citation.characters": "Postacie:",
   "chat.citation.hitCount": "Liczba trafień:",
   "chat.citation.hitScore": "Wynik trafień:",

--- a/web/i18n/pt-BR/common.json
+++ b/web/i18n/pt-BR/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Você tem certeza de que deseja remover sua foto de perfil? Sua conta usará o avatar padrão inicial.",
   "avatar.deleteTitle": "Remover Avatar",
   "avatar.editAction": "Editar Avatar",
+  "calendar.selectedDate": "Selecionada",
   "chat.citation.characters": "Personagens:",
   "chat.citation.hitCount": "Contagem de recuperação:",
   "chat.citation.hitScore": "Pontuação de recuperação:",

--- a/web/i18n/ro-RO/common.json
+++ b/web/i18n/ro-RO/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Ești sigur că vrei să îți ștergi fotografia de profil? Contul tău va folosi avatarul inițial implicit.",
   "avatar.deleteTitle": "Îndepărtează avatarul",
   "avatar.editAction": "Editează avatarul",
+  "calendar.selectedDate": "Selectată",
   "chat.citation.characters": "Caractere:",
   "chat.citation.hitCount": "Număr de recuperări:",
   "chat.citation.hitScore": "Scor de recuperare:",

--- a/web/i18n/ru-RU/common.json
+++ b/web/i18n/ru-RU/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Вы уверены, что хотите удалить свою фотографию профиля? Ваш аккаунт будет использовать стандартный аватар.",
   "avatar.deleteTitle": "Удалить аватар",
   "avatar.editAction": "Изменить аватар",
+  "calendar.selectedDate": "Выбрана",
   "chat.citation.characters": "Символы:",
   "chat.citation.hitCount": "Количество совпадений:",
   "chat.citation.hitScore": "Оценка совпадения:",

--- a/web/i18n/sl-SI/common.json
+++ b/web/i18n/sl-SI/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Ali ste prepričani, da želite odstraniti svojo profilno sliko? Vaš račun bo uporabljal privzeti začetni avatar.",
   "avatar.deleteTitle": "Odstrani avatar",
   "avatar.editAction": "Uredi avatar",
+  "calendar.selectedDate": "Izbran",
   "chat.citation.characters": "Znakov:",
   "chat.citation.hitCount": "Število pridobivanja:",
   "chat.citation.hitScore": "Rezultat pridobivanja:",

--- a/web/i18n/th-TH/common.json
+++ b/web/i18n/th-TH/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "คุณแน่ใจหรือไม่ว่าต้องการลบรูปโปรไฟล์ของคุณ? บัญชีของคุณจะใช้รูปโปรไฟล์เริ่มต้นตามค่าเริ่มต้น.",
   "avatar.deleteTitle": "ลบอวตาร",
   "avatar.editAction": "แก้ไขอวตาร",
+  "calendar.selectedDate": "เลือกแล้ว",
   "chat.citation.characters": "อักขระ:",
   "chat.citation.hitCount": "จํานวนการดึงข้อมูล:",
   "chat.citation.hitScore": "คะแนนการดึงข้อมูล:",

--- a/web/i18n/tr-TR/common.json
+++ b/web/i18n/tr-TR/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Profil resminizi kaldırmak istediğinize emin misiniz? Hesabınız varsayılan başlangıç avatarını kullanacaktır.",
   "avatar.deleteTitle": "Avatarı kaldır",
   "avatar.editAction": "Avatarı düzenle",
+  "calendar.selectedDate": "Seçili",
   "chat.citation.characters": "Karakterler:",
   "chat.citation.hitCount": "Geri Alım Sayısı:",
   "chat.citation.hitScore": "Geri Alım Skoru:",

--- a/web/i18n/uk-UA/common.json
+++ b/web/i18n/uk-UA/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Ви впевнені, що хочете видалити своє фото профілю? Ваш обліковий запис використовуватиме стандартний початковий аватар.",
   "avatar.deleteTitle": "Видалити аватар",
   "avatar.editAction": "Редагувати аватар",
+  "calendar.selectedDate": "Вибрано",
   "chat.citation.characters": "Символів:",
   "chat.citation.hitCount": "Кількість звернень:",
   "chat.citation.hitScore": "Оцінка звернення:",

--- a/web/i18n/vi-VN/common.json
+++ b/web/i18n/vi-VN/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "Bạn có chắc chắn muốn xóa ảnh đại diện của mình không? Tài khoản của bạn sẽ sử dụng avatar mặc định.",
   "avatar.deleteTitle": "Xóa Ảnh Đại Diện",
   "avatar.editAction": "Chỉnh Sửa Ảnh Đại Diện",
+  "calendar.selectedDate": "Đã chọn",
   "chat.citation.characters": "Ký tự:",
   "chat.citation.hitCount": "Số lượt truy xuất:",
   "chat.citation.hitScore": "Điểm truy xuất:",

--- a/web/i18n/zh-Hans/common.json
+++ b/web/i18n/zh-Hans/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "确定要删除你的个人头像吗？你的账号将使用默认的首字母头像。",
   "avatar.deleteTitle": "删除头像",
   "avatar.editAction": "编辑头像",
+  "calendar.selectedDate": "已选中",
   "chat.citation.characters": "字符：",
   "chat.citation.hitCount": "召回次数：",
   "chat.citation.hitScore": "召回得分：",

--- a/web/i18n/zh-Hant/common.json
+++ b/web/i18n/zh-Hant/common.json
@@ -107,6 +107,7 @@
   "avatar.deleteDescription": "您確定要刪除您的個人資料照片嗎？您的帳戶將使用默認的初始頭像。",
   "avatar.deleteTitle": "移除頭像",
   "avatar.editAction": "編輯頭像",
+  "calendar.selectedDate": "已選取",
   "chat.citation.characters": "字元：",
   "chat.citation.hitCount": "檢索次數：",
   "chat.citation.hitScore": "檢索得分：",


### PR DESCRIPTION
## Summary

- Restore native table and column-header semantics in document, log, annotation, CSV preview, member, and archive views without adding unnecessary `scope="col"` attributes.
- Expose sorting and unread states, label document switches, and make document navigation, retrieval-history reuse, and Webhook row deletion accessible by keyboard.
- Give calendar buttons localized Gregorian date names, selected/today states, native disabled behavior, and visible focus.

Fixes SNP-788

[Linear issue](https://linear.app/dify/issue/SNP-788)

## Validation

- Scoped format, lint, and type checks passed with 0 errors (25 warnings).
- Full repository check failed in unchanged main-navigation files: missing local `bowser` dependency (TS2307) and unsupported React `onBrowserBailout` option (TS2353).

- 3,608 unit tests passed across 219 files in the expanded regression run.
- 2 Chromium Browser Mode tests passed for the date picker and Webhook deletion focus.
- E2E locator audit found no affected steps; full E2E execution was not performed because the local runtime services were unavailable.
- Actual screen-reader testing and full-page visual verification remain outstanding.

From Codex
