### PR TITLE
fix(agent): persist plugin blob outputs and show attachments in logs

### DIFF
--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -44,12 +44,13 @@ from core.app.apps.agent_app.session_store import (
 )
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.exc import GenerateTaskStoppedError
-from core.app.entities.app_invoke_entities import DifyRunContext
+from core.app.entities.app_invoke_entities import DifyRunContext, InvokeFrom
 from core.app.entities.queue_entities import (
     QueueAgentMessageEvent,
     QueueAgentThoughtEvent,
     QueueLLMChunkEvent,
     QueueMessageEndEvent,
+    QueueMessageFileEvent,
 )
 from core.repositories.human_input_repository import HumanInputFormRepository, HumanInputFormRepositoryImpl
 from core.workflow.nodes.agent_v2.ask_human_hitl import AskHumanFormBuildError, create_ask_human_form
@@ -67,8 +68,10 @@ from graphon.model_runtime.errors.invoke import (
 )
 from models.agent import AgentConfigVersionKind
 from models.agent_config_entities import AgentSoulConfig
-from models.enums import CreatorUserRole
-from models.model import Message, MessageAgentThought
+from graphon.file import FileTransferMethod, FileType
+from models.enums import CreatorUserRole, MessageFileBelongsTo
+from models.model import Message, MessageAgentThought, MessageFile
+from models.tools import ToolFile
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +90,28 @@ _AGENT_BACKEND_INVOKE_ERROR_BY_REASON: Mapping[str, type[InvokeError]] = {
     "InvokeRateLimitError": InvokeRateLimitError,
     "InvokeServerUnavailableError": InvokeServerUnavailableError,
 }
+
+
+def _resolve_tool_file_type(tool_file_payload: dict[str, Any], tool_file: ToolFile) -> FileType:
+    payload_type = tool_file_payload.get("type")
+    if isinstance(payload_type, str):
+        try:
+            return FileType(payload_type)
+        except ValueError:
+            pass
+    mime_type = tool_file_payload.get("mime_type")
+    if not isinstance(mime_type, str) or not mime_type:
+        mime_type = tool_file.mimetype
+    if isinstance(mime_type, str):
+        if "image" in mime_type:
+            return FileType.IMAGE
+        if "video" in mime_type:
+            return FileType.VIDEO
+        if "audio" in mime_type:
+            return FileType.AUDIO
+        if "text" in mime_type or "pdf" in mime_type:
+            return FileType.DOCUMENT
+    return FileType.CUSTOM
 
 
 def _agent_backend_failure_to_exception(event: AgentBackendRunFailedInternalEvent) -> Exception:
@@ -436,6 +461,62 @@ class _AgentProcessRecorder:
         if content is None:
             content = part
         self._record_tool_observation(tool_call_id=tool_call_id, tool_name=tool_name, observation=content)
+        self._persist_tool_files_from_metadata(part.get("metadata"))
+
+    def _persist_tool_files_from_metadata(self, metadata: Any) -> None:
+        if not isinstance(metadata, dict):
+            return
+        tool_files = metadata.get("tool_files")
+        if not isinstance(tool_files, list) or not tool_files:
+            return
+
+        message = db.session.get(Message, self._message_id)
+        if message is None:
+            return
+
+        created_role = (
+            CreatorUserRole.ACCOUNT
+            if self._dify_context.invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}
+            else CreatorUserRole.END_USER
+        )
+        for tool_file_payload in tool_files:
+            if not isinstance(tool_file_payload, dict):
+                continue
+            tool_file_id = tool_file_payload.get("tool_file_id")
+            if not isinstance(tool_file_id, str) or not tool_file_id:
+                continue
+            tool_file = db.session.get(ToolFile, tool_file_id)
+            if tool_file is None or tool_file.tenant_id != self._dify_context.tenant_id:
+                continue
+            if message.conversation_id and tool_file.conversation_id not in {None, message.conversation_id}:
+                continue
+            if tool_file.user_id != self._dify_context.user_id:
+                continue
+
+            url = tool_file_payload.get("url")
+            if not isinstance(url, str) or not url:
+                extension = tool_file_payload.get("extension")
+                if isinstance(extension, str) and extension and not extension.startswith("."):
+                    extension = f".{extension}"
+                url = f"/files/tools/{tool_file_id}{extension if isinstance(extension, str) else '.bin'}"
+
+            file_type = _resolve_tool_file_type(tool_file_payload, tool_file)
+            message_file = MessageFile(
+                message_id=self._message_id,
+                type=file_type,
+                transfer_method=FileTransferMethod.TOOL_FILE,
+                belongs_to=MessageFileBelongsTo.ASSISTANT,
+                url=url,
+                upload_file_id=tool_file_id,
+                created_by_role=created_role,
+                created_by=self._dify_context.user_id,
+            )
+            db.session.add(message_file)
+            db.session.commit()
+            self._queue_manager.publish(
+                QueueMessageFileEvent(message_file_id=message_file.id),
+                PublishFrom.APPLICATION_MANAGER,
+            )
 
     def _record_tool_observation(self, *, tool_call_id: str | None, tool_name: str | None, observation: Any) -> None:
         self._close_thinking_segments()

--- a/api/fields/agent_fields.py
+++ b/api/fields/agent_fields.py
@@ -4,6 +4,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from fields.base import ResponseModel
+from fields.conversation_fields import MessageFile
 from libs.helper import to_timestamp
 from models.agent import (
     AgentConfigDraftType,
@@ -189,6 +190,7 @@ class AgentLogMessageItemResponse(ResponseModel):
     from_account_id: str | None = None
     feedback_enabled: bool = False
     feedbacks: list[AgentLogFeedbackResponse] = Field(default_factory=list)
+    message_files: list[MessageFile] = Field(default_factory=list)
     message_tokens: int
     answer_tokens: int
     total_tokens: int

--- a/api/services/agent/observability_service.py
+++ b/api/services/agent/observability_service.py
@@ -143,8 +143,16 @@ class AgentObservabilityService:
         message: Message,
         conversation: Conversation | None = None,
         feedbacks: Sequence[MessageFeedback] = (),
+        *,
+        session: Any | None = None,
     ) -> dict[str, Any]:
         invoke_from = message.invoke_from.value if message.invoke_from else None
+        message_files: list[dict[str, Any]] = []
+        if session is not None:
+            message_files = [
+                dict(file_info)
+                for file_info in message.message_files_with_session(session=session)
+            ]
         return {
             "id": message.id,
             "message_id": message.id,
@@ -160,6 +168,7 @@ class AgentObservabilityService:
             "from_account_id": message.from_account_id,
             "feedback_enabled": True,
             "feedbacks": [cls._serialize_message_feedback(feedback) for feedback in feedbacks],
+            "message_files": message_files,
             "message_tokens": int(message.message_tokens or 0),
             "answer_tokens": int(message.answer_tokens or 0),
             "total_tokens": cls._total_tokens(message),
@@ -219,6 +228,7 @@ class AgentObservabilityService:
                     self.serialize_log_message(
                         message,
                         feedbacks=feedbacks_by_message.get(message.id, ()),
+                        session=self._session,
                     )
                     for message in messages
                 )

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -63,6 +63,7 @@ from core.app.entities.queue_entities import (
     QueueAgentThoughtEvent,
     QueueLLMChunkEvent,
     QueueMessageEndEvent,
+    QueueMessageFileEvent,
 )
 from core.workflow.nodes.agent_v2.ask_human_resume import AskHumanResumeOutcome
 from core.workflow.nodes.agent_v2.dify_tools_builder import WorkflowAgentToolLayers
@@ -70,7 +71,8 @@ from graphon.model_runtime.entities.llm_entities import LLMResult, LLMUsage
 from graphon.model_runtime.errors.invoke import InvokeRateLimitError
 from models.agent_config_entities import AgentSoulConfig
 from models.enums import ConversationFromSource
-from models.model import AppMode, Message, MessageAgentThought
+from models.model import AppMode, Message, MessageAgentThought, MessageFile
+from models.tools import ToolFile
 
 
 @pytest.fixture(autouse=True)
@@ -1117,6 +1119,64 @@ def test_tool_call_part_binds_late_call_id_to_delta_row(sqlite_session: Session)
     assert rows[0].tool == "knowledge_base_search"
     assert rows[0].tool_input == '{"query": "browser"}'
     assert rows[0].observation == "Knowledge base search results: browser skill"
+
+
+def test_tool_return_metadata_persists_assistant_message_files(sqlite_session: Session) -> None:
+    message = _message_record()
+    sqlite_session.add(message)
+    tool_file = ToolFile(
+        user_id="user-1",
+        tenant_id="tenant-1",
+        conversation_id="conv-1",
+        file_key="tool-files/tool-file-1",
+        mimetype="image/png",
+        name="cat.png",
+        size=128,
+    )
+    tool_file.id = "tool-file-1"
+    sqlite_session.add(tool_file)
+    sqlite_session.commit()
+
+    qm = _FakeQueueManager()
+    recorder = app_runner_module._AgentProcessRecorder(
+        dify_context=_dify_ctx(),
+        message_id=message.id,
+        queue_manager=qm,  # type: ignore[arg-type]
+    )
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_result",
+                "part": {
+                    "part_kind": "tool-return",
+                    "tool_name": "gpt_image_2_generate",
+                    "content": (
+                        "image has been created and sent to user already, "
+                        "you do not need to create it, just tell the user to check it now."
+                    ),
+                    "tool_call_id": "tool-call-1",
+                    "metadata": {
+                        "tool_files": [
+                            {
+                                "tool_file_id": "tool-file-1",
+                                "url": "/files/tools/tool-file-1.png",
+                                "mime_type": "image/png",
+                                "type": "image",
+                                "transfer_method": "tool_file",
+                            }
+                        ]
+                    },
+                },
+            },
+        )
+    )
+
+    message_files = list(sqlite_session.scalars(select(MessageFile).where(MessageFile.message_id == message.id)).all())
+    assert len(message_files) == 1
+    assert message_files[0].upload_file_id == "tool-file-1"
+    assert message_files[0].belongs_to.value == "assistant"
+    assert any(isinstance(event, QueueMessageFileEvent) for event in qm.events)
 
 
 def test_thinking_after_tool_starts_new_snapshot_row(sqlite_session: Session) -> None:

--- a/api/tests/unit_tests/services/agent/test_agent_observability_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_observability_service.py
@@ -658,6 +658,7 @@ def test_serialize_log_message_returns_frontend_log_shape() -> None:
             {"rating": "like", "content": "Useful", "from_source": "user"},
             {"rating": "dislike", "content": "Needs more detail", "from_source": "admin"},
         ],
+        "message_files": [],
         "message_tokens": 3,
         "answer_tokens": 4,
         "total_tokens": 7,

--- a/dify-agent/src/dify_agent/layers/dify_plugin/tools_layer.py
+++ b/dify-agent/src/dify_agent/layers/dify_plugin/tools_layer.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel, ConfigDict, JsonValue, ValidationError
-from pydantic_ai import RunContext, Tool
+from pydantic_ai import RunContext, Tool, ToolReturn
 from pydantic_ai.tools import ToolDefinition
 from typing_extensions import Self, override
 
@@ -55,7 +55,10 @@ PLUGIN_FILE_DEFAULT_TYPE = "custom"
 _FILE_UPLOAD_BEGIN = "<<<DIFY_PLUGIN_TOOL_FILE_UPLOAD_BEGIN>>>"
 _FILE_UPLOAD_END = "<<<DIFY_PLUGIN_TOOL_FILE_UPLOAD_END>>>"
 _FILE_UPLOAD_TIMEOUT_SECONDS = 60.0
+_TOOL_BLOB_UPLOAD_TIMEOUT_SECONDS = 120.0
+_MAX_TOOL_BLOB_UPLOAD_BYTES = 30 * 1024 * 1024
 _SUPPORTED_REMOTE_URL_PREFIXES = ("http://", "https://")
+_TOOL_FILE_URL_PATTERN = "/files/tools/"
 
 
 class DifyPluginToolsDeps(LayerDeps):
@@ -81,6 +84,18 @@ class _DownloadFileResponse(BaseModel):
     mime_type: str | None = None
     size: int
     download_url: str
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+
+class _UploadedToolFileResponse(BaseModel):
+    id: str
+    reference: str | None = None
+    name: str
+    size: int
+    extension: str | None = None
+    mime_type: str | None = None
+    preview_url: str | None = None
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
@@ -152,6 +167,92 @@ class _DifyPluginToolFileClient:
             return _DownloadFileResponse.model_validate(envelope.data)
         except ValidationError as exc:
             raise DifyPluginToolClientError("Invalid Dify API file download data.") from exc
+
+    async def upload_blob(
+        self,
+        *,
+        execution_context: DifyExecutionContextLayerConfig,
+        blob: bytes,
+        mimetype: str,
+        filename: str | None = None,
+    ) -> _UploadedToolFileResponse:
+        missing_fields = []
+        if execution_context.user_id is None:
+            missing_fields.append("user_id")
+        if execution_context.user_from is None:
+            missing_fields.append("user_from")
+        if missing_fields:
+            missing = ", ".join(missing_fields)
+            raise DifyPluginToolsClientConfigurationError(
+                f"Missing required execution context fields for blob uploads: {missing}."
+            )
+        if len(blob) > _MAX_TOOL_BLOB_UPLOAD_BYTES:
+            raise DifyPluginToolClientError(
+                f"Tool blob exceeds the {_MAX_TOOL_BLOB_UPLOAD_BYTES} byte upload limit.",
+                status_code=413,
+            )
+
+        resolved_filename = filename or _default_blob_filename(mimetype)
+        upload_request_payload = {
+            "tenant_id": execution_context.tenant_id,
+            "user_id": execution_context.user_id,
+            "user_from": execution_context.user_from,
+            "filename": resolved_filename,
+            "mimetype": mimetype,
+            "conversation_id": execution_context.conversation_id,
+            "max_size": _MAX_TOOL_BLOB_UPLOAD_BYTES,
+        }
+        try:
+            upload_request = await self.http_client.post(
+                f"{self.base_url}/inner/api/agent/files/upload-request",
+                headers={
+                    "X-Inner-Api-Key": self.api_key,
+                    "Content-Type": "application/json",
+                },
+                json=upload_request_payload,
+                timeout=_TOOL_BLOB_UPLOAD_TIMEOUT_SECONDS,
+            )
+        except (httpx.InvalidURL, httpx.UnsupportedProtocol) as exc:
+            raise DifyPluginToolClientError(f"Dify API file upload is misconfigured: {exc}") from exc
+        except httpx.TimeoutException as exc:
+            raise DifyPluginToolClientError("Dify API file upload request timed out.") from exc
+        except httpx.RequestError as exc:
+            raise DifyPluginToolClientError(f"Dify API file upload request failed: {exc}") from exc
+
+        if upload_request.status_code >= 400:
+            raise DifyPluginToolClientError(
+                upload_request.text or f"HTTP {upload_request.status_code}",
+                status_code=upload_request.status_code,
+            )
+        try:
+            upload_request_body = upload_request.json()
+        except ValueError as exc:
+            raise DifyPluginToolClientError("Invalid Dify API file upload request response.") from exc
+        upload_uri = upload_request_body.get("upload_uri")
+        if not isinstance(upload_uri, str) or not upload_uri:
+            raise DifyPluginToolClientError("Dify API file upload request response is missing upload_uri.")
+
+        upload_url = upload_uri if _is_remote_url(upload_uri) else f"{self.base_url.rstrip('/')}{upload_uri}"
+        try:
+            upload_response = await self.http_client.post(
+                upload_url,
+                files={"file": (resolved_filename, blob, mimetype)},
+                timeout=_TOOL_BLOB_UPLOAD_TIMEOUT_SECONDS,
+            )
+        except httpx.TimeoutException as exc:
+            raise DifyPluginToolClientError("Dify API file upload timed out.") from exc
+        except httpx.RequestError as exc:
+            raise DifyPluginToolClientError(f"Dify API file upload failed: {exc}") from exc
+
+        if upload_response.status_code >= 400:
+            raise DifyPluginToolClientError(
+                upload_response.text or f"HTTP {upload_response.status_code}",
+                status_code=upload_response.status_code,
+            )
+        try:
+            return _UploadedToolFileResponse.model_validate(upload_response.json())
+        except ValidationError as exc:
+            raise DifyPluginToolClientError("Invalid Dify API file upload response.") from exc
 
 
 @dataclass(slots=True)
@@ -259,7 +360,7 @@ def _build_pydantic_ai_tool(
     tool_description = tool_config.description or tool_name
     tool_schema = deepcopy(tool_config.parameters_json_schema)
 
-    async def invoke_tool(_ctx: RunContext[object], **tool_arguments: object) -> str:
+    async def invoke_tool(_ctx: RunContext[object], **tool_arguments: object) -> str | ToolReturn:
         try:
             merged_arguments = await _prepare_tool_arguments(
                 effective_parameters,
@@ -274,7 +375,18 @@ def _build_pydantic_ai_tool(
                 credentials=dict(tool_config.credentials),
                 tool_parameters=merged_arguments,
             )
-            return _convert_tool_response_to_text(messages)
+            observation, tool_files = await _convert_tool_response(
+                messages,
+                file_client=file_context.file_client,
+                execution_context=file_context.execution_context,
+            )
+            if tool_files:
+                return ToolReturn(
+                    return_value=observation,
+                    content=observation,
+                    metadata={"tool_files": tool_files},
+                )
+            return observation
         except DifyPluginToolClientError as exc:
             return _tool_error_text(tool_name=tool_name, error=exc)
         except ValueError as exc:
@@ -633,18 +745,21 @@ def _tool_error_text(*, tool_name: str, error: DifyPluginToolClientError) -> str
     return f"tool invoke error: {error}"
 
 
-def _convert_tool_response_to_text(tool_response: Sequence[DifyPluginToolInvokeMessage]) -> str:
-    """Convert daemon stream messages into the plain-text tool observation.
+async def _convert_tool_response(
+    tool_response: Sequence[DifyPluginToolInvokeMessage],
+    *,
+    file_client: _DifyPluginToolFileClient,
+    execution_context: DifyExecutionContextLayerConfig,
+) -> tuple[str, list[dict[str, object]]]:
+    """Convert daemon stream messages into a compact observation and file metadata.
 
-    This preserves the user-facing semantics Dify's agent tool runtime relies on:
-    text is appended directly, links/images become user-check instructions, JSON
-    output is included unless explicitly suppressed, variable messages stay
-    internal, and everything else falls back to ``str(message)``. JSON fragments
-    are deduplicated against existing text so mixed text/JSON streams do not
-    repeat the same content unnecessarily.
+    Binary BLOB outputs are persisted through Dify's signed upload API so the
+    model receives a short description plus reusable file references instead of
+    a Python-style byte representation.
     """
     parts: list[str] = []
     json_parts: list[str] = []
+    tool_files: list[dict[str, object]] = []
 
     for response in tool_response:
         if response.type is DifyPluginToolInvokeMessage.MessageType.TEXT:
@@ -655,6 +770,9 @@ def _convert_tool_response_to_text(tool_response: Sequence[DifyPluginToolInvokeM
             link_message = response.message
             if isinstance(link_message, DifyPluginToolInvokeMessage.TextMessage):
                 parts.append(f"result link: {link_message.text}. please tell user to check it.")
+                tool_file = _tool_file_metadata_from_meta_or_url(response.meta, link_message.text)
+                if tool_file is not None:
+                    tool_files.append(tool_file)
         elif response.type in {
             DifyPluginToolInvokeMessage.MessageType.IMAGE_LINK,
             DifyPluginToolInvokeMessage.MessageType.IMAGE,
@@ -663,6 +781,45 @@ def _convert_tool_response_to_text(tool_response: Sequence[DifyPluginToolInvokeM
                 "image has been created and sent to user already, "
                 "you do not need to create it, just tell the user to check it now."
             )
+            link_message = response.message
+            if isinstance(link_message, DifyPluginToolInvokeMessage.TextMessage):
+                tool_file = _tool_file_metadata_from_meta_or_url(response.meta, link_message.text, file_type="image")
+                if tool_file is not None:
+                    tool_files.append(tool_file)
+        elif response.type is DifyPluginToolInvokeMessage.MessageType.BINARY_LINK:
+            link_message = response.message
+            if isinstance(link_message, DifyPluginToolInvokeMessage.TextMessage):
+                parts.append(
+                    f"generated file: {link_message.text}. please tell the user to check the attachment."
+                )
+                tool_file = _tool_file_metadata_from_meta_or_url(response.meta, link_message.text)
+                if tool_file is not None:
+                    tool_files.append(tool_file)
+        elif response.type is DifyPluginToolInvokeMessage.MessageType.BLOB:
+            meta = response.meta or {}
+            mimetype = meta.get("mime_type") if isinstance(meta.get("mime_type"), str) else None
+            mimetype = mimetype or "application/octet-stream"
+            filename = meta.get("filename") if isinstance(meta.get("filename"), str) else None
+            if not isinstance(response.message, DifyPluginToolInvokeMessage.BlobMessage):
+                raise ValueError("unexpected blob message payload")
+            uploaded = await file_client.upload_blob(
+                execution_context=execution_context,
+                blob=response.message.blob,
+                mimetype=mimetype,
+                filename=filename,
+            )
+            tool_file = _tool_file_metadata_from_upload(uploaded)
+            tool_files.append(tool_file)
+            if "image" in (uploaded.mime_type or mimetype):
+                parts.append(
+                    "image has been created and sent to user already, "
+                    "you do not need to create it, just tell the user to check it now."
+                )
+            else:
+                parts.append(
+                    f"generated file `{uploaded.name}` has been saved. "
+                    "please tell the user to check the attachment."
+                )
         elif response.type is DifyPluginToolInvokeMessage.MessageType.JSON:
             json_message = response.message
             if isinstance(json_message, DifyPluginToolInvokeMessage.JsonMessage) and not json_message.suppress_output:
@@ -675,7 +832,64 @@ def _convert_tool_response_to_text(tool_response: Sequence[DifyPluginToolInvokeM
     if json_parts:
         existing_parts = set(parts)
         parts.extend(part for part in json_parts if part not in existing_parts)
-    return "".join(parts)
+    return "".join(parts), tool_files
+
+
+def _default_blob_filename(mimetype: str) -> str:
+    extension = mimetypes.guess_extension(mimetype) or ".bin"
+    return f"tool-output{extension}"
+
+
+def _tool_file_metadata_from_upload(uploaded: _UploadedToolFileResponse) -> dict[str, object]:
+    extension = uploaded.extension or _extension_from_filename(uploaded.name) or ".bin"
+    return {
+        "tool_file_id": uploaded.id,
+        "reference": uploaded.reference,
+        "filename": uploaded.name,
+        "mime_type": uploaded.mime_type,
+        "url": f"{_TOOL_FILE_URL_PATTERN}{uploaded.id}{extension}",
+        "transfer_method": "tool_file",
+        "type": "image" if uploaded.mime_type and "image" in uploaded.mime_type else "custom",
+    }
+
+
+def _tool_file_metadata_from_meta_or_url(
+    meta: Mapping[str, object] | None,
+    url: str,
+    *,
+    file_type: str | None = None,
+) -> dict[str, object] | None:
+    normalized_meta = dict(meta or {})
+    tool_file_id = normalized_meta.get("tool_file_id")
+    if not isinstance(tool_file_id, str) or not tool_file_id:
+        tool_file_id = _extract_tool_file_id(url)
+    if not tool_file_id:
+        return None
+    mime_type = normalized_meta.get("mime_type")
+    filename = normalized_meta.get("filename")
+    extension = _extension_from_filename(filename if isinstance(filename, str) else None)
+    resolved_type = file_type
+    if resolved_type is None and isinstance(mime_type, str) and "image" in mime_type:
+        resolved_type = "image"
+    return {
+        "tool_file_id": tool_file_id,
+        "reference": normalized_meta.get("reference"),
+        "filename": filename,
+        "mime_type": mime_type,
+        "url": url,
+        "transfer_method": "tool_file",
+        "type": resolved_type or "custom",
+        **({"extension": extension} if extension else {}),
+    }
+
+
+def _extract_tool_file_id(url: str) -> str | None:
+    if _TOOL_FILE_URL_PATTERN not in url:
+        return None
+    file_part = url.split(_TOOL_FILE_URL_PATTERN, 1)[-1].split("?")[0]
+    if not file_part:
+        return None
+    return file_part.rsplit(".", 1)[0] if "." in file_part else file_part
 
 
 __all__ = ["DifyPluginToolsDeps", "DifyPluginToolsLayer"]

--- a/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_layers.py
+++ b/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_layers.py
@@ -224,6 +224,18 @@ def _invoke_stream_response(
     return httpx.Response(200, text=stream_payload)
 
 
+def _uploaded_tool_file_response() -> dict[str, object]:
+    return {
+        "id": "tool-file-1",
+        "reference": "dify-file-ref:tool-file-1",
+        "name": "tool-output.bin",
+        "size": 11,
+        "extension": ".bin",
+        "mime_type": "application/octet-stream",
+        "preview_url": "/files/tools/tool-file-1.bin",
+    }
+
+
 def _tool_transport(
     *,
     invoke_error_payload: dict[str, object] | None = None,
@@ -243,6 +255,15 @@ def _tool_transport(
                 "auth_scope": "workspace",
             }
             return _invoke_stream_response(error_payload=invoke_error_payload, chunked_blob=chunked_blob)
+
+        if request.url.path.endswith("/inner/api/agent/files/upload-request"):
+            payload = json.loads(request.content.decode("utf-8"))
+            assert payload["tenant_id"] == "tenant-1"
+            assert payload["user_id"] == "user-1"
+            return httpx.Response(200, json={"upload_uri": "/files/upload/for-plugin?sign=test"})
+
+        if request.url.path.endswith("/files/upload/for-plugin"):
+            return httpx.Response(201, json=_uploaded_tool_file_response())
 
         raise AssertionError(f"Unexpected request path: {request.url.path}")
 
@@ -1041,7 +1062,88 @@ def test_dify_plugin_tools_layer_merges_blob_chunks_before_observation_conversio
                     None,  # pyright: ignore[reportArgumentType]
                 )
 
-                assert "hello world" in result
-                assert "sequence=0" not in result
+                assert hasattr(result, "metadata")
+                assert "generated file" in str(result.content)
+                assert "sequence=0" not in str(result.content)
+                assert result.metadata == {
+                    "tool_files": [
+                        {
+                            "tool_file_id": "tool-file-1",
+                            "reference": "dify-file-ref:tool-file-1",
+                            "filename": "tool-output.bin",
+                            "mime_type": "application/octet-stream",
+                            "url": "/files/tools/tool-file-1.bin",
+                            "transfer_method": "tool_file",
+                            "type": "custom",
+                        }
+                    ]
+                }
+
+    asyncio.run(scenario())
+
+
+def test_dify_plugin_tools_layer_uploads_image_blob_and_returns_compact_observation() -> None:
+    async def scenario() -> None:
+        compositor = Compositor(
+            [
+                LayerNode("execution_context", _execution_context_provider()),
+                LayerNode("tools", _tools_provider(), deps={"execution_context": "execution_context"}),
+            ]
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/dispatch/tool/invoke"):
+                stream_payload = "\n".join(
+                    [
+                        "data: "
+                        + json.dumps(
+                            {
+                                "code": 0,
+                                "message": "ok",
+                                "data": {
+                                    "type": "blob",
+                                    "message": {"blob": "aGVsbG8="},
+                                    "meta": {"mime_type": "image/png", "filename": "cat.png"},
+                                },
+                            }
+                        ),
+                        "",
+                    ]
+                )
+                return httpx.Response(200, text=stream_payload)
+            if request.url.path.endswith("/inner/api/agent/files/upload-request"):
+                return httpx.Response(200, json={"upload_uri": "/files/upload/for-plugin?sign=test"})
+            if request.url.path.endswith("/files/upload/for-plugin"):
+                return httpx.Response(
+                    201,
+                    json={
+                        "id": "tool-file-image",
+                        "reference": "dify-file-ref:tool-file-image",
+                        "name": "cat.png",
+                        "size": 5,
+                        "extension": ".png",
+                        "mime_type": "image/png",
+                        "preview_url": "/files/tools/tool-file-image.png",
+                    },
+                )
+            raise AssertionError(f"Unexpected request path: {request.url.path}")
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            async with compositor.enter(
+                configs={"execution_context": _execution_context_config(), "tools": _tools_config()}
+            ) as run:
+                tool = (
+                    await run.get_layer("tools", DifyPluginToolsLayer).get_tools(
+                        http_client=client, dify_api_http_client=client
+                    )
+                )[0]
+                result = await tool.function_schema.call(
+                    {"query": "dify", "region": "global"},
+                    None,  # pyright: ignore[reportArgumentType]
+                )
+
+                assert "image has been created" in str(result.content)
+                assert "blob=" not in str(result.content)
+                assert result.metadata["tool_files"][0]["type"] == "image"
 
     asyncio.run(scenario())

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -837,6 +837,7 @@ export type AgentLogMessageItemResponse = {
   from_end_user_id?: string | null
   id: string
   latency: number
+  message_files?: Array<MessageFile>
   message_id: string
   message_tokens: number
   query: string

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -1199,6 +1199,7 @@ export const zAgentLogMessageItemResponse = z.object({
   from_end_user_id: z.string().nullish(),
   id: z.string(),
   latency: z.number(),
+  message_files: z.array(zMessageFile).optional(),
   message_id: z.string(),
   message_tokens: z.int(),
   query: z.string(),

--- a/web/features/agent-v2/agent-detail/logs/components/log-detail-panel.tsx
+++ b/web/features/agent-v2/agent-detail/logs/components/log-detail-panel.tsx
@@ -4,6 +4,8 @@ import type {
 } from '@dify/contracts/api/console/agent/types.gen'
 import type { IChatItem } from '@/app/components/base/chat/chat/type'
 import type { ChatConfig, OnFeedback } from '@/app/components/base/chat/types'
+import type { TransferMethod } from '@/types/app'
+import type { FileResponse } from '@/types/workflow'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
@@ -11,6 +13,7 @@ import { skipToken, useMutation, useQuery, useQueryClient } from '@tanstack/reac
 import { useTranslation } from 'react-i18next'
 import Chat from '@/app/components/base/chat/chat'
 import CopyIcon from '@/app/components/base/copy-icon'
+import { getProcessedFilesFromResponse } from '@/app/components/base/file-uploader/utils'
 import Loading from '@/app/components/base/loading'
 import useTimestamp from '@/hooks/use-timestamp'
 import { consoleQuery } from '@/service/client'
@@ -162,6 +165,21 @@ export function AgentLogDetailPanel({
   )
 }
 
+const toFileResponse = (
+  file: NonNullable<AgentLogMessageItemResponse['message_files']>[number],
+): FileResponse => ({
+  related_id: file.id ?? file.upload_file_id,
+  extension: '',
+  filename: file.filename,
+  size: file.size ?? 0,
+  mime_type: file.mime_type ?? '',
+  transfer_method: file.transfer_method as TransferMethod,
+  type: file.type,
+  url: file.url ?? '',
+  upload_file_id: file.upload_file_id ?? '',
+  remote_url: file.url ?? '',
+})
+
 function formatAgentLogMessages({
   conversationId,
   formatLogTime,
@@ -176,15 +194,20 @@ function formatAgentLogMessages({
   messages.forEach((message) => {
     const userFeedback = message.feedbacks?.find((feedback) => feedback.from_source === 'user')
     const adminFeedback = message.feedbacks?.find((feedback) => feedback.from_source === 'admin')
+    const questionFiles = message.message_files?.filter((file) => file.belongs_to === 'user') || []
+    const answerFiles =
+      message.message_files?.filter((file) => file.belongs_to === 'assistant') || []
+    const answer = message.answer || message.error || ''
     chatList.push({
       id: `question-${message.id}`,
       content: message.query,
       isAnswer: false,
+      message_files: getProcessedFilesFromResponse(questionFiles.map(toFileResponse)),
       parentMessageId: undefined,
     })
     chatList.push({
       id: message.id,
-      content: message.answer || message.error || '',
+      content: answer,
       conversationId,
       feedback: userFeedback,
       adminFeedback,
@@ -198,8 +221,13 @@ function formatAgentLogMessages({
       isAnswer: true,
       log: [
         { role: 'user', text: message.query },
-        { role: 'assistant', text: message.answer || message.error || '' },
+        {
+          role: 'assistant',
+          text: answer,
+          files: getProcessedFilesFromResponse(answerFiles.map(toFileResponse)),
+        },
       ],
+      message_files: getProcessedFilesFromResponse(answerFiles.map(toFileResponse)),
       more: {
         latency: message.latency.toFixed(2),
         time: formatLogTime(message.created_at ?? message.updated_at ?? 0),


### PR DESCRIPTION
## Summary

Fixes #42114

When plugin tools return binary BLOB outputs (for example image generation), the standalone `dify-agent` plugin tools layer was stringifying bytes into tool observations (`blob=b'\x89PNG...'`), inflating model context and omitting generated files from chat and Agents logs.

This change:

- Uploads binary plugin tool outputs through Dify's signed file-upload API
- Returns compact tool observations plus reusable file references in `ToolReturn.metadata`
- Persists assistant `MessageFile` rows and emits the existing chat file event
- Includes persisted attachments in Agents log responses
- Renders attachments in the Agents log detail panel

## Test plan

- [x] `dify-agent` plugin layer tests for blob chunk merge + upload flow
- [x] `dify-agent` plugin layer test for image blob upload compact observation
- [x] API test for tool return metadata persisting assistant message files
- [x] API test for agent log serialization including `message_files`