### PR TITLE
feat(web): support sys.conversation_id deep links for chat/agent webapps

### DIFF
--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -2218,6 +2218,38 @@ describe('useChatWithHistory', () => {
     })
   })
 
+  // Scenario: URL-provided sys.conversation_id deep-links /chat and /agent webapps (issue #41997).
+  describe('URL conversation_id deep linking', () => {
+    it('should prioritize URL conversation_id over localStorage', async () => {
+      setConversationIdInfo('app-1', 'stored-conv-id')
+      const { getProcessedSystemVariablesFromUrlParams } = await import('../../utils')
+      vi.mocked(getProcessedSystemVariablesFromUrlParams).mockResolvedValueOnce({
+        user_id: 'user-1',
+        conversation_id: 'url-conv-id',
+      })
+      mockFetchConversations.mockResolvedValue(createConversationData())
+      mockFetchChatList.mockResolvedValue({ data: [] })
+
+      const { result } = await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        expect(result!.current.currentConversationId).toBe('url-conv-id')
+      })
+    })
+
+    it('should fall back to localStorage when no URL conversation_id is provided', async () => {
+      setConversationIdInfo('app-1', 'stored-conv-id')
+      mockFetchConversations.mockResolvedValue(createConversationData())
+      mockFetchChatList.mockResolvedValue({ data: [] })
+
+      const { result } = await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        expect(result!.current.currentConversationId).toBe('stored-conv-id')
+      })
+    })
+  })
+
   // Scenario: conversation id update should no-op without appId and use DEFAULT key without userId.
   describe('handleConversationIdInfoChange fallback branches', () => {
     it('should no-op when appId is absent', async () => {

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -168,9 +168,11 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
   const appId = useMemo(() => appData?.app_id, [appData])
   const conversationScopeId = getWebAppConversationScopeId(resolveWebAppAddress(), appId)
   const [userId, setUserId] = useState<string>()
+  const [conversationId, setConversationId] = useState<string>()
   useEffect(() => {
-    getProcessedSystemVariablesFromUrlParams().then(({ user_id }) => {
+    getProcessedSystemVariablesFromUrlParams().then(({ user_id, conversation_id }) => {
       setUserId(user_id)
+      setConversationId(conversation_id)
     })
   }, [])
   useEffect(() => {
@@ -191,6 +193,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
   const { currentConversationId, handleConversationIdInfoChange } = useConversationSelection({
     scopeId: isInstalledApp || appData?.end_user_id ? conversationScopeId : '',
     userId: isInstalledApp ? userId : appData?.end_user_id,
+    conversationId,
   })
   const [newConversationId, setNewConversationId] = useState('')
   const chatShouldReloadKey = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixes #41997 (first slice: conversation deep-linking only).

`/chat/[token]` and `/agent/[token]` now consume `sys.conversation_id` from URL params the same way `/chatbot/[token]` and the embedded bubble already do. This enables cross-browser/device conversation hand-off via deep links.

Changes:
- Read `conversation_id` from `getProcessedSystemVariablesFromUrlParams()` in `useChatWithHistory`
- Pass it to `useConversationSelection`, which already prioritizes URL `conversationId` over localStorage

**Out of scope for this PR:** auto-send first message via `sys.query` / hand-off tokens (needs separate security design per discussion on the issue).

## Test plan

- [x] `vitest run app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx -t "URL conversation_id"`
- [x] URL `conversation_id` takes precedence over localStorage
- [x] Falls back to localStorage when URL param is absent