### PR TITLE
chore: bump version to 1.17.1

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.17.0"
+version = "1.17.1"
 requires-python = "~=3.12.0"
 
 dependencies = [

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1341,7 +1341,7 @@ wheels = [
 
 [[package]]
 name = "dify-agent"
-version = "1.17.0"
+version = "1.17.1"
 source = { editable = "../dify-agent" }
 dependencies = [
     { name = "httpx" },
@@ -1391,7 +1391,7 @@ docs = [
 
 [[package]]
 name = "dify-api"
-version = "1.17.0"
+version = "1.17.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aliyun-log-python-sdk" },

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langgenius/difyctl",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Dify command-line interface",
   "license": "Apache-2.0",
   "files": [
@@ -72,7 +72,7 @@
     "channel": "stable",
     "compat": {
       "minDify": "1.16.0",
-      "maxDify": "1.17.0"
+      "maxDify": "1.17.1"
     },
     "release": {
       "tagPrefix": "difyctl-v",

--- a/dify-agent/pyproject.toml
+++ b/dify-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-agent"
-version = "1.17.0"
+version = "1.17.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"

--- a/dify-agent/uv.lock
+++ b/dify-agent/uv.lock
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "dify-agent"
-version = "1.17.0"
+version = "1.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -220,7 +220,7 @@ services:
   # API service
   api:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     environment:
       MODE: api
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -268,7 +268,7 @@ services:
   # WebSocket service for workflow collaboration.
   api_websocket:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     profiles:
       - collaboration
     environment:
@@ -299,7 +299,7 @@ services:
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
     <<: *shared-worker-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     environment:
       MODE: worker
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -346,7 +346,7 @@ services:
   # Celery beat for scheduling periodic tasks.
   worker_beat:
     <<: *shared-worker-beat-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     environment:
       MODE: beat
     depends_on:
@@ -379,7 +379,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.17.0
+    image: langgenius/dify-web:1.17.1
     restart: always
     env_file:
       - path: ./envs/core-services/web.env
@@ -540,7 +540,7 @@ services:
   # on port 3128, which only allows agent_backend /agent-stub/ and the Dify API
   # /files/* endpoints (see ssrf_proxy/squid-agent.conf.template).
   local_sandbox:
-    image: langgenius/dify-agent-local-sandbox:1.17.0
+    image: langgenius/dify-agent-local-sandbox:1.17.1
     restart: always
     env_file:
       - path: ./envs/core-services/local-sandbox.env
@@ -652,7 +652,7 @@ services:
 
   # Dify Agent backend service.
   agent_backend:
-    image: langgenius/dify-agent-backend:1.17.0
+    image: langgenius/dify-agent-backend:1.17.1
     restart: always
     env_file:
       - path: ./envs/core-services/dify-agent.env

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -131,7 +131,7 @@ services:
   # Exposes port 5004 on the host so a locally-run agent backend can reach it
   # at http://localhost:5004 (DIFY_AGENT_LOCAL_SANDBOX_ENDPOINT).
   local_sandbox:
-    image: langgenius/dify-agent-local-sandbox:1.17.0
+    image: langgenius/dify-agent-local-sandbox:1.17.1
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -226,7 +226,7 @@ services:
   # API service
   api:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     environment:
       MODE: api
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -274,7 +274,7 @@ services:
   # WebSocket service for workflow collaboration.
   api_websocket:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     profiles:
       - collaboration
     environment:
@@ -305,7 +305,7 @@ services:
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
     <<: *shared-worker-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     environment:
       MODE: worker
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -352,7 +352,7 @@ services:
   # Celery beat for scheduling periodic tasks.
   worker_beat:
     <<: *shared-worker-beat-config
-    image: langgenius/dify-api:1.17.0
+    image: langgenius/dify-api:1.17.1
     environment:
       MODE: beat
     depends_on:
@@ -385,7 +385,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.17.0
+    image: langgenius/dify-web:1.17.1
     restart: always
     env_file:
       - path: ./envs/core-services/web.env
@@ -546,7 +546,7 @@ services:
   # on port 3128, which only allows agent_backend /agent-stub/ and the Dify API
   # /files/* endpoints (see ssrf_proxy/squid-agent.conf.template).
   local_sandbox:
-    image: langgenius/dify-agent-local-sandbox:1.17.0
+    image: langgenius/dify-agent-local-sandbox:1.17.1
     restart: always
     env_file:
       - path: ./envs/core-services/local-sandbox.env
@@ -658,7 +658,7 @@ services:
 
   # Dify Agent backend service.
   agent_backend:
-    image: langgenius/dify-agent-backend:1.17.0
+    image: langgenius/dify-agent-backend:1.17.1
     restart: always
     env_file:
       - path: ./envs/core-services/dify-agent.env

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dify-web",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary

Bump the project version from `1.17.0` to `1.17.1` across all version-carrying files:

- `api/pyproject.toml` and `api/uv.lock` (`dify-api`, `dify-agent`)
- `dify-agent/pyproject.toml` and `dify-agent/uv.lock`
- `web/package.json`
- `cli/package.json` — `difyctl` version and compat `maxDify` bumped to `1.17.1` (`minDify` stays at `1.16.0`, so the CLI still supports the 1.16.x range)
- `docker/docker-compose-template.yaml` and `docker/docker-compose.yaml` image tags
- `docker/docker-compose.middleware.yaml` — `local_sandbox` image tag. This file was not part of the 1.17.0 bump because the service was added to the middleware stack after that release; it now carries a versioned Dify image and needs to track the release.

#### Test plan
- [x] `docker/docker-compose.yaml` regenerated with `docker/generate_docker_compose` — output matches the hand-applied bump
- [x] `uv lock --check` passes for both `api` and `dify-agent`
- [x] No lingering `1.17.0` references in version-carrying files (`six` and `types-six` pins are unrelated coincidences)
- [ ] CI passes

Generated with [Devin](https://devin.ai)