### PR TITLE
feat: per-node first-token deadline for LLM nodes

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -62,6 +62,8 @@ class ModelConfigConverter:
         if "stop" in completion_params:
             stop = completion_params["stop"]
             del completion_params["stop"]
+        # Workflow-only setting; never forward it to providers.
+        completion_params.pop("first_token_timeout_ms", None)
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)
 

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from typing import Any
 
@@ -13,6 +14,8 @@ from graphon.model_runtime.entities.model_entities import ModelFeature, ModelPro
 from graphon.nodes.llm.entities import ModelConfig
 from graphon.nodes.llm.exc import LLMModeRequiredError, ModelNotExistError
 from graphon.nodes.llm.protocols import CredentialsProvider
+
+logger = logging.getLogger(__name__)
 
 
 class DifyCredentialsProvider:
@@ -161,21 +164,35 @@ def resolve_model_supports_vision(
     return ModelFeature.VISION in (model_instance.get_model_schema().features or [])
 
 
-def _normalize_completion_params(completion_params: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+def _normalize_completion_params(
+    completion_params: dict[str, Any],
+) -> tuple[dict[str, Any], list[str], float | None]:
     """
-    Split node-level completion params into provider parameters and stop sequences.
+    Split node-level completion params into provider parameters, stop sequences,
+    and the first-token budget.
 
     Workflow LLM-compatible nodes still consume runtime invocation settings from
-    ``ModelInstance.parameters`` and ``ModelInstance.stop``. Keep the
-    ``ModelInstance`` view and the returned config entity aligned here so callers
-    do not need to duplicate normalization logic.
+    ``ModelInstance.parameters``, ``ModelInstance.stop`` and
+    ``ModelInstance.first_token_timeout``. Keep the ``ModelInstance`` view and the
+    returned config entity aligned here so callers do not need to duplicate
+    normalization logic.
+
+    ``first_token_timeout_ms`` never reaches providers; this is the only ms->s
+    conversion on the path. An invalid value disables the budget.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])
     if not isinstance(stop, list) or not all(isinstance(item, str) for item in stop):
         stop = []
 
-    return normalized_parameters, stop
+    raw_timeout_ms = normalized_parameters.pop("first_token_timeout_ms", None)
+    first_token_timeout: float | None = None
+    if isinstance(raw_timeout_ms, (int, float)) and not isinstance(raw_timeout_ms, bool) and raw_timeout_ms > 0:
+        first_token_timeout = float(raw_timeout_ms) / 1000
+    elif raw_timeout_ms is not None:
+        logger.debug("Ignoring invalid first_token_timeout_ms in completion_params: %r", raw_timeout_ms)
+
+    return normalized_parameters, stop, first_token_timeout
 
 
 def fetch_model_config(
@@ -214,12 +231,13 @@ def fetch_model_config(
     if model_schema is None:
         raise ModelNotExistError(f"Model {node_data_model.name} schema does not exist.")
 
-    parameters, stop = _normalize_completion_params(node_data_model.completion_params)
+    parameters, stop, first_token_timeout = _normalize_completion_params(node_data_model.completion_params)
     model_instance.provider = node_data_model.provider
     model_instance.model_name = node_data_model.name
     model_instance.credentials = credentials
     model_instance.parameters = parameters
     model_instance.stop = tuple(stop)
+    model_instance.first_token_timeout = first_token_timeout
 
     return model_instance, ModelConfigWithCredentialsEntity(
         provider=node_data_model.provider,

--- a/api/core/model_manager.py
+++ b/api/core/model_manager.py
@@ -64,6 +64,7 @@ class ModelInstance:
         # Runtime LLM invocation fields.
         self.parameters: Mapping[str, Any] = {}
         self.stop: Sequence[str] = ()
+        self.first_token_timeout: float | None = None
         self.model_type_instance = self.provider_model_bundle.model_type_instance
         self.load_balancing_manager = self._get_load_balancing_manager(
             configuration=provider_model_bundle.configuration,

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -33,6 +33,7 @@ from core.plugin.impl.exc import (
     PluginRuntimeError,
     PluginUniqueIdentifierError,
 )
+from core.plugin.impl.first_token_timeout import FirstTokenTimeoutError, first_token_backstop
 from core.trigger.errors import (
     EventIgnoreError,
     TriggerInvokeError,
@@ -93,6 +94,24 @@ def use_plugin_daemon_request_timeout(timeout_seconds: float) -> Generator[None,
 
 def _get_plugin_daemon_request_timeout() -> httpx.Timeout | None:
     return _plugin_daemon_request_timeout_override.get() or plugin_daemon_request_timeout
+
+
+def _resolve_stream_timeout(first_token_timeout: float | None) -> httpx.Timeout | None:
+    """Widen the read window so it never cuts a first-token budget short.
+
+    The window is only ever extended, never narrowed. Narrowing it to the budget would
+    make it bound every inter-token gap too, which is not what the setting means -- and
+    it is not needed, because the plugin enforces the budget and the daemon re-enforces
+    it at ``budget + e``. This is the outermost rung and only fires when both are wedged.
+    """
+    base = _get_plugin_daemon_request_timeout()
+    if not first_token_timeout or first_token_timeout <= 0 or base is None:
+        return base
+
+    backstop = first_token_backstop(first_token_timeout)
+    if base.read is None or base.read >= backstop:
+        return base
+    return httpx.Timeout(connect=base.connect, read=backstop, write=base.write, pool=base.pool)
 
 
 def _normalize_plugin_daemon_response_for_type(json_response: Any, type_: type[object]) -> Any:
@@ -227,6 +246,7 @@ class BasePluginClient:
         headers: dict[str, str] | None = None,
         data: bytes | dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
+        first_token_timeout: float | None = None,
     ) -> Generator[str, None, None]:
         """
         Make a stream request to the plugin daemon inner API
@@ -239,12 +259,14 @@ class BasePluginClient:
             "headers": headers,
             "params": params,
             "files": files,
-            "timeout": _get_plugin_daemon_request_timeout(),
+            "timeout": _resolve_stream_timeout(first_token_timeout),
         }
         if isinstance(prepared_data, dict):
             stream_kwargs["data"] = prepared_data
         elif prepared_data is not None:
             stream_kwargs["content"] = prepared_data
+
+        first_line_seen = False
 
         try:
             with _httpx_client.stream(**stream_kwargs) as response:
@@ -256,7 +278,17 @@ class BasePluginClient:
                     if line.startswith("data:"):
                         line = line[5:].strip()
                     if line:
+                        first_line_seen = True
                         yield line
+        except httpx.ReadTimeout as e:
+            if first_token_timeout and not first_line_seen:
+                # The daemon should have named this itself; reaching here means it never
+                # answered at all, so this side is the only one left that can say why.
+                raise FirstTokenTimeoutError(
+                    f"The plugin daemon sent nothing within {first_token_timeout}s of a first-token budget."
+                ) from e
+            logger.exception("Stream request to Plugin Daemon Service failed")
+            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed") from e
         except httpx.RequestError:
             logger.exception("Stream request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
@@ -358,11 +390,12 @@ class BasePluginClient:
         data: bytes | dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
+        first_token_timeout: float | None = None,
     ) -> Generator[T, None, None]:
         """
         Make a stream request to the plugin daemon inner API and yield the response as a model.
         """
-        for line in self._stream_request(method, path, params, headers, data, files):
+        for line in self._stream_request(method, path, params, headers, data, files, first_token_timeout):
             try:
                 rep = PluginDaemonBasicResponse[type_].model_validate_json(line)  # type: ignore
             except (ValueError, TypeError):
@@ -398,10 +431,15 @@ class BasePluginClient:
         match error_type:
             case PluginDaemonInnerError.__name__:
                 raise PluginDaemonInnerError(code=-500, message=message)
+            case FirstTokenTimeoutError.__name__:
+                # Raised by the daemon's own gate, one rung out from the plugin's.
+                raise FirstTokenTimeoutError(description=message)
             case PluginInvokeError.__name__:
                 error_object = json.loads(message)
                 invoke_error_type = error_object.get("error_type")
                 match invoke_error_type:
+                    case FirstTokenTimeoutError.__name__:
+                        raise FirstTokenTimeoutError(description=error_object.get("message"))
                     case InvokeRateLimitError.__name__:
                         raise InvokeRateLimitError(description=error_object.get("message"))
                     case InvokeAuthorizationError.__name__:

--- a/api/core/plugin/impl/first_token_timeout.py
+++ b/api/core/plugin/impl/first_token_timeout.py
@@ -1,0 +1,37 @@
+"""Per-node first-token budget for LLM invocations through the plugin daemon.
+
+Configured as ``completion_params.first_token_timeout_ms`` and popped into
+``ModelInstance.first_token_timeout`` by ``_normalize_completion_params`` -- the only
+ms->s conversion, everything past that point is seconds. ``DifyPreparedLLM`` puts it on
+``request_metadata`` for streaming invocations only, ``PluginModelRuntime`` reads it back
+off, and ``PluginModelClient.invoke_llm`` sends it to the daemon as a request field.
+
+Enforcement belongs to the plugin process, the only layer holding the provider
+connection. The daemon re-enforces at ``budget + e`` and this side widens its read window
+to ``budget + 2e`` when the configured one is shorter. Whichever rung fires is therefore
+the innermost layer that knows why the call stalled, and the outer ones only come into
+play when an inner one is wedged.
+"""
+
+from graphon.model_runtime.errors.invoke import InvokeError
+
+FIRST_TOKEN_TIMEOUT_METADATA_KEY = "first_token_timeout"
+
+_GRACE_FLOOR_SECONDS = 0.25
+_GRACE_RATIO = 0.05
+
+
+class FirstTokenTimeoutError(InvokeError):
+    """The model did not stream its first token within the configured budget."""
+
+    description = "The first streamed token was not received in time."
+
+
+def first_token_grace(budget: float) -> float:
+    """One rung of the deadline ladder, matching the daemon's own epsilon."""
+    return max(_GRACE_FLOOR_SECONDS, budget * _GRACE_RATIO)
+
+
+def first_token_backstop(budget: float) -> float:
+    """Transport deadline for a request carrying ``budget``, two rungs out from it."""
+    return budget + 2 * first_token_grace(budget)

--- a/api/core/plugin/impl/model.py
+++ b/api/core/plugin/impl/model.py
@@ -181,10 +181,27 @@ class PluginModelClient(BasePluginClient):
         stop: list[str] | None = None,
         stream: bool = True,
         app_id: str | None = None,
+        first_token_timeout: float | None = None,
     ) -> Generator[LLMResultChunk, None, None]:
         """
         Invoke llm
         """
+        data: dict[str, Any] = {
+            "provider": provider,
+            "model_type": "llm",
+            "model": model,
+            "credentials": credentials,
+            "prompt_messages": prompt_messages,
+            "model_parameters": model_parameters,
+            "tools": tools,
+            "stop": stop,
+            "stream": stream,
+        }
+        # Omitted rather than sent as null, so a daemon that predates the field is
+        # byte-for-byte unaffected.
+        if first_token_timeout and first_token_timeout > 0:
+            data["first_token_timeout"] = first_token_timeout
+
         response = self._request_with_plugin_daemon_response_stream(
             method="POST",
             path=f"plugin/{tenant_id}/dispatch/llm/invoke",
@@ -192,17 +209,7 @@ class PluginModelClient(BasePluginClient):
             data=jsonable_encoder(
                 self._dispatch_payload(
                     user_id=user_id,
-                    data={
-                        "provider": provider,
-                        "model_type": "llm",
-                        "model": model,
-                        "credentials": credentials,
-                        "prompt_messages": prompt_messages,
-                        "model_parameters": model_parameters,
-                        "tools": tools,
-                        "stop": stop,
-                        "stream": stream,
-                    },
+                    data=data,
                     app_id=app_id,
                 )
             ),
@@ -210,6 +217,7 @@ class PluginModelClient(BasePluginClient):
                 "X-Plugin-ID": plugin_id,
                 "Content-Type": "application/json",
             },
+            first_token_timeout=first_token_timeout,
         )
 
         try:

--- a/api/core/plugin/impl/model_runtime.py
+++ b/api/core/plugin/impl/model_runtime.py
@@ -15,6 +15,7 @@ from core.llm_generator.output_parser.structured_output import (
 )
 from core.plugin.entities.plugin_daemon import PluginModelProviderDeclaration
 from core.plugin.impl.asset import PluginAssetManager
+from core.plugin.impl.first_token_timeout import FIRST_TOKEN_TIMEOUT_METADATA_KEY
 from core.plugin.impl.model import PluginModelClient
 from core.plugin.plugin_service import PluginService
 from extensions.ext_redis import redis_client
@@ -322,6 +323,9 @@ class PluginModelRuntime(ModelRuntime):
         app_id = request_metadata.get("app_id") if request_metadata else None
         if not isinstance(app_id, str):
             app_id = None
+        first_token_timeout = request_metadata.get(FIRST_TOKEN_TIMEOUT_METADATA_KEY) if request_metadata else None
+        if not isinstance(first_token_timeout, (int, float)) or isinstance(first_token_timeout, bool):
+            first_token_timeout = None
         plugin_id, provider_name = self._split_provider(provider)
         if app_id is None:
             result = self.client.invoke_llm(
@@ -336,6 +340,7 @@ class PluginModelRuntime(ModelRuntime):
                 tools=tools,
                 stop=list(stop) if stop else None,
                 stream=stream,
+                first_token_timeout=first_token_timeout,
             )
         else:
             result = self.client.invoke_llm(
@@ -351,6 +356,7 @@ class PluginModelRuntime(ModelRuntime):
                 stop=list(stop) if stop else None,
                 stream=stream,
                 app_id=app_id,
+                first_token_timeout=first_token_timeout,
             )
         if stream:
             return result

--- a/api/core/workflow/node_runtime.py
+++ b/api/core/workflow/node_runtime.py
@@ -23,6 +23,7 @@ from core.llm_generator.output_parser.structured_output import invoke_llm_with_s
 from core.model_context import use_credit_usage_metadata
 from core.model_manager import ModelInstance, QuotaManagedModelInstance
 from core.plugin.impl.exc import PluginDaemonClientSideError, PluginInvokeError
+from core.plugin.impl.first_token_timeout import FIRST_TOKEN_TIMEOUT_METADATA_KEY
 from core.plugin.impl.plugin import PluginInstaller
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
 from core.repositories.human_input_repository import (
@@ -176,6 +177,22 @@ class DifyFileReferenceFactory(FileReferenceFactoryProtocol):
         )
 
 
+def _with_first_token_budget(
+    request_metadata: Mapping[str, object] | None,
+    first_token_timeout: float | None,
+    stream: bool,
+) -> Mapping[str, object] | None:
+    """Attach the node's first-token budget to the metadata carried with the request.
+
+    Streaming only: without a stream the single result arrives once generation has
+    finished, so a first-token budget there would quietly become a total-time budget.
+    """
+    if not stream or not first_token_timeout or first_token_timeout <= 0:
+        return request_metadata
+
+    return {**(request_metadata or {}), FIRST_TOKEN_TIMEOUT_METADATA_KEY: first_token_timeout}
+
+
 class DifyPreparedLLM(LLMProtocol):
     """Workflow-layer adapter that hides the full `ModelInstance` API from `graphon` nodes."""
 
@@ -260,7 +277,11 @@ class DifyPreparedLLM(LLMProtocol):
             tools=list(tools or []),
             stop=list(stop or []),
             stream=stream,
-            request_metadata=self._request_metadata,
+            request_metadata=_with_first_token_budget(
+                self._request_metadata,
+                self._model_instance.first_token_timeout,
+                stream,
+            ),
         )
 
     @overload
@@ -304,7 +325,11 @@ class DifyPreparedLLM(LLMProtocol):
             model_parameters=model_parameters,
             stop=list(stop or []),
             stream=stream,
-            request_metadata=self._request_metadata,
+            request_metadata=_with_first_token_budget(
+                self._request_metadata,
+                self._model_instance.first_token_timeout,
+                stream,
+            ),
         )
 
     @override

--- a/api/tests/integration_tests/model_runtime/__mock/plugin_model.py
+++ b/api/tests/integration_tests/model_runtime/__mock/plugin_model.py
@@ -249,5 +249,6 @@ class MockModelClass(PluginModelClient):
         stop: list[str] | None = None,
         stream: bool = True,
         app_id: str | None = None,
+        first_token_timeout: float | None = None,
     ):
         return MockModelClass.mocked_chat_create_stream(model=model, prompt_messages=prompt_messages, tools=tools)

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
@@ -100,6 +100,14 @@ class TestModelConfigConverter:
         assert result.parameters == {"temperature": 0.7}
         assert result.stop == ["\n"]
 
+    def test_convert_drops_first_token_timeout_ms(self, mock_app_config, patch_provider_manager):
+        """The workflow-only setting must never reach providers through app configs."""
+        mock_app_config.model.parameters = {"temperature": 0.7, "first_token_timeout_ms": 2000}
+
+        result = ModelConfigConverter.convert(mock_app_config)
+
+        assert result.parameters == {"temperature": 0.7}
+
     def test_convert_mode_from_schema_valid(self, mock_app_config, mock_provider_bundle, mocker: MockerFixture):
         mock_app_config.model.mode = None
 

--- a/api/tests/unit_tests/core/app/llm/test_model_access.py
+++ b/api/tests/unit_tests/core/app/llm/test_model_access.py
@@ -87,3 +87,21 @@ def test_resolve_model_supports_vision_reads_selected_model_schema(
         )
         is expected
     )
+
+
+def test_normalize_completion_params_pops_the_first_token_budget() -> None:
+    parameters, stop, first_token_timeout = model_access._normalize_completion_params(
+        {"temperature": 0.1, "stop": ["END"], "first_token_timeout_ms": 2500}
+    )
+
+    assert parameters == {"temperature": 0.1}
+    assert stop == ["END"]
+    assert first_token_timeout == pytest.approx(2.5)
+
+
+@pytest.mark.parametrize("raw", [None, 0, -1, "2000", True])
+def test_normalize_completion_params_disables_the_budget_for_an_invalid_value(raw: object) -> None:
+    parameters, _, first_token_timeout = model_access._normalize_completion_params({"first_token_timeout_ms": raw})
+
+    assert first_token_timeout is None
+    assert "first_token_timeout_ms" not in parameters

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -1,0 +1,142 @@
+import json
+from collections.abc import Iterator
+from types import TracebackType
+from typing import override
+
+import httpx
+import pytest
+
+from core.plugin.entities.plugin_daemon import PluginDaemonInnerError
+from core.plugin.impl.base import BasePluginClient, _resolve_stream_timeout
+from core.plugin.impl.first_token_timeout import (
+    FirstTokenTimeoutError,
+    first_token_backstop,
+    first_token_grace,
+)
+
+
+class _StreamContext:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    def __enter__(self) -> "_StreamContext":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        return False
+
+    def iter_lines(self) -> Iterator[str]:
+        yield from self._lines
+
+
+def _timed_out(**_kwargs: object) -> _StreamContext:
+    raise httpx.ReadTimeout("timed out")
+
+
+class TestFirstTokenLadder:
+    def test_grace_has_a_floor_and_a_ratio(self) -> None:
+        assert first_token_grace(1.0) == pytest.approx(0.25)
+        assert first_token_grace(2.0) == pytest.approx(0.25)
+        assert first_token_grace(20.0) == pytest.approx(1.0)
+
+    def test_the_backstop_sits_two_rungs_out(self) -> None:
+        assert first_token_backstop(2.0) == pytest.approx(2.5)
+        assert first_token_backstop(20.0) == pytest.approx(22.0)
+
+
+class TestResolveStreamTimeout:
+    def test_no_budget_leaves_the_configured_timeout_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        base = httpx.Timeout(600.0)
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", base)
+
+        assert _resolve_stream_timeout(None) is base
+        assert _resolve_stream_timeout(0) is base
+
+    def test_a_budget_inside_the_window_does_not_narrow_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Narrowing would make the budget bound every inter-token gap as well."""
+        base = httpx.Timeout(600.0)
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", base)
+
+        assert _resolve_stream_timeout(2.0) is base
+
+    def test_a_budget_past_the_window_widens_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        base = httpx.Timeout(600.0)
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", base)
+
+        resolved = _resolve_stream_timeout(900.0)
+
+        assert resolved is not None
+        assert resolved.read == pytest.approx(first_token_backstop(900.0))
+        assert resolved.connect == base.connect
+        assert resolved.write == base.write
+
+    def test_an_unlimited_window_stays_unlimited(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", None)
+
+        assert _resolve_stream_timeout(2.0) is None
+
+
+class TestStreamRequestBackstop:
+    def test_a_read_timeout_before_any_frame_is_named_as_a_first_token_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("core.plugin.impl.base._httpx_client.stream", _timed_out)
+
+        with pytest.raises(FirstTokenTimeoutError) as excinfo:
+            list(BasePluginClient()._stream_request("POST", "some/path", first_token_timeout=2.0))
+
+        assert "2.0" in str(excinfo.value)
+
+    def test_a_read_timeout_after_a_frame_is_a_plain_transport_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _StalledAfterFirstFrame(_StreamContext):
+            @override
+            def iter_lines(self) -> Iterator[str]:
+                yield "data: first"
+                raise httpx.ReadTimeout("timed out")
+
+        monkeypatch.setattr(
+            "core.plugin.impl.base._httpx_client.stream",
+            lambda **_kwargs: _StalledAfterFirstFrame([]),
+        )
+
+        stream = BasePluginClient()._stream_request("POST", "some/path", first_token_timeout=2.0)
+        assert next(stream) == "first"
+
+        with pytest.raises(PluginDaemonInnerError):
+            next(stream)
+
+    def test_a_read_timeout_without_a_budget_is_a_plain_transport_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.plugin.impl.base._httpx_client.stream", _timed_out)
+
+        with pytest.raises(PluginDaemonInnerError):
+            list(BasePluginClient()._stream_request("POST", "some/path"))
+
+
+class TestTypedErrorFrames:
+    def test_the_daemon_gate_maps_to_a_first_token_timeout(self) -> None:
+        with pytest.raises(FirstTokenTimeoutError) as excinfo:
+            BasePluginClient()._handle_plugin_daemon_error(
+                "FirstTokenTimeoutError",
+                "no token was received within 2s",
+            )
+
+        assert "no token was received within 2s" in str(excinfo.value)
+
+    def test_the_plugin_gate_maps_to_a_first_token_timeout(self) -> None:
+        message = json.dumps(
+            {
+                "error_type": "FirstTokenTimeoutError",
+                "message": "The first token was not received within 2.0s.",
+                "args": {},
+            }
+        )
+
+        with pytest.raises(FirstTokenTimeoutError) as excinfo:
+            BasePluginClient()._handle_plugin_daemon_error("PluginInvokeError", message)
+
+        assert "The first token was not received within 2.0s." in str(excinfo.value)

--- a/api/tests/unit_tests/core/plugin/impl/test_model_client.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_model_client.py
@@ -198,6 +198,46 @@ class TestPluginModelClient:
 
         assert "app_id" not in stream_mock.call_args.kwargs["data"]
 
+    def test_invoke_llm_sends_the_first_token_budget(self, mocker: MockerFixture):
+        client = PluginModelClient()
+        stream_mock = mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=iter([]))
+
+        list(
+            client.invoke_llm(
+                tenant_id="tenant-1",
+                user_id="user-1",
+                plugin_id="org/plugin:1",
+                provider="provider-a",
+                model="gpt-test",
+                credentials={},
+                prompt_messages=[],
+                first_token_timeout=2.0,
+            )
+        )
+
+        call_kwargs = stream_mock.call_args.kwargs
+        assert call_kwargs["data"]["data"]["first_token_timeout"] == 2.0
+        assert call_kwargs["first_token_timeout"] == 2.0
+
+    def test_invoke_llm_omits_the_first_token_budget_when_unset(self, mocker: MockerFixture):
+        """A daemon that predates the field must see a byte-identical payload."""
+        client = PluginModelClient()
+        stream_mock = mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=iter([]))
+
+        list(
+            client.invoke_llm(
+                tenant_id="tenant-1",
+                user_id="user-1",
+                plugin_id="org/plugin:1",
+                provider="provider-a",
+                model="gpt-test",
+                credentials={},
+                prompt_messages=[],
+            )
+        )
+
+        assert "first_token_timeout" not in stream_mock.call_args.kwargs["data"]["data"]
+
     def test_invoke_llm_wraps_plugin_daemon_inner_error(self, mocker: MockerFixture):
         client = PluginModelClient()
 

--- a/api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py
+++ b/api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py
@@ -283,6 +283,7 @@ class TestPluginModelRuntime:
             tools=None,
             stop=None,
             stream=False,
+            first_token_timeout=None,
         )
 
     def test_invoke_llm_forwards_string_app_id_from_request_metadata(self) -> None:
@@ -316,6 +317,7 @@ class TestPluginModelRuntime:
             stop=None,
             stream=True,
             app_id="app-1",
+            first_token_timeout=None,
         )
 
     def test_invoke_llm_ignores_non_string_app_id_request_metadata(self) -> None:
@@ -368,7 +370,50 @@ class TestPluginModelRuntime:
             tools=None,
             stop=["END"],
             stream=True,
+            first_token_timeout=None,
         )
+
+    def test_invoke_llm_forwards_the_first_token_budget_from_request_metadata(self) -> None:
+        client = Mock(spec=PluginModelClient)
+        client.invoke_llm.return_value = iter([])
+        runtime = PluginModelRuntime(tenant_id="tenant", user_id="user", client=client, plugin_service=PluginService)
+
+        list(
+            runtime.invoke_llm(
+                provider="langgenius/openai/openai",
+                model="gpt-4o-mini",
+                credentials={"api_key": "secret"},
+                model_parameters={},
+                prompt_messages=[],
+                tools=None,
+                stop=None,
+                stream=True,
+                request_metadata={"first_token_timeout": 2.0},
+            )
+        )
+
+        assert client.invoke_llm.call_args.kwargs["first_token_timeout"] == 2.0
+
+    def test_invoke_llm_ignores_a_non_numeric_first_token_budget(self) -> None:
+        client = Mock(spec=PluginModelClient)
+        client.invoke_llm.return_value = iter([])
+        runtime = PluginModelRuntime(tenant_id="tenant", user_id="user", client=client, plugin_service=PluginService)
+
+        list(
+            runtime.invoke_llm(
+                provider="langgenius/openai/openai",
+                model="gpt-4o-mini",
+                credentials={"api_key": "secret"},
+                model_parameters={},
+                prompt_messages=[],
+                tools=None,
+                stop=None,
+                stream=True,
+                request_metadata={"first_token_timeout": "2.0"},
+            )
+        )
+
+        assert client.invoke_llm.call_args.kwargs["first_token_timeout"] is None
 
     def test_start_llm_polling_resolves_plugin_fields(self) -> None:
         client = Mock(spec=PluginModelClient)

--- a/api/tests/unit_tests/core/workflow/test_node_runtime.py
+++ b/api/tests/unit_tests/core/workflow/test_node_runtime.py
@@ -141,6 +141,7 @@ class _ModelInstanceStub:
         self.model_name = "gpt-4o-mini"
         self.parameters = {"temperature": 0.2}
         self.stop = ("stop",)
+        self.first_token_timeout: float | None = None
         self.credentials = {"api_key": "secret"}
         self.model_type_instance = _ModelTypeInstanceStub(
             model_schema=model_schema,
@@ -1121,3 +1122,57 @@ def test_build_dify_llm_file_saver_wires_runtime_adapters(monkeypatch: pytest.Mo
     assert isinstance(tool_file_manager, DifyToolFileManager)
     assert isinstance(file_reference_factory, DifyFileReferenceFactory)
     assert file_saver_cls.call_args.kwargs["http_client"] is http_client
+
+
+class TestFirstTokenBudgetMetadata:
+    def test_a_streaming_invocation_carries_the_budget(self):
+        merged = node_runtime._with_first_token_budget({"app_id": "app-1"}, 2.0, stream=True)
+
+        assert merged == {"app_id": "app-1", "first_token_timeout": 2.0}
+
+    def test_metadata_is_left_alone_without_a_budget(self):
+        metadata = {"app_id": "app-1"}
+
+        assert node_runtime._with_first_token_budget(metadata, None, stream=True) is metadata
+        assert node_runtime._with_first_token_budget(metadata, 0, stream=True) is metadata
+        assert node_runtime._with_first_token_budget(None, None, stream=True) is None
+
+    def test_a_non_streaming_invocation_never_carries_the_budget(self):
+        """The single result arrives when generation is done, so the budget would stop
+        being about the first token."""
+        metadata = {"app_id": "app-1"}
+
+        assert node_runtime._with_first_token_budget(metadata, 2.0, stream=False) is metadata
+
+    def test_prepared_llm_puts_the_budget_on_the_request(self):
+        model_instance = MagicMock()
+        model_instance.first_token_timeout = 2.0
+        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"})
+
+        prepared.invoke_llm(
+            prompt_messages=[],
+            model_parameters={},
+            tools=None,
+            stop=None,
+            stream=True,
+        )
+
+        assert model_instance.invoke_llm.call_args.kwargs["request_metadata"] == {
+            "app_id": "app-1",
+            "first_token_timeout": 2.0,
+        }
+
+    def test_prepared_llm_leaves_a_non_streaming_request_alone(self):
+        model_instance = MagicMock()
+        model_instance.first_token_timeout = 2.0
+        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"})
+
+        prepared.invoke_llm(
+            prompt_messages=[],
+            model_parameters={},
+            tools=None,
+            stop=None,
+            stream=False,
+        )
+
+        assert model_instance.invoke_llm.call_args.kwargs["request_metadata"] == {"app_id": "app-1"}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -415,6 +415,32 @@ describe('ModelParameterModal', () => {
     expect(screen.getByText(/debugAsSingleModel/i)).toBeInTheDocument()
   })
 
+  it('should append the first token timeout parameter when the panel supports it', () => {
+    render(
+      <ModelParameterModal
+        {...defaultProps}
+        isAdvancedMode
+        isInWorkflow
+        supportFirstTokenTimeout
+      />,
+    )
+
+    openSettings()
+
+    expect(screen.getByTestId('param-first_token_timeout_ms')).toBeInTheDocument()
+  })
+
+  it('should not append the first token timeout parameter for workflow panels that do not support it', () => {
+    // Workflow context alone must not render it — that would be dead config on
+    // panels the backend does not consume.
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
+
+    openSettings()
+
+    expect(screen.getByTestId('param-stop')).toBeInTheDocument()
+    expect(screen.queryByTestId('param-first_token_timeout_ms')).not.toBeInTheDocument()
+  })
+
   it('should render the empty loading fallback when rules resolve to an empty list', () => {
     parameterRules = []
     isRulesLoading = true

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -15,7 +15,11 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ArrowNarrowLeft } from '@/app/components/base/icons/src/vender/line/arrows'
 import Loading from '@/app/components/base/loading'
-import { PROVIDER_WITH_PRESET_TONE, STOP_PARAMETER_RULE } from '@/config'
+import {
+  FIRST_TOKEN_TIMEOUT_PARAMETER_RULE,
+  PROVIDER_WITH_PRESET_TONE,
+  STOP_PARAMETER_RULE,
+} from '@/config'
 import { useModelParameterRules } from '@/service/use-common'
 import { ModelStatusEnum } from '../declarations'
 import { useTextGenerationCurrentProviderAndModelAndModelList } from '../hooks'
@@ -48,6 +52,9 @@ export type ModelParameterModalProps = Pick<PopoverContentProps, 'placement'> & 
   readonly?: boolean
   modelSelectorReadonly?: boolean
   isInWorkflow?: boolean
+  // Pass only from panels that invoke the model as a stream (LLM, question
+  // classifier). Anywhere else the budget is ignored downstream and would be dead config.
+  supportFirstTokenTimeout?: boolean
   scope?: string
   nodesOutputVars?: NodeOutPutVar[]
   availableNodes?: Node[]
@@ -75,6 +82,7 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
   readonly,
   modelSelectorReadonly,
   isInWorkflow,
+  supportFirstTokenTimeout,
   nodesOutputVars,
   availableNodes,
   modelList,
@@ -238,22 +246,26 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
                   <Loading />
                 </div>
               ) : (
-                [...parameterRules, ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : [])].map(
-                  (parameter) => (
-                    <ParameterItem
-                      key={`${modelId}-${parameter.name}`}
-                      parameterRule={parameter}
-                      value={completionParams?.[parameter.name]}
-                      onChange={(v) => handleParamChange(parameter.name, v)}
-                      onSwitch={(checked, assignValue) =>
-                        handleSwitch(parameter.name, checked, assignValue)
-                      }
-                      isInWorkflow={isInWorkflow}
-                      nodesOutputVars={nodesOutputVars}
-                      availableNodes={availableNodes}
-                    />
-                  ),
-                )
+                [
+                  ...parameterRules,
+                  ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : []),
+                  ...(isAdvancedMode && supportFirstTokenTimeout
+                    ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE]
+                    : []),
+                ].map((parameter) => (
+                  <ParameterItem
+                    key={`${modelId}-${parameter.name}`}
+                    parameterRule={parameter}
+                    value={completionParams?.[parameter.name]}
+                    onChange={(v) => handleParamChange(parameter.name, v)}
+                    onSwitch={(checked, assignValue) =>
+                      handleSwitch(parameter.name, checked, assignValue)
+                    }
+                    isInWorkflow={isInWorkflow}
+                    nodesOutputVars={nodesOutputVars}
+                    availableNodes={availableNodes}
+                  />
+                ))
               )}
             </div>
           )}

--- a/web/app/components/workflow/nodes/llm/panel.tsx
+++ b/web/app/components/workflow/nodes/llm/panel.tsx
@@ -255,6 +255,7 @@ const Panel: FC<NodePanelProps<LLMNodeType>> = ({ id, data }) => {
               popupClassName="w-[387px]!"
               isInWorkflow
               isAdvancedMode={true}
+              supportFirstTokenTimeout
               provider={model?.provider}
               completionParams={model?.completion_params}
               modelId={model?.name}

--- a/web/app/components/workflow/nodes/question-classifier/panel.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/panel.tsx
@@ -50,6 +50,7 @@ const Panel: FC<NodePanelProps<QuestionClassifierNodeType>> = ({ id, data }) => 
             popupClassName="w-[387px]!"
             isInWorkflow
             isAdvancedMode={true}
+            supportFirstTokenTimeout
             provider={model?.provider}
             completionParams={model.completion_params}
             modelId={model.name}

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -347,6 +347,27 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
   },
 }
 
+// Consumed by the Dify backend, never sent to model providers.
+export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
+  default: 2000,
+  min: 100,
+  max: 600000,
+  precision: 0,
+  help: {
+    en_US:
+      'Max milliseconds to wait for the first streamed token. Generation after that token is not affected. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans:
+      '等待首个流式 Token 的最长毫秒数。首个 Token 之后的生成过程不受影响。超时后节点失败，可配合节点重试自动重跑。',
+  },
+  label: {
+    en_US: 'First token timeout (ms)',
+    zh_Hans: '首个 Token 超时（毫秒）',
+  },
+  name: 'first_token_timeout_ms',
+  required: false,
+  type: 'int',
+}
+
 export const PARTNER_STACK_CONFIG = {
   cookieName: 'partner_stack_info',
   saveCookieDays: 90,


### PR DESCRIPTION
The dify side of a per-node first-token timeout. The layers that enforce the budget are already up: langgenius/dify-plugin-sdks#384 (plugin process) and langgenius/dify-plugin-daemon#814 (daemon).

**Supersedes #38586.** Same user-facing feature and the same UI, but the mechanism is different — see *What changed vs #38586* below. Branched off current `main`, so this is the one to review.

## The problem

An LLM node has no way to say how long it will wait for the first token. The only bound is `PLUGIN_DAEMON_TIMEOUT` — ten minutes, and global. A provider that accepts the connection and then goes quiet holds a latency-sensitive node (a live conversational turn, say) for as long as it likes.

## What this does

Adds `first_token_timeout_ms` to the model settings popover for nodes that stream, and carries it to the daemon as a **first-class request field**:

```
completion_params.first_token_timeout_ms
  -> ModelInstance.first_token_timeout          (the only ms->s conversion)
  -> request_metadata["first_token_timeout"]    (DifyPreparedLLM)
  -> graphon                                     (already threads request_metadata opaquely)
  -> PluginModelRuntime
  -> PluginModelClient.invoke_llm payload
```

It never enters `model_parameters`, so it cannot leak to a provider, and it is omitted from the payload when unset so an older daemon sees a byte-identical request.

Enforcement happens where the provider connection actually lives — the plugin process — with the daemon re-enforcing at `budget + ε`. Both answer with a typed frame, and **both frame shapes now map to `FirstTokenTimeoutError`**: the daemon's own gate arrives as a top-level `error_type`, the plugin's as a nested one under `PluginInvokeError`. Error-strategy routing and tracing get a stable `error_type` instead of having to infer a stall from a transport error.

## What changed vs #38586

| | #38586 | here |
|---|---|---|
| how the budget reaches the daemon | not sent; inferred from `httpx` read timeout | request field |
| how it reaches the transport | ContextVar, same-thread only | `request_metadata`, explicit parameter |
| what enforces it | dify's socket read | the plugin process, then the daemon |
| what the read timeout does | *is* the semantics | backstop only, and only ever widened |
| inter-token gaps | also bounded by the same window (known side effect) | unaffected |
| error naming | inferred from `ReadTimeout` | typed frame from whichever layer fired |
| non-streaming nodes | budget applied as a total-time budget | not applied |

The correctness of #38586 rested on three things that are not contracts: that the daemon lazily flushes response headers so TTFT lands in "waiting for headers"; that it sends zero bytes before the first token, so nothing resets the read clock; and that the first *frame* is the first *token*. None of those matter now — the daemon counts frames and knows which ones carry content.

## Notes for review

**The read timeout is only ever widened.** Narrowing it to the budget is what made #38586 bound inter-token gaps as well. It is now raised to `budget + 2ε` only when the configured window is shorter (a budget longer than `PLUGIN_DAEMON_TIMEOUT`, e.g. a slow reasoning model). If it fires before any frame arrived, the daemon never answered at all — this side is the only layer left that can name the cause, so it still raises `FirstTokenTimeoutError`.

**Streaming only, in all three repos.** Without a stream the single result arrives once generation is done, so enforcing there would quietly turn a first-token budget into a total-time budget. The parameter extractor invokes with `stream=False`, so it no longer offers the setting — that closes the "configurable but wrong" gap #38586 had.

**Per-node TTFT is not in this PR.** The metadata key (`WorkflowNodeExecutionMetadataKey`) and the LLM node that would write it both live in `graphon`, so it belongs with the change there. The daemon already exports `plugin_time_to_first_token_seconds`, which is what an operator needs to pick a budget.

**Polling models still ignore the budget.** `DifyPreparedPollingLLM` does not stream, so nothing enforces it there. Pre-existing, not a regression; the fix is capability-driven UI gating, which lands with the `graphon` and web change.

## Testing

- `api/tests/unit_tests/core/{plugin,workflow,app}` — 2928 passed
- `web` unit tests for the modal — 46 passed
- `ruff check`, `pyrefly check` (0 new diagnostics), `tsc --noEmit` all clean
- each commit passes on its own
