### PR TITLE
fix(web): make workflow condition variable selectors keyboard accessible

### DIFF
--- a/web/app/components/workflow/nodes/__tests__/condition-variable-selector-keyboard.spec.tsx
+++ b/web/app/components/workflow/nodes/__tests__/condition-variable-selector-keyboard.spec.tsx
@@ -17,7 +17,7 @@ function IfElseSelectorHarness() {
     <IfElseConditionVarSelector
       open={open}
       onOpenChange={setOpen}
-      valueSelector={['source', 'previous']}
+      valueSelector={['env', 'answer']}
       varType={VarType.number}
       availableNodes={[]}
       nodesOutputVars={variables}
@@ -32,7 +32,7 @@ function LoopSelectorHarness() {
     <LoopConditionVarSelector
       open={open}
       onOpenChange={setOpen}
-      valueSelector={['source', 'previous']}
+      valueSelector={['env', 'answer']}
       varType={VarType.number}
       availableNodes={[]}
       nodesOutputVars={variables}

--- a/web/app/components/workflow/nodes/__tests__/condition-variable-selector-keyboard.spec.tsx
+++ b/web/app/components/workflow/nodes/__tests__/condition-variable-selector-keyboard.spec.tsx
@@ -1,0 +1,81 @@
+import type { NodeOutPutVar } from '@/app/components/workflow/types'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { ReactFlowProvider } from 'reactflow'
+import { VarType } from '@/app/components/workflow/types'
+import IfElseConditionVarSelector from '../if-else/components/condition-list/condition-var-selector'
+import KnowledgeConditionVariableSelector from '../knowledge-retrieval/components/metadata/condition-list/condition-variable-selector'
+import LoopConditionVarSelector from '../loop/components/condition-list/condition-var-selector'
+
+const answer = { variable: 'answer', type: VarType.number }
+const variables: NodeOutPutVar[] = [{ nodeId: 'source', title: 'Source', vars: [answer] }]
+
+function IfElseSelectorHarness() {
+  const [open, setOpen] = useState(false)
+  return (
+    <IfElseConditionVarSelector
+      open={open}
+      onOpenChange={setOpen}
+      valueSelector={['source', 'previous']}
+      varType={VarType.number}
+      availableNodes={[]}
+      nodesOutputVars={variables}
+      onChange={vi.fn()}
+    />
+  )
+}
+
+function LoopSelectorHarness() {
+  const [open, setOpen] = useState(false)
+  return (
+    <LoopConditionVarSelector
+      open={open}
+      onOpenChange={setOpen}
+      valueSelector={['source', 'previous']}
+      varType={VarType.number}
+      availableNodes={[]}
+      nodesOutputVars={variables}
+      onChange={vi.fn()}
+    />
+  )
+}
+
+function KnowledgeSelectorHarness() {
+  return (
+    <KnowledgeConditionVariableSelector
+      nodesOutputVars={variables}
+      onChange={vi.fn()}
+    />
+  )
+}
+
+const selectorCases = [
+  ['If/Else', IfElseSelectorHarness],
+  ['Loop', LoopSelectorHarness],
+  ['Knowledge Retrieval metadata', KnowledgeSelectorHarness],
+] as const
+
+const activationKeys = [
+  ['Enter', '{Enter}'],
+  ['Space', ' '],
+] as const
+
+describe.each(selectorCases)('%s condition variable selector', (_name, SelectorHarness) => {
+  it.each(activationKeys)('opens from the keyboard with %s', async (_keyName, key) => {
+    const user = userEvent.setup()
+    render(
+      <ReactFlowProvider>
+        <SelectorHarness />
+      </ReactFlowProvider>,
+    )
+
+    await user.tab()
+    const trigger = screen.getByRole('button')
+    expect(trigger).toHaveFocus()
+
+    await user.keyboard(key)
+
+    expect(screen.getByRole('searchbox')).toBeInTheDocument()
+  })
+})

--- a/web/app/components/workflow/nodes/if-else/components/condition-list/condition-var-selector.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-list/condition-var-selector.tsx
@@ -33,7 +33,7 @@ const ConditionVarSelector = ({
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger
-        // TODO: Declare non-native button semantics for this div trigger to support keyboard activation.
+        nativeButton={false}
         render={
           <div className="w-full cursor-pointer">
             <VariableTag

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-variable-selector.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-variable-selector.tsx
@@ -37,7 +37,7 @@ const ConditionVariableSelector = ({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
-        // TODO: Declare non-native button semantics for this div trigger to support keyboard activation.
+        nativeButton={false}
         render={
           <div className="flex h-6 grow cursor-pointer items-center">
             {!!valueSelector.length && (

--- a/web/app/components/workflow/nodes/loop/components/condition-list/condition-var-selector.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-list/condition-var-selector.tsx
@@ -33,7 +33,7 @@ const ConditionVarSelector = ({
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger
-        // TODO: Declare non-native button semantics for this div trigger to support keyboard activation.
+        nativeButton={false}
         render={
           <div className="cursor-pointer">
             <VariableTag


### PR DESCRIPTION
## Summary

Follow-up to #42121 and fixes #42132.

This keeps the scope narrow: the three condition-variable selectors that render `PopoverTrigger` with a `<div>` now explicitly declare non-native button semantics via `nativeButton={false}`.

Affected selectors:

- If/Else condition variable selector
- Loop condition variable selector
- Knowledge Retrieval metadata condition variable selector

The goal is to make the existing triggers keyboard-operable without changing visuals, mouse behavior, controlled open state, or the initial-focus behavior introduced in #42121.

## Validation

Added focused regression coverage for all three selectors:

- the trigger is reachable by Tab;
- Enter opens the popover;
- Space opens the popover.

Upstream GitHub Actions are currently awaiting maintainer approval to run for this fork PR, so no CI job result is available yet.

From ChatGPT