### PR TITLE
fix(ci): set up Node.js in sync-e2b-template job

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -245,6 +245,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Use Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: package.json
+          cache: ''
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 


### PR DESCRIPTION
## Summary
- `sync-e2b-template` in `build-push.yml` runs `npx @e2b/cli` from the repo root without an explicit Node setup step, so it falls back to the GitHub-hosted runner's preinstalled Node.
- The repo root `package.json` declares `devEngines.runtime` requiring Node `24.20.0`. When the ambient Node doesn't match exactly, npm aborts with `EBADDEVENGINES` before `@e2b/cli` ever runs — see the failing run: https://github.com/langgenius/dify/actions/runs/34460552613/job/102817893777
- Adds an `actions/setup-node` step using `node-version-file: package.json` (same pattern already used in `tool-test-sdks.yaml`), so the job's Node version tracks whatever `engines.node` declares instead of hardcoding a version that will drift again on the next Node bump.

## Test plan
- [ ] Re-run `sync-e2b-template (dev)` / `sync-e2b-template (prod)` on a tag push and confirm `npx --yes @e2b/cli@...` no longer fails with `EBADDEVENGINES`