### PR TITLE
fix(web): preserve editor shortcut in Skills publish bar

### DIFF
--- a/web/features/skills/detail/__tests__/publish-bar.spec.tsx
+++ b/web/features/skills/detail/__tests__/publish-bar.spec.tsx
@@ -31,6 +31,29 @@ describe('SkillPublishBar', () => {
     expect(onPublish).toHaveBeenCalledTimes(2)
   })
 
+  it('does not publish from the shortcut while an editing field is focused', async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <SkillPublishBar
+          metaLabel="Saved 5 min ago"
+          state="draft"
+          onOpenVersions={onOpenVersions}
+          onPublish={onPublish}
+        />
+        <textarea aria-label="Skill code editor" />
+      </>,
+    )
+
+    const editor = screen.getByRole('textbox', { name: 'Skill code editor' })
+    await user.click(editor)
+    expect(editor).toHaveFocus()
+
+    await user.keyboard('{Control>}{Shift>}p{/Shift}{/Control}')
+
+    expect(onPublish).not.toHaveBeenCalled()
+  })
+
   it('shows the published state as up to date and disables publishing', () => {
     render(
       <SkillPublishBar

--- a/web/features/skills/detail/publish-bar.tsx
+++ b/web/features/skills/detail/publish-bar.tsx
@@ -58,7 +58,7 @@ export function SkillPublishBar({
 
   useHotkey(PUBLISH_SKILL_HOTKEY, onPublish, {
     enabled: canPublish,
-    ignoreInputs: false,
+    ignoreInputs: true,
   })
 
   const stateMeta = {


### PR DESCRIPTION
## Summary

Fixes #42136.

The Skills publish bar registers `Mod+Shift+P` globally. Skills code files are edited through Dify's Monaco-based editor, where the same key combination belongs to the editor command palette.

This keeps the existing Dify publish shortcut outside editing fields while preventing the global publish handler from taking over editor/input shortcuts.

## Changes

- set the Skills publish hotkey to `ignoreInputs: true`;
- add a focused regression test showing that the shortcut still publishes outside editing fields but does not publish while an editing field is focused.

No Monaco keybindings or global publish shortcut conventions are changed.
