### PR TITLE
feat(agent-app): emit human_input_required SSE on ask_human pause

### DIFF
--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -48,6 +48,7 @@ from core.app.entities.app_invoke_entities import DifyRunContext
 from core.app.entities.queue_entities import (
     QueueAgentMessageEvent,
     QueueAgentThoughtEvent,
+    QueueHumanInputRequiredEvent,
     QueueLLMChunkEvent,
     QueueMessageEndEvent,
 )
@@ -864,12 +865,33 @@ class AgentAppRunner:
 
         # The structured form is delivered via the HITL surface(s); the chat turn
         # ends by echoing the agent's question so the conversation reflects the ask.
-        self._publish_answer(
+        answer = self._ask_human_message(created.args)
+        usage = _llm_usage_from_agent_backend(terminal.usage)
+        publish_text_delta(
             queue_manager=queue_manager,
             model_name=model_name,
-            answer=self._ask_human_message(created.args),
-            query=query,
-            usage=_llm_usage_from_agent_backend(terminal.usage),
+            delta=answer,
+            user_query=query,
+        )
+        queue_manager.publish(
+            QueueHumanInputRequiredEvent(
+                form_id=created.form_id,
+                node_id=message_id,
+                node_title=created.node_title,
+                form_content=created.node_data.form_content,
+                inputs=list(created.node_data.inputs),
+                actions=list(created.node_data.user_actions),
+                resolved_default_values=created.resolved_default_values,
+                display_in_ui=True,
+            ),
+            PublishFrom.APPLICATION_MANAGER,
+        )
+        publish_message_end(
+            queue_manager=queue_manager,
+            model_name=model_name,
+            answer=answer,
+            user_query=query,
+            usage=usage,
         )
 
     def _resolve_pending_ask_human(

--- a/api/core/app/apps/agent_app/human_input_sse.py
+++ b/api/core/app/apps/agent_app/human_input_sse.py
@@ -1,0 +1,135 @@
+"""Emit ``human_input_required`` SSE for Agent App ask_human pauses.
+
+Agent App chat turns reuse the existing HITL webapp contract (``HumanInputFormList``
++ ``/form/human_input/<form_token>``) instead of degrading to plain-text confirmation.
+There is no workflow run for standalone Agent apps, so ``workflow_run_id`` in the SSE
+payload is the owning message id — a stable correlation token for the paused turn.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from sqlalchemy import select
+
+from core.app.entities.app_invoke_entities import InvokeFrom
+from core.app.entities.queue_entities import QueueHumanInputRequiredEvent
+from core.app.entities.task_entities import HumanInputRequiredResponse
+from core.db.session_factory import session_factory
+from core.workflow.human_input_forms import load_form_dispositions_by_form_id
+from core.workflow.human_input_policy import HumanInputSurface
+from core.workflow.nodes.agent_v2.ask_human_hitl import AskHumanFormCreated
+from libs.datetime_utils import to_utc_timestamp
+from models.human_input import HumanInputForm
+
+_INVOKE_FROM_TO_HITL_SURFACE: Mapping[InvokeFrom, HumanInputSurface] = {
+    InvokeFrom.SERVICE_API: HumanInputSurface.SERVICE_API,
+    InvokeFrom.OPENAPI: HumanInputSurface.OPENAPI,
+}
+
+
+def build_human_input_required_stream_response(
+    *,
+    task_id: str,
+    message_id: str,
+    created: AskHumanFormCreated,
+    invoke_from: InvokeFrom,
+) -> HumanInputRequiredResponse:
+    """Build the shared ``human_input_required`` SSE payload for an ask_human pause."""
+    hitl_surface = _INVOKE_FROM_TO_HITL_SURFACE.get(invoke_from)
+    with session_factory.create_session() as session:
+        row = session.execute(
+            select(
+                HumanInputForm.id,
+                HumanInputForm.expiration_time,
+                HumanInputForm.form_definition,
+            ).where(HumanInputForm.id == created.form_id)
+        ).one()
+        form_id, expiration_time, form_definition = row
+        try:
+            definition_payload = json.loads(form_definition) if form_definition else {}
+        except (TypeError, json.JSONDecodeError):
+            definition_payload = {}
+        display_in_ui = bool(definition_payload.get("display_in_ui"))
+        dispositions = load_form_dispositions_by_form_id(
+            [str(form_id)],
+            session=session,
+            surface=hitl_surface,
+        )
+
+    disposition = dispositions.get(created.form_id)
+    return HumanInputRequiredResponse(
+        task_id=task_id,
+        # Agent App chat has no workflow run; reuse the message id as the public
+        # correlation token expected by the shared HITL client contract.
+        workflow_run_id=message_id,
+        data=HumanInputRequiredResponse.Data(
+            form_id=created.form_id,
+            node_id=message_id,
+            node_title=created.node_title,
+            form_content=created.node_data.form_content,
+            inputs=list(created.node_data.inputs),
+            actions=list(created.node_data.user_actions),
+            display_in_ui=display_in_ui,
+            form_token=disposition.form_token if disposition else None,
+            approval_channels=list(disposition.approval_channels) if disposition else [],
+            resolved_default_values=created.resolved_default_values,
+            expiration_time=to_utc_timestamp(expiration_time),
+        ),
+    )
+
+
+def build_human_input_required_stream_response_from_queue_event(
+    *,
+    task_id: str,
+    message_id: str,
+    event: QueueHumanInputRequiredEvent,
+    invoke_from: InvokeFrom,
+) -> HumanInputRequiredResponse:
+    """Build ``human_input_required`` SSE from a queued Agent App ask_human pause."""
+    hitl_surface = _INVOKE_FROM_TO_HITL_SURFACE.get(invoke_from)
+    with session_factory.create_session() as session:
+        row = session.execute(
+            select(
+                HumanInputForm.id,
+                HumanInputForm.expiration_time,
+                HumanInputForm.form_definition,
+            ).where(HumanInputForm.id == event.form_id)
+        ).one()
+        form_id, expiration_time, form_definition = row
+        try:
+            definition_payload = json.loads(form_definition) if form_definition else {}
+        except (TypeError, json.JSONDecodeError):
+            definition_payload = {}
+        display_in_ui = bool(definition_payload.get("display_in_ui", event.display_in_ui))
+        dispositions = load_form_dispositions_by_form_id(
+            [str(form_id)],
+            session=session,
+            surface=hitl_surface,
+        )
+
+    disposition = dispositions.get(event.form_id)
+    return HumanInputRequiredResponse(
+        task_id=task_id,
+        workflow_run_id=message_id,
+        data=HumanInputRequiredResponse.Data(
+            form_id=event.form_id,
+            node_id=event.node_id,
+            node_title=event.node_title,
+            form_content=event.form_content,
+            inputs=list(event.inputs),
+            actions=list(event.actions),
+            display_in_ui=display_in_ui,
+            form_token=disposition.form_token if disposition else None,
+            approval_channels=list(disposition.approval_channels) if disposition else [],
+            resolved_default_values=event.resolved_default_values,
+            expiration_time=to_utc_timestamp(expiration_time),
+        ),
+    )
+
+
+__all__ = [
+    "build_human_input_required_stream_response",
+    "build_human_input_required_stream_response_from_queue_event",
+]

--- a/api/core/app/entities/queue_entities.py
+++ b/api/core/app/entities/queue_entities.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from core.app.entities.agent_strategy import AgentStrategyInfo
 from core.rag.entities import RetrievalSourceMetadata
+from core.workflow.nodes.human_input.entities import FormInputConfig, UserActionConfig
 from core.workflow.nodes.human_input.pause_reason import PauseReason
 from graphon.entities import WorkflowStartReason
 from graphon.enums import NodeType, WorkflowNodeExecutionMetadataKey
@@ -52,6 +53,7 @@ class QueueEvent(StrEnum):
     PAUSE = "pause"
     HUMAN_INPUT_FORM_FILLED = "human_input_form_filled"
     HUMAN_INPUT_FORM_TIMEOUT = "human_input_form_timeout"
+    HUMAN_INPUT_REQUIRED = "human_input_required"
 
 
 class AppQueueEvent(BaseModel):
@@ -550,6 +552,21 @@ class QueueHumanInputFormTimeoutEvent(AppQueueEvent):
     node_type: NodeType
     node_title: str
     expiration_time: datetime
+
+
+class QueueHumanInputRequiredEvent(AppQueueEvent):
+    """Queue event for Agent App ask_human pauses surfaced through the shared HITL SSE contract."""
+
+    event: QueueEvent = QueueEvent.HUMAN_INPUT_REQUIRED
+
+    form_id: str
+    node_id: str
+    node_title: str
+    form_content: str
+    inputs: Sequence[FormInputConfig] = Field(default_factory=list)
+    actions: Sequence[UserActionConfig] = Field(default_factory=list)
+    resolved_default_values: Mapping[str, Any] = Field(default_factory=dict)
+    display_in_ui: bool = True
 
 
 class QueueMessage(BaseModel):

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from core.app.apps.agent_app.human_input_sse import build_human_input_required_stream_response_from_queue_event
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.entities.app_invoke_entities import (
     AgentChatAppGenerateEntity,
@@ -20,6 +21,7 @@ from core.app.entities.queue_entities import (
     QueueAgentThoughtEvent,
     QueueAnnotationReplyEvent,
     QueueErrorEvent,
+    QueueHumanInputRequiredEvent,
     QueueLLMChunkEvent,
     QueueMessageEndEvent,
     QueueMessageFileEvent,
@@ -37,6 +39,7 @@ from core.app.entities.task_entities import (
     CompletionAppStreamResponse,
     EasyUITaskState,
     ErrorStreamResponse,
+    HumanInputRequiredResponse,
     MessageAudioEndStreamResponse,
     MessageAudioStreamResponse,
     MessageEndStreamResponse,
@@ -62,7 +65,9 @@ from graphon.model_runtime.entities.message_entities import (
 )
 from graphon.model_runtime.model_providers.base.large_language_model import LargeLanguageModel
 from libs.datetime_utils import naive_utc_now
-from models.model import AppMode, Conversation, Message, MessageAgentThought, MessageFile, UploadFile
+from models.enums import MessageStatus
+from models.execution_extra_content import HumanInputContent, UploadFile
+from models.model import AppMode, Conversation, Message, MessageAgentThought, MessageFile
 
 logger = logging.getLogger(__name__)
 
@@ -389,6 +394,8 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
                     )
                 case QueueMessageReplaceEvent():
                     yield self._message_cycle_manager.message_replace_to_stream_response(answer=event.text)
+                case QueueHumanInputRequiredEvent():
+                    yield self._human_input_required_to_stream_response(event)
                 case QueuePingEvent():
                     yield self.ping_stream_response()
                 case _:
@@ -568,6 +575,41 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
             metadata=metadata_dict,
             files=files,
         )
+
+    def _human_input_required_to_stream_response(
+        self, event: QueueHumanInputRequiredEvent
+    ) -> HumanInputRequiredResponse:
+        response = build_human_input_required_stream_response_from_queue_event(
+            task_id=self._application_generate_entity.task_id,
+            message_id=self._message_id,
+            event=event,
+            invoke_from=self._application_generate_entity.invoke_from,
+        )
+        self._persist_human_input_extra_content(form_id=event.form_id)
+        return response
+
+    def _persist_human_input_extra_content(self, *, form_id: str) -> None:
+        """Persist pending ask_human form metadata for reconnect/replay."""
+        with session_factory.create_session() as session:
+            exists_stmt = select(HumanInputContent).where(
+                HumanInputContent.workflow_run_id == self._message_id,
+                HumanInputContent.message_id == self._message_id,
+                HumanInputContent.form_id == form_id,
+            )
+            if session.scalar(exists_stmt) is not None:
+                return
+
+            session.add(
+                HumanInputContent.new(
+                    workflow_run_id=self._message_id,
+                    form_id=form_id,
+                    message_id=self._message_id,
+                )
+            )
+            message = session.get(Message, self._message_id)
+            if message is not None:
+                message.status = MessageStatus.PAUSED
+            session.commit()
 
     def _agent_message_to_stream_response(self, answer: str, message_id: str) -> AgentMessageStreamResponse:
         """

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -61,6 +61,7 @@ from core.app.entities.app_invoke_entities import DifyRunContext, InvokeFrom, Us
 from core.app.entities.queue_entities import (
     QueueAgentMessageEvent,
     QueueAgentThoughtEvent,
+    QueueHumanInputRequiredEvent,
     QueueLLMChunkEvent,
     QueueMessageEndEvent,
 )
@@ -1632,7 +1633,15 @@ def test_ask_human_pauses_turn_creates_form_and_persists_correlation() -> None:
     created_params = fake_repo.create_form.call_args.args[0]
     assert created_params.conversation_id == "conv-1"
     assert created_params.workflow_execution_id is None
+    human_input_events = [e for e in qm.events if isinstance(e, QueueHumanInputRequiredEvent)]
+    assert len(human_input_events) == 1
+    assert human_input_events[0].form_id == "form-1"
+    assert human_input_events[0].node_id == "msg-1"
     assert [e for e in qm.events if isinstance(e, QueueMessageEndEvent)]
+    llm_chunk_index = next(i for i, e in enumerate(qm.events) if isinstance(e, QueueLLMChunkEvent))
+    human_input_index = next(i for i, e in enumerate(qm.events) if isinstance(e, QueueHumanInputRequiredEvent))
+    message_end_index = next(i for i, e in enumerate(qm.events) if isinstance(e, QueueMessageEndEvent))
+    assert llm_chunk_index < human_input_index < message_end_index
     assert _saved_user_query(qm) == "hello"
     assert _llm_result(qm).usage.total_tokens == 8
     # The pause correlation is persisted so a form submission can resume the run.

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_human_input_sse.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_human_input_sse.py
@@ -1,0 +1,106 @@
+"""Tests for Agent App ask_human ``human_input_required`` SSE helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from dify_agent.layers.ask_human import AskHumanAction, AskHumanToolArgs
+
+from core.app.apps.agent_app.human_input_sse import (
+    build_human_input_required_stream_response,
+    build_human_input_required_stream_response_from_queue_event,
+)
+from core.app.entities.app_invoke_entities import InvokeFrom
+from core.app.entities.queue_entities import QueueHumanInputRequiredEvent
+from core.workflow.human_input_policy import FormDisposition
+from core.workflow.nodes.agent_v2.ask_human_hitl import AskHumanFormCreated, ask_human_args_to_node_data
+from models.human_input import HumanInputForm
+
+
+def _created_form(*, form_id: str = "form-1") -> AskHumanFormCreated:
+    args = AskHumanToolArgs(
+        question="Approve this change?",
+        actions=[AskHumanAction(id="approve", label="Approve")],
+    )
+    node_data = ask_human_args_to_node_data(args, node_title="Agent")
+    return AskHumanFormCreated(
+        form_id=form_id,
+        args=args,
+        node_data=node_data,
+        node_title="Agent",
+        resolved_default_values={},
+    )
+
+
+@pytest.fixture
+def _patch_human_input_sse_db(monkeypatch: pytest.MonkeyPatch, sqlite_session) -> None:
+    form = HumanInputForm(
+        id="form-1",
+        tenant_id="tenant-1",
+        app_id="app-1",
+        conversation_id="conv-1",
+        node_id="msg-1",
+        form_definition='{"display_in_ui": true}',
+        rendered_content="Approve this change?",
+        expiration_time=datetime.now(UTC) + timedelta(hours=1),
+    )
+    sqlite_session.add(form)
+    sqlite_session.commit()
+
+    session_cm = MagicMock()
+    session_cm.__enter__.return_value = sqlite_session
+    session_cm.__exit__.return_value = None
+    monkeypatch.setattr(
+        "core.app.apps.agent_app.human_input_sse.session_factory.create_session",
+        lambda: session_cm,
+    )
+    monkeypatch.setattr(
+        "core.app.apps.agent_app.human_input_sse.load_form_dispositions_by_form_id",
+        lambda *_args, **_kwargs: {
+            "form-1": FormDisposition(form_token="web-token", approval_channels=[]),
+        },
+    )
+
+
+@pytest.mark.usefixtures("_patch_human_input_sse_db")
+def test_build_human_input_required_stream_response_uses_message_id_as_workflow_run_id() -> None:
+    response = build_human_input_required_stream_response(
+        task_id="task-1",
+        message_id="msg-1",
+        created=_created_form(),
+        invoke_from=InvokeFrom.WEB_APP,
+    )
+
+    assert response.event.value == "human_input_required"
+    assert response.workflow_run_id == "msg-1"
+    assert response.data.form_id == "form-1"
+    assert response.data.form_token == "web-token"
+    assert response.data.node_id == "msg-1"
+    assert response.data.actions[0].id == "approve"
+
+
+@pytest.mark.usefixtures("_patch_human_input_sse_db")
+def test_build_human_input_required_stream_response_from_queue_event() -> None:
+    created = _created_form()
+    queue_event = QueueHumanInputRequiredEvent(
+        form_id=created.form_id,
+        node_id="msg-1",
+        node_title=created.node_title,
+        form_content=created.node_data.form_content,
+        inputs=list(created.node_data.inputs),
+        actions=list(created.node_data.user_actions),
+        resolved_default_values=created.resolved_default_values,
+        display_in_ui=True,
+    )
+
+    response = build_human_input_required_stream_response_from_queue_event(
+        task_id="task-1",
+        message_id="msg-1",
+        event=queue_event,
+        invoke_from=InvokeFrom.WEB_APP,
+    )
+
+    assert response.data.form_token == "web-token"
+    assert response.data.form_content == created.node_data.form_content


### PR DESCRIPTION
## Summary

Fixes #41996.

When a standalone Agent app (`mode=agent`) pauses on `dify.ask_human`, emit the existing `human_input_required` SSE event so the webapp renders `HumanInputFormList` instead of degrading to plain-text confirmation.

## Changes

- Publish `QueueHumanInputRequiredEvent` from the Agent App runner between the answer chunk and `message_end`
- Handle the queue event in the EasyUI task pipeline and stream `HumanInputRequiredResponse` with the same HITL payload shape as Chatflow
- Persist pending form metadata on the message for reconnect/replay and mark the turn as paused

## Event ordering

```
LLM chunk (question) → human_input_required → message_end
```

Form submission continues to use the existing `/form/human_input/<form_token>` endpoints and resume path.

## Test plan

- [x] `test_ask_human_pauses_turn_creates_form_and_persists_correlation` asserts queue event ordering
- [x] `test_human_input_sse.py` covers SSE payload building