### PR TITLE
fix(workflow): parse stringified file inputs when replaying run history

### DIFF
--- a/web/app/components/base/chat/chat/__tests__/utils.spec.ts
+++ b/web/app/components/base/chat/chat/__tests__/utils.spec.ts
@@ -80,6 +80,29 @@ describe('chat/chat/utils.ts', () => {
       expect(result.file2).toHaveProperty('processed', true)
     })
 
+    it('processes singleFile from stringified log history payload', () => {
+      const inputs = {
+        file1: JSON.stringify({
+          dify_model_identity: '__dify__file__',
+          type: 'custom',
+          transfer_method: 'local_file',
+          remote_url: '',
+          related_id: '5bed104b-203c-4e54-9e69-aa6c6082c3da',
+          filename: 'sql_result.zip',
+        }),
+      }
+      const inputsForm = [{ variable: 'file1', type: InputVarType.singleFile as string }]
+
+      const result = getProcessedInputs(inputs, inputsForm as InputForm[])
+
+      expect(result.file1).toEqual({
+        type: 'custom',
+        transfer_method: 'local_file',
+        url: '',
+        upload_file_id: '5bed104b-203c-4e54-9e69-aa6c6082c3da',
+      })
+    })
+
     it('processes multiFiles using transfer_method logic', () => {
       const inputs = {
         files1: [{ transfer_method: 'local_file', url: '1' }],
@@ -90,8 +113,32 @@ describe('chat/chat/utils.ts', () => {
         { variable: 'files2', type: InputVarType.multiFiles as string },
       ]
       const result = getProcessedInputs(inputs, inputsForm as InputForm[])
-      expect(result.files1[0]).toHaveProperty('transfer_method', 'local_file')
-      expect(result.files2[0]).toHaveProperty('processed', true)
+      expect((result.files1 as Array<Record<string, unknown>>)[0]).toHaveProperty(
+        'transfer_method',
+        'local_file',
+      )
+      expect((result.files2 as Array<Record<string, unknown>>)[0]).toHaveProperty('processed', true)
+    })
+
+    it('ignores cleared multiFiles entries from log history', () => {
+      const inputs = {
+        files1: [
+          undefined,
+          { transfer_method: 'local_file', remote_url: 'http://example.com/a.zip' },
+        ],
+      }
+      const inputsForm = [{ variable: 'files1', type: InputVarType.multiFiles as string }]
+
+      const result = getProcessedInputs(inputs, inputsForm as InputForm[])
+
+      expect(result.files1).toEqual([
+        {
+          transfer_method: 'local_file',
+          type: undefined,
+          url: 'http://example.com/a.zip',
+          upload_file_id: undefined,
+        },
+      ])
     })
 
     it('processes jsonObject parsing correct json', () => {

--- a/web/app/components/base/chat/chat/utils.ts
+++ b/web/app/components/base/chat/chat/utils.ts
@@ -1,10 +1,11 @@
 import type { InputForm } from './type'
+import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import { getProcessedFiles } from '@/app/components/base/file-uploader/utils'
 import { InputVarType } from '@/app/components/workflow/types'
 
 export const processOpeningStatement = (
   openingStatement: string,
-  inputs: Record<string, any>,
+  inputs: Record<string, unknown>,
   inputsForm: InputForm[],
 ) => {
   if (!openingStatement) return openingStatement
@@ -13,7 +14,7 @@ export const processOpeningStatement = (
     const name = inputs[key]
     if (name) {
       // has set value
-      return name
+      return String(name)
     }
 
     const valueObj = inputsForm.find((v) => v.variable === key)
@@ -21,7 +22,7 @@ export const processOpeningStatement = (
   })
 }
 
-export const processInputFileFromServer = (fileItem: Record<string, any>) => {
+export const processInputFileFromServer = (fileItem: Record<string, unknown>) => {
   return {
     type: fileItem.type,
     transfer_method: fileItem.transfer_method,
@@ -30,7 +31,31 @@ export const processInputFileFromServer = (fileItem: Record<string, any>) => {
   }
 }
 
-export const getProcessedInputs = (inputs: Record<string, any>, inputsForm: InputForm[]) => {
+const parseFileInputValue = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value
+
+  try {
+    const parsed = JSON.parse(value)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed
+  } catch {
+    // Keep raw string values for non-JSON file inputs.
+  }
+
+  return value
+}
+
+const isServerFileValue = (value: unknown): value is Record<string, unknown> => {
+  const normalized = parseFileInputValue(value)
+
+  return (
+    normalized != null &&
+    typeof normalized === 'object' &&
+    !Array.isArray(normalized) &&
+    'transfer_method' in normalized
+  )
+}
+
+export const getProcessedInputs = (inputs: Record<string, unknown>, inputsForm: InputForm[]) => {
   const processedInputs = { ...inputs }
 
   inputsForm.forEach((item) => {
@@ -44,13 +69,25 @@ export const getProcessedInputs = (inputs: Record<string, any>, inputsForm: Inpu
     if (inputValue == null) return
 
     if (item.type === InputVarType.singleFile) {
-      if ('transfer_method' in inputValue)
-        processedInputs[item.variable] = processInputFileFromServer(inputValue)
-      else processedInputs[item.variable] = getProcessedFiles([inputValue])[0]
+      const normalizedValue = parseFileInputValue(inputValue)
+      if (isServerFileValue(normalizedValue))
+        processedInputs[item.variable] = processInputFileFromServer(normalizedValue)
+      else if (normalizedValue != null)
+        processedInputs[item.variable] = getProcessedFiles([normalizedValue as FileEntity])[0]
     } else if (item.type === InputVarType.multiFiles) {
-      if ('transfer_method' in inputValue[0])
-        processedInputs[item.variable] = inputValue.map(processInputFileFromServer)
-      else processedInputs[item.variable] = getProcessedFiles(inputValue)
+      const fileValues = (Array.isArray(inputValue) ? inputValue : [inputValue]).filter(
+        (value) => value != null,
+      )
+      if (fileValues.length === 0) return
+
+      if (isServerFileValue(fileValues[0]))
+        processedInputs[item.variable] = fileValues.map((value) => {
+          const normalized = parseFileInputValue(value)
+          return processInputFileFromServer(
+            isServerFileValue(normalized) ? normalized : (value as Record<string, unknown>),
+          )
+        })
+      else processedInputs[item.variable] = getProcessedFiles(fileValues as FileEntity[])
     } else if (item.type === InputVarType.jsonObject) {
       // Prefer sending an object if the user entered valid JSON; otherwise keep the raw string.
       try {


### PR DESCRIPTION
Fixes #42135

## Summary

Re-running a workflow test from log history crashes when a start-node file input was stored as a JSON string (via `coerceReplayUserInputs`). `getProcessedInputs` used the `in` operator on that string to detect server-side file payloads.

## Changes

- Parse JSON string file values before checking `transfer_method`
- Skip cleared `undefined` entries in multi-file inputs when rebuilding run payloads
- Add regression tests for stringified log-history file payloads and cleared multi-file arrays

## Test plan

- [x] `web/app/components/base/chat/chat/__tests__/utils.spec.ts`
- [ ] Manual: replay a workflow run with a file input from log history, click Test Run, confirm no console error and run starts