### PR TITLE
feat: move the LLM first-token timeout onto a per-node invocation policy

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -62,6 +62,8 @@ class ModelConfigConverter:
         if "stop" in completion_params:
             stop = completion_params["stop"]
             del completion_params["stop"]
+        # Workflow-only setting; never forward it to providers.
+        completion_params.pop("first_token_timeout_ms", None)
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)
 

--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -62,8 +62,6 @@ class ModelConfigConverter:
         if "stop" in completion_params:
             stop = completion_params["stop"]
             del completion_params["stop"]
-        # Workflow-only setting; never forward it to providers.
-        completion_params.pop("first_token_timeout_ms", None)
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)
 

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from typing import Any
 
@@ -13,6 +14,8 @@ from graphon.model_runtime.entities.model_entities import ModelFeature, ModelPro
 from graphon.nodes.llm.entities import ModelConfig
 from graphon.nodes.llm.exc import LLMModeRequiredError, ModelNotExistError
 from graphon.nodes.llm.protocols import CredentialsProvider
+
+logger = logging.getLogger(__name__)
 
 
 class DifyCredentialsProvider:
@@ -161,21 +164,35 @@ def resolve_model_supports_vision(
     return ModelFeature.VISION in (model_instance.get_model_schema().features or [])
 
 
-def _normalize_completion_params(completion_params: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+def _normalize_completion_params(
+    completion_params: dict[str, Any],
+) -> tuple[dict[str, Any], list[str], float | None]:
     """
-    Split node-level completion params into provider parameters and stop sequences.
+    Split node-level completion params into provider parameters, stop sequences,
+    and the first-token budget.
 
     Workflow LLM-compatible nodes still consume runtime invocation settings from
-    ``ModelInstance.parameters`` and ``ModelInstance.stop``. Keep the
-    ``ModelInstance`` view and the returned config entity aligned here so callers
-    do not need to duplicate normalization logic.
+    ``ModelInstance.parameters``, ``ModelInstance.stop`` and
+    ``ModelInstance.first_token_timeout``. Keep the ``ModelInstance`` view and the
+    returned config entity aligned here so callers do not need to duplicate
+    normalization logic.
+
+    ``first_token_timeout_ms`` never reaches providers; this is the only ms->s
+    conversion on the path. An invalid value disables the budget.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])
     if not isinstance(stop, list) or not all(isinstance(item, str) for item in stop):
         stop = []
 
-    return normalized_parameters, stop
+    raw_timeout_ms = normalized_parameters.pop("first_token_timeout_ms", None)
+    first_token_timeout: float | None = None
+    if isinstance(raw_timeout_ms, (int, float)) and not isinstance(raw_timeout_ms, bool) and raw_timeout_ms > 0:
+        first_token_timeout = float(raw_timeout_ms) / 1000
+    elif raw_timeout_ms is not None:
+        logger.debug("Ignoring invalid first_token_timeout_ms in completion_params: %r", raw_timeout_ms)
+
+    return normalized_parameters, stop, first_token_timeout
 
 
 def fetch_model_config(
@@ -214,12 +231,13 @@ def fetch_model_config(
     if model_schema is None:
         raise ModelNotExistError(f"Model {node_data_model.name} schema does not exist.")
 
-    parameters, stop = _normalize_completion_params(node_data_model.completion_params)
+    parameters, stop, first_token_timeout = _normalize_completion_params(node_data_model.completion_params)
     model_instance.provider = node_data_model.provider
     model_instance.model_name = node_data_model.name
     model_instance.credentials = credentials
     model_instance.parameters = parameters
     model_instance.stop = tuple(stop)
+    model_instance.first_token_timeout = first_token_timeout
 
     return model_instance, ModelConfigWithCredentialsEntity(
         provider=node_data_model.provider,

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from copy import deepcopy
 from typing import Any
 
@@ -14,8 +13,6 @@ from graphon.model_runtime.entities.model_entities import ModelFeature, ModelPro
 from graphon.nodes.llm.entities import ModelConfig
 from graphon.nodes.llm.exc import LLMModeRequiredError, ModelNotExistError
 from graphon.nodes.llm.protocols import CredentialsProvider
-
-logger = logging.getLogger(__name__)
 
 
 class DifyCredentialsProvider:
@@ -164,35 +161,21 @@ def resolve_model_supports_vision(
     return ModelFeature.VISION in (model_instance.get_model_schema().features or [])
 
 
-def _normalize_completion_params(
-    completion_params: dict[str, Any],
-) -> tuple[dict[str, Any], list[str], float | None]:
+def _normalize_completion_params(completion_params: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     """
-    Split node-level completion params into provider parameters, stop sequences,
-    and the first-token budget.
+    Split node-level completion params into provider parameters and stop sequences.
 
     Workflow LLM-compatible nodes still consume runtime invocation settings from
-    ``ModelInstance.parameters``, ``ModelInstance.stop`` and
-    ``ModelInstance.first_token_timeout``. Keep the ``ModelInstance`` view and the
-    returned config entity aligned here so callers do not need to duplicate
-    normalization logic.
-
-    ``first_token_timeout_ms`` never reaches providers; this is the only ms->s
-    conversion on the path. An invalid value disables the budget.
+    ``ModelInstance.parameters`` and ``ModelInstance.stop``. Keep the
+    ``ModelInstance`` view and the returned config entity aligned here so callers
+    do not need to duplicate normalization logic.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])
     if not isinstance(stop, list) or not all(isinstance(item, str) for item in stop):
         stop = []
 
-    raw_timeout_ms = normalized_parameters.pop("first_token_timeout_ms", None)
-    first_token_timeout: float | None = None
-    if isinstance(raw_timeout_ms, (int, float)) and not isinstance(raw_timeout_ms, bool) and raw_timeout_ms > 0:
-        first_token_timeout = float(raw_timeout_ms) / 1000
-    elif raw_timeout_ms is not None:
-        logger.debug("Ignoring invalid first_token_timeout_ms in completion_params: %r", raw_timeout_ms)
-
-    return normalized_parameters, stop, first_token_timeout
+    return normalized_parameters, stop
 
 
 def fetch_model_config(
@@ -231,13 +214,12 @@ def fetch_model_config(
     if model_schema is None:
         raise ModelNotExistError(f"Model {node_data_model.name} schema does not exist.")
 
-    parameters, stop, first_token_timeout = _normalize_completion_params(node_data_model.completion_params)
+    parameters, stop = _normalize_completion_params(node_data_model.completion_params)
     model_instance.provider = node_data_model.provider
     model_instance.model_name = node_data_model.name
     model_instance.credentials = credentials
     model_instance.parameters = parameters
     model_instance.stop = tuple(stop)
-    model_instance.first_token_timeout = first_token_timeout
 
     return model_instance, ModelConfigWithCredentialsEntity(
         provider=node_data_model.provider,

--- a/api/core/model_manager.py
+++ b/api/core/model_manager.py
@@ -64,6 +64,7 @@ class ModelInstance:
         # Runtime LLM invocation fields.
         self.parameters: Mapping[str, Any] = {}
         self.stop: Sequence[str] = ()
+        self.first_token_timeout: float | None = None
         self.model_type_instance = self.provider_model_bundle.model_type_instance
         self.load_balancing_manager = self._get_load_balancing_manager(
             configuration=provider_model_bundle.configuration,

--- a/api/core/model_manager.py
+++ b/api/core/model_manager.py
@@ -64,7 +64,6 @@ class ModelInstance:
         # Runtime LLM invocation fields.
         self.parameters: Mapping[str, Any] = {}
         self.stop: Sequence[str] = ()
-        self.first_token_timeout: float | None = None
         self.model_type_instance = self.provider_model_bundle.model_type_instance
         self.load_balancing_manager = self._get_load_balancing_manager(
             configuration=provider_model_bundle.configuration,

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -33,6 +33,7 @@ from core.plugin.impl.exc import (
     PluginRuntimeError,
     PluginUniqueIdentifierError,
 )
+from core.plugin.impl.first_token_timeout import FirstTokenTimeoutError, first_token_backstop
 from core.trigger.errors import (
     EventIgnoreError,
     TriggerInvokeError,
@@ -93,6 +94,24 @@ def use_plugin_daemon_request_timeout(timeout_seconds: float) -> Generator[None,
 
 def _get_plugin_daemon_request_timeout() -> httpx.Timeout | None:
     return _plugin_daemon_request_timeout_override.get() or plugin_daemon_request_timeout
+
+
+def _resolve_stream_timeout(first_token_timeout: float | None) -> httpx.Timeout | None:
+    """Widen the read window so it never cuts a first-token budget short.
+
+    The window is only ever extended, never narrowed. Narrowing it to the budget would
+    make it bound every inter-token gap too, which is not what the setting means -- and
+    it is not needed, because the plugin enforces the budget and the daemon re-enforces
+    it at ``budget + e``. This is the outermost rung and only fires when both are wedged.
+    """
+    base = _get_plugin_daemon_request_timeout()
+    if not first_token_timeout or first_token_timeout <= 0 or base is None:
+        return base
+
+    backstop = first_token_backstop(first_token_timeout)
+    if base.read is None or base.read >= backstop:
+        return base
+    return httpx.Timeout(connect=base.connect, read=backstop, write=base.write, pool=base.pool)
 
 
 def _normalize_plugin_daemon_response_for_type(json_response: Any, type_: type[object]) -> Any:
@@ -227,6 +246,7 @@ class BasePluginClient:
         headers: dict[str, str] | None = None,
         data: bytes | dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
+        first_token_timeout: float | None = None,
     ) -> Generator[str, None, None]:
         """
         Make a stream request to the plugin daemon inner API
@@ -239,12 +259,14 @@ class BasePluginClient:
             "headers": headers,
             "params": params,
             "files": files,
-            "timeout": _get_plugin_daemon_request_timeout(),
+            "timeout": _resolve_stream_timeout(first_token_timeout),
         }
         if isinstance(prepared_data, dict):
             stream_kwargs["data"] = prepared_data
         elif prepared_data is not None:
             stream_kwargs["content"] = prepared_data
+
+        first_line_seen = False
 
         try:
             with _httpx_client.stream(**stream_kwargs) as response:
@@ -256,7 +278,17 @@ class BasePluginClient:
                     if line.startswith("data:"):
                         line = line[5:].strip()
                     if line:
+                        first_line_seen = True
                         yield line
+        except httpx.ReadTimeout as e:
+            if first_token_timeout and not first_line_seen:
+                # The daemon should have named this itself; reaching here means it never
+                # answered at all, so this side is the only one left that can say why.
+                raise FirstTokenTimeoutError(
+                    f"The plugin daemon sent nothing within {first_token_timeout}s of a first-token budget."
+                ) from e
+            logger.exception("Stream request to Plugin Daemon Service failed")
+            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed") from e
         except httpx.RequestError:
             logger.exception("Stream request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
@@ -358,11 +390,12 @@ class BasePluginClient:
         data: bytes | dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
+        first_token_timeout: float | None = None,
     ) -> Generator[T, None, None]:
         """
         Make a stream request to the plugin daemon inner API and yield the response as a model.
         """
-        for line in self._stream_request(method, path, params, headers, data, files):
+        for line in self._stream_request(method, path, params, headers, data, files, first_token_timeout):
             try:
                 rep = PluginDaemonBasicResponse[type_].model_validate_json(line)  # type: ignore
             except (ValueError, TypeError):
@@ -398,10 +431,15 @@ class BasePluginClient:
         match error_type:
             case PluginDaemonInnerError.__name__:
                 raise PluginDaemonInnerError(code=-500, message=message)
+            case FirstTokenTimeoutError.__name__:
+                # Raised by the daemon's own gate, one rung out from the plugin's.
+                raise FirstTokenTimeoutError(description=message)
             case PluginInvokeError.__name__:
                 error_object = json.loads(message)
                 invoke_error_type = error_object.get("error_type")
                 match invoke_error_type:
+                    case FirstTokenTimeoutError.__name__:
+                        raise FirstTokenTimeoutError(description=error_object.get("message"))
                     case InvokeRateLimitError.__name__:
                         raise InvokeRateLimitError(description=error_object.get("message"))
                     case InvokeAuthorizationError.__name__:

--- a/api/core/plugin/impl/first_token_timeout.py
+++ b/api/core/plugin/impl/first_token_timeout.py
@@ -1,0 +1,37 @@
+"""Per-node first-token budget for LLM invocations through the plugin daemon.
+
+Configured as ``completion_params.first_token_timeout_ms`` and popped into
+``ModelInstance.first_token_timeout`` by ``_normalize_completion_params`` -- the only
+ms->s conversion, everything past that point is seconds. ``DifyPreparedLLM`` puts it on
+``request_metadata`` for streaming invocations only, ``PluginModelRuntime`` reads it back
+off, and ``PluginModelClient.invoke_llm`` sends it to the daemon as a request field.
+
+Enforcement belongs to the plugin process, the only layer holding the provider
+connection. The daemon re-enforces at ``budget + e`` and this side widens its read window
+to ``budget + 2e`` when the configured one is shorter. Whichever rung fires is therefore
+the innermost layer that knows why the call stalled, and the outer ones only come into
+play when an inner one is wedged.
+"""
+
+from graphon.model_runtime.errors.invoke import InvokeError
+
+FIRST_TOKEN_TIMEOUT_METADATA_KEY = "first_token_timeout"
+
+_GRACE_FLOOR_SECONDS = 0.25
+_GRACE_RATIO = 0.05
+
+
+class FirstTokenTimeoutError(InvokeError):
+    """The model did not stream its first token within the configured budget."""
+
+    description = "The first streamed token was not received in time."
+
+
+def first_token_grace(budget: float) -> float:
+    """One rung of the deadline ladder, matching the daemon's own epsilon."""
+    return max(_GRACE_FLOOR_SECONDS, budget * _GRACE_RATIO)
+
+
+def first_token_backstop(budget: float) -> float:
+    """Transport deadline for a request carrying ``budget``, two rungs out from it."""
+    return budget + 2 * first_token_grace(budget)

--- a/api/core/plugin/impl/model.py
+++ b/api/core/plugin/impl/model.py
@@ -181,10 +181,27 @@ class PluginModelClient(BasePluginClient):
         stop: list[str] | None = None,
         stream: bool = True,
         app_id: str | None = None,
+        first_token_timeout: float | None = None,
     ) -> Generator[LLMResultChunk, None, None]:
         """
         Invoke llm
         """
+        data: dict[str, Any] = {
+            "provider": provider,
+            "model_type": "llm",
+            "model": model,
+            "credentials": credentials,
+            "prompt_messages": prompt_messages,
+            "model_parameters": model_parameters,
+            "tools": tools,
+            "stop": stop,
+            "stream": stream,
+        }
+        # Omitted rather than sent as null, so a daemon that predates the field is
+        # byte-for-byte unaffected.
+        if first_token_timeout and first_token_timeout > 0:
+            data["first_token_timeout"] = first_token_timeout
+
         response = self._request_with_plugin_daemon_response_stream(
             method="POST",
             path=f"plugin/{tenant_id}/dispatch/llm/invoke",
@@ -192,17 +209,7 @@ class PluginModelClient(BasePluginClient):
             data=jsonable_encoder(
                 self._dispatch_payload(
                     user_id=user_id,
-                    data={
-                        "provider": provider,
-                        "model_type": "llm",
-                        "model": model,
-                        "credentials": credentials,
-                        "prompt_messages": prompt_messages,
-                        "model_parameters": model_parameters,
-                        "tools": tools,
-                        "stop": stop,
-                        "stream": stream,
-                    },
+                    data=data,
                     app_id=app_id,
                 )
             ),
@@ -210,6 +217,7 @@ class PluginModelClient(BasePluginClient):
                 "X-Plugin-ID": plugin_id,
                 "Content-Type": "application/json",
             },
+            first_token_timeout=first_token_timeout,
         )
 
         try:

--- a/api/core/plugin/impl/model_runtime.py
+++ b/api/core/plugin/impl/model_runtime.py
@@ -15,6 +15,7 @@ from core.llm_generator.output_parser.structured_output import (
 )
 from core.plugin.entities.plugin_daemon import PluginModelProviderDeclaration
 from core.plugin.impl.asset import PluginAssetManager
+from core.plugin.impl.first_token_timeout import FIRST_TOKEN_TIMEOUT_METADATA_KEY
 from core.plugin.impl.model import PluginModelClient
 from core.plugin.plugin_service import PluginService
 from extensions.ext_redis import redis_client
@@ -322,6 +323,9 @@ class PluginModelRuntime(ModelRuntime):
         app_id = request_metadata.get("app_id") if request_metadata else None
         if not isinstance(app_id, str):
             app_id = None
+        first_token_timeout = request_metadata.get(FIRST_TOKEN_TIMEOUT_METADATA_KEY) if request_metadata else None
+        if not isinstance(first_token_timeout, (int, float)) or isinstance(first_token_timeout, bool):
+            first_token_timeout = None
         plugin_id, provider_name = self._split_provider(provider)
         if app_id is None:
             result = self.client.invoke_llm(
@@ -336,6 +340,7 @@ class PluginModelRuntime(ModelRuntime):
                 tools=tools,
                 stop=list(stop) if stop else None,
                 stream=stream,
+                first_token_timeout=first_token_timeout,
             )
         else:
             result = self.client.invoke_llm(
@@ -351,6 +356,7 @@ class PluginModelRuntime(ModelRuntime):
                 stop=list(stop) if stop else None,
                 stream=stream,
                 app_id=app_id,
+                first_token_timeout=first_token_timeout,
             )
         if stream:
             return result

--- a/api/core/workflow/node_factory.py
+++ b/api/core/workflow/node_factory.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, cast, final, override
 
+from pydantic import BaseModel
 from sqlalchemy import select
 
 from configs import dify_config
@@ -670,12 +671,52 @@ class DifyNodeFactory(NodeFactory):
         model_instance: ModelInstance,
         request_metadata: Mapping[str, object] | None = None,
     ) -> DifyPreparedLLM:
+        first_token_timeout = DifyNodeFactory._node_first_token_timeout(node_data)
         # Only graphon's LLM node consumes the polling protocol. Keep classifier
         # and extractor nodes on the existing wrapper even if the same model
         # advertises polling support.
         if node_data.type == BuiltinNodeTypes.LLM and DifyNodeFactory._supports_plugin_llm_polling(model_instance):
-            return DifyPreparedPollingLLM(model_instance, request_metadata=request_metadata)
-        return DifyPreparedLLM(model_instance, request_metadata=request_metadata)
+            return DifyPreparedPollingLLM(
+                model_instance,
+                request_metadata=request_metadata,
+                first_token_timeout=first_token_timeout,
+            )
+        return DifyPreparedLLM(
+            model_instance,
+            request_metadata=request_metadata,
+            first_token_timeout=first_token_timeout,
+        )
+
+    @staticmethod
+    def _node_first_token_timeout(node_data: LLMCompatibleNodeData) -> float | None:
+        """Read the node's first-token timeout off its invocation policy.
+
+        Only the nodes that stream carry the block. The parameter extractor invokes
+        with ``stream=False``, where the single result arrives once generation has
+        finished, so a first-token timeout there would quietly become a
+        total-generation timeout.
+
+        The block is read through ``BaseNodeData.get`` rather than as an attribute:
+        graphon declares ``invocation`` as a field only from the release that
+        introduces it, and before that the key rides along as an undeclared
+        compatibility extra. So it arrives either as a plain dict or as a model, and
+        both are normalized to a mapping here, which keeps this working across the
+        pin bump. The value is validated either way, because an extra arrives
+        unvalidated. This is the only ms->s conversion on the path.
+        """
+        if node_data.type not in {BuiltinNodeTypes.LLM, BuiltinNodeTypes.QUESTION_CLASSIFIER}:
+            return None
+
+        invocation = node_data.get("invocation")
+        if isinstance(invocation, BaseModel):
+            invocation = invocation.model_dump()
+        if not isinstance(invocation, Mapping):
+            return None
+
+        timeout_ms = invocation.get("first_token_timeout_ms")
+        if not isinstance(timeout_ms, (int, float)) or isinstance(timeout_ms, bool) or timeout_ms <= 0:
+            return None
+        return float(timeout_ms) / 1000
 
     @staticmethod
     def _supports_plugin_llm_polling(model_instance: ModelInstance) -> bool:

--- a/api/core/workflow/node_runtime.py
+++ b/api/core/workflow/node_runtime.py
@@ -196,9 +196,15 @@ def _with_first_token_budget(
 class DifyPreparedLLM(LLMProtocol):
     """Workflow-layer adapter that hides the full `ModelInstance` API from `graphon` nodes."""
 
-    def __init__(self, model_instance: ModelInstance, request_metadata: Mapping[str, object] | None = None) -> None:
+    def __init__(
+        self,
+        model_instance: ModelInstance,
+        request_metadata: Mapping[str, object] | None = None,
+        first_token_timeout: float | None = None,
+    ) -> None:
         self._model_instance = model_instance
         self._request_metadata = request_metadata
+        self._first_token_timeout = first_token_timeout
 
     @property
     @override
@@ -279,7 +285,7 @@ class DifyPreparedLLM(LLMProtocol):
             stream=stream,
             request_metadata=_with_first_token_budget(
                 self._request_metadata,
-                self._model_instance.first_token_timeout,
+                self._first_token_timeout,
                 stream,
             ),
         )
@@ -327,7 +333,7 @@ class DifyPreparedLLM(LLMProtocol):
             stream=stream,
             request_metadata=_with_first_token_budget(
                 self._request_metadata,
-                self._model_instance.first_token_timeout,
+                self._first_token_timeout,
                 stream,
             ),
         )
@@ -343,8 +349,13 @@ class DifyPreparedLLM(LLMProtocol):
 class DifyPreparedPollingLLM(DifyPreparedLLM, LLMPollingCapableProtocol):
     """Prepared workflow LLM adapter that exposes Graphon's polling protocol."""
 
-    def __init__(self, model_instance: ModelInstance, request_metadata: Mapping[str, object] | None = None) -> None:
-        super().__init__(model_instance, request_metadata=request_metadata)
+    def __init__(
+        self,
+        model_instance: ModelInstance,
+        request_metadata: Mapping[str, object] | None = None,
+        first_token_timeout: float | None = None,
+    ) -> None:
+        super().__init__(model_instance, request_metadata=request_metadata, first_token_timeout=first_token_timeout)
         model_type_instance = cast(LargeLanguageModel, model_instance.model_type_instance)
         self._polling_runtime = cast(PollingLLMRuntimeProtocol, model_type_instance.model_runtime)
         self._polling_quota_reservation = None

--- a/api/core/workflow/node_runtime.py
+++ b/api/core/workflow/node_runtime.py
@@ -23,6 +23,7 @@ from core.llm_generator.output_parser.structured_output import invoke_llm_with_s
 from core.model_context import use_credit_usage_metadata
 from core.model_manager import ModelInstance, QuotaManagedModelInstance
 from core.plugin.impl.exc import PluginDaemonClientSideError, PluginInvokeError
+from core.plugin.impl.first_token_timeout import FIRST_TOKEN_TIMEOUT_METADATA_KEY
 from core.plugin.impl.plugin import PluginInstaller
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
 from core.repositories.human_input_repository import (
@@ -176,6 +177,22 @@ class DifyFileReferenceFactory(FileReferenceFactoryProtocol):
         )
 
 
+def _with_first_token_budget(
+    request_metadata: Mapping[str, object] | None,
+    first_token_timeout: float | None,
+    stream: bool,
+) -> Mapping[str, object] | None:
+    """Attach the node's first-token budget to the metadata carried with the request.
+
+    Streaming only: without a stream the single result arrives once generation has
+    finished, so a first-token budget there would quietly become a total-time budget.
+    """
+    if not stream or not first_token_timeout or first_token_timeout <= 0:
+        return request_metadata
+
+    return {**(request_metadata or {}), FIRST_TOKEN_TIMEOUT_METADATA_KEY: first_token_timeout}
+
+
 class DifyPreparedLLM(LLMProtocol):
     """Workflow-layer adapter that hides the full `ModelInstance` API from `graphon` nodes."""
 
@@ -260,7 +277,11 @@ class DifyPreparedLLM(LLMProtocol):
             tools=list(tools or []),
             stop=list(stop or []),
             stream=stream,
-            request_metadata=self._request_metadata,
+            request_metadata=_with_first_token_budget(
+                self._request_metadata,
+                self._model_instance.first_token_timeout,
+                stream,
+            ),
         )
 
     @overload
@@ -304,7 +325,11 @@ class DifyPreparedLLM(LLMProtocol):
             model_parameters=model_parameters,
             stop=list(stop or []),
             stream=stream,
-            request_metadata=self._request_metadata,
+            request_metadata=_with_first_token_budget(
+                self._request_metadata,
+                self._model_instance.first_token_timeout,
+                stream,
+            ),
         )
 
     @override

--- a/api/tests/integration_tests/model_runtime/__mock/plugin_model.py
+++ b/api/tests/integration_tests/model_runtime/__mock/plugin_model.py
@@ -249,5 +249,6 @@ class MockModelClass(PluginModelClient):
         stop: list[str] | None = None,
         stream: bool = True,
         app_id: str | None = None,
+        first_token_timeout: float | None = None,
     ):
         return MockModelClass.mocked_chat_create_stream(model=model, prompt_messages=prompt_messages, tools=tools)

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
@@ -100,6 +100,14 @@ class TestModelConfigConverter:
         assert result.parameters == {"temperature": 0.7}
         assert result.stop == ["\n"]
 
+    def test_convert_drops_first_token_timeout_ms(self, mock_app_config, patch_provider_manager):
+        """The workflow-only setting must never reach providers through app configs."""
+        mock_app_config.model.parameters = {"temperature": 0.7, "first_token_timeout_ms": 2000}
+
+        result = ModelConfigConverter.convert(mock_app_config)
+
+        assert result.parameters == {"temperature": 0.7}
+
     def test_convert_mode_from_schema_valid(self, mock_app_config, mock_provider_bundle, mocker: MockerFixture):
         mock_app_config.model.mode = None
 

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
@@ -100,14 +100,6 @@ class TestModelConfigConverter:
         assert result.parameters == {"temperature": 0.7}
         assert result.stop == ["\n"]
 
-    def test_convert_drops_first_token_timeout_ms(self, mock_app_config, patch_provider_manager):
-        """The workflow-only setting must never reach providers through app configs."""
-        mock_app_config.model.parameters = {"temperature": 0.7, "first_token_timeout_ms": 2000}
-
-        result = ModelConfigConverter.convert(mock_app_config)
-
-        assert result.parameters == {"temperature": 0.7}
-
     def test_convert_mode_from_schema_valid(self, mock_app_config, mock_provider_bundle, mocker: MockerFixture):
         mock_app_config.model.mode = None
 

--- a/api/tests/unit_tests/core/app/llm/test_model_access.py
+++ b/api/tests/unit_tests/core/app/llm/test_model_access.py
@@ -87,21 +87,3 @@ def test_resolve_model_supports_vision_reads_selected_model_schema(
         )
         is expected
     )
-
-
-def test_normalize_completion_params_pops_the_first_token_budget() -> None:
-    parameters, stop, first_token_timeout = model_access._normalize_completion_params(
-        {"temperature": 0.1, "stop": ["END"], "first_token_timeout_ms": 2500}
-    )
-
-    assert parameters == {"temperature": 0.1}
-    assert stop == ["END"]
-    assert first_token_timeout == pytest.approx(2.5)
-
-
-@pytest.mark.parametrize("raw", [None, 0, -1, "2000", True])
-def test_normalize_completion_params_disables_the_budget_for_an_invalid_value(raw: object) -> None:
-    parameters, _, first_token_timeout = model_access._normalize_completion_params({"first_token_timeout_ms": raw})
-
-    assert first_token_timeout is None
-    assert "first_token_timeout_ms" not in parameters

--- a/api/tests/unit_tests/core/app/llm/test_model_access.py
+++ b/api/tests/unit_tests/core/app/llm/test_model_access.py
@@ -87,3 +87,21 @@ def test_resolve_model_supports_vision_reads_selected_model_schema(
         )
         is expected
     )
+
+
+def test_normalize_completion_params_pops_the_first_token_budget() -> None:
+    parameters, stop, first_token_timeout = model_access._normalize_completion_params(
+        {"temperature": 0.1, "stop": ["END"], "first_token_timeout_ms": 2500}
+    )
+
+    assert parameters == {"temperature": 0.1}
+    assert stop == ["END"]
+    assert first_token_timeout == pytest.approx(2.5)
+
+
+@pytest.mark.parametrize("raw", [None, 0, -1, "2000", True])
+def test_normalize_completion_params_disables_the_budget_for_an_invalid_value(raw: object) -> None:
+    parameters, _, first_token_timeout = model_access._normalize_completion_params({"first_token_timeout_ms": raw})
+
+    assert first_token_timeout is None
+    assert "first_token_timeout_ms" not in parameters

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -1,0 +1,142 @@
+import json
+from collections.abc import Iterator
+from types import TracebackType
+from typing import override
+
+import httpx
+import pytest
+
+from core.plugin.entities.plugin_daemon import PluginDaemonInnerError
+from core.plugin.impl.base import BasePluginClient, _resolve_stream_timeout
+from core.plugin.impl.first_token_timeout import (
+    FirstTokenTimeoutError,
+    first_token_backstop,
+    first_token_grace,
+)
+
+
+class _StreamContext:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    def __enter__(self) -> "_StreamContext":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        return False
+
+    def iter_lines(self) -> Iterator[str]:
+        yield from self._lines
+
+
+def _timed_out(**_kwargs: object) -> _StreamContext:
+    raise httpx.ReadTimeout("timed out")
+
+
+class TestFirstTokenLadder:
+    def test_grace_has_a_floor_and_a_ratio(self) -> None:
+        assert first_token_grace(1.0) == pytest.approx(0.25)
+        assert first_token_grace(2.0) == pytest.approx(0.25)
+        assert first_token_grace(20.0) == pytest.approx(1.0)
+
+    def test_the_backstop_sits_two_rungs_out(self) -> None:
+        assert first_token_backstop(2.0) == pytest.approx(2.5)
+        assert first_token_backstop(20.0) == pytest.approx(22.0)
+
+
+class TestResolveStreamTimeout:
+    def test_no_budget_leaves_the_configured_timeout_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        base = httpx.Timeout(600.0)
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", base)
+
+        assert _resolve_stream_timeout(None) is base
+        assert _resolve_stream_timeout(0) is base
+
+    def test_a_budget_inside_the_window_does_not_narrow_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Narrowing would make the budget bound every inter-token gap as well."""
+        base = httpx.Timeout(600.0)
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", base)
+
+        assert _resolve_stream_timeout(2.0) is base
+
+    def test_a_budget_past_the_window_widens_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        base = httpx.Timeout(600.0)
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", base)
+
+        resolved = _resolve_stream_timeout(900.0)
+
+        assert resolved is not None
+        assert resolved.read == pytest.approx(first_token_backstop(900.0))
+        assert resolved.connect == base.connect
+        assert resolved.write == base.write
+
+    def test_an_unlimited_window_stays_unlimited(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.plugin.impl.base.plugin_daemon_request_timeout", None)
+
+        assert _resolve_stream_timeout(2.0) is None
+
+
+class TestStreamRequestBackstop:
+    def test_a_read_timeout_before_any_frame_is_named_as_a_first_token_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("core.plugin.impl.base._httpx_client.stream", _timed_out)
+
+        with pytest.raises(FirstTokenTimeoutError) as excinfo:
+            list(BasePluginClient()._stream_request("POST", "some/path", first_token_timeout=2.0))
+
+        assert "2.0" in str(excinfo.value)
+
+    def test_a_read_timeout_after_a_frame_is_a_plain_transport_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _StalledAfterFirstFrame(_StreamContext):
+            @override
+            def iter_lines(self) -> Iterator[str]:
+                yield "data: first"
+                raise httpx.ReadTimeout("timed out")
+
+        monkeypatch.setattr(
+            "core.plugin.impl.base._httpx_client.stream",
+            lambda **_kwargs: _StalledAfterFirstFrame([]),
+        )
+
+        stream = BasePluginClient()._stream_request("POST", "some/path", first_token_timeout=2.0)
+        assert next(stream) == "first"
+
+        with pytest.raises(PluginDaemonInnerError):
+            next(stream)
+
+    def test_a_read_timeout_without_a_budget_is_a_plain_transport_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.plugin.impl.base._httpx_client.stream", _timed_out)
+
+        with pytest.raises(PluginDaemonInnerError):
+            list(BasePluginClient()._stream_request("POST", "some/path"))
+
+
+class TestTypedErrorFrames:
+    def test_the_daemon_gate_maps_to_a_first_token_timeout(self) -> None:
+        with pytest.raises(FirstTokenTimeoutError) as excinfo:
+            BasePluginClient()._handle_plugin_daemon_error(
+                "FirstTokenTimeoutError",
+                "no token was received within 2s",
+            )
+
+        assert "no token was received within 2s" in str(excinfo.value)
+
+    def test_the_plugin_gate_maps_to_a_first_token_timeout(self) -> None:
+        message = json.dumps(
+            {
+                "error_type": "FirstTokenTimeoutError",
+                "message": "The first token was not received within 2.0s.",
+                "args": {},
+            }
+        )
+
+        with pytest.raises(FirstTokenTimeoutError) as excinfo:
+            BasePluginClient()._handle_plugin_daemon_error("PluginInvokeError", message)
+
+        assert "The first token was not received within 2.0s." in str(excinfo.value)

--- a/api/tests/unit_tests/core/plugin/impl/test_model_client.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_model_client.py
@@ -198,6 +198,46 @@ class TestPluginModelClient:
 
         assert "app_id" not in stream_mock.call_args.kwargs["data"]
 
+    def test_invoke_llm_sends_the_first_token_budget(self, mocker: MockerFixture):
+        client = PluginModelClient()
+        stream_mock = mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=iter([]))
+
+        list(
+            client.invoke_llm(
+                tenant_id="tenant-1",
+                user_id="user-1",
+                plugin_id="org/plugin:1",
+                provider="provider-a",
+                model="gpt-test",
+                credentials={},
+                prompt_messages=[],
+                first_token_timeout=2.0,
+            )
+        )
+
+        call_kwargs = stream_mock.call_args.kwargs
+        assert call_kwargs["data"]["data"]["first_token_timeout"] == 2.0
+        assert call_kwargs["first_token_timeout"] == 2.0
+
+    def test_invoke_llm_omits_the_first_token_budget_when_unset(self, mocker: MockerFixture):
+        """A daemon that predates the field must see a byte-identical payload."""
+        client = PluginModelClient()
+        stream_mock = mocker.patch.object(client, "_request_with_plugin_daemon_response_stream", return_value=iter([]))
+
+        list(
+            client.invoke_llm(
+                tenant_id="tenant-1",
+                user_id="user-1",
+                plugin_id="org/plugin:1",
+                provider="provider-a",
+                model="gpt-test",
+                credentials={},
+                prompt_messages=[],
+            )
+        )
+
+        assert "first_token_timeout" not in stream_mock.call_args.kwargs["data"]["data"]
+
     def test_invoke_llm_wraps_plugin_daemon_inner_error(self, mocker: MockerFixture):
         client = PluginModelClient()
 

--- a/api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py
+++ b/api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py
@@ -283,6 +283,7 @@ class TestPluginModelRuntime:
             tools=None,
             stop=None,
             stream=False,
+            first_token_timeout=None,
         )
 
     def test_invoke_llm_forwards_string_app_id_from_request_metadata(self) -> None:
@@ -316,6 +317,7 @@ class TestPluginModelRuntime:
             stop=None,
             stream=True,
             app_id="app-1",
+            first_token_timeout=None,
         )
 
     def test_invoke_llm_ignores_non_string_app_id_request_metadata(self) -> None:
@@ -368,7 +370,50 @@ class TestPluginModelRuntime:
             tools=None,
             stop=["END"],
             stream=True,
+            first_token_timeout=None,
         )
+
+    def test_invoke_llm_forwards_the_first_token_budget_from_request_metadata(self) -> None:
+        client = Mock(spec=PluginModelClient)
+        client.invoke_llm.return_value = iter([])
+        runtime = PluginModelRuntime(tenant_id="tenant", user_id="user", client=client, plugin_service=PluginService)
+
+        list(
+            runtime.invoke_llm(
+                provider="langgenius/openai/openai",
+                model="gpt-4o-mini",
+                credentials={"api_key": "secret"},
+                model_parameters={},
+                prompt_messages=[],
+                tools=None,
+                stop=None,
+                stream=True,
+                request_metadata={"first_token_timeout": 2.0},
+            )
+        )
+
+        assert client.invoke_llm.call_args.kwargs["first_token_timeout"] == 2.0
+
+    def test_invoke_llm_ignores_a_non_numeric_first_token_budget(self) -> None:
+        client = Mock(spec=PluginModelClient)
+        client.invoke_llm.return_value = iter([])
+        runtime = PluginModelRuntime(tenant_id="tenant", user_id="user", client=client, plugin_service=PluginService)
+
+        list(
+            runtime.invoke_llm(
+                provider="langgenius/openai/openai",
+                model="gpt-4o-mini",
+                credentials={"api_key": "secret"},
+                model_parameters={},
+                prompt_messages=[],
+                tools=None,
+                stop=None,
+                stream=True,
+                request_metadata={"first_token_timeout": "2.0"},
+            )
+        )
+
+        assert client.invoke_llm.call_args.kwargs["first_token_timeout"] is None
 
     def test_start_llm_polling_resolves_plugin_fields(self) -> None:
         client = Mock(spec=PluginModelClient)

--- a/api/tests/unit_tests/core/workflow/test_node_factory.py
+++ b/api/tests/unit_tests/core/workflow/test_node_factory.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch, sentinel
 
 import pytest
+from pydantic import BaseModel
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -25,6 +26,7 @@ from graphon.nodes.llm.entities import LLMNodeData
 from graphon.nodes.llm.node import LLMNode
 from graphon.nodes.llm.runtime_protocols import LLMPollingCapableProtocol
 from graphon.nodes.parameter_extractor.entities import ParameterExtractorNodeData
+from graphon.nodes.question_classifier.entities import QuestionClassifierNodeData
 from graphon.variables.segments import ArrayObjectSegment, ObjectSegment, StringSegment
 from models.base import TypeBase
 from models.model import AppMode, Conversation, ConversationFromSource
@@ -82,6 +84,12 @@ def _build_llm_model_schema(*, features: list[ModelFeature] | None = None) -> AI
         model_properties={},
         features=features,
     )
+
+
+class _InvocationConfigStub(BaseModel):
+    """Stands in for the graphon release that declares `invocation` as a field."""
+
+    first_token_timeout_ms: int | None = None
 
 
 class _ModelTypeInstanceStub(LargeLanguageModel):
@@ -886,12 +894,98 @@ class TestDifyNodeFactoryCreateNode:
         )
 
         wrapped = node_factory.DifyNodeFactory._wrap_model_instance_for_node(
-            node_data=SimpleNamespace(type=node_type),
+            node_data=SimpleNamespace(type=node_type, get=lambda _key: None),
             model_instance=model_instance,
         )
 
         assert type(wrapped) is DifyPreparedLLM
         assert not isinstance(wrapped, LLMPollingCapableProtocol)
+
+    def test_wrap_model_instance_passes_the_node_first_token_timeout_to_the_adapter(self):
+        node_data = LLMNodeData.model_validate(
+            {
+                "type": BuiltinNodeTypes.LLM,
+                "title": "LLM",
+                "model": {"provider": "provider", "name": "model", "mode": "chat", "completion_params": {}},
+                "invocation": {"first_token_timeout_ms": 2500},
+                "prompt_template": [{"role": "system", "text": "x"}],
+                "context": {"enabled": False, "variable_selector": []},
+                "vision": {"enabled": False},
+            }
+        )
+        model_instance = _ModelInstanceStub(
+            model_runtime=object(),
+            model_schema=_build_llm_model_schema(),
+        )
+
+        wrapped = node_factory.DifyNodeFactory._wrap_model_instance_for_node(
+            node_data=node_data,
+            model_instance=model_instance,
+        )
+
+        assert wrapped._first_token_timeout == pytest.approx(2.5)
+
+    @pytest.mark.parametrize(
+        "invocation",
+        [
+            {"first_token_timeout_ms": 2500},
+            _InvocationConfigStub(first_token_timeout_ms=2500),
+        ],
+        ids=["undeclared-extra", "declared-field"],
+    )
+    def test_node_first_token_timeout_reads_either_shape_of_the_invocation_policy(self, invocation):
+        """graphon carries the block as an extra until the release that declares it."""
+        node_data = SimpleNamespace(type=BuiltinNodeTypes.LLM, get=lambda _key: invocation)
+
+        assert node_factory.DifyNodeFactory._node_first_token_timeout(node_data) == pytest.approx(2.5)
+
+    def test_node_first_token_timeout_converts_a_classifier_policy_to_seconds(self):
+        node_data = QuestionClassifierNodeData.model_validate(
+            {
+                "type": BuiltinNodeTypes.QUESTION_CLASSIFIER,
+                "title": "Classifier",
+                "query_variable_selector": ["start", "sys.query"],
+                "model": {"provider": "provider", "name": "model", "mode": "chat", "completion_params": {}},
+                "invocation": {"first_token_timeout_ms": 2500},
+                "classes": [{"id": "billing", "name": "Invoices"}],
+            }
+        )
+
+        assert node_factory.DifyNodeFactory._node_first_token_timeout(node_data) == pytest.approx(2.5)
+
+    def test_node_first_token_timeout_is_none_without_an_invocation_policy(self):
+        node_data = LLMNodeData.model_validate(
+            {
+                "type": BuiltinNodeTypes.LLM,
+                "title": "LLM",
+                "model": {"provider": "provider", "name": "model", "mode": "chat", "completion_params": {}},
+                "prompt_template": [{"role": "system", "text": "x"}],
+                "context": {"enabled": False, "variable_selector": []},
+                "vision": {"enabled": False},
+            }
+        )
+
+        assert node_factory.DifyNodeFactory._node_first_token_timeout(node_data) is None
+
+    @pytest.mark.parametrize(
+        "timeout_ms", [0, -1, "2500", True, None], ids=["zero", "negative", "string", "bool", "null"]
+    )
+    def test_node_first_token_timeout_rejects_a_value_an_undeclared_extra_never_validated(self, timeout_ms):
+        node_data = SimpleNamespace(
+            type=BuiltinNodeTypes.LLM,
+            get=lambda _key: {"first_token_timeout_ms": timeout_ms},
+        )
+
+        assert node_factory.DifyNodeFactory._node_first_token_timeout(node_data) is None
+
+    def test_node_first_token_timeout_is_none_for_the_parameter_extractor(self):
+        """That node invokes with stream=False, where the timeout would bound total generation."""
+        node_data = SimpleNamespace(
+            type=BuiltinNodeTypes.PARAMETER_EXTRACTOR,
+            get=lambda _key: {"first_token_timeout_ms": 2500},
+        )
+
+        assert node_factory.DifyNodeFactory._node_first_token_timeout(node_data) is None
 
     def test_create_node_passes_alias_preserving_llm_data_to_constructor(self, monkeypatch, factory):
         created_node = object()

--- a/api/tests/unit_tests/core/workflow/test_node_runtime.py
+++ b/api/tests/unit_tests/core/workflow/test_node_runtime.py
@@ -141,7 +141,6 @@ class _ModelInstanceStub:
         self.model_name = "gpt-4o-mini"
         self.parameters = {"temperature": 0.2}
         self.stop = ("stop",)
-        self.first_token_timeout: float | None = None
         self.credentials = {"api_key": "secret"}
         self.model_type_instance = _ModelTypeInstanceStub(
             model_schema=model_schema,
@@ -1146,8 +1145,7 @@ class TestFirstTokenBudgetMetadata:
 
     def test_prepared_llm_puts_the_budget_on_the_request(self):
         model_instance = MagicMock()
-        model_instance.first_token_timeout = 2.0
-        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"})
+        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"}, first_token_timeout=2.0)
 
         prepared.invoke_llm(
             prompt_messages=[],
@@ -1162,10 +1160,23 @@ class TestFirstTokenBudgetMetadata:
             "first_token_timeout": 2.0,
         }
 
+    def test_prepared_llm_carries_no_budget_when_the_node_configured_none(self):
+        model_instance = MagicMock()
+        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"})
+
+        prepared.invoke_llm(
+            prompt_messages=[],
+            model_parameters={},
+            tools=None,
+            stop=None,
+            stream=True,
+        )
+
+        assert model_instance.invoke_llm.call_args.kwargs["request_metadata"] == {"app_id": "app-1"}
+
     def test_prepared_llm_leaves_a_non_streaming_request_alone(self):
         model_instance = MagicMock()
-        model_instance.first_token_timeout = 2.0
-        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"})
+        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"}, first_token_timeout=2.0)
 
         prepared.invoke_llm(
             prompt_messages=[],

--- a/api/tests/unit_tests/core/workflow/test_node_runtime.py
+++ b/api/tests/unit_tests/core/workflow/test_node_runtime.py
@@ -141,6 +141,7 @@ class _ModelInstanceStub:
         self.model_name = "gpt-4o-mini"
         self.parameters = {"temperature": 0.2}
         self.stop = ("stop",)
+        self.first_token_timeout: float | None = None
         self.credentials = {"api_key": "secret"}
         self.model_type_instance = _ModelTypeInstanceStub(
             model_schema=model_schema,
@@ -1121,3 +1122,57 @@ def test_build_dify_llm_file_saver_wires_runtime_adapters(monkeypatch: pytest.Mo
     assert isinstance(tool_file_manager, DifyToolFileManager)
     assert isinstance(file_reference_factory, DifyFileReferenceFactory)
     assert file_saver_cls.call_args.kwargs["http_client"] is http_client
+
+
+class TestFirstTokenBudgetMetadata:
+    def test_a_streaming_invocation_carries_the_budget(self):
+        merged = node_runtime._with_first_token_budget({"app_id": "app-1"}, 2.0, stream=True)
+
+        assert merged == {"app_id": "app-1", "first_token_timeout": 2.0}
+
+    def test_metadata_is_left_alone_without_a_budget(self):
+        metadata = {"app_id": "app-1"}
+
+        assert node_runtime._with_first_token_budget(metadata, None, stream=True) is metadata
+        assert node_runtime._with_first_token_budget(metadata, 0, stream=True) is metadata
+        assert node_runtime._with_first_token_budget(None, None, stream=True) is None
+
+    def test_a_non_streaming_invocation_never_carries_the_budget(self):
+        """The single result arrives when generation is done, so the budget would stop
+        being about the first token."""
+        metadata = {"app_id": "app-1"}
+
+        assert node_runtime._with_first_token_budget(metadata, 2.0, stream=False) is metadata
+
+    def test_prepared_llm_puts_the_budget_on_the_request(self):
+        model_instance = MagicMock()
+        model_instance.first_token_timeout = 2.0
+        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"})
+
+        prepared.invoke_llm(
+            prompt_messages=[],
+            model_parameters={},
+            tools=None,
+            stop=None,
+            stream=True,
+        )
+
+        assert model_instance.invoke_llm.call_args.kwargs["request_metadata"] == {
+            "app_id": "app-1",
+            "first_token_timeout": 2.0,
+        }
+
+    def test_prepared_llm_leaves_a_non_streaming_request_alone(self):
+        model_instance = MagicMock()
+        model_instance.first_token_timeout = 2.0
+        prepared = DifyPreparedLLM(model_instance, {"app_id": "app-1"})
+
+        prepared.invoke_llm(
+            prompt_messages=[],
+            model_parameters={},
+            tools=None,
+            stop=None,
+            stream=False,
+        )
+
+        assert model_instance.invoke_llm.call_args.kwargs["request_metadata"] == {"app_id": "app-1"}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -415,6 +415,32 @@ describe('ModelParameterModal', () => {
     expect(screen.getByText(/debugAsSingleModel/i)).toBeInTheDocument()
   })
 
+  it('should append the first token timeout parameter when the panel supports it', () => {
+    render(
+      <ModelParameterModal
+        {...defaultProps}
+        isAdvancedMode
+        isInWorkflow
+        supportFirstTokenTimeout
+      />,
+    )
+
+    openSettings()
+
+    expect(screen.getByTestId('param-first_token_timeout_ms')).toBeInTheDocument()
+  })
+
+  it('should not append the first token timeout parameter for workflow panels that do not support it', () => {
+    // Workflow context alone must not render it — that would be dead config on
+    // panels the backend does not consume.
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
+
+    openSettings()
+
+    expect(screen.getByTestId('param-stop')).toBeInTheDocument()
+    expect(screen.queryByTestId('param-first_token_timeout_ms')).not.toBeInTheDocument()
+  })
+
   it('should render the empty loading fallback when rules resolve to an empty list', () => {
     parameterRules = []
     isRulesLoading = true

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -79,9 +79,18 @@ vi.mock('../parameter-item', () => ({
       data-has-available-nodes={!!availableNodes}
     >
       {parameterRule.label.en_US}
-      <button onClick={() => onChange(0.9)}>Change</button>
-      <button onClick={() => onSwitch(false, undefined)}>Remove</button>
-      <button onClick={() => onSwitch(true, 'assigned')}>Add</button>
+      <button data-testid={`change-${parameterRule.name}`} onClick={() => onChange(0.9)}>
+        Change
+      </button>
+      <button
+        data-testid={`remove-${parameterRule.name}`}
+        onClick={() => onSwitch(false, undefined)}
+      >
+        Remove
+      </button>
+      <button data-testid={`add-${parameterRule.name}`} onClick={() => onSwitch(true, 'assigned')}>
+        Add
+      </button>
     </div>
   ),
 }))
@@ -415,13 +424,14 @@ describe('ModelParameterModal', () => {
     expect(screen.getByText(/debugAsSingleModel/i)).toBeInTheDocument()
   })
 
-  it('should append the first token timeout parameter when the panel supports it', () => {
+  it('should append the first token timeout parameter when the node has an invocation policy', () => {
     render(
       <ModelParameterModal
         {...defaultProps}
         isAdvancedMode
         isInWorkflow
-        supportFirstTokenTimeout
+        invocation={{ first_token_timeout_ms: 2000 }}
+        onInvocationChange={vi.fn()}
       />,
     )
 
@@ -430,15 +440,75 @@ describe('ModelParameterModal', () => {
     expect(screen.getByTestId('param-first_token_timeout_ms')).toBeInTheDocument()
   })
 
-  it('should not append the first token timeout parameter for workflow panels that do not support it', () => {
-    // Workflow context alone must not render it — that would be dead config on
-    // panels the backend does not consume.
+  it('should not append the first token timeout parameter for a node without an invocation policy', () => {
+    // Workflow context alone must not render it. A node whose data has no
+    // invocation block has nowhere to store the value.
     render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
 
     openSettings()
 
     expect(screen.getByTestId('param-stop')).toBeInTheDocument()
     expect(screen.queryByTestId('param-first_token_timeout_ms')).not.toBeInTheDocument()
+  })
+
+  it('should not append the first token timeout parameter for a polling model', () => {
+    // A polling model hands back a job to poll instead of streaming, so there is
+    // no first token to wait for.
+    currentModel = { ...currentModel!, features: ['polling'] }
+
+    render(
+      <ModelParameterModal
+        {...defaultProps}
+        isAdvancedMode
+        isInWorkflow
+        onInvocationChange={vi.fn()}
+      />,
+    )
+
+    openSettings()
+
+    expect(screen.getByTestId('param-stop')).toBeInTheDocument()
+    expect(screen.queryByTestId('param-first_token_timeout_ms')).not.toBeInTheDocument()
+  })
+
+  it('should route first token timeout edits to the invocation policy, not the completion params', () => {
+    const onInvocationChange = vi.fn()
+    const onCompletionParamsChange = vi.fn()
+
+    render(
+      <ModelParameterModal
+        {...defaultProps}
+        isAdvancedMode
+        isInWorkflow
+        onCompletionParamsChange={onCompletionParamsChange}
+        onInvocationChange={onInvocationChange}
+      />,
+    )
+
+    openSettings()
+    fireEvent.click(screen.getByTestId('change-first_token_timeout_ms'))
+
+    expect(onInvocationChange).toHaveBeenCalledWith({ first_token_timeout_ms: 0.9 })
+    expect(onCompletionParamsChange).not.toHaveBeenCalled()
+  })
+
+  it('should clear the first token timeout from the invocation policy when switched off', () => {
+    const onInvocationChange = vi.fn()
+
+    render(
+      <ModelParameterModal
+        {...defaultProps}
+        isAdvancedMode
+        isInWorkflow
+        invocation={{ first_token_timeout_ms: 2000 }}
+        onInvocationChange={onInvocationChange}
+      />,
+    )
+
+    openSettings()
+    fireEvent.click(screen.getByTestId('remove-first_token_timeout_ms'))
+
+    expect(onInvocationChange).toHaveBeenCalledWith({ first_token_timeout_ms: undefined })
   })
 
   it('should render the empty loading fallback when rules resolve to an empty list', () => {

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -7,7 +7,7 @@ import type {
   ModelSelectorValue,
 } from '../model-selector/types'
 import type { ParameterValue } from './parameter-item'
-import type { Node, NodeOutPutVar } from '@/app/components/workflow/types'
+import type { InvocationConfig, Node, NodeOutPutVar } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
 import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
@@ -21,7 +21,7 @@ import {
   STOP_PARAMETER_RULE,
 } from '@/config'
 import { useModelParameterRules } from '@/service/use-common'
-import { ModelStatusEnum } from '../declarations'
+import { ModelFeatureEnum, ModelStatusEnum } from '../declarations'
 import { useTextGenerationCurrentProviderAndModelAndModelList } from '../hooks'
 import { ModelSelector, SplitModelSelector } from '../model-selector'
 import { ModelSettingsTrigger } from './model-settings-trigger'
@@ -52,9 +52,12 @@ export type ModelParameterModalProps = Pick<PopoverContentProps, 'placement'> & 
   readonly?: boolean
   modelSelectorReadonly?: boolean
   isInWorkflow?: boolean
-  // Pass only from panels that invoke the model as a stream (LLM, question
-  // classifier). Anywhere else the budget is ignored downstream and would be dead config.
-  supportFirstTokenTimeout?: boolean
+  // The node's invocation policy, if its node data declares one. Passing the pair
+  // is what makes the first-token timeout renderable: a node without the block has
+  // nowhere to store the value, so the control is structurally absent rather than
+  // hidden behind a flag each panel has to remember not to set.
+  invocation?: InvocationConfig
+  onInvocationChange?: (invocation: InvocationConfig) => void
   scope?: string
   nodesOutputVars?: NodeOutPutVar[]
   availableNodes?: Node[]
@@ -82,7 +85,8 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
   readonly,
   modelSelectorReadonly,
   isInWorkflow,
-  supportFirstTokenTimeout,
+  invocation,
+  onInvocationChange,
   nodesOutputVars,
   availableNodes,
   modelList,
@@ -137,6 +141,20 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
         [key]: assignValue,
       })
     }
+  }
+
+  // A polling model answers by handing back a job to poll rather than by streaming,
+  // so there is no first token to wait for and the setting would be dead config.
+  // The model schema is the backend's own declaration, so the panels do not have to
+  // know which models these are.
+  const supportsFirstTokenTimeout =
+    !!onInvocationChange && !currentModel?.features?.includes(ModelFeatureEnum.polling)
+
+  const handleFirstTokenTimeoutChange = (value: ParameterValue) => {
+    onInvocationChange?.({
+      ...invocation,
+      first_token_timeout_ms: typeof value === 'number' ? value : undefined,
+    })
   }
 
   const handleSelectPresetParameter = (toneId: number) => {
@@ -246,26 +264,38 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
                   <Loading />
                 </div>
               ) : (
-                [
-                  ...parameterRules,
-                  ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : []),
-                  ...(isAdvancedMode && supportFirstTokenTimeout
-                    ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE]
-                    : []),
-                ].map((parameter) => (
-                  <ParameterItem
-                    key={`${modelId}-${parameter.name}`}
-                    parameterRule={parameter}
-                    value={completionParams?.[parameter.name]}
-                    onChange={(v) => handleParamChange(parameter.name, v)}
-                    onSwitch={(checked, assignValue) =>
-                      handleSwitch(parameter.name, checked, assignValue)
-                    }
-                    isInWorkflow={isInWorkflow}
-                    nodesOutputVars={nodesOutputVars}
-                    availableNodes={availableNodes}
-                  />
-                ))
+                <>
+                  {[...parameterRules, ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : [])].map(
+                    (parameter) => (
+                      <ParameterItem
+                        key={`${modelId}-${parameter.name}`}
+                        parameterRule={parameter}
+                        value={completionParams?.[parameter.name]}
+                        onChange={(v) => handleParamChange(parameter.name, v)}
+                        onSwitch={(checked, assignValue) =>
+                          handleSwitch(parameter.name, checked, assignValue)
+                        }
+                        isInWorkflow={isInWorkflow}
+                        nodesOutputVars={nodesOutputVars}
+                        availableNodes={availableNodes}
+                      />
+                    ),
+                  )}
+                  {isAdvancedMode && supportsFirstTokenTimeout && (
+                    <ParameterItem
+                      key={`${modelId}-${FIRST_TOKEN_TIMEOUT_PARAMETER_RULE.name}`}
+                      parameterRule={FIRST_TOKEN_TIMEOUT_PARAMETER_RULE}
+                      value={invocation?.first_token_timeout_ms}
+                      onChange={handleFirstTokenTimeoutChange}
+                      onSwitch={(checked, assignValue) =>
+                        handleFirstTokenTimeoutChange(checked ? assignValue : undefined)
+                      }
+                      isInWorkflow={isInWorkflow}
+                      nodesOutputVars={nodesOutputVars}
+                      availableNodes={availableNodes}
+                    />
+                  )}
+                </>
               )}
             </div>
           )}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -15,7 +15,11 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ArrowNarrowLeft } from '@/app/components/base/icons/src/vender/line/arrows'
 import Loading from '@/app/components/base/loading'
-import { PROVIDER_WITH_PRESET_TONE, STOP_PARAMETER_RULE } from '@/config'
+import {
+  FIRST_TOKEN_TIMEOUT_PARAMETER_RULE,
+  PROVIDER_WITH_PRESET_TONE,
+  STOP_PARAMETER_RULE,
+} from '@/config'
 import { useModelParameterRules } from '@/service/use-common'
 import { ModelStatusEnum } from '../declarations'
 import { useTextGenerationCurrentProviderAndModelAndModelList } from '../hooks'
@@ -48,6 +52,9 @@ export type ModelParameterModalProps = Pick<PopoverContentProps, 'placement'> & 
   readonly?: boolean
   modelSelectorReadonly?: boolean
   isInWorkflow?: boolean
+  // Pass only from panels that invoke the model as a stream (LLM, question
+  // classifier). Anywhere else the budget is ignored downstream and would be dead config.
+  supportFirstTokenTimeout?: boolean
   scope?: string
   nodesOutputVars?: NodeOutPutVar[]
   availableNodes?: Node[]
@@ -75,6 +82,7 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
   readonly,
   modelSelectorReadonly,
   isInWorkflow,
+  supportFirstTokenTimeout,
   nodesOutputVars,
   availableNodes,
   modelList,
@@ -238,22 +246,26 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
                   <Loading />
                 </div>
               ) : (
-                [...parameterRules, ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : [])].map(
-                  (parameter) => (
-                    <ParameterItem
-                      key={`${modelId}-${parameter.name}`}
-                      parameterRule={parameter}
-                      value={completionParams?.[parameter.name]}
-                      onChange={(v) => handleParamChange(parameter.name, v)}
-                      onSwitch={(checked, assignValue) =>
-                        handleSwitch(parameter.name, checked, assignValue)
-                      }
-                      isInWorkflow={isInWorkflow}
-                      nodesOutputVars={nodesOutputVars}
-                      availableNodes={availableNodes}
-                    />
-                  ),
-                )
+                [
+                  ...parameterRules,
+                  ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : []),
+                  ...(isAdvancedMode && supportFirstTokenTimeout
+                    ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE]
+                    : []),
+                ].map((parameter) => (
+                  <ParameterItem
+                    key={`${modelId}-${parameter.name}`}
+                    parameterRule={parameter}
+                    value={completionParams?.[parameter.name]}
+                    onChange={(v) => handleParamChange(parameter.name, v)}
+                    onSwitch={(checked, assignValue) =>
+                      handleSwitch(parameter.name, checked, assignValue)
+                    }
+                    isInWorkflow={isInWorkflow}
+                    nodesOutputVars={nodesOutputVars}
+                    availableNodes={availableNodes}
+                  />
+                ))
               )}
             </div>
           )}

--- a/web/app/components/workflow/nodes/llm/__tests__/use-config.spec.ts
+++ b/web/app/components/workflow/nodes/llm/__tests__/use-config.spec.ts
@@ -291,6 +291,21 @@ describe('llm/use-config', () => {
     expect(appendDefaultPromptConfig).not.toHaveBeenCalled()
   })
 
+  it('writes the invocation policy outside the completion params', () => {
+    const { result } = renderHook(() => useConfig('llm-node', inputRef.current))
+
+    act(() => {
+      result.current.handleInvocationChange({ first_token_timeout_ms: 2500 })
+    })
+
+    expect(setInputs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invocation: { first_token_timeout_ms: 2500 },
+        model: expect.objectContaining({ completion_params: { temperature: 0.7 } }),
+      }),
+    )
+  })
+
   it('hydrates the model from the current provider, appends mode-specific defaults, and triggers the vision follow-up effect', async () => {
     inputRef.current = createPayload({
       model: {

--- a/web/app/components/workflow/nodes/llm/panel.tsx
+++ b/web/app/components/workflow/nodes/llm/panel.tsx
@@ -64,6 +64,7 @@ const Panel: FC<NodePanelProps<LLMNodeType>> = ({ id, data }) => {
     handleModelSelectorChange,
     hasSetBlockStatus,
     handleCompletionParamsChange,
+    handleInvocationChange,
     handleContextVarChange,
     filterInputVar,
     filterVar,
@@ -255,12 +256,13 @@ const Panel: FC<NodePanelProps<LLMNodeType>> = ({ id, data }) => {
               popupClassName="w-[387px]!"
               isInWorkflow
               isAdvancedMode={true}
-              supportFirstTokenTimeout
               provider={model?.provider}
               completionParams={model?.completion_params}
+              invocation={inputs.invocation}
               modelId={model?.name}
               setModel={handleModelChange}
               onCompletionParamsChange={handleCompletionParamsChange}
+              onInvocationChange={handleInvocationChange}
               hideDebugWithMultipleModel
               debugWithMultipleModel={false}
               readonly={readOnly || isEnvironmentModelSource}

--- a/web/app/components/workflow/nodes/llm/panel.tsx
+++ b/web/app/components/workflow/nodes/llm/panel.tsx
@@ -255,6 +255,7 @@ const Panel: FC<NodePanelProps<LLMNodeType>> = ({ id, data }) => {
               popupClassName="w-[387px]!"
               isInWorkflow
               isAdvancedMode={true}
+              supportFirstTokenTimeout
               provider={model?.provider}
               completionParams={model?.completion_params}
               modelId={model?.name}

--- a/web/app/components/workflow/nodes/llm/types.ts
+++ b/web/app/components/workflow/nodes/llm/types.ts
@@ -1,5 +1,6 @@
 import type {
   CommonNodeType,
+  InvocationConfig,
   Memory,
   ModelConfig,
   PromptItem,
@@ -10,6 +11,7 @@ import type {
 
 export type LLMNodeType = CommonNodeType & {
   model: ModelConfig
+  invocation?: InvocationConfig
   model_selector?: ValueSelector
   prompt_template: PromptItem[] | PromptItem
   prompt_config?: {

--- a/web/app/components/workflow/nodes/llm/use-config.ts
+++ b/web/app/components/workflow/nodes/llm/use-config.ts
@@ -1,6 +1,10 @@
 import type { LLMDefaultConfig } from './hooks/use-llm-input-manager'
 import type { LLMNodeType } from './types'
-import type { EnvironmentVariable, ValueSelector } from '@/app/components/workflow/types'
+import type {
+  EnvironmentVariable,
+  InvocationConfig,
+  ValueSelector,
+} from '@/app/components/workflow/types'
 import { produce } from 'immer'
 import { useCallback, useEffect, useState } from 'react'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
@@ -185,6 +189,16 @@ const useConfig = (id: string, payload: LLMNodeType) => {
     [inputRef, setInputs],
   )
 
+  const handleInvocationChange = useCallback(
+    (invocation: InvocationConfig) => {
+      const newInputs = produce(inputRef.current, (draft) => {
+        draft.invocation = invocation
+      })
+      setInputs(newInputs)
+    },
+    [inputRef, setInputs],
+  )
+
   // change to vision model to set vision enabled, else disabled
   useEffect(() => {
     if (!modelChanged) return
@@ -228,6 +242,7 @@ const useConfig = (id: string, payload: LLMNodeType) => {
     handleModelSourceChange,
     handleModelSelectorChange,
     handleCompletionParamsChange,
+    handleInvocationChange,
     isShowVars: promptConfig.isShowVars,
     handleVarListChange: promptConfig.handleVarListChange,
     handleVarNameChange: promptConfig.handleVarNameChange,

--- a/web/app/components/workflow/nodes/question-classifier/__tests__/integration.spec.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/__tests__/integration.spec.tsx
@@ -192,6 +192,7 @@ const createConfigResult = (
   isChatMode: true,
   isChatModel: true,
   handleCompletionParamsChange: vi.fn(),
+  handleInvocationChange: vi.fn(),
   handleQueryVarChange: vi.fn(),
   filterVar: vi.fn(() => true),
   handleTopicsChange: vi.fn(),

--- a/web/app/components/workflow/nodes/question-classifier/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/__tests__/panel.spec.tsx
@@ -110,6 +110,7 @@ const panelProps = {} as PanelProps
 describe('question-classifier/panel', () => {
   const handleModelChanged = vi.fn()
   const handleCompletionParamsChange = vi.fn()
+  const handleInvocationChange = vi.fn()
   const handleQueryVarChange = vi.fn()
   const handleVisionResolutionEnabledChange = vi.fn()
   const handleVisionResolutionChange = vi.fn()
@@ -123,6 +124,7 @@ describe('question-classifier/panel', () => {
       isChatMode: true,
       isChatModel: true,
       handleCompletionParamsChange,
+      handleInvocationChange,
       handleQueryVarChange,
       handleTopicsChange: vi.fn(),
       hasSetBlockStatus: { context: false, history: false, query: false },

--- a/web/app/components/workflow/nodes/question-classifier/__tests__/use-config.spec.ts
+++ b/web/app/components/workflow/nodes/question-classifier/__tests__/use-config.spec.ts
@@ -167,6 +167,21 @@ describe('question-classifier/use-config', () => {
     })
   })
 
+  it('writes the invocation policy outside the completion params', () => {
+    const { result } = renderHook(() => useConfig('question-classifier-node', createPayload()))
+
+    act(() => {
+      result.current.handleInvocationChange({ first_token_timeout_ms: 2500 })
+    })
+
+    expect(setInputs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invocation: { first_token_timeout_ms: 2500 },
+        model: expect.objectContaining({ completion_params: {} }),
+      }),
+    )
+  })
+
   it('does not default the query selector to sys.query in snippet flows', async () => {
     mockFlowType.value = FlowType.snippet
     mockUseWorkflow.mockReturnValue({

--- a/web/app/components/workflow/nodes/question-classifier/panel.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/panel.tsx
@@ -50,6 +50,7 @@ const Panel: FC<NodePanelProps<QuestionClassifierNodeType>> = ({ id, data }) => 
             popupClassName="w-[387px]!"
             isInWorkflow
             isAdvancedMode={true}
+            supportFirstTokenTimeout
             provider={model?.provider}
             completionParams={model.completion_params}
             modelId={model.name}

--- a/web/app/components/workflow/nodes/question-classifier/panel.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/panel.tsx
@@ -26,6 +26,7 @@ const Panel: FC<NodePanelProps<QuestionClassifierNodeType>> = ({ id, data }) => 
     isChatMode,
     isChatModel,
     handleCompletionParamsChange,
+    handleInvocationChange,
     handleQueryVarChange,
     handleTopicsChange,
     hasSetBlockStatus,
@@ -50,12 +51,13 @@ const Panel: FC<NodePanelProps<QuestionClassifierNodeType>> = ({ id, data }) => 
             popupClassName="w-[387px]!"
             isInWorkflow
             isAdvancedMode={true}
-            supportFirstTokenTimeout
             provider={model?.provider}
             completionParams={model.completion_params}
+            invocation={inputs.invocation}
             modelId={model.name}
             setModel={handleModelChanged}
             onCompletionParamsChange={handleCompletionParamsChange}
+            onInvocationChange={handleInvocationChange}
             hideDebugWithMultipleModel
             debugWithMultipleModel={false}
             readonly={readOnly}

--- a/web/app/components/workflow/nodes/question-classifier/types.ts
+++ b/web/app/components/workflow/nodes/question-classifier/types.ts
@@ -1,5 +1,6 @@
 import type {
   CommonNodeType,
+  InvocationConfig,
   Memory,
   ModelConfig,
   ValueSelector,
@@ -15,6 +16,7 @@ export type Topic = {
 export type QuestionClassifierNodeType = CommonNodeType & {
   query_variable_selector: ValueSelector
   model: ModelConfig
+  invocation?: InvocationConfig
   classes: Topic[]
   instruction: string
   memory?: Memory

--- a/web/app/components/workflow/nodes/question-classifier/use-config.ts
+++ b/web/app/components/workflow/nodes/question-classifier/use-config.ts
@@ -1,4 +1,4 @@
-import type { Memory, ValueSelector, Var } from '../../types'
+import type { InvocationConfig, Memory, ValueSelector, Var } from '../../types'
 import type { QuestionClassifierNodeType, Topic } from './types'
 import { produce } from 'immer'
 import { startTransition, useCallback, useEffect, useRef } from 'react'
@@ -99,6 +99,16 @@ const useConfig = (id: string, payload: QuestionClassifierNodeType) => {
     (newParams: Record<string, unknown>) => {
       const newInputs = produce(inputs, (draft) => {
         draft.model.completion_params = newParams
+      })
+      setInputs(newInputs)
+    },
+    [inputs, setInputs],
+  )
+
+  const handleInvocationChange = useCallback(
+    (invocation: InvocationConfig) => {
+      const newInputs = produce(inputs, (draft) => {
+        draft.invocation = invocation
       })
       setInputs(newInputs)
     },
@@ -255,6 +265,7 @@ const useConfig = (id: string, payload: QuestionClassifierNodeType) => {
     isChatMode,
     isChatModel,
     handleCompletionParamsChange,
+    handleInvocationChange,
     handleQueryVarChange,
     filterVar,
     handleTopicsChange: handleClassesChange,

--- a/web/app/components/workflow/run/__tests__/meta.spec.tsx
+++ b/web/app/components/workflow/run/__tests__/meta.spec.tsx
@@ -56,6 +56,25 @@ describe('Meta', () => {
     expect(mockFormatTime).toHaveBeenCalledWith(1700000000000, expect.any(String))
   })
 
+  it('renders the time to first token when the node measured one', () => {
+    render(<Meta status="succeeded" timeToFirstToken={0.2504} />)
+
+    expect(screen.getByText('runLog.meta.timeToFirstToken')).toBeInTheDocument()
+    expect(screen.getByText('0.250s')).toBeInTheDocument()
+  })
+
+  it('omits the time to first token row when the node measured none', () => {
+    render(<Meta status="succeeded" />)
+
+    expect(screen.queryByText('runLog.meta.timeToFirstToken')).not.toBeInTheDocument()
+  })
+
+  it('renders a time to first token of zero rather than treating it as missing', () => {
+    render(<Meta status="succeeded" timeToFirstToken={0} />)
+
+    expect(screen.getByText('0.000s')).toBeInTheDocument()
+  })
+
   it('falls back to default values when metadata is missing', () => {
     render(<Meta status="failed" />)
 

--- a/web/app/components/workflow/run/meta.tsx
+++ b/web/app/components/workflow/run/meta.tsx
@@ -9,6 +9,7 @@ type Props = {
   readonly startTime?: number
   readonly time?: number
   readonly tokens?: number
+  readonly timeToFirstToken?: number
   readonly steps?: number
   readonly showSteps?: boolean
 }
@@ -19,6 +20,7 @@ const MetaData: FC<Props> = ({
   startTime,
   time,
   tokens,
+  timeToFirstToken,
   steps = 1,
   showSteps = true,
 }) => {
@@ -97,6 +99,16 @@ const MetaData: FC<Props> = ({
             {!['running', 'paused'].includes(status) && <span>{`${tokens || 0} Tokens`}</span>}
           </div>
         </div>
+        {timeToFirstToken !== undefined && (
+          <div className="flex">
+            <div className="w-26 shrink-0 truncate px-2 py-1.5 system-xs-regular text-text-tertiary">
+              {t(($) => $['meta.timeToFirstToken'], { ns: 'runLog' })}
+            </div>
+            <div className="grow px-2 py-1.5 system-xs-regular text-text-secondary">
+              <span>{`${timeToFirstToken.toFixed(3)}s`}</span>
+            </div>
+          </div>
+        )}
         {showSteps && (
           <div className="flex">
             <div className="w-26 shrink-0 truncate px-2 py-1.5 system-xs-regular text-text-tertiary">

--- a/web/app/components/workflow/run/result-panel.tsx
+++ b/web/app/components/workflow/run/result-panel.tsx
@@ -172,6 +172,7 @@ const ResultPanel: FC<ResultPanelProps> = ({
           startTime={created_at}
           time={elapsed_time}
           tokens={total_tokens}
+          timeToFirstToken={execution_metadata?.time_to_first_token}
           steps={steps}
           showSteps={showSteps}
         />

--- a/web/app/components/workflow/types.ts
+++ b/web/app/components/workflow/types.ts
@@ -249,6 +249,13 @@ export type ModelConfig = LLMEnvironmentVariableValue & {
   completion_params: LLMCompletionParams
 }
 
+// Per-node policy for how the model is called, as opposed to what is asked of it.
+// Deliberately a sibling of `model` rather than part of `completion_params`, which
+// is forwarded to the provider verbatim.
+export type InvocationConfig = {
+  first_token_timeout_ms?: number
+}
+
 export enum PromptRole {
   system = 'system',
   user = 'user',

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -347,6 +347,27 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
   },
 }
 
+// Consumed by the Dify backend, never sent to model providers.
+export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
+  default: 2000,
+  min: 100,
+  max: 600000,
+  precision: 0,
+  help: {
+    en_US:
+      'Max milliseconds to wait for the first streamed token. Generation after that token is not affected. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans:
+      '等待首个流式 Token 的最长毫秒数。首个 Token 之后的生成过程不受影响。超时后节点失败，可配合节点重试自动重跑。',
+  },
+  label: {
+    en_US: 'First token timeout (ms)',
+    zh_Hans: '首个 Token 超时（毫秒）',
+  },
+  name: 'first_token_timeout_ms',
+  required: false,
+  type: 'int',
+}
+
 export const PARTNER_STACK_CONFIG = {
   cookieName: 'partner_stack_info',
   saveCookieDays: 90,

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -347,7 +347,8 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
   },
 }
 
-// Consumed by the Dify backend, never sent to model providers.
+// Rendered like a model parameter, but stored on the node's invocation policy and
+// consumed by the Dify backend. It is never sent to model providers.
 export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
   default: 2000,
   min: 100,

--- a/web/i18n/ar-TN/run-log.json
+++ b/web/i18n/ar-TN/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "الحالة",
   "meta.steps": "خطوات التشغيل",
   "meta.time": "الوقت المستغرق",
+  "meta.timeToFirstToken": "زمن أول رمز",
   "meta.title": "البيانات الوصفية",
   "meta.tokens": "إجمالي الرموز",
   "result": "نتيجة",

--- a/web/i18n/de-DE/run-log.json
+++ b/web/i18n/de-DE/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Status",
   "meta.steps": "Ausführungsschritte",
   "meta.time": "Verstrichene Zeit",
+  "meta.timeToFirstToken": "Zeit bis zum ersten Token",
   "meta.title": "METADATEN",
   "meta.tokens": "Gesamtzeichen",
   "result": "ERGEBNIS",

--- a/web/i18n/en-US/run-log.json
+++ b/web/i18n/en-US/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Status",
   "meta.steps": "Run Steps",
   "meta.time": "Elapsed Time",
+  "meta.timeToFirstToken": "Time to First Token",
   "meta.title": "METADATA",
   "meta.tokens": "Total Tokens",
   "result": "RESULT",

--- a/web/i18n/es-ES/run-log.json
+++ b/web/i18n/es-ES/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Estado",
   "meta.steps": "Pasos de ejecución",
   "meta.time": "Tiempo transcurrido",
+  "meta.timeToFirstToken": "Tiempo hasta el primer token",
   "meta.title": "METADATOS",
   "meta.tokens": "Total de tokens",
   "result": "RESULTADO",

--- a/web/i18n/fa-IR/run-log.json
+++ b/web/i18n/fa-IR/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "وضعیت",
   "meta.steps": "گام‌های اجرا",
   "meta.time": "زمان گذشته",
+  "meta.timeToFirstToken": "زمان تا اولین توکن",
   "meta.title": "فراداده",
   "meta.tokens": "کل توکن‌ها",
   "result": "نتیجه",

--- a/web/i18n/fr-FR/run-log.json
+++ b/web/i18n/fr-FR/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Statut",
   "meta.steps": "Étapes d'exécution",
   "meta.time": "Temps écoulé",
+  "meta.timeToFirstToken": "Délai jusqu'au premier jeton",
   "meta.title": "MÉTADONNÉES",
   "meta.tokens": "Total des jetons",
   "result": "RÉSULTAT",

--- a/web/i18n/hi-IN/run-log.json
+++ b/web/i18n/hi-IN/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "स्थिति",
   "meta.steps": "चालाने के चरण",
   "meta.time": "समय की अवधि",
+  "meta.timeToFirstToken": "पहले टोकन तक का समय",
   "meta.title": "मेटाडाटा",
   "meta.tokens": "कुल टोकन्स",
   "result": "नतीजा",

--- a/web/i18n/id-ID/run-log.json
+++ b/web/i18n/id-ID/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Keadaan",
   "meta.steps": "Jalankan Langkah-langkah",
   "meta.time": "Waktu yang telah berlalu",
+  "meta.timeToFirstToken": "Waktu ke Token Pertama",
   "meta.title": "METADATA",
   "meta.tokens": "Total Token",
   "result": "HASIL",

--- a/web/i18n/it-IT/run-log.json
+++ b/web/i18n/it-IT/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Stato",
   "meta.steps": "Fasi Eseguite",
   "meta.time": "Tempo Trascorso",
+  "meta.timeToFirstToken": "Tempo al Primo Token",
   "meta.title": "METADATI",
   "meta.tokens": "Token Totali",
   "result": "RISULTATO",

--- a/web/i18n/ja-JP/run-log.json
+++ b/web/i18n/ja-JP/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "状態",
   "meta.steps": "処理ステップ数",
   "meta.time": "総処理時間",
+  "meta.timeToFirstToken": "最初のトークンまでの時間",
   "meta.title": "メタデータ",
   "meta.tokens": "トークン総数",
   "result": "結果",

--- a/web/i18n/ko-KR/run-log.json
+++ b/web/i18n/ko-KR/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "상태",
   "meta.steps": "실행 단계",
   "meta.time": "소요 시간",
+  "meta.timeToFirstToken": "첫 토큰까지 소요 시간",
   "meta.title": "메타데이터",
   "meta.tokens": "토큰 총합",
   "result": "결과",

--- a/web/i18n/lo-LA/run-log.json
+++ b/web/i18n/lo-LA/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "ສະຖານະ",
   "meta.steps": "ຂັ້ນຕອນການເຮັດວຽກ",
   "meta.time": "ເວລາທີ່ໃຊ້ໄປ",
+  "meta.timeToFirstToken": "ເວລາຮອດໂທເຄັນທຳອິດ",
   "meta.title": "ຂໍ້ມູນເມຕາ",
   "meta.tokens": "ໂທເຄັນທັງໝົດ",
   "result": "ຜົນລັດ",

--- a/web/i18n/nl-NL/run-log.json
+++ b/web/i18n/nl-NL/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Status",
   "meta.steps": "Run Steps",
   "meta.time": "Elapsed Time",
+  "meta.timeToFirstToken": "Time to First Token",
   "meta.title": "METADATA",
   "meta.tokens": "Total Tokens",
   "result": "RESULT",

--- a/web/i18n/pl-PL/run-log.json
+++ b/web/i18n/pl-PL/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Status",
   "meta.steps": "Kroki wykonania",
   "meta.time": "Czas trwania",
+  "meta.timeToFirstToken": "Czas do pierwszego tokenu",
   "meta.title": "METADANE",
   "meta.tokens": "Liczba tokenów",
   "result": "WYNIK",

--- a/web/i18n/pt-BR/run-log.json
+++ b/web/i18n/pt-BR/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Status",
   "meta.steps": "Passos de Execução",
   "meta.time": "Tempo Decorrido",
+  "meta.timeToFirstToken": "Tempo até o Primeiro Token",
   "meta.title": "METADADOS",
   "meta.tokens": "Total de Tokens",
   "result": "RESULTADO",

--- a/web/i18n/ro-RO/run-log.json
+++ b/web/i18n/ro-RO/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Stare",
   "meta.steps": "Pași de rulare",
   "meta.time": "Timp scurs",
+  "meta.timeToFirstToken": "Timp până la primul token",
   "meta.title": "METADATE",
   "meta.tokens": "Total tokeni",
   "result": "REZULTAT",

--- a/web/i18n/ru-RU/run-log.json
+++ b/web/i18n/ru-RU/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Статус",
   "meta.steps": "Шаги выполнения",
   "meta.time": "Прошедшее время",
+  "meta.timeToFirstToken": "Время до первого токена",
   "meta.title": "МЕТАДАННЫЕ",
   "meta.tokens": "Всего токенов",
   "result": "РЕЗУЛЬТАТ",

--- a/web/i18n/sl-SI/run-log.json
+++ b/web/i18n/sl-SI/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Status",
   "meta.steps": "Koraki izvajanja",
   "meta.time": "Pretečeni čas",
+  "meta.timeToFirstToken": "Čas do prvega žetona",
   "meta.title": "METAPODATKI",
   "meta.tokens": "Skupni žetoni",
   "result": "REZULTAT",

--- a/web/i18n/th-TH/run-log.json
+++ b/web/i18n/th-TH/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "สถานะ",
   "meta.steps": "เรียกใช้ขั้นตอน",
   "meta.time": "เวลาที่ผ่านไป",
+  "meta.timeToFirstToken": "เวลาถึงโทเค็นแรก",
   "meta.title": "ข้อมูลเมตา",
   "meta.tokens": "โทเค็นทั้งหมด",
   "result": "ผล",

--- a/web/i18n/tr-TR/run-log.json
+++ b/web/i18n/tr-TR/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Durum",
   "meta.steps": "Çalıştırma Adımları",
   "meta.time": "Geçen Zaman",
+  "meta.timeToFirstToken": "İlk Token Süresi",
   "meta.title": "META VERİ",
   "meta.tokens": "Toplam Token",
   "result": "SONUÇ",

--- a/web/i18n/uk-UA/run-log.json
+++ b/web/i18n/uk-UA/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Статус",
   "meta.steps": "Кроки виконання",
   "meta.time": "Час виконання",
+  "meta.timeToFirstToken": "Час до першого токена",
   "meta.title": "МЕТАДАНІ",
   "meta.tokens": "Загальна кількість токенів",
   "result": "РЕЗУЛЬТАТ",

--- a/web/i18n/vi-VN/run-log.json
+++ b/web/i18n/vi-VN/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "Trạng thái",
   "meta.steps": "Các bước chạy",
   "meta.time": "Thời gian đã trôi qua",
+  "meta.timeToFirstToken": "Thời gian đến token đầu tiên",
   "meta.title": "DỮ LIỆU META",
   "meta.tokens": "Tổng số token",
   "result": "KẾT QUẢ",

--- a/web/i18n/zh-Hans/run-log.json
+++ b/web/i18n/zh-Hans/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "状态",
   "meta.steps": "运行步数",
   "meta.time": "运行时间",
+  "meta.timeToFirstToken": "首个 Token 耗时",
   "meta.title": "元数据",
   "meta.tokens": "总 token 数",
   "result": "结果",

--- a/web/i18n/zh-Hant/run-log.json
+++ b/web/i18n/zh-Hant/run-log.json
@@ -7,6 +7,7 @@
   "meta.status": "狀態",
   "meta.steps": "執行步數",
   "meta.time": "執行時間",
+  "meta.timeToFirstToken": "首個 Token 耗時",
   "meta.title": "元資料",
   "meta.tokens": "總 token 數",
   "result": "結果",


### PR DESCRIPTION
## Summary

Builds on #42134 and carries its two commits, so review that one first. The diff reduces to this PR's own two commits once #42134 merges.

This step moves the per-node first-token timeout off `completion_params` and closes the two coverage holes the earlier PR left open.

**Where the setting lives.** `completion_params` is the dictionary forwarded to model providers verbatim, so a Dify-internal timeout does not belong in it: every consumer needed a defensive `pop`, one forgotten `pop` sends an unknown argument to a provider, and the value shows up in exported DSL next to `temperature` as if the provider understood it. It now lives on the node's own `invocation` block, a sibling of `model`, holding per-node policy about *how* the model is called rather than *what* is asked of it:

```yaml
data:
  model: { provider: openai, name: gpt-4o, mode: chat, completion_params: {} }
  invocation:
    first_token_timeout_ms: 2000
```

`_normalize_completion_params`, `ModelInstance.first_token_timeout` and the converter's defensive `pop` are all gone — those three files are byte-identical to `main` again. `DifyNodeFactory` reads the block once, converts ms to seconds, and hands the value to `DifyPreparedLLM`, which is where a request-scoped value belongs; `ModelInstance` is shared plumbing, not a node concern.

**Two dead-config holes, closed structurally rather than by convention.**

The previous PR gated the control with a `supportFirstTokenTimeout` prop, which asked every panel author to remember not to set it. Now the control renders only when the caller passes an `invocation` value/onChange pair — a node whose data has no `invocation` block has nowhere to store the value, so the control is structurally absent. That is what keeps the parameter extractor out: it invokes with `stream=False`, where the single result arrives once generation has finished and a first-token timeout would quietly become a total-generation timeout.

It is additionally hidden for a model whose schema declares the `polling` feature. A polling model answers by handing back a job to poll rather than by streaming, so there is no first token to wait for. That check reads the backend's own model schema, so no panel has to know which models those are.

**Per-node TTFT is now visible.** The LLM node already measures it into `LLMUsage.time_to_first_token`; the node run panel now shows it as *Time to First Token* when execution metadata carries one. Without that number a user has no basis for choosing a timeout at all. Zero is a measurement and renders as `0.000s`; a run that streamed no content has no row.

**On the graphon dependency.** The `invocation` block is declared as a field in langgenius/graphon#293. It does not need to land first: `BaseNodeData` is `extra="allow"`, so on the current `graphon==0.7.0` pin the key survives every validate/dump hop as an undeclared compatibility extra, and `BaseNodeData.get` — the accessor whose docstring exists for exactly this — returns it. `_node_first_token_timeout` accepts both the extra-dict and the declared-field shape, with a test for each, so this works today and keeps working across the bump. Because an extra arrives unvalidated, the value is validated on this side either way. Once the pin moves, the helper can collapse to `node_data.invocation.first_token_timeout`.

The metadata key the run panel reads, `time_to_first_token`, does come from that graphon release, so the TTFT row stays empty until the bump. Nothing else waits on it.

## Screenshots

| Before | After |
| ------ | ----- |
| First-token timeout listed among the provider's model parameters, rendered on any panel that remembered to set `supportFirstTokenTimeout`; no per-node TTFT anywhere. | Same control, stored on the node's `invocation` block, absent on nodes without one and on polling models; node run metadata gains a **Time to First Token** row. |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

