### PR TITLE
fix(web): align workflow and agent sidebar identity layouts

### DIFF
--- a/web/app/components/app-sidebar/app-detail-section.tsx
+++ b/web/app/components/app-sidebar/app-detail-section.tsx
@@ -198,7 +198,7 @@ const AppDetailSection = ({ expand = true }: AppDetailSectionProps) => {
           />
         </div>
       )}
-      <div className="px-1 py-2">
+      <div className={cn('px-1 py-2', expand && '-mx-2')}>
         <AppInfoView expand={expand} actions={appInfoActions} />
       </div>
       <nav className={cn('flex flex-col gap-y-0.5 py-1', expand ? 'px-1' : 'px-3')}>

--- a/web/app/components/app-sidebar/app-info/__tests__/app-info-trigger.spec.tsx
+++ b/web/app/components/app-sidebar/app-info/__tests__/app-info-trigger.spec.tsx
@@ -95,7 +95,7 @@ describe('AppInfoTrigger', () => {
     })
     render(<AppInfoTrigger {...props} />)
 
-    expect(screen.getByText('🤖')).toHaveAttribute('data-size', 'large')
+    expect(screen.getByText('🤖')).toHaveAttribute('data-size', 'medium')
     expect(screen.getByText('My Chatbot')).toBeInTheDocument()
     expect(screen.getByText('app.types.advanced')).toBeInTheDocument()
     expect(screen.getByText('My Chatbot').closest('button')).toBeNull()

--- a/web/app/components/app-sidebar/app-info/app-info-trigger.tsx
+++ b/web/app/components/app-sidebar/app-info/app-info-trigger.tsx
@@ -123,7 +123,7 @@ const AppInfoTrigger = ({
       <div className="flex shrink-0 items-center">
         <div>
           <AppIcon
-            size={expand ? 'large' : 'medium'}
+            size="medium"
             iconType={appDetail.icon_type}
             icon={appDetail.icon}
             background={appDetail.icon_background}

--- a/web/app/components/app-sidebar/app-info/app-operations.tsx
+++ b/web/app/components/app-sidebar/app-info/app-operations.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -34,14 +35,19 @@ const AppOperations = ({ appName, operationGroups }: AppOperationsProps) => {
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger
-        aria-label={t(($) => $['operation.moreActionsFor'], {
-          ns: 'common',
-          name: appName,
-        })}
-        className="flex size-5 shrink-0 items-center justify-center rounded-md p-0.5 text-text-tertiary hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden data-popup-open:bg-state-base-hover"
-      >
-        <span aria-hidden className="i-ri-more-fill size-4" />
-      </DropdownMenuTrigger>
+        render={
+          <IconButton
+            aria-label={t(($) => $['operation.moreActionsFor'], {
+              ns: 'common',
+              name: appName,
+            })}
+            size="md"
+            className="-mx-1 -my-0.5 data-popup-open:bg-state-base-hover data-popup-open:text-text-secondary"
+          >
+            <span aria-hidden className="i-ri-more-fill size-4" />
+          </IconButton>
+        }
+      />
       <DropdownMenuContent placement="bottom-end" sideOffset={4} className="min-w-40">
         {visibleGroups.map((group, groupIndex) => (
           <Fragment key={group.map((operation) => operation.id).join('-')}>

--- a/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
+++ b/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
@@ -137,15 +137,20 @@ describe('AgentDetailSection', () => {
     expect(screen.queryByText('agentV2.agentDetail.title')).not.toBeInTheDocument()
     expect(container.querySelector('em-emoji')).toHaveAttribute('id', '🧪')
     expect(agentAvatar).toHaveClass('h-10', 'w-10', 'rounded-full')
-    expect(agentAvatar?.parentElement?.parentElement).toHaveClass('mr-2')
-    expect(agentName.parentElement?.parentElement).toHaveClass('h-10')
-    expect(agentName.parentElement?.parentElement?.parentElement).toHaveClass(
-      'h-13',
-      'py-1.5',
-      'pl-1.5',
-      'pr-2',
-    )
   })
+
+  it.each([null, '', '   '])(
+    'omits an empty role without adding a type placeholder (%s)',
+    (role) => {
+      mocks.queryData = createAgent({ role })
+      renderAgentDetailSection()
+
+      expect(screen.getByText('Research Agent')).toBeInTheDocument()
+      expect(screen.queryByText('Research Assistant')).not.toBeInTheDocument()
+      expect(screen.queryByText('agentV2.agentDetail.type')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Research Agent/ })).toBeInTheDocument()
+    },
+  )
 
   it('renders compact more actions beside the expanded sidebar agent identity', async () => {
     const user = userEvent.setup()

--- a/web/features/agent-v2/agent-detail/navigation.tsx
+++ b/web/features/agent-v2/agent-detail/navigation.tsx
@@ -217,16 +217,23 @@ export function AgentDetailSection({ expand = true }: AgentDetailSectionProps) {
               />
             </span>
           </div>
-          <div className={cn('flex h-10 min-w-0 flex-1 items-center gap-2', !expand && 'hidden')}>
-            <div className="flex min-w-0 flex-1 flex-col justify-center">
-              <div className="truncate system-md-semibold text-text-secondary">
-                {agent?.name ?? t(($) => $['agentDetail.title'])}
-              </div>
-              <div className="truncate system-2xs-medium-uppercase text-text-tertiary">
-                {agent?.role ?? t(($) => $['agentDetail.type'])}
-              </div>
+          <div
+            className={cn(
+              'relative flex h-10 min-w-0 flex-1 flex-col justify-center gap-0.5 pr-7',
+              !expand && 'hidden',
+            )}
+          >
+            <div className="truncate system-md-semibold text-text-secondary">
+              {agent?.name ?? t(($) => $['agentDetail.title'])}
             </div>
-            {agent && expand && <AgentDetailSidebarActions agent={agent} />}
+            {agent?.role?.trim() && (
+              <div className="truncate system-xs-regular text-text-tertiary">{agent.role}</div>
+            )}
+            {agent && expand && (
+              <div className="absolute -top-px right-0">
+                <AgentDetailSidebarActions agent={agent} />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/web/features/agent-v2/agent-detail/sidebar-actions.tsx
+++ b/web/features/agent-v2/agent-detail/sidebar-actions.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
+import { IconButton } from '@langgenius/dify-ui/icon-button'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -67,11 +68,16 @@ export function AgentDetailSidebarActions({ agent }: { agent: AgentDetailSidebar
     <>
       <DropdownMenu>
         <DropdownMenuTrigger
-          aria-label={t(($) => $['roster.moreActions'], { name: agent.name })}
-          className="flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-text-tertiary hover:bg-state-base-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden data-popup-open:bg-state-base-hover data-popup-open:text-text-secondary"
-        >
-          <span aria-hidden className="i-ri-more-fill size-4" />
-        </DropdownMenuTrigger>
+          render={
+            <IconButton
+              aria-label={t(($) => $['roster.moreActions'], { name: agent.name })}
+              size="md"
+              className="data-popup-open:bg-state-base-hover data-popup-open:text-text-secondary"
+            >
+              <span aria-hidden className="i-ri-more-fill size-4" />
+            </IconButton>
+          }
+        />
         <DropdownMenuContent placement="bottom-end" sideOffset={4} className="w-40">
           {capabilities.canEdit && (
             <DropdownMenuItem className="gap-2" onClick={handleEditOpen}>


### PR DESCRIPTION
## Summary

Align the workflow sidebar identity block with its Figma layout: use a 36px avatar and restore the intended horizontal spacing. Both sidebar More menus use a 24px IconButton with a 16px glyph.

Keep the Agent More button at the design position independently of the text layout. Center the name and optional role as a group, omit empty roles, and use the designed 12px/16px role typography. This keeps the action stable when a role is absent.

