### PR TITLE
fix(api): mark async trigger log failed when celery dispatch raises

### DIFF
--- a/api/services/async_workflow_service.py
+++ b/api/services/async_workflow_service.py
@@ -175,8 +175,22 @@ class AsyncWorkflowService:
             else:  # SANDBOX
                 task = execute_workflow_sandbox.delay(task_data_dict)
             quota_charge.commit()
-        except Exception:
+        except Exception as e:
             quota_charge.refund()
+            # The Celery task was never enqueued, so no worker will pick it up.
+            # Mark the log FAILED (with the dispatch error) instead of leaving it
+            # PENDING forever, invisible to the failed-log retry query.
+            trigger_log.status = WorkflowTriggerStatus.FAILED
+            trigger_log.error = f"Failed to dispatch workflow task: {e}"
+            trigger_log_repo.update(trigger_log)
+            session.commit()
+            logger.exception(
+                "Failed to dispatch workflow task for tenant %s, app %s, workflow %s, trigger log %s",
+                trigger_data.tenant_id,
+                trigger_data.app_id,
+                workflow.id,
+                trigger_log.id,
+            )
             raise
 
         # 10. Update trigger log with task info

--- a/api/tests/unit_tests/services/test_async_workflow_service.py
+++ b/api/tests/unit_tests/services/test_async_workflow_service.py
@@ -350,6 +350,41 @@ class TestAsyncWorkflowService:
         mocks["team_task"].delay.assert_not_called()
         mocks["sandbox_task"].delay.assert_not_called()
 
+    def test_should_mark_log_failed_when_celery_dispatch_raises(
+        self,
+        async_workflow_trigger_mocks,
+        sqlite_session: Session,
+    ):
+        """Test dispatch-failure path marks the trigger log FAILED instead of leaving it PENDING."""
+        # Arrange
+        sqlite_session.add(AsyncWorkflowServiceTestDataFactory.create_app())
+        sqlite_session.commit()
+        trigger_data = AsyncWorkflowServiceTestDataFactory.create_trigger_data()
+        workflow = AsyncWorkflowServiceTestDataFactory.create_workflow()
+
+        mocks = async_workflow_trigger_mocks
+        mocks["dispatcher"].get_queue_name.return_value = QueuePriority.TEAM
+        mocks["get_workflow"].return_value = workflow
+        mocks["team_task"].delay.side_effect = RuntimeError("broker unavailable")
+
+        quota_charge_mock = MagicMock()
+        mocks["quota_service"].reserve.return_value = quota_charge_mock
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="broker unavailable"):
+            AsyncWorkflowService.trigger_workflow_async(
+                session=sqlite_session,
+                user=AsyncWorkflowServiceTestDataFactory.create_end_user("user-123"),
+                trigger_data=trigger_data,
+            )
+
+        quota_charge_mock.refund.assert_called_once()
+        quota_charge_mock.commit.assert_not_called()
+        updated_log = sqlite_session.scalar(select(WorkflowTriggerLog))
+        assert updated_log is not None
+        assert updated_log.status == WorkflowTriggerStatus.FAILED
+        assert "broker unavailable" in (updated_log.error or "")
+
     def test_should_raise_when_reinvoke_target_log_does_not_exist(self, sqlite_session: Session):
         """Test reinvoke_trigger error path when original trigger log is missing."""
         # Arrange


### PR DESCRIPTION
Fixes #42148

Summary:
- If the Celery `delay()` call in `trigger_workflow_async` raises, the trigger log kept its initial `PENDING` status even though no task was ever queued. It stayed that way permanently: no worker picks it up, and the retry query only returns `FAILED`/`RATE_LIMITED` logs.
- The dispatch-failure handler now marks the log `FAILED` with the dispatch error and commits before re-raising, mirroring the existing quota-exceeded path in the same method. This also makes failed dispatches retryable via `reinvoke_trigger`.

Checklist:
- [x] Added regression test (`test_should_mark_log_failed_when_celery_dispatch_raises`)
- [x] New test fails on base (`pending` instead of `failed`), passes with the fix
- [x] Full `test_async_workflow_service.py` suite green (18 passed); neighboring trigger/task suites green (132 passed, 1 skipped)
- [x] `ruff format --check` and `ruff check` clean; no new mypy errors in the changed file