### PR TITLE
fix(api): agent detail returns empty permission_keys

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -440,7 +440,7 @@ def _serialize_agent_app_detail(
         agent_id=agent.id,
         session=session,
     )
-    payload["permission_keys"] = permissions.agent.permission_keys_by_resource_ids([agent.id]).get(agent.id, [])
+    payload["permission_keys"] = permissions.agent.permission_keys_by_resource_ids([agent.id]).get(str(agent.id), [])
     return AgentAppDetailWithSite.model_validate(payload).model_dump(mode="json", exclude={"bound_agent_id"})
 
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #42150.

Follow-up to #42095: that PR fixed the empty `permission_keys` in the agents **list** serializer by looking the UUID-typed id up as `str(agent.id)`, but the agent app **detail** serializer (`_serialize_agent_app_detail`) has the same raw `.get(agent.id)` against the str-keyed map, so detail responses still always return `[]`. One-line fix mirroring #42095; no-op when ids are already strings. The app detail (`app.py`) and dataset detail endpoints already coerce both sides to `str`.

Verified with a repro script (legacy owner snapshot holds 11 agent keys; old expression returns `[]`, fixed expression returns all 11) and ran the neighboring unit suites: `test_rbac_service.py` (73 passed) plus console workspace/common controller tests (40 passed). Ruff check and format clean on the touched file.

## Screenshots

| Before | After |
| ------ | ----- |
| `permission_keys: []` | `permission_keys: [<role keys>]` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods