### PR TITLE
fix(rag): preserve CSV cell text in batch segment import

### DIFF
--- a/api/tasks/batch_create_segment_to_index_task.py
+++ b/api/tasks/batch_create_segment_to_index_task.py
@@ -112,7 +112,7 @@ def batch_create_segment_to_index_task(
         file_path = f"{temp_dir}/{next(tempfile._get_candidate_names())}{suffix}"  # type: ignore
         storage.download(upload_file_key, file_path)
 
-        df = pd.read_csv(file_path)
+        df = pd.read_csv(file_path, dtype=str, keep_default_na=False)
         content = []
         for _, row in df.iterrows():
             if document_config["doc_form"] == IndexStructureType.QA_INDEX:

--- a/api/tests/test_containers_integration_tests/tasks/test_batch_create_segment_to_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_batch_create_segment_to_index_task.py
@@ -324,6 +324,49 @@ class TestBatchCreateSegmentToIndexTask:
         cache_value = redis_client.get(cache_key)
         assert cache_value == b"completed"
 
+    def test_batch_create_segment_to_index_task_preserves_csv_cell_text(
+        self, db_session_with_containers: Session, mock_external_service_dependencies
+    ):
+        """Test that numeric-looking and NA CSV cells remain text in QA segments."""
+        account, tenant = self._create_test_account_and_tenant(db_session_with_containers)
+        dataset = self._create_test_dataset(db_session_with_containers, account, tenant)
+        document = self._create_test_document(db_session_with_containers, account, tenant, dataset)
+        document.doc_form = IndexStructureType.QA_INDEX
+        db_session_with_containers.commit()
+        upload_file = self._create_test_upload_file(db_session_with_containers, account, tenant)
+
+        csv_content = "content,answer\n00123,NA\nNA,00456\n"
+        mock_storage = mock_external_service_dependencies["storage"]
+
+        def mock_download(key, file_path):
+            Path(file_path).write_text(csv_content, encoding="utf-8")
+
+        mock_storage.download.side_effect = mock_download
+
+        job_id = str(uuid.uuid4())
+        batch_create_segment_to_index_task(
+            job_id=job_id,
+            upload_file_id=upload_file.id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            tenant_id=tenant.id,
+            user_id=account.id,
+        )
+
+        segments = db_session_with_containers.scalars(
+            select(DocumentSegment).where(DocumentSegment.document_id == document.id).order_by(DocumentSegment.position)
+        ).all()
+
+        assert [(segment.content, segment.answer, segment.word_count) for segment in segments] == [
+            ("00123", "NA", 7),
+            ("NA", "00456", 7),
+        ]
+
+        from extensions.ext_redis import redis_client
+
+        cache_key = f"segment_batch_import_{job_id}"
+        assert redis_client.get(cache_key) == b"completed"
+
     def test_batch_create_segment_to_index_task_dataset_not_found(
         self, db_session_with_containers: Session, mock_external_service_dependencies
     ):


### PR DESCRIPTION
## Summary

Fixes #42157

The batch segment import task now reads uploaded CSV files with `dtype=str` and `keep_default_na=False`. This preserves numeric-looking values and literal `NA` values as text for both paragraph and QA imports, including leading zeros in values such as `00123`.

No new dependency is required.

## Root cause and scope

The batch task used the default Pandas type inference. Values such as `00123` and `NA` could become NumPy numeric or missing-value scalars, and the subsequent `len(content)` call raised `TypeError`.

This change is limited to the batch segment import path. It is separate from #41922, which fixes the standard `CSVExtractor` path, and #38863, which addresses batch-task Redis error status handling.

## Validation

### Before

On the pre-fix `upstream/main` commit `f0d69e7b39`, the same CSV:

```csv
content,answer
00123,NA
NA,00456
```

was read as:

```
before: dtypes={'content': 'float64', 'answer': 'float64'}, values=[('float64', np.float64(123.0), 'float64', np.float64(nan)), ('float64', np.float64(nan), 'float64', np.float64(456.0))]
```

The task-level reproduction failed with:

```
TypeError: object of type 'numpy.float64' has no len()
```

### After

The same task-level reproduction, using the real task function and real Pandas parsing with database, storage, Redis, and vector service boundaries mocked in memory, passed with:

```
observed=[('str', '00123', 'NA', 7), ('str', 'NA', '00456', 7)]
redis=[('segment_batch_import_job-id', 600, 'completed')]
```

The direct Pandas comparison now reports:

```
after: dtypes={'content': 'str', 'answer': 'str'}, values=[('str', '00123', 'str', 'NA'), ('str', 'NA', 'str', '00456')]
```

Other checks:

- `pytest -q api/tests/unit_tests/core/rag/extractor/test_csv_extractor.py --no-cov`: 15 passed
- Targeted `ruff check`: All checks passed
- Targeted `ruff format --check`: 2 files already formatted
- `git diff --check`: passed
- Added a task-level regression test covering numeric-looking content, literal `NA`, and QA answers.

The container integration test was not runnable to completion locally because the current user cannot access the Docker daemon socket (`Permission denied` on `/var/run/docker.sock`). The production fix itself does not require Docker; this limitation only affects the repository's Testcontainers-based PostgreSQL/Redis integration fixture. CI can run the integration test in its normal container-enabled environment.

## Screenshots

| Before | After |
| ------ | ----- |
| Not applicable - backend-only change | Not applicable - backend-only change |

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change
- [ ] I've updated the documentation accordingly
- [ ] I ran `make lint && make type-check`; targeted Ruff checks were run instead

From Codex.