### PR TITLE
docs: sync zh-CN README — observability integrations and "Seeking help" section

### DIFF
--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -66,7 +66,7 @@
   <a href="https://trendshift.io/repositories/2152" target="_blank"><img src="https://trendshift.io/api/badge/repositories/2152" alt="langgenius%2Fdify | 趋势转变" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </div>
 
-Dify 是一个开源的 LLM 应用开发平台。其直观的界面结合了 AI 工作流、RAG 管道、Agent、模型管理、可观测性功能等，让您可以快速从原型到生产。以下是其核心功能列表：
+Dify 是一个开源的 LLM 应用开发平台。其直观的界面结合了 AI 工作流、RAG 管道、Agent、模型管理、可观测性功能（包括 [Opik](https://www.comet.com/docs/opik/integrations/dify)、[Langfuse](https://docs.langfuse.com) 和 [Arize Phoenix](https://docs.arize.com/phoenix)）等，让您可以快速从原型到生产。以下是其核心功能列表：
 </br> </br>
 
 **1. 工作流**:
@@ -130,6 +130,12 @@ docker compose up -d
 ```
 
 运行后，可以在浏览器上访问 [http://localhost/install](http://localhost/install) 进入 Dify 控制台并开始初始化安装操作。
+
+#### 获取帮助
+
+如果在安装 Dify 时遇到问题，请参阅我们的[常见问题](https://docs.dify.ai/getting-started/install-self-hosted/faqs)。如果问题仍未解决，请联系[社区和我们](#%E7%A4%BE%E5%8C%BA%E4%B8%8E%E6%94%AF%E6%8C%81)。
+
+> 如果您希望为 Dify 贡献代码或进行额外的开发，请参阅我们的[源码部署指南](https://docs.dify.ai/getting-started/install-self-hosted/local-source-code)
 
 ### 高级设置
 


### PR DESCRIPTION
Closes #42160

## Summary

Syncs `docs/zh-CN/README.md` with the root `README.md`, which had drifted in two places.

### 1. Intro paragraph — name the observability integrations

The English README lists them inline; the Chinese one only said 「可观测性功能等」. Now:

> ...模型管理、可观测性功能（包括 [Opik](https://www.comet.com/docs/opik/integrations/dify)、[Langfuse](https://docs.langfuse.com) 和 [Arize Phoenix](https://docs.arize.com/phoenix)）等...

### 2. Add the missing 「获取帮助」 (Seeking help) subsection

Present in the English "Quick start" section, absent from the Chinese one. Adds:

- link to the [installation FAQ](https://docs.dify.ai/getting-started/install-self-hosted/faqs)
- anchor to the existing `## 社区与支持` section
- blockquote linking the [deploy-from-source guide](https://docs.dify.ai/getting-started/install-self-hosted/local-source-code)

## Notes

- Purely additive — 7 lines added, 1 modified, nothing removed.
- Wording mirrors the English README so it can be verified line by line.
- Product names (Opik, Langfuse, Arize Phoenix) stay in English, consistent with how `docs/zh-CN/README.md` already handles `Prompt IDE`, `RAG Pipeline`, `LLMOps`.
- Per CONTRIBUTING.md, issue #42160 was opened first and is linked above.