### PR TITLE
fix(workflow): deduplicate classic agent node output variables

### DIFF
--- a/web/app/components/workflow/constants.ts
+++ b/web/app/components/workflow/constants.ts
@@ -130,12 +130,16 @@ export const AGENT_OUTPUT_STRUCT: Var[] = [
     type: VarType.string,
   },
   {
+    variable: 'usage',
+    type: VarType.object,
+  },
+  {
     variable: 'files',
     type: VarType.arrayFile,
   },
   {
     variable: 'json',
-    type: VarType.object,
+    type: VarType.arrayObject,
   },
 ]
 

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
@@ -1,4 +1,5 @@
 import type { AgentV2NodeType } from '@/app/components/workflow/nodes/agent-v2/types'
+import type { AgentNodeType } from '@/app/components/workflow/nodes/agent/types'
 import type { AnswerNodeType } from '@/app/components/workflow/nodes/answer/types'
 import type { HumanInputNodeType } from '@/app/components/workflow/nodes/human-input/types'
 import type { LLMNodeType } from '@/app/components/workflow/nodes/llm/types'
@@ -109,6 +110,41 @@ describe('variable utils', () => {
         variable: 'usage',
         type: VarType.object,
       })
+    })
+
+    it('deduplicates classic agent output vars and includes usage', () => {
+      const node = createNode<AgentNodeType>({
+        type: BlockEnum.Agent,
+        title: 'Agent',
+        desc: '',
+        output_schema: {
+          properties: {
+            text: {
+              type: 'string',
+              description: 'duplicate text from strategy schema',
+            },
+            summary: {
+              type: 'string',
+              description: 'custom summary output',
+            },
+          },
+        },
+      })
+
+      const availableVars = toNodeAvailableVars({
+        beforeNodes: [node],
+        isChatMode: false,
+        filterVar: () => true,
+        allPluginInfoList: {},
+      })
+
+      const agentVars = availableVars.find((item) => item.nodeId === 'node-1')?.vars ?? []
+      const variableNames = agentVars.map(({ variable }) => variable)
+
+      expect(variableNames).toEqual(['text', 'usage', 'files', 'json', 'summary'])
+      expect(variableNames.filter((name) => name === 'text')).toHaveLength(1)
+      expect(variableNames.filter((name) => name === 'files')).toHaveLength(1)
+      expect(variableNames.filter((name) => name === 'json')).toHaveLength(1)
     })
 
     it('uses Agent v2 declared outputs from graph data', () => {

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -570,10 +570,13 @@ const formatItem = (
       }
 
       const payload = data as AgentNodeType
-      const outputs: Var[] = []
+      const standardVarNames = new Set(AGENT_OUTPUT_STRUCT.map(({ variable }) => variable))
+      const schemaOutputs: Var[] = []
       Object.keys(payload.output_schema?.properties || {}).forEach((outputKey) => {
+        if (standardVarNames.has(outputKey)) return
+
         const output = payload.output_schema.properties[outputKey]
-        outputs.push({
+        schemaOutputs.push({
           variable: outputKey,
           type:
             output.type === 'array'
@@ -581,7 +584,7 @@ const formatItem = (
               : (`${output.type ? output.type.slice(0, 1).toLocaleUpperCase() + output.type.slice(1) : 'Unknown'}` as VarType),
         })
       })
-      res.vars = [...outputs, ...TOOL_OUTPUT_STRUCT, ...AGENT_OUTPUT_STRUCT]
+      res.vars = [...AGENT_OUTPUT_STRUCT, ...schemaOutputs]
       break
     }
 


### PR DESCRIPTION
Fixes #38360

## Summary

Classic Agent nodes exposed duplicate output variables (`text`, `files`, `json`) in the workflow variable picker because `toNodeAvailableVars` merged both `TOOL_OUTPUT_STRUCT` and `AGENT_OUTPUT_STRUCT`.

This PR:
- Uses a single canonical `AGENT_OUTPUT_STRUCT` for classic Agent nodes
- Aligns standard outputs with the backend contract: `text`, `usage`, `files`, `json`
- Skips strategy `output_schema` keys that collide with standard outputs
- Adds a regression test

## Context

The empty-output symptom reported in #38360 for Function Calling + thinking mode is already addressed on `main` by #41764 (unclosed `` tag repair in workflow agent streaming). This PR fixes the remaining duplicate-variable bug from the same issue.

## Testing

- `cd web && node_modules/.bin/vitest run app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts`