### PR TITLE
fix(workflow): restore loop assigner parent metadata and single-run

### DIFF
--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -49,6 +49,7 @@ import {
   getNodesConnectedSourceOrTargetHandleIdsMap,
   getNodesWithSameDefaultDataType,
   getTopLeftNodePosition,
+  resolveContainerParentId,
   isClipboardEdgeStructurallyValid,
   isClipboardNodeStructurallyValid,
   isClipboardValueCompatibleWithDefault,
@@ -884,14 +885,17 @@ export const useNodesInteractions = () => {
             ? lastOutgoer.position.y + lastOutgoer.height! + Y_OFFSET
             : prevNode!.position.y,
         }
-        newNode.parentId = prevNode!.parentId
+        const containerParentId = resolveContainerParentId(prevNode!)
+        newNode.parentId = containerParentId
         newNode.extent = prevNode!.extent
 
-        const parentNode = nodes.find((node) => node.id === prevNode!.parentId) || null
+        const parentNode = containerParentId
+          ? nodes.find((node) => node.id === containerParentId) || null
+          : null
         const isInIteration = !!parentNode && parentNode.data.type === BlockEnum.Iteration
         const isInLoop = !!parentNode && parentNode.data.type === BlockEnum.Loop
 
-        if (prevNode!.parentId) {
+        if (containerParentId) {
           newNode.data.isInIteration = isInIteration
           newNode.data.isInLoop = isInLoop
           if (isInIteration) {
@@ -936,11 +940,11 @@ export const useNodesInteractions = () => {
               targetType: newNode.data.type,
               isInIteration,
               isInLoop,
-              iteration_id: isInIteration ? prevNode!.parentId : undefined,
-              loop_id: isInLoop ? prevNode!.parentId : undefined,
+              iteration_id: isInIteration ? containerParentId : undefined,
+              loop_id: isInLoop ? containerParentId : undefined,
               _connectedNodeIsSelected: true,
             },
-            zIndex: prevNode!.parentId ? NESTED_ELEMENT_Z_INDEX : 0,
+            zIndex: containerParentId ? NESTED_ELEMENT_Z_INDEX : 0,
           }
         }
 
@@ -960,14 +964,14 @@ export const useNodesInteractions = () => {
               }
             }
 
-            if (node.data.type === BlockEnum.Iteration && prevNode!.parentId === node.id) {
+            if (node.data.type === BlockEnum.Iteration && containerParentId === node.id) {
               node.data._children?.push({
                 nodeId: newNode.id,
                 nodeType: newNode.data.type,
               })
             }
 
-            if (node.data.type === BlockEnum.Loop && prevNode!.parentId === node.id) {
+            if (node.data.type === BlockEnum.Loop && containerParentId === node.id) {
               node.data._children?.push({
                 nodeId: newNode.id,
                 nodeType: newNode.data.type,
@@ -1026,14 +1030,17 @@ export const useNodesInteractions = () => {
           x: nextNode.position.x,
           y: nextNode.position.y,
         }
-        newNode.parentId = nextNode.parentId
+        const nextContainerParentId = resolveContainerParentId(nextNode)
+        newNode.parentId = nextContainerParentId
         newNode.extent = nextNode.extent
 
-        const parentNode = nodes.find((node) => node.id === nextNode.parentId) || null
+        const parentNode = nextContainerParentId
+          ? nodes.find((node) => node.id === nextContainerParentId) || null
+          : null
         const isInIteration = !!parentNode && parentNode.data.type === BlockEnum.Iteration
         const isInLoop = !!parentNode && parentNode.data.type === BlockEnum.Loop
 
-        if (parentNode && nextNode.parentId) {
+        if (parentNode && nextContainerParentId) {
           newNode.data.isInIteration = isInIteration
           newNode.data.isInLoop = isInLoop
           if (isInIteration) {
@@ -1066,11 +1073,11 @@ export const useNodesInteractions = () => {
               targetType: nextNode.data.type,
               isInIteration,
               isInLoop,
-              iteration_id: isInIteration ? nextNode.parentId : undefined,
-              loop_id: isInLoop ? nextNode.parentId : undefined,
+              iteration_id: isInIteration ? nextContainerParentId : undefined,
+              loop_id: isInLoop ? nextContainerParentId : undefined,
               _connectedNodeIsSelected: true,
             },
-            zIndex: nextNode.parentId ? NESTED_ELEMENT_Z_INDEX : 0,
+            zIndex: nextContainerParentId ? NESTED_ELEMENT_Z_INDEX : 0,
           }
         }
 
@@ -1099,7 +1106,7 @@ export const useNodesInteractions = () => {
               }
             }
 
-            if (node.data.type === BlockEnum.Iteration && nextNode.parentId === node.id) {
+            if (node.data.type === BlockEnum.Iteration && nextContainerParentId === node.id) {
               node.data._children?.push({
                 nodeId: newNode.id,
                 nodeType: newNode.data.type,
@@ -1111,7 +1118,7 @@ export const useNodesInteractions = () => {
               node.data.startNodeType = newNode.data.type
             }
 
-            if (node.data.type === BlockEnum.Loop && nextNode.parentId === node.id) {
+            if (node.data.type === BlockEnum.Loop && nextContainerParentId === node.id) {
               node.data._children?.push({
                 nodeId: newNode.id,
                 nodeType: newNode.data.type,
@@ -1155,14 +1162,17 @@ export const useNodesInteractions = () => {
           x: nextNode.position.x,
           y: nextNode.position.y,
         }
-        newNode.parentId = prevNode.parentId
+        const betweenContainerParentId = resolveContainerParentId(prevNode)
+        newNode.parentId = betweenContainerParentId
         newNode.extent = prevNode.extent
 
-        const parentNode = nodes.find((node) => node.id === prevNode.parentId) || null
+        const parentNode = betweenContainerParentId
+          ? nodes.find((node) => node.id === betweenContainerParentId) || null
+          : null
         const isInIteration = !!parentNode && parentNode.data.type === BlockEnum.Iteration
         const isInLoop = !!parentNode && parentNode.data.type === BlockEnum.Loop
 
-        if (parentNode && prevNode.parentId) {
+        if (parentNode && betweenContainerParentId) {
           newNode.data.isInIteration = isInIteration
           newNode.data.isInLoop = isInLoop
           if (isInIteration) {
@@ -1193,17 +1203,20 @@ export const useNodesInteractions = () => {
               targetType: newNode.data.type,
               isInIteration,
               isInLoop,
-              iteration_id: isInIteration ? prevNode.parentId : undefined,
-              loop_id: isInLoop ? prevNode.parentId : undefined,
+              iteration_id: isInIteration ? betweenContainerParentId : undefined,
+              loop_id: isInLoop ? betweenContainerParentId : undefined,
               _connectedNodeIsSelected: true,
             },
-            zIndex: prevNode.parentId ? NESTED_ELEMENT_Z_INDEX : 0,
+            zIndex: betweenContainerParentId ? NESTED_ELEMENT_Z_INDEX : 0,
           }
         }
 
         let newNextEdge: Edge | null = null
 
-        const nextNodeParentNode = nodes.find((node) => node.id === nextNode.parentId) || null
+        const nextContainerParentId = resolveContainerParentId(nextNode)
+        const nextNodeParentNode = nextContainerParentId
+          ? nodes.find((node) => node.id === nextContainerParentId) || null
+          : null
         const isNextNodeInIteration =
           !!nextNodeParentNode && nextNodeParentNode.data.type === BlockEnum.Iteration
         const isNextNodeInLoop =
@@ -1227,11 +1240,11 @@ export const useNodesInteractions = () => {
               targetType: nextNode.data.type,
               isInIteration: isNextNodeInIteration,
               isInLoop: isNextNodeInLoop,
-              iteration_id: isNextNodeInIteration ? nextNode.parentId : undefined,
-              loop_id: isNextNodeInLoop ? nextNode.parentId : undefined,
+              iteration_id: isNextNodeInIteration ? nextContainerParentId : undefined,
+              loop_id: isNextNodeInLoop ? nextContainerParentId : undefined,
               _connectedNodeIsSelected: true,
             },
-            zIndex: nextNode.parentId ? NESTED_ELEMENT_Z_INDEX : 0,
+            zIndex: nextContainerParentId ? NESTED_ELEMENT_Z_INDEX : 0,
           }
         }
         const nodesConnectedSourceOrTargetHandleIdsMap =
@@ -1258,13 +1271,13 @@ export const useNodesInteractions = () => {
             }
             if (afterNodesInSameBranchIds.includes(node.id)) node.position.x += NODE_WIDTH_X_OFFSET
 
-            if (node.data.type === BlockEnum.Iteration && prevNode.parentId === node.id) {
+            if (node.data.type === BlockEnum.Iteration && betweenContainerParentId === node.id) {
               node.data._children?.push({
                 nodeId: newNode.id,
                 nodeType: newNode.data.type,
               })
             }
-            if (node.data.type === BlockEnum.Loop && prevNode.parentId === node.id) {
+            if (node.data.type === BlockEnum.Loop && betweenContainerParentId === node.id) {
               node.data._children?.push({
                 nodeId: newNode.id,
                 nodeType: newNode.data.type,

--- a/web/app/components/workflow/utils/__tests__/node.spec.ts
+++ b/web/app/components/workflow/utils/__tests__/node.spec.ts
@@ -16,6 +16,7 @@ import {
   getNodeCustomTypeByNodeDataType,
   getTopLeftNodePosition,
   hasRetryNode,
+  resolveContainerParentId,
 } from '../node'
 
 describe('nested workflow node layering', () => {
@@ -154,6 +155,36 @@ describe('getIterationStartNode', () => {
     expect(node.draggable).toBe(false)
     expect(node.zIndex).toBe(NESTED_ELEMENT_Z_INDEX)
     expect(node.position).toEqual({ x: 24, y: 68 })
+  })
+})
+
+describe('resolveContainerParentId', () => {
+  it('should prefer parentId when present', () => {
+    const node = {
+      id: 'child',
+      parentId: 'loop-1',
+      data: { isInLoop: true, loop_id: 'loop-2' },
+    } as Node
+
+    expect(resolveContainerParentId(node)).toBe('loop-1')
+  })
+
+  it('should fall back to loop_id when parentId is missing', () => {
+    const node = {
+      id: 'child',
+      data: { isInLoop: true, loop_id: 'loop-1' },
+    } as Node
+
+    expect(resolveContainerParentId(node)).toBe('loop-1')
+  })
+
+  it('should fall back to iteration_id when parentId is missing', () => {
+    const node = {
+      id: 'child',
+      data: { isInIteration: true, iteration_id: 'iter-1' },
+    } as Node
+
+    expect(resolveContainerParentId(node)).toBe('iter-1')
   })
 })
 

--- a/web/app/components/workflow/utils/__tests__/workflow-init.spec.ts
+++ b/web/app/components/workflow/utils/__tests__/workflow-init.spec.ts
@@ -221,6 +221,35 @@ describe('initialNodes', () => {
     expect(parentNode.zIndex! + 1000).toBeLessThan(childNode.zIndex!)
   })
 
+  it('should repair missing parentId from loop_id metadata', () => {
+    const nodes = [
+      createNode({
+        id: 'loop-1',
+        data: { type: BlockEnum.Loop, title: '', desc: '' },
+      }),
+      createNode({
+        id: 'assigner-1',
+        data: {
+          type: BlockEnum.Assigner,
+          title: '',
+          desc: '',
+          isInLoop: true,
+          loop_id: 'loop-1',
+        },
+      }),
+    ]
+
+    const result = initialNodes(nodes, [])
+    const assignerNode = result.find((node) => node.id === 'assigner-1')!
+    const loopNode = result.find((node) => node.id === 'loop-1')!
+
+    expect(assignerNode.parentId).toBe('loop-1')
+    expect((loopNode.data as LoopNodeType)._children).toContainEqual({
+      nodeId: 'assigner-1',
+      nodeType: BlockEnum.Assigner,
+    })
+  })
+
   it('should set positions when first node has no position', () => {
     const nodes = [
       createNode({ id: 'n1', data: { type: BlockEnum.Start, title: '', desc: '' } }),

--- a/web/app/components/workflow/utils/__tests__/workflow.spec.ts
+++ b/web/app/components/workflow/utils/__tests__/workflow.spec.ts
@@ -41,8 +41,8 @@ describe('canRunBySingle', () => {
     expect(canRunBySingle(type, false)).toBe(true)
   })
 
-  it('should return false for Assigner when it is a child node', () => {
-    expect(canRunBySingle(BlockEnum.Assigner, true)).toBe(false)
+  it('should return true for Assigner when it is a child node', () => {
+    expect(canRunBySingle(BlockEnum.Assigner, true)).toBe(true)
   })
 
   it('should return true for LLM even as a child node', () => {

--- a/web/app/components/workflow/utils/node.ts
+++ b/web/app/components/workflow/utils/node.ts
@@ -13,6 +13,14 @@ export function getNodeCatalogType(data: CommonNodeType): BlockEnum {
   return isAgentV2NodeData(data) ? BlockEnum.AgentV2 : data.type
 }
 
+/** Resolve the iteration/loop container id for a nested node. */
+export const resolveContainerParentId = (node: Node): string | undefined => {
+  if (node.parentId) return node.parentId
+  if (node.data.isInLoop && node.data.loop_id) return node.data.loop_id
+  if (node.data.isInIteration && node.data.iteration_id) return node.data.iteration_id
+  return undefined
+}
+
 export function generateNewNode({
   data,
   position,

--- a/web/app/components/workflow/utils/workflow-init.ts
+++ b/web/app/components/workflow/utils/workflow-init.ts
@@ -201,6 +201,14 @@ export const initialNodes = (originNodes: Node[], originEdges: Edge[]) => {
     })
   }
 
+  nodes.forEach((node) => {
+    if (!node.parentId && node.data.isInLoop && node.data.loop_id) {
+      node.parentId = node.data.loop_id
+    } else if (!node.parentId && node.data.isInIteration && node.data.iteration_id) {
+      node.parentId = node.data.iteration_id
+    }
+  })
+
   const iterationOrLoopNodeMap = nodes.reduce(
     (acc, node) => {
       if (node.parentId) {

--- a/web/app/components/workflow/utils/workflow.ts
+++ b/web/app/components/workflow/utils/workflow.ts
@@ -3,9 +3,7 @@ import { uniqBy } from 'es-toolkit/compat'
 import { getOutgoers } from 'reactflow'
 import { BlockEnum } from '../types'
 
-export const canRunBySingle = (nodeType: BlockEnum, isChildNode: boolean) => {
-  // child node means in iteration or loop. Set value to iteration(or loop) may cause variable not exit problem in backend.
-  if (isChildNode && nodeType === BlockEnum.Assigner) return false
+export const canRunBySingle = (nodeType: BlockEnum, _isChildNode: boolean) => {
   return (
     nodeType === BlockEnum.LLM ||
     nodeType === BlockEnum.KnowledgeRetrieval ||


### PR DESCRIPTION
## Summary

Fixes #38246

Assign Variable nodes inside Loop nodes could be saved with `loop_id` / `isInLoop` metadata but without `parentId`. That left them out of the loop container's `_children` map and caused them to be skipped during execution, with no single-run button available.

This PR:

- Repairs missing `parentId` from `loop_id` / `iteration_id` when workflows are loaded
- Ensures newly added nested nodes inherit the container id even when the predecessor only has loop metadata
- Re-enables single-node testing for Assigner nodes inside loops/iterations, matching existing backend draft-run support

## Test plan

- [x] `vitest run` for `workflow.spec.ts`, `node.spec.ts`, and `workflow-init.spec.ts` (133 tests passing)
- [ ] Add an Assign Variable node inside a Loop node and confirm the run button appears
- [ ] Run the loop and confirm Assign Variable nodes execute and show Last Run records
- [ ] Export DSL and verify nested assigner nodes include `parentId` matching the loop container id