### PR TITLE
fix(api): mask secrets in app and agent api key lists

### DIFF
--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -129,9 +129,11 @@ class BaseApiKeyListResource(Resource):
                 getattr(ApiToken, self.resource_id_field) == resource_id,
             )
         ).all()
-        # App and agent keys keep their existing (unmasked) list behavior; reveal-once
-        # masking is scoped to dataset keys, which build their list in datasets.py.
-        return ApiKeyList(data=[ApiKeyItem.model_validate(key, from_attributes=True) for key in keys])
+        # Reveal-once: list responses expose only masked secrets (prefix + last 4),
+        # matching the dataset key lists in datasets.py. The full secret is only
+        # returned by the create endpoint, so an existing key's bearer value cannot
+        # be retrieved afterwards by any workspace member able to list keys.
+        return build_masked_api_key_list(keys)
 
     @edit_permission_required
     @with_session

--- a/api/tests/unit_tests/controllers/console/test_apikey.py
+++ b/api/tests/unit_tests/controllers/console/test_apikey.py
@@ -18,6 +18,7 @@ from controllers.console.apikey import (
     BaseApiKeyListResource,
     BaseApiKeyResource,
     DatasetApiKeyListResource,
+    mask_api_token,
 )
 from controllers.console.datasets.datasets import DatasetApiKeyApi
 from core.rbac import RBACPermission, RBACResourceScope
@@ -105,7 +106,40 @@ def test_list_api_keys_uses_injected_session_and_tenant_id(sqlite_session: Sessi
     result = raw_get(resource, session, "app-1", "tenant-1")
     data = cast(list[dict[str, object]], result["data"])
 
-    assert {item["token"] for item in data} == {"app-token", "legacy-app-token"}
+    assert {item["token"] for item in data} == {"app-t...oken", "legac...oken"}
+
+
+def test_list_api_keys_masks_secrets_while_create_reveals_once(sqlite_session: Session) -> None:
+    """List responses must never disclose full secrets (reveal-once).
+
+    Any workspace member with edit permission (e.g. EDITOR, non-admin) can reach
+    the key list endpoints, so returning full bearer secrets there discloses
+    long-lived credentials beyond their need-to-know. The full secret is only
+    returned by the create endpoint.
+    """
+    resource = _make_list_resource()
+    session = sqlite_session
+    _persist_app(session)
+    secret = "app-abcdefghijklmnopqrstuvwxyz123456"
+    session.add(
+        ApiToken(
+            type=ApiTokenType.APP,
+            token=secret,
+            app_id="app-1",
+            tenant_id="tenant-1",
+        )
+    )
+    session.commit()
+
+    listed = resource._get_api_key_list("app-1", "tenant-1", session=session)
+    assert len(listed.data) == 1
+    assert listed.data[0].token == mask_api_token(secret)
+    assert listed.data[0].token != secret
+
+    created = resource._create_api_key("app-1", "tenant-1", session=session)
+    assert created.token.startswith("app-")
+    stored = session.scalar(select(ApiToken).where(ApiToken.token == created.token))
+    assert stored is not None
 
 
 def test_create_api_key_uses_injected_session_and_tenant_id(sqlite_session: Session) -> None:

--- a/e2e/features/step-definitions/agent-v2/access-point-service-api.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/access-point-service-api.steps.ts
@@ -71,9 +71,13 @@ Then('Agent v2 API keys should not expose a secret by default', async function (
   await expect(dialog.getByText('CREATED', { exact: true })).toBeVisible()
   await expect(dialog.getByText('LAST USED', { exact: true })).toBeVisible()
   await expect(dialog.getByRole('button', { name: 'Create new Secret key' })).toBeVisible()
-  if (existingSecret)
+  if (existingSecret) {
     await expect(dialog.getByText(existingSecret, { exact: true })).not.toBeVisible()
-  await expect(dialog.getByText(/^app-/)).not.toBeVisible()
+    // Lists now show masked values (prefix + '...' + last 4); only the full secret must stay hidden.
+    const maskedSecret =
+      existingSecret.length <= 8 ? '***' : `${existingSecret.slice(0, 5)}...${existingSecret.slice(-4)}`
+    await expect(dialog.getByText(maskedSecret, { exact: true })).toBeVisible()
+  }
   await expect(page.getByRole('dialog', { name: 'Internal Server Error' })).not.toBeVisible()
 })
 
@@ -138,7 +142,9 @@ Then(
 
     await expect(apiKeyDialog).toBeVisible()
     await expect(apiKeyDialog.getByText(fullSecret, { exact: true })).not.toBeVisible()
-    await expect(apiKeyDialog.getByText(/^app-/)).not.toBeVisible()
+    const maskedSecret =
+      fullSecret.length <= 8 ? '***' : `${fullSecret.slice(0, 5)}...${fullSecret.slice(-4)}`
+    await expect(apiKeyDialog.getByText(maskedSecret, { exact: true })).toBeVisible()
     await expect(apiKeyDialog.getByLabel('Copy').first()).toBeVisible()
   },
 )


### PR DESCRIPTION
Fixes #42167

List endpoints for app, agent, and per-dataset API keys returned the full bearer secret to anyone with edit permission. They now return masked values, same as the workspace dataset key lists. The full secret is still returned once by the create endpoint.

Tests: added a regression test for masked lists plus reveal-once create; updated the existing list test. Console controller suite passes (2043 passed), ruff check and format clean.

Note: the web key table copy button reads its value from list data, so it will now copy the masked value. The create dialog still shows the full key once, matching the dataset flow.