### PR TITLE
fix(api): bound remote file downloads against oversized responses

### DIFF
--- a/api/core/rag/extractor/extract_processor.py
+++ b/api/core/rag/extractor/extract_processor.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from configs import dify_config
 from core.file import remote_fetcher
+from core.helper import ssrf_proxy
 from core.rag.extractor.csv_extractor import CSVExtractor
 from core.rag.extractor.entity.datasource_type import DatasourceType
 from core.rag.extractor.entity.extract_setting import ExtractSetting
@@ -39,6 +40,24 @@ USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124"
     " Safari/537.36"
 )
+
+
+def _max_url_load_bytes() -> int:
+    """Largest configured upload allowance, in bytes.
+
+    URL-loaded documents are classified after download, so the pre-download
+    bound uses the ceiling across all upload categories.
+    """
+    return (
+        max(
+            dify_config.UPLOAD_FILE_SIZE_LIMIT,
+            dify_config.UPLOAD_IMAGE_FILE_SIZE_LIMIT,
+            dify_config.UPLOAD_VIDEO_FILE_SIZE_LIMIT,
+            dify_config.UPLOAD_AUDIO_FILE_SIZE_LIMIT,
+        )
+        * 1024
+        * 1024
+    )
 
 
 class ExtractProcessor:
@@ -77,16 +96,25 @@ class ExtractProcessor:
 
     @classmethod
     def load_from_url(cls, url: str, return_text: bool = False) -> list[Document] | str:
-        response = remote_fetcher.make_request("GET", url, headers={"User-Agent": USER_AGENT})
+        # Stream with a hard size bound: the URL and its response are fully
+        # attacker-controlled, so buffering blindly exhausts memory and disk.
+        response = remote_fetcher.make_request("GET", url, headers={"User-Agent": USER_AGENT}, stream_response=True)
+        try:
+            buffered = ssrf_proxy.buffer_response(response, max_response_bytes=_max_url_load_bytes())
+        except ssrf_proxy.ResponseTooLargeError as error:
+            raise ValueError(f"remote file at {url} exceeds the size limit") from error
+        except ssrf_proxy.UnsupportedResponseEncodingError as error:
+            raise ValueError(f"remote file at {url} uses an unsupported content encoding") from error
+        content = buffered.content
 
         with tempfile.TemporaryDirectory() as temp_dir:
             suffix = Path(url).suffix
             if not suffix and suffix != ".":
                 # get content-type
-                if response.headers.get("Content-Type"):
-                    suffix = "." + response.headers.get("Content-Type").split("/")[-1]
+                if buffered.headers.get("Content-Type"):
+                    suffix = "." + buffered.headers.get("Content-Type").split("/")[-1]
                 else:
-                    content_disposition = response.headers.get("Content-Disposition")
+                    content_disposition = buffered.headers.get("Content-Disposition")
                     filename_match = re.search(r'filename="([^"]+)"', content_disposition)
                     if filename_match:
                         filename = unquote(filename_match.group(1))
@@ -98,7 +126,7 @@ class ExtractProcessor:
             # https://stackoverflow.com/questions/26541416/generate-temporary-file-names-without-creating-actual-file-in-python#comment90414256_26541521
             # Generate a temporary filename under the created temp_dir and ensure the directory exists
             file_path = f"{temp_dir}/{next(tempfile._get_candidate_names())}{suffix}"  # type: ignore
-            Path(file_path).write_bytes(response.content)
+            Path(file_path).write_bytes(content)
             extract_setting = ExtractSetting(datasource_type=DatasourceType.FILE, document_model="text_model")
             if return_text:
                 delimiter = "\n"

--- a/api/core/tools/tool_file_manager.py
+++ b/api/core/tools/tool_file_manager.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from configs import dify_config
 from core.db.session_factory import session_factory
 from core.file import remote_fetcher
+from core.helper import ssrf_proxy
 from core.workflow.file_reference import build_file_reference
 from extensions.ext_storage import storage
 from graphon.file import File, FileTransferMethod, get_file_type_by_mime_type
@@ -110,9 +111,20 @@ class ToolFileManager:
     ) -> ToolFile:
         # try to download image
         try:
-            response = remote_fetcher.make_request("GET", file_url)
-            response.raise_for_status()
-            blob = response.content
+            # Stream with a hard size bound: the URL and its response are fully
+            # attacker-controlled, so buffering blindly exhausts worker memory.
+            response = remote_fetcher.make_request("GET", file_url, stream_response=True)
+            try:
+                response.raise_for_status()
+            except Exception:
+                response.close()
+                raise
+            try:
+                blob = ssrf_proxy.buffer_response(response, max_response_bytes=_max_tool_file_download_bytes()).content
+            except ssrf_proxy.ResponseTooLargeError as error:
+                raise ValueError(f"file too large when downloading file from {file_url}") from error
+            except ssrf_proxy.UnsupportedResponseEncodingError as error:
+                raise ValueError(f"unsupported content encoding when downloading file from {file_url}") from error
         except httpx.TimeoutException:
             raise ValueError(f"timeout when downloading file from {file_url}")
 
@@ -227,6 +239,24 @@ def resolve_extension(*, filename: str | None, mimetype: str) -> str:
     if filename_extension:
         return filename_extension
     return guess_extension(mimetype) or ".bin"
+
+
+def _max_tool_file_download_bytes() -> int:
+    """Largest configured upload allowance, in bytes.
+
+    Tool files are classified after download, so the pre-download bound uses
+    the ceiling across all upload categories instead of an extension limit.
+    """
+    return (
+        max(
+            dify_config.UPLOAD_FILE_SIZE_LIMIT,
+            dify_config.UPLOAD_IMAGE_FILE_SIZE_LIMIT,
+            dify_config.UPLOAD_VIDEO_FILE_SIZE_LIMIT,
+            dify_config.UPLOAD_AUDIO_FILE_SIZE_LIMIT,
+        )
+        * 1024
+        * 1024
+    )
 
 
 set_tool_file_manager_factory(_factory)

--- a/api/services/remote_file_service.py
+++ b/api/services/remote_file_service.py
@@ -7,6 +7,7 @@ import httpx
 
 from core.file import remote_fetcher
 from core.file.remote_file_metadata import InvalidRemoteFileMetadataError, guess_file_info_from_response
+from core.helper import ssrf_proxy
 from core.helper.ssrf_proxy import MaxRetriesExceededError
 from core.tools.errors import ToolSSRFError
 from graphon.file import helpers as file_helpers
@@ -69,8 +70,18 @@ class RemoteFileService:
     def fetch_info(self, *, url: str) -> RemoteFileInfoResult:
         response = self._request("HEAD", url=url)
         if response.status_code != httpx.codes.OK:
-            response = self._request("GET", url=url, timeout=3)
-        self._ensure_success(response)
+            # Fall back to GET for servers that refuse HEAD, but stream so only
+            # headers are inspected — the body must never be buffered by a probe.
+            response = self._request("GET", url=url, timeout=3, stream_response=True)
+            try:
+                return self._info_from_response(response)
+            finally:
+                response.close()
+        return self._info_from_response(response)
+
+    @staticmethod
+    def _info_from_response(response: httpx.Response) -> RemoteFileInfoResult:
+        RemoteFileService._ensure_success(response)
 
         content_length = response.headers.get("Content-Length")
         try:
@@ -90,9 +101,9 @@ class RemoteFileService:
         user: Account | EndUser,
         tenant_id: str | None = None,
     ) -> RemoteFileUploadResult:
-        response = self._fetch_for_upload(url=url)
+        metadata, content = self._fetch_for_upload(url=url)
         try:
-            file_info = guess_file_info_from_response(response)
+            file_info = guess_file_info_from_response(metadata)
         except InvalidRemoteFileMetadataError as error:
             raise RemoteFileInvalidResponseError("The remote response contains invalid file metadata") from error
         except ValueError as error:
@@ -108,10 +119,13 @@ class RemoteFileService:
         ):
             raise FileTooLargeError()
 
-        if response.request.method == "GET":
-            content = response.content
-        else:
-            content = self._fetch_content(url=url)
+        extension_limit = FileService.file_size_limit(extension=file_info.extension)
+        if content is None:
+            content = self._fetch_content(url=url, limit=extension_limit)
+        elif len(content) > extension_limit:
+            # The fallback metadata read was bounded by the largest configured
+            # allowance, so enforce the file's own extension limit here.
+            raise FileTooLargeError()
 
         upload_file = self._files.upload_file(
             filename=file_info.filename,
@@ -158,13 +172,58 @@ class RemoteFileService:
             raise RemoteFileUnavailableError("The remote file request failed") from error
 
     @classmethod
-    def _fetch_for_upload(cls, *, url: str) -> httpx.Response:
-        response = cls._request("HEAD", url=url)
-        if response.status_code != httpx.codes.OK:
-            response = cls._request("GET", url=url, timeout=3, follow_redirects=True)
+    def _fetch_for_upload(cls, *, url: str) -> tuple[httpx.Response, bytes | None]:
+        """Fetch metadata for an upload, prefetching bounded content on GET fallback.
 
-        cls._ensure_success(response)
-        return response
+        Returns the metadata response plus prefetched body bytes when the metadata
+        already came from a GET. Prefetched bytes are bounded by the largest
+        configured upload allowance; the caller enforces the extension limit.
+        """
+        response = cls._request("HEAD", url=url)
+        if response.status_code == httpx.codes.OK:
+            return response, None
+
+        # Some servers refuse HEAD: fall back to GET, but stream and bound the
+        # read so a malicious response cannot exhaust server memory or disk.
+        # The buffered response keeps headers and body for metadata guessing.
+        fallback = cls._request("GET", url=url, timeout=3, follow_redirects=True, stream_response=True)
+        try:
+            cls._ensure_success(fallback)
+        except Exception:
+            fallback.close()
+            raise
+        buffered = cls._buffer_bounded(fallback, limit=_max_upload_bytes())
+        return buffered, buffered.content
+
+    @classmethod
+    def _fetch_content(cls, *, url: str, limit: int) -> bytes:
+        """Download upload content with a hard size bound.
+
+        Streams the body and aborts once `limit` bytes are exceeded, so a
+        server that lies about Content-Length cannot exhaust worker memory.
+        """
+        response = cls._request("GET", url=url, stream_response=True)
+        try:
+            cls._ensure_success(response)
+        except Exception:
+            response.close()
+            raise
+        return cls._buffer_bounded(response, limit=limit).content
+
+    @staticmethod
+    def _buffer_bounded(response: httpx.Response, *, limit: int) -> httpx.Response:
+        """Buffer one streaming response under `limit` bytes (fail-closed)."""
+        if limit <= 0:
+            response.close()
+            raise FileTooLargeError()
+        try:
+            return ssrf_proxy.buffer_response(response, max_response_bytes=limit)
+        except ssrf_proxy.ResponseTooLargeError as error:
+            raise FileTooLargeError() from error
+        except ssrf_proxy.UnsupportedResponseEncodingError as error:
+            # Encoded bodies cannot be size-bounded before decoding (gzip bomb),
+            # so refuse them instead of buffering blindly.
+            raise RemoteFileInvalidResponseError("The remote response uses an unsupported content encoding") from error
 
     @staticmethod
     def _ensure_success(response: httpx.Response) -> None:
@@ -178,8 +237,12 @@ class RemoteFileService:
 
         raise RemoteFileUnavailableError(f"The remote file request returned HTTP {response.status_code}")
 
-    @classmethod
-    def _fetch_content(cls, *, url: str) -> bytes:
-        response = cls._request("GET", url=url)
-        cls._ensure_success(response)
-        return response.content
+
+def _max_upload_bytes() -> int:
+    """Largest configured per-extension upload allowance, in bytes.
+
+    Bounds reads taken before the file's extension is known (GET fallback
+    prefetch). The extension-specific limit is still enforced afterwards.
+    Representative extensions cover every branch of FileService.file_size_limit.
+    """
+    return max(FileService.file_size_limit(extension=extension) for extension in (".bin", ".png", ".mp4", ".mp3"))

--- a/api/tests/unit_tests/core/rag/extractor/test_extract_processor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_extract_processor.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from sqlalchemy.orm import Session
 
@@ -120,7 +121,7 @@ class TestExtractProcessorLoaders:
     def test_load_from_url_builds_temp_file_with_correct_suffix(
         self, monkeypatch: pytest.MonkeyPatch, url, headers, expected_suffix
     ):
-        response = SimpleNamespace(headers=headers, content=b"body")
+        response = httpx.Response(httpx.codes.OK, headers=headers, content=b"body", request=httpx.Request("GET", url))
         monkeypatch.setattr(processor_module.remote_fetcher, "make_request", lambda *args, **kwargs: response)
         monkeypatch.setattr(processor_module, "ExtractSetting", lambda **kwargs: SimpleNamespace(**kwargs))
 
@@ -144,7 +145,13 @@ class TestExtractProcessorLoaders:
 
     def test_load_from_url_extracts_long_text_without_upload_file(self, monkeypatch: pytest.MonkeyPatch):
         content = "a" * 100_000
-        response = SimpleNamespace(headers={"Content-Type": "text/plain"}, content=content.encode())
+        url = "https://example.com/response.txt"
+        response = httpx.Response(
+            httpx.codes.OK,
+            headers={"Content-Type": "text/plain"},
+            content=content.encode(),
+            request=httpx.Request("GET", url),
+        )
         monkeypatch.setattr(processor_module.remote_fetcher, "make_request", lambda *args, **kwargs: response)
         apply_config_overrides(monkeypatch, ETL_TYPE="SelfHosted")
 
@@ -153,7 +160,13 @@ class TestExtractProcessorLoaders:
         assert text == content
 
     def test_load_from_url_extracts_pdf_without_upload_file(self, monkeypatch: pytest.MonkeyPatch):
-        response = SimpleNamespace(headers={"Content-Type": "application/pdf"}, content=b"%PDF-1.1 body")
+        url = "https://example.com/report"
+        response = httpx.Response(
+            httpx.codes.OK,
+            headers={"Content-Type": "application/pdf"},
+            content=b"%PDF-1.1 body",
+            request=httpx.Request("GET", url),
+        )
         monkeypatch.setattr(processor_module.remote_fetcher, "make_request", lambda *args, **kwargs: response)
         factory = _patch_all_extractors(monkeypatch)
         apply_config_overrides(monkeypatch, ETL_TYPE="dify")
@@ -166,6 +179,21 @@ class TestExtractProcessorLoaders:
         # no upload_file for URL-loaded files: tenant/user context must be None
         assert args[1] is None
         assert args[2] is None
+
+    def test_load_from_url_rejects_oversized_body(self, monkeypatch: pytest.MonkeyPatch):
+        """An attacker-controlled response past the cap must be cut off, not buffered."""
+        monkeypatch.setattr(processor_module, "_max_url_load_bytes", lambda: 1024)
+        url = "https://example.com/report"
+        response = httpx.Response(
+            httpx.codes.OK,
+            headers={"Content-Type": "application/pdf"},
+            content=b"x" * 2048,
+            request=httpx.Request("GET", url),
+        )
+        monkeypatch.setattr(processor_module.remote_fetcher, "make_request", lambda *args, **kwargs: response)
+
+        with pytest.raises(ValueError, match="exceeds the size limit"):
+            ExtractProcessor.load_from_url(url, return_text=True)
 
 
 class TestExtractProcessorFileRouting:

--- a/api/tests/unit_tests/core/tools/test_tool_file_manager.py
+++ b/api/tests/unit_tests/core/tools/test_tool_file_manager.py
@@ -7,7 +7,7 @@ remote HTTP remain mocked because they are external I/O boundaries.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import httpx
@@ -119,10 +119,12 @@ def test_create_file_by_raw_prefers_filename_extension_over_mimetype(
 def test_create_file_by_url_downloads_and_persists_record(sqlite_tool_file_session: Session) -> None:
     manager = ToolFileManager()
     tenant_id = str(uuid4())
-    response = Mock()
-    response.content = b"binary"
-    response.headers = {"Content-Type": "application/octet-stream"}
-    response.raise_for_status.return_value = None
+    response = httpx.Response(
+        httpx.codes.OK,
+        content=b"binary",
+        headers={"Content-Type": "application/octet-stream"},
+        request=httpx.Request("GET", "https://example.com/f.bin"),
+    )
 
     with (
         patch("core.tools.tool_file_manager.storage") as storage,
@@ -143,10 +145,12 @@ def test_create_file_by_url_prefers_url_extension_over_mimetype(
 ) -> None:
     manager = ToolFileManager()
     tenant_id = str(uuid4())
-    response = Mock()
-    response.content = b"docx"
-    response.headers = {"Content-Type": "application/octet-stream"}
-    response.raise_for_status.return_value = None
+    response = httpx.Response(
+        httpx.codes.OK,
+        content=b"docx",
+        headers={"Content-Type": "application/octet-stream"},
+        request=httpx.Request("GET", "https://example.com/report.docx?download=1"),
+    )
 
     with (
         patch("core.tools.tool_file_manager.storage") as storage,
@@ -173,6 +177,29 @@ def test_create_file_by_url_raises_on_timeout() -> None:
     ):
         with pytest.raises(ValueError, match="timeout when downloading file"):
             manager.create_file_by_url("u1", "t1", "https://example.com/f.bin", "c1")
+
+
+def test_create_file_by_url_rejects_oversized_body(
+    sqlite_tool_file_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An attacker-controlled response past the cap must be cut off, not buffered."""
+    manager = ToolFileManager()
+    monkeypatch.setattr(tool_file_manager_module, "_max_tool_file_download_bytes", lambda: 1024)
+    response = httpx.Response(
+        httpx.codes.OK,
+        content=b"x" * 2048,
+        headers={"Content-Type": "application/octet-stream"},
+        request=httpx.Request("GET", "https://example.com/f.bin"),
+    )
+
+    with (
+        patch("core.tools.tool_file_manager.storage") as storage,
+        patch("core.tools.tool_file_manager.remote_fetcher.make_request", return_value=response),
+    ):
+        with pytest.raises(ValueError, match="file too large when downloading file"):
+            manager.create_file_by_url(str(uuid4()), str(uuid4()), "https://example.com/f.bin", str(uuid4()))
+
+    storage.save.assert_not_called()
 
 
 def test_get_file_binary_returns_none_when_not_found(sqlite_tool_file_session: Session) -> None:

--- a/api/tests/unit_tests/services/test_remote_file_service.py
+++ b/api/tests/unit_tests/services/test_remote_file_service.py
@@ -86,7 +86,43 @@ def test_fetch_info_falls_back_to_get(remote_file_service: RemoteFileService) ->
 
     assert result.content_type == "application/octet-stream"
     assert result.content_length is None
-    assert make_request.call_args_list == [call("HEAD", url=REMOTE_URL), call("GET", url=REMOTE_URL, timeout=3)]
+    assert make_request.call_args_list == [
+        call("HEAD", url=REMOTE_URL),
+        call("GET", url=REMOTE_URL, timeout=3, stream_response=True),
+    ]
+    # A metadata probe must not touch the body: the fallback stream is closed
+    # without reading it. (Plain test doubles are already fully read, so close
+    # is a no-op for them; the no-body-read guarantee is covered by
+    # test_fetch_info_fallback_does_not_read_body below.)
+
+
+def test_fetch_info_fallback_does_not_read_body(remote_file_service: RemoteFileService) -> None:
+    """The GET fallback is headers-only: body access must never happen."""
+
+    class _HeadersOnlyResponse:
+        status_code = httpx.codes.OK
+        headers = {"Content-Type": "application/pdf", "Content-Length": "16"}
+        closed = False
+
+        @property
+        def content(self) -> bytes:
+            raise AssertionError("metadata probe must not read the body")
+
+        def close(self) -> None:
+            self.closed = True
+
+    head_response = _response("HEAD", httpx.codes.METHOD_NOT_ALLOWED)
+    get_response = _HeadersOnlyResponse()
+
+    with patch(
+        "services.remote_file_service.remote_fetcher.make_request",
+        side_effect=[head_response, get_response],
+    ):
+        result = remote_file_service.fetch_info(url=REMOTE_URL)
+
+    assert result.content_type == "application/pdf"
+    assert result.content_length == 16
+    assert get_response.closed
 
 
 @pytest.mark.parametrize(
@@ -207,7 +243,7 @@ def test_upload_reuses_get_fallback_content_and_returns_signed_result(
 
     assert make_request.call_args_list == [
         call("HEAD", url=REMOTE_URL),
-        call("GET", url=REMOTE_URL, timeout=3, follow_redirects=True),
+        call("GET", url=REMOTE_URL, timeout=3, follow_redirects=True, stream_response=True),
     ]
     file_service.is_file_size_within_limit.assert_called_once_with(extension=".pdf", file_size=14)
     file_service.upload_file.assert_called_once_with(
@@ -259,7 +295,10 @@ def test_upload_fetches_content_after_successful_head(
     ):
         remote_file_service.upload_from_url(url=REMOTE_URL, user=account)
 
-    assert make_request.call_args_list == [call("HEAD", url=REMOTE_URL), call("GET", url=REMOTE_URL)]
+    assert make_request.call_args_list == [
+        call("HEAD", url=REMOTE_URL),
+        call("GET", url=REMOTE_URL, stream_response=True),
+    ]
     assert file_service.upload_file.call_args.kwargs["content"] == b"downloaded content"
     assert file_service.upload_file.call_args.kwargs["tenant_id"] is None
 
@@ -354,4 +393,101 @@ def test_upload_rejects_file_that_exceeds_size_limit(
             remote_file_service.upload_from_url(url=REMOTE_URL, user=_account())
 
     file_service.is_file_size_within_limit.assert_called_once_with(extension=".pdf", file_size=1024)
+    file_service.upload_file.assert_not_called()
+
+
+def _oversized_body() -> bytes:
+    limit = FileService.file_size_limit(extension=".pdf")
+    return b"x" * (limit + 1024)
+
+
+def test_upload_aborts_oversized_fallback_body_with_lying_content_length(
+    remote_file_service: RemoteFileService,
+    file_service: MagicMock,
+) -> None:
+    """A server that declares 16 bytes but streams past the cap must be cut off.
+
+    Regression test: the GET fallback used to buffer the entire body into
+    memory before any size check ran (worker memory exhaustion via a
+    low-privilege remote-URL upload).
+    """
+    head_response = _response("HEAD", httpx.codes.METHOD_NOT_ALLOWED)
+    get_response = _response(
+        "GET",
+        httpx.codes.OK,
+        content=_oversized_body(),
+        headers={"Content-Type": "application/pdf", "Content-Length": "16"},
+    )
+    file_info = FileInfo(filename="report.pdf", extension=".pdf", mimetype="application/pdf", size=16)
+
+    with (
+        patch(
+            "services.remote_file_service.remote_fetcher.make_request",
+            side_effect=[head_response, get_response],
+        ) as make_request,
+        patch("services.remote_file_service.guess_file_info_from_response", return_value=file_info),
+    ):
+        with pytest.raises(FileTooLargeError):
+            remote_file_service.upload_from_url(url=REMOTE_URL, user=_account())
+
+    assert make_request.call_args_list[1] == call(
+        "GET", url=REMOTE_URL, timeout=3, follow_redirects=True, stream_response=True
+    )
+    file_service.upload_file.assert_not_called()
+
+
+def test_upload_aborts_oversized_content_after_successful_head(
+    remote_file_service: RemoteFileService,
+    file_service: MagicMock,
+) -> None:
+    head_response = _response(
+        "HEAD", httpx.codes.OK, headers={"Content-Type": "application/pdf", "Content-Length": "16"}
+    )
+    content_response = _response(
+        "GET",
+        httpx.codes.OK,
+        content=_oversized_body(),
+        headers={"Content-Type": "application/pdf", "Content-Length": "16"},
+    )
+    file_info = FileInfo(filename="report.pdf", extension=".pdf", mimetype="application/pdf", size=16)
+
+    with (
+        patch(
+            "services.remote_file_service.remote_fetcher.make_request",
+            side_effect=[head_response, content_response],
+        ),
+        patch("services.remote_file_service.guess_file_info_from_response", return_value=file_info),
+    ):
+        with pytest.raises(FileTooLargeError):
+            remote_file_service.upload_from_url(url=REMOTE_URL, user=_account())
+
+    file_service.upload_file.assert_not_called()
+
+
+def test_upload_rejects_unsupported_content_encoding(
+    remote_file_service: RemoteFileService,
+    file_service: MagicMock,
+) -> None:
+    """Encoded bodies cannot be size-bounded before decoding (gzip bomb)."""
+    head_response = _response("HEAD", httpx.codes.OK, headers={"Content-Type": "application/pdf"})
+    # NOTE: plain Mock, not httpx.Response — httpx eagerly decodes `content`
+    # at construction time when Content-Encoding is set, so a real Response
+    # cannot even represent the undecodable wire bytes this guards against.
+    content_response = MagicMock()
+    content_response.status_code = httpx.codes.OK
+    # lowercase key: buffer_response looks up "content-encoding" on the mapping
+    # (real httpx headers are case-insensitive; a plain dict is not)
+    content_response.headers = {"Content-Type": "application/pdf", "content-encoding": "gzip"}
+    file_info = FileInfo(filename="report.pdf", extension=".pdf", mimetype="application/pdf", size=7)
+
+    with (
+        patch(
+            "services.remote_file_service.remote_fetcher.make_request",
+            side_effect=[head_response, content_response],
+        ),
+        patch("services.remote_file_service.guess_file_info_from_response", return_value=file_info),
+    ):
+        with pytest.raises(RemoteFileInvalidResponseError):
+            remote_file_service.upload_from_url(url=REMOTE_URL, user=_account())
+
     file_service.upload_file.assert_not_called()


### PR DESCRIPTION
Remote file downloads buffered the full response into memory with no size bound. Since both the URL and the response are attacker-controlled, a single oversized response exhausts worker memory (and disk, via the temp file in the RAG path).

This streams the three download sites (`remote_file_service`, tool file manager, RAG URL extractor) through the existing `ssrf_proxy.buffer_response` bound, capped at the largest configured upload allowance, and converts over-limit/unsupported-encoding responses into plain `ValueError`s instead of buffering blindly.

How I verified: new tests feed oversized and oddly-encoded bodies and expect `ValueError`; 8 of them fail on base and pass with the fix. Full neighbor suites green (275 passed), ruff check + format clean.
