### PR TITLE
fix(rag): preserve Notion mention and equation text

### DIFF
--- a/api/core/rag/extractor/notion_extractor.py
+++ b/api/core/rag/extractor/notion_extractor.py
@@ -205,9 +205,8 @@ class NotionExtractor(BaseExtractor):
                 else:
                     if "rich_text" in result_obj:
                         for rich_text in result_obj["rich_text"]:
-                            # skip if doesn't have text object
-                            if "text" in rich_text:
-                                text = rich_text["text"]["content"]
+                            text = rich_text.get("plain_text") or rich_text.get("text", {}).get("content", "")
+                            if text:
                                 cur_result_text_arr.append(text)
 
                     result_block_id = result["id"]
@@ -263,9 +262,8 @@ class NotionExtractor(BaseExtractor):
                 else:
                     if "rich_text" in result_obj:
                         for rich_text in result_obj["rich_text"]:
-                            # skip if doesn't have text object
-                            if "text" in rich_text:
-                                text = rich_text["text"]["content"]
+                            text = rich_text.get("plain_text") or rich_text.get("text", {}).get("content", "")
+                            if text:
                                 prefix = "\t" * num_tabs
                                 cur_result_text_arr.append(prefix + text)
                     result_block_id = result["id"]

--- a/api/tests/unit_tests/core/rag/extractor/test_notion_page_rich_text.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_notion_page_rich_text.py
@@ -3,7 +3,7 @@ from unittest import mock
 from core.rag.extractor import notion_extractor
 
 
-def _mock_response(data):
+def _mock_response(data: dict[str, object]) -> mock.Mock:
     response = mock.Mock()
     response.status_code = 200
     response.text = ""
@@ -21,7 +21,7 @@ def _extractor() -> notion_extractor.NotionExtractor:
     )
 
 
-def _mixed_rich_text():
+def _mixed_rich_text() -> list[dict[str, object]]:
     return [
         {"type": "text", "plain_text": "See ", "text": {"content": "See "}},
         {
@@ -33,7 +33,7 @@ def _mixed_rich_text():
     ]
 
 
-def _paragraph_payload():
+def _paragraph_payload() -> dict[str, object]:
     return {
         "results": [
             {
@@ -47,7 +47,7 @@ def _paragraph_payload():
     }
 
 
-def test_get_notion_block_data_preserves_mentions_and_equations():
+def test_get_notion_block_data_preserves_mentions_and_equations() -> None:
     extractor = _extractor()
 
     with mock.patch("httpx.request", return_value=_mock_response(_paragraph_payload())):
@@ -56,7 +56,7 @@ def test_get_notion_block_data_preserves_mentions_and_equations():
     assert lines == ["See \nProject Alpha\nE = mc^2\n\n"]
 
 
-def test_read_block_preserves_mentions_and_equations():
+def test_read_block_preserves_mentions_and_equations() -> None:
     extractor = _extractor()
 
     with mock.patch("httpx.request", return_value=_mock_response(_paragraph_payload())):

--- a/api/tests/unit_tests/core/rag/extractor/test_notion_page_rich_text.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_notion_page_rich_text.py
@@ -1,0 +1,65 @@
+from unittest import mock
+
+from core.rag.extractor import notion_extractor
+
+
+def _mock_response(data):
+    response = mock.Mock()
+    response.status_code = 200
+    response.text = ""
+    response.json.return_value = data
+    return response
+
+
+def _extractor() -> notion_extractor.NotionExtractor:
+    return notion_extractor.NotionExtractor(
+        notion_workspace_id="ws",
+        notion_obj_id="obj",
+        notion_page_type="page",
+        tenant_id="tenant",
+        notion_access_token="token",
+    )
+
+
+def _mixed_rich_text():
+    return [
+        {"type": "text", "plain_text": "See ", "text": {"content": "See "}},
+        {
+            "type": "mention",
+            "plain_text": "Project Alpha",
+            "mention": {"type": "page", "page": {"id": "page-id"}},
+        },
+        {"type": "equation", "plain_text": "E = mc^2", "equation": {"expression": "E = mc^2"}},
+    ]
+
+
+def _paragraph_payload():
+    return {
+        "results": [
+            {
+                "type": "paragraph",
+                "id": "paragraph-id",
+                "has_children": False,
+                "paragraph": {"rich_text": _mixed_rich_text()},
+            }
+        ],
+        "next_cursor": None,
+    }
+
+
+def test_get_notion_block_data_preserves_mentions_and_equations():
+    extractor = _extractor()
+
+    with mock.patch("httpx.request", return_value=_mock_response(_paragraph_payload())):
+        lines = extractor._get_notion_block_data("page-id")
+
+    assert lines == ["See \nProject Alpha\nE = mc^2\n\n"]
+
+
+def test_read_block_preserves_mentions_and_equations():
+    extractor = _extractor()
+
+    with mock.patch("httpx.request", return_value=_mock_response(_paragraph_payload())):
+        content = extractor._read_block("child-block-id", num_tabs=1)
+
+    assert content == "\tSee \n\tProject Alpha\n\tE = mc^2\n\n"


### PR DESCRIPTION
## Summary

Fixes #42170.

Notion page imports currently keep only rich-text segments that contain a `text` object in the ordinary page/block paths. Valid `mention` and `equation` segments therefore disappear from indexed knowledge content even though Notion provides their rendered value through `plain_text`.

This change keeps the existing extraction structure and only changes how each rich-text segment is read:

- prefer the segment's `plain_text`, which covers text, mentions, and equations;
- fall back to the existing `text.content` shape when `plain_text` is absent;
- continue skipping genuinely empty segments;
- preserve the current block joining, indentation, recursion, table, and database-property behavior.

The same `plain_text` rule is already used by the merged table-cell path after #41993 and by database rich-text/title extraction after #42050.

## Validation

Added focused regression coverage for both affected paths:

- `_get_notion_block_data()` preserves a mixed text + page mention + equation payload;
- `_read_block()` preserves the same segments while retaining child-block indentation.

The tests exercise the real extractor methods with only the Notion HTTP response mocked. They are intended to fail on the pre-fix implementation because it drops the mention and equation segments.

Repository test/lint suites were not run locally in this connector-backed environment; CI is left to validate the submitted branch.

## Screenshots

Not applicable; backend extraction only.

## Checklist

- [ ] This change requires a documentation update — not expected; no API or configuration change.
- [x] I understand that this PR may be closed in case there was no previous discussion or issue.
- [x] Added focused regression coverage for the changed behavior.
- [ ] Ran the repository-wide backend lint/type-check locally — CI pending.

From ChatGPT