### PR TITLE
fix(mcp): stop returning opaque 500s from MCP connect/auth

### DIFF
--- a/api/core/mcp/auth/auth_flow.py
+++ b/api/core/mcp/auth/auth_flow.py
@@ -531,7 +531,9 @@ def register_client(
         headers={"Content-Type": "application/json"},
     )
     if not response.is_success:
-        response.raise_for_status()
+        # Callers only translate RequestError/ValueError into a user-facing error,
+        # so a raise_for_status() here would escape as an opaque 500.
+        raise ValueError(f"Client registration failed: HTTP {response.status_code}, Response: {response.text}")
     return OAuthClientInformationFull.model_validate(response.json())
 
 

--- a/api/core/mcp/client/sse_client.py
+++ b/api/core/mcp/client/sse_client.py
@@ -297,6 +297,13 @@ def sse_client(
         if exc.response.status_code == 401:
             raise MCPAuthError(response=exc.response)
         raise MCPConnectionError()
+    except httpx.RequestError as exc:
+        # Transport-level failures (refused connection, DNS, protocol errors, timeouts)
+        # must keep the MCP error contract: MCPClient only falls back to streamable
+        # HTTP on MCPConnectionError, and the console API only turns MCP errors into
+        # a 4xx. A raw httpx error skips both and surfaces as an opaque 500.
+        logger.exception("Error connecting to SSE endpoint")
+        raise MCPConnectionError(f"Failed to connect to SSE endpoint: {exc}") from exc
     except Exception:
         logger.exception("Error connecting to SSE endpoint")
         raise

--- a/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
+++ b/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
@@ -500,6 +500,38 @@ class TestAuthorizationFlow:
             headers={"Content-Type": "application/json"},
         )
 
+    @patch("core.helper.ssrf_proxy.post")
+    def test_register_client_rejected_by_server(self, mock_post):
+        """A rejected dynamic registration must raise ValueError, not httpx.HTTPStatusError.
+
+        `auth()` lets anything that is not a RequestError propagate, and the
+        console MCP auth endpoint only turns MCPError/ValueError into a 4xx, so
+        a raw HTTPStatusError here surfaces as an opaque 500.
+        """
+        mock_response = Mock()
+        mock_response.is_success = False
+        mock_response.status_code = 400
+        mock_response.text = '{"error":"invalid_redirect_uri"}'
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Bad Request", request=Mock(), response=mock_response
+        )
+        mock_post.return_value = mock_response
+
+        metadata = OAuthMetadata(
+            authorization_endpoint="https://auth.example.com/authorize",
+            token_endpoint="https://auth.example.com/token",
+            registration_endpoint="https://auth.example.com/register",
+            response_types_supported=["code"],
+        )
+        client_metadata = OAuthClientMetadata(client_name="Dify", redirect_uris=["https://redirect.example.com"])
+
+        with pytest.raises(ValueError) as exc_info:
+            register_client("https://api.example.com", metadata, client_metadata)
+
+        message = str(exc_info.value)
+        assert "400" in message
+        assert "invalid_redirect_uri" in message
+
     def test_register_client_no_endpoint(self):
         """Test client registration when no endpoint available."""
         metadata = OAuthMetadata(
@@ -1244,13 +1276,13 @@ class TestAuthOrchestration:
         with pytest.raises(ValueError, match="does not support dynamic client registration"):
             register_client("https://api", metadata, client_metadata)
 
-        # Failure: HTTP
+        # Failure: HTTP. A rejected registration must be reported as a ValueError so
+        # callers can turn it into a user-facing error instead of a bare 500.
         res.is_success = False
-        res.raise_for_status = Mock()
         res.status_code = 400
-        # If is_success is false, it should call raise_for_status
-        register_client("https://api", None, client_metadata)
-        res.raise_for_status.assert_called_once()
+        res.text = '{"error":"invalid_redirect_uri"}'
+        with pytest.raises(ValueError, match="Client registration failed: HTTP 400"):
+            register_client("https://api", None, client_metadata)
 
     @patch("core.mcp.auth.auth_flow.discover_oauth_metadata")
     def test_auth_orchestration_failures(self, mock_discover):

--- a/api/tests/unit_tests/core/mcp/client/test_sse.py
+++ b/api/tests/unit_tests/core/mcp/client/test_sse.py
@@ -173,6 +173,38 @@ def test_sse_client_error_handling():
                     pass
 
 
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        httpx.ConnectError("[Errno 111] Connection refused"),
+        httpx.RemoteProtocolError("Server disconnected without sending a response."),
+        httpx.ReadTimeout("timed out"),
+    ],
+    ids=["connect_error", "remote_protocol_error", "read_timeout"],
+)
+def test_sse_client_wraps_transport_errors(transport_error: httpx.RequestError):
+    """Transport failures must surface as MCPConnectionError, not raw httpx errors.
+
+    Callers rely on the MCP error contract: MCPClient only falls back to
+    streamable HTTP on MCPConnectionError/ValueError, and the console API maps
+    those to a 4xx with a readable message instead of a bare 500.
+    """
+    test_url = "http://test.example/sse"
+
+    with (
+        patch("core.mcp.client.sse_client.create_ssrf_proxy_mcp_http_client"),
+        patch("core.mcp.client.sse_client.ssrf_proxy_sse_connect") as mock_sse_connect,
+    ):
+        mock_sse_connect.side_effect = transport_error
+
+        with pytest.raises(MCPConnectionError) as exc_info:
+            with sse_client(test_url):
+                pass
+
+    # The underlying reason must survive so the user can act on it.
+    assert str(transport_error) in str(exc_info.value)
+
+
 def test_sse_client_timeout_configuration():
     """Test SSE client timeout configuration."""
     test_url = "http://test.example/sse"

--- a/api/tests/unit_tests/core/mcp/test_mcp_client.py
+++ b/api/tests/unit_tests/core/mcp/test_mcp_client.py
@@ -4,6 +4,7 @@ from contextlib import ExitStack
 from types import TracebackType
 from unittest.mock import MagicMock, Mock, patch
 
+import httpx
 import pytest
 from sqlalchemy.orm import Session
 
@@ -210,6 +211,56 @@ class TestMCPClient:
 
         # Verify session was created with MCP
         assert client._session == mock_session
+
+    @patch("core.mcp.client.sse_client.ssrf_proxy_sse_connect")
+    @patch("core.mcp.client.sse_client.create_ssrf_proxy_mcp_http_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_fallback_from_sse_transport_error_to_mcp(
+        self, mock_client_session, mock_streamable_client, mock_http_client, mock_sse_connect
+    ):
+        """A transport failure on the SSE probe must still fall back to streamable HTTP.
+
+        Uses the real sse_client so the exception translation between the two
+        layers is exercised: an httpx error leaking out of sse_client skips the
+        fallback entirely and reaches the console API as an opaque 500.
+        """
+        mock_sse_connect.side_effect = httpx.ConnectError("[Errno 111] Connection refused")
+
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_client_context = Mock()
+        mock_streamable_client.return_value.__enter__.return_value = (
+            mock_read_stream,
+            mock_write_stream,
+            mock_client_context,
+        )
+
+        mock_session = Mock()
+        mock_client_session.return_value.__enter__.return_value = mock_session
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+        client._initialize()
+
+        mock_streamable_client.assert_called_once()
+        assert client._session == mock_session
+
+    @patch("core.mcp.client.sse_client.ssrf_proxy_sse_connect")
+    @patch("core.mcp.client.sse_client.create_ssrf_proxy_mcp_http_client")
+    def test_initialize_sse_transport_error_raises_mcp_error(self, mock_http_client, mock_sse_connect):
+        """When both transports fail the caller gets an MCPError, never a raw httpx error.
+
+        The console MCP endpoints only translate MCPError/ValueError into a 4xx;
+        anything else becomes `{"code": "unknown", "status": 500}`.
+        """
+        mock_sse_connect.side_effect = httpx.ConnectError("[Errno 111] Connection refused")
+
+        client = MCPClient(server_url="http://test.example.com/sse")
+
+        with pytest.raises(MCPConnectionError) as exc_info:
+            client._initialize()
+
+        assert "Connection refused" in str(exc_info.value)
 
     @patch("core.mcp.mcp_client.streamablehttp_client")
     @patch("core.mcp.mcp_client.ClientSession")


### PR DESCRIPTION
## Summary

Fixes #42176

Authorizing an MCP tool provider answers `{"message":"Internal Server Error","code":"unknown","status":500}` whenever the MCP server cannot be reached, so the user is never told what went wrong.

`ToolMCPAuthApi.post` and its sibling console MCP endpoints translate `MCPError` / `ValueError` into a 4xx carrying the reason, and let everything else become a 500. Two paths leak raw `httpx` exceptions through that filter:

1. `sse_client` re-raises transport errors (`ConnectError`, `RemoteProtocolError`, `ReadTimeout`, …) unchanged via its `except Exception: … raise` arm. Besides the 500, this defeats the transport fallback in `MCPClient._initialize`, which only catches `MCPConnectionError` / `ValueError` — so a streamable-HTTP server whose URL does not end in `/mcp` never gets a streamable-HTTP attempt at all.
2. `register_client()` calls `response.raise_for_status()` when dynamic client registration is rejected. `auth()` converts only `RequestError`, and the auth endpoint's inner handler catches only `MCPRefreshTokenError`, so the resulting `HTTPStatusError` escapes.

This PR wraps both in the error types callers already handle, keeping the underlying reason in the message. No change to which conditions are errors — only to how they are reported.

### Behaviour change

Measured with `MCPClient` against stub servers; `->` is the response the console endpoint produces:

| scenario | before | after |
| --- | --- | --- |
| connection refused, URL without `/mcp` or `/sse` suffix | `httpx.ConnectError` -> **500** | falls back to streamable HTTP, `ValueError` -> **400** |
| connection refused, `/sse` URL | `httpx.ConnectError` -> **500** | `MCPConnectionError` -> **400** |
| server closes connection without a response, URL without suffix | `httpx.RemoteProtocolError` -> **500** | falls back to streamable HTTP -> **400** |
| DNS failure, URL without suffix | `httpx.RemoteProtocolError` -> **500** | -> **400** |
| connection refused, `/mcp` URL | `ValueError` -> 400 | unchanged |
| non-401 HTTP status on the SSE endpoint | `MCPConnectionError` -> 400 | unchanged |
| 401 on the SSE endpoint | `MCPAuthError` -> OAuth flow | unchanged |

Related: #40001 shows the same `httpx.RemoteProtocolError` escaping `sse_client.py` while authorizing a new MCP server. This is a different defect from the `provider_id` / `server_identifier` mix-up in #41109 / #41328 / #42061 (fixed by #41360) — that one requires a non-UUID `provider_id` to fail the `::uuid` cast, whereas this one reproduces with a valid provider UUID.

`tests/unit_tests/core/mcp/auth/test_auth_flow.py::TestAuthOrchestration::test_register_client` asserted the old behaviour (`raise_for_status` is called, with a mock that never raises, so the rejected registration was parsed as if it had succeeded). It now asserts the `ValueError`.

## Screenshots

Not applicable; this changes error mapping for the console MCP endpoints.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

`make lint` passes. `make type-check` fails in my checkout at `dev/pyrefly-check-local` with ``No Python files matched pattern `api/tests/test_containers_integration_tests` `` — it fails identically on an unmodified `main` @ a3b2786b32, so it is unrelated to this change; `pyrefly` and `mypy` on the two touched modules report no issues. No frontend files are touched, so `vp staged` does not apply.

From Claude Code
