### PR TITLE
refactor(web): migrate numeric variable constraints to NumberField

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -318,11 +318,6 @@
       "count": 4
     }
   },
-  "web/app/components/app/configuration/config-var/config-string/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/app/configuration/config-var/index.tsx": {
     "dify/require-disable-directive-description": {
       "count": 1
@@ -4180,11 +4175,6 @@
       "count": 1
     },
     "typescript/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-number.tsx": {
-    "no-restricted-imports": {
       "count": 1
     }
   },

--- a/web/app/components/app/configuration/config-var/config-modal/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/__tests__/index.spec.tsx
@@ -117,9 +117,9 @@ describe('ConfigModal', () => {
     expect(screen.getByRole('textbox', { name: 'appDebug.variableConfig.labelName' })).toHaveValue(
       'Question',
     )
-    expect(
-      screen.getByRole('spinbutton', { name: 'appDebug.variableConfig.maxLength' }),
-    ).toHaveValue(32)
+    expect(screen.getByRole('textbox', { name: 'appDebug.variableConfig.maxLength' })).toHaveValue(
+      '32',
+    )
     const defaultInput = screen.getByRole('textbox', {
       name: 'appDebug.variableConfig.defaultValue',
     })

--- a/web/app/components/app/configuration/config-var/config-string/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config-var/config-string/__tests__/index.spec.tsx
@@ -1,103 +1,60 @@
-import type { IConfigStringProps } from '../index'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import ConfigString from '../index'
 
-const renderConfigString = (props?: Partial<IConfigStringProps>) => {
-  const onChange = vi.fn()
-  const defaultProps: IConfigStringProps = {
-    value: 5,
-    maxLength: 10,
-    modelId: 'model-id',
-    onChange,
-  }
-
-  render(<ConfigString {...defaultProps} {...props} />)
-
-  return { onChange }
+function LengthField({ maxLength = 10, initialValue = 5, onChange = vi.fn() }) {
+  const [value, setValue] = useState<number | undefined>(initialValue)
+  return (
+    <>
+      <label htmlFor="max-length">Maximum length</label>
+      <ConfigString
+        id="max-length"
+        value={value}
+        maxLength={maxLength}
+        modelId="model-id"
+        onChange={(nextValue) => {
+          setValue(nextValue)
+          onChange(nextValue)
+        }}
+      />
+    </>
+  )
 }
 
 describe('ConfigString', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+  it.each([
+    ['12', '10', 10],
+    ['0', '1', 1],
+    ['7.8', '8', 8],
+  ])('commits %s as a bounded integer', async (entered, displayed, expected) => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<LengthField onChange={onChange} />)
+    const input = screen.getByRole('textbox', { name: 'Maximum length' })
+    await user.clear(input)
+    await user.type(input, entered)
+    await user.tab()
+    expect(input).toHaveValue(displayed)
+    expect(onChange).toHaveBeenLastCalledWith(expected)
   })
 
-  describe('Rendering', () => {
-    it('should render numeric input with bounds', () => {
-      renderConfigString({ value: 3, maxLength: 8 })
-
-      const input = screen.getByRole('spinbutton')
-
-      expect(input)!.toHaveValue(3)
-      expect(input)!.toHaveAttribute('min', '1')
-      expect(input)!.toHaveAttribute('max', '8')
-    })
-
-    it('should render empty input when value is undefined', () => {
-      const { onChange } = renderConfigString({ value: undefined })
-
-      expect(screen.getByRole('spinbutton'))!.toHaveValue(null)
-      expect(onChange).not.toHaveBeenCalled()
-    })
+  it('clears to an unset value instead of NaN', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<LengthField onChange={onChange} />)
+    const input = screen.getByRole('textbox', { name: 'Maximum length' })
+    await user.clear(input)
+    await user.tab()
+    expect(input).toHaveValue('')
+    expect(onChange).toHaveBeenLastCalledWith(undefined)
   })
 
-  describe('Effect behavior', () => {
-    it('should clamp initial value to maxLength when it exceeds limit', async () => {
-      const onChange = vi.fn()
-      render(<ConfigString value={15} maxLength={10} modelId="model-id" onChange={onChange} />)
-
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(10)
-      })
-      expect(onChange).toHaveBeenCalledTimes(1)
-    })
-
-    it('should clamp when updated prop value exceeds maxLength', async () => {
-      const onChange = vi.fn()
-      const { rerender } = render(
-        <ConfigString value={4} maxLength={6} modelId="model-id" onChange={onChange} />,
-      )
-
-      rerender(<ConfigString value={9} maxLength={6} modelId="model-id" onChange={onChange} />)
-
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith(6)
-      })
-      expect(onChange).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  describe('User interactions', () => {
-    it('should clamp entered value above maxLength', () => {
-      const { onChange } = renderConfigString({ maxLength: 7 })
-
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '12' } })
-
-      expect(onChange).toHaveBeenCalledWith(7)
-    })
-
-    it('should raise value below minimum to one', () => {
-      const { onChange } = renderConfigString()
-
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '0' } })
-
-      expect(onChange).toHaveBeenCalledWith(1)
-    })
-
-    it('should forward parsed value when within bounds', () => {
-      const { onChange } = renderConfigString({ maxLength: 9 })
-
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '7' } })
-
-      expect(onChange).toHaveBeenCalledWith(7)
-    })
-
-    it('should pass through NaN when input is cleared', () => {
-      const { onChange } = renderConfigString()
-
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } })
-
-      expect(onChange).toHaveBeenCalledTimes(1)
-      expect(onChange.mock.calls[0]![0]).toBeNaN()
-    })
+  it('updates the draft when the allowed maximum becomes smaller', async () => {
+    const onChange = vi.fn()
+    const { rerender } = render(<LengthField initialValue={9} onChange={onChange} />)
+    rerender(<LengthField initialValue={9} maxLength={6} onChange={onChange} />)
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(6))
+    expect(screen.getByRole('textbox', { name: 'Maximum length' })).toHaveValue('6')
   })
 })

--- a/web/app/components/app/configuration/config-var/config-string/index.tsx
+++ b/web/app/components/app/configuration/config-var/config-string/index.tsx
@@ -4,7 +4,7 @@ import { NumberField, NumberFieldGroup, NumberFieldInput } from '@langgenius/dif
 import * as React from 'react'
 import { useEffect } from 'react'
 
-export type IConfigStringProps = {
+type IConfigStringProps = {
   id?: string
   value: number | undefined
   maxLength: number

--- a/web/app/components/app/configuration/config-var/config-string/index.tsx
+++ b/web/app/components/app/configuration/config-var/config-string/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 import type { FC } from 'react'
+import { NumberField, NumberFieldGroup, NumberFieldInput } from '@langgenius/dify-ui/number-field'
 import * as React from 'react'
 import { useEffect } from 'react'
-import Input from '@/app/components/base/input'
 
 export type IConfigStringProps = {
   id?: string
@@ -18,22 +18,19 @@ const ConfigString: FC<IConfigStringProps> = ({ id, value, onChange, maxLength }
   }, [value, maxLength, onChange])
 
   return (
-    <div>
-      <Input
-        id={id}
-        type="number"
-        max={maxLength}
-        min={1}
-        value={value || ''}
-        onChange={(e) => {
-          let value = Number.parseInt(e.target.value, 10)
-          if (value > maxLength) value = maxLength
-          else if (value < 1) value = 1
-
-          onChange(value)
-        }}
-      />
-    </div>
+    <NumberField
+      id={id}
+      min={1}
+      max={maxLength}
+      step={1}
+      format={{ maximumFractionDigits: 0, useGrouping: false }}
+      value={value ?? null}
+      onValueChange={(value) => onChange(value ?? undefined)}
+    >
+      <NumberFieldGroup>
+        <NumberFieldInput />
+      </NumberFieldGroup>
+    </NumberField>
   )
 }
 

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/__tests__/condition-number.spec.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/__tests__/condition-number.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import ConditionNumber from '../condition-number'
+
+function NumericCondition({ onChange }: { onChange: (value?: string | number) => void }) {
+  const [value, setValue] = useState<string | number | undefined>(0)
+  return (
+    <ConditionNumber
+      value={value}
+      onChange={(nextValue) => {
+        setValue(nextValue)
+        onChange(nextValue)
+      }}
+      valueMethod="constant"
+      onValueMethodChange={vi.fn()}
+      nodesOutputVars={[]}
+      availableNodes={[]}
+      commonVariables={[]}
+    />
+  )
+}
+
+describe('numeric metadata condition', () => {
+  it('preserves signed decimal precision and clears without producing zero', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<NumericCondition onChange={onChange} />)
+    const input = screen.getByRole('textbox', {
+      name: 'workflow.nodes.knowledgeRetrieval.metadata.panel.placeholder',
+    })
+    expect(input).toHaveValue('0')
+    await user.clear(input)
+    await user.type(input, '-7.123456')
+    await user.tab()
+    expect(input).toHaveValue('-7.123456')
+    expect(onChange).toHaveBeenLastCalledWith(-7.123456)
+    await user.clear(input)
+    await user.tab()
+    expect(input).toHaveValue('')
+    expect(onChange).toHaveBeenLastCalledWith(undefined)
+  })
+})

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-number.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-number.tsx
@@ -1,8 +1,8 @@
 import type { ConditionValueMethodProps } from './condition-value-method'
 import type { Node, NodeOutPutVar, ValueSelector } from '@/app/components/workflow/types'
+import { NumberField, NumberFieldGroup, NumberFieldInput } from '@langgenius/dify-ui/number-field'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { VarType } from '@/app/components/workflow/types'
 import ConditionCommonVariableSelector from './condition-common-variable-selector'
 import ConditionValueMethod from './condition-value-method'
@@ -63,18 +63,25 @@ const ConditionNumber = ({
         />
       )}
       {valueMethod === 'constant' && (
-        <Input
-          className="border-none bg-transparent outline-hidden hover:bg-transparent focus:bg-transparent focus:shadow-none"
-          value={value}
-          onChange={(e) => {
-            const v = e.target.value
-            onChange(v ? Number(e.target.value) : undefined)
-          }}
-          placeholder={t(($) => $['nodes.knowledgeRetrieval.metadata.panel.placeholder'], {
-            ns: 'workflow',
-          })}
-          type="number"
-        />
+        <NumberField
+          className="min-w-0 flex-1"
+          value={typeof value === 'number' ? value : null}
+          format={{ maximumSignificantDigits: 21, useGrouping: false }}
+          onValueChange={(value) => onChange(value ?? undefined)}
+        >
+          <NumberFieldGroup className="border-0 bg-transparent hover:bg-transparent">
+            <NumberFieldInput
+              className="rounded-lg focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:ring-inset"
+              inputMode="decimal"
+              aria-label={t(($) => $['nodes.knowledgeRetrieval.metadata.panel.placeholder'], {
+                ns: 'workflow',
+              })}
+              placeholder={t(($) => $['nodes.knowledgeRetrieval.metadata.panel.placeholder'], {
+                ns: 'workflow',
+              })}
+            />
+          </NumberFieldGroup>
+        </NumberField>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Migrate maximum-length configuration and numeric metadata constants from legacy Input to NumberField.
- Keep bounded integer lengths and full-precision decimal constants distinct; clear values to undefined instead of NaN.
- Preserve the maximum-length label and provide accessible naming and keyboard focus for embedded numeric conditions.

## Verification
- 18 affected unit suites: 126 tests passed. Workspace check, targeted accessibility lint, and Knip passed.
- Compared both controls against main in Chrome: unchanged heights and no visible layout regression.
- Created an empty Knowledge collection without uploading files; verified numeric metadata precision, keyboard clearing, popup reopening, and visible focus on the real page.
- Fixed the unused props-type export reported by CI. All applicable CI checks passed, including Web tests, Storybook, and full-stack E2E.