### PR TITLE
fix(web): keep dataset detail sidebar on document create routes

### DIFF
--- a/web/app/(commonLayout)/@detailSidebar/datasets/[datasetId]/documents/create-from-pipeline/page.tsx
+++ b/web/app/(commonLayout)/@detailSidebar/datasets/[datasetId]/documents/create-from-pipeline/page.tsx
@@ -1,3 +1,5 @@
+import { DatasetDetailSidebarSlot } from '../../sidebar-page'
+
 export default function DatasetDocumentCreateFromPipelineDetailSidebarSlot() {
-  return null
+  return <DatasetDetailSidebarSlot />
 }

--- a/web/app/(commonLayout)/@detailSidebar/datasets/[datasetId]/documents/create/page.tsx
+++ b/web/app/(commonLayout)/@detailSidebar/datasets/[datasetId]/documents/create/page.tsx
@@ -1,3 +1,5 @@
+import { DatasetDetailSidebarSlot } from '../../sidebar-page'
+
 export default function DatasetDocumentCreateDetailSidebarSlot() {
-  return null
+  return <DatasetDetailSidebarSlot />
 }

--- a/web/app/components/main-nav/__tests__/layout.spec.tsx
+++ b/web/app/components/main-nav/__tests__/layout.spec.tsx
@@ -140,7 +140,12 @@ describe('MainNavLayout', () => {
     expect(main).toHaveFocus()
   })
 
-  it.each(['/datasets/dataset-1/documents', '/datasets/dataset-1/documents/document-1/settings'])(
+  it.each([
+    '/datasets/dataset-1/documents',
+    '/datasets/dataset-1/documents/document-1/settings',
+    '/datasets/dataset-1/documents/create',
+    '/datasets/dataset-1/documents/create-from-pipeline',
+  ])(
     'renders the detail sidebar slot outside the single skip navigation target on route %s',
     (pathname) => {
       ;(usePathname as Mock).mockReturnValue(pathname)
@@ -205,7 +210,7 @@ describe('MainNavLayout', () => {
     expect(screen.getByTestId('main-nav')).toBeInTheDocument()
   })
 
-  it.each(['/datasets/create', '/datasets/new/create', '/datasets/dataset-1/documents/create'])(
+  it.each(['/datasets/create', '/datasets/new/create'])(
     'keeps the global main nav on collection and creation route %s',
     (pathname) => {
       ;(usePathname as Mock).mockReturnValue(pathname)

--- a/web/app/components/main-nav/__tests__/routes.spec.ts
+++ b/web/app/components/main-nav/__tests__/routes.spec.ts
@@ -1,0 +1,29 @@
+import { shouldUseDetailSidebar } from '../routes'
+
+const defaultOptions = {
+  agentV2Enabled: true,
+  isCurrentWorkspaceDatasetOperator: false,
+}
+
+describe('shouldUseDetailSidebar', () => {
+  it.each([
+    '/datasets/dataset-1/documents',
+    '/datasets/dataset-1/documents/document-1/settings',
+    '/datasets/dataset-1/documents/create',
+    '/datasets/dataset-1/documents/create-from-pipeline',
+    '/datasets/dataset-1/hitTesting',
+    '/datasets/dataset-1/settings',
+  ])('returns true for dataset detail route %s', (pathname) => {
+    expect(shouldUseDetailSidebar(pathname, defaultOptions)).toBe(true)
+  })
+
+  it.each([
+    '/datasets',
+    '/datasets/create',
+    '/datasets/create-from-pipeline',
+    '/datasets/connect',
+    '/datasets/new/create',
+  ])('returns false for dataset collection route %s', (pathname) => {
+    expect(shouldUseDetailSidebar(pathname, defaultOptions)).toBe(false)
+  })
+})

--- a/web/app/components/main-nav/routes.ts
+++ b/web/app/components/main-nav/routes.ts
@@ -3,7 +3,6 @@ import { buildIntegrationPath } from '@/app/components/integrations/routes'
 type MainNavRouteVisibility = (options: MainNavRouteVisibilityOptions) => boolean
 
 const DATASET_COLLECTION_ROUTES = new Set(['create', 'create-from-pipeline', 'connect'])
-const DATASET_DOCUMENT_CREATION_ROUTES = new Set(['create', 'create-from-pipeline'])
 
 export type MainNavRouteConfig = {
   key: string
@@ -127,16 +126,13 @@ function isAppDetailPathname(pathname: string) {
 }
 
 function isDatasetDetailPathname(pathname: string) {
-  const [section, datasetId, subSection, action] = pathname.split('/').filter(Boolean)
+  const [section, datasetId, subSection] = pathname.split('/').filter(Boolean)
 
   if (section !== 'datasets' || !datasetId) return false
 
   if (DATASET_COLLECTION_ROUTES.has(datasetId)) return false
 
   if (datasetId === 'new' && subSection === 'create') return false
-
-  if (subSection === 'documents' && action && DATASET_DOCUMENT_CREATION_ROUTES.has(action))
-    return false
 
   return true
 }


### PR DESCRIPTION
## Summary

Fixes #42174

When clicking **Add File** on a knowledge base document page, the left sidebar incorrectly switched to the global Dify main menu instead of keeping the knowledge base detail sidebar.

## Root cause

Two issues combined:

1. `isDatasetDetailPathname()` explicitly excluded `/datasets/:id/documents/create` and `create-from-pipeline` routes, so `MainNavLayout` rendered the global `MainNav` instead of the detail sidebar slot.
2. The parallel `@detailSidebar` routes for those paths returned `null` instead of `DatasetDetailSidebarSlot`.

## Changes

- Treat dataset document creation routes as dataset detail routes in `shouldUseDetailSidebar`
- Render `DatasetDetailSidebarSlot` in the `@detailSidebar` slots for `documents/create` and `documents/create-from-pipeline`
- Add regression tests for route detection and layout behavior

## Test plan

- [x] `pnpm vitest run app/components/main-nav/__tests__/routes.spec.ts app/components/main-nav/__tests__/layout.spec.tsx`
- [ ] Manually verify: open a knowledge base → Documents → Add File → sidebar stays on knowledge base detail nav