### PR TITLE
fix(web): deduplicate server i18next initialization

### DIFF
--- a/web/i18n-config/__tests__/server.spec.ts
+++ b/web/i18n-config/__tests__/server.spec.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+
+const mocks = vi.hoisted(() => ({ loadResource: vi.fn() }))
+
+vi.mock('@/next/headers', () => ({ cookies: vi.fn(), headers: vi.fn() }))
+vi.mock('../load-resource', () => ({ loadI18nResource: mocks.loadResource }))
+
+// Unit tests have no RSC dispatcher; provide its memoization boundary here.
+vi.mock('react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react')>()),
+  cache: <T extends (...args: never[]) => unknown>(factory: T) => {
+    const results = new Map<string, ReturnType<T>>()
+    return (...args: Parameters<T>) => {
+      const key = JSON.stringify(args)
+      if (!results.has(key)) results.set(key, factory(...args) as ReturnType<T>)
+      return results.get(key)
+    }
+  },
+}))
+
+describe('server translations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mocks.loadResource.mockImplementation(async (locale: string, namespace: string) => ({
+      default:
+        namespace === 'common'
+          ? locale === 'en-US'
+            ? { 'operation.save': 'Save', 'operation.cancel': 'Cancel' }
+            : { 'operation.save': '保存' }
+          : {},
+    }))
+  })
+
+  it('loads resources once for concurrent consumers and reuses them after initialization', async () => {
+    const { getTranslation } = await import('../server')
+    const translations = await Promise.all([
+      getTranslation('en-US', 'plugin'),
+      getTranslation('en-US', 'app'),
+      getTranslation('en-US', 'explore'),
+      getTranslation('en-US', 'pluginTags'),
+      getTranslation('en-US', 'common'),
+    ])
+
+    expect(translations[4].t(($) => $['operation.save'], { ns: 'common' })).toBe('Save')
+    const loadedResources = mocks.loadResource.mock.calls.map(
+      ([locale, namespace]) => `${locale}/${namespace}`,
+    )
+    expect(loadedResources.filter((resource) => resource === 'en-US/common')).toHaveLength(1)
+    expect(new Set(loadedResources).size).toBe(loadedResources.length)
+
+    mocks.loadResource.mockClear()
+    const { t } = await getTranslation('en-US', 'common')
+    expect(t(($) => $['operation.save'], { ns: 'common' })).toBe('Save')
+    expect(mocks.loadResource).not.toHaveBeenCalled()
+  })
+
+  it('keeps fallback and cross-namespace translations available', async () => {
+    const { getTranslation } = await import('../server')
+    const { t } = await getTranslation('zh-Hans')
+
+    expect(t(($) => $['operation.save'], { ns: 'common' })).toBe('保存')
+    expect(t(($) => $['operation.cancel'], { ns: 'common' })).toBe('Cancel')
+  })
+
+  it('initializes the requested language independently of an earlier consumer', async () => {
+    const { getTranslation } = await import('../server')
+    const english = await getTranslation('en-US', 'common')
+    const chinese = await getTranslation('zh-Hans', 'common')
+
+    expect(chinese.t(($) => $['operation.save'], { ns: 'common' })).toBe('保存')
+    expect(english.t(($) => $['operation.save'], { ns: 'common' })).toBe('Save')
+  })
+})

--- a/web/i18n-config/server.ts
+++ b/web/i18n-config/server.ts
@@ -1,4 +1,4 @@
-import type { i18n as I18nInstance, Resource, ResourceLanguage } from 'i18next'
+import type { Resource, ResourceLanguage } from 'i18next'
 import type { Locale } from '.'
 import type { Namespace, NamespaceInFileName } from './resources'
 import { match } from '@formatjs/intl-localematcher'
@@ -16,13 +16,9 @@ import { namespacesInFileName } from './resources'
 import { getInitOptions } from './settings'
 
 const [getLocaleCache, setLocaleCache] = serverOnlyContext<Locale | null>(null)
-const [getI18nInstance, setI18nInstance] = serverOnlyContext<I18nInstance | null>(null)
 
-const getOrCreateI18next = async (lng: Locale) => {
-  let instance = getI18nInstance()
-  if (instance) return instance
-
-  instance = createInstance()
+const getOrCreateI18next = cache(async (lng: Locale) => {
+  const instance = createInstance()
   await instance
     .use(initReactI18next)
     .use(
@@ -34,9 +30,8 @@ const getOrCreateI18next = async (lng: Locale) => {
       ...getInitOptions(),
       lng,
     })
-  setI18nInstance(instance)
   return instance
-}
+})
 
 export async function getTranslation<T extends Namespace>(lng: Locale, ns?: T) {
   const i18nextInstance = await getOrCreateI18next(lng)


### PR DESCRIPTION
Concurrent server translation calls can initialize multiple i18next instances before the first initialization finishes. The templates page starts five such calls in parallel.

Cache the initialization promise by locale with React `cache`, so concurrent and subsequent consumers share an instance within the request. Preserve namespace loading, English fallback, and cross-namespace translations.

Fixes SNP-792
