### PR TITLE
fix(web): use tool-call capability for customizable Agent V2 models

### DIFF
--- a/web/app/components/header/account-setting/model-provider-page/model-selector/types.ts
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/types.ts
@@ -12,6 +12,7 @@ export type ModelSelectorValue = {
 export type ModelSelectorModel = Pick<
   ProviderModelWithStatusEntity,
   | 'deprecated'
+  | 'fetch_from'
   | 'has_invalid_load_balancing_configs'
   | 'label'
   | 'load_balancing_enabled'

--- a/web/features/agent-v2/agent-detail/configure/__tests__/model-compatibility.spec.ts
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/model-compatibility.spec.ts
@@ -4,6 +4,7 @@ import type {
 } from '@dify/contracts/api/console/workspaces/types.gen'
 import {
   ConfigurationMethodEnum,
+  ModelFeatureEnum,
   ModelStatusEnum,
   ModelTypeEnum,
 } from '@/app/components/header/account-setting/model-provider-page/declarations'
@@ -172,9 +173,78 @@ describe('isAgentCompatibleModel', () => {
     expect(isAgentCompatibleModel(provider, createModelItem('grok-4'))).toBe(true)
     expect(isAgentCompatibleModel(provider, createModelItem('qwen3.7-max'))).toBe(true)
   })
+
+  it('should use declared function-calling capability for customizable models', () => {
+    const provider = createModel('openai-api-compatible')
+
+    expect(
+      isAgentCompatibleModel(
+        provider,
+        createModelItem('qwen-max', {
+          fetch_from: ConfigurationMethodEnum.customizableModel,
+          features: [ModelFeatureEnum.toolCall],
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      isAgentCompatibleModel(
+        provider,
+        createModelItem('custom-model', {
+          fetch_from: ConfigurationMethodEnum.customizableModel,
+          features: [ModelFeatureEnum.streamToolCall],
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      isAgentCompatibleModel(
+        provider,
+        createModelItem('custom-model', {
+          fetch_from: ConfigurationMethodEnum.customizableModel,
+          features: undefined,
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      isAgentCompatibleModel(
+        provider,
+        createModelItem('custom-model', {
+          fetch_from: ConfigurationMethodEnum.customizableModel,
+          features: [ModelFeatureEnum.vision],
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('should keep predefined-model blacklist behavior unchanged', () => {
+    const provider = createModel('qwen')
+
+    expect(isAgentCompatibleModel(provider, createModelItem('qwen-max'))).toBe(false)
+    expect(
+      isAgentCompatibleModel(
+        provider,
+        createModelItem('qwen-max', {
+          fetch_from: ConfigurationMethodEnum.predefinedModel,
+          features: [ModelFeatureEnum.toolCall],
+        }),
+      ),
+    ).toBe(false)
+  })
 })
 
 describe('isAgentSuggestedModel', () => {
+  it('should not auto-suggest customizable models that become technically eligible', () => {
+    const provider = createModel('openai-api-compatible')
+
+    expect(
+      isAgentSuggestedModel(
+        provider,
+        createModelItem('qwen-max', {
+          fetch_from: ConfigurationMethodEnum.customizableModel,
+          features: [ModelFeatureEnum.toolCall],
+        }),
+      ),
+    ).toBe(false)
+  })
   it('should suggest configured Agent baseline models by English label', () => {
     const provider = createModel('any-provider')
 

--- a/web/features/agent-v2/agent-detail/configure/__tests__/model-compatibility.spec.ts
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/model-compatibility.spec.ts
@@ -177,12 +177,23 @@ describe('isAgentCompatibleModel', () => {
   it('should use declared function-calling capability for customizable models', () => {
     const provider = createModel('openai-api-compatible')
 
+    // Regression: customizable qwen-max must not be blocked by the predefined
+    // family blacklist when tool-call is declared (#42092 / #39623).
     expect(
       isAgentCompatibleModel(
         provider,
         createModelItem('qwen-max', {
           fetch_from: ConfigurationMethodEnum.customizableModel,
           features: [ModelFeatureEnum.toolCall],
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      isAgentCompatibleModel(
+        provider,
+        createModelItemWithLabel('custom-id', 'gpt-4o', {
+          fetch_from: ConfigurationMethodEnum.customizableModel,
+          features: [ModelFeatureEnum.multiToolCall],
         }),
       ),
     ).toBe(true)

--- a/web/features/agent-v2/agent-detail/configure/model-compatibility.ts
+++ b/web/features/agent-v2/agent-detail/configure/model-compatibility.ts
@@ -2,6 +2,8 @@ import type {
   ModelSelectorModel,
   ModelSelectorProvider,
 } from '@/app/components/header/account-setting/model-provider-page/model-selector/types'
+import { ConfigurationMethodEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
+import { supportFunctionCall } from '@/utils/tool-call'
 
 const agentIncompatibleModelPatterns: RegExp[] = [
   // openai
@@ -95,11 +97,18 @@ const agentSuggestedModelPatterns: RegExp[] = [
   /^glm[ .-]5\.1$/i,
 ]
 
+function isPredefinedModelBlacklisted(modelItem: ModelSelectorModel) {
+  return agentIncompatibleModelPatterns.some((pattern) => pattern.test(modelItem.label.en_US))
+}
+
 export function isAgentCompatibleModel(
   _provider: ModelSelectorProvider,
   modelItem: ModelSelectorModel,
 ) {
-  return !agentIncompatibleModelPatterns.some((pattern) => pattern.test(modelItem.label.en_US))
+  if (modelItem.fetch_from === ConfigurationMethodEnum.customizableModel)
+    return supportFunctionCall(modelItem.features)
+
+  return !isPredefinedModelBlacklisted(modelItem)
 }
 
 export function isAgentSuggestedModel(


### PR DESCRIPTION
## Summary

Fixes #42092

Customizable models were classified as `Incompatible` in Agent V2 when their configured label matched a predefined-model blacklist pattern, even when the model explicitly declared function/tool-calling support.

This PR separates the two policies:

- **Predefined models** — keep the existing curated Agent compatibility baseline (name-pattern blacklist unchanged)
- **Customizable models** — evaluate technical eligibility via declared function-calling capability (`tool-call`, `multi-tool-call`, or `stream-tool-call`)

`isAgentSuggestedModel()` is unchanged; technically eligible customizable models are not auto-suggested.

## Changes

- Expose `fetch_from` on `ModelSelectorModel` so compatibility logic can distinguish model origin
- Route customizable models through `supportFunctionCall()` instead of the predefined blacklist
- Add focused regression tests for customizable vs predefined behavior

## Test plan

- [x] `cd web && node_modules/.bin/vitest run features/agent-v2/agent-detail/configure/__tests__/model-compatibility.spec.ts` (11 tests pass)