### PR TITLE
refactor(models): pass session into App.app_model_config and App.workflow

### DIFF
--- a/api/controllers/mcp/mcp.py
+++ b/api/controllers/mcp/mcp.py
@@ -88,7 +88,7 @@ class MCPAppApi(Resource):
             self._validate_server_status(mcp_server)
 
             # Get user input form
-            user_input_form = self._get_user_input_form(app)
+            user_input_form = self._get_user_input_form(app, session)
 
             # Handle notification vs request differently
             return self._process_mcp_message(
@@ -180,17 +180,19 @@ class MCPAppApi(Resource):
 
         return helper.compact_generate_response(result.model_dump(by_alias=True, mode="json", exclude_none=True))
 
-    def _get_user_input_form(self, app: App) -> list[VariableEntity]:
+    def _get_user_input_form(self, app: App, session: Session) -> list[VariableEntity]:
         """Get and convert user input form"""
         # Get raw user input form based on app mode
         if app.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
-            if not app.workflow:
+            workflow = app.workflow_with_session(session=session)
+            if not workflow:
                 raise MCPRequestError(mcp_types.INVALID_REQUEST, "App is unavailable")
-            raw_user_input_form = app.workflow.user_input_form(to_old_structure=True)
+            raw_user_input_form = workflow.user_input_form(to_old_structure=True)
         else:
-            if not app.app_model_config:
+            app_model_config = app.app_model_config_with_session(session=session)
+            if not app_model_config:
                 raise MCPRequestError(mcp_types.INVALID_REQUEST, "App is unavailable")
-            features_dict = app.app_model_config.to_dict()
+            features_dict = app_model_config.to_dict()
             raw_user_input_form = features_dict.get("user_input_form", [])
 
         # Convert to VariableEntity objects

--- a/api/core/plugin/backwards_invocation/app.py
+++ b/api/core/plugin/backwards_invocation/app.py
@@ -281,7 +281,10 @@ class PluginAppBackwardsInvocation(BaseBackwardsInvocation):
     @classmethod
     def _get_workflow(cls, app: App) -> Workflow | None:
         """
-        get workflow without relying on App.workflow's request-scoped session property
+        get workflow with an owned session, additionally scoped by tenant and app
+
+        `App.workflow_with_session` resolves by `workflow_id` alone; a plugin
+        invocation must also confirm the workflow belongs to this tenant and app.
         """
         if not app.workflow_id:
             return None

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -470,19 +470,11 @@ class App(Base):
     def site_with_session(self, *, session: Session) -> Site | None:
         return session.scalar(select(Site).where(Site.app_id == self.id))
 
-    @property
-    def app_model_config(self) -> AppModelConfig | None:
-        return self.app_model_config_with_session(session=db.session())
-
     def app_model_config_with_session(self, *, session: Session) -> AppModelConfig | None:
         if self.app_model_config_id:
             return session.scalar(select(AppModelConfig).where(AppModelConfig.id == self.app_model_config_id))
 
         return None
-
-    @property
-    def workflow(self) -> Workflow | None:
-        return self.workflow_with_session(session=db.session())
 
     def workflow_with_session(self, *, session: Session) -> Workflow | None:
         if self.workflow_id:

--- a/api/services/agent/dsl_service.py
+++ b/api/services/agent/dsl_service.py
@@ -203,7 +203,7 @@ class AgentDslService:
             package=package,
             package_path="agent",
         )
-        if app.app_model_config is None:
+        if app.app_model_config_with_session(session=self.session) is None:
             model_config = AppModelConfig(app_id=app.id, created_by=account.id, updated_by=account.id)
             self.session.add(model_config)
             self.session.flush()

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -809,9 +809,12 @@ class AppService:
                 def __init__(self, app):
                     self.__dict__.update(app.__dict__)
 
-                @property
                 @override
-                def app_model_config(self):
+                def app_model_config_with_session(self, *, session: Session) -> AppModelConfig | None:
+                    # Hand back the in-memory config the masking pass above produced, and
+                    # deliberately ignore `session`: re-reading the row here would undo the
+                    # masking. Response paths resolve the config through this accessor
+                    # (`AppResponseView.app_model_config`), so the override has to sit here.
                     return model_config
 
             app = ModifiedApp(app)

--- a/api/services/tools/workflow_tools_manage_service.py
+++ b/api/services/tools/workflow_tools_manage_service.py
@@ -61,17 +61,17 @@ class WorkflowToolManageService:
         if existing_workflow_tool_provider is not None:
             raise ValueError(f"Tool with name {name} or app_id {workflow_app_id} already exists")
 
-        # query the app
+        # query the app and its published workflow in the same session
         app: App | None = None
+        workflow: Workflow | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             app = _session.scalar(select(App).where(App.id == workflow_app_id, App.tenant_id == tenant_id).limit(1))
+            if app is not None:
+                workflow = app.workflow_with_session(session=_session)
 
         # if not found raise error
         if app is None:
             raise ValueError(f"App {workflow_app_id} not found")
-
-        # query the workflow
-        workflow: Workflow | None = app.workflow
 
         # if not found raise error
         if workflow is None:
@@ -172,19 +172,19 @@ class WorkflowToolManageService:
         if workflow_tool_provider is None:
             raise ValueError(f"Tool {workflow_tool_id} not found")
 
-        # query the app
+        # query the app and its published workflow in the same session
         app: App | None = None
+        workflow: Workflow | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             app = _session.scalar(
                 select(App).where(App.id == workflow_tool_provider.app_id, App.tenant_id == tenant_id).limit(1)
             )
+            if app is not None:
+                workflow = app.workflow_with_session(session=_session)
 
         # if not found raise error
         if app is None:
             raise ValueError(f"App {workflow_tool_provider.app_id} not found")
-
-        # query the workflow
-        workflow: Workflow | None = app.workflow
 
         # if not found raise error
         if workflow is None:
@@ -342,15 +342,17 @@ class WorkflowToolManageService:
             raise ValueError("Tool not found")
 
         workflow_app: App | None = None
+        workflow: Workflow | None = None
         with sessionmaker(db.engine, expire_on_commit=False).begin() as _session:
             workflow_app = _session.scalar(
                 select(App).where(App.id == db_tool.app_id, App.tenant_id == db_tool.tenant_id).limit(1)
             )
+            if workflow_app is not None:
+                workflow = workflow_app.workflow_with_session(session=_session)
 
         if workflow_app is None:
             raise ValueError(f"App {db_tool.app_id} not found")
 
-        workflow = workflow_app.workflow
         if not workflow:
             raise ValueError("Workflow not found")
 

--- a/api/tests/test_containers_integration_tests/services/test_agent_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_agent_service.py
@@ -133,8 +133,9 @@ class TestAgentService:
         app = app_service.create_app(tenant.id, app_args, account, session=db_session_with_containers)
 
         # Update the app model config to set agent_mode for agent-chat mode
-        if app.mode == AppMode.AGENT_CHAT and app.app_model_config:
-            app.app_model_config.agent_mode = json.dumps({"enabled": True, "strategy": "react", "tools": []})
+        app_model_config = app.app_model_config_with_session(session=db_session_with_containers)
+        if app.mode == AppMode.AGENT_CHAT and app_model_config:
+            app_model_config.agent_mode = json.dumps({"enabled": True, "strategy": "react", "tools": []})
 
             db_session_with_containers.commit()
 

--- a/api/tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py
@@ -537,6 +537,9 @@ class TestWorkflowToolManageService:
                 ]
             }
         )
+        # The service reads the published workflow in its own session, so the graph has
+        # to be committed — matching test_update_workflow_tool_human_input_node_error.
+        db_session_with_containers.commit()
 
         tool_parameters = self._create_test_workflow_tool_parameters()
         with pytest.raises(WorkflowToolHumanInputNotSupportedError) as exc_info:
@@ -877,6 +880,9 @@ class TestWorkflowToolManageService:
             ]
         }
         workflow.graph = json.dumps(workflow_graph)
+        # The service reads the published workflow in its own session, so the graph has
+        # to be committed for this setup to reach it.
+        db_session_with_containers.commit()
 
         # Setup workflow tool parameters with FILE type
         file_parameters = [
@@ -952,6 +958,9 @@ class TestWorkflowToolManageService:
             ]
         }
         workflow.graph = json.dumps(workflow_graph)
+        # The service reads the published workflow in its own session, so the graph has
+        # to be committed for this setup to reach it.
+        db_session_with_containers.commit()
 
         # Setup workflow tool parameters with FILES type
         files_parameters = [

--- a/api/tests/test_containers_integration_tests/services/workflow/test_workflow_converter.py
+++ b/api/tests/test_containers_integration_tests/services/workflow/test_workflow_converter.py
@@ -325,7 +325,7 @@ class TestWorkflowConverter:
         workflow_converter = WorkflowConverter()
         workflow = workflow_converter.convert_app_model_config_to_workflow(
             app_model=app,
-            app_model_config=app.app_model_config,
+            app_model_config=app.app_model_config_with_session(session=db_session_with_containers),
             account_id=account.id,
             session=db_session_with_containers,
         )

--- a/api/tests/unit_tests/controllers/console/app/test_model_config_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_model_config_api.py
@@ -4,7 +4,6 @@ import importlib
 import json
 import os
 from inspect import unwrap
-from typing import Never
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -21,13 +20,13 @@ from models.model import App, AppMode, AppModelConfig
 app_wraps_module = importlib.import_module("controllers.console.app.wraps")
 
 
-def _poison_implicit_app_config_properties(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fail(_app: App) -> Never:
-        raise AssertionError("implicit App model-config property was accessed")
-
-    # `App.is_agent` used to be poisoned here too. It no longer exists as an
-    # implicit property, so its absence enforces the same thing outright.
-    monkeypatch.setattr(App, "app_model_config", property(fail))
+def _assert_no_implicit_app_config_properties() -> None:
+    # `App.is_agent` and `App.app_model_config` used to be poisoned here with a
+    # raising property. Neither exists as an implicit accessor any more, so their
+    # absence enforces the same thing outright — assert it instead of
+    # monkeypatching an attribute that is gone.
+    assert not hasattr(App, "is_agent")
+    assert not hasattr(App, "app_model_config")
 
 
 @pytest.mark.parametrize("app_mode", [AppMode.CHAT, AppMode.COMPLETION])
@@ -54,7 +53,7 @@ def test_post_updates_non_agent_model_config_without_implicit_properties(
     original_config.agent_mode = None
     sqlite_session.add(original_config)
     sqlite_session.commit()
-    _poison_implicit_app_config_properties(monkeypatch)
+    _assert_no_implicit_app_config_properties()
     monkeypatch.setattr(
         model_config_module.AppModelConfigService,
         "validate_configuration",
@@ -184,7 +183,7 @@ def test_post_encrypts_agent_tool_parameters(
         updated_by=None,
         updated_at=None,
     )
-    _poison_implicit_app_config_properties(monkeypatch)
+    _assert_no_implicit_app_config_properties()
 
     original_config = AppModelConfig(app_id="app-1", created_by="u1", updated_by="u1")
     original_config.id = "config-0"

--- a/api/tests/unit_tests/models/test_app_models.py
+++ b/api/tests/unit_tests/models/test_app_models.py
@@ -33,6 +33,7 @@ from models.model import (
     Site,
     load_annotation_reply_config,
 )
+from models.workflow import Workflow, WorkflowType
 
 
 class TestAppModelValidation:
@@ -266,6 +267,110 @@ class TestAppModelValidation:
 
         # Assert
         assert result == AppMode.AGENT_CHAT
+
+    @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
+    def test_app_model_config_with_session_reads_through_the_caller_session(self, sqlite_session: Session):
+        """`app_model_config_with_session` resolves the linked config through the caller's session."""
+        # Arrange
+        app = App(
+            tenant_id=str(uuid4()),
+            name="Test App",
+            mode=AppMode.CHAT,
+            enable_site=True,
+            enable_api=False,
+            created_by=str(uuid4()),
+        )
+        sqlite_session.add(app)
+        sqlite_session.flush()
+        model_config = AppModelConfig(app_id=app.id, agent_mode=json.dumps({"enabled": False}))
+        sqlite_session.add(model_config)
+        sqlite_session.flush()
+        app.app_model_config_id = model_config.id
+        sqlite_session.commit()
+
+        # Act: a session the model never owns, proving the lookup does not reach for a global one
+        with Session(sqlite_session.get_bind(), expire_on_commit=False) as caller_session:
+            result = app.app_model_config_with_session(session=caller_session)
+
+            # Assert
+            assert result is not None
+            assert result.id == model_config.id
+            assert result in caller_session
+
+    @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
+    def test_app_model_config_with_session_returns_none_when_unlinked(self, sqlite_session: Session):
+        """An app without `app_model_config_id` resolves to None without querying."""
+        # Arrange
+        app = App(
+            tenant_id=str(uuid4()),
+            name="Test App",
+            mode=AppMode.CHAT,
+            enable_site=True,
+            enable_api=False,
+            created_by=str(uuid4()),
+        )
+        sqlite_session.add(app)
+        sqlite_session.flush()
+
+        # Act / Assert: an unbound session would raise if the guard were dropped
+        with Session(expire_on_commit=False) as unbound_session:
+            assert app.app_model_config_with_session(session=unbound_session) is None
+
+    @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
+    def test_workflow_with_session_reads_through_the_caller_session(self, sqlite_session: Session):
+        """`workflow_with_session` resolves the published workflow through the caller's session."""
+        # Arrange
+        app = App(
+            tenant_id=str(uuid4()),
+            name="Test App",
+            mode=AppMode.WORKFLOW,
+            enable_site=True,
+            enable_api=False,
+            created_by=str(uuid4()),
+        )
+        sqlite_session.add(app)
+        sqlite_session.flush()
+        workflow = Workflow(
+            tenant_id=app.tenant_id,
+            app_id=app.id,
+            type=WorkflowType.WORKFLOW,
+            version="1",
+            graph=json.dumps({"nodes": [], "edges": []}),
+            created_by=app.created_by,
+        )
+        workflow._features = "{}"
+        sqlite_session.add(workflow)
+        sqlite_session.flush()
+        app.workflow_id = workflow.id
+        sqlite_session.commit()
+
+        # Act: a session the model never owns, proving the lookup does not reach for a global one
+        with Session(sqlite_session.get_bind(), expire_on_commit=False) as caller_session:
+            result = app.workflow_with_session(session=caller_session)
+
+            # Assert
+            assert result is not None
+            assert result.id == workflow.id
+            assert result in caller_session
+
+    @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
+    def test_workflow_with_session_returns_none_when_unpublished(self, sqlite_session: Session):
+        """An app without `workflow_id` resolves to None without querying."""
+        # Arrange
+        app = App(
+            tenant_id=str(uuid4()),
+            name="Test App",
+            mode=AppMode.WORKFLOW,
+            enable_site=True,
+            enable_api=False,
+            created_by=str(uuid4()),
+        )
+        sqlite_session.add(app)
+        sqlite_session.flush()
+
+        # Act / Assert: an unbound session would raise if the guard were dropped
+        with Session(expire_on_commit=False) as unbound_session:
+            assert app.workflow_with_session(session=unbound_session) is None
 
     @pytest.mark.parametrize("sqlite_session", [(App, AppModelConfig)], indirect=True)
     def test_deleted_tools_checks_plugin_builtin_providers_through_core_plugin_service(self, sqlite_session: Session):

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from datetime import datetime
 from types import SimpleNamespace
@@ -543,6 +544,32 @@ class TestGetApp:
 
         is_agent.assert_not_called()
         get_model_config.assert_called_once_with(session=unbound_session)
+
+    def test_masked_agent_config_is_served_through_the_session_accessor(self, unbound_session: Session):
+        """The masked config must be reachable via `app_model_config_with_session`.
+
+        Every response path resolves an `App`'s model config through that accessor
+        (`AppResponseView.app_model_config`), never through a raw attribute, so the
+        masking `get_app` applies has to be observable there.
+        """
+        app = App(mode=AppMode.AGENT_CHAT)
+        app.id = str(uuid4())
+        masked_config = AppModelConfig(app_id=app.id, agent_mode=json.dumps({"enabled": True, "tools": []}))
+        # A second, unmasked instance: what a fresh lookup would hand back if the
+        # returned app ever fell through to the base accessor.
+        refetched_config = AppModelConfig(app_id=app.id, agent_mode=json.dumps({"enabled": True, "tools": []}))
+        account = Account(name="Test Account", email="test@example.com")
+        account._current_tenant = Tenant(name="Test Tenant")
+        account._current_tenant.id = "tenant-1"
+
+        with (
+            patch.object(App, "app_model_config_with_session", side_effect=[masked_config, refetched_config]),
+            patch("services.app_service.current_user", account),
+        ):
+            result = AppService().get_app(app, session=unbound_session)
+
+            assert result is not app
+            assert result.app_model_config_with_session(session=unbound_session) is masked_config
 
 
 class TestAgentAppType:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> 1. Associated issue: #40372 (claimed in [this comment](https://github.com/langgenius/dify/issues/40372#issuecomment-5630755563)).

## Summary

Part of #40372, follow-up to #41942 / #41964 / #41983 / #41998. Removes two of the three remaining `@property` wrappers on `App` whose whole body was `return self.<name>_with_session(session=db.session())`:

| Removed | Kept (unchanged) |
| --- | --- |
| `App.app_model_config` | `app_model_config_with_session(self, *, session: Session)` |
| `App.workflow` | `workflow_with_session(self, *, session: Session)` |

`App.desc_or_prompt` (`api/models/model.py:453`) is the third and is left for #40814, whose hunk it sits in. Separately `App.tenant` (`api/models/model.py:538`) still reaches `db.session` directly and has no twin yet, so #40372 stays open for `App`.

The earlier slices were pure deletions because nothing read them. These two are read in production, so this threads a caller session through the readers instead.

## Readers

A receiver-level sweep of `api/` — AST over every `.workflow` / `.app_model_config` attribute node, classifying each receiver — gives the first four rows. That kind of sweep structurally cannot see a name passed as a string, and a literal-name sweep over `"app_model_config"` / `"workflow"` in `getattr`/`hasattr`/`setattr`/`patch.object` surfaces exactly one more site, the fifth row. Every reader already had a session in hand:

| Reader | Change |
| --- | --- |
| `controllers/mcp/mcp.py` `_get_user_input_form` | takes `session: Session`; its only caller already runs inside the `with sessionmaker(...).begin() as session:` block at `mcp.py:85` and passes the same session to `_process_mcp_message` on the next line |
| `services/tools/workflow_tools_manage_service.py` ×3 | workflow lookup folded into the existing `with ... as _session:` block |
| `services/agent/dsl_service.py` | `self.session` |
| `services/app_service.py` `AppService.get_app` | the `ModifiedApp` override moves onto the session-aware accessor — see below |
| `tests/unit_tests/controllers/console/app/test_model_config_api.py` | the string-literal site: its poison helper becomes an absence assertion — see below |
| `tests/.../services/test_agent_service.py`, `tests/.../services/workflow/test_workflow_converter.py` | swap the accessor for its twin, using `db_session_with_containers` |
| `tests/.../services/tools/test_workflow_tools_manage_service.py` | needs `db_session_with_containers.commit()` — see below |
| `core/plugin/backwards_invocation/app.py` | docstring only: it named `App.workflow`'s request-scoped session property |

No response model can reach the raw names: `AppResponseView` (`app_service.py:199,206`) defines its own `app_model_config` / `workflow` properties forwarding to the twins, and `AppResponseModel._use_request_session` converts every `App` — `ModifiedApp` included — into that view before validation.

## Two latent problems this removes

**1. A cross-transaction read in `workflow_tools_manage_service.py`.** All three sites loaded the `App` inside a `with sessionmaker(..., expire_on_commit=False).begin() as _session:` block and then read `app.workflow` **after that block had closed**, so the workflow row was fetched on the global `db.session` in a different transaction from the `App` it was derived from. The lookup now sits inside the block. `expire_on_commit=False` keeps the returned `Workflow` usable afterwards, and the only attributes read after the block are `graph_dict` (a plain `json.loads` of the loaded `graph` column) and `version` — `Workflow` declares no relationships and no deferred columns, so nothing lazy-loads on the detached instance.

The behavioural consequence worth stating: the service now requires the published workflow to be **committed**. Both production callers already are — the console controller commits its own session before calling, and `import_service._ensure_workflow_app_is_published` commits inside its own `sessionmaker(db.engine).begin()` block first.

**2. An inert override in `AppService.get_app`.** It built a local `class ModifiedApp(App)` overriding `app_model_config` **as a `@property`** to return the tool-parameter-masked config. Nothing read that property — `AppResponseView.app_model_config` resolves through `app_model_config_with_session`, so the masking survived only because the same session's identity map returned the same mutated row. The override now sits on the session-aware accessor, which is the path responses actually take, and `@override` stays meaningful (`mypy` reports it as overriding nothing once the base property is gone). It deliberately ignores its `session` argument: re-reading the row there would hand back the **unmasked** row, so this is also stricter than before for any caller passing a different session.

## Three tests that depended on the old implicit behaviour

- `tests/unit_tests/controllers/console/app/test_model_config_api.py:30` poisoned the accessor with `monkeypatch.setattr(App, "app_model_config", property(fail))`. With the property gone, `monkeypatch.setattr` raises `AttributeError` and 3 tests error. The helper's own comment already records the resolution for the previous symbol — `App.is_agent` "no longer exists as an implicit property, so its absence enforces the same thing outright" — so the poison becomes `assert not hasattr(App, ...)` for both names, which is a stronger guard than a raising property.
- `tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py:530` mutates `workflow.graph` **without committing** and relied on the service seeing it through the shared global session. With the lookup inside the service's own transaction that mutation is invisible and `WorkflowToolHumanInputNotSupportedError` never fires. Added the commit, matching `test_update_workflow_tool_human_input_node_error` in the same file, which already commits after the identical mutation.
- Two more cases in that file (`..._with_file_parameter_default`, `..._with_files_parameter_default`) mutate `workflow.graph` without committing too. They stay green either way — `create_workflow_tool` only feeds the graph to `ensure_no_human_input_nodes`, and `WorkflowToolProviderController.from_db` is mocked — but without a commit the FILE / Array[File] graph each case is named for would no longer reach the service at all, so they get the same commit.

## Tests

Neither twin had unit coverage. Five new cases:

`tests/unit_tests/models/test_app_models.py` (+4)
- `app_model_config_with_session` / `workflow_with_session` resolve the linked row **through a session the model never owns** (a second `Session` over the same bind), and the result is attached to that session.
- Both return `None` when the foreign key is unset, asserted against an **unbound** `Session`, so dropping the `if self.<fk>:` guard raises rather than silently passing.

`tests/unit_tests/services/test_app_service.py` (+1)
- `get_app` serves the masked config through `app_model_config_with_session`. The base accessor is stubbed with `side_effect=[masked, refetched]` so the assertion distinguishes the override from a fall-through.

Mutation-checked against the otherwise-fixed tree, each run as
`pytest tests/unit_tests/models/test_app_models.py tests/unit_tests/services/test_app_service.py` (93 passed unmutated, 88 with the five new cases reverted):

| Mutation | Result |
| --- | --- |
| drop the `if self.<fk>:` guard on both twins | 2 failed, 91 passed (both "returns None" cases) |
| point both lookups at the wrong column (`.app_id` instead of `.id`) | 3 failed, 90 passed (both "caller session" cases, plus an existing `deleted_tools` case that shares the predicate) |
| leave the `ModifiedApp` override on the raw property | 1 failed, 92 passed (`DID NOT` serve the masked config) |

## Verification

On `a3b2786`, from the repo root:

- `pytest api/tests/unit_tests` — **18782 passed, 6 skipped, 138 subtests passed**, 0 failed
- `pytest api/tests/unit_tests/models/ api/tests/unit_tests/services/test_app_service.py api/tests/unit_tests/controllers/mcp/ api/tests/unit_tests/controllers/console/app/` — **935 passed**
- `make lint` — `ruff format`, `ruff check --fix`, `lint-imports` (31 contracts kept, 0 broken), `dotenv-linter`, `dev/lint_response_contracts.py` (528 valid, 0 mismatch): clean
- `mypy --exclude-gitignore --check-untyped-defs --disable-error-code=import-untyped .` — no issues in 1796 source files
- `pyrefly check` — 0 diagnostics
- `api/uv.lock` unchanged

Container-integration suites: all three touched files run locally against Docker — `pytest tests/test_containers_integration_tests/services/tools/test_workflow_tools_manage_service.py tests/test_containers_integration_tests/services/test_agent_service.py tests/test_containers_integration_tests/services/workflow/test_workflow_converter.py` → **51 passed**. Dropping the added `commit()` from `test_create_workflow_tool_human_input_node_error` reproduces the failure this PR fixes: `Failed: DID NOT RAISE WorkflowToolHumanInputNotSupportedError`.

## Screenshots

N/A (backend-only refactor).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

From Claude Code
