### PR TITLE
fix: strip reasoning blocks before suggested-questions parse

### DIFF
--- a/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
+++ b/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
@@ -7,6 +7,22 @@ from core.llm_generator.prompts import DEFAULT_SUGGESTED_QUESTIONS_AFTER_ANSWER_
 
 logger = logging.getLogger(__name__)
 
+_CLOSED_REASONING_BLOCK_RE = re.compile(
+    r"<(think|thought)>.*?</\1>",
+    re.DOTALL | re.IGNORECASE,
+)
+_UNCLOSED_REASONING_BLOCK_RE = re.compile(
+    r"<(think|thought)>.*",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _strip_reasoning_blocks(text: str) -> str:
+    """Remove closed and unclosed ``<think>`` / ``<thought>`` blocks."""
+    stripped = _CLOSED_REASONING_BLOCK_RE.sub("", text)
+    stripped = _UNCLOSED_REASONING_BLOCK_RE.sub("", stripped)
+    return stripped.strip()
+
 
 class SuggestedQuestionsAfterAnswerOutputParser:
     def __init__(self, instruction_prompt: str | None = None) -> None:
@@ -23,7 +39,7 @@ class SuggestedQuestionsAfterAnswerOutputParser:
         return self._instruction_prompt
 
     def parse(self, text: str) -> Sequence[str]:
-        stripped_text = text.strip()
+        stripped_text = _strip_reasoning_blocks(text)
         action_match = re.search(r"\[.*?\]", stripped_text, re.DOTALL)
         questions: list[str] = []
         if action_match is not None:

--- a/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
+++ b/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
@@ -1,0 +1,35 @@
+from core.llm_generator.output_parser.suggested_questions_after_answer import (
+    SuggestedQuestionsAfterAnswerOutputParser,
+)
+
+
+class TestSuggestedQuestionsAfterAnswerOutputParser:
+    def test_parse_clean_json_array(self):
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = 'questions:\n["What is Dify?", "How to build an app?", "Why use RAG?"]'
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?", "How to build an app?", "Why use RAG?"]
+
+    def test_parse_strips_closed_think_block_with_inner_brackets(self):
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = (
+            "<think>\n"
+            "Relevant tokens are [MASK] and probabilities [0.2, 0.8]. "
+            'Ignore ["bad question from reasoning"].\n'
+            "</think>\n"
+            '["What is Dify?", "How to build an app?", "Why use RAG?"]'
+        )
+
+        result = parser.parse(text)
+
+        assert list(result) == ["What is Dify?", "How to build an app?", "Why use RAG?"]
+
+    def test_parse_strips_unclosed_think_block(self):
+        parser = SuggestedQuestionsAfterAnswerOutputParser()
+        text = '<think>Analyzing the answer: score vector [0.1, 0.9] and ["bad question from reasoning"]'
+
+        result = parser.parse(text)
+
+        assert list(result) == []


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #41854

I previously asked on the issue whether @however-yir still plans to finish the abandoned #41881, and requested assignment. Happy to adjust if a maintainer prefers a different owner.

### Root cause

`SuggestedQuestionsAfterAnswerOutputParser.parse` searches the raw completion for the first `[...]` pair. `_default_suggested_questions_model_parameters` already tries to disable thinking when the model schema allows it, but reasoning models can still emit `<think>` / `<thought>` blocks. Brackets inside those blocks (for example `[0.2, 0.8]`, `[MASK]`, or a string list) are matched first, so the parser either fails to decode or keeps a non-string list and the suggested-question API returns `[]`.

Unclosed tags (truncated completions) have the same failure mode because the first bracket pair is still taken from the reasoning text.

### Fix

Strip closed and unclosed `<think>` / `<thought>` blocks (case-insensitive) in the parser **before** the JSON-array extract. The helper in `api/core/workflow/nodes/agent/think_tags.py` is stream-oriented (it repairs tags for UI streaming), so this uses a small dedicated strip local to the parser.

Non-reasoning output is unchanged: a clean JSON array still extracts as before.

### Test plan

Unit tests in `api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py`:

- Clean JSON array still extracts the questions
- Closed `<think>` with brackets inside does not steal the match; the payload after the block is used
- Unclosed `<think>` with brackets inside is discarded so inner arrays are not returned

```bash
make test TARGET_TESTS=./api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
```

Ran the targeted unit tests (3 passed), plus `ruff check` / `ruff format --check` and mypy on the touched files.

## Screenshots

N/A — parser behavior is covered by unit tests.

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
