### PR TITLE
fix: normalize json part before deduplicating

### DIFF
--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -273,8 +273,15 @@ class ToolEngine:
 
         # Add JSON parts, avoiding duplicates from text parts.
         if json_parts:
-            existing_parts = set(parts)
-            parts.extend(p for p in json_parts if p not in existing_parts)
+
+            def normalize_json(text: str) -> str:
+                try:
+                    return json.dumps(json.loads(text), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+                except (ValueError, RecursionError):
+                    return text
+
+            existing_parts = {normalize_json(p) for p in parts}
+            parts.extend(p for p in json_parts if normalize_json(p) not in existing_parts)
 
         return "".join(parts)
 

--- a/api/tests/unit_tests/core/tools/test_tool_engine.py
+++ b/api/tests/unit_tests/core/tools/test_tool_engine.py
@@ -162,6 +162,90 @@ def test_convert_tool_response_to_str_and_extract_binary_messages():
         )
 
 
+@pytest.mark.parametrize("json_first", [True, False])
+@pytest.mark.parametrize(
+    ("text", "json_object"),
+    [
+        pytest.param('{"a":1,"b":2}', {"a": 1, "b": 2}, id="compact"),
+        pytest.param(' \r\n{\n  "a": 1,\n  "b": 2\n}\t', {"a": 1, "b": 2}, id="whitespace"),
+        pytest.param('{"b": 2, "a": 1}', {"a": 1, "b": 2}, id="key-order"),
+        pytest.param(
+            '{"items":[{"b":2,"a":1}],"nested":{"y":2,"x":1}}',
+            {"nested": {"x": 1, "y": 2}, "items": [{"a": 1, "b": 2}]},
+            id="nested-key-order",
+        ),
+        pytest.param(r'{"\u540d\u79f0":"\u4e2d\u6587"}', {"名称": "中文"}, id="unicode-escapes"),
+        pytest.param(r'{"path":"\/a\/b"}', {"path": "/a/b"}, id="slash-escapes"),
+        pytest.param('{"a":1e0}', {"a": 1.0}, id="exponent"),
+        pytest.param(" { } ", {}, id="empty-object"),
+        pytest.param('[ {"b":2,"a":1},null,true ]', [{"a": 1, "b": 2}, None, True], id="array"),
+    ],
+)
+def test_convert_tool_response_deduplicates_equivalent_json(
+    text: str, json_object: dict[str, Any] | list[Any], json_first: bool
+):
+    tool = _build_tool()
+    messages = [
+        ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.JSON,
+            message=ToolInvokeMessage.JsonMessage(json_object=json_object),
+        ),
+        tool.create_text_message(text),
+    ]
+    if not json_first:
+        messages.reverse()
+
+    assert ToolEngine.tool_response_to_str(messages) == text
+
+
+@pytest.mark.parametrize(
+    ("text", "json_object", "json_text"),
+    [
+        pytest.param("plain text", {"a": 1}, '{"a": 1}', id="plain-text"),
+        pytest.param("[" * 2000 + "0" + "]" * 2000, {"a": 1}, '{"a": 1}', id="deeply-nested-text"),
+        pytest.param("9" * 5000, {"a": 1}, '{"a": 1}', id="oversized-integer"),
+        pytest.param("{'a': 1}", {"a": 1}, '{"a": 1}', id="invalid-json"),
+        pytest.param('result: {"a":1}', {"a": 1}, '{"a": 1}', id="embedded-json"),
+        pytest.param('{"a":1}{"a":1}', {"a": 1}, '{"a": 1}', id="concatenated-json"),
+        pytest.param('{"a":1}', {"a": 2}, '{"a": 2}', id="different-value"),
+        pytest.param('{"a":1}', {"b": 1}, '{"b": 1}', id="different-key"),
+        pytest.param('{"a":[1,2]}', {"a": [2, 1]}, '{"a": [2, 1]}', id="array-order"),
+        pytest.param('{"a":true}', {"a": 1}, '{"a": 1}', id="boolean-vs-number"),
+        pytest.param('{"a":null}', {"a": False}, '{"a": false}', id="null-vs-boolean"),
+        pytest.param('{"a":"1"}', {"a": 1}, '{"a": 1}', id="string-vs-number"),
+        pytest.param('{"a":"a b"}', {"a": "ab"}, '{"a": "ab"}', id="string-whitespace"),
+    ],
+)
+def test_convert_tool_response_preserves_distinct_json(text: str, json_object: dict[str, Any], json_text: str):
+    tool = _build_tool()
+    messages = [tool.create_json_message(json_object), tool.create_text_message(text)]
+
+    assert ToolEngine.tool_response_to_str(messages) == text + json_text
+
+
+@pytest.mark.parametrize("suppress_output", [True, False])
+def test_convert_tool_response_preserves_json_only_output(suppress_output: bool):
+    tool = _build_tool()
+    messages = [tool.create_json_message({"b": 2, "a": "中文"}, suppress_output=suppress_output)]
+
+    assert ToolEngine.tool_response_to_str(messages) == ("" if suppress_output else '{"b": 2, "a": "中文"}')
+
+
+def test_convert_tool_response_deduplicates_only_matching_json():
+    tool = _build_tool()
+    text = '{"b":2,"a":1}'
+    messages = [
+        tool.create_json_message({"a": 1, "b": 2}),
+        tool.create_text_message(text),
+        tool.create_text_message("result"),
+        tool.create_text_message(text),
+        tool.create_json_message({"c": 3}),
+        tool.create_json_message({"c": 3}),
+    ]
+
+    assert ToolEngine.tool_response_to_str(messages) == text + "result" + text + '{"c": 3}{"c": 3}'
+
+
 @pytest.mark.parametrize("sqlite_session", [(MessageFile,)], indirect=True)
 def test_create_message_files_and_invoke_generator(sqlite_engine: Engine, sqlite_session: Session):
     binaries = [


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary
fixes #42195
resolves ENG-837 internally
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1222" height="608" alt="image" src="https://github.com/user-attachments/assets/78a9855c-8df7-41f2-9189-1bfbc1aef2a6" />    |  <img width="1192" height="666" alt="image" src="https://github.com/user-attachments/assets/73c84e23-e1f0-4e18-b144-006065d7ebac" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
