### PR TITLE
fix: allow Knowledge deployment to finish Celery drain

### DIFF
--- a/.github/workflows/deploy-knowledge.yml
+++ b/.github/workflows/deploy-knowledge.yml
@@ -67,5 +67,7 @@ jobs:
           host: ${{ secrets.SSH_NEW_RAG_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          # Allow the shared deployment lock and Celery warm shutdown to finish.
+          command_timeout: 300m
           script: |
             ${{ vars.SSH_SCRIPT || secrets.SSH_SCRIPT }}


### PR DESCRIPTION
The Knowledge deployment was terminated by the SSH action's default 10-minute timeout while restoring containers, leaving the test stack with containers in `Created` state. Set `command_timeout` to 300 minutes so the shared deployment lock (up to 130 minutes), Celery warm shutdown (125 minutes), and readiness checks can finish. The existing GitHub job limit remains 360 minutes.

Validation: parsed the workflow YAML and compared the before/after documents; only the SSH command timeout changes. `git diff --check` passed. This does not shorten worker shutdown grace or interrupt active jobs.

Observed failure: https://github.com/langgenius/dify/actions/runs/34578175356
