### PR TITLE
fix(rag): cap QA indexing preview results

### DIFF
--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -400,7 +400,8 @@ class IndexingRunner:
             )
             total_segments += len(documents)
             for document in documents:
-                if len(preview_texts) < 10:
+                preview_count = len(qa_preview_texts) if doc_form == "qa_model" else len(preview_texts)
+                if preview_count < 10:
                     if doc_form and doc_form == "qa_model":
                         qa_detail = QAPreviewDetail(
                             question=document.page_content, answer=document.metadata.get("answer") or ""

--- a/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
+++ b/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
@@ -1796,6 +1796,36 @@ class TestIndexingRunnerEstimate:
                 session=mock_dependencies["session"],
             )
 
+    def test_indexing_estimate_limits_qa_preview(self, mock_dependencies, config_overrides):
+        """Test indexing estimate returns no more than ten QA preview items."""
+        config_overrides(DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY)
+        runner = IndexingRunner()
+        mock_processor = MagicMock()
+        mock_dependencies["factory"].return_value.init_index_processor.return_value = mock_processor
+
+        qa_documents = [
+            Document(
+                page_content=f"Question {index}",
+                metadata={"answer": f"Answer {index}"},
+            )
+            for index in range(11)
+        ]
+        mock_processor.extract.return_value = [Document(page_content="Source content")]
+        mock_processor.transform.return_value = qa_documents
+
+        result = runner.indexing_estimate(
+            tenant_id=str(uuid.uuid4()),
+            extract_settings=[MagicMock()],
+            tmp_processing_rule=create_mock_process_rule(),
+            doc_form=IndexStructureType.QA_INDEX,
+            session=mock_dependencies["session"],
+        )
+
+        assert result.total_segments == 220
+        assert result.qa_preview is not None
+        assert len(result.qa_preview) == 10
+        assert result.qa_preview[-1].question == "Question 9"
+
     def test_indexing_estimate_commits_preview_cleanup_before_summary_workers(
         self, mock_dependencies, config_overrides
     ):


### PR DESCRIPTION
## Summary

Fixes #42204

In QA indexing mode, `IndexingRunner.indexing_estimate()` appends preview items to `qa_preview_texts` but checks the length of `preview_texts`. Since the latter remains empty in QA mode, the intended ten-item preview limit is never applied.

Use the active QA preview list for the limit check. This keeps the full `total_segments` estimate unchanged while limiting only the preview returned to the frontend.

## Verification

All verification was run locally on Python 3.12.

The following deterministic probe exercised the actual `IndexingRunner`, `QAIndexProcessor`, QA parser, and preview response path. Only the external LLM response was replaced with a fixed response containing 11 valid Q&A pairs.

```
Before fix (upstream/main bb02d3efcc):
{'LLM_pairs': 11, 'returned_qa_preview': 11, 'total_segments': 220}

After fix (81bc376eff):
{'LLM_pairs': 11, 'returned_qa_preview': 10, 'total_segments': 220}
```

The regression test also failed on the pre-fix implementation with `AssertionError: assert 11 == 10`, and passes after the fix.

Checks:

- `228 passed` across the indexing runner, QA processor, index processor, console dataset, and dataset document test suites.
- `ruff check` and `ruff format --check` passed.
- `pyrefly check api/core/indexing_runner.py` passed with 0 diagnostics.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A - backend-only change | N/A - backend-only change |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods