### PR TITLE
refactor: clean unnecessary | None type annotations in request.py

### DIFF
--- a/api/core/plugin/entities/request.py
+++ b/api/core/plugin/entities/request.py
@@ -36,7 +36,7 @@ class InvokeCredentials(BaseModel):
 
 
 class PluginInvokeContext(BaseModel):
-    credentials: InvokeCredentials | None = Field(
+    credentials: InvokeCredentials = Field(
         default_factory=InvokeCredentials,
         description="Credentials context for the plugin invocation or backward invocation.",
     )
@@ -71,8 +71,8 @@ class RequestInvokeLLM(BaseRequestInvokeModel):
     mode: str
     completion_params: dict[str, Any] = Field(default_factory=dict)
     prompt_messages: list[PromptMessage] = Field(default_factory=list)
-    tools: list[PromptMessageTool] | None = Field(default_factory=list[PromptMessageTool])
-    stop: list[str] | None = Field(default_factory=list[str])
+    tools: list[PromptMessageTool] = Field(default_factory=list[PromptMessageTool])
+    stop: list[str] = Field(default_factory=list[str])
     stream: bool = False
 
     model_config = ConfigDict(protected_namespaces=())


### PR DESCRIPTION
Remove unnecessary `| None` from three fields in `api/core/plugin/entities/request.py` where the default value is never None:

1. `PluginInvokeContext.credentials`: `InvokeCredentials | None` -> `InvokeCredentials` (default_factory=InvokeCredentials, never None)

2. `RequestInvokeLLM.tools`: `list[PromptMessageTool] | None` -> `list[PromptMessageTool]` (default_factory=list, never None)

3. `RequestInvokeLLM.stop`: `list[str] | None` -> `list[str]` (default_factory=list, never None)

Part of #35557

## Summary

Remove unnecessary `| None` type annotations from three fields in `api/core/plugin/entities/request.py` where the default value is never `None`. This makes the type signatures more accurate and prevents unnecessary None checks.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
