### PR TITLE
fix(web): send provider credential delete params in query

### DIFF
--- a/web/service/__tests__/use-models.spec.tsx
+++ b/web/service/__tests__/use-models.spec.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { renderHook } from '@/test/console/render'
+import { useDeleteProviderCredential } from '../use-models'
+
+const { mockDel } = vi.hoisted(() => ({
+  mockDel: vi.fn(),
+}))
+
+vi.mock('@/service/base', () => ({
+  del: mockDel,
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useDeleteProviderCredential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDel.mockResolvedValue({ result: 'success' })
+  })
+
+  it('sends credential_id as a DELETE query parameter', async () => {
+    const credentialId = '123e4567-e89b-12d3-a456-426614174000'
+    const { result } = renderHook(() => useDeleteProviderCredential('openai'), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ credential_id: credentialId })
+    })
+
+    expect(mockDel).toHaveBeenCalledWith('/workspaces/current/model-providers/openai/credentials', {
+      params: {
+        credential_id: credentialId,
+      },
+    })
+  })
+})

--- a/web/service/use-models.ts
+++ b/web/service/use-models.ts
@@ -60,7 +60,7 @@ export const useDeleteProviderCredential = (provider: string) => {
   return useMutation({
     mutationFn: (data: { credential_id: string }) =>
       del<{ result: string }>(`/workspaces/current/model-providers/${provider}/credentials`, {
-        body: data,
+        params: data,
       }),
   })
 }


### PR DESCRIPTION
## Summary

Fixes #42207.

Follow-up on #42162 for the remaining provider-credential DELETE path.

`useDeleteProviderCredential()` still sent `credential_id` in a DELETE request body. Dify's shared DELETE request validation already accepts query parameters first and retains JSON-body fallback compatibility, so the Web client can use the safer query form without changing backend behavior.

### Changes

- send provider-credential `credential_id` through `params` instead of `body`;
- add focused `useDeleteProviderCredential` hook coverage that asserts the DELETE request shape using a valid UUID credential ID.

This PR is deliberately scoped to the browser runtime path. The endpoint's OpenAPI body annotation / generated contract can be cleaned up separately with contract regeneration rather than mixing a generated-contract migration into this small transport fix.

## Validation

The regression exercises the mutation and asserts:

```ts
del('/workspaces/current/model-providers/openai/credentials', {
  params: { credential_id: '123e4567-e89b-12d3-a456-426614174000' },
})
```

No backend/service semantics are changed, and older body-based callers remain supported by the existing DELETE body fallback.

Final branch shape: 1 commit, 2 Web files, based on current upstream `main`.

From ChatGPT