### PR TITLE
fix(web): clear stale conversation_id from localStorage on 404

### DIFF
--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -2433,4 +2433,19 @@ describe('useChatWithHistory', () => {
       })
     })
   })
+
+  // Scenario: a stale conversation_id that 404s is cleared from storage
+  // so the chatbot falls back to a new conversation (issue #39484).
+  describe('Stale conversation recovery', () => {
+    it('clears conversationIdInfo from storage when chat list returns 404', async () => {
+      setConversationIdInfo('app-1', 'stale-conversation-id')
+      mockFetchChatList.mockRejectedValue(new Response(null, { status: 404 }))
+
+      await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        expect(localStorage.getItem(CONVERSATION_ID_INFO)).not.toContain('app-1')
+      })
+    })
+  })
 })

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -188,10 +188,11 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
     },
     [appId, setStoredSidebarCollapseState],
   )
-  const { currentConversationId, handleConversationIdInfoChange } = useConversationSelection({
-    scopeId: isInstalledApp || appData?.end_user_id ? conversationScopeId : '',
-    userId: isInstalledApp ? userId : appData?.end_user_id,
-  })
+  const { currentConversationId, handleConversationIdInfoChange, removeConversationIdInfo } =
+    useConversationSelection({
+      scopeId: isInstalledApp || appData?.end_user_id ? conversationScopeId : '',
+      userId: isInstalledApp ? userId : appData?.end_user_id,
+    })
   const [newConversationId, setNewConversationId] = useState('')
   const chatShouldReloadKey = useMemo(() => {
     if (currentConversationId === newConversationId) return ''
@@ -252,6 +253,20 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
     // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing Environment conversation must clear the rendered chat.
     setClearChatList(true)
   }, [appChatListError, handleConversationIdInfoChange])
+  // When the backend reports the conversation no longer exists (404), clear the
+  // stale conversation_id so the chatbot falls back to a new conversation
+  // instead of retrying forever (issue #39484). Environment addresses have their
+  // own 404 protocol handled by the effect above.
+  useEffect(() => {
+    if (resolveWebAppAddress()?.kind === 'environment') return
+    if (!(appChatListError instanceof Response) || appChatListError.status !== 404) return
+
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation resets the active conversation.
+    setNewConversationId('')
+    removeConversationIdInfo()
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation must clear the rendered chat.
+    setClearChatList(true)
+  }, [appChatListError, removeConversationIdInfo])
   const appPrevChatTree = useMemo(
     () =>
       currentConversationId && appChatListData?.data.length

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
@@ -1035,4 +1035,23 @@ describe('useEmbeddedChatbot', () => {
       })
     })
   })
+
+  // Scenario: a stale conversation_id that 404s is cleared from storage
+  // so the chatbot falls back to a new conversation (issue #39484).
+  describe('Stale conversation recovery', () => {
+    it('clears conversationIdInfo from storage when chat list returns 404', async () => {
+      mockStoreState.embeddedConversationId = null
+      localStorage.setItem(
+        CONVERSATION_ID_INFO,
+        JSON.stringify({ 'app-1': { 'user-1': 'stale-conversation-id' } }),
+      )
+      mockFetchChatList.mockRejectedValue(new Response(null, { status: 404 }))
+
+      await renderWithClient(() => useEmbeddedChatbot(AppSourceType.webApp))
+
+      await waitFor(() => {
+        expect(localStorage.getItem(CONVERSATION_ID_INFO)).not.toContain('app-1')
+      })
+    })
+  })
 })

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -145,7 +145,11 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       pinned: false,
       limit: 100,
     })
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
+  const {
+    data: appChatListData,
+    error: appChatListError,
+    isLoading: appChatListDataLoading,
+  } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
     appId,
@@ -153,6 +157,20 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)
+  // When the backend reports the conversation no longer exists (404), clear the
+  // stale conversation_id so the chatbot falls back to a new conversation
+  // instead of retrying forever (issue #39484). Environment addresses carry their
+  // own 404 protocol and are not handled here.
+  useEffect(() => {
+    if (resolveWebAppAddress()?.kind === 'environment') return
+    if (!(appChatListError instanceof Response) || appChatListError.status !== 404) return
+
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation resets the active conversation.
+    setNewConversationId('')
+    removeConversationIdInfo()
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation must clear the rendered chat.
+    setClearChatList(true)
+  }, [appChatListError, removeConversationIdInfo])
   const appPrevChatList = useMemo(
     () =>
       currentConversationId && appChatListData?.data.length

--- a/web/service/use-share.spec.tsx
+++ b/web/service/use-share.spec.tsx
@@ -265,6 +265,23 @@ describe('useShareChatList', () => {
     expect(mockFetchChatList).toHaveBeenCalledTimes(1)
   })
 
+  it('should not retry when chat list returns 404', async () => {
+    const queryClient = new QueryClient()
+    const wrapper = createWrapper(queryClient)
+    const params = {
+      conversationId: 'stale-conversation',
+      appSourceType: AppSourceType.webApp,
+    }
+    mockFetchChatList.mockRejectedValue(new Response(null, { status: 404 }))
+
+    const { result } = renderHook(() => useShareChatList(params), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(mockFetchChatList).toHaveBeenCalledTimes(1)
+  })
+
   it('should always consider data stale to ensure fresh data on conversation switch (GitHub #30378)', async () => {
     // This test verifies that chat list data is always considered stale (staleTime: 0)
     // which ensures fresh data is fetched when switching back to a conversation.

--- a/web/service/use-share.ts
+++ b/web/service/use-share.ts
@@ -164,6 +164,14 @@ export const useShareChatList = (params: ShareChatListParams, options: ShareQuer
     // back to a conversation. This fixes issue where recent messages don't appear
     // until switching away and back again (GitHub issue #30378).
     staleTime: 0,
+    // Do not retry when the conversation no longer exists server-side (either a
+    // plain 404 or the environment-specific not-found error); the hook layer
+    // clears the stale id. Other errors keep the default 3 retries.
+    retry: (failureCount, error) => {
+      if (error instanceof Response && error.status === 404) return false
+      if (error instanceof EnvironmentConversationNotFoundError) return false
+      return failureCount < 3
+    },
   })
 }
 


### PR DESCRIPTION
## Summary

Fixes the infinite 404 loop when a Web App chatbot has a stale `conversation_id` in `localStorage` (deleted server-side or cleaned up by `ENABLE_CONVERSATION_CLEANUP_TASK`).

- **`useShareChatList`**: disable TanStack Query retries for 404 responses and `EnvironmentConversationNotFoundError`
- **`embedded-chatbot` / `chat-with-history` hooks**: consume the query error; on plain 404, clear stale id via `removeConversationIdInfo()` and reset chat state
- **Tests**: added coverage in all three affected test files (123 tests pass)

Fixes #42194 (same root cause as #39484).

## Test plan

- [x] `vitest run service/use-share.spec.tsx`
- [x] `vitest run app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx`
- [x] `vitest run app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx`