### PR TITLE
fix(api): repair legacy dataset api-keys route and surface retrieval quota errors

### DIFF
--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -21,6 +21,7 @@ from models import Account
 from models.dataset import Dataset
 from models.enums import ApiTokenType
 from models.model import ApiToken, App
+from services import dataset_api_key_service
 from services.api_token_service import ApiTokenCache
 from services.app_service import AppService
 
@@ -320,6 +321,9 @@ class AppApiKeyResource(BaseApiKeyResource):
 # The per-dataset routes below remain for callers that key an API token to a single dataset.
 @console_ns.route("/datasets/<uuid:resource_id>/api-keys")
 class DatasetApiKeyListResource(BaseApiKeyListResource):
+    max_keys = 10
+    token_prefix = "ds-"
+
     @console_ns.doc("get_dataset_api_keys")
     @console_ns.doc(description="Get all API keys for a dataset")
     @console_ns.doc(params={"resource_id": "Dataset ID"})
@@ -330,10 +334,11 @@ class DatasetApiKeyListResource(BaseApiKeyListResource):
     @with_session(write=False)
     def get(self, session: Session, current_tenant_id: str, resource_id: UUID) -> dict[str, object]:
         """Get all API keys for a dataset"""
-        return dump_response(
-            ApiKeyList,
-            self._get_api_key_list(str(resource_id), current_tenant_id, session=session),  # pyrefly: ignore[unnecessary-type-conversion]
-        )
+        dataset_id = str(resource_id)
+        _get_resource(dataset_id, current_tenant_id, Dataset, session=session)
+        keys = dataset_api_key_service.list_keys_for_dataset(session, current_tenant_id, dataset_id)
+        bindings_by_token = dataset_api_key_service.list_bindings_by_token(session, [str(key.id) for key in keys])
+        return dump_response(ApiKeyList, build_masked_api_key_list(keys, bindings_by_token))
 
     @console_ns.doc("create_dataset_api_key")
     @console_ns.doc(description="Create a new API key for a dataset")
@@ -346,19 +351,31 @@ class DatasetApiKeyListResource(BaseApiKeyListResource):
     @with_session
     def post(self, session: Session, current_tenant_id: str, resource_id: UUID) -> tuple[dict[str, object], int]:
         """Create a new API key for a dataset"""
-        return dump_response(
-            ApiKeyItem,
-            self._create_api_key(str(resource_id), current_tenant_id, session=session),  # pyrefly: ignore[unnecessary-type-conversion]
-        ), 201
-
-    resource_type = ApiTokenType.DATASET
-    resource_model = Dataset
-    resource_id_field = "dataset_id"
-    token_prefix = "ds-"
+        dataset_id = str(resource_id)
+        _get_resource(dataset_id, current_tenant_id, Dataset, session=session)
+        try:
+            api_token = dataset_api_key_service.create_key_for_dataset(
+                session,
+                current_tenant_id,
+                dataset_id,
+                token_prefix=self.token_prefix,
+                max_keys=self.max_keys,
+            )
+        except ValueError as error:
+            flask_restx.abort(
+                HTTPStatus.BAD_REQUEST,
+                message=str(error),
+                custom="max_keys_exceeded",
+            )
+        item = ApiKeyItem.model_validate(api_token, from_attributes=True)
+        item.dataset_ids = [dataset_id]
+        return dump_response(ApiKeyItem, item), 201
 
 
 @console_ns.route("/datasets/<uuid:resource_id>/api-keys/<uuid:api_key_id>")
 class DatasetApiKeyResource(BaseApiKeyResource):
+    resource_type = ApiTokenType.DATASET
+
     @console_ns.doc("delete_dataset_api_key")
     @console_ns.doc(description="Delete an API key for a dataset")
     @console_ns.doc(params={"resource_id": "Dataset ID", "api_key_id": "API key ID"})
@@ -376,15 +393,25 @@ class DatasetApiKeyResource(BaseApiKeyResource):
         api_key_id: UUID,
     ) -> tuple[str, int]:
         """Delete an API key for a dataset"""
-        self._delete_api_key(
-            str(resource_id),  # pyrefly: ignore[unnecessary-type-conversion]
-            str(api_key_id),
-            current_tenant_id,
-            current_user,
-            session=session,
-        )
-        return "", 204
+        dataset_id = str(resource_id)
+        api_key_id_str = str(api_key_id)
+        _get_resource(dataset_id, current_tenant_id, Dataset, session=session)
 
-    resource_type = ApiTokenType.DATASET
-    resource_model = Dataset
-    resource_id_field = "dataset_id"
+        if not dify_config.RBAC_ENABLED and not current_user.is_admin_or_owner:
+            raise Forbidden()
+
+        key = session.scalar(
+            select(ApiToken)
+            .where(
+                ApiToken.tenant_id == current_tenant_id,
+                ApiToken.type == self.resource_type,
+                ApiToken.id == api_key_id_str,
+            )
+            .limit(1)
+        )
+        if key is None or not dataset_api_key_service.key_can_access_dataset(session, api_key_id_str, dataset_id):
+            flask_restx.abort(HTTPStatus.NOT_FOUND, message="API key not found")
+
+        ApiTokenCache.delete(key.token, key.type)
+        session.delete(key)
+        return "", 204

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -33,6 +33,7 @@ from core.callback_handler.index_tool_callback_handler import DatasetIndexToolCa
 from core.db.session_factory import session_factory
 from core.entities.agent_entities import PlanningStrategy
 from core.entities.model_entities import ModelStatus
+from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.memory.token_buffer_memory import TokenBufferMemory
 from core.model_context import with_credit_usage_created_by, with_credit_usage_metadata
 from core.model_manager import ModelInstance, ModelManager
@@ -108,6 +109,19 @@ default_retrieval_model: DefaultRetrievalModelDict = {
 }
 
 logger = logging.getLogger(__name__)
+
+_RETRIEVER_FATAL_ERRORS = (
+    QuotaExceededError,
+    ProviderTokenNotInitError,
+    ModelCurrentlyNotSupportError,
+    exc.KnowledgeRetrievalNodeError,
+)
+
+
+def _should_propagate_retriever_error(error: Exception) -> bool:
+    """Quota and credential failures must not be swallowed by per-dataset skip logic."""
+    return isinstance(error, _RETRIEVER_FATAL_ERRORS)
+
 
 _POSTGRES_DEADLOCK_SQLSTATE = "40P01"
 _HIT_COUNT_UPDATE_MAX_ATTEMPTS = 3
@@ -1273,7 +1287,7 @@ class DatasetRetrieval:
                 attachment_ids=attachment_ids,
             )
         except Exception as exc:
-            if skip_on_error:
+            if skip_on_error and not _should_propagate_retriever_error(exc):
                 logger.warning(
                     "Skipping dataset retrieval because retriever failed, dataset_id=%s, error_type=%s, error=%s",
                     dataset_id,

--- a/api/services/dataset_api_key_service.py
+++ b/api/services/dataset_api_key_service.py
@@ -17,6 +17,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from models.dataset import Dataset
+from models.enums import ApiTokenType
 from models.model import ApiToken, DatasetApiTokenBinding
 
 
@@ -63,6 +64,51 @@ def bind_datasets(session: Session, api_token_id: str, dataset_ids: Iterable[str
     """Add one binding row per dataset id. The caller controls the transaction."""
     for dataset_id in dataset_ids:
         session.add(DatasetApiTokenBinding(api_token_id=api_token_id, dataset_id=dataset_id))
+
+
+def key_can_access_dataset(session: Session, api_token_id: str, dataset_id: str) -> bool:
+    """Return whether a dataset API key may access the given knowledge base."""
+    bound_dataset_ids = get_bound_dataset_ids(session, api_token_id)
+    return not bound_dataset_ids or dataset_id in bound_dataset_ids
+
+
+def list_keys_for_dataset(session: Session, tenant_id: str, dataset_id: str) -> list[ApiToken]:
+    """Return dataset API keys that can access ``dataset_id`` (unrestricted or bound)."""
+    keys = session.scalars(
+        select(ApiToken).where(ApiToken.tenant_id == tenant_id, ApiToken.type == ApiTokenType.DATASET)
+    ).all()
+    bindings_by_token = list_bindings_by_token(session, [str(key.id) for key in keys])
+    return [
+        key for key in keys if not bindings_by_token.get(str(key.id)) or dataset_id in bindings_by_token[str(key.id)]
+    ]
+
+
+def count_keys_for_dataset(session: Session, tenant_id: str, dataset_id: str) -> int:
+    """Count dataset API keys that can access ``dataset_id``."""
+    return len(list_keys_for_dataset(session, tenant_id, dataset_id))
+
+
+def create_key_for_dataset(
+    session: Session,
+    tenant_id: str,
+    dataset_id: str,
+    *,
+    token_prefix: str,
+    max_keys: int,
+) -> ApiToken:
+    """Create a dataset API key scoped to a single knowledge base."""
+    if count_keys_for_dataset(session, tenant_id, dataset_id) >= max_keys:
+        raise ValueError(f"Cannot create more than {max_keys} API keys for this resource type.")
+
+    key = ApiToken.generate_api_key(token_prefix, 24, session=session)
+    api_token = ApiToken()
+    api_token.tenant_id = tenant_id
+    api_token.token = key
+    api_token.type = ApiTokenType.DATASET
+    session.add(api_token)
+    session.flush()
+    bind_datasets(session, api_token.id, [dataset_id])
+    return api_token
 
 
 def delete_keys_scoped_only_to(session: Session, dataset_id: str) -> list[str]:

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -3815,6 +3815,33 @@ class TestKnowledgeRetrievalRegression:
         assert "dataset_id=dataset-1" in caplog.text
         assert "Skipping dataset retrieval because retriever failed" in caplog.text
 
+    def test_run_retriever_thread_safely_propagates_quota_errors_when_skip_requested(self):
+        from core.errors.error import QuotaExceededError
+
+        dataset_retrieval = DatasetRetrieval()
+        all_documents: list[Document] = []
+        cancel_event = threading.Event()
+        thread_exceptions: list[Exception] = []
+        expected_error = QuotaExceededError("Model quota has been exceeded")
+
+        with patch.object(dataset_retrieval, "_retriever", side_effect=expected_error):
+            dataset_retrieval._run_retriever_thread_safely(
+                flask_app=_FakeFlaskApp(),
+                dataset_id="dataset-1",
+                query="test query",
+                top_k=3,
+                all_documents=all_documents,
+                document_ids_filter=None,
+                metadata_condition=None,
+                attachment_ids=None,
+                cancel_event=cancel_event,
+                thread_exceptions=thread_exceptions,
+                skip_on_error=True,
+            )
+
+        assert cancel_event.is_set()
+        assert thread_exceptions == [expected_error]
+
     def test_multiple_retrieve_thread_skips_failed_dataset(self, mock_dataset, caplog):
         dataset_retrieval = DatasetRetrieval()
         flask_app = Flask(__name__)

--- a/api/tests/unit_tests/services/test_dataset_api_key_service.py
+++ b/api/tests/unit_tests/services/test_dataset_api_key_service.py
@@ -5,6 +5,7 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from models.dataset import Dataset
 from models.enums import ApiTokenType
 from models.model import ApiToken, DatasetApiTokenBinding
 from services import dataset_api_key_service
@@ -19,6 +20,53 @@ def _dataset_token(session: Session) -> ApiToken:
     )
     session.add(token)
     return token
+
+
+class TestListKeysForDataset:
+    def test_lists_unrestricted_and_bound_keys(self, sqlite_session: Session) -> None:
+        dataset_id = str(uuid.uuid4())
+        other_dataset_id = str(uuid.uuid4())
+        tenant_id = str(uuid.uuid4())
+        unrestricted = _dataset_token(sqlite_session)
+        unrestricted.tenant_id = tenant_id
+        bound = _dataset_token(sqlite_session)
+        bound.tenant_id = tenant_id
+        foreign = _dataset_token(sqlite_session)
+        foreign.tenant_id = tenant_id
+        sqlite_session.add(DatasetApiTokenBinding(api_token_id=bound.id, dataset_id=dataset_id))
+        sqlite_session.add(DatasetApiTokenBinding(api_token_id=foreign.id, dataset_id=other_dataset_id))
+        sqlite_session.commit()
+
+        keys = dataset_api_key_service.list_keys_for_dataset(sqlite_session, tenant_id, dataset_id)
+
+        assert {key.id for key in keys} == {unrestricted.id, bound.id}
+
+    def test_create_key_for_dataset_persists_binding(self, sqlite_session: Session) -> None:
+        tenant_id = str(uuid.uuid4())
+        dataset_id = str(uuid.uuid4())
+        dataset = Dataset(
+            id=dataset_id,
+            tenant_id=tenant_id,
+            name="Dataset",
+            data_source_type="upload_file",
+            created_by=str(uuid.uuid4()),
+            permission="only_me",
+            provider="vendor",
+        )
+        sqlite_session.add(dataset)
+        sqlite_session.commit()
+
+        api_token = dataset_api_key_service.create_key_for_dataset(
+            sqlite_session,
+            tenant_id,
+            dataset_id,
+            token_prefix="ds-",
+            max_keys=2,
+        )
+        sqlite_session.commit()
+
+        assert api_token.token.startswith("ds-")
+        assert dataset_api_key_service.get_bound_dataset_ids(sqlite_session, api_token.id) == {dataset_id}
 
 
 class TestDeleteKeysScopedOnlyTo:


### PR DESCRIPTION
## Summary

Addresses two root causes reported in #42087:

### 1. `GET /console/api/datasets/{dataset_id}/api-keys` → 500

`ApiToken` no longer has a `dataset_id` column — scoping moved to `DatasetApiTokenBinding`. The legacy per-dataset route still queried `ApiToken.dataset_id`, which raises at runtime and returns 500.

**Fix:** migrate the legacy route to the binding model (same semantics as workspace-level `/datasets/api-keys`):
- **GET** — list unrestricted keys + keys bound to the dataset
- **POST** — create a key scoped to that dataset via binding
- **DELETE** — delete key if it can access the dataset

### 2. Workflow Knowledge Retrieval returns `{"result":[]}` while Retrieval Testing works

`DatasetRetrieval._multiple_retrieve_thread` uses `skip_on_error=True` for per-dataset threads, which **silently swallowed** quota/credential failures (e.g. exhausted Dify Cloud credits). The workflow node then succeeded with an empty result instead of surfacing the error.

**Fix:** propagate fatal errors (`QuotaExceededError`, `ProviderTokenNotInitError`, `ModelCurrentlyNotSupportError`, `KnowledgeRetrievalNodeError`) even when `skip_on_error` is enabled.

## Notes

- The supported API key UI uses `GET /console/api/datasets/api-keys` (Knowledge list → Service API popover). The legacy per-dataset route is now fixed for API consumers still calling it.
- Cloud BYOK vs exhausted workspace credits may still need separate billing investigation if Service API continues to bill against Dify credits despite custom Gemini keys.

Fixes #42087

## Test plan

- [x] `pytest tests/unit_tests/services/test_dataset_api_key_service.py`
- [x] `pytest tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py::TestKnowledgeRetrievalRegression::test_run_retriever_thread_safely_propagates_quota_errors_when_skip_requested`