### PR TITLE
fix: ignore blank keyword rows in moderation limit

### DIFF
--- a/api/core/moderation/keywords/keywords.py
+++ b/api/core/moderation/keywords/keywords.py
@@ -25,8 +25,8 @@ class KeywordsModeration(Moderation):
         if len(config.get("keywords", [])) > 10000:
             raise ValueError("keywords length must be less than 10000")
 
-        keywords_row_len = config["keywords"].split("\n")
-        if len(keywords_row_len) > 100:
+        keywords_rows = cls._keyword_rows(config["keywords"])
+        if len(keywords_rows) > 100:
             raise ValueError("the number of rows for the keywords must be less than 100")
 
     @override

--- a/api/tests/unit_tests/core/moderation/test_keyword_row_validation.py
+++ b/api/tests/unit_tests/core/moderation/test_keyword_row_validation.py
@@ -1,0 +1,11 @@
+from core.moderation.keywords.keywords import KeywordsModeration
+
+
+def test_validate_config_ignores_trailing_blank_keyword_row() -> None:
+    config = {
+        "inputs_config": {"enabled": True, "preset_response": "Blocked"},
+        "outputs_config": {"enabled": False},
+        "keywords": "\n".join(f"word{i}" for i in range(100)) + "\n",
+    }
+
+    KeywordsModeration.validate_config("tenant", config)


### PR DESCRIPTION
## Summary

Fixes #42211.

Follow-up to #42048: keyword moderation already strips whitespace and drops empty rows at runtime, but `validate_config()` still counted the raw `split("\n")` rows when enforcing the 100-row limit.

That means exactly 100 real keywords plus a common trailing newline are counted as 101 rows and rejected even though moderation would ignore the blank row.

This change reuses the existing `_keyword_rows()` normalization for the row-limit check so validation and runtime use the same definition of a keyword row.

## Scope

- `api/core/moderation/keywords/keywords.py`: enforce the 100-row limit on normalized non-empty rows.
- Add a focused regression test for 100 keywords plus a trailing newline.

No change to matching semantics, the 10,000-character limit, or the 100 effective-keyword limit.

## Testing

The regression is constructed directly against `KeywordsModeration.validate_config()`: before this change, 100 keywords plus `\n` raises the row-limit error; after the change it validates successfully.

CI is the authority for full repository checks.

## Checklist

- [ ] This change requires a documentation update — not needed.
- [x] I understand that this PR may be closed in case there was no previous discussion or issue.
- [x] I've added focused regression coverage for the changed validation behavior.

From ChatGPT