### PR TITLE
docs: sync Japanese README observability and help links

### DIFF
--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -66,7 +66,7 @@
   <a href="https://trendshift.io/repositories/2152" target="_blank"><img src="https://trendshift.io/api/badge/repositories/2152" alt="langgenius%2Fdify | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 
-DifyはオープンソースのLLMアプリケーション開発プラットフォームです。直感的なインターフェイスには、AIワークフロー、RAGパイプライン、エージェント機能、モデル管理、観測機能などが組み合わさっており、プロトタイプから生産まで迅速に進めることができます。以下の機能が含まれます：
+DifyはオープンソースのLLMアプリケーション開発プラットフォームです。直感的なインターフェイスには、AIワークフロー、RAGパイプライン、エージェント機能、モデル管理、[Opik](https://www.comet.com/docs/opik/integrations/dify)、[Langfuse](https://docs.langfuse.com)、[Arize Phoenix](https://docs.arize.com/phoenix)を含む観測機能などが組み合わさっており、プロトタイプから生産まで迅速に進めることができます。以下の機能が含まれます：
 </br> </br>
 
 **1. ワークフロー**:
@@ -128,6 +128,10 @@ docker compose up -d
 ```
 
 実行後、ブラウザで[http://localhost/install](http://localhost/install)にアクセスし、初期化プロセスを開始できます。
+
+#### ヘルプが必要な場合
+
+Difyのセットアップで問題が発生した場合は、[FAQ](https://docs.dify.ai/getting-started/install-self-hosted/faqs)をご確認ください。それでも解決しない場合は、[コミュニティとお問い合わせ](#コミュニティ--お問い合わせ)をご利用ください。
 
 > Difyに貢献したり、追加の開発を行う場合は、[ソースコードからのデプロイガイド](https://docs.dify.ai/getting-started/install-self-hosted/local-source-code)を参照してください。
 


### PR DESCRIPTION
## Summary

Fixes #42213.

Bring the Japanese README back in sync with two recent root README updates:

- include the current Opik, Langfuse, and Arize Phoenix observability integration links in the introduction;
- add the setup FAQ / community help guidance after Quick Start.

This is the same class of localized README drift recently corrected for Simplified Chinese in #42161, scoped only to the Japanese README.

## Scope

- 1 file
- 6 additions / 2 deletions
- no code, dependency, or product behavior changes

## Validation

Compared the two updated sections directly against the current root README and preserved the existing Japanese structure and links.

## Checklist

- [x] Documentation-only change.
- [x] I understand that this PR may be closed if there was no previous discussion or issue.
- [x] No generated files or runtime tests are required for this README-only synchronization.

From ChatGPT