### PR TITLE
fix(api): parse first unfenced JSON value

### DIFF
--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -15,6 +15,16 @@ def parse_json_markdown(json_string: str):
     start_candidates = [i for i in (json_string.find("{"), json_string.find("[")) if i != -1]
     if start_candidates:
         start_index = min(start_candidates)
+
+        # For unfenced model output, decode the first complete JSON value instead
+        # of greedily slicing through the last closing bracket. This preserves a
+        # valid first object when the model emits another JSON object afterwards.
+        # Keep fenced output on the existing path so multiple explicit JSON
+        # blocks remain an error rather than being silently ignored.
+        if "```" not in json_string:
+            parsed, _ = json.JSONDecoder().raw_decode(json_string[start_index:])
+            return parsed
+
         end_index = max(json_string.rfind("}"), json_string.rfind("]"))
         if end_index != -1 and start_index < end_index:
             end_index += 1

--- a/api/tests/unit_tests/libs/test_json_in_md_parser_multiple_values.py
+++ b/api/tests/unit_tests/libs/test_json_in_md_parser_multiple_values.py
@@ -1,0 +1,7 @@
+from libs.json_in_md_parser import parse_json_markdown
+
+
+def test_parse_json_markdown_uses_first_unfenced_json_value() -> None:
+    src = '{"category_id": "first"}\n{"category_id": "second"}'
+
+    assert parse_json_markdown(src) == {"category_id": "first"}


### PR DESCRIPTION
## Summary

Fixes #42006.

`parse_json_markdown()` currently slices from the first opening `{` / `[` to the last closing `}` / `]`. When an LLM returns two unfenced JSON objects, that combines both values into one string and `json.loads()` raises `JSONDecodeError: Extra data`, even though the first object is valid.

For unfenced output, use `json.JSONDecoder().raw_decode()` from the first JSON token so the parser consumes the first complete JSON value and ignores a subsequent value.

The existing behavior for multiple explicit fenced JSON blocks is intentionally preserved: fenced output stays on the current extraction path, so ambiguous multiple fenced blocks still fail rather than silently selecting one.

## Scope

- `api/libs/json_in_md_parser.py`: use `raw_decode()` only for unfenced bracketed JSON output.
- Add a focused regression test for two consecutive unfenced JSON objects.

No changes to expected-key validation, single-item list unwrapping, fenced scalar parsing, or the existing multiple-fenced-block behavior.

## Testing

Added `test_parse_json_markdown_uses_first_unfenced_json_value`, which reproduces the reported `Extra data` shape with two adjacent JSON objects and asserts the first object is returned.

CI is the authority for the full repository checks.

## Checklist

- [ ] Documentation update required — not needed.
- [x] This PR is linked to an existing bug report.
- [x] Added focused regression coverage for the changed parser behavior.

From ChatGPT