### PR TITLE
fix(web): send MCP provider delete params in query

### DIFF
--- a/web/service/__tests__/use-tools.spec.tsx
+++ b/web/service/__tests__/use-tools.spec.tsx
@@ -3,15 +3,16 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { renderHook } from '@/test/console/render'
-import { useAllToolProviders, useRefreshMCPServerCode } from '../use-tools'
+import { useAllToolProviders, useDeleteMCP, useRefreshMCPServerCode } from '../use-tools'
 
-const { mockGet, mockPost } = vi.hoisted(() => ({
+const { mockDel, mockGet, mockPost } = vi.hoisted(() => ({
+  mockDel: vi.fn(),
   mockGet: vi.fn(),
   mockPost: vi.fn(),
 }))
 
 vi.mock('@/service/base', () => ({
-  del: vi.fn(),
+  del: mockDel,
   get: mockGet,
   post: mockPost,
   put: vi.fn(),
@@ -66,6 +67,29 @@ describe('useRefreshMCPServerCode', () => {
       },
     })
     expect(mockGet).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDeleteMCP', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends provider_id as a DELETE query parameter', async () => {
+    const providerId = '123e4567-e89b-12d3-a456-426614174000'
+    const { result } = renderHook(() => useDeleteMCP({}), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync(providerId)
+    })
+
+    expect(mockDel).toHaveBeenCalledWith('/workspaces/current/tool-provider/mcp', {
+      params: {
+        provider_id: providerId,
+      },
+    })
   })
 })
 

--- a/web/service/use-tools.ts
+++ b/web/service/use-tools.ts
@@ -150,7 +150,7 @@ export const useDeleteMCP = ({ onSuccess }: { onSuccess?: () => void }) => {
     mutationKey: [NAME_SPACE, 'delete-mcp'],
     mutationFn: (id: string) => {
       return del('/workspaces/current/tool-provider/mcp', {
-        body: {
+        params: {
           provider_id: id,
         },
       })


### PR DESCRIPTION
## Summary

Fixes #42218.

`useDeleteMCP()` still sent `provider_id` in a DELETE request body. Dify's shared DELETE request validation already accepts query parameters first and retains JSON-body fallback compatibility, so the Web client can use the safer query form without changing backend behavior.

### Changes

- send MCP provider `provider_id` through `params` instead of `body`;
- add focused `useDeleteMCP` service-hook coverage that asserts the DELETE request shape using a valid UUID provider ID.

This is the same transport fix class as the adjacent model credential DELETE changes in #42162, but deliberately keeps this PR scoped to the browser runtime path. The endpoint's OpenAPI body annotation can be cleaned up separately together with generated-contract regeneration.

## Validation

The regression test exercises the mutation and asserts:

```ts
del('/workspaces/current/tool-provider/mcp', {
  params: { provider_id: '123e4567-e89b-12d3-a456-426614174000' },
})
```

No backend/service semantics are changed, and older body-based callers remain supported by the existing DELETE body fallback.

From ChatGPT