### PR TITLE
fix(api): preserve literal NA in annotation CSV imports

### DIFF
--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -481,6 +481,7 @@ class AppAnnotationService:
             df = pd.read_csv(
                 file.stream,
                 dtype=str,
+                keep_default_na=False,
                 nrows=max_records + 1,  # Read one extra to detect overflow
                 engine="python",
                 on_bad_lines="skip",  # Skip malformed lines instead of crashing

--- a/api/tests/unit_tests/services/test_annotation_import_literal_na.py
+++ b/api/tests/unit_tests/services/test_annotation_import_literal_na.py
@@ -22,11 +22,7 @@ def test_batch_import_preserves_literal_na(monkeypatch: pytest.MonkeyPatch) -> N
     session = MagicMock()
     session.scalar.return_value = SimpleNamespace(id="app-1")
     file = FileStorage(
-        stream=BytesIO(
-            b"question,answer\n"
-            b"NA,valid answer\n"
-            b"valid question,NA\n"
-        ),
+        stream=BytesIO(b"question,answer\nNA,valid answer\nvalid question,NA\n"),
         filename="annotations.csv",
         content_type="text/csv",
     )

--- a/api/tests/unit_tests/services/test_annotation_import_literal_na.py
+++ b/api/tests/unit_tests/services/test_annotation_import_literal_na.py
@@ -1,0 +1,51 @@
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from werkzeug.datastructures import FileStorage
+
+import services.annotation_service as annotation_service_module
+from enums import DeploymentEdition
+from services.annotation_service import AppAnnotationService
+from tests.unit_tests.config_override import config_overrides_context
+
+
+def test_batch_import_preserves_literal_na(monkeypatch: pytest.MonkeyPatch) -> None:
+    account = SimpleNamespace(id="account-1")
+    monkeypatch.setattr(
+        annotation_service_module,
+        "current_account_with_tenant",
+        lambda: (account, "tenant-1"),
+    )
+
+    session = MagicMock()
+    session.scalar.return_value = SimpleNamespace(id="app-1")
+    file = FileStorage(
+        stream=BytesIO(
+            b"question,answer\n"
+            b"NA,valid answer\n"
+            b"valid question,NA\n"
+        ),
+        filename="annotations.csv",
+        content_type="text/csv",
+    )
+
+    with (
+        patch.object(annotation_service_module, "batch_import_annotations_task") as task,
+        patch.object(annotation_service_module, "redis_client"),
+        patch.object(annotation_service_module.uuid, "uuid4", return_value="job-1"),
+        config_overrides_context(
+            DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
+            ANNOTATION_IMPORT_MAX_RECORDS=5,
+            ANNOTATION_IMPORT_MIN_RECORDS=1,
+        ),
+    ):
+        result = AppAnnotationService.batch_import_app_annotations("app-1", file, session)
+
+    assert result == {"job_id": "job-1", "job_status": "waiting", "record_count": 2}
+    task.delay.assert_called_once()
+    assert task.delay.call_args.args[1] == [
+        {"question": "NA", "answer": "valid answer"},
+        {"question": "valid question", "answer": "NA"},
+    ]


### PR DESCRIPTION
## Summary

Fixes #42220.

Annotation CSV import uses `pd.read_csv(..., dtype=str)` but left Pandas' default NA detection enabled. A literal `NA` question or answer was therefore converted to `NaN` and then dropped by the existing `nan` guard instead of being imported as text.

This is the same Pandas NA-inference bug class already fixed for batch segment CSV import in #42159.

## Changes

- set `keep_default_na=False` for annotation CSV parsing;
- add a focused regression using the real CSV parser for both `NA` in the question column and `NA` in the answer column.

The change is intentionally bounded: row limits, malformed-line handling, length validation, empty-field handling, and quota behavior are unchanged.

## Validation

The regression feeds:

```csv
question,answer
NA,valid answer
valid question,NA
```

and asserts both annotations reach `batch_import_annotations_task` with the literal `NA` values preserved.

Final diff against the PR base is 2 files: one production-line addition plus the focused regression test. CI is the authority for the repository checks.

## Checklist

- [ ] Documentation update required — not needed; no user-facing API/configuration change.
- [x] Linked to an existing bug report.
- [x] Added focused regression coverage for the changed behavior.

From ChatGPT