### PR TITLE
fix(web): hide installed plugins from remaining marketplace selectors

### DIFF
--- a/web/app/components/workflow/block-selector/__tests__/installed-marketplace-filtering.spec.tsx
+++ b/web/app/components/workflow/block-selector/__tests__/installed-marketplace-filtering.spec.tsx
@@ -1,0 +1,153 @@
+import type { ReactElement } from 'react'
+import type { ToolWithProvider } from '../../types'
+import type { TriggerWithProvider } from '../types'
+import { screen, within } from '@testing-library/react'
+import { useMarketplacePlugins } from '@/app/components/plugins/marketplace/query'
+import { useFeaturedTriggersRecommendations } from '@/service/use-plugins'
+import { useAllTriggerPlugins, useInvalidateAllTriggerPlugins } from '@/service/use-triggers'
+import { renderWithConsoleQuery } from '@/test/console/query-data'
+import { BlockEnum } from '../../types'
+import AllStartBlocks from '../all-start-blocks'
+import DataSources from '../data-sources'
+import { createPlugin } from './factories'
+
+vi.mock('@/context/i18n', () => ({
+  useGetLanguage: vi.fn(() => 'en_US'),
+  useLocale: vi.fn(() => 'en_US'),
+}))
+
+vi.mock('@/hooks/use-theme', () => ({
+  default: vi.fn(() => ({ theme: 'light' })),
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: unknown) => (typeof key === 'string' ? key : 'translated'),
+    }),
+  }
+})
+
+vi.mock('@/app/components/plugins/marketplace/query', () => ({
+  useMarketplacePlugins: vi.fn(),
+}))
+
+vi.mock('@/service/use-triggers', () => ({
+  useAllTriggerPlugins: vi.fn(),
+  useInvalidateAllTriggerPlugins: vi.fn(),
+}))
+
+vi.mock('@/service/use-plugins', () => ({
+  useFeaturedTriggersRecommendations: vi.fn(),
+}))
+
+vi.mock('../tools', () => ({ default: () => null }))
+vi.mock('../start-blocks', () => ({ default: () => null }))
+vi.mock('../trigger-plugin/list', () => ({ default: () => null }))
+vi.mock('../featured-triggers', () => ({ default: () => null }))
+
+vi.mock('../marketplace-plugin/list', async () => {
+  const { forwardRef } = await import('react')
+  return {
+    default: forwardRef<HTMLDivElement, { list: Array<{ plugin_id: string }> }>(({ list }, ref) => (
+      <div ref={ref} data-testid="marketplace-list">
+        {list.map((plugin) => (
+          <span key={plugin.plugin_id}>{plugin.plugin_id}</span>
+        ))}
+      </div>
+    )),
+  }
+})
+
+const mockUseMarketplacePlugins = vi.mocked(useMarketplacePlugins)
+const mockUseAllTriggerPlugins = vi.mocked(useAllTriggerPlugins)
+const mockUseInvalidateAllTriggerPlugins = vi.mocked(useInvalidateAllTriggerPlugins)
+const mockUseFeaturedTriggersRecommendations = vi.mocked(useFeaturedTriggersRecommendations)
+
+const render = (ui: ReactElement) =>
+  renderWithConsoleQuery(ui, {
+    systemFeatures: { enable_marketplace: true },
+  })
+
+const marketplaceResult = (installedPluginId: string, availablePluginId: string) =>
+  ({
+    data: {
+      pages: [
+        {
+          plugins: [
+            createPlugin({ plugin_id: installedPluginId }),
+            createPlugin({ plugin_id: availablePluginId }),
+          ],
+          page: 1,
+          page_size: 40,
+          total: 2,
+        },
+      ],
+      pageParams: [1],
+    },
+    isFetching: false,
+  }) as ReturnType<typeof useMarketplacePlugins>
+
+describe('installed marketplace plugin filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseInvalidateAllTriggerPlugins.mockReturnValue(vi.fn())
+    mockUseFeaturedTriggersRecommendations.mockReturnValue({
+      plugins: [],
+      isLoading: false,
+    } as ReturnType<typeof useFeaturedTriggersRecommendations>)
+  })
+
+  it('excludes installed data-source plugins from marketplace search results', () => {
+    mockUseMarketplacePlugins.mockReturnValue(
+      marketplaceResult('installed-datasource', 'available-datasource'),
+    )
+    const installedProvider = {
+      id: 'installed-datasource/provider',
+      plugin_id: 'installed-datasource',
+      name: 'installed-datasource',
+      tools: [],
+    } as ToolWithProvider
+
+    render(
+      <DataSources
+        searchText="datasource"
+        onSelect={vi.fn()}
+        dataSources={[installedProvider]}
+      />,
+    )
+
+    const marketplaceList = screen.getByTestId('marketplace-list')
+    expect(within(marketplaceList).queryByText('installed-datasource')).not.toBeInTheDocument()
+    expect(within(marketplaceList).getByText('available-datasource')).toBeInTheDocument()
+  })
+
+  it('excludes installed trigger plugins from marketplace search results', () => {
+    mockUseMarketplacePlugins.mockReturnValue(
+      marketplaceResult('installed-trigger', 'available-trigger'),
+    )
+    mockUseAllTriggerPlugins.mockReturnValue({
+      data: [
+        {
+          id: 'installed-trigger/provider',
+          plugin_id: 'installed-trigger',
+          plugin_unique_identifier: 'installed-trigger@1.0.0',
+        } as TriggerWithProvider,
+      ],
+    } as ReturnType<typeof useAllTriggerPlugins>)
+
+    render(
+      <AllStartBlocks
+        searchText="trigger"
+        onSelect={vi.fn()}
+        availableBlocksTypes={[BlockEnum.TriggerPlugin]}
+      />,
+    )
+
+    const marketplaceList = screen.getByTestId('marketplace-list')
+    expect(within(marketplaceList).queryByText('installed-trigger')).not.toBeInTheDocument()
+    expect(within(marketplaceList).getByText('available-trigger')).toBeInTheDocument()
+  })
+})

--- a/web/app/components/workflow/block-selector/all-start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/all-start-blocks.tsx
@@ -118,8 +118,11 @@ function AllStartBlocks({
   const { data: marketplacePluginsData, isFetching: isMarketplaceFetching } =
     useMarketplacePlugins(marketplaceSearchParams)
   const marketplacePlugins = useMemo(
-    () => marketplacePluginsData?.pages.flatMap((page) => page.plugins) ?? [],
-    [marketplacePluginsData?.pages],
+    () =>
+      marketplacePluginsData?.pages.flatMap((page) =>
+        page.plugins.filter((plugin) => !providerMap.has(plugin.plugin_id)),
+      ) ?? [],
+    [marketplacePluginsData?.pages, providerMap],
   )
 
   const shouldShowFeatured = enableTriggerPlugin && enable_marketplace && !hasFilter

--- a/web/app/components/workflow/block-selector/data-sources.tsx
+++ b/web/app/components/workflow/block-selector/data-sources.tsx
@@ -106,9 +106,16 @@ function DataSources({
     ],
   )
   const { data: marketplacePluginsData } = useMarketplacePlugins(marketplaceSearchParams)
+  const installedPluginIds = useMemo(
+    () => new Set(dataSources.map((provider) => provider.plugin_id || provider.id)),
+    [dataSources],
+  )
   const notInstalledPlugins = useMemo(
-    () => marketplacePluginsData?.pages.flatMap((page) => page.plugins) ?? [],
-    [marketplacePluginsData?.pages],
+    () =>
+      marketplacePluginsData?.pages.flatMap((page) =>
+        page.plugins.filter((plugin) => !installedPluginIds.has(plugin.plugin_id)),
+      ) ?? [],
+    [installedPluginIds, marketplacePluginsData?.pages],
   )
 
   return (

--- a/web/app/components/workflow/nodes/_base/components/__tests__/agent-strategy-marketplace-filtering.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/agent-strategy-marketplace-filtering.spec.tsx
@@ -1,0 +1,125 @@
+import type { ReactNode } from 'react'
+import type { StrategyPluginDetail } from '@/app/components/plugins/types'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { AgentStrategySelector } from '../agent-strategy-selector'
+
+const mocks = vi.hoisted(() => ({
+  useSuspenseQuery: vi.fn(),
+  useStrategyProviders: vi.fn(),
+  useMarketplacePlugins: vi.fn(),
+  useStrategyInfo: vi.fn(),
+  queryPluginsWithDebounced: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useSuspenseQuery: mocks.useSuspenseQuery,
+}))
+
+vi.mock('@/service/use-strategy', () => ({
+  useStrategyProviders: mocks.useStrategyProviders,
+}))
+
+vi.mock('@/app/components/plugins/marketplace/hooks', () => ({
+  useMarketplacePlugins: mocks.useMarketplacePlugins,
+}))
+
+vi.mock('@/app/components/workflow/nodes/agent/use-config', () => ({
+  useStrategyInfo: mocks.useStrategyInfo,
+}))
+
+vi.mock('@/app/components/plugins/install-plugin/base/use-get-icon', () => ({
+  default: () => ({ getIconUrl: (icon: string) => `https://example.com/${icon}` }),
+}))
+
+vi.mock('@/app/components/base/search-input', () => ({
+  SearchInput: ({ value, onValueChange, placeholder }: {
+    value: string
+    onValueChange: (value: string) => void
+    placeholder?: string
+  }) => (
+    <input aria-label={placeholder} value={value} onChange={(e) => onValueChange(e.target.value)} />
+  ),
+}))
+
+vi.mock('@/app/components/workflow/block-selector/view-type-select', () => ({
+  default: () => <div />,
+  ViewType: { flat: 'flat', grid: 'grid' },
+}))
+
+vi.mock('@/app/components/workflow/block-selector/tools', () => ({
+  default: () => <div data-testid="tools-list" />,
+}))
+
+vi.mock('@/app/components/workflow/block-selector/marketplace-plugin/list', () => ({
+  default: ({ list }: { list: Array<{ plugin_id: string }> }) => (
+    <div data-testid="plugin-list">{list.map((plugin) => plugin.plugin_id).join(',')}</div>
+  ),
+}))
+
+vi.mock('@/app/components/workflow/nodes/_base/components/install-plugin-button', () => ({
+  InstallPluginButton: () => <div />,
+}))
+
+vi.mock('@/app/components/workflow/nodes/_base/components/switch-plugin-version', () => ({
+  SwitchPluginVersion: () => <div />,
+}))
+
+vi.mock('@/next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+const createStrategyDetail = (name: string): StrategyPluginDetail =>
+  ({
+    plugin_unique_identifier: `provider/${name}`,
+    plugin_id: `plugin-${name}`,
+    declaration: {
+      identity: {
+        author: 'Dify',
+        name,
+        description: { en_US: `${name} description` },
+        icon: `${name}.png`,
+        label: { en_US: `${name} label` },
+        tags: [],
+      },
+      strategies: [
+        {
+          identity: { name: `${name}-strategy`, author: 'Dify', label: { en_US: `${name} Strategy` } },
+          description: { en_US: `${name} strategy description` },
+          parameters: [],
+          output_schema: {},
+        },
+      ],
+    },
+    meta: { version: '1.0.0' },
+  }) as unknown as StrategyPluginDetail
+
+describe('AgentStrategySelector marketplace filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useSuspenseQuery.mockReturnValue({ data: true })
+    mocks.useStrategyProviders.mockReturnValue({ data: [createStrategyDetail('alpha')] })
+    mocks.useMarketplacePlugins.mockReturnValue({
+      queryPluginsWithDebounced: mocks.queryPluginsWithDebounced,
+      plugins: [{ plugin_id: 'plugin-alpha' }, { plugin_id: 'market-agent' }],
+    })
+    mocks.useStrategyInfo.mockReturnValue({ strategyStatus: undefined, refetch: vi.fn() })
+  })
+
+  it('excludes installed strategy plugins from marketplace results', async () => {
+    const user = userEvent.setup()
+    render(<AgentStrategySelector onChange={vi.fn()} />)
+
+    await user.click(
+      screen
+        .getByText(/(?:^|\.)nodes\.agent\.strategy\.selectTip(?=$|:)/)
+        .closest('[aria-haspopup]')!,
+    )
+
+    expect(screen.getByTestId('plugin-list')).toHaveTextContent('market-agent')
+    expect(screen.getByTestId('plugin-list')).not.toHaveTextContent('plugin-alpha')
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/agent-strategy-selector.tsx
+++ b/web/app/components/workflow/nodes/_base/components/agent-strategy-selector.tsx
@@ -113,6 +113,10 @@ export const AgentStrategySelector = memo((props: AgentStrategySelectorProps) =>
   const stra = useStrategyProviders()
   const { getIconUrl } = useGetIcon()
   const list = stra.data ? formatStrategy(stra.data, getIconUrl) : undefined
+  const installedPluginIds = useMemo(
+    () => new Set(stra.data?.map((provider) => provider.plugin_id) ?? []),
+    [stra.data],
+  )
   const filteredTools = useMemo(() => {
     if (!list) return []
     return list.filter((tool) => tool.name.toLowerCase().includes(query.toLowerCase()))
@@ -147,8 +151,12 @@ export const AgentStrategySelector = memo((props: AgentStrategySelectorProps) =>
 
   const wrapElemRef = useRef<HTMLDivElement>(null)
 
-  const { queryPluginsWithDebounced: fetchPlugins, plugins: notInstalledPlugins = [] } =
+  const { queryPluginsWithDebounced: fetchPlugins, plugins: marketplacePlugins } =
     useMarketplacePlugins()
+  const notInstalledPlugins = useMemo(
+    () => (marketplacePlugins ?? []).filter((plugin) => !installedPluginIds.has(plugin.plugin_id)),
+    [installedPluginIds, marketplacePlugins],
+  )
 
   useEffect(() => {
     if (!enable_marketplace) return


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #42222.
Consolidates the same-root-cause Agent Strategy sibling reported in #42224.

PR #42199 established that selector surfaces should exclude already-installed plugins from Marketplace search results. Three remaining selectors still combined their installed-provider lists with unfiltered Marketplace results:

- Data Source picker;
- Trigger / Start Block picker;
- Agent Strategy selector.

This change applies the installed-plugin state each selector already has:

- Data Sources: filter Marketplace results against installed data-source plugin IDs;
- Triggers: filter against the existing trigger `providerMap`;
- Agent Strategies: derive installed strategy plugin IDs from `useStrategyProviders()` and filter Marketplace agent plugins against them.

Available Marketplace plugins remain visible. Provider loading, plugin installation, featured-trigger behavior, strategy selection/version switching, and Marketplace APIs are unchanged.

## Validation

- Added focused regression coverage for Data Source + Trigger picker filtering.
- Added focused Agent Strategy selector coverage proving an installed strategy plugin is removed while an available Marketplace plugin remains.
- Audited the consolidated branch against upstream `main`: 2 commits, 5 files; production changes are limited to the three installed-filter wiring sites.

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change
- [ ] I've updated the documentation accordingly
- [ ] I ran `vp staged` / full Web checks

From ChatGPT