### PR TITLE
fix(workflow): sync snippet insertion with collaboration

### DIFF
--- a/web/app/components/workflow/block-selector/snippets/__tests__/use-insert-snippet.spec.tsx
+++ b/web/app/components/workflow/block-selector/snippets/__tests__/use-insert-snippet.spec.tsx
@@ -1,9 +1,15 @@
 import type { SnippetWorkflowResponse } from '@dify/contracts/api/console/snippets/types.gen'
 import type { QueryClient } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt/base64'
 import { consoleQuery } from '@/service/console'
 import { createQueryClientWrapper } from '@/test/console/query-client'
 import { createTestQueryClient } from '@/test/query-client'
+import {
+  CollaborationManager,
+  collaborationManager,
+} from '../../../collaboration/core/collaboration-manager'
+import { crdtRuntime } from '../../../collaboration/core/crdt-runtime'
 import { NESTED_ELEMENT_Z_INDEX } from '../../../constants'
 import { useInsertSnippet } from '../use-insert-snippet'
 
@@ -108,6 +114,19 @@ const seedPublishedWorkflow = (queryClient: QueryClient, workflow: PublishedWork
   queryClient.setQueryData<PublishedWorkflow>(queryOptions.queryKey, workflow)
 }
 
+const attachCrdtDocument = (manager: CollaborationManager, doc: LoroDoc) => {
+  const internals = manager as unknown as {
+    crdtRuntime: typeof crdtRuntime
+    doc: LoroDoc
+    nodesMap: ReturnType<LoroDoc['getMap']>
+    edgesMap: ReturnType<LoroDoc['getMap']>
+  }
+  internals.crdtRuntime = crdtRuntime
+  internals.doc = doc
+  internals.nodesMap = doc.getMap('nodes')
+  internals.edgesMap = doc.getMap('edges')
+}
+
 describe('useInsertSnippet', () => {
   let queryClient: QueryClient
   const renderUseInsertSnippet = () =>
@@ -129,10 +148,106 @@ describe('useInsertSnippet', () => {
   })
 
   afterEach(() => {
+    collaborationManager.destroy()
+    vi.restoreAllMocks()
     queryClient.clear()
   })
 
   describe('Insert Flow', () => {
+    it('should not record a partial insertion while collaborative graph state is unavailable', async () => {
+      seedPublishedWorkflow(queryClient, {
+        graph: {
+          nodes: [
+            {
+              id: 'snippet-node',
+              position: { x: 10, y: 20 },
+              data: { type: 'code', selected: false },
+            },
+          ],
+          edges: [],
+        },
+      })
+      const canApplyMutation = vi
+        .spyOn(collaborationManager, 'canApplyLocalGraphMutation')
+        .mockReturnValue(false)
+
+      const { result } = renderUseInsertSnippet()
+      let inserted: boolean | undefined
+      await act(async () => {
+        inserted = await result.current.handleInsertSnippet('snippet-1')
+      })
+
+      expect(inserted).toBe(false)
+      expect(mockSetNodes).not.toHaveBeenCalled()
+      expect(mockSetEdges).not.toHaveBeenCalled()
+      expect(mockHandleSyncWorkflowDraft).not.toHaveBeenCalled()
+      expect(mockSaveStateToHistory).not.toHaveBeenCalled()
+      expect(mockIncrementSnippetUseCount).not.toHaveBeenCalled()
+
+      canApplyMutation.mockRestore()
+    })
+
+    it('should preserve inserted nodes and edges in a Loro snapshot', async () => {
+      mockEdges = []
+      mockGetNodes.mockReturnValue([
+        {
+          id: 'start',
+          position: { x: 0, y: 0 },
+          data: { type: 'start', selected: false },
+        },
+      ])
+      seedPublishedWorkflow(queryClient, {
+        graph: {
+          nodes: [
+            {
+              id: 'snippet-source',
+              position: { x: 10, y: 20 },
+              data: { type: 'code', selected: false },
+            },
+            {
+              id: 'snippet-target',
+              position: { x: 310, y: 20 },
+              data: { type: 'end', selected: false },
+            },
+          ],
+          edges: [
+            {
+              id: 'snippet-edge',
+              source: 'snippet-source',
+              sourceHandle: 'source',
+              target: 'snippet-target',
+              targetHandle: 'target',
+              data: { sourceType: 'code', targetType: 'end' },
+            },
+          ],
+        },
+      })
+
+      const sourceDoc = new LoroDoc()
+      attachCrdtDocument(collaborationManager, sourceDoc)
+      collaborationManager.setNodes([], mockGetNodes())
+
+      const { result } = renderUseInsertSnippet()
+      await act(async () => {
+        await result.current.handleInsertSnippet('snippet-1')
+      })
+
+      const restoredDoc = LoroDoc.fromSnapshot(sourceDoc.export({ mode: 'snapshot' }))
+      const restoredManager = new CollaborationManager()
+      attachCrdtDocument(restoredManager, restoredDoc)
+      const restoredNodes = restoredManager.getNodes()
+      const restoredEdges = restoredManager.getEdges()
+      const restoredNodeIds = new Set(restoredNodes.map((node) => node.id))
+
+      expect(restoredNodes).toHaveLength(3)
+      expect(restoredEdges).toHaveLength(1)
+      expect(
+        restoredEdges.every(
+          (edge) => restoredNodeIds.has(edge.source) && restoredNodeIds.has(edge.target),
+        ),
+      ).toBe(true)
+    })
+
     it('should append remapped snippet graph into current workflow graph', async () => {
       seedPublishedWorkflow(queryClient, {
         graph: {

--- a/web/app/components/workflow/block-selector/snippets/use-insert-snippet.ts
+++ b/web/app/components/workflow/block-selector/snippets/use-insert-snippet.ts
@@ -5,10 +5,11 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStoreApi } from 'reactflow'
 import { consoleQuery } from '@/service/console'
 import { useIncrementSnippetUseCountMutation } from '@/service/use-snippets'
+import { collaborationManager } from '../../collaboration/core/collaboration-manager'
 import { CUSTOM_EDGE, NESTED_ELEMENT_Z_INDEX, NODE_WIDTH_X_OFFSET, X_OFFSET } from '../../constants'
+import { useCollaborativeWorkflow } from '../../hooks/use-collaborative-workflow'
 import { useNodesSyncDraft } from '../../hooks/use-nodes-sync-draft'
 import { useWorkflowHistory, WorkflowHistoryEvent } from '../../hooks/use-workflow-history'
 import { getNodeUsedVars, updateNodeVars } from '../../nodes/_base/components/variable/utils'
@@ -350,7 +351,7 @@ const createBoundaryEdges = ({
 export const useInsertSnippet = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const store = useStoreApi()
+  const collaborativeWorkflow = useCollaborativeWorkflow()
   const { handleSyncWorkflowDraft } = useNodesSyncDraft()
   const { saveStateToHistory } = useWorkflowHistory()
   const { mutate: incrementSnippetUseCount } = useIncrementSnippetUseCountMutation()
@@ -368,9 +369,9 @@ export const useInsertSnippet = () => {
         const { nodes: snippetNodes, edges: snippetEdges } = getSnippetGraph(workflow.graph)
 
         if (!snippetNodes.length) return
+        if (!collaborationManager.canApplyLocalGraphMutation()) return false
 
-        const { getNodes, setNodes, edges, setEdges } = store.getState()
-        const currentNodes = getNodes()
+        const { nodes: currentNodes, setNodes, edges, setEdges } = collaborativeWorkflow.getState()
         const remappedGraph = remapSnippetGraph(
           currentNodes,
           snippetNodes,
@@ -524,7 +525,14 @@ export const useInsertSnippet = () => {
         return false
       }
     },
-    [handleSyncWorkflowDraft, incrementSnippetUseCount, queryClient, saveStateToHistory, store, t],
+    [
+      collaborativeWorkflow,
+      handleSyncWorkflowDraft,
+      incrementSnippetUseCount,
+      queryClient,
+      saveStateToHistory,
+      t,
+    ],
   )
 
   return {


### PR DESCRIPTION
## Summary

Fixes #42226

Snippet insertion writes the graph directly to React Flow without updating the collaboration document. Inserted nodes can disappear when the workflow is reopened, leaving dangling edges. Use the existing `useCollaborativeWorkflow` setters and reject insertion before side effects when collaboration cannot accept a local graph mutation.

This PR is independent of the assigner-reference remapping fix.

## Validation

Based independently on main commit `085a79c748be47111d2e1c1b65b3f82200998d5c`.

- New regression tests against unmodified main: 2 failed, 6 existing tests passed.
- With the fix: snippet directory suite passed, 25 tests across 6 files.
- `vp check` on both changed files: formatting, lint and type diagnostics passed.
- `vp staged`: passed.
- Root `vp run -w check` was attempted; formatting stops at unchanged `web/CLAUDE.md`, a Git symlink checked out as a regular file on Windows. Full repository check is not claimed passed.
- No new complete browser/backend deployment run was performed for this rebased branch.

Historical deployed validation used a source frontend and the official Dify 1.17.0 backend with PostgreSQL, Redis and Sandbox. Before this collaboration fix, reopening a freshly inserted graph reduced six nodes to one. After it, reopening and a second tab retained the graph; another already-open tab received the inserted nodes without refresh. The tabs used the same test account. These historical checks used the assigner fix as well; they are not a deployment test of this standalone branch on current main.

## Screenshots

Historical browser evidence, on the official 1.17.0 backend with a source frontend based on ad90cb91. These screenshots are not from a deployment of the rebased main branch.

| Before | After |
| --- | --- |
| ![Reopening leaves missing nodes and MISSING_NODE errors](https://github.com/user-attachments/assets/780009f4-aa98-49fd-8565-0aa407aaada6) | ![Reopening preserves the graph and successful output](https://github.com/user-attachments/assets/336381b6-48a3-4c72-94f2-4ce234137ea6) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

Implementation and test preparation used AI assistance. The frontend checks above apply to this frontend-only change; no backend files were changed. No public documentation change is needed.

From Codex