### PR TITLE
fix(workflow): remap assigner references on snippet insertion

### DIFF
--- a/web/app/components/workflow/block-selector/snippets/__tests__/use-insert-snippet.spec.tsx
+++ b/web/app/components/workflow/block-selector/snippets/__tests__/use-insert-snippet.spec.tsx
@@ -20,6 +20,14 @@ type TestNode = {
     _connectedSourceHandleIds?: string[]
     _connectedTargetHandleIds?: string[]
     variables?: { variable: string; value_selector: string[] }[]
+    items?: {
+      variable_selector: string[]
+      input_type: 'variable' | 'constant'
+      operation: string
+      value: unknown
+    }[]
+    assigned_variable_selector?: string[]
+    input_variable_selector?: string[]
     iteration_id?: string
     loop_id?: string
     start_node_id?: string
@@ -269,6 +277,244 @@ describe('useInsertSnippet', () => {
         { variable: 'arg1', value_selector: [insertedLLMNode.id, 'text'] },
         { variable: 'arg2', value_selector: [insertedLLMNode.id, 'text'] },
       ])
+    })
+
+    it('should remap current and legacy assigner selectors inside a loop snippet', async () => {
+      seedPublishedWorkflow(queryClient, {
+        graph: {
+          nodes: [
+            {
+              id: 'snippet-loop',
+              position: { x: 10, y: 20 },
+              data: {
+                type: 'loop',
+                selected: false,
+                _children: [
+                  { nodeId: 'snippet-loop-start', nodeType: 'loop-start' },
+                  { nodeId: 'snippet-code', nodeType: 'code' },
+                  { nodeId: 'snippet-assigner-v2', nodeType: 'assigner' },
+                  { nodeId: 'snippet-assigner-v1', nodeType: 'assigner' },
+                ],
+                start_node_id: 'snippet-loop-start',
+              },
+            },
+            {
+              id: 'snippet-loop-start',
+              parentId: 'snippet-loop',
+              position: { x: 30, y: 40 },
+              data: {
+                type: 'loop-start',
+                selected: false,
+                loop_id: 'snippet-loop',
+              },
+            },
+            {
+              id: 'snippet-code',
+              parentId: 'snippet-loop',
+              position: { x: 120, y: 40 },
+              data: {
+                type: 'code',
+                selected: false,
+                loop_id: 'snippet-loop',
+                variables: [{ variable: 'current', value_selector: ['snippet-loop', 'current'] }],
+              },
+            },
+            {
+              id: 'snippet-assigner-v2',
+              parentId: 'snippet-loop',
+              position: { x: 360, y: 40 },
+              data: {
+                type: 'assigner',
+                version: '2',
+                selected: false,
+                loop_id: 'snippet-loop',
+                items: [
+                  {
+                    variable_selector: ['snippet-loop', 'steps'],
+                    input_type: 'variable',
+                    operation: 'append',
+                    value: ['snippet-code', 'result'],
+                  },
+                  {
+                    variable_selector: ['snippet-loop', 'current'],
+                    input_type: 'constant',
+                    operation: '-=',
+                    value: 1,
+                  },
+                ],
+              },
+            },
+            {
+              id: 'snippet-assigner-v1',
+              parentId: 'snippet-loop',
+              position: { x: 600, y: 40 },
+              data: {
+                type: 'assigner',
+                version: '1',
+                selected: false,
+                loop_id: 'snippet-loop',
+                assigned_variable_selector: ['snippet-loop', 'legacy-target'],
+                input_variable_selector: ['snippet-code', 'result'],
+                write_mode: 'over-write',
+              },
+            },
+          ],
+          edges: [],
+        },
+      })
+
+      const { result } = renderUseInsertSnippet()
+
+      await act(async () => {
+        await result.current.handleInsertSnippet('snippet-1')
+      })
+
+      const nextNodes = mockSetNodes.mock.calls[0]![0] as TestNode[]
+      const insertedLoop = nextNodes.find((node) => node.data.type === 'loop')!
+      const insertedCode = nextNodes.find((node) => node.data.type === 'code')!
+      const insertedAssigners = nextNodes.filter((node) => node.data.type === 'assigner')
+      const insertedV2Assigner = insertedAssigners.find((node) => node.data.items)!
+      const insertedV1Assigner = insertedAssigners.find(
+        (node) => node.data.assigned_variable_selector,
+      )!
+
+      expect(insertedCode.data.variables).toEqual([
+        { variable: 'current', value_selector: [insertedLoop.id, 'current'] },
+      ])
+      expect(insertedV2Assigner.data.items).toEqual([
+        {
+          variable_selector: [insertedLoop.id, 'steps'],
+          input_type: 'variable',
+          operation: 'append',
+          value: [insertedCode.id, 'result'],
+        },
+        {
+          variable_selector: [insertedLoop.id, 'current'],
+          input_type: 'constant',
+          operation: '-=',
+          value: 1,
+        },
+      ])
+      expect(insertedV1Assigner.data.assigned_variable_selector).toEqual([
+        insertedLoop.id,
+        'legacy-target',
+      ])
+      expect(insertedV1Assigner.data.input_variable_selector).toEqual([insertedCode.id, 'result'])
+    })
+
+    it('should preserve external and constant selectors across independent repeated insertions', async () => {
+      const sourceGraph = {
+        nodes: [
+          {
+            id: 'snippet-source',
+            position: { x: 10, y: 20 },
+            data: {
+              type: 'code',
+              selected: false,
+              variables: [{ variable: 'external', value_selector: ['env', 'api_key'] }],
+            },
+          },
+          {
+            id: 'snippet-assigner',
+            position: { x: 310, y: 20 },
+            data: {
+              type: 'assigner',
+              version: '2',
+              selected: false,
+              items: [
+                {
+                  variable_selector: ['conversation', 'latest'],
+                  input_type: 'variable',
+                  operation: 'over-write',
+                  value: ['snippet-source', 'result'],
+                },
+                {
+                  variable_selector: ['conversation', 'api_key'],
+                  input_type: 'variable',
+                  operation: 'over-write',
+                  value: ['env', 'api_key'],
+                },
+                {
+                  variable_selector: ['conversation', 'literal_selector'],
+                  input_type: 'constant',
+                  operation: 'set',
+                  value: ['snippet-source', 'literal'],
+                },
+                {
+                  variable_selector: ['conversation', 'count'],
+                  input_type: 'constant',
+                  operation: 'set',
+                  value: 3,
+                },
+              ],
+            },
+          },
+        ],
+        edges: [],
+      }
+      const originalGraph = structuredClone(sourceGraph)
+      seedPublishedWorkflow(queryClient, { graph: sourceGraph })
+      const { result } = renderUseInsertSnippet()
+
+      await act(async () => {
+        await result.current.handleInsertSnippet('snippet-1')
+      })
+
+      const firstInsertion = mockSetNodes.mock.calls[0]![0] as TestNode[]
+      const firstSource = firstInsertion.find((node) => node.id.includes('snippet-source'))!
+      const firstAssigner = firstInsertion.find((node) => node.id.includes('snippet-assigner'))!
+      mockGetNodes.mockReturnValue(firstInsertion)
+
+      await act(async () => {
+        await result.current.handleInsertSnippet('snippet-1')
+      })
+
+      const secondInsertion = mockSetNodes.mock.calls[1]![0] as TestNode[]
+      const insertedSources = secondInsertion.filter((node) => node.id.includes('snippet-source'))
+      const secondSource = insertedSources.find((node) => node.id !== firstSource.id)!
+      const firstAssignerAfterSecondInsert = secondInsertion.find(
+        (node) => node.id === firstAssigner.id,
+      )!
+      const secondAssigner = secondInsertion.find(
+        (node) => node.id.includes('snippet-assigner') && node.id !== firstAssigner.id,
+      )!
+
+      expect(firstAssignerAfterSecondInsert.data.items![0]).toEqual(
+        expect.objectContaining({
+          variable_selector: ['conversation', 'latest'],
+          value: [firstSource.id, 'result'],
+        }),
+      )
+      expect(secondAssigner.data.items).toEqual([
+        {
+          variable_selector: ['conversation', 'latest'],
+          input_type: 'variable',
+          operation: 'over-write',
+          value: [secondSource.id, 'result'],
+        },
+        {
+          variable_selector: ['conversation', 'api_key'],
+          input_type: 'variable',
+          operation: 'over-write',
+          value: ['env', 'api_key'],
+        },
+        {
+          variable_selector: ['conversation', 'literal_selector'],
+          input_type: 'constant',
+          operation: 'set',
+          value: ['snippet-source', 'literal'],
+        },
+        {
+          variable_selector: ['conversation', 'count'],
+          input_type: 'constant',
+          operation: 'set',
+          value: 3,
+        },
+      ])
+      expect(secondSource.data.variables).toEqual([
+        { variable: 'external', value_selector: ['env', 'api_key'] },
+      ])
+      expect(sourceGraph).toEqual(originalGraph)
     })
 
     it('should remap structural node ids inside a loop snippet', async () => {

--- a/web/app/components/workflow/block-selector/snippets/use-insert-snippet.ts
+++ b/web/app/components/workflow/block-selector/snippets/use-insert-snippet.ts
@@ -1,3 +1,4 @@
+import type { AssignerNodeType } from '../../nodes/assigner/types'
 import type { IterationNodeType } from '../../nodes/iteration/types'
 import type { LoopNodeType } from '../../nodes/loop/types'
 import type { Edge, Node, OnNodeAdd, ValueSelector } from '../../types'
@@ -12,10 +13,16 @@ import { CUSTOM_EDGE, NESTED_ELEMENT_Z_INDEX, NODE_WIDTH_X_OFFSET, X_OFFSET } fr
 import { useNodesSyncDraft } from '../../hooks/use-nodes-sync-draft'
 import { useWorkflowHistory, WorkflowHistoryEvent } from '../../hooks/use-workflow-history'
 import { getNodeUsedVars, updateNodeVars } from '../../nodes/_base/components/variable/utils'
+import { AssignerNodeInputType } from '../../nodes/assigner/types'
 import { BlockEnum } from '../../types'
 import { getNodesConnectedSourceOrTargetHandleIdsMap } from '../../utils'
 
 type SnippetInsertPayload = Parameters<OnNodeAdd>[1]
+
+type LegacyAssignerNodeType = Node['data'] & {
+  assigned_variable_selector?: ValueSelector
+  input_variable_selector?: ValueSelector
+}
 
 const getSnippetGraph = (graph: Record<string, unknown> | undefined) => {
   if (!graph) return { nodes: [] as Node[], edges: [] as Edge[] }
@@ -113,6 +120,48 @@ const remapSnippetValueSelector = (
   if (!mappedNodeId) return selector
 
   return [mappedNodeId, ...selector.slice(1)]
+}
+
+const remapSnippetAssignerReferences = (node: Node, idMapping: Map<string, string>): Node => {
+  if (node.data.type !== BlockEnum.Assigner) return node
+
+  const assignerData = node.data as AssignerNodeType
+  if (assignerData.version === '2') {
+    const data: AssignerNodeType = {
+      ...assignerData,
+      items: (assignerData.items ?? []).map((item) => ({
+        ...item,
+        variable_selector: remapSnippetValueSelector(item.variable_selector, idMapping)!,
+        value:
+          item.input_type === AssignerNodeInputType.variable
+            ? remapSnippetValueSelector(item.value, idMapping)
+            : item.value,
+      })),
+    }
+
+    return {
+      ...node,
+      data,
+    }
+  }
+
+  const legacyAssignerData = node.data as LegacyAssignerNodeType
+  const data: LegacyAssignerNodeType = {
+    ...legacyAssignerData,
+    assigned_variable_selector: remapSnippetValueSelector(
+      legacyAssignerData.assigned_variable_selector,
+      idMapping,
+    ),
+    input_variable_selector: remapSnippetValueSelector(
+      legacyAssignerData.input_variable_selector,
+      idMapping,
+    ),
+  }
+
+  return {
+    ...node,
+    data,
+  }
 }
 
 const remapSnippetNodeStructuralReferences = (node: Node, idMapping: Map<string, string>): Node => {
@@ -220,7 +269,11 @@ const remapSnippetGraph = (
 
     const structurallyRemappedNode = remapSnippetNodeStructuralReferences(remappedNode, idMapping)
 
-    return remapSnippetNodeVariableReferences(structurallyRemappedNode, idMapping)
+    const variableRemappedNode = remapSnippetNodeVariableReferences(
+      structurallyRemappedNode,
+      idMapping,
+    )
+    return remapSnippetAssignerReferences(variableRemappedNode, idMapping)
   })
 
   const edges = snippetEdges.map((edge) => ({


### PR DESCRIPTION
## Summary

Fixes #42227

Related discussion: https://github.com/langgenius/dify/discussions/39869

Snippet insertion allocates new node IDs, but current and legacy `type: assigner` selectors retain the old IDs and can fail with a missing-variable error. Remap v2 assignment targets and variable inputs, plus legacy input/target selectors, using the existing snippet ID map. Treat a missing operation list as empty. Preserve literal values, external selectors and the cached source graph across repeated insertions.

Keep the remapping at the insertion boundary because shared variable-discovery helpers also serve deletion, renaming and execution preparation. This PR is independent of the collaborative insertion persistence fix and does not repair already-inserted graphs.

## Validation

Based independently on main commit `085a79c748be47111d2e1c1b65b3f82200998d5c`.

- New regression tests against unmodified main: 2 failed, 6 existing tests passed.
- With the fix: snippet directory suite passed, 25 tests across 6 files.
- `vp check` on both changed files: formatting, lint and type diagnostics passed.
- `vp staged`: passed.
- Root `vp run -w check` was attempted; formatting stops at unchanged `web/CLAUDE.md`, a Git symlink checked out as a regular file on Windows. Full repository check is not claimed passed.
- No new complete browser/backend deployment run was performed for this rebased branch.

Historical deployed validation used a source frontend and the official Dify 1.17.0 backend with PostgreSQL, Redis and Sandbox. An independently constructed, published countdown snippet failed after baseline insertion with `Variable ['loop', 'steps'] not found`; insertion with the assigner fix returned `{"steps":["3","2","1"]}`. Server-saved graphs confirmed stale selectors before and updated selectors after the fix. This is historical evidence, not a deployment run of the rebased branch; the original discussion attachment was not reproduced unchanged. No LLM calls were involved.

## Screenshots

Historical browser evidence, on the official 1.17.0 backend with a source frontend based on ad90cb91. These screenshots are not from a deployment of the rebased main branch.

| Before | After |
| --- | --- |
| ![Insertion leaves stale selectors and execution fails](https://github.com/user-attachments/assets/233af84c-316a-4555-a874-2f29eb54f0ad) | ![Remapped selectors allow successful execution](https://github.com/user-attachments/assets/fa245df7-7158-4bac-ad73-a5bb0196cd6f) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

Implementation and test preparation used AI assistance. The frontend checks above apply to this frontend-only change; no backend files were changed. No public documentation change is needed.

From Codex