### PR TITLE
fix(api): avoid per-row MAX(position) queries in batch segment import

### DIFF
--- a/api/tasks/batch_create_segment_to_index_task.py
+++ b/api/tasks/batch_create_segment_to_index_task.py
@@ -141,20 +141,24 @@ def batch_create_segment_to_index_task(
         tokens_list = [0] * len(content)
 
     with session_factory.create_session() as session, session.begin():
+        max_position = (
+            session.scalar(
+                select(func.max(DocumentSegment.position)).where(DocumentSegment.document_id == document_config["id"])
+            )
+            or 0
+        )
         for segment, tokens in zip(content, tokens_list):
             content = segment["content"]
             doc_id = str(uuid.uuid4())
             segment_hash = helper.generate_text_hash(content)
-            max_position = session.scalar(
-                select(func.max(DocumentSegment.position)).where(DocumentSegment.document_id == document_config["id"])
-            )
+            max_position += 1
             segment_document = DocumentSegment(
                 tenant_id=tenant_id,
                 dataset_id=dataset_id,
                 document_id=document_id,
                 index_node_id=doc_id,
                 index_node_hash=segment_hash,
-                position=max_position + 1 if max_position else 1,
+                position=max_position,
                 content=content,
                 word_count=len(content),
                 tokens=tokens,

--- a/api/tests/unit_tests/tasks/test_batch_create_segment_to_index_task.py
+++ b/api/tests/unit_tests/tasks/test_batch_create_segment_to_index_task.py
@@ -1,0 +1,110 @@
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+from uuid import uuid4
+
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from extensions.storage.storage_type import StorageType
+from models.dataset import Dataset, Document, DocumentSegment
+from models.enums import CreatorUserRole, DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from models.model import UploadFile
+from tasks.batch_create_segment_to_index_task import batch_create_segment_to_index_task
+
+
+def test_batch_create_segment_to_index_task_queries_max_position_once_per_batch(
+    sqlite_session: Session,
+    sqlite_engine: Engine,
+) -> None:
+    tenant_id = str(uuid4())
+    user_id = str(uuid4())
+    dataset = Dataset(
+        id=str(uuid4()),
+        tenant_id=tenant_id,
+        name="Batch import dataset",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        created_by=user_id,
+        indexing_technique=IndexTechniqueType.ECONOMY,
+    )
+    document = Document(
+        id=str(uuid4()),
+        tenant_id=tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="document.txt",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by=user_id,
+        indexing_status=IndexingStatus.COMPLETED,
+        enabled=True,
+        archived=False,
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+        word_count=0,
+    )
+    upload_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key="batch-import.csv",
+        name="batch-import.csv",
+        size=32,
+        extension=".csv",
+        mime_type="text/csv",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by=user_id,
+        created_at=datetime.now(UTC),
+        used=False,
+    )
+    existing_segment = DocumentSegment(
+        tenant_id=tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=7,
+        content="existing",
+        word_count=1,
+        tokens=1,
+        created_by=user_id,
+        index_node_id="existing-node",
+        index_node_hash="existing-hash",
+        status=SegmentStatus.COMPLETED,
+    )
+    sqlite_session.add_all([dataset, document, upload_file, existing_segment])
+    sqlite_session.commit()
+
+    def mock_download(_key: str, file_path: str) -> None:
+        Path(file_path).write_text("content\nfirst\nsecond\nthird\n", encoding="utf-8")
+
+    max_position_queries: list[str] = []
+
+    def count_max_position_query(_connection, _cursor, statement, _parameters, _context, _executemany) -> None:
+        normalized_statement = statement.lower()
+        if "max(" in normalized_statement and "document_segments.position" in normalized_statement:
+            max_position_queries.append(statement)
+
+    event.listen(sqlite_engine, "before_cursor_execute", count_max_position_query)
+    try:
+        with (
+            patch("tasks.batch_create_segment_to_index_task.storage.download", side_effect=mock_download),
+            patch("tasks.batch_create_segment_to_index_task.VectorService.create_segments_vector"),
+        ):
+            batch_create_segment_to_index_task(
+                job_id=str(uuid4()),
+                upload_file_id=upload_file.id,
+                dataset_id=dataset.id,
+                document_id=document.id,
+                tenant_id=tenant_id,
+                user_id=user_id,
+            )
+    finally:
+        event.remove(sqlite_engine, "before_cursor_execute", count_max_position_query)
+
+    positions = sqlite_session.scalars(
+        select(DocumentSegment.position)
+        .where(DocumentSegment.document_id == document.id)
+        .order_by(DocumentSegment.position)
+    ).all()
+    assert positions == [7, 8, 9, 10]
+    assert len(max_position_queries) == 1


### PR DESCRIPTION
## Summary

Fixes #42232.

The batch segment import task queried `MAX(DocumentSegment.position)` inside the per-row insert loop. For a CSV containing `N` rows, this caused `N` aggregate queries and unnecessary database round trips.

This change reads the current maximum segment position once before the insert loop and increments the value in memory for each imported row.

The existing position behavior is preserved:

- An empty document starts at position `1`.
- If the current maximum position is `7`, newly imported segments receive positions `8`, `9`, and so on.
- Imported segments retain their existing order.
- No new dependency or database schema change is required.

This restores the approach previously used in [#12929](https://github.com/langgenius/dify/pull/12929). The regression was introduced when the session refactor in [#32085](https://github.com/langgenius/dify/pull/32085) moved the segment creation loop into a new session and reintroduced the aggregate query inside the loop. The later query syntax migration in [#34684](https://github.com/langgenius/dify/pull/34684) changed `session.query()` to `select()`/`session.scalar()` but did not change the query placement.

## Verification

Regression test evidence on the same local SQLite ORM task path:

| State | Result |
| --- | --- |
| Before the fix (`79effdd498`) | `1 failed`: 3 CSV rows produced 3 `MAX(position)` queries; the test expected 1 |
| After the fix (`075bea50b7`) | `1 passed`: existing position 7 produced positions 7, 8, 9, 10 and only 1 `MAX(position)` query |

Additional checks after the fix:

- Backend task unit tests: `312 passed, 2 warnings`.
- Ruff format/check on the changed files: passed.
- Mypy on `batch_create_segment_to_index_task.py`: `Success: no issues found in 1 source file`.
- Pyrefly on `batch_create_segment_to_index_task.py`: `0 diagnostics`.
- `git diff --check`: passed.

The TestContainers integration test was not run locally because the Docker socket is unavailable (`PermissionError: [Errno 13] Permission denied`). The regression test uses the real task and SQLAlchemy ORM against SQLite, and does not require Docker.


## Screenshots

| Before | After |
| ------ | ----- |
| Not applicable — backend-only performance issue | Not applicable — backend-only performance fix |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods