### PR TITLE
fix: rebuild summary vectors after dataset reindexing

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -103,7 +103,6 @@ from tasks.disable_segments_from_index_task import disable_segments_from_index_t
 from tasks.document_indexing_update_task import document_indexing_update_task
 from tasks.enable_segments_to_index_task import enable_segments_to_index_task
 from tasks.recover_document_indexing_task import recover_document_indexing_task
-from tasks.regenerate_summary_index_task import regenerate_summary_index_task
 from tasks.remove_document_from_index_task import remove_document_from_index_task
 from tasks.retry_document_indexing_task import retry_document_indexing_task
 from tasks.sync_website_document_indexing_task import sync_website_document_indexing_task
@@ -836,13 +835,6 @@ class DatasetService:
         # Trigger vector index task if indexing technique changed
         if action:
             deal_dataset_vector_index_task.delay(dataset.id, action)
-            # If embedding_model changed, also regenerate summary vectors
-            if action == "update":
-                regenerate_summary_index_task.delay(
-                    dataset.id,
-                    regenerate_reason="embedding_model_changed",
-                    regenerate_vectors_only=True,
-                )
 
         # Note: summary_index_setting changes do not trigger automatic regeneration of existing summaries.
         # The new setting will only apply to:

--- a/api/tasks/deal_dataset_index_update_task.py
+++ b/api/tasks/deal_dataset_index_update_task.py
@@ -12,6 +12,7 @@ from core.rag.index_processor.index_processor_factory import IndexProcessorFacto
 from core.rag.models.document import AttachmentDocument, ChildDocument, Document
 from models.dataset import Dataset, DocumentSegment
 from models.dataset import Document as DatasetDocument
+from tasks.regenerate_summary_index_task import regenerate_summary_index_task
 
 
 @shared_task(queue="dataset")
@@ -216,3 +217,12 @@ def deal_dataset_index_update_task(dataset_id: str, action: str):
             )
         except Exception:
             logging.exception("Deal dataset vector index failed")
+            return
+
+    if action == "update":
+        # Rebuild summaries after all index cleanup and document state commits.
+        regenerate_summary_index_task.delay(
+            dataset_id,
+            regenerate_reason="embedding_model_changed",
+            regenerate_vectors_only=True,
+        )

--- a/api/tasks/deal_dataset_vector_index_task.py
+++ b/api/tasks/deal_dataset_vector_index_task.py
@@ -12,6 +12,7 @@ from core.rag.index_processor.index_processor_factory import IndexProcessorFacto
 from core.rag.models.document import AttachmentDocument, ChildDocument, Document
 from models.dataset import Dataset, DocumentSegment
 from models.dataset import Document as DatasetDocument
+from tasks.regenerate_summary_index_task import regenerate_summary_index_task
 
 logger = logging.getLogger(__name__)
 
@@ -212,3 +213,12 @@ def deal_dataset_vector_index_task(dataset_id: str, action: str):
             )
         except Exception:
             logger.exception("Deal dataset vector index failed")
+            return
+
+    if action == "update":
+        # Rebuild summaries after all index cleanup and document state commits.
+        regenerate_summary_index_task.delay(
+            dataset_id,
+            regenerate_reason="embedding_model_changed",
+            regenerate_vectors_only=True,
+        )

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_update_dataset.py
@@ -509,7 +509,7 @@ class TestDatasetServiceUpdateDataset:
                 "services.dataset_service.DatasetCollectionBindingService.get_dataset_collection_binding"
             ) as mock_get_binding,
             patch("services.dataset_service.deal_dataset_vector_index_task") as mock_task,
-            patch("services.dataset_service.regenerate_summary_index_task") as mock_regenerate_task,
+            patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay") as mock_regenerate_task,
         ):
             mock_model_manager.return_value.get_model_instance.return_value = embedding_model
             mock_get_binding.return_value = binding
@@ -524,11 +524,7 @@ class TestDatasetServiceUpdateDataset:
             )
             mock_get_binding.assert_called_once_with("openai", "text-embedding-3-small", db_session_with_containers)
             mock_task.delay.assert_called_once_with(dataset.id, "update")
-            mock_regenerate_task.delay.assert_called_once_with(
-                dataset.id,
-                regenerate_reason="embedding_model_changed",
-                regenerate_vectors_only=True,
-            )
+            mock_regenerate_task.assert_not_called()
 
         db_session_with_containers.refresh(dataset)
         assert dataset.embedding_model == "text-embedding-3-small"

--- a/api/tests/test_containers_integration_tests/tasks/test_deal_dataset_vector_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_deal_dataset_vector_index_task.py
@@ -25,6 +25,11 @@ from tests.test_containers_integration_tests.helpers import generate_valid_passw
 class TestDealDatasetVectorIndexTask:
     """Integration tests for deal_dataset_vector_index_task using testcontainers."""
 
+    @pytest.fixture(autouse=True)
+    def mock_summary_dispatch(self):
+        with patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay") as dispatch:
+            yield dispatch
+
     @pytest.fixture
     def mock_external_service_dependencies(self):
         """Mock setup for external service dependencies."""

--- a/api/tests/unit_tests/services/test_dataset_service_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_dataset.py
@@ -634,31 +634,48 @@ class TestDatasetServiceCreationAndUpdate:
                 sqlite_session,
             )
 
-    def test_update_internal_dataset_executes_real_update_without_committing(self, sqlite_session: Session) -> None:
-        dataset = _dataset(name="Before")
+    @pytest.mark.parametrize("embedding_model", ["embedding-model", "new-model"])
+    def test_update_internal_dataset_executes_real_update_without_committing(
+        self, sqlite_session: Session, embedding_model: str
+    ) -> None:
+        dataset = _dataset(name="Before", indexing_technique=IndexTechniqueType.HIGH_QUALITY)
+        dataset.summary_index_setting = {"enable": True}
         sqlite_session.add(dataset)
         sqlite_session.commit()
         transaction_events: list[str] = []
         event.listen(sqlite_session, "after_commit", lambda _session: transaction_events.append("commit"))
 
         with (
-            patch.object(DatasetService, "_handle_indexing_technique_change", return_value="update"),
-            patch.object(DatasetService, "_update_pipeline_knowledge_base_node_data"),
+            patch("services.dataset_service.current_user", _account()),
+            patch("services.dataset_service.ModelManager") as model_manager_cls,
             patch("services.dataset_service.deal_dataset_vector_index_task.delay") as vector_task,
-            patch("services.dataset_service.regenerate_summary_index_task.delay") as summary_task,
+            patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay") as summary_task,
         ):
+            model_manager_cls.for_tenant.return_value.get_model_instance.return_value = SimpleNamespace(
+                provider="provider", model_name=embedding_model
+            )
             updated = DatasetService._update_internal_dataset(
                 dataset,
-                {"name": "After", "description": "Changed"},
+                {
+                    "name": "After",
+                    "description": "Changed",
+                    "indexing_technique": IndexTechniqueType.HIGH_QUALITY,
+                    "embedding_model_provider": "provider",
+                    "embedding_model": embedding_model,
+                },
                 _account(),
                 sqlite_session,
             )
 
         assert updated.name == "After"
         assert updated.description == "Changed"
+        assert updated.embedding_model == embedding_model
         assert transaction_events == []
-        vector_task.assert_called_once_with(dataset.id, "update")
-        summary_task.assert_called_once()
+        if embedding_model == "new-model":
+            vector_task.assert_called_once_with(dataset.id, "update")
+        else:
+            vector_task.assert_not_called()
+        summary_task.assert_not_called()
 
     def test_update_pipeline_node_data_returns_for_non_pipeline_or_missing_pipeline(
         self, sqlite_session: Session

--- a/api/tests/unit_tests/tasks/test_dataset_summary_rebuild.py
+++ b/api/tests/unit_tests/tasks/test_dataset_summary_rebuild.py
@@ -1,0 +1,223 @@
+import importlib
+import uuid
+from collections.abc import Generator
+from contextlib import contextmanager
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import event, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from core.rag.models.document import Document as IndexDocument
+from models.dataset import Dataset, Document, DocumentSegment, DocumentSegmentSummary
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus, SummaryStatus
+
+
+@pytest.fixture(params=["deal_dataset_vector_index_task", "deal_dataset_index_update_task"])
+def task_module(request: pytest.FixtureRequest) -> ModuleType:
+    return importlib.import_module(f"tasks.{request.param}")
+
+
+@pytest.fixture
+def indexed_dataset(sqlite_session: Session) -> tuple[Dataset, list[Document]]:
+    tenant_id = str(uuid.uuid4())
+    created_by = str(uuid.uuid4())
+    dataset = Dataset(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        name="Summary rebuild dataset",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        created_by=created_by,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        is_multimodal=False,
+        summary_index_setting={"enable": True},
+    )
+    documents = []
+    sqlite_session.add(dataset)
+    for position in (1, 2):
+        document = Document(
+            id=str(uuid.uuid4()),
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            position=position,
+            data_source_type=DataSourceType.UPLOAD_FILE,
+            batch="batch-1",
+            name=f"document-{position}.txt",
+            created_from=DocumentCreatedFrom.WEB,
+            created_by=created_by,
+            indexing_status=IndexingStatus.COMPLETED,
+            doc_form=IndexStructureType.PARAGRAPH_INDEX,
+        )
+        segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=1,
+            content=f"Body {position}",
+            word_count=2,
+            tokens=2,
+            created_by=created_by,
+            index_node_id=f"node-{position}",
+            index_node_hash=f"hash-{position}",
+            status=SegmentStatus.COMPLETED,
+        )
+        summary = DocumentSegmentSummary(
+            dataset_id=dataset.id,
+            document_id=document.id,
+            chunk_id=segment.id,
+            summary_content=f"Summary {position}",
+            summary_index_node_id=f"summary-{position}",
+            status=SummaryStatus.COMPLETED,
+        )
+        sqlite_session.add_all([document, segment, summary])
+        documents.append(document)
+    sqlite_session.commit()
+    return dataset, documents
+
+
+@contextmanager
+def _record_commits(factory: sessionmaker[Session], events: list[str]) -> Generator[None]:
+    def after_commit(_session: Session) -> None:
+        events.append("commit")
+
+    event.listen(factory.class_, "after_commit", after_commit)
+    try:
+        yield
+    finally:
+        event.remove(factory.class_, "after_commit", after_commit)
+
+
+@pytest.mark.parametrize("failed_document", [False, True], ids=["all-loaded", "one-load-fails"])
+@pytest.mark.parametrize("summaries_enabled", [True, False], ids=["summaries-enabled", "summaries-disabled"])
+def test_update_dispatches_summaries_after_body_rebuild_commits(
+    task_module: ModuleType,
+    indexed_dataset: tuple[Dataset, list[Document]],
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+    failed_document: bool,
+    summaries_enabled: bool,
+) -> None:
+    dataset, documents = indexed_dataset
+    dataset.summary_index_setting = {"enable": summaries_enabled}
+    sqlite_session.commit()
+    expected_statuses = {
+        document.id: IndexingStatus.ERROR if failed_document and index == 0 else IndexingStatus.COMPLETED
+        for index, document in enumerate(documents)
+    }
+    events: list[str] = []
+    observed_statuses: list[dict[str, IndexingStatus]] = []
+    processor = MagicMock()
+    processor.clean.side_effect = lambda *_args, **_kwargs: events.append("clean")
+
+    def load(_dataset, body_documents: list[IndexDocument], **_kwargs) -> None:
+        document_id = body_documents[0].metadata["document_id"]
+        events.append(f"load:{document_id}")
+        if failed_document and document_id == documents[0].id:
+            raise RuntimeError("Embedding request failed")
+
+    def dispatch(*_args, **_kwargs) -> None:
+        events.append("dispatch")
+        assert not processor.clean.call_args.kwargs["session"].in_transaction()
+        # A worker starts with a fresh session and must see every final document status.
+        with sqlite_session_factory() as session:
+            observed_statuses.append(
+                dict(
+                    session.execute(
+                        select(Document.id, Document.indexing_status).where(Document.dataset_id == dataset.id)
+                    )
+                    .tuples()
+                    .all()
+                )
+            )
+
+    processor.load.side_effect = load
+    with (
+        _record_commits(sqlite_session_factory, events),
+        patch.object(task_module, "IndexProcessorFactory") as processor_factory,
+        patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay", side_effect=dispatch) as delay,
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        getattr(task_module, task_module.__name__.rsplit(".", 1)[1]).run(dataset.id, "update")
+
+    delay.assert_called_once_with(dataset.id, regenerate_reason="embedding_model_changed", regenerate_vectors_only=True)
+    assert observed_statuses == [expected_statuses]
+    assert events[:2] == ["commit", "clean"]
+    assert set(events[2:-1:2]) == {f"load:{document.id}" for document in documents}
+    assert events[3:-1:2] == ["commit", "commit"]
+    assert events[-1] == "dispatch"
+
+
+def test_update_does_not_dispatch_summaries_when_cleanup_fails(
+    task_module: ModuleType,
+    indexed_dataset: tuple[Dataset, list[Document]],
+) -> None:
+    dataset, _documents = indexed_dataset
+    with (
+        patch.object(task_module, "IndexProcessorFactory") as processor_factory,
+        patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay") as delay,
+    ):
+        processor = processor_factory.return_value.init_index_processor.return_value
+        processor.clean.side_effect = RuntimeError("Vector store unavailable")
+        getattr(task_module, task_module.__name__.rsplit(".", 1)[1]).run(dataset.id, "update")
+
+    processor.load.assert_not_called()
+    delay.assert_not_called()
+
+
+def test_update_dispatches_after_cleanup_without_completed_documents(
+    task_module: ModuleType,
+    indexed_dataset: tuple[Dataset, list[Document]],
+    sqlite_session: Session,
+) -> None:
+    dataset, documents = indexed_dataset
+    for document in documents:
+        document.indexing_status = IndexingStatus.ERROR
+    sqlite_session.commit()
+    events: list[str] = []
+
+    def dispatch(*_args, **_kwargs) -> None:
+        events.append("dispatch")
+        assert not processor.clean.call_args.kwargs["session"].in_transaction()
+
+    with (
+        patch.object(task_module, "IndexProcessorFactory") as processor_factory,
+        patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay") as delay,
+    ):
+        processor = processor_factory.return_value.init_index_processor.return_value
+        processor.clean.side_effect = lambda *_args, **_kwargs: events.append("clean")
+        delay.side_effect = dispatch
+        getattr(task_module, task_module.__name__.rsplit(".", 1)[1]).run(dataset.id, "update")
+
+    processor.load.assert_not_called()
+    delay.assert_called_once_with(dataset.id, regenerate_reason="embedding_model_changed", regenerate_vectors_only=True)
+    assert events == ["clean", "dispatch"]
+
+
+def test_other_actions_do_not_dispatch_summary_rebuild(
+    task_module: ModuleType,
+    indexed_dataset: tuple[Dataset, list[Document]],
+) -> None:
+    dataset, _documents = indexed_dataset
+    actions = ("add", "remove") if task_module.__name__.endswith("vector_index_task") else ("upgrade",)
+    with (
+        patch.object(task_module, "IndexProcessorFactory"),
+        patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay") as delay,
+    ):
+        task = getattr(task_module, task_module.__name__.rsplit(".", 1)[1])
+        for action in actions:
+            task.run(dataset.id, action)
+
+    delay.assert_not_called()
+
+
+def test_missing_dataset_does_not_dispatch_summary_rebuild(task_module: ModuleType) -> None:
+    with (
+        patch.object(task_module, "IndexProcessorFactory") as processor_factory,
+        patch("tasks.regenerate_summary_index_task.regenerate_summary_index_task.delay") as delay,
+    ):
+        getattr(task_module, task_module.__name__.rsplit(".", 1)[1]).run(str(uuid.uuid4()), "update")
+
+    processor_factory.assert_not_called()
+    delay.assert_not_called()


### PR DESCRIPTION
## Summary

Changing a knowledge base's embedding model could delete newly rebuilt summary vectors because document and summary rebuild tasks ran independently. Pipeline updates also rebuilt document vectors without migrating existing summaries to the new model's collection.

Queue summary re-vectorization from both document update tasks after index cleanup, document loading and final status commits, outside the database session. Remove the independent summary dispatch from the settings service and retain the `dataset_summary` queue. Partial document failures and datasets with no completed documents still reach summary rebuilding; cleanup failures do not.

Fixes #42234.

## Validation

- 83 tests passed across `test_dataset_summary_rebuild.py`, `test_dataset_service_dataset.py` and `test_summary_queue_isolation.py`:

  ```sh
  uv run --project api pytest -o addopts='' -q api/tests/unit_tests/tasks/test_dataset_summary_rebuild.py api/tests/unit_tests/services/test_dataset_service_dataset.py api/tests/unit_tests/tasks/test_summary_queue_isolation.py
  ```

- The 16 new task cases cover dispatch after committed document states, partial load failures, cleanup failures, no completed documents, disabled summary settings, other actions and missing datasets.
- Ruff checks and formatting passed for all changed files. The complete `make type-check-core` check passed, including Pyrefly and mypy (1,796 source files). The new task tests also passed a targeted strict Pyrefly check.
- All 31 import-layer contracts, the response contract linter (528 valid, 0 mismatches), both baseline-aware guards (`no-new-getattr` and controller SQLAlchemy), dotenv checks and `git diff --check` passed.
- The `vp staged` pre-commit hook passed for all seven Python files.
- Additional local verification with the actual Qdrant adapter and official in-memory engine changed the three cases in #42234 from two failures and one pass to three passes. This was a local harness, not a Celery-cluster end-to-end run.
- Container integration test mocks were updated; those tests are left to CI.

## Screenshots

Not applicable; this changes backend task scheduling.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

No documentation update is needed. The backend CI checks and targeted test results are listed above; the combined `make lint && make type-check` command was not run.