### PR TITLE
fix(web): keep chat action bar visible on touch-only mobile devices

### DIFF
--- a/web/app/components/base/chat/chat/__tests__/question.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/question.spec.tsx
@@ -211,6 +211,18 @@ describe('Question component', () => {
     expect(screen.queryByRole('button', { name: 'common.operation.edit' })).not.toBeInTheDocument()
   })
 
+  it('should keep action bar visible on touch-only devices (no hover)', () => {
+    renderWithProvider(makeItem(), vi.fn() as unknown as OnRegenerate)
+
+    // On touch-only devices the action bar must be visible without a hover
+    // state. Hover-capable devices still hide it via the [@media(hover:hover)]
+    // media query until the parent is hovered.
+    const actionContainer = screen.getByTestId('action-container')
+    expect(actionContainer).toHaveClass('flex')
+    expect(actionContainer).toHaveClass('[@media(hover:hover)]:hidden')
+    expect(actionContainer).toHaveClass('[@media(hover:hover)]:group-hover:flex')
+  })
+
   it('should enter edit mode when edit action clicked, allow editing and call onRegenerate on resend', async () => {
     const user = userEvent.setup()
     const onRegenerate = vi.fn() as unknown as OnRegenerate

--- a/web/app/components/base/chat/chat/answer/__tests__/operation.spec.tsx
+++ b/web/app/components/base/chat/chat/answer/__tests__/operation.spec.tsx
@@ -352,11 +352,21 @@ describe('Operation', () => {
       renderOperation({ ...baseProps, showPromptLog: true })
 
       expect(screen.getByTestId('operation-actions')).toHaveClass(
-        'group-has-[[data-popup-open]]:flex',
+        '[@media(hover:hover)]:group-has-[[data-popup-open]]:flex',
       )
       expect(screen.getByTestId('log-btn').parentElement).toHaveClass(
-        'group-has-[[data-popup-open]]:block',
+        '[@media(hover:hover)]:group-has-[[data-popup-open]]:block',
       )
+    })
+
+    it('should keep action buttons visible on touch-only devices (no hover)', () => {
+      renderOperation()
+
+      // The action bar should be visible by default (display: flex) so that
+      // touch-only devices can tap it. Hover-capable devices still hide it
+      // until the parent is hovered via the [@media(hover:hover)] media query.
+      expect(screen.getByTestId('operation-actions')).toHaveClass('flex')
+      expect(screen.getByTestId('operation-actions')).toHaveClass('[@media(hover:hover)]:hidden')
     })
 
     it('should not show prompt log for opening statements', () => {

--- a/web/app/components/base/chat/chat/answer/operation.tsx
+++ b/web/app/components/base/chat/chat/answer/operation.tsx
@@ -44,10 +44,15 @@ type FeedbackTooltipProps = {
 }
 
 const feedbackTooltipClassName = 'max-w-[260px]'
-const answerActiveFlexClassName = 'group-hover:flex group-has-[[data-popup-open]]:flex'
-const answerActiveBlockClassName = 'group-hover:block group-has-[[data-popup-open]]:block'
+// On touch-only devices there is no hover, so the action bar must be visible
+// without a hover state. On hover-capable devices we keep the desktop pattern
+// (hidden until the parent message is hovered or a popup is open inside it).
+const answerActiveFlexClassName =
+  'flex [@media(hover:hover)]:hidden [@media(hover:hover)]:group-hover:flex [@media(hover:hover)]:group-has-[[data-popup-open]]:flex'
+const answerActiveBlockClassName =
+  'block [@media(hover:hover)]:hidden [@media(hover:hover)]:group-hover:block [@media(hover:hover)]:group-has-[[data-popup-open]]:block'
 const feedbackActionsClassName =
-  'flex pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 has-[[data-popup-open]]:pointer-events-auto has-[[data-popup-open]]:opacity-100'
+  'flex pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 has-[[data-popup-open]]:pointer-events-auto has-[[data-popup-open]]:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100'
 const accentPressedClassName =
   'data-pressed:bg-state-accent-active data-pressed:text-text-accent data-pressed:hover:bg-state-accent-active-alt'
 const destructivePressedClassName =
@@ -457,14 +462,14 @@ function Operation({
           </DialogContent>
         </Dialog>
         {showPromptLog && !isOpeningStatement && (
-          <div className={cn('hidden', answerActiveBlockClassName)}>
+          <div className={cn('block', answerActiveBlockClassName)}>
             <Log logItem={item} />
           </div>
         )}
         {!isOpeningStatement && (
           <div
             className={cn(
-              'ml-1 hidden items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
+              'ml-1 flex items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
               answerActiveFlexClassName,
             )}
             data-testid="operation-actions"

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -155,7 +155,7 @@ const Question: FC<QuestionProps> = ({
         <div className={cn('mr-2 gap-1', isEditing ? 'hidden' : 'flex')}>
           <div
             data-testid="action-container"
-            className="absolute hidden gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs group-hover:flex"
+            className="absolute flex gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs [@media(hover:hover)]:hidden [@media(hover:hover)]:group-hover:flex"
             style={{ right: contentWidth + 8 }}
           >
             <IconButton


### PR DESCRIPTION
Closes #42038

## Problem

Mobile web app users reported that the chat message action buttons were
missing entirely on touch devices:

- AI messages: Like, Dislike, Copy, Regenerate
- User messages: Edit, Copy

Both `operation.tsx` and `question.tsx` used `hidden` / `opacity-0` plus
`group-hover:flex` / `group-hover:opacity-100` to reveal the action bar
on hover. Phones and tablets do not produce hover, so the bar stayed
permanently invisible.

## Fix

Switch the action containers to a hover-capable-only hide pattern using
Tailwind arbitrary media queries:

- Base: `flex` (or `opacity-100`) so touch devices always see the bar
- `[@media(hover:hover)]:hidden` / `[@media(hover:hover)]:opacity-0`
  restores the desktop default
- `[@media(hover:hover)]:group-hover:flex` and
  `[@media(hover:hover)]:group-has-[[data-popup-open]]:flex` keep the
  desktop hover and popup-open reveal behaviour
- For the feedback bar: `[@media(hover:none)]:pointer-events-auto`
  `[@media(hover:none)]:opacity-100` ensures taps register on touch

This pattern is already used elsewhere in the web app
(`plugins/plugin-item`, `metadata/base/date-picker`,
`workflow/.../tool-date-picker`, `block-selector/featured-tools`).

## Files

- `web/app/components/base/chat/chat/answer/operation.tsx`
- `web/app/components/base/chat/chat/question.tsx`

## Tests

- Updated the existing popup-open assertion in
  `operation.spec.tsx` to match the renamed selector.
- Added a new test verifying the AI message action bar stays visible on
  touch-only devices (`operation.spec.tsx`).
- Added a new test verifying the user message action bar stays visible
  on touch-only devices (`question.spec.tsx`).

Local `pnpm test` runs both `operation.spec.tsx` (69 tests, 1022 ms) and
`question.spec.tsx` (51 tests, 1081 ms) green. `pnpm type-check` passes.