### PR TITLE
fix: show chat action buttons on touch devices

### DIFF
--- a/web/app/components/base/chat/chat/answer/more.tsx
+++ b/web/app/components/base/chat/chat/answer/more.tsx
@@ -12,7 +12,7 @@ const More: FC<MoreProps> = ({ more }) => {
 
   return (
     <div
-      className="mt-1 flex items-center system-xs-regular text-text-quaternary opacity-0 group-hover:opacity-100"
+      className="mt-1 flex items-center system-xs-regular text-text-quaternary opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100"
       data-testid="more-container"
     >
       {more && (

--- a/web/app/components/base/chat/chat/answer/operation.tsx
+++ b/web/app/components/base/chat/chat/answer/operation.tsx
@@ -44,8 +44,10 @@ type FeedbackTooltipProps = {
 }
 
 const feedbackTooltipClassName = 'max-w-[260px]'
-const answerActiveFlexClassName = 'group-hover:flex group-has-[[data-popup-open]]:flex'
-const answerActiveBlockClassName = 'group-hover:block group-has-[[data-popup-open]]:block'
+const answerActiveFlexClassName =
+  'group-hover:flex group-has-[[data-popup-open]]:flex [@media(hover:none)]:flex'
+const answerActiveBlockClassName =
+  'group-hover:block group-has-[[data-popup-open]]:block [@media(hover:none)]:block'
 const feedbackActionsClassName =
   'flex pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 has-[[data-popup-open]]:pointer-events-auto has-[[data-popup-open]]:opacity-100'
 const accentPressedClassName =

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -155,7 +155,7 @@ const Question: FC<QuestionProps> = ({
         <div className={cn('mr-2 gap-1', isEditing ? 'hidden' : 'flex')}>
           <div
             data-testid="action-container"
-            className="absolute hidden gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs group-hover:flex"
+            className="absolute hidden gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs group-hover:flex [@media(hover:none)]:flex"
             style={{ right: contentWidth + 8 }}
           >
             <IconButton


### PR DESCRIPTION
Fixes #42038

## Problem

On mobile and touch devices, the chat action buttons (copy, like, dislike, regenerate, more) and metadata are invisible because they rely on `group-hover:flex` / `group-hover:opacity-100`, which does not fire on touchscreens.

## Solution

Add `[@media(hover:none)]:flex` and `[@media(hover:none)]:opacity-100` Tailwind utilities alongside the existing `group-hover` rules. This pattern is already used in 10+ files across the codebase.

## Changes

- `operation.tsx`: Answer action buttons visible on touch
- `question.tsx`: User message action buttons visible on touch
- `more.tsx`: Metadata text visible on touch

## Testing

- Open Chrome DevTools → Device Toolbar → iPhone 14
- Touch/hover over messages — buttons should appear
- Desktop hover behavior unchanged

## Checklist

- [x] I have read the Contributing Guide
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I ran `vp staged` (frontend) to appease the lint gods